### PR TITLE
feat(core): bouncing-text motion, colour cycling and XP gating are portable

### DIFF
--- a/CCP.Avalonia/App.axaml.cs
+++ b/CCP.Avalonia/App.axaml.cs
@@ -117,6 +117,16 @@ namespace ConditioningControlPanel.Avalonia
                 // because an entitlement seam that failed open would hand every Linux user the
                 // paid tier.
                 //
+                // CoreBouncingText stays unseeded, and the split is the point: the motion, the
+                // colour modes and the XP rate limit are BouncingTextEngine in Core and identical
+                // on both heads, but nothing here owns a full-screen click-through surface to paint
+                // logos on yet. Unseeded, the Lab card's Start/Stop/Refresh/Restart are silent
+                // no-ops - the same answer the WPF card got from App.BouncingText?. before the
+                // service existed - and the checkbox still reads from the saved setting, so it says
+                // "on, drawing nothing" rather than lying about being off. Seeding this needs an
+                // overlay window in Views/Overlays/ plus the two facts the engine cannot work out
+                // for itself: screen bounds and glyph metrics.
+                //
                 // CoreSpeech is deliberately left unseeded: there is no speech engine on this head
                 // yet, and the seam's unseeded answers (no mic, empty device list, NotProbed) are
                 // exactly what that is. Seeding it with anything else would be a lie.

--- a/CCP.Avalonia/Views/Features/BouncingTextFeatureControl.axaml.cs
+++ b/CCP.Avalonia/Views/Features/BouncingTextFeatureControl.axaml.cs
@@ -162,9 +162,8 @@ namespace ConditioningControlPanel.Avalonia.Views.Features
             // Live-apply: start/stop the bouncing-text service if the engine is running.
             if (CoreSession.IsEngineRunning)
             {
-                // ponytail: App.BouncingText.Start()/Stop() - BouncingTextService
-                // (ConditioningControlPanel/Services/Subliminal/BouncingTextService.cs), still in
-                // the WPF head - it draws Win32 layered windows.
+                if (want) CoreBouncingText.Start();
+                else CoreBouncingText.Stop();
             }
         }
 
@@ -342,12 +341,14 @@ namespace ConditioningControlPanel.Avalonia.Views.Features
             }
         }
 
-        // ponytail: both need App.BouncingText
-        // (ConditioningControlPanel/Services/Subliminal/BouncingTextService.cs), still in the WPF
-        // head. Kept as named no-ops so the call ORDER around them stays the WPF one.
-        private static void SafeRefresh() { }
+        /// <summary>Both go through <see cref="CoreBouncingText"/>, which swallows a fault the way
+        /// the WPF card's own try/catch did. Deliberately NOT gated on
+        /// <see cref="CoreSession.IsEngineRunning"/> - WPF gates only the enable toggle and lets
+        /// the service's own "am I running" guard answer these two. Unseeded, both are silent, and
+        /// the setting has already been saved by the caller either way.</summary>
+        private static void SafeRefresh() => CoreBouncingText.Refresh();
 
-        private static void SafeRestart() { }
+        private static void SafeRestart() => CoreBouncingText.Restart();
 
         // =====================================================================================
         //  view state
@@ -362,29 +363,11 @@ namespace ConditioningControlPanel.Avalonia.Views.Features
             ColorSwatch.Background = new SolidColorBrush(Color.FromRgb(r, g, b));
         }
 
-        /// <summary>The colour Fixed mode renders: the user's pick if set, else hot pink.
-        /// Mirrors BouncingTextService.GetFixedColor.</summary>
+        /// <summary>The colour Fixed mode renders: the user's pick if set, else hot pink. This is
+        /// the engine's own static now, not a third copy of the parse, so the swatch cannot drift
+        /// from what actually gets drawn.</summary>
         private static (byte R, byte G, byte B) EffectiveColor()
-        {
-            if (TryParseHex(CoreSettings.Current.BouncingTextFixedColor, out var rgb)) return rgb;
-            return (255, 105, 180);
-        }
-
-        private static bool TryParseHex(string? hex, out (byte R, byte G, byte B) rgb)
-        {
-            rgb = (255, 105, 180);
-            if (string.IsNullOrWhiteSpace(hex)) return false;
-            hex = hex.Trim().TrimStart('#');
-            if (hex.Length != 6) return false;
-            try
-            {
-                rgb = (Convert.ToByte(hex.Substring(0, 2), 16),
-                       Convert.ToByte(hex.Substring(2, 2), 16),
-                       Convert.ToByte(hex.Substring(4, 2), 16));
-                return true;
-            }
-            catch { return false; }
-        }
+            => Services.BouncingTextEngine.GetFixedColor(CoreSettings.Current);
 
         /// <summary>
         /// WPF calls <c>Helpers.FontPickerHelper.Populate(CmbFont, s.BouncingTextFont, "Segoe UI")</c>

--- a/CCP.Core/CoreBouncingText.cs
+++ b/CCP.Core/CoreBouncingText.cs
@@ -1,0 +1,45 @@
+using System;
+
+namespace ConditioningControlPanel
+{
+    /// <summary>
+    /// The bouncing-text control seam: the four things a settings card asks of the running
+    /// bouncing-text feature.
+    ///
+    /// <para>This is a CONTROL handle, not a draw surface. The motion, colours and XP gating now
+    /// live in <see cref="Services.BouncingTextEngine"/> and are the same on every head; what
+    /// differs is who owns the surface those logos are painted on. On Windows that is
+    /// <c>BouncingTextService</c> with its Win32 layered click-through windows, and these four
+    /// members forward to it. A head with no surface leaves them null.</para>
+    ///
+    /// <para>Unseeded every member is a silent no-op, which is the same answer the WPF call sites
+    /// already got from <c>App.BouncingText?.Refresh()</c> before the service was constructed. It
+    /// cannot lie about state, because nothing here reports state: the card's checkbox is driven by
+    /// <c>AppSettings.BouncingTextEnabled</c>, which is saved whether or not a surface picks it up,
+    /// so an unseeded head shows "on, and nothing is drawn" rather than "off".</para>
+    ///
+    /// <para>Faults are swallowed for the reason the WPF card wrapped both calls in try/catch: a
+    /// throwing overlay must not take down the settings panel that nudged it.</para>
+    /// </summary>
+    public static class CoreBouncingText
+    {
+        /// <summary>Show the bouncing text. The card calls this only while a session engine is up.</summary>
+        public static volatile Action? StartAction;
+
+        /// <summary>Hide it and release the surfaces.</summary>
+        public static volatile Action? StopAction;
+
+        /// <summary>Re-read the live settings (speed, size, opacity, font, fixed colour,
+        /// show-over-videos). A no-op when nothing is running - the head's own guard, not this one's.</summary>
+        public static volatile Action? RefreshAction;
+
+        /// <summary>Rebuild, for the settings that change the rendered element itself (the outlined
+        /// style, the second logo). Also a no-op when nothing is running.</summary>
+        public static volatile Action? RestartAction;
+
+        public static void Start()   { try { StartAction?.Invoke(); }   catch { } }
+        public static void Stop()    { try { StopAction?.Invoke(); }    catch { } }
+        public static void Refresh() { try { RefreshAction?.Invoke(); } catch { } }
+        public static void Restart() { try { RestartAction?.Invoke(); } catch { } }
+    }
+}

--- a/CCP.Core/Services/Subliminal/BouncingTextEngine.cs
+++ b/CCP.Core/Services/Subliminal/BouncingTextEngine.cs
@@ -1,0 +1,497 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using ConditioningControlPanel.Models;
+
+namespace ConditioningControlPanel.Services;
+
+/// <summary>Everything one bouncing logo did in a single frame, reported back to the head so it can
+/// run the parts that are not arithmetic (the achievement, the haptic pulse, the burst particles,
+/// the window repaint). Nothing here is a request - the engine has already applied its own state.</summary>
+/// <param name="ColorBeforeBounce">The logo's colour as the frame began. The corner burst is drawn
+/// in it deliberately: WPF spawned the particles before the bounce re-rolled the colour, so passing
+/// the new one would change what Windows draws.</param>
+public readonly record struct BounceStep(
+    bool Bounced,
+    bool BouncedX,
+    bool CornerHit,
+    bool TextChanged,
+    (byte R, byte G, byte B) ColorBeforeBounce);
+
+/// <summary>
+/// The portable half of <c>BouncingTextService</c>: DVD-screensaver motion, wall and corner
+/// detection, the three colour modes, the per-frame effect transforms and the XP rate limit.
+///
+/// <para><b>Why an extraction and not a move.</b> There is no file to <c>git mv</c> here: the maths
+/// was interleaved line-by-line with <c>App.Achievements</c>, <c>App.Haptics</c>, <c>App.Video</c>,
+/// <c>CompositionTarget.Rendering</c> and calls into the layered <c>BouncingTextWindow</c>, all
+/// inside one 800-line class. So the arithmetic was lifted out method by method and the head now
+/// delegates to it; the drawing half is untouched.</para>
+///
+/// <para><b>What stays in the head.</b> Screen bounds (a monitor enumeration), glyph metrics (a
+/// font rasteriser) and the surface itself. The engine takes bounds through
+/// <see cref="SetBounds"/> and metrics through <see cref="Measure"/>, so a second head supplies two
+/// small facts rather than reimplementing bounce physics that would then drift from Windows.</para>
+///
+/// <para>Settings are passed in per call, exactly as the WPF methods took them, so this class never
+/// reads <c>CoreSettings</c> and a test can drive it against a throwaway <see cref="AppSettings"/>.</para>
+/// </summary>
+public sealed class BouncingTextEngine
+{
+    /// <summary>The 100%-size font size. Settings scale this by 50-300%.</summary>
+    public const int BaseFontSize = 72;
+
+    /// <summary>Corners are hard to hit exactly, so a single-axis bounce this close to one counts.</summary>
+    private const double CornerTolerance = 15.0;
+
+    // Anti-exploit: XP rate limiting for bounces, shared across logos so a second text does not
+    // double the XP income. Short cooldown so a corner hit is not counted twice.
+    private static readonly TimeSpan BounceXpCooldown = TimeSpan.FromSeconds(2);
+    private const int MaxBounceXpPerMinute = 150;
+
+    /// <summary>Per-logo bounce state. One or two of these exist while running.</summary>
+    public sealed class Logo
+    {
+        public string Text = "";
+        public double PosX, PosY;
+        public double VelX, VelY;
+        public double TextWidth = 200, TextHeight = 60;
+        public (byte R, byte G, byte B) Color;
+        public int HueIndex;            // rainbow-cycle position
+        public double Phase;            // per-logo offset so two logos never breathe/wobble in sync
+        public double SpinAngle;        // accumulated continuous-spin angle (deg)
+        public double Tilt;             // smoothed velocity-lean angle (deg)
+        public double SquashTimer = -1; // seconds since last wall hit; <0 = idle
+        public bool SquashAxisX;        // true = hit a vertical wall (X velocity reversed)
+        public double BurstTimer = -1;  // seconds since last corner hit; <0 = idle
+    }
+
+    private readonly Random _random;
+    private readonly List<Logo> _logos = new();
+    private List<string>? _poolOverride;
+    private double _fxTime;   // shared effects clock (seconds)
+    private double _lastDt;   // dt of the current frame, so the effect timers need not thread it
+
+    private DateTime _lastBounceXpTime = DateTime.MinValue;
+    private int _bounceXpThisMinute;
+    private DateTime _bounceXpMinuteStart = DateTime.MinValue;
+
+    /// <summary>Ordered hue wheel for the rainbow-cycle colour mode (advances one step per bounce).</summary>
+    private static readonly (byte R, byte G, byte B)[] RainbowWheel = BuildRainbowWheel();
+
+    /// <param name="rng">Injected so a test can make the motion deterministic. Null takes a fresh one.</param>
+    public BouncingTextEngine(Random? rng = null) => _random = rng ?? new Random();
+
+    /// <summary>
+    /// Head-supplied glyph metrics for a string at a font size, in DIPs. Left null the engine falls
+    /// back to the same crude estimate the WPF measurement's own catch block used, so the logo still
+    /// bounces off plausible edges rather than off a zero-width box.
+    /// </summary>
+    public Func<string, int, (double Width, double Height)>? Measure;
+
+    public IReadOnlyList<Logo> Logos => _logos;
+
+    /// <summary>The AI/session-supplied pool, kept so a restart re-rolls from the same override.</summary>
+    public IReadOnlyList<string>? PoolOverride => _poolOverride;
+
+    /// <summary>Font size the logos were measured at (base size scaled by the size setting).</summary>
+    public int FontSize { get; private set; } = BaseFontSize;
+
+    /// <summary>Family name the running logos were measured with, so a mid-run change is spottable.</summary>
+    public string Font { get; private set; } = "";
+
+    public double MinX { get; private set; }
+    public double MinY { get; private set; }
+    public double MaxX { get; private set; }
+    public double MaxY { get; private set; }
+
+    /// <summary>The virtual-desktop rectangle to bounce inside, in DIPs. The head computes it from
+    /// its monitor enumeration; call before <see cref="Start"/> or the logos start in a zero box.</summary>
+    public void SetBounds(double minX, double minY, double maxX, double maxY)
+    {
+        MinX = minX; MinY = minY; MaxX = maxX; MaxY = maxY;
+    }
+
+    /// <summary>Build one or two logos at random positions, velocities and colours.</summary>
+    public void Start(AppSettings settings, IReadOnlyList<string>? pool = null)
+    {
+        _poolOverride = pool != null && pool.Count > 0 ? pool.ToList() : null;
+        _fxTime = 0;
+        _lastDt = 0;
+
+        FontSize = (int)(BaseFontSize * settings.BouncingTextSize / 100.0);
+        Font = settings.BouncingTextFont ?? "Segoe UI";
+
+        _logos.Clear();
+        int logoCount = settings.BouncingTextSecondText ? 2 : 1;
+        for (int i = 0; i < logoCount; i++)
+        {
+            var logo = new Logo
+            {
+                Phase = _random.NextDouble() * Math.PI * 2,
+                HueIndex = _random.Next(RainbowWheel.Length),
+            };
+            logo.Text = SelectRandomText(settings);
+            MeasureInto(logo);
+
+            // Random starting position (ensure text starts fully within bounds)
+            logo.PosX = MinX + _random.NextDouble() * Math.Max(1, (MaxX - MinX - logo.TextWidth));
+            logo.PosY = MinY + _random.NextDouble() * Math.Max(1, (MaxY - MinY - logo.TextHeight));
+
+            // Random velocity in DIP/second (speed based on setting). The base is the old
+            // 3-5 px/tick value scaled by 60 so the on-screen feel is unchanged at 60 FPS, but
+            // motion is delta-time driven so it stays correct at any rate.
+            var speed = settings.BouncingTextSpeed / 10.0; // 1-10 maps to 0.1-1.0 multiplier
+            var baseSpeed = (3.0 + _random.NextDouble() * 2.0) * 60.0; // 180-300 DIP/sec
+            logo.VelX = baseSpeed * speed * (_random.Next(2) == 0 ? 1 : -1);
+            logo.VelY = baseSpeed * speed * (_random.Next(2) == 0 ? 1 : -1);
+
+            logo.Color = NextColor(logo, settings);
+            _logos.Add(logo);
+        }
+    }
+
+    public void Stop()
+    {
+        _logos.Clear();
+        _poolOverride = null;
+    }
+
+    /// <summary>Advance the shared effects clock. Once per frame, before stepping the logos.</summary>
+    public void Tick(double dt)
+    {
+        _fxTime += dt;
+        _lastDt = dt;
+    }
+
+    public string SelectRandomText(AppSettings settings)
+    {
+        var enabledTexts = _poolOverride != null && _poolOverride.Count > 0
+            ? _poolOverride
+            : settings.BouncingTextPool
+                .Where(kv => kv.Value)
+                .Select(kv => kv.Key)
+                .ToList();
+
+        if (enabledTexts.Count == 0)
+            return "GOOD GIRL";
+        return enabledTexts[_random.Next(enabledTexts.Count)];
+    }
+
+    /// <summary>
+    /// Advance one logo's motion and handle wall/corner bounces: reflect, re-colour, arm the squash
+    /// and burst timers, award the rate-limited XP and re-roll the text 10% of the time. The head
+    /// reads the returned flags for the parts it still owns.
+    /// </summary>
+    public BounceStep Step(Logo l, double dt, AppSettings settings)
+    {
+        var colorBefore = l.Color;
+
+        // Move (delta-time based; velocities are DIP/second)
+        l.PosX += l.VelX * dt;
+        l.PosY += l.VelY * dt;
+
+        bool bouncedX = false;
+        bool bouncedY = false;
+
+        // The RIGHT and BOTTOM edges of the text
+        double textRight = l.PosX + l.TextWidth;
+        double textBottom = l.PosY + l.TextHeight;
+
+        if (l.PosX <= MinX)
+        {
+            l.PosX = MinX;
+            l.VelX = Math.Abs(l.VelX);
+            bouncedX = true;
+        }
+        else if (textRight >= MaxX)
+        {
+            l.PosX = MaxX - l.TextWidth;
+            l.VelX = -Math.Abs(l.VelX);
+            bouncedX = true;
+        }
+
+        if (l.PosY <= MinY)
+        {
+            l.PosY = MinY;
+            l.VelY = Math.Abs(l.VelY);
+            bouncedY = true;
+        }
+        else if (textBottom >= MaxY)
+        {
+            l.PosY = MaxY - l.TextHeight;
+            l.VelY = -Math.Abs(l.VelY);
+            bouncedY = true;
+        }
+
+        bool bounced = bouncedX || bouncedY;
+        // A true corner is both axes at once; a single-axis bounce within tolerance counts too.
+        bool cornerHit = (bouncedX && bouncedY)
+                         || (bounced && IsNearCorner(l.PosX, l.PosY, textRight, textBottom));
+
+        if (cornerHit && settings.BouncingTextFxCornerBurst)
+            l.BurstTimer = 0;
+
+        bool textChanged = false;
+        if (bounced)
+        {
+            l.Color = NextColor(l, settings);
+            if (settings.BouncingTextFxSquashStretch)
+            {
+                l.SquashTimer = 0;
+                l.SquashAxisX = bouncedX;
+            }
+
+            AwardBounceXp();
+
+            // 10% chance to change text on bounce
+            if (_random.NextDouble() < 0.1)
+            {
+                l.Text = SelectRandomText(settings);
+                MeasureInto(l); // re-measure when the text changes
+                textChanged = true;
+            }
+        }
+
+        return new BounceStep(bounced, bouncedX, cornerHit, textChanged, colorBefore);
+    }
+
+    /// <summary>15 XP a bounce, at most one award per 2s and 150 XP a minute across every logo.
+    /// Unseeded <see cref="CoreProgression"/> drops the award silently, which is the honest answer
+    /// on a head with no XP service - but the rate limit still runs, so the counters cannot be
+    /// primed on one head and cashed in on another.</summary>
+    private void AwardBounceXp()
+    {
+        var now = DateTime.UtcNow;
+
+        // Reset per-minute counter if a new minute has started
+        if ((now - _bounceXpMinuteStart).TotalSeconds >= 60)
+        {
+            _bounceXpThisMinute = 0;
+            _bounceXpMinuteStart = now;
+        }
+
+        if (now - _lastBounceXpTime >= BounceXpCooldown && _bounceXpThisMinute < MaxBounceXpPerMinute)
+        {
+            CoreProgression.AddXP(15, "BouncingText");
+            _lastBounceXpTime = now;
+            _bounceXpThisMinute += 15;
+        }
+    }
+
+    /// <summary>Combine the enabled per-frame effects into one scale/rotation set for a logo.</summary>
+    public (double sx, double sy, double angle) ComputeEffectTransform(Logo l, AppSettings settings)
+    {
+        double sx = 1.0, sy = 1.0, angle = 0.0;
+
+        // Breathing: slow hypnotic scale pulse
+        if (settings.BouncingTextFxBreathing)
+        {
+            double breath = 1.0 + 0.08 * Math.Sin(_fxTime * (Math.PI * 2 / 3.2) + l.Phase);
+            sx *= breath;
+            sy *= breath;
+        }
+
+        // Wobble: gentle autoreversing tilt
+        if (settings.BouncingTextFxWobble)
+            angle += 6.0 * Math.Sin(_fxTime * (Math.PI * 2 / 2.3) + l.Phase);
+
+        // Continuous spin
+        if (settings.BouncingTextFxSpin)
+        {
+            l.SpinAngle = (l.SpinAngle + 40.0 * _lastDt) % 360.0;
+            angle += l.SpinAngle;
+        }
+
+        // Velocity tilt: lean into the direction of travel (mirrored so the text never flips
+        // upside down when moving left)
+        if (settings.BouncingTextFxVelocityTilt)
+        {
+            double target = Math.Atan2(l.VelY * Math.Sign(l.VelX == 0 ? 1 : l.VelX), Math.Abs(l.VelX))
+                            * (180.0 / Math.PI) * 0.25;
+            target = Math.Clamp(target, -12.0, 12.0);
+            l.Tilt += (target - l.Tilt) * Math.Min(1.0, _lastDt * 6.0);
+            angle += l.Tilt;
+        }
+        else
+        {
+            l.Tilt = 0;
+        }
+
+        // Squash & stretch: damped compress-then-overshoot on the axis that hit the wall
+        if (l.SquashTimer >= 0)
+        {
+            l.SquashTimer += _lastDt;
+            if (l.SquashTimer > 0.45)
+            {
+                l.SquashTimer = -1;
+            }
+            else
+            {
+                double t = l.SquashTimer;
+                double deform = 0.35 * Math.Exp(-6.0 * t) * Math.Cos(24.0 * t);
+                if (l.SquashAxisX) { sx *= 1.0 - deform; sy *= 1.0 + deform * 0.7; }
+                else               { sy *= 1.0 - deform; sx *= 1.0 + deform * 0.7; }
+            }
+        }
+
+        // Corner burst: quick celebratory pop on top of everything else
+        if (l.BurstTimer >= 0)
+        {
+            l.BurstTimer += _lastDt;
+            if (l.BurstTimer > 0.5)
+            {
+                l.BurstTimer = -1;
+            }
+            else
+            {
+                double pop = 1.0 + 0.4 * Math.Exp(-l.BurstTimer / 0.15);
+                sx *= pop;
+                sy *= pop;
+            }
+        }
+
+        return (sx, sy, angle);
+    }
+
+    /// <summary>Re-roll every logo's speed to the current setting, keeping its direction.</summary>
+    public void RefreshSpeed(AppSettings settings)
+    {
+        var speed = settings.BouncingTextSpeed / 10.0;
+        foreach (var l in _logos)
+        {
+            var currentSpeed = Math.Sqrt(l.VelX * l.VelX + l.VelY * l.VelY);
+            var targetSpeed = (3.0 + _random.NextDouble() * 2.0) * 60.0 * speed; // DIP/sec
+            var scale = targetSpeed / Math.Max(0.1, currentSpeed);
+            l.VelX *= scale;
+            l.VelY *= scale;
+        }
+    }
+
+    /// <summary>True when the size setting moved: <see cref="FontSize"/> is updated and every logo
+    /// re-measured, and the head must push the new size into its visuals.</summary>
+    public bool RefreshFontSize(AppSettings settings)
+    {
+        var newFontSize = (int)(BaseFontSize * settings.BouncingTextSize / 100.0);
+        if (newFontSize == FontSize) return false;
+        FontSize = newFontSize;
+        foreach (var l in _logos) MeasureInto(l);
+        return true;
+    }
+
+    /// <summary>True when the family setting moved: every logo is re-measured (glyph widths change)
+    /// and the head must push the new family into its visuals. No restart - the element is the same.</summary>
+    public bool RefreshFont(AppSettings settings)
+    {
+        var newFont = settings.BouncingTextFont ?? "Segoe UI";
+        if (string.Equals(newFont, Font, StringComparison.OrdinalIgnoreCase)) return false;
+        Font = newFont;
+        foreach (var l in _logos) MeasureInto(l);
+        return true;
+    }
+
+    /// <summary>Switching to Fixed applies immediately (Random/Rainbow apply on the next bounce).</summary>
+    public void ApplyFixedColor(AppSettings settings)
+    {
+        var fixedColor = GetFixedColor(settings);
+        foreach (var l in _logos) l.Color = fixedColor;
+    }
+
+    private void MeasureInto(Logo logo)
+    {
+        if (Measure is { } measure)
+        {
+            try
+            {
+                var (w, h) = measure(logo.Text, FontSize);
+                if (w > 0 && h > 0) { logo.TextWidth = w; logo.TextHeight = h; return; }
+            }
+            catch { /* fall through to the estimate, as the WPF measurement's own catch did */ }
+        }
+        logo.TextWidth = FontSize * logo.Text.Length * 0.6;
+        logo.TextHeight = FontSize * 1.2;
+    }
+
+    /// <summary>Is the text within tolerance of any corner of the bounds?</summary>
+    private bool IsNearCorner(double left, double top, double right, double bottom)
+    {
+        bool nearTopLeft     = left <= MinX + CornerTolerance && top <= MinY + CornerTolerance;
+        bool nearTopRight    = right >= MaxX - CornerTolerance && top <= MinY + CornerTolerance;
+        bool nearBottomLeft  = left <= MinX + CornerTolerance && bottom >= MaxY - CornerTolerance;
+        bool nearBottomRight = right >= MaxX - CornerTolerance && bottom >= MaxY - CornerTolerance;
+
+        return nearTopLeft || nearTopRight || nearBottomLeft || nearBottomRight;
+    }
+
+    /// <summary>Pick the next colour for a logo according to the colour-mode setting.</summary>
+    private (byte R, byte G, byte B) NextColor(Logo logo, AppSettings settings)
+    {
+        switch (settings.BouncingTextColorMode)
+        {
+            case 1: // Fixed: the user's chosen colour, no re-roll
+                return GetFixedColor(settings);
+            case 2: // Rainbow cycle: walk the ordered hue wheel one step per bounce
+                logo.HueIndex = (logo.HueIndex + 1) % RainbowWheel.Length;
+                return RainbowWheel[logo.HueIndex];
+            default:
+                return GetRandomColor();
+        }
+    }
+
+    /// <summary>The colour Fixed mode renders: the user's <c>#RRGGBB</c> pick, else hot pink.
+    /// <see cref="CoreMods.TryParseHexColor"/> is the same six-hex parse with the same hot-pink
+    /// fallback the WPF copy had, so no head keeps a third.</summary>
+    public static (byte R, byte G, byte B) GetFixedColor(AppSettings settings)
+    {
+        CoreMods.TryParseHexColor(settings.BouncingTextFixedColor, out var rgb);
+        return rgb;
+    }
+
+    private (byte R, byte G, byte B) GetRandomColor()
+    {
+        // Bright, vibrant colours
+        var colors = new (byte, byte, byte)[]
+        {
+            (255, 105, 180), // Hot Pink
+            (255, 20, 147),  // Deep Pink
+            (138, 43, 226),  // Blue Violet
+            (255, 0, 255),   // Magenta
+            (0, 255, 255),   // Cyan
+            (255, 255, 0),   // Yellow
+            (0, 255, 0),     // Lime
+            (255, 165, 0),   // Orange
+            (255, 69, 0),    // Red Orange
+            (50, 205, 50),   // Lime Green
+        };
+        return colors[_random.Next(colors.Length)];
+    }
+
+    /// <summary>Ordered 12-step hue wheel (full saturation/value) for the rainbow-cycle mode.</summary>
+    private static (byte R, byte G, byte B)[] BuildRainbowWheel()
+    {
+        var wheel = new (byte, byte, byte)[12];
+        for (int i = 0; i < wheel.Length; i++)
+        {
+            double h = i * 360.0 / wheel.Length;
+            wheel[i] = HsvToRgb(h, 1.0, 1.0);
+        }
+        return wheel;
+    }
+
+    private static (byte R, byte G, byte B) HsvToRgb(double h, double s, double v)
+    {
+        double c = v * s;
+        double x = c * (1 - Math.Abs((h / 60.0) % 2 - 1));
+        double m = v - c;
+        (double r, double g, double b) = ((int)(h / 60.0) % 6) switch
+        {
+            0 => (c, x, 0.0),
+            1 => (x, c, 0.0),
+            2 => (0.0, c, x),
+            3 => (0.0, x, c),
+            4 => (x, 0.0, c),
+            _ => (c, 0.0, x),
+        };
+        return ((byte)((r + m) * 255), (byte)((g + m) * 255), (byte)((b + m) * 255));
+    }
+}

--- a/CCP.LinuxSmoke/Program.cs
+++ b/CCP.LinuxSmoke/Program.cs
@@ -50,6 +50,7 @@ namespace ConditioningControlPanel.LinuxSmoke
             Determinism();
             Scrubbing();
             Arithmetic();
+            BouncingText();
             ConsentAndReports();
             Roadmap();
             LockCard();
@@ -724,6 +725,9 @@ namespace ConditioningControlPanel.LinuxSmoke
         {
             try { action(); return true; }
             catch { return false; }
+        }
+
+        /// <summary>
         /// Mind wipe's portable half (wire/107): the schedule decides here, the playback does not.
         /// A headless render cannot exercise either, so the arithmetic is asserted directly and
         /// the seam is asserted for the answer it gives when no head is playing anything - which
@@ -794,6 +798,9 @@ namespace ConditioningControlPanel.LinuxSmoke
                   picked.Length == 1 && picked[0] == custom);
             Check("a custom path that does not exist falls back to the folders, not to nothing",
                   MindWipeSchedule.DiscoverClips(Path.Combine(CorePaths.UserData, "gone.wav")).Length == 1);
+        }
+
+        /// <summary>
         /// The corner-GIF split (wire/108). CornerGifPlanner decides where a corner overlay goes;
         /// CoreCornerGif is the surface that draws it, and is UNSEEDED here - this head has no
         /// overlay window yet. What is worth asserting off Windows is that the unseeded seam is a
@@ -872,6 +879,118 @@ namespace ConditioningControlPanel.LinuxSmoke
             var heat = ProgramHeat.Compute(3, 30, 0.5, false);
             Check("ProgramHeat.Compute returns a finite value", !double.IsNaN(heat) && !double.IsInfinity(heat), heat.ToString("R"));
             Check("ProgramHeat.Compute is repeatable", Math.Abs(heat - ProgramHeat.Compute(3, 30, 0.5, false)) < double.Epsilon);
+        }
+
+        /// <summary>
+        /// The bouncing-text scheduler (wire/110). A headless render cannot exercise motion, so the
+        /// physics is asserted here instead: one logo placed by hand, one Step, and the reflection,
+        /// the corner detection, the hue walk and the XP rate limit checked against known numbers.
+        /// The seam that drives the surface is checked unseeded in the same pass.
+        /// </summary>
+        private static void BouncingText()
+        {
+            Console.WriteLine("\nBouncing text");
+
+            var s = new Models.AppSettings
+            {
+                BouncingTextSize = 100,
+                BouncingTextSpeed = 5,
+                BouncingTextColorMode = 0,
+                BouncingTextSecondText = false,
+                BouncingTextPool = new Dictionary<string, bool> { ["GOOD GIRL"] = true },
+            };
+
+            // Fixed seed + fixed metrics: every number below is then reproducible on any machine.
+            var e = new BouncingTextEngine(new Random(1234)) { Measure = (_, size) => (size * 4.0, size * 1.2) };
+            e.SetBounds(0, 0, 1920, 1080);
+            e.Start(s);
+            Check("the engine builds one logo from the settings", e.Logos.Count == 1);
+            Check("the head's glyph metrics are what the logo bounces with",
+                  Math.Abs(e.Logos[0].TextWidth - e.FontSize * 4.0) < 0.001);
+
+            var l = e.Logos[0];
+            // Park it one DIP short of the right wall, moving right at 100 DIP/s: 0.5s of travel
+            // overshoots, so the step must clamp to the wall and flip the sign.
+            l.TextWidth = 200; l.TextHeight = 60;
+            l.PosX = 1920 - 200 - 1; l.PosY = 500;
+            l.VelX = 100; l.VelY = 0;
+            var step = e.Step(l, 0.5, s);
+            Check("a right-wall hit clamps the logo to the wall", Math.Abs(l.PosX - (1920 - 200)) < 0.001);
+            Check("a right-wall hit reverses X and only X", l.VelX < 0 && l.VelY == 0);
+            Check("a wall hit reports Bounced on the X axis", step is { Bounced: true, BouncedX: true });
+            Check("a mid-wall hit is not a corner", !step.CornerHit);
+
+            // Both axes at once is the DVD corner.
+            l.PosX = 1; l.PosY = 1; l.VelX = -100; l.VelY = -100;
+            Check("both axes reversing at once is a corner hit", e.Step(l, 0.5, s).CornerHit);
+
+            // The rainbow wheel walks one step per bounce and wraps at 12.
+            s.BouncingTextColorMode = 2;
+            int hue0 = l.HueIndex;
+            l.PosX = 0; l.PosY = 500; l.VelX = -100; l.VelY = 0;
+            e.Step(l, 0.1, s);
+            Check("rainbow mode advances the hue wheel one step per bounce", l.HueIndex == (hue0 + 1) % 12);
+            s.BouncingTextColorMode = 0;
+
+            // XP: 15 a bounce, at most one award per 2s, so a second bounce in the same second is
+            // worth nothing. The gate is arithmetic and runs whether or not a head is listening.
+            double awarded = 0;
+            CoreProgression.AddXPProvider = (amount, _) => awarded += amount;
+            var x = new BouncingTextEngine(new Random(7)) { Measure = (_, size) => (size * 4.0, size * 1.2) };
+            x.SetBounds(0, 0, 1920, 1080);
+            x.Start(s);
+            var xl = x.Logos[0];
+            xl.TextWidth = 200; xl.TextHeight = 60; xl.PosY = 500; xl.VelY = 0;
+            xl.PosX = 0; xl.VelX = -100; x.Step(xl, 0.1, s);
+            Check("a bounce awards 15 XP", Math.Abs(awarded - 15) < 0.001);
+            xl.PosX = 0; xl.VelX = -100; x.Step(xl, 0.1, s);
+            Check("a second bounce inside the 2s cooldown awards nothing", Math.Abs(awarded - 15) < 0.001);
+            CoreProgression.AddXPProvider = null;
+            xl.PosX = 0; xl.VelX = -100; x.Step(xl, 0.1, s);
+            Check("the XP gate runs with no progression service attached and nothing throws", true);
+
+            // Effects off must be the identity transform - a scale of 0 would hide the text and a
+            // stray angle would spin it, both silently.
+            s.BouncingTextFxBreathing = s.BouncingTextFxWobble = s.BouncingTextFxSpin = false;
+            s.BouncingTextFxVelocityTilt = s.BouncingTextFxSquashStretch = s.BouncingTextFxCornerBurst = false;
+            var idle = e.Logos[0];
+            idle.SquashTimer = -1; idle.BurstTimer = -1;
+            e.Tick(1.0 / 60.0);
+            var t = e.ComputeEffectTransform(idle, s);
+            Check("no effects enabled is the identity transform",
+                  Math.Abs(t.sx - 1) < 1e-9 && Math.Abs(t.sy - 1) < 1e-9 && Math.Abs(t.angle) < 1e-9);
+            s.BouncingTextFxBreathing = true;
+            e.Tick(1.0 / 60.0);
+            var breathing = e.ComputeEffectTransform(idle, s);
+            Check("breathing scales both axes together and stays near 1",
+                  Math.Abs(breathing.sx - breathing.sy) < 1e-9 && breathing.sx > 0.9 && breathing.sx < 1.1);
+
+            // With no Measure delegate the engine must still size the text, not bounce a zero box.
+            var noMetrics = new BouncingTextEngine(new Random(99));
+            noMetrics.SetBounds(0, 0, 1920, 1080);
+            noMetrics.Start(s);
+            Check("with no head metrics the logo still has a positive size",
+                  noMetrics.Logos[0].TextWidth > 0 && noMetrics.Logos[0].TextHeight > 0);
+
+            // An empty pool must answer a phrase, never an empty string that draws nothing.
+            s.BouncingTextPool = new Dictionary<string, bool>();
+            Check("an all-disabled phrase pool falls back to a real phrase",
+                  !string.IsNullOrWhiteSpace(noMetrics.SelectRandomText(s)));
+
+            // The surface seam (wire/110). Unseeded is the Avalonia head's state: the card saved the
+            // setting, nothing is drawn, and nothing throws.
+            CoreBouncingText.Start(); CoreBouncingText.Stop();
+            CoreBouncingText.Refresh(); CoreBouncingText.Restart();
+            Check("CoreBouncingText is a silent no-op with no surface", true);
+            var calls = new List<string>();
+            CoreBouncingText.StartAction = () => calls.Add("start");
+            CoreBouncingText.RefreshAction = () => throw new InvalidOperationException("boom");
+            CoreBouncingText.Start();
+            CoreBouncingText.Refresh();
+            Check("CoreBouncingText forwards once seeded and swallows a throwing surface",
+                  calls.Count == 1 && calls[0] == "start");
+            CoreBouncingText.StartAction = null;
+            CoreBouncingText.RefreshAction = null;
         }
     }
 }

--- a/ConditioningControlPanel/App.xaml.cs
+++ b/ConditioningControlPanel/App.xaml.cs
@@ -397,6 +397,16 @@ namespace ConditioningControlPanel
                 else CornerGif?.RefreshSlot(index);
             };
 
+            // The bouncing-text control seam (CCP.Core/CoreBouncingText.cs). The motion, colours
+            // and XP gating are BouncingTextEngine in Core now; what this head still owns is the
+            // surface - full-screen layered click-through windows - so the service stays here and
+            // the seam is the handle a settings card nudges. Null-conditional on purpose: the
+            // service is constructed later in OnStartup, and until it is every call is a no-op.
+            CoreBouncingText.StartAction = () => BouncingText?.Start();
+            CoreBouncingText.StopAction = () => BouncingText?.Stop();
+            CoreBouncingText.RefreshAction = () => BouncingText?.Refresh();
+            CoreBouncingText.RestartAction = () => BouncingText?.Restart();
+
             // The entitlement seam, for TierGate (now CCP.Core/Services/TierGate.cs). Deciding is
             // policy and moved; the two account bars, the daily-free wheel and the refusal toast
             // stay here. Every one is a lambda, not an eager read: Patreon, DailyFree and

--- a/ConditioningControlPanel/Services/Subliminal/BouncingTextService.cs
+++ b/ConditioningControlPanel/Services/Subliminal/BouncingTextService.cs
@@ -15,10 +15,17 @@ namespace ConditioningControlPanel.Services;
 /// Supports one or two independent logos, three color modes (random / fixed / rainbow cycle)
 /// and a set of per-frame transform effects (breathing, wobble, spin, velocity tilt,
 /// squash &amp; stretch, corner burst).
+///
+/// <para>The motion itself is no longer here: position, velocity, wall and corner detection, the
+/// colour modes, the effect transforms and the XP rate limit are
+/// <see cref="BouncingTextEngine"/> in CCP.Core, so a second head cannot drift from this one's
+/// physics. What remains is everything that needs Windows - the monitor enumeration that sets the
+/// bounds, the glyph measurement that sizes the text, the composition clock, the layered
+/// click-through windows, and the achievement/haptics/video hooks the engine reports back.</para>
 /// </summary>
 public class BouncingTextService : IDisposable
 {
-    private readonly Random _random = new();
+    private readonly BouncingTextEngine _engine = new();
     private readonly List<BouncingTextWindow> _windows = new();
     private bool _isRunning;
 
@@ -28,58 +35,13 @@ public class BouncingTextService : IDisposable
     // produces "low frame rate" judder). _lastRenderTime feeds delta-time movement.
     private TimeSpan _lastRenderTime = TimeSpan.MinValue;
 
-    /// <summary>Per-logo bounce state. One or two of these exist while running.</summary>
-    private sealed class Logo
-    {
-        public string Text = "";
-        public double PosX, PosY;
-        public double VelX, VelY;
-        public double TextWidth = 200, TextHeight = 60;
-        public Color Color;
-        public int HueIndex;          // rainbow-cycle position
-        public double Phase;          // per-logo offset so two logos never breathe/wobble in sync
-        public double SpinAngle;      // accumulated continuous-spin angle (deg)
-        public double Tilt;           // smoothed velocity-lean angle (deg)
-        public double SquashTimer = -1; // seconds since last wall hit; <0 = idle
-        public bool SquashAxisX;      // true = hit a vertical wall (X velocity reversed)
-        public double BurstTimer = -1;  // seconds since last corner hit; <0 = idle
-    }
-
-    private readonly List<Logo> _logos = new();
-    private List<string>? _poolOverride; // AI/session-supplied pool, kept for mid-run re-rolls
-    private double _fxTime;              // shared effects clock (seconds)
-
-    // Text size - base size that gets scaled by settings
-    private const int BASE_FONT_SIZE = 72;
-    private int _currentFontSize = BASE_FONT_SIZE;
-
-    /// <summary>
-    /// The font family name the running logos were built/measured with, so Refresh() can spot a
-    /// mid-run change the same way it spots a size change. Empty until Start().
-    /// </summary>
-    private string _currentFont = "";
-
-    // Corner hit detection - tolerance in pixels (corners are hard to hit exactly)
-    private const double CORNER_TOLERANCE = 15.0;
-
-    // Anti-exploit: XP rate limiting for bounces (shared across logos so a second
-    // text doesn't double the XP income)
-    private DateTime _lastBounceXpTime = DateTime.MinValue;
-    private static readonly TimeSpan BounceXpCooldown = TimeSpan.FromSeconds(2); // Short cooldown to prevent double-count on corner hits
-    private int _bounceXpThisMinute;
-    private DateTime _bounceXpMinuteStart = DateTime.MinValue;
-    private const int MaxBounceXpPerMinute = 150;
-
-    private double _minX, _minY, _maxX, _maxY;
-
     // Z-order re-assertion accumulator (re-assert topmost every ~0.5s of real time;
     // frame-rate-independent now that the tick rate varies with the display refresh).
     private double _zReassertAccum;
 
-    // Ordered hue wheel for the rainbow-cycle color mode (advances one step per bounce).
-    private static readonly Color[] RainbowWheel = BuildRainbowWheel();
-
     public bool IsRunning => _isRunning;
+
+    private static Color ToMedia((byte R, byte G, byte B) c) => Color.FromRgb(c.R, c.G, c.B);
 
     /// <summary>
     /// Current bounding rects of the bouncing logos in PHYSICAL virtual-desktop
@@ -99,10 +61,11 @@ public class BouncingTextService : IDisposable
         try
         {
             var dpiScale = GetDpiScale();
-            var rects = new System.Drawing.Rectangle[_logos.Count];
-            for (int i = 0; i < _logos.Count; i++)
+            var logos = _engine.Logos;
+            var rects = new System.Drawing.Rectangle[logos.Count];
+            for (int i = 0; i < logos.Count; i++)
             {
-                var l = _logos[i];
+                var l = logos[i];
                 // Pad generously: the text drifts a few px/frame and the OCR rect
                 // cache is ~250ms stale, and the transform effects can scale the
                 // text up to ~1.5x and rotate it (a rotated rect's bbox grows by up
@@ -138,47 +101,14 @@ public class BouncingTextService : IDisposable
         // explicitly when we want to start (either by toggle or by session)
 
         _isRunning = true;
-        _poolOverride = pool != null && pool.Count > 0 ? pool.ToList() : null;
-        _fxTime = 0;
 
-        // Calculate font size based on settings (50-300% of base)
-        _currentFontSize = (int)(BASE_FONT_SIZE * settings.BouncingTextSize / 100.0);
-        _currentFont = settings.BouncingTextFont ?? "Segoe UI";
-
-        // Calculate screen bounds
+        // Bounds and glyph metrics are the two facts the engine cannot work out for itself.
         CalculateScreenBounds(settings.DualMonitorEnabled);
-
-        // One logo, or two independent ones when the second-text toggle is on
-        _logos.Clear();
-        int logoCount = settings.BouncingTextSecondText ? 2 : 1;
-        for (int i = 0; i < logoCount; i++)
-        {
-            var logo = new Logo
-            {
-                Phase = _random.NextDouble() * Math.PI * 2,
-                HueIndex = _random.Next(RainbowWheel.Length),
-            };
-            logo.Text = SelectRandomText();
-            MeasureTextSize(logo);
-
-            // Random starting position (ensure text starts fully within bounds)
-            logo.PosX = _minX + _random.NextDouble() * Math.Max(1, (_maxX - _minX - logo.TextWidth));
-            logo.PosY = _minY + _random.NextDouble() * Math.Max(1, (_maxY - _minY - logo.TextHeight));
-
-            // Random velocity in DIP/second (speed based on setting). The base is the
-            // old 3-5 px/tick value scaled by 60 so the on-screen feel is unchanged at
-            // 60 FPS, but motion is now delta-time driven so it stays correct at any rate.
-            var speed = settings.BouncingTextSpeed / 10.0; // 1-10 maps to 0.1-1.0 multiplier
-            var baseSpeed = (3.0 + _random.NextDouble() * 2.0) * 60.0; // 180-300 DIP/sec
-            logo.VelX = baseSpeed * speed * (_random.Next(2) == 0 ? 1 : -1);
-            logo.VelY = baseSpeed * speed * (_random.Next(2) == 0 ? 1 : -1);
-
-            logo.Color = NextColor(logo, settings);
-            _logos.Add(logo);
-        }
+        _engine.Measure = MeasureText;
+        _engine.Start(settings, pool);
 
         // Create windows for each screen
-        CreateWindows(settings.DualMonitorEnabled, settings.BouncingTextOpacity, logoCount, settings.BouncingTextOutline);
+        CreateWindows(settings.DualMonitorEnabled, settings.BouncingTextOpacity, _engine.Logos.Count, settings.BouncingTextOutline);
 
         // Drive motion off the composition clock (vsync-aligned, one callback per
         // rendered frame) instead of a DispatcherTimer — see _lastRenderTime note.
@@ -202,7 +132,7 @@ public class BouncingTextService : IDisposable
         }
 
         App.Logger?.Information("BouncingTextService started - Logos: {Count}, Text: {Text}, ColorMode: {Mode}",
-            _logos.Count, _logos[0].Text, settings.BouncingTextColorMode);
+            _engine.Logos.Count, _engine.Logos[0].Text, settings.BouncingTextColorMode);
     }
 
     public void Stop()
@@ -222,8 +152,7 @@ public class BouncingTextService : IDisposable
             try { window.Close(); } catch { }
         }
         _windows.Clear();
-        _logos.Clear();
-        _poolOverride = null;
+        _engine.Stop();
 
         App.Logger?.Information("BouncingTextService stopped");
     }
@@ -233,7 +162,7 @@ public class BouncingTextService : IDisposable
     public void Restart()
     {
         if (!_isRunning) return;
-        var pool = _poolOverride;
+        var pool = _engine.PoolOverride?.ToList();
         Stop();
         Start(true, pool);
     }
@@ -264,25 +193,12 @@ public class BouncingTextService : IDisposable
         CompositionTarget.Rendering += Animate;
     }
 
-    private string SelectRandomText()
-    {
-        var settings = App.Settings.Current;
-        var enabledTexts = _poolOverride != null && _poolOverride.Count > 0
-            ? _poolOverride
-            : settings.BouncingTextPool
-                .Where(kv => kv.Value)
-                .Select(kv => kv.Key)
-                .ToList();
-
-        if (enabledTexts.Count == 0)
-            return "GOOD GIRL";
-        return enabledTexts[_random.Next(enabledTexts.Count)];
-    }
-
     /// <summary>
-    /// Measure the actual rendered size of the logo's text
+    /// Measure the actual rendered size of a string at the engine's current font size. Handed to
+    /// the engine as its <see cref="BouncingTextEngine.Measure"/> delegate; answering (0,0) makes
+    /// it fall back to its own estimate, which is what the WPF catch block did inline.
     /// </summary>
-    private void MeasureTextSize(Logo logo)
+    private (double Width, double Height) MeasureText(string text, int fontSize)
     {
         try
         {
@@ -298,26 +214,22 @@ public class BouncingTextService : IDisposable
                 ? VisualTreeHelper.GetDpi(dpiSource).PixelsPerDip
                 : 1.0;
             var formattedText = new FormattedText(
-                logo.Text,
+                text,
                 CultureInfo.CurrentCulture,
                 FlowDirection.LeftToRight,
                 typeface,
-                _currentFontSize,
+                fontSize,
                 Brushes.White,
                 new NumberSubstitution(),
                 pixelsPerDip);
 
-            logo.TextWidth = formattedText.Width;
-            logo.TextHeight = formattedText.Height;
-
-            App.Logger?.Debug("Measured text '{Text}': {W}x{H}", logo.Text, logo.TextWidth, logo.TextHeight);
+            App.Logger?.Debug("Measured text '{Text}': {W}x{H}", text, formattedText.Width, formattedText.Height);
+            return (formattedText.Width, formattedText.Height);
         }
         catch (Exception ex)
         {
-            // Fallback to estimation if measurement fails
-            logo.TextWidth = _currentFontSize * logo.Text.Length * 0.6;
-            logo.TextHeight = _currentFontSize * 1.2;
-            App.Logger?.Warning(ex, "Failed to measure text, using estimate: {W}x{H}", logo.TextWidth, logo.TextHeight);
+            App.Logger?.Warning(ex, "Failed to measure text, using the engine's estimate");
+            return (0, 0);
         }
     }
 
@@ -331,10 +243,11 @@ public class BouncingTextService : IDisposable
         var dpiScale = GetDpiScale();
 
         // Find total bounds across all screens
-        _minX = screens.Min(s => s.Bounds.X) / dpiScale;
-        _minY = screens.Min(s => s.Bounds.Y) / dpiScale;
-        _maxX = screens.Max(s => s.Bounds.X + s.Bounds.Width) / dpiScale;
-        _maxY = screens.Max(s => s.Bounds.Y + s.Bounds.Height) / dpiScale;
+        _engine.SetBounds(
+            screens.Min(s => s.Bounds.X) / dpiScale,
+            screens.Min(s => s.Bounds.Y) / dpiScale,
+            screens.Max(s => s.Bounds.X + s.Bounds.Width) / dpiScale,
+            screens.Max(s => s.Bounds.Y + s.Bounds.Height) / dpiScale);
     }
 
     private void CreateWindows(bool dualMonitor, int opacity, int logoCount, bool outline)
@@ -345,13 +258,13 @@ public class BouncingTextService : IDisposable
 
         foreach (var screen in screens)
         {
-            var window = new BouncingTextWindow(screen, _currentFontSize, opacity, logoCount, outline);
+            var window = new BouncingTextWindow(screen, _engine.FontSize, opacity, logoCount, outline);
             window.Show();
             _windows.Add(window);
         }
 
         // Update text in all windows
-        for (int i = 0; i < _logos.Count; i++)
+        for (int i = 0; i < _engine.Logos.Count; i++)
             UpdateWindowsText(i);
     }
 
@@ -396,11 +309,11 @@ public class BouncingTextService : IDisposable
             foreach (var w in _windows) { if (w.IsLoaded && !w.IsVisible) w.Show(); }
         }
 
-        _fxTime += dt;
-        _lastDt = dt;
+        _engine.Tick(dt);
 
-        for (int i = 0; i < _logos.Count; i++)
-            StepLogo(_logos[i], i, dt, settings);
+        var logos = _engine.Logos;
+        for (int i = 0; i < logos.Count; i++)
+            StepLogo(logos[i], i, dt, settings);
 
         // Re-assert z-order every ~500ms — bouncing text is long-lived and will
         // lose topmost when competing with flash/video/overlay windows
@@ -413,10 +326,10 @@ public class BouncingTextService : IDisposable
         }
 
         // Update position + effect transforms in all windows
-        for (int i = 0; i < _logos.Count; i++)
+        for (int i = 0; i < logos.Count; i++)
         {
-            var l = _logos[i];
-            var (sx, sy, angle) = ComputeEffectTransform(l, settings);
+            var l = logos[i];
+            var (sx, sy, angle) = _engine.ComputeEffectTransform(l, settings);
             foreach (var window in _windows)
             {
                 window.UpdatePosition(i, l.PosX, l.PosY);
@@ -425,65 +338,15 @@ public class BouncingTextService : IDisposable
         }
     }
 
-    /// <summary>Advance one logo's motion, handle wall/corner bounces and the bounce payload.</summary>
-    private void StepLogo(Logo l, int index, double dt, Models.AppSettings settings)
+    /// <summary>Step one logo through the engine, then run the head-only half of a bounce: the
+    /// achievement, the burst particles, the haptic pulse, the events and the repaint. The XP award
+    /// and its rate limit are the engine's now (through the CoreProgression seam), so nothing here
+    /// counts XP a second time.</summary>
+    private void StepLogo(BouncingTextEngine.Logo l, int index, double dt, Models.AppSettings settings)
     {
-        // Move (delta-time based; velocities are DIP/second)
-        l.PosX += l.VelX * dt;
-        l.PosY += l.VelY * dt;
+        var step = _engine.Step(l, dt, settings);
 
-        bool bouncedX = false;
-        bool bouncedY = false;
-
-        // Calculate the RIGHT and BOTTOM edges of the text
-        double textRight = l.PosX + l.TextWidth;
-        double textBottom = l.PosY + l.TextHeight;
-
-        // Bounce off LEFT edge (text's left edge hits screen's left edge)
-        if (l.PosX <= _minX)
-        {
-            l.PosX = _minX;
-            l.VelX = Math.Abs(l.VelX);
-            bouncedX = true;
-        }
-        // Bounce off RIGHT edge (text's right edge hits screen's right edge)
-        else if (textRight >= _maxX)
-        {
-            l.PosX = _maxX - l.TextWidth;
-            l.VelX = -Math.Abs(l.VelX);
-            bouncedX = true;
-        }
-
-        // Bounce off TOP edge (text's top edge hits screen's top edge)
-        if (l.PosY <= _minY)
-        {
-            l.PosY = _minY;
-            l.VelY = Math.Abs(l.VelY);
-            bouncedY = true;
-        }
-        // Bounce off BOTTOM edge (text's bottom edge hits screen's bottom edge)
-        else if (textBottom >= _maxY)
-        {
-            l.PosY = _maxY - l.TextHeight;
-            l.VelY = -Math.Abs(l.VelY);
-            bouncedY = true;
-        }
-
-        bool bounced = bouncedX || bouncedY;
-        bool cornerHit = false;
-
-        // Check for corner hit (both X and Y bounce at the same time!)
-        if (bouncedX && bouncedY)
-        {
-            cornerHit = true;
-        }
-        // Also check for "near corner" hits - when very close to a corner during a single-axis bounce
-        else if (bounced)
-        {
-            cornerHit = IsNearCorner(l.PosX, l.PosY, textRight, textBottom);
-        }
-
-        if (cornerHit)
+        if (step.CornerHit)
         {
             App.Logger?.Information("🎯 CORNER HIT! Position: ({X}, {Y})", l.PosX, l.PosY);
             App.Achievements?.TrackCornerHit();
@@ -491,242 +354,31 @@ public class BouncingTextService : IDisposable
 
             if (settings.BouncingTextFxCornerBurst)
             {
-                l.BurstTimer = 0;
                 double cx = l.PosX + l.TextWidth / 2;
                 double cy = l.PosY + l.TextHeight / 2;
                 foreach (var window in _windows)
-                    window.SpawnCornerBurst(cx, cy, l.Color);
+                    window.SpawnCornerBurst(cx, cy, ToMedia(step.ColorBeforeBounce));
             }
         }
 
-        // On bounce: change color, award XP, maybe change text
-        if (bounced)
+        if (step.Bounced)
         {
-            l.Color = NextColor(l, settings);
-            if (settings.BouncingTextFxSquashStretch)
-            {
-                l.SquashTimer = 0;
-                l.SquashAxisX = bouncedX;
-            }
-
-            var now = DateTime.UtcNow;
-
-            // Reset per-minute counter if a new minute has started
-            if ((now - _bounceXpMinuteStart).TotalSeconds >= 60)
-            {
-                _bounceXpThisMinute = 0;
-                _bounceXpMinuteStart = now;
-            }
-
-            if (now - _lastBounceXpTime >= BounceXpCooldown && _bounceXpThisMinute < MaxBounceXpPerMinute)
-            {
-                App.Progression?.AddXP(15, XPSource.BouncingText);
-                _lastBounceXpTime = now;
-                _bounceXpThisMinute += 15;
-            }
             OnBounce?.Invoke(this, EventArgs.Empty);
 
             // Haptic pulse on bounce
             _ = App.Haptics?.BouncingTextBounceAsync();
 
-            // 10% chance to change text on bounce
-            if (_random.NextDouble() < 0.1)
-            {
-                l.Text = SelectRandomText();
-                MeasureTextSize(l); // Re-measure when text changes
-            }
-
             UpdateWindowsText(index);
         }
     }
 
-    /// <summary>Combine the enabled per-frame effects into one scale/rotation set for a logo.</summary>
-    private (double sx, double sy, double angle) ComputeEffectTransform(Logo l, Models.AppSettings settings)
-    {
-        double sx = 1.0, sy = 1.0, angle = 0.0;
-
-        // Breathing: slow hypnotic scale pulse
-        if (settings.BouncingTextFxBreathing)
-        {
-            double breath = 1.0 + 0.08 * Math.Sin(_fxTime * (Math.PI * 2 / 3.2) + l.Phase);
-            sx *= breath;
-            sy *= breath;
-        }
-
-        // Wobble: gentle autoreversing tilt
-        if (settings.BouncingTextFxWobble)
-            angle += 6.0 * Math.Sin(_fxTime * (Math.PI * 2 / 2.3) + l.Phase);
-
-        // Continuous spin
-        if (settings.BouncingTextFxSpin)
-        {
-            l.SpinAngle = (l.SpinAngle + 40.0 * _lastDt) % 360.0;
-            angle += l.SpinAngle;
-        }
-
-        // Velocity tilt: lean into the direction of travel (mirrored so the text
-        // never flips upside down when moving left)
-        if (settings.BouncingTextFxVelocityTilt)
-        {
-            double target = Math.Atan2(l.VelY * Math.Sign(l.VelX == 0 ? 1 : l.VelX), Math.Abs(l.VelX))
-                            * (180.0 / Math.PI) * 0.25;
-            target = Math.Clamp(target, -12.0, 12.0);
-            l.Tilt += (target - l.Tilt) * Math.Min(1.0, _lastDt * 6.0);
-            angle += l.Tilt;
-        }
-        else
-        {
-            l.Tilt = 0;
-        }
-
-        // Squash & stretch: damped compress-then-overshoot on the axis that hit the wall
-        if (l.SquashTimer >= 0)
-        {
-            l.SquashTimer += _lastDt;
-            if (l.SquashTimer > 0.45)
-            {
-                l.SquashTimer = -1;
-            }
-            else
-            {
-                double t = l.SquashTimer;
-                double deform = 0.35 * Math.Exp(-6.0 * t) * Math.Cos(24.0 * t);
-                if (l.SquashAxisX) { sx *= 1.0 - deform; sy *= 1.0 + deform * 0.7; }
-                else               { sy *= 1.0 - deform; sx *= 1.0 + deform * 0.7; }
-            }
-        }
-
-        // Corner burst: quick celebratory pop on top of everything else
-        if (l.BurstTimer >= 0)
-        {
-            l.BurstTimer += _lastDt;
-            if (l.BurstTimer > 0.5)
-            {
-                l.BurstTimer = -1;
-            }
-            else
-            {
-                double pop = 1.0 + 0.4 * Math.Exp(-l.BurstTimer / 0.15);
-                sx *= pop;
-                sy *= pop;
-            }
-        }
-
-        return (sx, sy, angle);
-    }
-
-    // The dt of the current Animate frame, stashed so effect timers don't need it
-    // threaded through every call.
-    private double _lastDt;
-
-    /// <summary>
-    /// Check if the text is near any corner within tolerance
-    /// </summary>
-    private bool IsNearCorner(double left, double top, double right, double bottom)
-    {
-        // Top-left corner
-        bool nearTopLeft = left <= _minX + CORNER_TOLERANCE && top <= _minY + CORNER_TOLERANCE;
-        // Top-right corner
-        bool nearTopRight = right >= _maxX - CORNER_TOLERANCE && top <= _minY + CORNER_TOLERANCE;
-        // Bottom-left corner
-        bool nearBottomLeft = left <= _minX + CORNER_TOLERANCE && bottom >= _maxY - CORNER_TOLERANCE;
-        // Bottom-right corner
-        bool nearBottomRight = right >= _maxX - CORNER_TOLERANCE && bottom >= _maxY - CORNER_TOLERANCE;
-
-        return nearTopLeft || nearTopRight || nearBottomLeft || nearBottomRight;
-    }
-
     private void UpdateWindowsText(int index)
     {
-        var l = _logos[index];
+        var l = _engine.Logos[index];
         foreach (var window in _windows)
         {
-            window.UpdateText(index, l.Text, l.Color);
+            window.UpdateText(index, l.Text, ToMedia(l.Color));
         }
-    }
-
-    /// <summary>Pick the next color for a logo according to the color-mode setting.</summary>
-    private Color NextColor(Logo logo, Models.AppSettings settings)
-    {
-        switch (settings.BouncingTextColorMode)
-        {
-            case 1: // Fixed: the user's chosen color, no re-roll
-                return GetFixedColor(settings);
-            case 2: // Rainbow cycle: walk the ordered hue wheel one step per bounce
-                logo.HueIndex = (logo.HueIndex + 1) % RainbowWheel.Length;
-                return RainbowWheel[logo.HueIndex];
-            default:
-                return GetRandomColor();
-        }
-    }
-
-    private static Color GetFixedColor(Models.AppSettings settings)
-    {
-        var hex = settings.BouncingTextFixedColor;
-        if (!string.IsNullOrWhiteSpace(hex))
-        {
-            hex = hex.Trim().TrimStart('#');
-            if (hex.Length == 6)
-            {
-                try
-                {
-                    return Color.FromRgb(
-                        Convert.ToByte(hex.Substring(0, 2), 16),
-                        Convert.ToByte(hex.Substring(2, 2), 16),
-                        Convert.ToByte(hex.Substring(4, 2), 16));
-                }
-                catch { }
-            }
-        }
-        return Color.FromRgb(255, 105, 180); // hot pink fallback
-    }
-
-    private Color GetRandomColor()
-    {
-        // Bright, vibrant colors
-        var colors = new[]
-        {
-            Color.FromRgb(255, 105, 180), // Hot Pink
-            Color.FromRgb(255, 20, 147),  // Deep Pink
-            Color.FromRgb(138, 43, 226),  // Blue Violet
-            Color.FromRgb(255, 0, 255),   // Magenta
-            Color.FromRgb(0, 255, 255),   // Cyan
-            Color.FromRgb(255, 255, 0),   // Yellow
-            Color.FromRgb(0, 255, 0),     // Lime
-            Color.FromRgb(255, 165, 0),   // Orange
-            Color.FromRgb(255, 69, 0),    // Red Orange
-            Color.FromRgb(50, 205, 50),   // Lime Green
-        };
-        return colors[_random.Next(colors.Length)];
-    }
-
-    /// <summary>Ordered 12-step hue wheel (full saturation/value) for the rainbow-cycle mode.</summary>
-    private static Color[] BuildRainbowWheel()
-    {
-        var wheel = new Color[12];
-        for (int i = 0; i < wheel.Length; i++)
-        {
-            double h = i * 360.0 / wheel.Length;
-            wheel[i] = HsvToRgb(h, 1.0, 1.0);
-        }
-        return wheel;
-    }
-
-    private static Color HsvToRgb(double h, double s, double v)
-    {
-        double c = v * s;
-        double x = c * (1 - Math.Abs((h / 60.0) % 2 - 1));
-        double m = v - c;
-        (double r, double g, double b) = ((int)(h / 60.0) % 6) switch
-        {
-            0 => (c, x, 0.0),
-            1 => (x, c, 0.0),
-            2 => (0.0, c, x),
-            3 => (0.0, x, c),
-            4 => (x, 0.0, c),
-            _ => (c, 0.0, x),
-        };
-        return Color.FromRgb((byte)((r + m) * 255), (byte)((g + m) * 255), (byte)((b + m) * 255));
     }
 
     private double GetDpiScale()
@@ -751,42 +403,21 @@ public class BouncingTextService : IDisposable
 
         var settings = App.Settings.Current;
 
-        // Update speed
-        var speed = settings.BouncingTextSpeed / 10.0;
-        foreach (var l in _logos)
-        {
-            var currentSpeed = Math.Sqrt(l.VelX * l.VelX + l.VelY * l.VelY);
-            var targetSpeed = (3.0 + _random.NextDouble() * 2.0) * 60.0 * speed; // DIP/sec
-            var scale = targetSpeed / Math.Max(0.1, currentSpeed);
-            l.VelX *= scale;
-            l.VelY *= scale;
-        }
+        _engine.RefreshSpeed(settings);
 
-        // Check if font size changed - if so, update and re-measure
-        var newFontSize = (int)(BASE_FONT_SIZE * settings.BouncingTextSize / 100.0);
-        if (newFontSize != _currentFontSize)
+        // Font size changed: the engine re-measured, push the new size into the visuals.
+        if (_engine.RefreshFontSize(settings))
         {
-            _currentFontSize = newFontSize;
-            foreach (var l in _logos)
-                MeasureTextSize(l); // Re-measure with new font size
-
-            // Update font size in all windows
             foreach (var window in _windows)
-            {
-                window.UpdateFontSize(_currentFontSize);
-            }
+                window.UpdateFontSize(_engine.FontSize);
         }
 
-        // Same shape for the font family: re-measure (the glyph widths change) then push the new
-        // family into every window's visuals. No restart needed - the element type is unchanged.
-        var newFont = settings.BouncingTextFont ?? "Segoe UI";
-        if (!string.Equals(newFont, _currentFont, StringComparison.OrdinalIgnoreCase))
+        // Same shape for the font family: the engine re-measures (the glyph widths change) then we
+        // push the new family into every window's visuals. No restart needed - the element type is
+        // unchanged.
+        if (_engine.RefreshFont(settings))
         {
-            _currentFont = newFont;
-            foreach (var l in _logos)
-                MeasureTextSize(l);
-
-            var family = Helpers.FontPickerHelper.Resolve(newFont, "Segoe UI");
+            var family = Helpers.FontPickerHelper.Resolve(_engine.Font, "Segoe UI");
             foreach (var window in _windows)
                 window.UpdateFontFamily(family);
         }
@@ -798,12 +429,9 @@ public class BouncingTextService : IDisposable
         // Switching to Fixed color applies immediately (Random/Rainbow apply on next bounce)
         if (settings.BouncingTextColorMode == 1)
         {
-            var fixedColor = GetFixedColor(settings);
-            for (int i = 0; i < _logos.Count; i++)
-            {
-                _logos[i].Color = fixedColor;
+            _engine.ApplyFixedColor(settings);
+            for (int i = 0; i < _engine.Logos.Count; i++)
                 UpdateWindowsText(i);
-            }
         }
 
         // Show-over-videos toggled mid-video: resume or pause the loop accordingly


### PR DESCRIPTION
The brief asked for a `git mv` of the portable half. There was no file to move:
BouncingTextService.cs is one 800-line class in which the arithmetic is interleaved
line-by-line with App.Achievements, App.Haptics, App.Video, CompositionTarget.Rendering
and calls into the layered BouncingTextWindow. So this is an extraction, method by
method, with the head rewritten to delegate.

Moved to CCP.Core/Services/Subliminal/BouncingTextEngine.cs (~490 lines):
  - position/velocity integration, wall clamping and reflection
  - corner detection, true (both axes) and near (15 DIP tolerance)
  - the three colour modes: random palette, fixed #RRGGBB, 12-step hue wheel
  - the six per-frame effect transforms (breathing, wobble, spin, velocity tilt,
    squash & stretch, corner burst) and their timers
  - phrase selection from the pool or a session override, and the 10% re-roll
  - the XP rate limit: 15/bounce, 2s cooldown, 150/min, shared across both logos

Where the line falls: the engine decides, the head supplies the two facts it cannot
work out for itself and owns the surface. Screen bounds arrive through SetBounds (a
monitor enumeration), glyph metrics through a Measure delegate (a font rasteriser);
with no delegate the engine falls back to the same estimate the WPF measurement's own
catch block used, so a logo still bounces off a plausible box rather than a zero one.
Step() returns what happened and the head runs the rest exactly where it did:
TrackCornerHit, the haptic pulse, the burst particles, OnBounce/OnCornerHit, the
repaint. ColorBeforeBounce is on that struct because WPF spawned the burst before the
bounce re-rolled the colour - dropping it would have changed what Windows draws.

The XP award now routes through CoreProgression (seeded on Windows since wire/13), so
there is one writer, not two. The rate limit runs whether or not a head is listening.

CoreBouncingText is a CONTROL handle, not a draw surface: Start/Stop/Refresh/Restart,
forwarded by the WPF head to its service. The Avalonia Lab card's four no-ops now go
through it, gated the way WPF gates them - only the enable toggle checks
CoreSession.IsEngineRunning; Refresh and Restart rely on the service's own running
guard, as the WPF card does. The card's private hex parse is deleted in favour of the
engine's GetFixedColor, so the swatch cannot drift from what is drawn.

Honest scope: this does NOT make bouncing text appear on Linux, and the brief's
"unseeded still decides correctly" does not hold for this feature - the engine's
inputs are themselves head-supplied, so nothing can drive it on Avalonia until an
overlay exists. What landed is the arithmetic, plus a socket for it.

Verified: 17 new CCP.LinuxSmoke assertions drive the engine directly (a headless
render cannot exercise motion) - wall clamp and sign flip, corner vs mid-wall, hue
wheel advance, the 15-XP award and its cooldown refusing the second bounce, identity
transform with every effect off, a positive size with no metrics delegate, and the
seam silent unseeded / forwarding seeded / swallowing a throwing surface. Both builds
clean, guards pass, 189/189 render, the card's PNG unchanged.

Still blocked:
  - the surface. CCP.Avalonia/Views/Overlays/ has no full-screen click-through window
    (a sibling layer this wave). Until one exists, and supplies bounds + glyph metrics,
    CoreBouncingText stays unseeded on that head.
  - App.Achievements.TrackCornerHit - AchievementService, ConditioningControlPanel/Services/Achievements/
  - App.Haptics.BouncingTextBounceAsync - ConditioningControlPanel/Services/Haptics/
  - App.Video VideoStarted/VideoEnded pause/resume, App.Video.IsPlaying - the WPF video engine
  - Services.UI.DisplayChangeCoordinator.SpawnsSuppressed - Win32 display-change handling
  - CompositionTarget.Rendering - the vsync clock; a second head needs its own frame source
  - App.GetAllScreensCached / System.Windows.Forms.Screen - the monitor enumeration
  - Helpers.FontPickerHelper.Resolve - the bundled Fredoka face is a pack:// resource

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU