### PR TITLE
feat(emi-desk): EMI wears the outfit the Arcademy Locker armed

### DIFF
--- a/ConditioningControlPanel/Services/Arcademy/ArcademyHostService.cs
+++ b/ConditioningControlPanel/Services/Arcademy/ArcademyHostService.cs
@@ -565,6 +565,13 @@ internal static class ArcademyHostService
                 break;
             case "meta-command":
                 _meta?.Handle(o);
+                // THE LOCKER DRESSES THE DESKTOP TOO. Every equip the player makes is one of these
+                // (locker.js `metaSet(OUTFIT_KEY, ...)`), so this is where the desk hears about it
+                // without a poll and without the Arcademy having to close first. Read back through
+                // EquippedEmiOutfit, never off `o`: the store may have clamped or refused the write,
+                // and the wallet still has the last word on whether she may wear it.
+                if (string.Equals((string?)o["key"], EmiOutfitKey, StringComparison.Ordinal))
+                    PushEmiOutfitToDesk();
                 break;
             case "class-started":
                 _classActive = true;
@@ -899,6 +906,126 @@ internal static class ArcademyHostService
             App.Logger?.Debug("ArcademyHost.ReadOwnedSkus: {E}", ex.Message);
         }
         return owned;
+    }
+
+    // ============================ the Locker's outfit, read from outside ============================
+
+    /// <summary>The meta key the Locker arms EMI's outfit in (<c>OUTFIT_KEY</c>,
+    /// <c>Resources/web/arcademy/shell/locker.js</c>). Page-owned and free-form, like every other
+    /// non host-owned key in the blob.</summary>
+    public const string EmiOutfitKey = "lockerOutfit";
+
+    /// <summary>Which prize each garment is: the gate the Locker itself applies
+    /// (<c>OUTFIT_SKU</c>, locker.js) repeated verbatim so BOTH sides refuse the same thing.</summary>
+    private static readonly IReadOnlyDictionary<string, string> EmiOutfitSku =
+        new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["varsity"] = "emi_varsity",
+            ["labcoat"] = "emi_labcoat",
+            ["cheer"] = "emi_cheer",
+            ["swim"] = "emi_swim",
+        };
+
+    /// <summary>
+    /// WHAT IS EMI WEARING? The second door out of the Arcademy's state, and the one the EMI Desk
+    /// widget dresses off: the Locker arms an outfit on the campus, and the girl on the user's
+    /// desktop is the same girl, so she wears it there too (community ask, 2026-09-01).
+    ///
+    /// <para>Same two sources as <see cref="WalletOwnsSku"/> and for the same reason: the LIVE store
+    /// first, because while the Arcademy is open it is the only copy holding a pick made ten seconds
+    /// ago, and the persisted blob when it is closed (the store is minted at launch and dropped at
+    /// teardown, after a flush).</para>
+    ///
+    /// <para><b>Ownership is enforced HERE, not only page-side.</b> locker.js already clamps its own
+    /// read against the wallet (<c>readOutfit</c>), but that clamp lives in the same file that writes
+    /// the key, so a blob carrying a garment nobody bought - an older build, a hand-edited save, a
+    /// wallet that got rolled back by a sync - would dress her anyway. The desk asks the wallet
+    /// itself and answers null when the prize is not held.</para>
+    ///
+    /// <para>NEVER THROWS. Anything it cannot read, parse, recognise or verify is null, which is
+    /// "the standard art" - the sheet that has always been there.</para>
+    /// </summary>
+    /// <returns>An <see cref="EmiDesk.EmiChains.Outfits"/> name, or null for the standard art.</returns>
+    public static string? EquippedEmiOutfit()
+    {
+        try
+        {
+            var live = _meta;
+            var raw = live != null ? (string?)live.Get(EmiOutfitKey) : EmiOutfitOnDisk();
+
+            var name = EmiDesk.EmiChains.OutfitName(raw);
+            if (name == null) return null;
+
+            // Bought, or she is not wearing it. `varsity` has been gated since the restock and the
+            // other three got skus of their own in the same wave, so every name in the list has one.
+            if (!EmiOutfitSku.TryGetValue(name, out var sku)) return null;
+            if (!WalletOwnsSku(sku))
+            {
+                App.Logger?.Debug("ArcademyHost.EquippedEmiOutfit: '{Outfit}' is armed but {Sku} is not owned - standard art", name, sku);
+                return null;
+            }
+            return name;
+        }
+        catch (Exception ex)
+        {
+            App.Logger?.Debug("ArcademyHost.EquippedEmiOutfit: {E}", ex.Message);
+            return null;
+        }
+    }
+
+    private static readonly object _outfitDiskLock = new();
+    private static string? _outfitDiskValue;
+    private static long _outfitDiskStamp = -1L;   // -1 = never read; any write to the file moves it
+
+    /// <summary>The armed outfit out of the persisted blob, re-read only when the file's stamp
+    /// moves - the same cache shape as <see cref="WalletOwnsOnDisk"/>, so a desk that asks on every
+    /// summon costs one <c>FileInfo</c> and not one parse.</summary>
+    private static string? EmiOutfitOnDisk()
+    {
+        var path = Path.Combine(App.UserDataPath, "arcademy_meta.json");
+        long stamp;
+        try
+        {
+            var info = new FileInfo(path);
+            stamp = info.Exists ? (info.LastWriteTimeUtc.Ticks ^ info.Length) : 0L;
+        }
+        catch { stamp = 0L; }
+
+        lock (_outfitDiskLock)
+        {
+            if (_outfitDiskStamp != stamp)
+            {
+                _outfitDiskValue = ReadArmedOutfit(path);
+                _outfitDiskStamp = stamp;
+            }
+            return _outfitDiskValue;
+        }
+    }
+
+    private static string? ReadArmedOutfit(string path)
+    {
+        try
+        {
+            if (!File.Exists(path)) return null;
+            return (string?)JObject.Parse(File.ReadAllText(path))[EmiOutfitKey];
+        }
+        catch (Exception ex)
+        {
+            App.Logger?.Debug("ArcademyHost.ReadArmedOutfit: {E}", ex.Message);
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Tell the desk widget to re-read what the Locker armed. Cheap and safe from anywhere: it is a
+    /// no-op when she has never been summoned (the window is built on the first summon and lives
+    /// until the app closes), and the window itself re-reads on the way in, so this is only ever the
+    /// LIVE half - the swap that lands while she is already out.
+    /// </summary>
+    private static void PushEmiOutfitToDesk()
+    {
+        try { App.EmiDesk?.Window?.RefreshOutfit(); }
+        catch (Exception ex) { App.Logger?.Debug("ArcademyHost.PushEmiOutfitToDesk: {E}", ex.Message); }
     }
 
     /// <summary>
@@ -5764,6 +5891,12 @@ internal static class ArcademyHostService
             int emiMinutes = Math.Max(0, (int)(DateTime.UtcNow - _emiOpenedUtc).TotalMinutes);
             _emiOpenedUtc = DateTime.MinValue;
             try { App.EmiDesk?.Fire("arcademyClosed", new { minutes = emiMinutes }); } catch { }
+
+            // ...and she comes home in whatever the Locker put her in. The live hook on
+            // `meta-command` has normally already done this; this is the backstop for the session
+            // that changed an outfit and never sent the message we expected (a page error, a
+            // watchdog kill), so at worst the swap lands one Arcademy visit late instead of never.
+            PushEmiOutfitToDesk();
         }
 
         try

--- a/ConditioningControlPanel/Services/EmiDesk/EmiChains.cs
+++ b/ConditioningControlPanel/Services/EmiDesk/EmiChains.cs
@@ -237,14 +237,35 @@ public static class EmiChains
     /// Absolute path to a pose PNG next to the exe, or null when the art is missing. The art lives
     /// under <c>Resources/web/arcademy/art/emi/</c> and ships as Content (see the csproj's
     /// <c>Resources\web\**\*</c> glob), so it is beside the binary at runtime.
+    ///
+    /// <para><b>Outfit-aware, and that is not decoration.</b> A garment is TWO sheets - a re-drawn
+    /// body and the <c>over-</c> part that crosses her glass - so painting only the overlay would
+    /// hang a lab coat's collar on a girl still in her school shirt. Hand this the outfit and it
+    /// resolves <c>&lt;outfit&gt;/body-idle.png</c> instead: the same contract <see cref="OverPath"/>
+    /// uses one folder down, and the same one the campus's <c>outfitSrc</c> uses.</para>
+    ///
+    /// <para><b>Per FRAME it falls back rather than blanks.</b> A sheet missing one pose wears the
+    /// standard art for that pose only - a mixed look beats an invisible click target - and one
+    /// Debug line says which frame fell back.</para>
     /// </summary>
-    public static string? BodyPath(string? frame)
+    public static string? BodyPath(string? frame, string? outfit = null)
     {
         try
         {
             var key = FrameKey(frame) ?? "idle";
-            var path = Path.Combine(AppContext.BaseDirectory,
-                "Resources", "web", "arcademy", "art", "emi", BodyFrameFile[key]);
+            var file = BodyFrameFile[key];
+            var root = Path.Combine(AppContext.BaseDirectory, "Resources", "web", "arcademy", "art", "emi");
+
+            var dir = OutfitName(outfit);
+            if (dir != null)
+            {
+                var dressed = Path.Combine(root, dir, file);
+                if (File.Exists(dressed)) return dressed;
+                Log.Debug("[EmiDesk] outfit {Outfit} has no body art for {Pose}; wearing the standard sheet",
+                    dir, key);
+            }
+
+            var path = Path.Combine(root, file);
             return File.Exists(path) ? path : null;
         }
         catch (Exception ex)
@@ -254,25 +275,41 @@ public static class EmiChains
         }
     }
 
+    /// <summary>
+    /// The outfit name when it is one of ours, else null - the one gate every road into the
+    /// wardrobe passes. Junk, an unknown name and anything carrying a path separator all answer
+    /// null, which reads as "the standard art", so nothing downstream can be talked into opening a
+    /// folder the campus never shipped.
+    /// </summary>
+    public static string? OutfitName(string? outfit)
+    {
+        if (string.IsNullOrWhiteSpace(outfit)) return null;
+        var name = outfit.Trim();
+        if (name.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0) return null;
+        foreach (var o in Outfits)
+            if (string.Equals(o, name, StringComparison.Ordinal)) return o;
+        return null;
+    }
+
     // ------------------------------------------------------- the outfit overlay
 
     /// <summary>
     /// THE WARDROBE SHEETS THAT EXIST AS ART, and the whole of what the desk knows about outfits.
     ///
-    /// <para><b>The desk wears none of them today.</b> Nothing in <c>Services/EmiDesk/</c> or
-    /// <c>Windows/EmiDesk/</c> picks an outfit, prices one, unlocks one or draws one: the desk
-    /// paints the standard ten-pose set and nothing else. These four names are the campus's
-    /// (<c>OUTFITS</c> in <c>Resources/web/arcademy/emi/widget.js</c>), written down here so that
-    /// the day a sheet does reach the desk it resolves through the SAME contract the web already
-    /// uses rather than through a second one invented on the spot. Do not read a wardrobe, a
-    /// picker or a purchase into this list; there is none on this side.</para>
+    /// <para><b>The desk wears the one the Locker armed.</b> These four names are the campus's
+    /// (<c>OUTFITS</c> in <c>Resources/web/arcademy/emi/widget.js</c>) and the desk resolves them
+    /// through the SAME contract the web does rather than a second one invented on this side. There
+    /// is still no picker, no price and no purchase here: the Arcademy's Locker is the only place a
+    /// garment is chosen or owned, it writes the pick to the <c>lockerOutfit</c> meta key, and
+    /// <c>ArcademyHostService.EquippedEmiOutfit</c> is the door the desk reads it back through -
+    /// clamped against the wallet, so an outfit nobody bought is answered null here too.</para>
     ///
-    /// <para><b>The ART, however, is already here.</b> The desk renders out of the campus's own
-    /// <c>Resources/web/arcademy/art/emi/</c> tree, which ships as Content, so all four sheets -
-    /// and the ten <c>swim/over-body-*.png</c> overlay frames - are sitting beside the exe right
-    /// now. <see cref="OverPath"/> finds them, which is why this layer is a real guarantee and not
-    /// a placeholder: hand <c>EmiDeskWindow.SetOutfit</c> the name "swim" and the goggles go up,
-    /// over her face, where they belong.</para>
+    /// <para><b>The ART is already beside the exe.</b> The desk renders out of the campus's own
+    /// <c>Resources/web/arcademy/art/emi/</c> tree, which ships as Content, so all four sheets - ten
+    /// body frames AND ten <c>over-body-*.png</c> frames each - are on disk right now.
+    /// <see cref="BodyPath"/> finds the body, <see cref="OverPath"/> finds the part that rides over
+    /// her face, and between them a name like "swim" is a whole outfit rather than a pair of
+    /// goggles floating on her school shirt.</para>
     /// </summary>
     public static readonly IReadOnlyList<string> Outfits = new[] { "varsity", "labcoat", "cheer", "swim" };
 
@@ -284,10 +321,11 @@ public static class EmiChains
     /// file is the same 859x869 canvas, transparent everywhere except the prop, and it is what THE
     /// SKIN LAW above lays back over her face.
     ///
-    /// <para><b>It is optional and it is silent.</b> Most sheets have no overlay and never will
-    /// (on the web only <c>swim</c> ships one, for the goggles). A missing file is not an error:
-    /// <see cref="OverPath"/> answers null, the layer stays collapsed, and the caller is expected
-    /// to ask ONCE per outfit and cache the verdict for the sitting - never per frame.</para>
+    /// <para><b>It is optional and it is silent.</b> All four sheets in the tree today ship a full
+    /// set of ten overlay frames, but a sheet is allowed to arrive without one and a missing file is
+    /// not an error: <see cref="OverPath"/> answers null, the layer stays collapsed, and the caller
+    /// is expected to ask ONCE per outfit and cache the verdict for the sitting - never per
+    /// frame.</para>
     /// </summary>
     public static string OverFileName(string? frame)
     {
@@ -295,8 +333,9 @@ public static class EmiChains
         return "over-" + BodyFrameFile[key];
     }
 
-    /// <summary>Where a wardrobe sheet lives: one folder down from the standard art.</summary>
-    public static string OutfitDir(string? outfit) => outfit ?? string.Empty;
+    /// <summary>Where a wardrobe sheet lives: one folder down from the standard art, and only for a
+    /// name that is one of ours. Empty string means "the standard art".</summary>
+    public static string OutfitDir(string? outfit) => OutfitName(outfit) ?? string.Empty;
 
     /// <summary>
     /// Absolute path to a garment's OVERLAY frame - the art that rides over her face - or null when
@@ -310,9 +349,8 @@ public static class EmiChains
     {
         try
         {
-            if (string.IsNullOrWhiteSpace(outfit)) return null;
             var dir = OutfitDir(outfit);
-            if (dir.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0) return null;
+            if (dir.Length == 0) return null;
             var path = Path.Combine(AppContext.BaseDirectory,
                 "Resources", "web", "arcademy", "art", "emi", dir, OverFileName(frame));
             return File.Exists(path) ? path : null;

--- a/ConditioningControlPanel/Services/EmiDesk/EmiDeskService.cs
+++ b/ConditioningControlPanel/Services/EmiDesk/EmiDeskService.cs
@@ -304,6 +304,12 @@ public sealed class EmiDeskService : IDisposable
             }
 
             win.RestorePlacement();
+            // What did the Locker put her in? Asked on every way in rather than only when the
+            // Arcademy pushes a change, because the window outlives a dismiss: she can be sent away,
+            // re-dressed at the campus and called back, and a push is one message this side does not
+            // get to be sure of. Cached against the save file's stamp, so a summon that changes
+            // nothing costs one FileInfo.
+            win.RefreshOutfit();
             win.Show();
             win.RunSummon();
 

--- a/ConditioningControlPanel/Windows/EmiDesk/EmiDeskWindow.xaml.cs
+++ b/ConditioningControlPanel/Windows/EmiDesk/EmiDeskWindow.xaml.cs
@@ -206,17 +206,27 @@ public partial class EmiDeskWindow : Window
     // ---------------------------------------------------------------- state
 
     private readonly EmiChains.Player _player;
+
+    // ONE OUTFIT'S TEN FRAMES, never four outfits' forty. Each pose PNG decodes to ~3 MB of pixels,
+    // so a cache that kept every sheet she has ever worn would be a hundred-megabyte souvenir of a
+    // wardrobe she is not in. Both caches are dropped whole in `SetOutfit` - see the note there.
     private readonly Dictionary<string, ImageSource> _bodyCache = new(StringComparer.Ordinal);
 
-    // THE OUTFIT OVERLAY (THE SKIN LAW; see the block in EmiChains.cs). `_outfit` is null on every
-    // road today - nothing on the desk picks a garment - so all of this rests at zero cost.
-    // `_overArmed` is the ONE probe per outfit: null means "not asked yet", and once it is a bool
-    // the answer is final for the sitting, so a sheet without an overlay costs one File.Exists and
-    // never touches the disk again however many times she sways.
+    // THE OUTFIT OVERLAY (THE SKIN LAW; see the block in EmiChains.cs). `_outfit` is the garment the
+    // Arcademy's Locker armed, read through `ArcademyHostService.EquippedEmiOutfit` and null for the
+    // standard art, which is still the ordinary case - so all of this rests at zero cost for a
+    // player who has never bought a sheet. `_overArmed` is the ONE probe per outfit: absent means
+    // "not asked yet", and once it is a bool the answer is final for the sitting, so a sheet without
+    // an overlay costs one File.Exists and never touches the disk again however many times she sways.
     private readonly Dictionary<string, ImageSource> _overCache = new(StringComparer.Ordinal);
     private readonly Dictionary<string, bool> _overArmed = new(StringComparer.Ordinal);
     private string? _outfit;
     private string? _overPose;
+
+    /// <summary>The outfit the bitmap currently in <c>BodyImage</c> was resolved for. It exists so
+    /// <see cref="SetPose"/>'s "that pose is already up" early-out cannot swallow a WARDROBE change
+    /// on the same pose - which is every outfit swap, because she is nearly always at idle.</summary>
+    private string? _bodySkin;
 
     private DispatcherTimer? _idleTimer;
     private DispatcherTimer? _swayTimer;
@@ -344,6 +354,9 @@ public partial class EmiDeskWindow : Window
         catch { _bodyWidth = 220; }
 
         ApplyBodyWidth(_bodyWidth);
+        // Dressed BEFORE her first pose is painted, so the very first frame she is ever built with
+        // is already the sheet the Locker armed - she never flashes the standard art first.
+        RefreshOutfit();
         SetPose("idle");
         DrawFace(EmiChains.RestFace);
 
@@ -808,11 +821,12 @@ public partial class EmiDeskWindow : Window
         try
         {
             var key = EmiChains.FrameKey(frame) ?? "idle";
-            if (key == _pose && BodyImage.Source != null) return;
+            if (key == _pose && BodyImage.Source != null
+                && string.Equals(_bodySkin, _outfit, StringComparison.Ordinal)) return;
             _pose = key;
             if (!_bodyCache.TryGetValue(key, out var img))
             {
-                var path = EmiChains.BodyPath(key);
+                var path = EmiChains.BodyPath(key, _outfit);
                 if (path == null)
                 {
                     // Art is allowed to arrive after the code does: keep whatever is up rather than
@@ -830,6 +844,7 @@ public partial class EmiDeskWindow : Window
                 _bodyCache[key] = img;
             }
             BodyImage.Source = img;
+            _bodySkin = _outfit;
             PaintOutfitOver();
         }
         catch (Exception ex)
@@ -839,38 +854,76 @@ public partial class EmiDeskWindow : Window
     }
 
     /// <summary>
-    /// The garment she is wearing, or null for the standard art. Null on every road today: nothing
-    /// on the desk chooses an outfit yet (see <see cref="EmiChains.Outfits"/>).
+    /// The garment she is wearing, or null for the standard art. Whatever the Arcademy's Locker
+    /// last armed and the wallet still backs (see <see cref="RefreshOutfit"/>).
     /// </summary>
     public string? Outfit => _outfit;
 
     /// <summary>
-    /// Put a wardrobe sheet's OVERLAY on her, or take it off with null. THE SKIN LAW's one seam.
+    /// Dress her in a wardrobe sheet, or take it off with null. THE SKIN LAW's one seam.
     ///
-    /// <para>This is the neutral setter the campus calls <c>setOutfit</c>. It is deliberately not
-    /// wired to anything: the desk has no outfit picker, no wardrobe and no outfit BODY sheets, and
-    /// this method invents none of them. What it guarantees is that when a sheet does arrive, the
-    /// part of it that crosses her glass resolves through
-    /// <see cref="EmiChains.OverPath"/> and lands in <c>OutfitOverImage</c> - which the XAML
-    /// authors ABOVE the face and the glass, so the garment is on top and stays there.</para>
+    /// <para>This is the neutral setter the campus calls <c>setOutfit</c>, and it moves BOTH halves
+    /// of a garment, because a garment is two sheets: the re-drawn body
+    /// (<see cref="EmiChains.BodyPath"/>, repainted below) and the part that crosses her glass
+    /// (<see cref="EmiChains.OverPath"/>, which lands in <c>OutfitOverImage</c> - authored by the
+    /// XAML ABOVE the face and the glass, so the garment is on top and stays there). Painting only
+    /// the second is how you get a collar floating on a girl in her school shirt.</para>
+    ///
+    /// <para><b>Both caches go with it.</b> They are keyed by POSE, not by outfit-and-pose, and that
+    /// is on purpose: ten frames at ~3 MB of decoded pixels each is the price of the sheet she is
+    /// actually wearing, and keeping the other three sheets warm for a swap that happens once a week
+    /// would be forty. Dropping them is what makes the swap free of leaks; re-decoding ten PNGs is
+    /// what it costs, once, on a change nobody makes twice a minute.</para>
     ///
     /// <para>Silent about missing art, exactly like the web: an outfit with no overlay sheet asks
-    /// once, is answered once, and leaves one collapsed Image behind.</para>
+    /// once, is answered once, and leaves one collapsed Image behind; a body frame the sheet does
+    /// not have falls back to the standard one for that pose.</para>
     /// </summary>
     /// <param name="outfit">A name from <see cref="EmiChains.Outfits"/>, or null for standard.</param>
     public void SetOutfit(string? outfit)
     {
         try
         {
-            var want = string.IsNullOrWhiteSpace(outfit) ? null : outfit!.Trim();
+            var want = EmiChains.OutfitName(outfit);
             if (string.Equals(want, _outfit, StringComparison.Ordinal)) return;
+            Log.Information("[EmiDesk] outfit -> {Outfit}", want ?? "standard");
             _outfit = want;
             _overPose = null;
-            PaintOutfitOver();
+            _bodyCache.Clear();
+            _overCache.Clear();
+            SetPose(_pose);      // the body first: _bodySkin no longer matches, so this repaints
+            PaintOutfitOver();   // ...and again for the sheet whose body art was missing entirely
         }
         catch (Exception ex)
         {
             Log.Debug(ex, "[EmiDesk] SetOutfit failed for {Outfit}", outfit);
+        }
+    }
+
+    /// <summary>
+    /// ASK THE LOCKER WHAT SHE IS WEARING and put it on. The desk's whole road into the wardrobe:
+    /// the Arcademy owns the picking, the prices and the ownership, and this side owns nothing but
+    /// the painting (community ask, 2026-09-01).
+    ///
+    /// <para>Called on the way in (every summon, and once when the widget is built) and pushed live
+    /// by <c>ArcademyHostService</c> the moment the Locker writes the key, so an equip made with her
+    /// on screen lands without a restart. A no-op when the answer has not changed, which is nearly
+    /// always - so the summon path costs one cached file-stamp check.</para>
+    /// </summary>
+    public void RefreshOutfit()
+    {
+        try
+        {
+            if (!Dispatcher.CheckAccess())
+            {
+                Dispatcher.BeginInvoke(new Action(RefreshOutfit));
+                return;
+            }
+            SetOutfit(Services.Arcademy.ArcademyHostService.EquippedEmiOutfit());
+        }
+        catch (Exception ex)
+        {
+            Log.Debug(ex, "[EmiDesk] RefreshOutfit failed");
         }
     }
 

--- a/Tests/ConditioningControlPanel.Tests/EmiDeskLayerOrderTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/EmiDeskLayerOrderTests.cs
@@ -107,8 +107,11 @@ public class EmiDeskLayerOrderTests
             var over = (Image)w.FindName("OutfitOverImage")!;
             var body = (Image)w.FindName("BodyImage")!;
 
-            // Nothing on the desk chooses an outfit yet: she must come up wearing no overlay, with
-            // no Source decoded and nothing on screen.
+            // Undressed is the resting state, and it costs nothing: no overlay, no Source decoded,
+            // nothing on screen. Set explicitly rather than assumed, because the widget now asks the
+            // Arcademy what the Locker armed when it is built, and the machine running this suite is
+            // allowed to have a save file with a garment in it.
+            w.SetOutfit(null);
             Assert.Null(w.Outfit);
             Assert.Equal(Visibility.Collapsed, over.Visibility);
             Assert.Null(over.Source);
@@ -131,8 +134,9 @@ public class EmiDeskLayerOrderTests
         // This used to say "three of the four have no overlay art and never will". They do now:
         // the campus side of THE SKIN LAW drew the missing 30 sheets, so the outfit with no art
         // is no longer one of hers - it is a name the art tree has never heard of. The seam must
-        // still take that quietly: no throw, no blank Image over her face, and the widget still
-        // reports what it was asked to wear.
+        // still take that quietly: no throw, no blank Image over her face, and - since the desk
+        // started dressing off the Locker's meta key - no folder read either. A name that is not
+        // one of the four is REFUSED at the gate and reads back as the standard art.
         foreach (var frame in EmiChains.BodyFrameFile.Keys)
             Assert.Null(EmiChains.OverPath("no-such-outfit", frame));
 
@@ -141,7 +145,7 @@ public class EmiDeskLayerOrderTests
             var over = (Image)w.FindName("OutfitOverImage")!;
 
             w.SetOutfit("no-such-outfit");
-            Assert.Equal("no-such-outfit", w.Outfit);
+            Assert.Null(w.Outfit);
             Assert.Equal(Visibility.Collapsed, over.Visibility);
             Assert.Null(over.Source);
 

--- a/Tests/ConditioningControlPanel.Tests/EmiLockerOutfitTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/EmiLockerOutfitTests.cs
@@ -1,0 +1,168 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Windows.Controls;
+using System.Windows.Media.Imaging;
+using ConditioningControlPanel.Services.EmiDesk;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// THE LOCKER DRESSES THE DESKTOP.
+///
+/// <para><b>The ask.</b> A member asked on 2026-09-01 why the outfit they bought and armed in the
+/// Arcademy's Locker was not on the EMI who lives on their desktop. It was not, because the seam
+/// had no callers: <c>SetOutfit</c> painted the overlay only, nothing read the meta key, and
+/// <c>BodyPath</c> took no outfit at all - so the best that could have happened was a lab coat's
+/// collar floating over her school shirt.</para>
+///
+/// <para><b>What is pinned here.</b> Three things, and they are the three that were missing:
+/// the BODY resolves per outfit (with a per-frame fall back to the standard sheet, never a blank),
+/// a swap actually repaints the body she is already standing in - the pose is unchanged across a
+/// wardrobe change, so the "that pose is already up" early-out is exactly where this feature dies
+/// if nobody is watching - and the wiring that carries the pick from the campus to the widget
+/// exists on both roads (every summon, and live while she is on screen).</para>
+/// </summary>
+[Collection(CompanionWpfRenderCollection.Name)]
+public class EmiLockerOutfitTests
+{
+    private static string RepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir != null && !Directory.Exists(Path.Combine(dir.FullName, "ConditioningControlPanel", "Resources")))
+            dir = dir.Parent;
+        Assert.True(dir != null, "could not locate the repo root from " + AppContext.BaseDirectory);
+        return dir!.FullName;
+    }
+
+    private static string Read(params string[] parts) =>
+        File.ReadAllText(Path.Combine(RepoRoot(), "ConditioningControlPanel", Path.Combine(parts)));
+
+    [Fact]
+    public void Every_shipped_outfit_has_a_whole_body_sheet_beside_the_exe()
+    {
+        // A garment is TWO sheets and the overlay half was already pinned next door. This is the
+        // other half: lose one body PNG from any of the four and that pose silently falls back to
+        // the standard art mid-wardrobe, which reads as a costume change between blinks.
+        foreach (var outfit in EmiChains.Outfits)
+            foreach (var frame in EmiChains.BodyFrameFile.Keys)
+            {
+                var path = EmiChains.BodyPath(frame, outfit);
+                Assert.NotNull(path);
+                Assert.Equal(Path.Combine(outfit, EmiChains.BodyFrameFile[frame]),
+                    Path.Combine(Path.GetFileName(Path.GetDirectoryName(path)!), Path.GetFileName(path)));
+            }
+    }
+
+    [Fact]
+    public void An_outfit_the_tree_never_heard_of_wears_the_standard_art()
+    {
+        // NEVER A BLANK. The overlay is allowed to answer null (there is no standard overlay); the
+        // body is not, because a null body is an invisible click target sitting on the desktop.
+        foreach (var name in new string?[] { null, "", "   ", "no-such-outfit", "../../escape", "swim/../.." })
+        {
+            var path = EmiChains.BodyPath("idle", name);
+            Assert.NotNull(path);
+            Assert.Equal(EmiChains.BodyPath("idle"), path);
+        }
+
+        // ...and the gate every road passes agrees about which names are real.
+        Assert.Null(EmiChains.OutfitName("no-such-outfit"));
+        Assert.Null(EmiChains.OutfitName("../../escape"));
+        Assert.Null(EmiChains.OutfitName(null));
+        Assert.Equal("swim", EmiChains.OutfitName(" swim "));
+        foreach (var outfit in EmiChains.Outfits) Assert.Equal(outfit, EmiChains.OutfitName(outfit));
+    }
+
+    [Fact]
+    public void A_wardrobe_change_repaints_the_body_she_is_already_standing_in()
+    {
+        WpfRenderHarness.OnStaThread(() =>
+        {
+            EmiDeskWindow? w = null;
+            try
+            {
+                w = new EmiDeskWindow();
+                var body = (Image)w.FindName("BodyImage")!;
+                var over = (Image)w.FindName("OutfitOverImage")!;
+
+                w.SetOutfit(null);
+                w.SetPose("idle");
+                var plain = body.Source as BitmapImage;
+                Assert.NotNull(plain);
+
+                // THE REGRESSION THIS TEST EXISTS FOR: the pose does not change when the outfit
+                // does - she is nearly always at idle - so a body repaint keyed on the pose alone
+                // swallows the whole feature and leaves the overlay hanging on the standard sheet.
+                w.SetOutfit("labcoat");
+                Assert.Equal("labcoat", w.Outfit);
+                Assert.NotNull(body.Source);
+                Assert.NotSame(plain, body.Source);
+                Assert.NotNull(over.Source);
+
+                // A second sheet is a second body, not just a second overlay.
+                var coat = body.Source;
+                w.SetOutfit("swim");
+                Assert.NotSame(coat, body.Source);
+
+                // And taking it off puts the standard art back, on the same pose.
+                w.SetOutfit(null);
+                Assert.Null(w.Outfit);
+                Assert.Equal(plain!.UriSource, (body.Source as BitmapImage)?.UriSource);
+                Assert.Null(over.Source);
+            }
+            finally
+            {
+                try { w?.Close(); } catch (Exception ex) { Assert.Fail("widget teardown threw: " + ex); }
+            }
+        });
+    }
+
+    [Fact]
+    public void The_desk_and_the_locker_gate_the_same_four_prizes()
+    {
+        // TWO CLAMPS, ONE LIST. locker.js refuses to arm an outfit whose sku is not in the wallet,
+        // and ArcademyHostService refuses to hand one to the desk for the same reason - because the
+        // page's clamp lives in the file that writes the key, so a blob carrying a garment nobody
+        // bought would otherwise dress her anyway. If the two maps drift, one of the clamps is
+        // guarding a prize that does not exist.
+        var locker = Read("Resources", "web", "arcademy", "shell", "locker.js");
+        var host = Read("Services", "Arcademy", "ArcademyHostService.cs");
+
+        foreach (var outfit in EmiChains.Outfits)
+        {
+            var sku = "emi_" + outfit;
+            Assert.Contains(outfit + ": '" + sku + "'", locker);
+            Assert.Contains("[\"" + outfit + "\"] = \"" + sku + "\"", host);
+        }
+
+        // The key itself, spelled the same on both sides of the bridge.
+        Assert.Contains("OUTFIT_KEY = 'lockerOutfit'", locker);
+        Assert.Contains("EmiOutfitKey = \"lockerOutfit\"", host);
+    }
+
+    [Fact]
+    public void The_pick_reaches_the_widget_on_both_roads()
+    {
+        // The seam used to exist with ZERO callers, which is the whole reason the feature was
+        // missing rather than broken. Both roads are asserted so a refactor cannot quietly take one
+        // away: the SUMMON re-reads (she outlives a dismiss and can be re-dressed while away), and
+        // the meta-command hook pushes LIVE (an equip made with her on screen must land without a
+        // restart).
+        var summon = Read("Services", "EmiDesk", "EmiDeskService.cs");
+        Assert.Contains("win.RefreshOutfit();", summon);
+
+        var host = Read("Services", "Arcademy", "ArcademyHostService.cs");
+        Assert.Contains("PushEmiOutfitToDesk();", host);
+        Assert.Contains("App.EmiDesk?.Window?.RefreshOutfit()", host);
+
+        // ...and the widget dresses itself before its first pose is painted, so she is never built
+        // wearing the standard art and then swapped a frame later.
+        var win = Read("Windows", "EmiDesk", "EmiDeskWindow.xaml.cs");
+        var iRefresh = win.IndexOf("RefreshOutfit();\n        SetPose(\"idle\");", StringComparison.Ordinal);
+        Assert.True(iRefresh > 0 || win.Contains("RefreshOutfit();\r\n        SetPose(\"idle\");"),
+            "the constructor must RefreshOutfit() immediately before its first SetPose(\"idle\")");
+    }
+}


### PR DESCRIPTION
## What

The EMI Desk widget now wears the outfit the player armed in the Arcademy's Locker. Four sheets, all four already in the tree: varsity, lab coat, cheer, swim.

## Why

A member asked on Sept 1 why the outfit they had bought and equipped on campus was not on the EMI living on their desktop, and the answer was "on it" on Sept 2. It was not there because the seam had no callers: `EmiDeskWindow.SetOutfit` was documented as "deliberately not wired to anything", `_outfit` was null on every road, and `EmiChains.BodyPath` took no outfit argument at all - so even wired up, the most it could have produced was a lab coat's collar floating over the standard body.

## How it reaches her

1. `EmiChains.BodyPath(frame, outfit)` resolves `<outfit>/body-<pose>.png` - the same naming contract `OverPath` uses one folder down and the same one the campus's `outfitSrc` uses. A frame a sheet does not have falls back to the standard art **for that frame only**, with one Debug line. Never null while the standard art exists: a blank body is an invisible click target sitting on someone's desktop.
2. `ArcademyHostService.EquippedEmiOutfit()` reads the `lockerOutfit` meta key (`OUTFIT_KEY`, `locker.js`) the same two ways `WalletOwnsSku` already reads the wallet: the **live store** while a class is on (the only copy holding a pick made ten seconds ago) and the **persisted blob** when the school is shut, cached against the file's stamp so a per-summon caller cannot turn a cosmetic into a disk read.
3. `EmiDeskWindow.RefreshOutfit()` is called on **every summon**, once when the widget is built (before its first pose is painted, so she never flashes the standard art first), and **live** from the `meta-command` hook the moment the Locker writes the key - so an equip made with her on screen lands without a restart. A `PushEmiOutfitToDesk()` on the Arcademy's teardown funnel is the backstop for a session whose message never arrived.

## Ownership

Enforced **on the C# side too**, not only page-side. `locker.js` already clamps its own read against the wallet (`readOutfit`), but that clamp lives in the same file that writes the key - so a blob carrying a garment nobody bought (an older build, a hand-edited save, a wallet rolled back by a sync) would have dressed her anyway. `EquippedEmiOutfit` maps the name to its sku (`emi_varsity` / `emi_labcoat` / `emi_cheer` / `emi_swim`, the same map `OUTFIT_SKU` uses) and asks `WalletOwnsSku`; an unowned prize answers null, which is the standard art. A name that is not one of the four is refused at the gate (`EmiChains.OutfitName`) and never becomes a folder read.

## THE SKIN LAW

Untouched. The garment's `over-` sheet still paints above the face and the glass, `EmiDeskLayerOrderTests` still pins the child order, and the body half is now pinned the same way. One `over-` sheet per OUTFIT, never per pose.

XP and the economy are untouched: nothing here spends, earns or unlocks anything.

## Bitmap caches

Both caches are dropped whole on an outfit change. They are keyed by POSE, not by outfit-and-pose, on purpose: ten frames at ~3 MB of decoded pixels is the price of the sheet she is actually wearing, and keeping the other three warm for a swap that happens once a week would be forty. A new `_bodySkin` field stops `SetPose`'s "that pose is already up" early-out from swallowing the change - she is nearly always at idle, so that early-out is exactly where this feature would have died unnoticed.

## Test evidence

- **Full suite green: 5174 passed, 0 failed.**
- New `EmiLockerOutfitTests` (5 facts): every shipped outfit resolves a whole 10-frame body sheet beside the exe; junk / unknown / traversal names wear the standard art rather than blanking; **a wardrobe change repaints the body she is already standing in** (the early-out regression, on a real realized WPF tree with real PNGs decoding); the desk's sku map and `locker.js`'s `OUTFIT_SKU` do not drift; the pick reaches the widget on both roads.
- Two existing facts in `EmiDeskLayerOrderTests` updated: they encoded "nothing on the desk chooses an outfit yet", which is no longer true, and one of them assumed the machine running the suite has no garment in its save.
- **Runtime, on a real build:** launched the Debug build, summoned her from the dock chip. The save on this machine has `lockerOutfit: "swim"` with `emi_swim` in the wallet, and she came up **in the swim sheet** - goggles up over her face (the SKIN LAW holding), DEEP END board, swim shoes - with `[EmiDesk] outfit -> swim` in the log and no fallback or error lines. Screenshot: `Pictures/Screenshots/emi-desk-swim-crop.png`.

## Not verified at runtime

The **live** push (equipping a different outfit with the Arcademy open and her on screen) was not exercised - that would have meant opening the campus and writing to this machine's real save. It is unit-pinned on both ends (the hook exists, `RefreshOutfit` is dispatcher-safe and idempotent) but nobody has watched the swap happen mid-session. The per-frame fallback path was likewise never taken at runtime, because all four sheets are complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cbafJm7hrM8qf4Fr7Wj6r
