### PR TITLE
fix(flash): 100% Fade no longer costs the unified renderer a fullscreen present per frame

### DIFF
--- a/ConditioningControlPanel/Services/Flash/FlashService.cs
+++ b/ConditioningControlPanel/Services/Flash/FlashService.cs
@@ -2276,21 +2276,36 @@ namespace ConditioningControlPanel.Services
         // DropShadowEffect glow on top of that. At 0% the ramp is 2 writes per flash; at 100% it was
         // ~60 in and ~60 out per window, times MAX_CONCURRENT_FLASH. Two cheap brakes, layered path
         // only: cap the ramp length, and only write when the alpha has actually moved a visible step.
-        // Compositor/solid-host flashes write LayerItem.Opacity / a hosted element's Opacity, which
-        // costs nothing, so they keep the exact per-frame ramp.
+        //
+        // meadow again (#1134, still spiking on 6.9.1): that fix exempted the COMPOSITOR path on the
+        // premise that a LayerItem.Opacity write "costs nothing". It does not. Every write moves
+        // FlashLayer.FlashItem.Opacity, FlashLayer.Update sees the change and reports Dirty, and
+        // CompositorEngine.OnRendering answers one dirty layer with PresentSurface for the whole
+        // MAIN surface - a fullscreen raster of the entire layer stack plus a layered present, on
+        // every monitor. So a fading flash pins the unified renderer at one fullscreen present per
+        // composition frame, and because the ramp scales with the slider the duty cycle saturates:
+        // at 100% (1.0 s in, 1.0 s out) a flash is ramping for essentially its whole life, so the
+        // surface is dirty continuously with up to MAX_CONCURRENT_FLASH_HOST items on it. Lower
+        // percentages leave clean gaps, which is exactly the "smooth below 100%" the report says.
+        // Only the SOLID host is genuinely cheap (a plain WPF element opacity, composited off the
+        // UI thread by WPF itself), so the compositor now rides the quantiser as well. It keeps the
+        // slider's full ramp LENGTH: the quantiser bounds the writes per fade (target/epsilon),
+        // which makes a long ramp cost no more presents than a short one.
         private const double LAYERED_MAX_FADE_SECONDS = 0.5;
-        private const double LAYERED_ALPHA_EPSILON = 1.0 / 32.0;
+        private const double FADE_ALPHA_EPSILON = 1.0 / 32.0;
 
         /// <summary>
         /// Fade ramp length for one window. The layered (per-window, AllowsTransparency) path is
-        /// clamped to <see cref="LAYERED_MAX_FADE_SECONDS"/>; compositor and solid-host visuals are
-        /// cheap to nudge and keep the slider's full ramp. Pure so it can be unit-tested.
+        /// clamped to <see cref="LAYERED_MAX_FADE_SECONDS"/> because its cost is per FRAME of ramp;
+        /// compositor and solid-host visuals keep the slider's full ramp (their writes are thinned
+        /// instead, so ramp length is cost-neutral). Pure so it can be unit-tested.
         /// </summary>
-        internal static double ResolveFadeSeconds(double fadeSeconds, bool cheapAlpha)
-            => cheapAlpha ? fadeSeconds : Math.Min(fadeSeconds, LAYERED_MAX_FADE_SECONDS);
+        internal static double ResolveFadeSeconds(double fadeSeconds, bool fullRamp)
+            => fullRamp ? fadeSeconds : Math.Min(fadeSeconds, LAYERED_MAX_FADE_SECONDS);
 
         /// <summary>
-        /// Quantiser for the layered fade path: skip an opacity write the viewer cannot see, but
+        /// Quantiser for the layered and compositor fade paths: skip an opacity write the viewer
+        /// cannot see (on the compositor that write would cost a fullscreen present), but
         /// ALWAYS write the terminal values - the exact target alpha (so a fade-in settles where the
         /// Opacity slider says) and an exact 0 (the heartbeat's removal trigger reads
         /// <c>newAlpha &lt;= 0</c>, so a skipped zero would strand the window on screen).
@@ -2394,12 +2409,22 @@ namespace ConditioningControlPanel.Services
                     var showThisWindow = DateTime.Now < window.ExpiresAt && !window.IsFadingOut;
                     var targetAlpha = showThisWindow ? maxAlpha : 0.0;
 
+                    // #1134: the compositor spawn is off-thread, so the item can still be missing
+                    // here (the liveness check above kept the window alive for exactly that case).
+                    // Hold the ramp instead of running it forward against a dropped write, or the
+                    // flash pops in at whatever alpha the ramp reached while it was converting.
+                    if (window.UsesLayer && window.LayerItem == null) continue;
+
                     // Fade in/out per-window~ uwu (VisualOpacity routes to the hosted root in solid mode)
-                    // Layered windows pay a monitor-sized blit per opacity write, so their ramp is
-                    // clamped and their writes quantised; the ramp itself still advances every frame
-                    // (window.FadeAlpha), only the writes are thinned.
-                    var cheapAlpha = window.UsesLayer || window.UsesHost;
-                    var winFadeSeconds = ResolveFadeSeconds(fadeSeconds, cheapAlpha);
+                    // Only the SOLID host is cheap to nudge. A layered window pays a monitor-sized
+                    // blit per opacity write; a compositor write marks FlashLayer dirty, and the
+                    // engine answers that with a fullscreen re-raster + present of the shared
+                    // surface on every monitor (#1134). Both therefore quantise their writes; the
+                    // ramp itself still advances every frame (window.FadeAlpha), only the writes are
+                    // thinned. The compositor keeps the slider's full ramp length because the
+                    // quantiser, not the frame rate, is what bounds its writes.
+                    var cheapAlpha = window.UsesHost;
+                    var winFadeSeconds = ResolveFadeSeconds(fadeSeconds, fullRamp: cheapAlpha || window.UsesLayer);
                     var fadeStep = winFadeSeconds > 0 ? dt / winFadeSeconds : 1.0;
 
                     var currentAlpha = cheapAlpha ? window.VisualOpacity : window.FadeAlpha;
@@ -2407,7 +2432,7 @@ namespace ConditioningControlPanel.Services
                     {
                         var newAlpha = Math.Min(targetAlpha, currentAlpha + fadeStep);
                         window.FadeAlpha = newAlpha;
-                        if (cheapAlpha || ShouldWriteAlpha(window.LastWrittenAlpha, newAlpha, targetAlpha, LAYERED_ALPHA_EPSILON))
+                        if (cheapAlpha || ShouldWriteAlpha(window.LastWrittenAlpha, newAlpha, targetAlpha, FADE_ALPHA_EPSILON))
                         {
                             window.VisualOpacity = newAlpha;
                             window.LastWrittenAlpha = newAlpha;
@@ -2417,7 +2442,7 @@ namespace ConditioningControlPanel.Services
                     {
                         var newAlpha = Math.Max(0.0, currentAlpha - fadeStep);
                         window.FadeAlpha = newAlpha;
-                        if (cheapAlpha || ShouldWriteAlpha(window.LastWrittenAlpha, newAlpha, targetAlpha, LAYERED_ALPHA_EPSILON))
+                        if (cheapAlpha || ShouldWriteAlpha(window.LastWrittenAlpha, newAlpha, targetAlpha, FADE_ALPHA_EPSILON))
                         {
                             window.VisualOpacity = newAlpha;
                             window.LastWrittenAlpha = newAlpha;

--- a/Tests/ConditioningControlPanel.Tests/FlashFadeAndUnduckTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/FlashFadeAndUnduckTests.cs
@@ -18,6 +18,10 @@ namespace ConditioningControlPanel.Tests;
 ///
 /// The fade ramp used to write Window.Opacity every frame. A flash window is AllowsTransparency,
 /// so each write is a re-rasterise plus a monitor-sized UpdateLayeredWindow blit on the UI thread.
+///
+/// #1134 is the same report from the same reporter one renderer over: the 6.9.1 brakes exempted the
+/// unified compositor, where an opacity write is not free either - it marks the flash layer dirty
+/// and the engine answers with a fullscreen present of the shared surface on every monitor.
 /// </summary>
 public class FlashFadeAndUnduckTests
 {
@@ -79,21 +83,21 @@ public class FlashFadeAndUnduckTests
     public void ResolveFadeSeconds_ClampsTheLayeredPath()
     {
         // 100% on the slider = a 1.0 s ramp; layered windows get at most 0.5 s of blits.
-        Assert.Equal(0.5, FlashService.ResolveFadeSeconds(1.0, cheapAlpha: false));
+        Assert.Equal(0.5, FlashService.ResolveFadeSeconds(1.0, fullRamp: false));
     }
 
     [Fact]
     public void ResolveFadeSeconds_LeavesShortLayeredRampsAlone()
     {
-        Assert.Equal(0.4, FlashService.ResolveFadeSeconds(0.4, cheapAlpha: false), 9);
-        Assert.Equal(0.0, FlashService.ResolveFadeSeconds(0.0, cheapAlpha: false), 9);
+        Assert.Equal(0.4, FlashService.ResolveFadeSeconds(0.4, fullRamp: false), 9);
+        Assert.Equal(0.0, FlashService.ResolveFadeSeconds(0.0, fullRamp: false), 9);
     }
 
     [Fact]
     public void ResolveFadeSeconds_DoesNotTouchCompositorOrHost()
     {
-        Assert.Equal(1.0, FlashService.ResolveFadeSeconds(1.0, cheapAlpha: true), 9);
-        Assert.Equal(0.4, FlashService.ResolveFadeSeconds(0.4, cheapAlpha: true), 9);
+        Assert.Equal(1.0, FlashService.ResolveFadeSeconds(1.0, fullRamp: true), 9);
+        Assert.Equal(0.4, FlashService.ResolveFadeSeconds(0.4, fullRamp: true), 9);
     }
 
     // ---- Bug 2b: opacity writes are quantised, terminals always land ----------------------
@@ -175,5 +179,43 @@ public class FlashFadeAndUnduckTests
 
         Assert.True(alpha >= target, "the ramp must reach the target");
         Assert.Equal(target, last, 9);
+    }
+
+    // ---- #1134: the compositor path is quantised too --------------------------------------
+
+    [Fact]
+    public void CompositorWriteCountDoesNotGrowWithTheFadeSlider()
+    {
+        // #1134 in one assertion: every LayerItem.Opacity write costs the compositor a fullscreen
+        // re-raster + present of the shared surface, so a 100% fade must not cost more of them than
+        // a 20% fade. Unquantised the compositor wrote once per frame, so at 144 Hz the 1.0 s ramp
+        // cost ~144 writes against the 0.2 s ramp's ~29.
+        var slow = WritesForRamp(fadeSeconds: 1.0);
+        var fast = WritesForRamp(fadeSeconds: 0.2);
+        Assert.InRange(slow, 1, 33);
+        Assert.InRange(slow, 1, fast + 1);
+    }
+
+    /// <summary>Writes a full 0 -> 1 ramp of the given length at 144 Hz costs under the quantiser.</summary>
+    private static int WritesForRamp(double fadeSeconds)
+    {
+        const double dt = 1.0 / 144.0;
+        const double target = 1.0;
+        double alpha = 0.0, last = 0.0;
+        int writes = 0, frames = 0;
+
+        while (alpha < target && frames < 100_000)
+        {
+            frames++;
+            alpha = Math.Min(target, alpha + dt / fadeSeconds);
+            if (FlashService.ShouldWriteAlpha(last, alpha, target, Eps))
+            {
+                writes++;
+                last = alpha;
+            }
+        }
+
+        Assert.Equal(target, last, 9);
+        return writes;
     }
 }


### PR DESCRIPTION
Fixes the 100% Fade lag spikes meadow re-confirmed on 6.9.1 with the unified overlay renderer.

Closes CC-Labs-llc/ccp-bugs#1134. Reporter to credit: meadow.

## Why 100% costs more than 90%

The 6.9.1 fix (`adbbe885f`) braked the classic per-flash layered window and deliberately
exempted the compositor, on the premise in the comment that a `LayerItem.Opacity` write
"costs nothing". That premise is wrong, so meadow, who runs the unified renderer, got
none of the 6.9.1 benefit.

The chain, all in one frame:

1. `FlashService.Heartbeat_Tick` wrote `VisualOpacity` every composition frame for the
   compositor path (`FlashService.cs:2401` on main, old `cheapAlpha = window.UsesLayer || window.UsesHost`).
2. That sets `FlashLayer.FlashItem.Opacity`, and `FlashLayer.Update`
   (`Services/Compositor/FlashLayer.cs:155`) reports `Dirty` because the value moved.
3. `CompositorEngine.OnRendering` (`Services/Compositor/CompositorEngine.cs:306`) answers
   one dirty layer with `PresentSurface` for the whole MAIN surface: a fullscreen raster of
   the entire layer stack (flashes, pink tint, spiral, subliminals) plus a layered present,
   on every monitor.

So a fading flash pins the renderer at one fullscreen present per frame. The cost therefore
scales with the slider, and it saturates at the top rather than growing gently: the Fade
slider is 1% = 10 ms, so 100% is a 1.0 s ramp in and 1.0 s out. That is most or all of a
flash's on-screen life, so the surface never gets a clean frame, and up to
`MAX_CONCURRENT_FLASH_HOST` (30) items are re-rastered on each one. At lower percentages
the ramps finish early and leave clean gaps between flashes, which is precisely the "lower
fade values are smooth" in the report.

## The change

Small and in one place: stop exempting the compositor.

- `cheapAlpha` is now `window.UsesHost` only. The solid host really is cheap (a plain WPF
  element opacity, composited by WPF itself); the compositor is not, so it rides the same
  `ShouldWriteAlpha` quantiser as the layered path (1/32 alpha steps, terminal values always
  written so a fade-in still settles exactly on the Opacity slider and a fade-out still hits
  an exact 0, which is the heartbeat's removal trigger).
- The compositor keeps the slider's FULL ramp length (no `LAYERED_MAX_FADE_SECONDS` clamp).
  It does not need one any more: the quantiser bounds writes at target/epsilon per fade, so
  ramp length is cost neutral there. 100% still means a 1 second fade, it just costs about
  32 presents instead of one per frame.
- Holds the ramp while a compositor flash's off-thread frame conversion is still pending.
  The ramp now drives off `FadeAlpha` instead of reading the layer item back, and without
  the guard it would run ahead against dropped writes and pop the flash in at partial alpha.
- `LAYERED_ALPHA_EPSILON` renamed `FADE_ALPHA_EPSILON` (it is no longer layered-only), and
  `ResolveFadeSeconds`'s parameter renamed `cheapAlpha` to `fullRamp`, which is what it
  actually selects now.

Net effect at 144 Hz on a 1.0 s fade: about 144 fullscreen presents per ramp before, about
32 after, and it no longer grows when the slider does.

## Tests

`Tests/ConditioningControlPanel.Tests/FlashFadeAndUnduckTests.cs` gains
`CompositorWriteCountDoesNotGrowWithTheFadeSlider`, which asserts a 1.0 s ramp costs no more
writes than a 0.2 s one. Existing tests updated for the renamed parameter. 17/17 pass.

## What meadow should see

With the unified overlay renderer on and Fade at 100%, flashes should fade over the same
1 second they do today, with the same final opacity, but the stutter during the fade should
be gone or much reduced. The fade may look very slightly stepped if you stare at a single
large flash on a high refresh monitor, since alpha now moves in 1/32 increments. That is the
same trade the classic renderer has been making since 6.9.1. If spikes remain at 100% with
many simultaneous images, the next suspect is the union of several flashes' write frames
still landing on most frames, and the fix for that is a present-rate gate in the engine
rather than a per-window one.

## Not verified

Not play-tested. Build is green (0 errors, the usual CA1416/nullable warnings) and the unit
tests pass, but nothing was run on the reporter's machine and no session was run here, so
the frame-rate improvement is reasoned from the render path, not measured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X4Afw7mHMYCgHRqH2KpZEK
