### PR TITLE
feat(arcademy): the Front Gate - a way back to CC Labs from the campus

### DIFF
--- a/ConditioningControlPanel/Resources/web/arcademy/CLAUDE.md
+++ b/ConditioningControlPanel/Resources/web/arcademy/CLAUDE.md
@@ -366,11 +366,15 @@ shell/idcard.js    THE STUDENT ID: the laminated card in the corner of the
 shell/accountchip.js THE ACCOUNT CHIP: the round photo miniature at the far right
                    of the topbar AND of the campus top-right cluster, and the
                    front-desk menu under it (Signed in as / Open my card /
-                   Profile / Sign out). A HOST SLOT: mounted only when
+                   Profile / Front Gate / Sign out). A HOST SLOT: mounted only when
                    `init.account` (or `account` on a `profile` frame) arrives -
                    the C# host never sends it, so the desktop is unchanged. The
                    page holds NO url: it posts `account-action {action}` and
-                   the host walks (cclabs-web PROFILE-CONTRACT §8). Photo =
+                   the host walks (cclabs-web PROFILE-CONTRACT §8). FRONT GATE
+                   (2026-09-03) is the third verb, `dashboard`: a player who
+                   came in from the site had no breadcrumb back out. Drawn only
+                   when the host LISTS it in `actions`, which the C# host never
+                   does (the desktop's Play tab is already the way out). Photo =
                    same-origin path or a drawn monogram; "Open my card" is the
                    shell's own showIdCard. No Esc rung (trap 59's shape)
 shell/annexreveal.js THE NIGHT THE WALL MOVED: the once-ever reveal cinematic

--- a/ConditioningControlPanel/Resources/web/arcademy/core/lexicon.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/core/lexicon.js
@@ -408,6 +408,10 @@ export const DEFAULT_LEXICON = Object.freeze({
   account_signed_in_as: 'Signed in as',
   account_open_card: 'Open my card',
   account_profile: 'Profile',
+  /* THE FRONT GATE (2026-09-03): the way back out to the CC Labs site. Two
+     rows because the row is two lines - the verb and the quiet line under it. */
+  account_dashboard: 'Front Gate',
+  account_dashboard_hint: 'back to CC Labs',
   account_sign_out: 'Sign out',
 
   /* Semester II ghost labels behind the tape (unregistered games get their

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/accountchip.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/accountchip.js
@@ -11,7 +11,15 @@
  *
  *   init.account = { name, avatarUrl, actions }      (additive, legally absent)
  *   profile frame may carry `account` with the same shape (a late fetch)
- *   page -> host  { type:'account-action', action:'profile'|'signout' }
+ *   page -> host  { type:'account-action', action:'profile'|'dashboard'|'signout' }
+ *
+ * THE FRONT GATE (community ask, 2026-09-03): a player who walked into the
+ * campus from the site had no way back out of it - the menu could reach a
+ * profile page and it could end a session, and neither of those is "take me
+ * home". `dashboard` is that third verb. It is still a HOST verb: the page
+ * knows the label and nothing else, so the web host walks to the dashboard and
+ * the Discord activity opens the same address in the system browser (a
+ * top-level navigation closes an activity on Android).
  *
  * THREE RULES
  *  1. THE PAGE HOLDS NO URL. The host lists the ACTIONS it can honour and the
@@ -28,7 +36,7 @@
  * and the ladder never notices. The two document listeners are passive.
  * ==========================================================================*/
 
-const ACTIONS = Object.freeze(['profile', 'signout']);
+const ACTIONS = Object.freeze(['profile', 'dashboard', 'signout']);
 
 function el(tag, cls, text) {
   const n = document.createElement(tag);
@@ -119,11 +127,19 @@ export function createAccountChip({ t, account, isMobile, onOpenCard, onAction, 
   let destroyed = false;
   const items = [];
 
-  function item(cls, label, fn) {
-    const b = el('button', 'arc-acct-item ' + cls, label);
+  /* `hint` is a second, quieter line inside the same button (plain elements,
+   * never innerHTML). It is part of the button's accessible name on purpose:
+   * "Front Gate, back to CC Labs" is the whole point of the row. */
+  function item(cls, label, fn, hint) {
+    const b = el('button', 'arc-acct-item ' + cls);
     b.type = 'button';
     b.setAttribute('role', 'menuitem');
     b.tabIndex = -1;
+    b.appendChild(el('span', 'arc-acct-label', label));
+    if (hint) {
+      b.appendChild(el('span', 'arc-acct-hint', hint));
+      b.setAttribute('title', label + ' - ' + hint);
+    }
     b.addEventListener('click', () => { close(true); try { fn(); } catch (e) { say('account item threw: ' + ((e && e.message) || e)); } });
     menu.appendChild(b);
     items.push(b);
@@ -137,6 +153,14 @@ export function createAccountChip({ t, account, isMobile, onOpenCard, onAction, 
     }
     if (acct.actions.indexOf('profile') >= 0) {
       item('is-profile', tt('account_profile', 'Profile'), () => { if (onAction) onAction('profile'); });
+    }
+    if (acct.actions.indexOf('dashboard') >= 0) {
+      item(
+        'is-dashboard',
+        tt('account_dashboard', 'Front Gate'),
+        () => { if (onAction) onAction('dashboard'); },
+        tt('account_dashboard_hint', 'back to CC Labs'),
+      );
     }
     if (acct.actions.indexOf('signout') >= 0) {
       item('is-signout', tt('account_sign_out', 'Sign out'), () => { if (onAction) onAction('signout'); });

--- a/ConditioningControlPanel/Resources/web/arcademy/styles.css
+++ b/ConditioningControlPanel/Resources/web/arcademy/styles.css
@@ -5645,6 +5645,13 @@ html.arc-reduced .emi.arc-seep-frame::after { content:none; }
 .arc-acct-item:hover, .arc-acct-item:focus-visible { background:var(--panel); color:var(--ink); outline:none; }
 .arc-acct-item.is-signout { color:var(--ink-faint); }
 .arc-acct-item.is-card { color:var(--pink); }
+/* THE FRONT GATE row is two lines: the verb, and a quiet line saying where it
+   goes. The hint never carries meaning the label does not already carry. */
+.arc-acct-label { display:block; }
+.arc-acct-hint {
+  display:block; margin-top:2px; font-size:10px; letter-spacing:.04em;
+  color:var(--ink-faint); text-transform:none;
+}
 
 /* On a phone: a thumb-sized chip and a SHEET under the bar. Fixed and edge to
    edge so it never runs off the screen and never lands over the campus's own

--- a/ConditioningControlPanel/Services/Arcademy/ArcademyHostService.cs
+++ b/ConditioningControlPanel/Services/Arcademy/ArcademyHostService.cs
@@ -3093,6 +3093,11 @@ internal static class ArcademyHostService
         ["account_signed_in_as"] = "Signed in as",
         ["account_open_card"] = "Open my card",
         ["account_profile"] = "Profile",
+        // THE FRONT GATE (2026-09-03): the third account verb, the way back to the CC Labs site.
+        // Web/activity hosts only (they alone list "dashboard" in account.actions); mirrored here
+        // so a mod can re-voice it, same as the other four rows.
+        ["account_dashboard"] = "Front Gate",
+        ["account_dashboard_hint"] = "back to CC Labs",
         ["account_sign_out"] = "Sign out",
 
         // THE LOCKER (2026-08-28): RM 004 + the booth arrival beat and the purchase toast verbs.


### PR DESCRIPTION
## What

The Arcademy's account chip grows a third verb: **Front Gate**, which takes the
player back to the CC Labs site. Label "Front Gate", with a quiet second line
under it, "back to CC Labs".

## Why

Community ask, Sept 3: a member found no breadcrumb back to the CCP site from
the web Arcademy. The chip's menu offered *profile* and *sign out*, and neither
of those is "take me home" - and a player who landed on `/arcademy` from a link
has no back button to fall back on either.

## How

The page keeps holding **no url**. It draws whatever verbs the host lists in
`account.actions` and posts `account-action {action:'dashboard'}`; where that
leads is the host's business (cclabs-web `PROFILE-CONTRACT` §8 - the web tab
navigates, the Discord Activity opens the system browser through
`sdk.commands.openExternalLink`, because a top-level navigation closes an
activity on Android). The host half is cclabs-web PR (linked below).

**The desktop never draws it.** `ArcademyHostService` sends no `init.account`
at all, so no chip is mounted on the desktop and no verb is offered - the Play
tab is already the desktop's way out. The two lexicon rows are mirrored into
`NeutralLexicon` purely for the mirror law, so a mod can re-voice them.

Files:
- `shell/accountchip.js` - `dashboard` in `ACTIONS`, the menu row, and an
  optional second-line hint on an item (plain elements, no `innerHTML`)
- `core/lexicon.js` + `ArcademyHostService.NeutralLexicon` -
  `account_dashboard` / `account_dashboard_hint`
- `styles.css` - `.arc-acct-label` / `.arc-acct-hint`
- `Resources/web/arcademy/CLAUDE.md` - the accountchip entry now lists three verbs

50 insertions, 6 deletions.

## Test evidence

- `dotnet build` in `ConditioningControlPanel`: **0 errors** (344 pre-existing
  warnings, unchanged).
- The real `shell/accountchip.js` driven against a minimal DOM stub:
  - a three-verb host draws 4 rows (`is-card`, `is-profile`, `is-dashboard`,
    `is-signout`), the gate's two lines read "Front Gate" / "back to CC Labs",
    its `title` is `Front Gate - back to CC Labs`, and a click posts
    `dashboard`;
  - the activity's two-verb host draws `is-profile` + `is-dashboard` and no
    sign-out;
  - a host that lists only the old pair draws **no** gate (the desktop-shaped
    case), and `readAccount()` still drops an unknown verb and still returns
    `null` for an empty `actions`.
- cclabs-web's `sync-arcademy.mjs` lexicon parser re-run standalone against the
  modified `ArcademyHostService.cs`: 1382 rows parse, both new rows present and
  well under the 96-char mod-skin cap (trap 26).

Not verified by machine: nothing was run in a real browser or in the Discord
Activity - the visual placement of the hint line on a phone is by inspection of
the existing `html.arc-mobile` rules only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cbafJm7hrM8qf4Fr7Wj6r
