### PR TITLE
feat(arcademy): the Tardy Slip - reprice to 260, cap 2, stacked spend, Rake upsell

### DIFF
--- a/ConditioningControlPanel/Resources/web/arcademy/core/lexicon.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/core/lexicon.js
@@ -649,12 +649,12 @@ export const DEFAULT_LEXICON = Object.freeze({
    * translated string is a number a translator has to be trusted to keep.
    *
    * THE PASSIVE LINES ARE THE HONEST PART. There is exactly one consumable on
-   * this shelf and it has no press: a late slip is spent by the HOST, on the
+   * this shelf and it has no press: a tardy slip is spent by the HOST, on the
    * night you are not here, inside the attendance credit. So the row says so
    * rather than growing a button that would have nowhere to send you. */
   booth_holdings: 'What you are holding',
   booth_hold_none: 'Nothing in your pockets tonight. The shelf is through the window.',
-  booth_hold_late_slip: 'It spends itself the night you miss one. Nothing to press.',
+  booth_hold_late_slip: 'It files itself the night you miss one. Nothing to press.',
   booth_hold_passive: 'It spends itself the moment it is needed.',
   /* THE TWO SIGNS IN THE ALLEY (shell/alleysign.js). One pair, one alley: the
    * plate on the booth's right-hand wall points at RM 004 and the plate on the
@@ -687,7 +687,11 @@ export const DEFAULT_LEXICON = Object.freeze({
   /* the payout beat on the report card */
   payout_tickets: 'Tickets',
   payout_token_minted: 'A token dropped in the tray. That is your one for today.',
-  late_slip_used: 'A late slip covered you. Your streak never noticed.',
+  late_slip_used: 'A tardy slip was handed in for you. Your streak never noticed.',
+  /* THE ONE SMALL BUTTON under the jeopardy line (Deck V). `{name}` is filled
+   * from the catalog row's own name, so a mod that renames the slip renames
+   * the offer with it. */
+  rake_slip_offer: 'The counter sells a {name}.',
 
   /* ------------------------------------------------------------------------
    * THE LOCKER, RM 004 (the Locker wave, 2026-08-28).

--- a/ConditioningControlPanel/Resources/web/arcademy/emi/shop.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/emi/shop.js
@@ -124,7 +124,7 @@ export const SHOP_POOLS = Object.freeze({
     { t: "every grade gets a party now. even the c. especially the c.", face: '^_^' },
   ]),
   boughtLateSlip: bought('late_slip', [
-    { t: "a late slip. for emergencies. i won't tell the office.", face: '^_~', chain: 'wink' },
+    { t: "a tardy slip. for emergencies. i won't tell the office.", face: '^_~', chain: 'wink' },
     { t: "one free oops. keep it in the bag. don't spend it on a whim.", face: '0_0' },
     { t: "the slip! streak insurance. very grown up of you.", face: '(◠‿◠)' },
   ]),

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/exits.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/exits.js
@@ -175,6 +175,10 @@ export function exitBar(children, opts) {
  * @param {string} o.confirmLabel
  * @param {string} o.cancelLabel
  * @param {string=} o.note            an extra dim line under the buttons
+ * @param {Element=} o.noteAction     ONE small live node under that line (the
+ *                                   Tardy Slip offer). It is never a third
+ *                                   answer to the question and never takes
+ *                                   focus - `stay` still owns that.
  * @param {Function} o.onConfirm
  * @param {Function} o.onCancel
  * @returns {?Object} {root, close()} - null when there was nowhere to mount it
@@ -221,6 +225,7 @@ export function createConfirm(o) {
   actions.appendChild(go);
   card.appendChild(actions);
   if (s.note) card.appendChild(el('p', 'arc-note arc-confirm-note', s.note));
+  if (s.noteAction && s.noteAction.nodeType === 1) card.appendChild(s.noteAction);
 
   root.appendChild(card);
   s.mount.appendChild(root);

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/prizebooth.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/prizebooth.js
@@ -214,7 +214,7 @@ export const HOLD_GLYPH = '▤';
  * underneath for anything that arrives later without its own.
  */
 export const PASSIVE_LINES = Object.freeze({
-  late_slip: ['booth_hold_late_slip', 'It spends itself the night you miss one. Nothing to press.'],
+  late_slip: ['booth_hold_late_slip', 'It files itself the night you miss one. Nothing to press.'],
 });
 
 /** The floor under PASSIVE_LINES. */

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/shell.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/shell.js
@@ -2913,12 +2913,15 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
   }
 
   /** How many of a consumable may be held at once. Display only - the host is
-   *  the one that refuses the third late slip, with reason "full". */
+   *  the one that refuses an over-full stack, with reason "full". The fallback
+   *  is the Tardy Slip's own ceiling, because it is the only consumable on the
+   *  shelf and a row that reached here without a `max` is a host that predates
+   *  the field. */
   function stackMaxFor(sku) {
     const row = catalogRow(sku);
     if (!row || row.kind !== 'consumable') return 0;
     const n = Number(row.max);
-    return Number.isFinite(n) && n > 0 ? Math.floor(n) : 3;
+    return Number.isFinite(n) && n > 0 ? Math.floor(n) : 2;
   }
 
   /** Tonight's hot room, or null. Seeded per UTC day in C#; the page displays. */
@@ -3454,8 +3457,9 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
        * facts the shelf already reads, and not one of them is a proposal.
        *
        * NO `onUse`. Nothing on this shelf can be spent by hand: the one
-       * consumable, `late_slip`, is burned by the HOST inside the attendance
-       * credit (ArcademyEconomy.ConsumeLateSlip), so there is no press to wire
+       * consumable, `late_slip` (THE TARDY SLIP), is burned by the HOST inside
+       * the attendance credit (ArcademyEconomy.ConsumeLateSlips), so there is no
+       * press to wire
        * and the tray says so in words instead of growing a button that lies. */
       balance: () => walletBalance(),
       payday: () => economyPayday(),
@@ -4398,7 +4402,7 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
    *   - the numbers are unknown    -> say NOTHING (never invent jeopardy)
    * @returns {?string}
    */
-  function jeopardyLine() {
+  function streakFacts() {
     let s;
     try { s = store.streak(); } catch (e) { return null; }
     if (!s) return null;
@@ -4409,10 +4413,77 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
     if (!Number.isFinite(n) || n <= 0) return null;
     const credited = (s.lastLocalDate && String(s.lastLocalDate) === localDate)
       || (s.classesToday | 0) > 0;
-    const tpl = credited
+    return { n, credited };
+  }
+
+  function jeopardyLine() {
+    const f = streakFacts();
+    if (!f) return null;
+    const tpl = f.credited
       ? t('rake_streak_credited', 'Attendance x{n} is banked for today already.')
       : t('rake_streak_cold', 'Attendance x{n} goes cold if today ends here.');
-    return String(tpl).replace('{n}', String(n));
+    return String(tpl).replace('{n}', String(f.n));
+  }
+
+  /* ---------------- THE TARDY SLIP, OFFERED ONCE AND QUIETLY -------------
+   * House Book Deck V: the loss is disguised as a purchase. The jeopardy line
+   * above is the LOSS; this is the purchase, and it is ONE SMALL BUTTON that
+   * WALKS TO THE COUNTER. It never buys anything (the counter's echo law is
+   * the only thing that may move a wallet, trap 1), it never appears when a
+   * slip is already in the bag - the cover is bought, and saying so a second
+   * time is the nag Law VI forbids - never on a night the streak is already
+   * banked, never when the shutter is down, and never when the shelf does not
+   * stock the row at all. The line above it reads exactly the same whether the
+   * button is there or not, so nothing about the jeopardy changes to sell.
+   * -------------------------------------------------------------------- */
+
+  /** The wire id of the Tardy Slip. It is `late_slip` and it always will be:
+   *  the sku is a KEY (held inventory, the server catalog, EMI's bark pool),
+   *  and only the words on the shelf were ever rebranded. */
+  const SKU_TARDY_SLIP = 'late_slip';
+
+  /** How many slips are in the bag. A COUNT - the desk holds two. */
+  function slipsHeld() {
+    try {
+      const row = walletInv()[SKU_TARDY_SLIP];
+      const n = row && typeof row === 'object' ? Number(row.n) : 0;
+      return Number.isFinite(n) && n > 0 ? Math.floor(n) : 0;
+    } catch (e) { return 0; }
+  }
+
+  /** Does the offer stand right now? Five facts, and every one of them is the
+   *  host's own - the page invents no jeopardy and no stock. */
+  function slipOfferWanted() {
+    if (slipsHeld() > 0) return false;                  // already covered
+    if (counterClosed()) return false;                  // the shutter answers first
+    if (!catalogRow(SKU_TARDY_SLIP)) return false;      // the shelf does not stock it
+    const f = streakFacts();
+    return !!f && !f.credited;                          // only a COLD streak is jeopardy
+  }
+
+  /** OUT OF THE CLASS AND INTO RM 003. `teardownClass()` first because the
+   *  counter's own screen does not tear a live class down - only showBoard()
+   *  does - and a class left standing behind the shelf would keep its clock,
+   *  its listeners and its cameo. Then the booth, WITH its walk: the player
+   *  did cross the quad to get here, even if the quad never painted. */
+  function walkToCounter() {
+    say('tardy slip offer taken - walking to the counter');
+    try { teardownClass(); } catch (e) { /* noop */ }
+    showPrizeBooth({});
+  }
+
+  /** The one small button, or null when the offer does not stand. Mounting it
+   *  is the caller's business; it is never a second answer to the question the
+   *  card is asking, and it never holds focus. */
+  function slipOfferButton() {
+    if (!slipOfferWanted()) return null;
+    const name = t('prize_late_slip', 'Tardy Slip');
+    const label = String(t('rake_slip_offer', 'The counter sells a {name}.'))
+      .replace('{name}', name);
+    const b = el('button', 'btn ghost arc-slip-offer', label);
+    b.type = 'button';
+    b.addEventListener('click', () => walkToCounter());
+    return b;
   }
 
   /** Say the jeopardy on the way out. Never blocks, never delays, never asks. */
@@ -4813,6 +4884,8 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
       // What leaving actually costs, in the HOST's own attendance numbers.
       // Unknown numbers print nothing at all - never invent jeopardy.
       note: jeopardyLine(),
+      // ...and the counter's one small offer under it. Null nine nights in ten.
+      noteAction: slipOfferButton(),
       onConfirm: () => {
         // No toast on the way out: the card's own note has already said what
         // this costs, and saying it twice reads as a scold.
@@ -5973,6 +6046,11 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
         const jeopardy = jeopardyLine();
         if (jeopardy) {
           overlay.appendChild(el('p', 'arc-note arc-jeopardy', jeopardy));
+          /* ...and the ONE small button under it, when the streak is cold and
+           * the bag is empty. Under the line, below Resume/Options/Leave, so
+           * it can never be mistaken for the answer to "paused". */
+          const offer = slipOfferButton();
+          if (offer) overlay.appendChild(offer);
         }
         overlay.appendChild(el('p', 'arc-note', 'Hold Esc to leave the Arcademy.'));
         active.root.appendChild(overlay);
@@ -6519,11 +6597,11 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
           };
         }
       }
-      /* THE LATE SLIP. The host consumed one inside the attendance path, which
-       * is the one purchase a player never sees happen - so it is the one that
-       * has to be said out loud. */
+      /* THE TARDY SLIP. The host consumed one (or two) inside the attendance
+       * path, which is the one purchase a player never sees happen - so it is
+       * the one that has to be said out loud. */
       if (m.lateSlipUsed === true) {
-        try { shout(t('late_slip_used', 'A late slip covered you. Your streak never noticed.')); }
+        try { shout(t('late_slip_used', 'A tardy slip was handed in for you. Your streak never noticed.')); }
         catch (e) { /* a toast may never hold a door */ }
       }
       if (m.levelUp) shout('Level up');

--- a/ConditioningControlPanel/Resources/web/arcademy/styles.css
+++ b/ConditioningControlPanel/Resources/web/arcademy/styles.css
@@ -545,6 +545,18 @@ html.arc-reduced .arc-endcard-actions .arc-retake { animation:none; box-shadow:0
   padding-top:9px; margin-top:2px;
 }
 
+/* THE TARDY SLIP OFFER, under that line. SMALL by construction: the button it
+   must never out-shout is Resume (on the pause card) or Stay in class (on the
+   confirm), both of which are the lit primary above it. No bulbs, no pulse,
+   no fill - a shop sign, read once, at the size of the note it hangs off. */
+.arc-slip-offer {
+  margin-top:7px;
+  font-size:11px; letter-spacing:.05em;
+  padding:4px 10px; min-height:0;
+  opacity:.82;
+}
+.arc-slip-offer:hover, .arc-slip-offer:focus-visible { opacity:1; }
+
 /* ============================ THE TWO CURRENCIES =========================
    The ticket stub and the token, drawn once and worn by THREE surfaces: the
    campus wallet chip, the Prize Counter's shelf, and the report card's till.

--- a/ConditioningControlPanel/Services/Arcademy/ArcademyEconomy.cs
+++ b/ConditioningControlPanel/Services/Arcademy/ArcademyEconomy.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -29,7 +29,7 @@ namespace ConditioningControlPanel.Services.Arcademy;
 ///   "payDays":{ "yyyy-MM-dd": { "&lt;gameKey&gt;": 2 } },
 ///   "inv":{ "late_slip": { "n":2, "at":"yyyy-MM-dd" } },
 ///   "unlocks":{ "extra":false, "honors":false },
-///   "log":[ { "sku":"late_slip", "cur":"t", "cost":250, "at":"yyyy-MM-dd" } ] }
+///   "log":[ { "sku":"late_slip", "cur":"t", "cost":260, "at":"yyyy-MM-dd" } ] }
 /// </code>
 /// </summary>
 internal static class ArcademyEconomy
@@ -237,6 +237,12 @@ internal static class ArcademyEconomy
     public const string CurTokens = "k";
 
     public const string SkuLateSlip = "late_slip";
+
+    /// <summary>How many Tardy Slips the desk will hold — and therefore the longest absence one
+    /// can cover, because the attendance path spends exactly one per missed night. ONE number, read
+    /// by the catalog row's <c>StackMax</c>, by <see cref="ConsumeLateSlips"/> and by the attendance
+    /// credit, so "the counter sold me three and only two ever spend" can never happen.</summary>
+    public const int SlipStackMax = 2;
     public const string SkuHonorsLever = "honors_lever";
     public const string SkuFreeSwimKey = "free_swim_key";
     public const string SkuDeepEndWideBoard = "de_5x5";
@@ -267,11 +273,19 @@ internal static class ArcademyEconomy
             "prize_confetti_stamp", "Confetti Stamp",
             "prize_confetti_stamp_blurb",
             "Your stamp lands in a little burst of paper now, every single time it lands."),
-        new(SkuLateSlip, CurTickets, 250, "consumable",
-            "prize_late_slip", "Late Slip",
+        // THE TARDY SLIP (owner ruling 2026-09-04). Priced like a MID-TIER OUTFIT: the Locker
+        // hangs three at 180 / 260 / 340, so the middle rung is 260 and the slip sits exactly
+        // there — it costs what the cheer uniform costs, which is a good week of classes.
+        // Held TWO at a time, not three, because two is all the attendance path can ever spend
+        // (RecordAttendance covers at most two consecutive missed nights; a third breaks it).
+        // THE WIRE ID STAYS `late_slip`. It is a key, not a label: every slip already sitting in
+        // a player's `inv`, the server catalog's row, the mobile port and EMI's
+        // `shop.bought:late_slip` pool are all keyed on it. Only the words a player reads moved.
+        new(SkuLateSlip, CurTickets, 260, "consumable",
+            "prize_late_slip", "Tardy Slip",
             "prize_late_slip_blurb",
-            "Slide one across the desk and a single missed day never touches your streak.",
-            StackMax: 3),
+            "Hand one in and the night you missed is filed as excused. The desk will hold two for you.",
+            StackMax: SlipStackMax),
         new(SkuHonorsLever, CurTokens, 1, "unlock",
             "prize_honors_lever", "Honors Lever",
             "prize_honors_lever_blurb",
@@ -524,20 +538,29 @@ internal static class ArcademyEconomy
     }
 
     /// <summary>
-    /// SPEND A LATE SLIP. Called from the attendance path when the gap is exactly one missed day:
-    /// one slip comes off the stack and the streak carries on as though the player had been there.
+    /// SPEND TARDY SLIPS, one per missed night. Called from the attendance path with the number of
+    /// nights the player was away: the slips come off the stack together and the streak carries on
+    /// as though they had been there for every one of them.
+    ///
+    /// <para>ALL OR NOTHING, and that is the whole rule. Two missed nights with one slip in the bag
+    /// spends NOTHING and breaks the streak — half a cover is not a cover, and a slip burnt for a
+    /// streak that broke anyway is the worst trade the counter could make on the player's behalf.
+    /// <paramref name="nights"/> above <see cref="SlipStackMax"/> can never be covered, so a long
+    /// absence cannot be bought off by hoarding.</para>
     /// </summary>
-    /// <returns>True when a slip was actually spent.</returns>
-    public static bool ConsumeLateSlip(JObject w)
+    /// <param name="nights">How many nights were missed (1 or 2; anything else is refused).</param>
+    /// <returns>How many slips were actually spent — 0 when the streak is not covered.</returns>
+    public static int ConsumeLateSlips(JObject w, int nights)
     {
+        if (nights <= 0 || nights > SlipStackMax) return 0;
         var wallet = EnsureShape(w);
         var inv = (JObject)wallet["inv"]!;
-        if (inv[SkuLateSlip] is not JObject row) return false;
+        if (inv[SkuLateSlip] is not JObject row) return 0;
         var n = Math.Max((int?)row["n"] ?? 0, 0);
-        if (n <= 0) return false;
-        if (n == 1) inv.Remove(SkuLateSlip);
-        else row["n"] = n - 1;
-        return true;
+        if (n < nights) return 0;
+        if (n == nights) inv.Remove(SkuLateSlip);
+        else row["n"] = n - nights;
+        return nights;
     }
 
     /// <summary>The outcome of a <c>prize-buy</c>. <c>Reason</c> is one of unknown / poor / owned /
@@ -644,7 +667,8 @@ internal static class ArcademyEconomy
 
     /// <summary>Whole days from <paramref name="from"/> to <paramref name="to"/>, or -1 when either
     /// date is missing or unreadable. Same yyyy-MM-dd invariant shape the rest of the school uses.
-    /// A gap of 1 is an unbroken streak; a gap of 2 is the one a late slip can cover.</summary>
+    /// A gap of 1 is an unbroken streak; a gap of 2 or 3 is one or two missed nights, and that is
+    /// exactly the range a stack of Tardy Slips can cover (see <see cref="ConsumeLateSlips"/>).</summary>
     public static int DayGap(string? from, string? to)
     {
         if (string.IsNullOrWhiteSpace(from) || string.IsNullOrWhiteSpace(to)) return -1;

--- a/ConditioningControlPanel/Services/Arcademy/ArcademyHostService.cs
+++ b/ConditioningControlPanel/Services/Arcademy/ArcademyHostService.cs
@@ -1715,8 +1715,8 @@ internal static class ArcademyHostService
         ["prize_id_frame_navy_blurb"] = "Deep navy with a varsity edge, like the old team photos.",
         ["prize_confetti_stamp"] = "Confetti Stamp",
         ["prize_confetti_stamp_blurb"] = "Your stamp lands in a little burst of paper now, every time.",
-        ["prize_late_slip"] = "Late Slip",
-        ["prize_late_slip_blurb"] = "Slide one over and a single missed day never touches your streak.",
+        ["prize_late_slip"] = "Tardy Slip",
+        ["prize_late_slip_blurb"] = "Hand one in and the night you missed is filed as excused. Two on the desk, no more.",
         ["prize_honors_lever"] = "Honors Lever",
         ["prize_honors_lever_blurb"] = "Unbolts the third notch, which is where the S+ nights live.",
         ["prize_free_swim_key"] = "Free Swim Key",
@@ -1779,7 +1779,10 @@ internal static class ArcademyHostService
         ["free_swim_key_hint"] = "Your key opens this one for a practice run. Nothing counts, nothing costs.",
         ["payout_tickets"] = "Tickets",
         ["payout_token_minted"] = "A token dropped in the tray. That is your one for today.",
-        ["late_slip_used"] = "A late slip covered you. Your streak never noticed.",
+        ["late_slip_used"] = "A tardy slip was handed in for you. Your streak never noticed.",
+        // THE ONE SMALL BUTTON under the jeopardy line (Deck V, the Rake). `{name}` is filled
+        // from the catalog row itself, so a mod that renames the slip renames the offer too.
+        ["rake_slip_offer"] = "The counter sells a {name}.",
         // Reserved vocabulary: designed for, not built in v1 (GROUND-RULES §3).
         ["detention"] = "Detention",
         ["diploma"] = "Diploma",
@@ -3109,7 +3112,7 @@ internal static class ArcademyHostService
         // All four are well inside MergeModTable's 96-char skin cap (trap 26).
         ["booth_holdings"] = "What you are holding",
         ["booth_hold_none"] = "Nothing in your pockets tonight. The shelf is through the window.",
-        ["booth_hold_late_slip"] = "It spends itself the night you miss one. Nothing to press.",
+        ["booth_hold_late_slip"] = "It files itself the night you miss one. Nothing to press.",
         ["booth_hold_passive"] = "It spends itself the moment it is needed.",
         // The two wayfinding plates in the alley (shell/alleysign.js): the booth's
         // right-hand wall points at RM 004 and the Locker's left wall points back.
@@ -3645,8 +3648,11 @@ internal static class ArcademyHostService
             // running it unconditionally is what keeps a retake on a NEW local day (same UTC day,
             // player east of UTC) crediting the streak it has earned.
             var localDate = DateTime.Now.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
-            var (streak, perfect, classesToday, lateSlipUsed) =
-                _meta?.RecordAttendance(localDate, gameKey) ?? (0, 0, 0, false);
+            var (streak, perfect, classesToday, slipsSpent) =
+                _meta?.RecordAttendance(localDate, gameKey) ?? (0, 0, 0, 0);
+            // The page and the debrief only ever needed "did one cover me"; the COUNT is the
+            // server's business, because it holds the bag the slips come out of.
+            var lateSlipUsed = slipsSpent > 0;
 
             // ============================ THE TILL ============================
             // Tickets and tokens, wrapped on their own: the attendance credit above is the thing we
@@ -3659,7 +3665,7 @@ internal static class ArcademyHostService
             // MintCurrency runs here, in this order, exactly as it always has.
             var mintFrame = ArcademyWalletSyncService.DoorOpen
                 ? ArcademyWalletSyncService.BuildMintFrame(
-                    gameKey, grade, zen, streak, localDate, lever, lateSlipUsed, dayUtc)
+                    gameKey, grade, zen, streak, localDate, lever, slipsSpent, dayUtc)
                 : null;
             var till = mintFrame == null
                 ? MintCurrency(gameKey, grade, zen, streak, localDate, lever)

--- a/ConditioningControlPanel/Services/Arcademy/ArcademyMetaStore.cs
+++ b/ConditioningControlPanel/Services/Arcademy/ArcademyMetaStore.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -238,12 +238,16 @@ internal sealed class ArcademyMetaStore
     /// toward perfect attendance. A gap of exactly one day continues the streak, a larger gap
     /// restarts it at 1, and a day already credited leaves the streak alone.</para>
     /// </summary>
-    /// <para>THE LATE SLIP (economy, 2026-08-26). A gap of exactly two days is one missed day, and
-    /// a slip on the shelf covers it: the slip is spent, the streak carries on as though the player
-    /// had been there, and the caller is told so the debrief can say so. Nothing wider than one day
-    /// is coverable, and a player with no slips is exactly where they were before.</para>
-    /// <returns>(streak, perfectAttendance, classesToday, lateSlipUsed) after the write.</returns>
-    public (int Streak, int Perfect, int ClassesToday, bool LateSlipUsed) RecordAttendance(
+    /// <para>THE TARDY SLIP (economy 2026-08-26, STACKED 2026-09-04). A gap of N+1 days is N missed
+    /// nights, and the slips in the bag cover one night each: two slips carry a player over two
+    /// consecutive missed nights, a THIRD missed night breaks the streak exactly as it always did,
+    /// and nothing is spent unless the whole gap is covered (half a cover is not a cover — see
+    /// <see cref="ArcademyEconomy.ConsumeLateSlips"/>). The slip is spent HERE, automatically, with
+    /// nothing for the player to press, and the caller is told so the debrief can say so.</para>
+    /// <returns>(streak, perfectAttendance, classesToday, slipsSpent) after the write. The last is
+    /// a COUNT, not a flag: the server holds the authoritative bag and has to be told how many came
+    /// off it, and "a slip was used" is simply <c>&gt; 0</c>.</returns>
+    public (int Streak, int Perfect, int ClassesToday, int SlipsSpent) RecordAttendance(
         string localDate, string? gameKey)
     {
         lock (_lock)
@@ -251,18 +255,31 @@ internal sealed class ArcademyMetaStore
             var last = (string?)_state[AttendanceKey];
             int streak = (int?)_state[StreakKey] ?? 0;
             int perfect = (int?)_state[PerfectKey] ?? 0;
-            bool lateSlip = false;
+            int slipsSpent = 0;
 
             if (!string.Equals(last, localDate, StringComparison.Ordinal))
             {
+                // A gap of G days is G-1 missed nights. One slip per missed night, all or nothing,
+                // and never more than the desk will hold — so 2 covers two nights and a third
+                // night is the break it has always been. `spent` is 0 whenever the gap is not
+                // covered, which is the same "no" the no-slips player already got.
+                var gap = ArcademyEconomy.DayGap(last, localDate);
+                var missed = gap > 1 ? gap - 1 : 0;
+                int spent = 0;
+                if (!IsPreviousDay(last, localDate)
+                    && missed is > 0 and <= ArcademyEconomy.SlipStackMax)
+                {
+                    spent = ArcademyEconomy.ConsumeLateSlips(WalletUnlocked(), missed);
+                }
+
                 if (IsPreviousDay(last, localDate)) streak += 1;
-                else if (ArcademyEconomy.DayGap(last, localDate) == 2
-                         && ArcademyEconomy.ConsumeLateSlip(WalletUnlocked()))
+                else if (spent > 0)
                 {
                     streak += 1;
-                    lateSlip = true;
+                    slipsSpent = spent;
                     App.Logger?.Information(
-                        "ArcademyMetaStore: a late slip covered {Last} - streak carries on at {N}", last, streak);
+                        "ArcademyMetaStore: {Spent} tardy slip(s) covered {Missed} missed night(s) after {Last} - streak carries on at {N}",
+                        spent, missed, last, streak);
                 }
                 else streak = 1;
                 _state[AttendanceKey] = localDate;
@@ -289,7 +306,7 @@ internal sealed class ArcademyMetaStore
             }
 
             Touch();
-            return (streak, perfect, today.Count, lateSlip);
+            return (streak, perfect, today.Count, slipsSpent);
         }
     }
 

--- a/ConditioningControlPanel/Services/Arcademy/ArcademyWalletSyncService.cs
+++ b/ConditioningControlPanel/Services/Arcademy/ArcademyWalletSyncService.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -834,7 +834,7 @@ internal static class ArcademyWalletSyncService
     /// to reach UTC, so a player at UTC+2 sends -120.</para>
     /// </summary>
     public static JObject BuildMintFrame(string gameKey, string grade, bool zen, int streak,
-        string localDay, string lever, bool lateSlipUsed, string seed)
+        string localDay, string lever, int slipsSpent, string seed)
     {
         int tz;
         try { tz = -(int)Math.Round(TimeZoneInfo.Local.GetUtcOffset(DateTime.Now).TotalMinutes); }
@@ -849,7 +849,13 @@ internal static class ArcademyWalletSyncService
             ["localDay"] = localDay,
             ["tzOffsetMinutes"] = Math.Clamp(tz, -840, 840),
             ["streak"] = Math.Clamp(streak, 0, 3650),
-            ["lateSlipUsed"] = lateSlipUsed,
+            // TWO WORDS FOR ONE FACT, and both are sent on purpose. `lateSlipUsed` is the
+            // original boolean and a server that predates the stack still reads it; `lateSlipsUsed`
+            // is the COUNT, which is the only one that can say "two nights were covered". A server
+            // that honours the count ignores the flag; one that does not spends exactly one, which
+            // is what it would have done before the stack existed.
+            ["lateSlipUsed"] = slipsSpent > 0,
+            ["lateSlipsUsed"] = Math.Clamp(slipsSpent, 0, ArcademyEconomy.SlipStackMax),
             ["lever"] = lever,
             ["mintId"] = Guid.NewGuid().ToString("N"),
             ["seed"] = seed.Length <= 64 ? seed : seed[..64],

--- a/Tests/ConditioningControlPanel.Tests/ArcademyTardySlipTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/ArcademyTardySlipTests.cs
@@ -1,0 +1,225 @@
+using System.Linq;
+using ConditioningControlPanel.Services.Arcademy;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// THE TARDY SLIP (owner ruling 2026-09-04). The Prize Counter's one consumable, repriced to the
+/// middle rung of the Locker's three outfits, capped at two, and — this is the new part — SPENT IN
+/// A STACK: one slip per missed night, so two of them carry a streak over two consecutive missed
+/// nights and a third missed night breaks it exactly as it always did.
+///
+/// <para>Everything here runs for real. <see cref="ArcademyEconomy"/> is deliberately free of WPF
+/// and of <c>App</c>, so the whole till is exercisable without a window — which is the reason the
+/// money was put in that file in the first place. The attendance path itself
+/// (<c>ArcademyMetaStore.RecordAttendance</c>) needs a user-data folder and a dispatcher, so its
+/// half is covered by the gap arithmetic below plus a source tripwire.</para>
+/// </summary>
+public class ArcademyTardySlipTests
+{
+    private static CatalogItemView Slip()
+    {
+        var row = ArcademyEconomy.Catalog.Single(c => c.Sku == ArcademyEconomy.SkuLateSlip);
+        return new CatalogItemView(row.Cur, row.Cost, row.Kind, row.NameEn, row.StackMax);
+    }
+
+    private readonly record struct CatalogItemView(
+        string Cur, int Cost, string Kind, string NameEn, int StackMax);
+
+    private static JObject Purse(int tickets) => new() { ["t"] = tickets, ["k"] = 0 };
+
+    // =====================================================================================
+    //  the shelf
+    // =====================================================================================
+
+    [Fact]
+    public void SlipIsPricedAtTheMiddleLockerOutfit()
+    {
+        // The Locker hangs three outfits on tickets; the owner's ruling is "a mid-tier outfit",
+        // which is the MIDDLE of those three and nothing else. If a fourth outfit ever ships this
+        // test is the thing that notices the middle moved.
+        var outfits = ArcademyEconomy.Catalog
+            .Where(c => c.Sku.StartsWith("emi_") && c.Cur == ArcademyEconomy.CurTickets)
+            .Select(c => c.Cost)
+            .OrderBy(c => c)
+            .ToList();
+
+        Assert.Equal(3, outfits.Count);
+        var middle = outfits[outfits.Count / 2];
+
+        Assert.Equal(middle, Slip().Cost);
+        Assert.Equal(ArcademyEconomy.CurTickets, Slip().Cur);
+    }
+
+    [Fact]
+    public void SlipIsAConsumableCappedAtTwoAndNamedForThePlayer()
+    {
+        Assert.Equal("consumable", Slip().Kind);
+        Assert.Equal(2, ArcademyEconomy.SlipStackMax);
+        Assert.Equal(ArcademyEconomy.SlipStackMax, Slip().StackMax);
+        Assert.Equal("Tardy Slip", Slip().NameEn);
+    }
+
+    [Fact]
+    public void TheWireIdNeverMoves()
+    {
+        // The rebrand was words only. This id is a KEY: it is in every player's `inv`, in the
+        // server catalog, in the mobile port and in EMI's `shop.bought:late_slip` pool, and
+        // renaming it would silently orphan every slip anybody has already bought.
+        Assert.Equal("late_slip", ArcademyEconomy.SkuLateSlip);
+    }
+
+    [Fact]
+    public void TheShelfProjectsTheCapAsMax()
+    {
+        var row = ArcademyEconomy.CatalogJson()
+            .OfType<JObject>()
+            .Single(r => (string?)r["sku"] == ArcademyEconomy.SkuLateSlip);
+        Assert.Equal(ArcademyEconomy.SlipStackMax, (int?)row["max"]);
+    }
+
+    // =====================================================================================
+    //  the counter
+    // =====================================================================================
+
+    [Fact]
+    public void TwoSlipsFitAndTheThirdIsRefusedFull()
+    {
+        var w = Purse(Slip().Cost * 3);
+
+        Assert.True(ArcademyEconomy.Buy(w, ArcademyEconomy.SkuLateSlip, "2026-09-04").Ok);
+        Assert.True(ArcademyEconomy.Buy(w, ArcademyEconomy.SkuLateSlip, "2026-09-04").Ok);
+        Assert.Equal(2, ArcademyEconomy.Held(w, ArcademyEconomy.SkuLateSlip));
+
+        var third = ArcademyEconomy.Buy(w, ArcademyEconomy.SkuLateSlip, "2026-09-04");
+        Assert.False(third.Ok);
+        Assert.Equal("full", third.Reason);
+
+        // A refusal never leaves the wallet half-spent.
+        Assert.Equal(Slip().Cost, (int?)w["t"]);
+    }
+
+    [Fact]
+    public void AnEmptyPocketIsRefusedPoorAndCostsNothing()
+    {
+        var w = Purse(Slip().Cost - 1);
+        var r = ArcademyEconomy.Buy(w, ArcademyEconomy.SkuLateSlip, "2026-09-04");
+        Assert.False(r.Ok);
+        Assert.Equal("poor", r.Reason);
+        Assert.Equal(Slip().Cost - 1, (int?)w["t"]);
+        Assert.Equal(0, ArcademyEconomy.Held(w, ArcademyEconomy.SkuLateSlip));
+    }
+
+    // =====================================================================================
+    //  the spend
+    // =====================================================================================
+
+    [Fact]
+    public void OneNightSpendsOneSlip()
+    {
+        var w = Purse(Slip().Cost * 2);
+        ArcademyEconomy.Buy(w, ArcademyEconomy.SkuLateSlip, "2026-09-01");
+        ArcademyEconomy.Buy(w, ArcademyEconomy.SkuLateSlip, "2026-09-01");
+
+        Assert.Equal(1, ArcademyEconomy.ConsumeLateSlips(w, 1));
+        Assert.Equal(1, ArcademyEconomy.Held(w, ArcademyEconomy.SkuLateSlip));
+    }
+
+    [Fact]
+    public void TwoNightsSpendBothSlipsTogether()
+    {
+        var w = Purse(Slip().Cost * 2);
+        ArcademyEconomy.Buy(w, ArcademyEconomy.SkuLateSlip, "2026-09-01");
+        ArcademyEconomy.Buy(w, ArcademyEconomy.SkuLateSlip, "2026-09-01");
+
+        Assert.Equal(2, ArcademyEconomy.ConsumeLateSlips(w, 2));
+        Assert.Equal(0, ArcademyEconomy.Held(w, ArcademyEconomy.SkuLateSlip));
+        // The row goes away entirely rather than sitting at zero, so `inv` stays a bag of what
+        // is actually on the player.
+        Assert.False(((JObject)w["inv"]!).ContainsKey(ArcademyEconomy.SkuLateSlip));
+    }
+
+    [Fact]
+    public void HalfACoverIsNotACoverAndSpendsNothing()
+    {
+        var w = Purse(Slip().Cost);
+        ArcademyEconomy.Buy(w, ArcademyEconomy.SkuLateSlip, "2026-09-01");
+
+        // Two nights missed, one slip in the bag: the streak breaks and the slip is KEPT. Burning
+        // it for a streak that broke anyway is the worst trade the counter could make for them.
+        Assert.Equal(0, ArcademyEconomy.ConsumeLateSlips(w, 2));
+        Assert.Equal(1, ArcademyEconomy.Held(w, ArcademyEconomy.SkuLateSlip));
+    }
+
+    [Fact]
+    public void NothingWiderThanTheStackIsEverCoverable()
+    {
+        var w = Purse(Slip().Cost * 2);
+        ArcademyEconomy.Buy(w, ArcademyEconomy.SkuLateSlip, "2026-09-01");
+        ArcademyEconomy.Buy(w, ArcademyEconomy.SkuLateSlip, "2026-09-01");
+
+        Assert.Equal(0, ArcademyEconomy.ConsumeLateSlips(w, ArcademyEconomy.SlipStackMax + 1));
+        Assert.Equal(0, ArcademyEconomy.ConsumeLateSlips(w, 0));
+        Assert.Equal(0, ArcademyEconomy.ConsumeLateSlips(w, -1));
+        Assert.Equal(2, ArcademyEconomy.Held(w, ArcademyEconomy.SkuLateSlip));
+    }
+
+    [Fact]
+    public void AnEmptyBagSpendsNothingAndDoesNotThrow()
+    {
+        var w = Purse(0);
+        Assert.Equal(0, ArcademyEconomy.ConsumeLateSlips(w, 1));
+        Assert.Equal(0, ArcademyEconomy.ConsumeLateSlips(w, 2));
+    }
+
+    [Fact]
+    public void AGrandfatheredThreeStackStillSpends()
+    {
+        // Slips bought when the cap was three are still in the bag. The counter will not sell a
+        // fourth (or a third), but the attendance path must go on spending what is there.
+        var w = new JObject
+        {
+            ["t"] = 0,
+            ["inv"] = new JObject { [ArcademyEconomy.SkuLateSlip] = new JObject { ["n"] = 3 } },
+        };
+        Assert.Equal(2, ArcademyEconomy.ConsumeLateSlips(w, 2));
+        Assert.Equal(1, ArcademyEconomy.Held(w, ArcademyEconomy.SkuLateSlip));
+
+        var refused = ArcademyEconomy.Buy(Grandfathered(), ArcademyEconomy.SkuLateSlip, "2026-09-04");
+        Assert.False(refused.Ok);
+        Assert.Equal("full", refused.Reason);
+    }
+
+    private static JObject Grandfathered() => new()
+    {
+        ["t"] = 10000,
+        ["inv"] = new JObject { [ArcademyEconomy.SkuLateSlip] = new JObject { ["n"] = 3 } },
+    };
+
+    // =====================================================================================
+    //  the gap arithmetic the attendance path reads
+    // =====================================================================================
+
+    [Theory]
+    [InlineData("2026-09-01", "2026-09-02", 0)]   // no night missed - the streak just climbs
+    [InlineData("2026-09-01", "2026-09-03", 1)]   // one night, one slip
+    [InlineData("2026-09-01", "2026-09-04", 2)]   // two nights, both slips
+    [InlineData("2026-09-01", "2026-09-05", 3)]   // three nights - past the stack, it breaks
+    public void MissedNightsAreTheGapMinusOne(string last, string today, int expected)
+    {
+        var gap = ArcademyEconomy.DayGap(last, today);
+        var missed = gap > 1 ? gap - 1 : 0;
+        Assert.Equal(expected, missed);
+        Assert.Equal(expected > 0 && expected <= ArcademyEconomy.SlipStackMax,
+            missed > 0 && missed <= ArcademyEconomy.SlipStackMax);
+    }
+
+    [Fact]
+    public void AnUnreadableLastDateCoversNothing()
+    {
+        Assert.Equal(-1, ArcademyEconomy.DayGap(null, "2026-09-04"));
+        Assert.Equal(-1, ArcademyEconomy.DayGap("not-a-date", "2026-09-04"));
+    }
+}


### PR DESCRIPTION
## The Tardy Slip

The streak insurance already existed as the **Late Slip**: 250 tickets, cap 3, and it covered exactly **one** missed night. The owner's ruling repaints and re-rules it.

| | before | after |
|---|---|---|
| name | Late Slip | **Tardy Slip** |
| price | 250 tickets | **260 tickets** |
| hold | 3 | **2** |
| spends | 1 night, only when the gap was exactly 2 | **one per missed night**, up to the cap |
| upsell | none | one ghost button on the Rake's cold-streak card |

**Why 260.** The brief says "priced like a mid-tier outfit (look at the existing catalog prices for locker outfits and pick the middle)". The Locker hangs three outfits on tickets - `emi_labcoat` 180, `emi_cheer` 260, `emi_swim` 340 - so the middle is 260. A test asserts it stays the middle if a fourth outfit ever ships.

**Why the sku id does not change.** `late_slip` is a KEY, not a label. It is in every player's `inv`, in the server catalog `proxy/data/arcademy-catalog.json`, in the mobile port, and in EMI's `shop.bought:late_slip` bark pool. Renaming it would silently orphan every slip anybody has already bought. Only the display copy is rebranded; the lexicon keys (`prize_late_slip`, `late_slip_used`, `booth_hold_late_slip`) are frozen for the same reason - they are mod-reskin hooks.

### The stacked spend

`ArcademyEconomy.SlipStackMax = 2` is ONE number read by the catalog row's `StackMax`, by `ConsumeLateSlips` and by the attendance credit, so "the counter sold me three and only two ever spend" cannot happen.

A gap of G days is G-1 missed nights. The spend is **all or nothing**: if the bag cannot cover every missed night, nothing is spent and the streak breaks. Half a cover is not a cover, and burning a slip on a streak that breaks anyway is the worst trade the counter could make for the player.

Grandfathered 3-stacks (bought under the old cap) still spend normally; the counter simply answers `full` when they try to top up.

### The wire

The mint frame now carries **both** fields on purpose:

- `lateSlipUsed` (bool) - the original field. A server that predates the stack still reads it and spends exactly one, which is what it would have done before.
- `lateSlipsUsed` (int, 0..2) - the count. The only field that can say two nights were covered.

The matching server change is a separate PR in `CCP-Server` and **must deploy before this ships**, or a client buy 400s on the repriced SKU. Desktop is safe on its own (the local wallet is authority until the server answers).

### The Rake upsell

`shell.js`'s "Attendance x{n} goes cold if today ends here" line grows one small ghost button - "The counter sells a Tardy Slip." - that walks to the Prize Counter. It appears **only** when all four are true: the streak is genuinely cold, the player holds no slip, the counter is open, and the shelf actually stocks the row at this wave. House Book: the loss is disguised as a purchase. One button, no bulbs, no pulse, never focus-stealing, and it is not a third answer to the leave-class question.

### Tested

- `dotnet build` - 0 errors (344 pre-existing warnings).
- 17 new xUnit tests, all green: price is the middle outfit, kind/cap/name, the wire id is frozen, `max` reaches the wire, two fit and a third is `full`, a `poor` refusal costs nothing, 1-night and 2-night spends, half-a-cover spends nothing, over-cap/0/negative spend nothing, an empty bag does not throw, a grandfathered 3-stack still spends but cannot buy, and a gap -> missed-nights table.
- `node --check` on every touched JS file.

### Not tested

The attendance path itself (`ArcademyMetaStore.RecordAttendance`) needs a user-data folder and a dispatcher, so its arithmetic is covered by the gap table plus the economy tests rather than end to end. Nobody has played a real two-night absence against a running build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cbafJm7hrM8qf4Fr7Wj6r
