### PR TITLE
feat(core): the subliminal schedule and phrase pick are portable

### DIFF
--- a/CCP.Avalonia/Views/Features/SubliminalFeatureControl.axaml.cs
+++ b/CCP.Avalonia/Views/Features/SubliminalFeatureControl.axaml.cs
@@ -25,7 +25,10 @@ namespace ConditioningControlPanel.Avalonia.Views.Features
     /// sentinel: the face ships as a WPF <c>pack://</c> Resource and is not packed on this head,
     /// so offering it would name a font nothing can resolve.</para>
     ///
-    /// <para>Still head-side: SubliminalService (the flash loop) and the mod-aware feature art.</para>
+    /// <para>Still head-side: the flash SURFACE (the per-screen click-through window) and the
+    /// mod-aware feature art. The loop itself is not - the enable toggle, the interval and the
+    /// phrase pick are <see cref="CoreSubliminal"/>. Nothing on this head arms that scheduler
+    /// yet; see <see cref="ChkEnable_Changed"/> for exactly what is missing.</para>
     /// </summary>
     public partial class SubliminalFeatureControl : UserControl
     {
@@ -176,28 +179,25 @@ namespace ConditioningControlPanel.Avalonia.Views.Features
         }
 
         /// <summary>
-        /// WPF hands the whole toggle to <c>App.Subliminal.SetEnabled</c>, which is the single
-        /// authority. Its settings half - compare, write, save, log - is restored here verbatim;
-        /// only the idempotent Start/Stop it also does still needs the service.
+        /// The whole toggle, routed through the one authority - <see cref="CoreSubliminal.SetEnabled"/>,
+        /// which is where WPF's <c>SubliminalService.SetEnabled</c> now lives too. It writes the
+        /// flag, and while the engine is running it also arms or disarms the scheduler. The card
+        /// does not repeat any of that: two copies of "compare, write, gate, save" is exactly how
+        /// the heads drift apart.
+        ///
+        /// <para><b>What this actually does on THIS head today: it persists, and it does not arm.</b>
+        /// The scheduler is real and portable, but Core only starts it behind
+        /// <c>CoreSession.IsEngineRunning</c>, and this head seeds no
+        /// <c>IsEngineRunningProvider</c> (see <c>CCP.Avalonia/App.axaml.cs</c>) - so the gate
+        /// answers false and the toggle stops at the save. Two things have to arrive before a
+        /// subliminal appears here: that flag, and a <c>CoreSubliminal.ShowProvider</c> over a
+        /// click-through overlay in <c>CCP.Avalonia/Views/Overlays/</c>. Routing through the one
+        /// authority now is what makes both a seeding line rather than a rewrite.</para>
         /// </summary>
         private void ChkEnable_Changed(object? sender, RoutedEventArgs e)
         {
             if (_isLoading) return;
-            var s = CoreSettings.Current;
-            var on = ChkEnable.IsChecked ?? false;
-            if (s.SubliminalEnabled == on) return;
-            s.SubliminalEnabled = on;
-
-            // SetEnabled's gate, in its original position: between the write and the save.
-            if (CoreSession.IsEngineRunning)
-            {
-                // ponytail: the idempotent Start()/Stop() SetEnabled does here - SubliminalService
-                // (ConditioningControlPanel/Services/Subliminal/SubliminalService.cs), still in the
-                // WPF head. Route this whole handler back through it when it moves.
-            }
-
-            CoreSettings.Save();
-            Log.Information("Subliminals toggled: {Enabled}", on);
+            CoreSubliminal.SetEnabled(ChkEnable.IsChecked ?? false);
         }
 
         private void SliderPerMin_Changed(object? sender, RangeBaseValueChangedEventArgs e)

--- a/CCP.Core/CoreSubliminal.cs
+++ b/CCP.Core/CoreSubliminal.cs
@@ -1,0 +1,188 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using Serilog;
+
+namespace ConditioningControlPanel
+{
+    /// <summary>
+    /// The subliminal seam: the half of <c>SubliminalService</c> that DECIDES, plus the one
+    /// delegate a head fills to actually draw.
+    ///
+    /// <para>A subliminal show is two separable things. Deciding - how long until the next one,
+    /// which phrase, is the feature even on - is arithmetic over <see cref="CoreSettings"/> and a
+    /// clock, so it lives here and every head gets the same rhythm. Drawing is a full-screen
+    /// click-through layered surface, per-monitor DPI and Win32 ex-styles, so it stays in the head
+    /// behind <see cref="ShowProvider"/>.</para>
+    ///
+    /// <para><b>The whole 1,493-line service could not move.</b> A dry-run <c>git mv</c> into Core
+    /// produced 68 declaration-pass errors before the compiler reached a single method body -
+    /// <c>Window</c>, <c>Grid</c>, <c>Canvas</c>, <c>Color</c>, <c>DispatcherTimer</c>,
+    /// <c>System.Windows.Forms.Screen</c>, <c>NAudio</c>, <c>Compositor.SubliminalLayer</c>,
+    /// <c>AudioPlaybackHandle</c>. So this is an extraction, not a move: the WPF service keeps its
+    /// surface and delegates the schedule and the phrase pick here, and there is exactly one copy
+    /// of each rule.</para>
+    ///
+    /// <para><b>Unseeded is a supported state.</b> With no <see cref="ShowProvider"/> the scheduler
+    /// still runs, still picks phrases and still logs - it simply draws nothing. That is honest:
+    /// the Avalonia head has no subliminal surface yet, and a feature that decides correctly and
+    /// draws nothing is what it should report. Nothing here throws and nothing returns a null a
+    /// caller would dereference.</para>
+    ///
+    /// <para>Volatile for the reason <see cref="CoreMods"/> gives: heads seed on the startup thread
+    /// while the timer callback reads from the thread pool.</para>
+    /// </summary>
+    public static class CoreSubliminal
+    {
+        /// <summary>
+        /// Draw one subliminal for this phrase. The head owns everything visual: the audio lookup,
+        /// the haptic anticipation delay, the per-screen surfaces and the fade envelope. Null when
+        /// no head has attached a surface; the scheduler then runs silently.
+        /// </summary>
+        public static volatile Action<string>? ShowProvider;
+
+        /// <summary>
+        /// The scheduler armed (true) or disarmed (false). A head hangs its transition work off
+        /// this: the WPF head fires its EMI Desk moment on the way up and, on the way down, blanks
+        /// the keep-alive windows, pulls hosted cards off the shared host and stops the whisper
+        /// audio. Without it a checkbox toggle would silence the schedule and leave a card on
+        /// screen with the whisper still playing.
+        ///
+        /// <para>Fired AFTER <see cref="IsRunning"/> already reads the new value, so a handler that
+        /// calls back into <see cref="Start"/>/<see cref="Stop"/> is a no-op rather than a loop.</para>
+        /// </summary>
+        public static volatile Action<bool>? RunStateChanged;
+
+        private static readonly object Gate = new();
+        private static readonly Random Rng = new();
+        private static Timer? _timer;
+        private static volatile bool _isRunning;
+
+        /// <summary>True while the ambient scheduler is armed.</summary>
+        public static bool IsRunning => _isRunning;
+
+        /// <summary>
+        /// Seconds until the next subliminal for a given rate, with the randomness supplied by the
+        /// caller so the rule can be checked without a clock. <paramref name="roll"/> is a uniform
+        /// [0,1). The original: 60/frequency, jittered +-30%, floored at one second.
+        /// </summary>
+        public static double NextIntervalSeconds(int frequency, double roll)
+        {
+            var freq = Math.Max(1, frequency);
+            var baseInterval = 60.0 / freq;
+            var variance = baseInterval * 0.3;
+            return Math.Max(1, baseInterval + (roll * variance * 2 - variance));
+        }
+
+        /// <summary>
+        /// One phrase from the enabled half of the user's pool, or null when nothing is enabled -
+        /// which the caller treats as "no show this tick", exactly as the WPF original did.
+        /// </summary>
+        public static string? PickPhrase()
+        {
+            List<string> active;
+            try
+            {
+                active = CoreSettings.Current.SubliminalPool
+                    .Where(kvp => kvp.Value).Select(kvp => kvp.Key).ToList();
+            }
+            catch { return null; }
+
+            if (active.Count == 0)
+            {
+                Log.Debug("No active subliminal texts");
+                return null;
+            }
+            lock (Gate) return active[Rng.Next(active.Count)];
+        }
+
+        /// <summary>Arm the ambient scheduler. Idempotent.</summary>
+        public static void Start()
+        {
+            lock (Gate)
+            {
+                if (_isRunning) return;
+                _isRunning = true;
+                _timer ??= new Timer(OnTick, null, Timeout.Infinite, Timeout.Infinite);
+                ArmLocked();
+            }
+            Log.Information("SubliminalService started");
+            Notify(true);
+        }
+
+        /// <summary>Disarm the ambient scheduler. Idempotent; the head still owns taking any card
+        /// that is already on screen back off it.</summary>
+        public static void Stop()
+        {
+            lock (Gate)
+            {
+                if (!_isRunning && _timer == null) return;
+                _isRunning = false;
+                try { _timer?.Change(Timeout.Infinite, Timeout.Infinite); } catch { }
+            }
+            Log.Information("SubliminalService stopped");
+            Notify(false);
+        }
+
+        /// <summary>
+        /// The single authority for toggling the feature from any UI entry point. Persists the flag
+        /// and, only while the engine is actually running, starts or stops the scheduler - so a
+        /// checkbox and a popup that mirror each other cannot churn Start/Stop between them.
+        /// </summary>
+        public static void SetEnabled(bool on)
+        {
+            var s = CoreSettings.Current;
+            if (s.SubliminalEnabled != on)
+                s.SubliminalEnabled = on;
+
+            if (CoreSession.IsEngineRunning)
+            {
+                if (on && !_isRunning) Start();
+                else if (!on && _isRunning) Stop();
+            }
+
+            CoreSettings.Save();
+            Log.Information("Subliminals toggled: {Enabled}", on);
+        }
+
+        /// <summary>A head whose teardown throws must not take the schedule with it.</summary>
+        private static void Notify(bool running)
+        {
+            try { RunStateChanged?.Invoke(running); }
+            catch (Exception ex) { Log.Debug("Subliminal run-state handler failed: {Error}", ex.Message); }
+        }
+
+        /// <summary>Caller holds <see cref="Gate"/>. Schedules exactly one tick.</summary>
+        private static void ArmLocked()
+        {
+            if (!_isRunning || !CoreSettings.Current.SubliminalEnabled) return;
+            var seconds = NextIntervalSeconds(CoreSettings.Current.SubliminalFrequency, Rng.NextDouble());
+            try { _timer?.Change(TimeSpan.FromSeconds(seconds), Timeout.InfiniteTimeSpan); } catch { }
+        }
+
+        /// <summary>
+        /// Thread-pool tick. WPF ran the whole flash on a DispatcherTimer, i.e. on the UI thread,
+        /// so the body hops back through <see cref="CoreDispatch"/> - unseeded that runs in place.
+        /// The posted body re-checks running/enabled because a Stop can land between the post and
+        /// the hop.
+        /// </summary>
+        private static void OnTick(object? _)
+        {
+            CoreDispatch.Post(() =>
+            {
+                if (!_isRunning || !CoreSettings.Current.SubliminalEnabled) return;
+
+                var text = PickPhrase();
+                if (text != null)
+                {
+                    // A head whose surface throws must not kill the schedule.
+                    try { ShowProvider?.Invoke(text); }
+                    catch (Exception ex) { Log.Debug("Subliminal show provider failed: {Error}", ex.Message); }
+                }
+
+                lock (Gate) ArmLocked();
+            });
+        }
+    }
+}

--- a/CCP.LinuxSmoke/Program.cs
+++ b/CCP.LinuxSmoke/Program.cs
@@ -101,6 +101,74 @@ namespace ConditioningControlPanel.LinuxSmoke
                       poolMatches, $"{pool.Count} phrases vs BambiSleep's {bambiPool.Count}");
                 Check("the unseeded subliminal pool is deliberately NOT the CCP default's",
                       pool.Count != Models.BuiltInMods.CCPDefault.SubliminalPool!.Count);
+                // The subliminal split (wire/109). The schedule decides here; the flash surface is
+                // the head's, and with nothing seeded a scheduled subliminal must draw nothing
+                // rather than throw. The interval rule is checked with the roll injected, because a
+                // real clock cannot prove arithmetic.
+                Check("CoreSubliminal is not running cold", !CoreSubliminal.IsRunning);
+                Check("the median roll is exactly 60/frequency",
+                      Math.Abs(CoreSubliminal.NextIntervalSeconds(5, 0.5) - 12.0) < 1e-9,
+                      CoreSubliminal.NextIntervalSeconds(5, 0.5).ToString("R"));
+                Check("roll 0 is the -30% edge and roll 1 the +30% edge",
+                      Math.Abs(CoreSubliminal.NextIntervalSeconds(5, 0) - 8.4) < 1e-9 &&
+                      Math.Abs(CoreSubliminal.NextIntervalSeconds(5, 1) - 15.6) < 1e-9);
+                Check("the interval never drops below one second, however fast the rate",
+                      CoreSubliminal.NextIntervalSeconds(600, 0) >= 1.0 &&
+                      CoreSubliminal.NextIntervalSeconds(0, 0) >= 1.0);
+                var runStates = new List<bool>();
+                CoreSubliminal.RunStateChanged = running => runStates.Add(running);
+                CoreSubliminal.Start();
+                Check("Start arms the scheduler with no surface seeded and does not throw",
+                      CoreSubliminal.IsRunning);
+                CoreSubliminal.Stop();
+                Check("Stop disarms it", !CoreSubliminal.IsRunning);
+                Check("both transitions reached the head's run-state hook",
+                      runStates.Count == 2 && runStates[0] && !runStates[1],
+                      string.Join(",", runStates));
+                CoreSubliminal.RunStateChanged = null;
+                // The rest of this block edits the fallback settings, so snapshot them first -
+                // every later check in this runner reads the same instance.
+                var poolWas = CoreSettings.Current.SubliminalPool;
+                var freqWas = CoreSettings.Current.SubliminalFrequency;
+                var enabledWas = CoreSettings.Current.SubliminalEnabled;
+
+                // Every phrase in the fallback pool is off, so there is nothing to show and the
+                // scheduler must say so rather than hand the surface a null.
+                CoreSettings.Current.SubliminalPool = new Dictionary<string, bool> { ["x"] = false };
+                Check("PickPhrase returns null when nothing in the pool is enabled",
+                      CoreSubliminal.PickPhrase() is null);
+                CoreSettings.Current.SubliminalPool = new Dictionary<string, bool> { ["x"] = true };
+                Check("PickPhrase returns the one enabled phrase", CoreSubliminal.PickPhrase() == "x");
+                // Unseeded CoreSession answers false, so the toggle must persist the flag and leave
+                // the scheduler alone - a head with no engine is not running one.
+                CoreSubliminal.SetEnabled(true);
+                Check("SetEnabled writes the flag with no engine running",
+                      CoreSettings.Current.SubliminalEnabled);
+                Check("...and does NOT arm the scheduler behind a stopped engine",
+                      !CoreSubliminal.IsRunning);
+                CoreSubliminal.SetEnabled(false);
+
+                // THE assertion of the layer, and the only one a flag flip cannot fake: the timer
+                // must actually reach ShowProvider. Everything else here proves arithmetic and
+                // state; this proves the loop. 60 per minute arms in 1.0-1.3s, and the tick body
+                // runs in place because no head seeded CoreDispatch - so the wait is what carries
+                // it across, not a dispatcher.
+                CoreSettings.Current.SubliminalFrequency = 60;
+                CoreSettings.Current.SubliminalEnabled = true;
+                using (var shown = new System.Threading.ManualResetEventSlim())
+                {
+                    CoreSubliminal.ShowProvider = _ => shown.Set();
+                    CoreSubliminal.Start();
+                    Check("the scheduler actually fires a show, it does not merely flip a flag",
+                          shown.Wait(TimeSpan.FromSeconds(6)));
+                    CoreSubliminal.Stop();
+                    CoreSubliminal.ShowProvider = null;
+                }
+
+                CoreSettings.Current.SubliminalPool = poolWas;
+                CoreSettings.Current.SubliminalFrequency = freqWas;
+                CoreSettings.Current.SubliminalEnabled = enabledWas;
+
                 var finished = false;
                 CoreAudio.PlayOneShot("/nowhere.mp3", 1f, "smoke", onFinished: () => finished = true);
                 Check("CoreAudio.PlayOneShot fires onFinished at once with no audio", finished);

--- a/ConditioningControlPanel/App.xaml.cs
+++ b/ConditioningControlPanel/App.xaml.cs
@@ -369,6 +369,13 @@ namespace ConditioningControlPanel
             CoreProgram.ActivePackVideoCountProvider = () => ContentPacks?.GetAllActivePackVideos().Count ?? 0;
             CoreProgram.RoadmapProvider = () => Roadmap;
 
+            // The subliminal split (CCP.Core/CoreSubliminal.cs): Core owns the interval, the phrase
+            // pick and the enable toggle; this head owns the flash surface and the whisper. Both
+            // are lambdas, not eager reads - Subliminal is constructed in OnStartup, long after
+            // this ctor runs, and until then the scheduler simply draws nothing.
+            CoreSubliminal.ShowProvider = text => Subliminal?.FlashPhrase(text);
+            CoreSubliminal.RunStateChanged = running => Subliminal?.OnRunStateChanged(running);
+
             // The engine-running flag, for the feature cards that only live-apply while a session
             // is up. The engine stays here; the flag is the whole seam.
             CoreSession.IsEngineRunningProvider = () => IsEngineRunning;

--- a/ConditioningControlPanel/Services/Subliminal/SubliminalService.cs
+++ b/ConditioningControlPanel/Services/Subliminal/SubliminalService.cs
@@ -20,7 +20,6 @@ namespace ConditioningControlPanel.Services
     /// </summary>
     public class SubliminalService : IDisposable
     {
-        private readonly DispatcherTimer _timer;
         private readonly Random _random = new();
 
         // KEEP-ALIVE windows, one per screen: a subliminal "show" swaps the text content and
@@ -66,7 +65,9 @@ namespace ConditioningControlPanel.Services
         // The whisper device itself is owned by AudioService — this is only the stop handle.
         private AudioPlaybackHandle? _audioHandle;
 
-        private bool _isRunning;
+        // One truth for "is the ambient scheduler armed", and it is Core's - SetEnabled can now
+        // start/stop it without passing through this class at all.
+        private bool _isRunning => CoreSubliminal.IsRunning;
         private bool _oneShotActive; // Allow one-shot display when service not running (remote control)
 
         // #1045 - the same generation scheme FlashService uses. A point-fired subliminal carries the
@@ -83,7 +84,7 @@ namespace ConditioningControlPanel.Services
         private bool _disposed;
         private int _subliminalCount;
 
-        public bool IsRunning => _isRunning;
+        public bool IsRunning => CoreSubliminal.IsRunning;
 
         /// <summary>
         /// Fired when a subliminal is displayed
@@ -101,34 +102,44 @@ namespace ConditioningControlPanel.Services
             {
                 App.Logger?.Warning("SubliminalService: could not create {Path} - {Error}", _audioPath, ex.Message);
             }
-
-            _timer = new DispatcherTimer();
-            _timer.Tick += Timer_Tick;
         }
 
         /// <summary>
         /// Start the subliminal service
         /// </summary>
-        public void Start()
-        {
-            if (_isRunning) return;
-            
-            _isRunning = true;
-            ScheduleNext();
-            
-            App.Logger?.Information("SubliminalService started");
-
-            // EMI Desk (MOMENTS 4.B).
-            try { App.EmiDesk?.Fire("subliminalsStarted", null); } catch { }
-        }
+        public void Start() => CoreSubliminal.Start();
 
         /// <summary>
         /// Stop the subliminal service
         /// </summary>
         public void Stop()
         {
-            _isRunning = false;
-            _timer.Stop();
+            // Core disarms the schedule and calls OnRunStateChanged(false) back; the teardown also
+            // runs here directly so a Stop that Core treats as a no-op still clears our surfaces.
+            CoreSubliminal.Stop();
+            TearDownSurfaces();
+        }
+
+        /// <summary>
+        /// Core's run-state hook (seeded in App.xaml.cs). Everything the transition has to do to
+        /// THIS head lives here, because Core's SetEnabled can now flip the schedule without going
+        /// through Start()/Stop() at all - and a toggle that silenced the scheduler while leaving a
+        /// card up and the whisper playing would be a control lying about its own state.
+        /// </summary>
+        internal void OnRunStateChanged(bool running)
+        {
+            if (running)
+            {
+                // EMI Desk (MOMENTS 4.B).
+                try { App.EmiDesk?.Fire("subliminalsStarted", null); } catch { }
+                return;
+            }
+            TearDownSurfaces();
+        }
+
+        /// <summary>Idempotent: take every subliminal surface off screen and stop the whisper.</summary>
+        private void TearDownSurfaces()
+        {
             _visibleOneShotGen = null;
 
             // Blank + hide the keep-alive windows (don't close them — a Stop can land
@@ -156,8 +167,6 @@ namespace ConditioningControlPanel.Services
                 _layer.Clear();
 
             StopAudio();
-
-            App.Logger?.Information("SubliminalService stopped");
         }
 
         /// <summary>
@@ -225,48 +234,10 @@ namespace ConditioningControlPanel.Services
         /// </summary>
         public void SetEnabled(bool on)
         {
-            var s = App.Settings?.Current;
-            if (s == null) return;
-
-            if (s.SubliminalEnabled != on)
-                s.SubliminalEnabled = on;
-
-            if (App.IsEngineRunning)
-            {
-                if (on && !_isRunning) Start();
-                else if (!on && _isRunning) Stop();
-            }
-
-            App.Settings?.Save();
-            App.Logger?.Information("Subliminals toggled: {Enabled}", on);
-        }
-
-        private void ScheduleNext()
-        {
-            if (!_isRunning || !App.Settings.Current.SubliminalEnabled) return;
-            
-            // Calculate interval based on frequency (messages per minute)
-            var freq = Math.Max(1, App.Settings.Current.SubliminalFrequency);
-            var baseInterval = 60.0 / freq; // seconds between messages
-            
-            // Add some randomness (±30%)
-            var variance = baseInterval * 0.3;
-            var interval = baseInterval + (_random.NextDouble() * variance * 2 - variance);
-            interval = Math.Max(1, interval); // At least 1 second
-            
-            _timer.Interval = TimeSpan.FromSeconds(interval);
-            _timer.Start();
-        }
-
-        private void Timer_Tick(object? sender, EventArgs e)
-        {
-            _timer.Stop();
-
-            if (!_isRunning || !App.Settings.Current.SubliminalEnabled)
-                return;
-
-            FlashSubliminal();
-            ScheduleNext();
+            // Settings write, the IsEngineRunning gate, Start/Stop and the Save are all Core's now
+            // (CCP.Core/CoreSubliminal.cs), so the WPF checkbox, the feature popup and the Avalonia
+            // card share one authority instead of three copies of the same four lines.
+            CoreSubliminal.SetEnabled(on);
         }
 
         /// <summary>
@@ -274,18 +245,20 @@ namespace ConditioningControlPanel.Services
         /// </summary>
         public void FlashSubliminal()
         {
+            var text = CoreSubliminal.PickPhrase();
+            if (text == null) return;
+            FlashPhrase(text);
+        }
+
+        /// <summary>
+        /// Draw and sound ONE already-chosen phrase. This is what Core's scheduler calls back into
+        /// through <see cref="CoreSubliminal.ShowProvider"/>; the phrase pick and the interval are
+        /// its side of the split, everything below here is the head's.
+        /// </summary>
+        internal void FlashPhrase(string text)
+        {
             if (!_isRunning) _oneShotActive = true; // Allow display from remote control
-            var pool = App.Settings.Current.SubliminalPool;
-            var activeTexts = pool.Where(kvp => kvp.Value).Select(kvp => kvp.Key).ToList();
-            
-            if (activeTexts.Count == 0)
-            {
-                App.Logger?.Debug("No active subliminal texts");
-                return;
-            }
-            
-            var text = activeTexts[_random.Next(activeTexts.Count)];
-            
+
             // Check for linked audio
             string? audioPath = FindLinkedAudio(text);
             


### PR DESCRIPTION
The interval, the phrase pick and the enable toggle are one implementation in
Core now, shared by every head. The flash surface is not, and neither head-side
claim below is stretched: on Windows nothing changes, and on Linux the card
routes through the one authority and stops at the save.

The whole service could not move, and the dry run says so precisely: git mv of
SubliminalService.cs into Core produced 68 errors in the DECLARATION pass alone,
before the compiler reached one method body - Window, Grid, Canvas, Color,
DispatcherTimer, System.Windows.Forms.Screen, NAudio, Compositor.SubliminalLayer,
AudioPlaybackHandle. Reverted, and this layer is an extraction instead.

Moved to CCP.Core/CoreSubliminal.cs:
  - NextIntervalSeconds(frequency, roll): 60/freq, +-30% jitter, floored at 1s,
    with the random roll injected so the rule is checkable without a clock.
  - PickPhrase(): one phrase from the enabled half of SubliminalPool, null when
    nothing is enabled.
  - Start/Stop/IsRunning: a System.Threading.Timer armed one tick at a time,
    whose body runs inside CoreDispatch.Post because the WPF DispatcherTimer
    ticked on the UI thread. The posted body re-checks running+enabled, since a
    Stop can land between the post and the hop.
  - SetEnabled: the flag write, the CoreSession.IsEngineRunning gate, the
    idempotent Start/Stop, the Save and the log - one authority, shared by the
    WPF checkbox, the WPF feature popup and the Avalonia card.

Two delegates, no interface, unseeded answering safely:
  - ShowProvider(text): draw one flash. Unseeded, the scheduler runs silently.
  - RunStateChanged(bool): the transition. This is not optional. SetEnabled can
    now flip the schedule without passing through the head's Stop() at all, and
    a toggle that silenced the scheduler while leaving a card on screen and the
    whisper still playing would be a control lying about its own state. The WPF
    head hangs its EMI Desk moment and its whole surface teardown off it.

The line, exactly where the compiler put it: everything from ShowSubliminalVisuals
down stays in the WPF head - the per-screen keep-alive layered windows, solid
mode's shared-host cards, the compositor layer, the Win32 ex-styles, the DPI
probes, the OCR text rects, the fade storyboards. FlashSubliminal() now picks
through Core and calls the new internal FlashPhrase(), which is also what the
seam invokes; the one-shot generation scheme and its _oneShotActive latch are
untouched, since every entry point to them is a head-side public method.

The Avalonia card's #892 pool bookkeeping is deliberately not touched - it was
already correct against CoreMods.GetDefaultSubliminalPool, and a second copy of
that rule is the failure this structure exists to prevent.

A render cannot show a timer, so the LinuxSmoke block seeds a ShowProvider at
60/min and waits for the callback. That check is the layer: it goes red if
ArmLocked's Change or OnTick's dispatcher hop ever break, verified by breaking
each on purpose (runner exits 1). The interval bounds and the run-state hook were
proven fallible the same way.

Still blocked, exactly:
  - CoreSession.IsEngineRunningProvider is unseeded in CCP.Avalonia/App.axaml.cs
    (WPF seeds it at ConditioningControlPanel/App.xaml.cs:363). So on Linux the
    gate answers false and the card's toggle persists WITHOUT arming. That is
    correct - a head with no engine is not running one - but it means no
    subliminal is scheduled there yet either.
  - The flash surface on Linux. CoreSubliminal.ShowProvider is seeded only by
    ConditioningControlPanel/App.xaml.cs. A sibling layer is building
    CCP.Avalonia/Views/Overlays/ this wave; once a click-through overlay window
    exists there, this is one seeding line. Not built here.
  - The whisper audio. SubliminalService.FindLinkedAudio / GetModAudioPath need
    App.Mods.ActiveMod.InstalledPath; CoreMods.ActiveModToken is object? and is
    never dereferenced by contract, so there is no seam for a mod's install path
    yet. PlayWhisperAudio itself is already CoreAudio-shaped.
  - Haptic anticipation. App.Haptics.SubliminalAnticipationMs and
    TriggerSubliminalPatternAsync, ConditioningControlPanel/Services/Haptics/ -
    no seam.
  - TriggerBambiFreeze / ScheduleBambiReset stay head-side: the 90% roll and the
    4-8s delay are portable, but every one of their bodies ends in the WPF
    surface, so splitting them would buy two constants and a second call chain.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU