### PR TITLE
fix(remote): play_hypnotube lands on a surface the subject can actually see

### DIFF
--- a/ConditioningControlPanel/MainWindow/MainWindow.Browser.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.Browser.cs
@@ -330,9 +330,41 @@ namespace ConditioningControlPanel
                 return;
             }
 
+            // MainWindow itself may be away: TRAY-HIDDEN (Window.Hide(), via MinimizeToTrayForChaos
+            // when an Arcademy class or a DtRH descent takes the screen) or minimized (Graded
+            // Intake's duck). Activate()/Focus() are no-ops on both, so without this the page loads
+            // into a surface the user can never see and the navigation reads as "nothing happened"
+            // (ccp-bugs#1138).
+            RestoreWindowForBrowserSurface();
             ShowTab("settings");
             Activate();
             Focus();
+        }
+
+        /// <summary>
+        /// Brings the control panel itself back before we try to focus the embedded browser.
+        /// Tray-tucked (Hide()) and minimized are both states in which Activate() does nothing at
+        /// all, so a navigation into the embedded browser would stay invisible for as long as the
+        /// window stayed away - which for a remote-control command means "until someone happens to
+        /// restore the window", i.e. long after the controller has given up.
+        /// </summary>
+        private void RestoreWindowForBrowserSurface()
+        {
+            try
+            {
+                if (!IsVisible)
+                {
+                    App.Logger?.Information("Browser surface requested while the control panel was tray-hidden - restoring it");
+                    RestoreFromTrayForRemote();   // TrayIconService.ShowWindow(): Show + Normal + on-screen repair
+                    return;
+                }
+                if (WindowState == WindowState.Minimized)
+                {
+                    App.Logger?.Information("Browser surface requested while the control panel was minimized - restoring it");
+                    WindowState = WindowState.Normal;
+                }
+            }
+            catch (Exception ex) { App.Logger?.Debug("RestoreWindowForBrowserSurface failed: {Error}", ex.Message); }
         }
 
         private async System.Threading.Tasks.Task InitAndNavigateAsync(string url, bool autoPlayFullscreen)
@@ -2985,14 +3017,54 @@ namespace ConditioningControlPanel
         private bool _remoteBrowserVideoActive;
 
         /// <summary>
+        /// Names the screen-owning WebView2 host sitting ABOVE the control panel right now, or null
+        /// when nothing is. These windows are natively owned by MainWindow
+        /// (<c>ChaosWebViewHost.OwnedByMainWindow</c> glue), which is a rule about the future:
+        /// Windows will never let the owner - and therefore the browser embedded inside it - be
+        /// placed above them. A remote video routed into the embedded browser while one of these is
+        /// up therefore plays somewhere nobody can look at, no matter how hard we focus it.
+        /// </summary>
+        private static string? ScreenOwningWebHostName()
+        {
+            try
+            {
+                if (Services.Arcademy.ArcademyHostService.IsActive)
+                    return Services.Arcademy.ArcademyHostService.ProductName;
+                if (Services.Chaos.DtrhHostService.IsActive)
+                    return "Down the Rabbit Hole";
+                if (Services.Quiz.IntakeHostService.IsActive)
+                    return Services.Quiz.IntakeHostService.ProductName;
+            }
+            catch { /* a gate must never be the thing that throws */ }
+            return null;
+        }
+
+        /// <summary>
         /// Play a controller-supplied HypnoTube URL in the embedded browser (remote-control
         /// "play_hypnotube" command). Marks the browser video as remote-active so a later panic
         /// / session-end can stop it. The URL has already been allowlist-validated by
         /// RemoteControlService (HtUrlHelper.IsEligibleHtUrl).
         /// </summary>
-        public void PlayHypnotubeFromRemote(string url)
+        /// <returns>
+        /// null when the video was handed to the browser, otherwise a short reason the caller
+        /// reports back to the controller. Silence was the whole bug in ccp-bugs#1138: the command
+        /// was accepted, nothing appeared, and the controller kept pressing.
+        /// </returns>
+        public string? PlayHypnotubeFromRemote(string url)
         {
+            // Refuse, loudly, rather than navigate into a window that cannot be raised. The class
+            // / descent / intake stays where the subject put it - a controller command is not
+            // authority to close someone's game - but the controller is told why nothing happened
+            // instead of watching three commands vanish.
+            var ownedBy = ScreenOwningWebHostName();
+            if (ownedBy != null) return ownedBy + " is on screen";
+
             _remoteBrowserVideoActive = true;
+            // The remote-control overlay blindfolds the embedded browser for the WHOLE controller
+            // session (WebView2 airspace would otherwise paint over the WPF overlay). A video the
+            // controller just asked for is the one thing that has to win that contest, so lift the
+            // blindfold for as long as the remote video is up.
+            RevealBrowserForRemoteVideo(true);
             // A controller command is an explicit instruction from another person, so it takes
             // precedence over an in-flight video rather than being refused — but it must hand the
             // session over cleanly instead of navigating out from under the previous claim and
@@ -3004,8 +3076,11 @@ namespace ConditioningControlPanel
                 // Nothing is playing here, so don't leave the claim standing until the heartbeat
                 // retires it — panic/session-end would otherwise act on a video that never loaded.
                 _remoteBrowserVideoActive = false;
+                RevealBrowserForRemoteVideo(false);
                 App.BrowserMedia?.OnMediaStopped("remote-browser-unavailable");
+                return "the browser could not open it";
             }
+            return null;
         }
 
         /// <summary>
@@ -3019,6 +3094,9 @@ namespace ConditioningControlPanel
         {
             if (!_remoteBrowserVideoActive) return;
             _remoteBrowserVideoActive = false;
+            // Put the overlay's browser blindfold back: with the video gone there is nothing left
+            // for the WebView to paint over the "someone else is controlling your app" card with.
+            RevealBrowserForRemoteVideo(false);
             try
             {
                 if (_isBrowserFullscreen) ExitBrowserFullscreen();

--- a/ConditioningControlPanel/MainWindow/MainWindow.RemoteControl.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.RemoteControl.cs
@@ -1007,8 +1007,11 @@ namespace ConditioningControlPanel
                 sessionText += $"  PIN: {overlayPin}";
             TxtOverlaySessionCode.Text = sessionText;
 
-            // Hide browser to avoid WebView2 airspace issue (renders on top of WPF overlays)
-            SettingsTab.BrowserContainer.Visibility = System.Windows.Visibility.Hidden;
+            // Hide browser to avoid WebView2 airspace issue (renders on top of WPF overlays).
+            // NOT while the controller's own video is playing in it - see
+            // RevealBrowserForRemoteVideo. A reconnect mid-video must not blindfold it again.
+            if (!_remoteOverlayBrowserRevealed)
+                SettingsTab.BrowserContainer.Visibility = System.Windows.Visibility.Hidden;
             RemoteControlOverlay.Visibility = System.Windows.Visibility.Visible;
 
             var fadeIn = new System.Windows.Media.Animation.DoubleAnimation(0, 1, TimeSpan.FromMilliseconds(300));
@@ -1027,10 +1030,56 @@ namespace ConditioningControlPanel
                 RemoteControlOverlay.Visibility = System.Windows.Visibility.Collapsed;
                 // Restore browser visibility now that overlay is gone
                 SettingsTab.BrowserContainer.Visibility = System.Windows.Visibility.Visible;
+                _remoteOverlayBrowserRevealed = false;
             };
             RemoteControlOverlay.BeginAnimation(OpacityProperty, fadeOut);
             _remoteNotificationTimer?.Stop();
             _remoteSessionInfoTimer?.Stop();
+        }
+
+        // True while a controller-started browser video has lifted the overlay's browser
+        // blindfold. ShowRemoteControlOverlay must not re-apply the blindfold underneath it, and
+        // HideRemoteControlOverlay clears it along with the rest of the overlay state.
+        private bool _remoteOverlayBrowserRevealed;
+
+        /// <summary>
+        /// ccp-bugs#1138. <see cref="ShowRemoteControlOverlay"/> hides
+        /// <c>SettingsTab.BrowserContainer</c> for the WHOLE time a controller is connected, because
+        /// WebView2 airspace would otherwise paint over the WPF overlay. That is right for the idle
+        /// case and exactly wrong for the one command that deliberately puts a video in that
+        /// browser: <c>play_hypnotube</c> navigated into a container nobody could see, and the page
+        /// only became visible when the controller disconnected and
+        /// <see cref="HideRemoteControlOverlay"/> put the container back, which is precisely the
+        /// "it opened after they disconnected" the report describes. Lift the blindfold while a
+        /// remote video is up, put it back when it stops.
+        ///
+        /// <para>Losing the airspace fight is the POINT here: the controller's video belongs on top
+        /// of the "someone else is controlling your app" card, not behind it.</para>
+        /// </summary>
+        internal void RevealBrowserForRemoteVideo(bool reveal)
+        {
+            try
+            {
+                if (_remoteOverlayBrowserRevealed == reveal) return;
+                _remoteOverlayBrowserRevealed = reveal;
+
+                if (reveal)
+                {
+                    SettingsTab.BrowserContainer.Visibility = System.Windows.Visibility.Visible;
+                    App.Logger?.Information(
+                        "[RemoteControl] Browser un-hidden for a controller video (the remote overlay stays behind the WebView)");
+                }
+                else if (RemoteControlOverlay.Visibility == System.Windows.Visibility.Visible)
+                {
+                    // Controller still connected: the overlay needs its airspace back so the
+                    // session code is legible again.
+                    SettingsTab.BrowserContainer.Visibility = System.Windows.Visibility.Hidden;
+                }
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Debug("RevealBrowserForRemoteVideo failed: {Error}", ex.Message);
+            }
         }
 
         private void WireRemoteSessionCallbacks()

--- a/ConditioningControlPanel/Services/RemoteControlService.cs
+++ b/ConditioningControlPanel/Services/RemoteControlService.cs
@@ -647,7 +647,11 @@ namespace ConditioningControlPanel.Services
                     {
                         id = lastCmdId,
                         action = lastAction,
-                        status = "ok",
+                        // "ok" unless a handler called ReportCommandRefused. The server stores
+                        // last_executed verbatim, so the extra reason costs nothing on the wire and
+                        // gives the controller something to show besides a stuck "Sent".
+                        status = _lastCommandStatus,
+                        reason = _lastCommandReason,
                         at = DateTime.UtcNow.ToString("o")
                     };
                 }
@@ -1070,8 +1074,44 @@ namespace ConditioningControlPanel.Services
             }
         }
 
+        /// <summary>
+        /// Status reported for the command named by <c>last_executed</c> on the next status push,
+        /// and the short reason behind it. Reset at the top of every <see cref="ExecuteCommand"/>,
+        /// so it always describes the command whose id we are echoing. "fail" is the value the
+        /// controller page already renders as "Failed"; anything unknown reads as "Sent", which is
+        /// the silence ccp-bugs#1138 was made of.
+        /// </summary>
+        private string _lastCommandStatus = "ok";
+        private string? _lastCommandReason;
+
+        /// <summary>
+        /// A command we cannot honour has to SAY SO on every channel that exists rather than be
+        /// swallowed: the local log (so the next bug report carries it), the status push (so the
+        /// controller's command log stops saying "Sent"), and the emote back-channel (the one
+        /// subject→controller path the controller page definitely renders). Before ccp-bugs#1138 a
+        /// play_hypnotube that landed on a surface the subject could not see still reported "ok".
+        /// </summary>
+        private void ReportCommandRefused(string action, string reason)
+        {
+            _lastCommandStatus = "fail";
+            _lastCommandReason = reason;
+            App.Logger?.Warning("[RemoteControl] {Action} not delivered: {Reason}", action, reason);
+            try
+            {
+                var text = $"Can't open that: {reason}";
+                if (text.Length > 60) text = text.Substring(0, 60);
+                _ = SendEmoteAsync(text, "🚫", "custom");
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Debug("[RemoteControl] Refusal emote failed: {Error}", ex.Message);
+            }
+        }
+
         private void ExecuteCommand(string action, JObject? parameters)
         {
+            _lastCommandStatus = "ok";
+            _lastCommandReason = null;
             DispatcherHelper.RunOnUISync(() =>
             {
                 try
@@ -1216,7 +1256,13 @@ namespace ConditioningControlPanel.Services
                             }
                             App.Logger?.Information("[RemoteControl] play_hypnotube id={Id}",
                                 Helpers.HtUrlHelper.TryExtractHtVideoId(htUrl));
-                            MainWindowRef?.PlayHypnotubeFromRemote(htUrl);
+                            // Non-null = the video was NOT handed to the browser (an Arcademy class
+                            // / DtRH descent / Graded Intake owns the screen above the control
+                            // panel, or the browser could not be brought up). Say so on every
+                            // channel instead of accepting the command and showing nothing.
+                            var htRefusal = MainWindowRef?.PlayHypnotubeFromRemote(htUrl);
+                            if (!string.IsNullOrEmpty(htRefusal))
+                                ReportCommandRefused("play_hypnotube", htRefusal!);
                             break;
 
                         case "trigger_haptic":

--- a/ConditioningControlPanel/docs/primers/REMOTE_CONTROL_PRIMER.md
+++ b/ConditioningControlPanel/docs/primers/REMOTE_CONTROL_PRIMER.md
@@ -187,7 +187,25 @@ no caller in this repo** — the server/web side of the loop is the remaining wo
 | `set_pink_opacity` / `set_spiral_opacity` | clamp 0–50 → settings (`:1054`/`:1065`) | |
 | `start_bubbles` / `stop_bubbles` | `App.Bubbles.Start(bypassLevelCheck:true)` / `.Stop()` (`:1076`/`:1080`) | |
 | `trigger_video` / `start_video` / `stop_video` | `App.Video.TriggerVideo()` / `.Start()` / `.Stop()` (`:1085`/`:1089`/`:1093`) | |
-| `play_hypnotube` | `MainWindowRef.PlayHypnotubeFromRemote(url)` (`:1097`) | **Hard-gated**: URL must pass `HtUrlHelper.IsEligibleHtUrl` (`:1106`); routed through WebView2, NOT LibVLC. Only command that validates untrusted input. |
+| `play_hypnotube` | `MainWindowRef.PlayHypnotubeFromRemote(url)` (`:1097`) | **Hard-gated**: URL must pass `HtUrlHelper.IsEligibleHtUrl` (`:1106`); routed through WebView2, NOT LibVLC. Only command that validates untrusted input. **Returns a refusal string** - see below. |
+
+**`play_hypnotube` and the surface it needs** (ccp-bugs#1138). The video goes into the embedded
+browser, which lives inside MainWindow, so the command only means anything when MainWindow can be
+seen. Three things used to make it invisible, all silently:
+
+1. **The remote overlay's blindfold.** `ShowRemoteControlOverlay` hides `SettingsTab.BrowserContainer`
+   for the whole time a controller is connected (WebView2 airspace would paint over the WPF overlay).
+   `MainWindow.RevealBrowserForRemoteVideo(true)` now lifts that blindfold while a controller video is
+   up and puts it back when the video stops. Losing the airspace fight is the point: the controller's
+   video belongs above the "someone else is controlling your app" card.
+2. **A tray-tucked or minimized control panel.** `FocusBrowserSurface` called `Activate()`, which is a
+   no-op on a hidden window. It now calls `RestoreWindowForBrowserSurface()` first.
+3. **A screen-owning webview host.** An Arcademy class, a DtRH descent and a Graded Intake are
+   natively OWNED by MainWindow (`ChaosWebViewHost.OwnedByMainWindow`), so Windows will never let the
+   control panel be placed above them. `PlayHypnotubeFromRemote` therefore **refuses** while one is
+   open (the subject's game is not closed by a remote command) and returns the reason.
+   `ReportCommandRefused` logs it, sets `last_executed.status` to `"fail"` with a `reason`, and sends
+   it up the emote back-channel so the controller sees why nothing happened.
 | `trigger_haptic` | `App.Haptics.TriggerAsync("remote_control", 0.7, 2000)` (`:1116`) | |
 | `duck_audio` / `unduck_audio` | `App.Audio.Duck(80)` / `.ForceUnduck()` (`:1120`/`:1124`) | |
 | `start_autonomy` / `stop_autonomy` | `App.Autonomy.Start()`/`.Stop()` (`:1129`/`:1133`) | |


### PR DESCRIPTION
Fixes ccp-bugs#1138 (BUG-NUA3U5V94A, v6.9.1). beebee: "3 open hypnotube remote
commands fail to open. Remote control started while I had Arcademy up... Then
the hypnotube page opened after the remote user disconnected but the video
didn't play."

## Root cause

Three separate reasons the command hit a surface nobody could see, none of them
a queue and none of them logged.

**1. The remote overlay blindfolds the browser for the entire controller session.**
`ShowRemoteControlOverlay` sets `SettingsTab.BrowserContainer.Visibility = Hidden`
the moment a controller connects (`MainWindow.RemoteControl.cs:1010`), because
WebView2 airspace paints over the WPF overlay. The only thing that puts it back
is `HideRemoteControlOverlay`, on disconnect (`:1028`). `play_hypnotube` routes
through `NavigateToUrlInBrowser` into that hidden container, so the page became
visible at exactly the moment the controller left. That is the reported timing.
And because `StopEffectsOnRemoteDisconnect` runs `StopBrowserVideoFromRemote`
first, which navigates to the HypnoTube homepage, what finally appeared was the
site homepage with no video: "the page opened but the video didn't play".

**2. `FocusBrowserSurface` cannot raise a tray-tucked window.**
`ArcademyHostService.Launch` calls `mw.MinimizeToTrayForChaos()`
(`ArcademyHostService.cs:319`) which is `TrayIconService.MinimizeToTray()` which
is `_mainWindow.Hide()` (`TrayIconService.cs:147`). `FocusBrowserSurface`
(`MainWindow.Browser.cs:318`) only did `ShowTab("settings"); Activate(); Focus();`
and all three are no-ops on a hidden window.

**3. An Arcademy class cannot be out-ranked.** Arcademy / DtRH / Graded Intake
windows are natively owned by MainWindow via `ChaosWebViewHost`'s
`OwnedByMainWindow` glue (`Chaos/ChaosWebViewHost.cs:584`). Ownership is a rule
about the future: Windows will never place the owner above them. So a remote
video inside the embedded browser plays where nobody can look at it for as long
as a class is open, no matter how hard the app focuses it.

There is no deliberate guard anywhere on this path. The command reported `"ok"`
on the wire while showing nothing, which is why the controller pressed it three
times.

## What changed

- `MainWindow.RevealBrowserForRemoteVideo(bool)` lifts the overlay's browser
  blindfold while a controller video is up and restores it when the video
  stops. `ShowRemoteControlOverlay` no longer re-applies it underneath a live
  remote video (a reconnect mid-video used to). Losing the airspace fight is the
  point: the controller's video belongs above the "someone else is controlling
  your app" card.
- `RestoreWindowForBrowserSurface()` restores the control panel from the tray,
  or from minimized, before `FocusBrowserSurface` tries to focus anything.
- `PlayHypnotubeFromRemote` returns a refusal string instead of `void`. It
  refuses while a screen-owning webview host is open. The subject's class is
  NOT closed by a remote command.
- `ReportCommandRefused` puts the refusal on all three channels: a Warning in
  the app log, `last_executed.status = "fail"` plus a `reason` on the next
  status push (the server stores `last_executed` verbatim; the controller page
  already renders `fail` as "Failed"), and the emote back-channel, which is the
  one subject-to-controller path the controller page definitely displays.
- `docs/primers/REMOTE_CONTROL_PRIMER.md` documents the surface contract.

197 insertions, 6 deletions across 4 files.

## Verification

`dotnet build` green from a fresh worktree at origin/main: 0 errors, 344
warnings (all pre-existing CA1416 / CS8602 / IL3000).

**Not play-tested.** Nobody ran a live remote session against a build of this.
The specific things a play-test would need to confirm: that the WebView really
does paint over `RemoteControlOverlay` once the container is visible again (the
whole design rests on the airspace behaviour the original code was working
around); that the refusal emote reaches the controller UI; and that
`RestoreFromTrayForRemote` from a hidden window brings the panel back cleanly
while an Arcademy window is glued above it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X4Afw7mHMYCgHRqH2KpZEK
