### PR TITLE
fix(companion): roster cards show each companion's XP mechanic again

### DIFF
--- a/ConditioningControlPanel/MainWindow/MainWindow.CompanionTab.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.CompanionTab.cs
@@ -117,6 +117,13 @@ namespace ConditioningControlPanel
 
                 // All companions are unlocked from level 1
                 levelTexts[i].Text = progress.IsMaxLevel ? "MAX" : $"Lv.{progress.Level}";
+                // The roster lost its per-companion blurb in the Companion Room rework (the hero
+                // card shows the active one, nothing shows the others), so the XP mechanic each
+                // companion applies became invisible: Brainwashed Slavedoll still drains XP but
+                // nowhere says so (#ask-support 2026-09-03). Hover the card to read both lines.
+                var mechanic = App.Mods?.MakeModAware(def.XPMechanicDescription) ?? def.XPMechanicDescription;
+                var flavor = App.Mods?.MakeModAware(def.Description) ?? def.Description;
+                cards[i].ToolTip = string.IsNullOrWhiteSpace(mechanic) ? flavor : $"{flavor}\n{mechanic}";
 
                 // Highlight active companion with colored border
                 var isActive = companionId == activeId;


### PR DESCRIPTION
**What:** the five roster cards in the Companion Room lost their per-companion blurb in the rework. `XPMechanicDescription` is rendered nowhere on main and `Description` only reaches the hero card for the active companion, so nothing tells you Brainwashed Slavedoll drains 3 XP/sec while it is on.

**Fix:** tooltip on each roster card, description + mechanic, mod-aware. 8 lines in `MainWindow.CompanionTab.cs`. Build green.

**Source:** #ask-support 2026-09-03, UrdnotChivay asked, Mort confirmed the drain still runs. Tracks CC-Labs-llc/ccp-bugs#1133.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X4Afw7mHMYCgHRqH2KpZEK