### PR TITLE
feat(arcademy): the slip, part 3 - the button, the tick and the print beat

### DIFF
--- a/ConditioningControlPanel/Resources/web/arcademy/core/lexicon.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/core/lexicon.js
@@ -79,6 +79,15 @@ export const DEFAULT_LEXICON = Object.freeze({
   replay_board: 'Flip the board again',
   share: 'Copy share card',
   shared: 'Copied to clipboard',
+
+  /* the SLIP (shell/sharecard.js): the night drawn as a paper report card.
+   * The image itself is deliberately unskinnable - its header and its class
+   * names are the neutral English ones, so a paste never names your mod - but
+   * the BUTTONS around it are ordinary chrome and a mod may re-voice them. */
+  share_image: 'Share report card',
+  share_add_name: 'Add my name',
+  share_saved: 'Report card saved',
+  share_unavailable: 'Sharing is not available here',
   done: 'Done',
   xp: 'XP',
   streak: 'Streak',

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/reportcard.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/reportcard.js
@@ -8,18 +8,33 @@
  *
  * SHARE, v1 (DECISIONS #6, SYNTHESIS #5): exactly one renderer, and exactly one
  * payload shape reaches it - Daily Trigger's spoiler-free emoji grid, copied to
- * the clipboard as TEXT. No canvas, no image export, no URL. Every other game's
- * `share` payload is IGNORED with one log line (once per session, not once per
- * class - a shell that logs 60 times a day is a shell nobody reads).
+ * the clipboard as TEXT. Every other game's `share` payload is IGNORED with one
+ * log line (once per session, not once per class - a shell that logs 60 times a
+ * day is a shell nobody reads).
+ *
+ * SHARE v2, THE SLIP (community ask, 2026-09-02 - "grades posted somewhere,
+ * maybe in image format"): a SECOND delivery of the SAME night, beside the text
+ * one and never in place of it. The whole report - the day's classes with their
+ * grades, the attendance meter, the seal when it was earned - drawn onto a
+ * canvas as a paper slip by `shell/sharecard.js` and handed over as a PNG. v1's
+ * text share is untouched down to the byte: `SHARE_ALLOWED` and
+ * `buildShareText` emit exactly what they always emitted, because two players
+ * comparing grids across a year of pastes is a contract.
  *
  * The share header is deliberately MOD-ANONYMOUS: the literal string "The
  * Arcademy", not t('arcademy'). A skinned header would out the player's mod in a
- * Discord paste, which is the one thing a share card must never do.
+ * Discord paste, which is the one thing a share card must never do. The IMAGE
+ * obeys the same law twice over - the crest is the school's own art, and every
+ * class on it is lettered from sharecard.js's neutral table rather than from a
+ * `game_<key>` row. It is also ANONYMOUS BY DEFAULT: your name and student
+ * number reach the slip only when you have ticked the box beside the button,
+ * and that tick is remembered in the meta bag so it sticks.
  * ==========================================================================*/
 
 import { t, gradeLabel, tierLabel } from '../core/lexicon.js';
 import { gradeKey } from '../core/grades.js';
 import { exitBar, sign as signExit, campusPillRow } from './exits.js';
+import { canRenderCard, renderShareCard } from './sharepaint.js';
 
 /** Mod-anonymous, name-only, no URL. Do not "improve" this. */
 export const SHARE_HEADER = 'The Arcademy';
@@ -27,6 +42,8 @@ export const SHARE_HEADER = 'The Arcademy';
 export const SHARE_ALLOWED = Object.freeze(['daily_trigger']);
 /** Mod-anonymous display names for share text only (never for the UI). */
 const SHARE_NAMES = Object.freeze({ daily_trigger: 'Daily Trigger' });
+/** The meta key the "add my name" tick lives under. Page-owned. */
+export const SHARE_NAME_KEY = 'shareNamed';
 
 let ignoredShareLogged = false;
 
@@ -134,6 +151,94 @@ async function copyText(text) {
 }
 
 /* ----------------------------------------------------------------------------
+ * SHARE IMAGE - THE SLIP
+ * -------------------------------------------------------------------------- */
+
+/** Reduced motion, either signal - the shell's own class or the OS preference. */
+function reducedMotion() {
+  try {
+    const root = (typeof document !== 'undefined') && document.documentElement;
+    if (root && root.classList && typeof root.classList.contains === 'function'
+      && root.classList.contains('arc-reduced')) return true;
+  } catch (e) { /* noop */ }
+  try {
+    if (typeof window !== 'undefined' && typeof window.matchMedia === 'function') {
+      const m = window.matchMedia('(prefers-reduced-motion: reduce)');
+      if (m && m.matches) return true;
+    }
+  } catch (e) { /* noop */ }
+  return false;
+}
+
+/** The file name the slip is saved under. Mod-anonymous, like everything else. */
+export function shareFileName(dateLabel) {
+  const d = String(dateLabel || '').replace(/[^0-9A-Za-z-]/g, '') || 'today';
+  return 'arcademy-report-' + d + '.png';
+}
+
+/**
+ * DELIVERY, RUNG 1: hand the player the file.
+ *
+ * A `blob:` url on an `<a download>`, clicked once and revoked. This is the
+ * LAST fallback in the finished ladder and the only one in this wave, and it is
+ * also the one that a host can refuse outright: the Discord Activity iframe
+ * sandbox drops navigations it did not initiate, so the click can be a silent
+ * no-op. There is no event for that refusal, which is why the ladder above this
+ * one exists at all - and why a host that has NEITHER is told so out loud
+ * rather than left looking like it worked.
+ *
+ * @returns {boolean} whether the browser accepted the attempt
+ */
+export function deliverDownload(blob, fileName) {
+  let url = null;
+  try {
+    if (!blob || typeof document === 'undefined') return false;
+    const U = (typeof URL !== 'undefined') ? URL : null;
+    if (!U || typeof U.createObjectURL !== 'function') return false;
+    const a = document.createElement('a');
+    /* `download` on an anchor is the feature test AND the verb: a host that
+     * does not implement it simply never has the property. */
+    if (!('download' in a)) return false;
+    url = U.createObjectURL(blob);
+    a.href = url;
+    a.download = String(fileName || 'report.png');
+    a.rel = 'noopener';
+    a.style.position = 'fixed';
+    a.style.opacity = '0';
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    return true;
+  } catch (e) {
+    return false;
+  } finally {
+    /* revoked on the next turn - revoking inside the same tick has raced the
+     * download in every browser this school runs on */
+    if (url && typeof setTimeout === 'function') {
+      setTimeout(() => { try { URL.revokeObjectURL(url); } catch (e2) { /* noop */ } }, 4000);
+    }
+  }
+}
+
+/**
+ * THE PRINT BEAT. Pressing Share is a committed action, so the button does not
+ * simply go grey - a slip of paper slides out from under it while the canvas
+ * draws, and one `paper` cue rides the same frame (Law X: sound and sight land
+ * together). Under reduced motion the slip is still MINTED and still says the
+ * same thing, it just fades in place, which is the House Book's own
+ * "<=120ms opacity change" collapse rather than a beat that vanishes.
+ */
+function printBeat(host, reduced) {
+  try {
+    if (!host || typeof document === 'undefined') return () => {};
+    const slip = el('span', 'arc-shareslip' + (reduced ? ' still' : ''));
+    slip.setAttribute('aria-hidden', 'true');
+    host.appendChild(slip);
+    return () => { try { slip.remove(); } catch (e) { /* noop */ } };
+  } catch (e) { return () => {}; }
+}
+
+/* ----------------------------------------------------------------------------
  * THE CARD
  * -------------------------------------------------------------------------- */
 /**
@@ -156,14 +261,41 @@ async function copyText(text) {
  *                                 counter to walk to - the shell owns the
  *                                 catalog, the shutter and the walk, and this
  *                                 is one callback out.
+ * @param {Function=} o.identity   () -> {name, number} - who the player is, for
+ *                                 the ONE case they asked to be named on the
+ *                                 slip. Absent, or answering null, and the
+ *                                 "add my name" tick is not even drawn: a
+ *                                 checkbox that cannot do anything is worse
+ *                                 than no checkbox.
+ * @param {Object=} o.shareNamed   {get(), set(v)} over the page-owned meta key
+ *                                 SHARE_NAME_KEY. Absent = the tick still
+ *                                 works for this sitting and forgets after it,
+ *                                 which is the honest degradation for a
+ *                                 preference with nowhere to live.
  */
-export function createReportCard({ ceremonies, seep, toast, log, onCounter } = {}) {
+export function createReportCard({
+  ceremonies, seep, toast, log, onCounter, identity, shareNamed,
+} = {}) {
   const say = typeof log === 'function' ? log : () => {};
   const shout = typeof toast === 'function' ? toast : () => {};
   /* THE ONE DOOR THIS CARD OFFERS BESIDES 'done'. Captured once, asked at
    * render: a card built without it is not a card with a dead button on it,
    * it is the card that has no button at all (see the chip below). */
   const toCounter = typeof onCounter === 'function' ? onCounter : null;
+  /* WHO YOU ARE, AND WHETHER YOU SAID SO. Both are captured once and asked at
+   * render, the same discipline `onCounter` above set. Neither is ever read
+   * unless the player has ticked the box - `readIdentity()` is not called on
+   * the anonymous path at all, so a card that nobody named never so much as
+   * looks up a display name. */
+  const readIdentity = typeof identity === 'function' ? identity : null;
+  const namedGet = (shareNamed && typeof shareNamed.get === 'function') ? shareNamed.get : null;
+  const namedSet = (shareNamed && typeof shareNamed.set === 'function') ? shareNamed.set : null;
+  let namedLocal = false;    // the sitting's answer when there is nowhere to save one
+  const isNamed = () => (namedGet ? namedGet() === true : namedLocal);
+  const setNamed = (v) => {
+    namedLocal = !!v;
+    if (namedSet) { try { namedSet(!!v); } catch (e) { say('share name pref failed to save'); } }
+  };
   // The report is a fullscreen beat now (shell marks <html> arc-report-on):
   // the stage is the night ground under a desk lamp, and everything the card
   // used to box sits on one graded PAPER laid on it. Same DOM order, same
@@ -520,6 +652,84 @@ export function createReportCard({ ceremonies, seep, toast, log, onCounter } = {
         box.appendChild(el('pre', 'arc-sharepreview', text));
         put(box);
       }
+    }
+
+    /* --- THE SLIP: the same night, as a picture ---------------------------
+     * Offered on EVERY night, not only a Daily Trigger one - the text grid is
+     * one game's spoiler-free puzzle and this is the whole report card, so the
+     * two answer different asks. Drawn only where a canvas exists: the headless
+     * DOM double the suites drive answers `canRenderCard()` false and this
+     * whole block is skipped, which is why the suites can still build a report.
+     */
+    if (canRenderCard()) {
+      const imgBox = el('div', 'arc-sharebox arc-shareimg');
+      const shareBtn = el('button', 'btn', t('share_image', 'Share report card'));
+      shareBtn.type = 'button';
+      imgBox.appendChild(shareBtn);
+
+      /* THE TICK. Anonymous is the default and the default is not a nag: the
+       * box is drawn unticked, it is remembered once ticked, and it is not
+       * drawn at all when there is no identity to print. */
+      let nameBox = null;
+      if (readIdentity) {
+        const lbl = el('label', 'arc-sharename');
+        nameBox = el('input');
+        try {
+          nameBox.type = 'checkbox';
+          nameBox.checked = isNamed();
+        } catch (e) { /* the node double carries neither */ }
+        if (typeof nameBox.addEventListener === 'function') {
+          nameBox.addEventListener('change', () => { setNamed(nameBox.checked === true); });
+        }
+        lbl.appendChild(nameBox);
+        lbl.appendChild(el('span', null, t('share_add_name', 'Add my name')));
+        imgBox.appendChild(lbl);
+      }
+
+      let busy = false;
+      shareBtn.addEventListener('click', () => {
+        if (busy) return;
+        busy = true;
+        setBusy(shareBtn, true);
+        const reduced = reducedMotion();
+        const endBeat = printBeat(imgBox, reduced);
+        sfx('paper', 0.4);
+        const dateLabel = s.dateLabel || (s.timetable && s.timetable.dateSeed) || '';
+        const ident = (nameBox && nameBox.checked === true && readIdentity)
+          ? (() => { try { return readIdentity(); } catch (e) { return null; } })()
+          : null;
+        renderShareCard({
+          dateLabel,
+          classes: classes.map((c) => ({
+            gameKey: c.gameKey,
+            grade: results[c.gameKey] ? results[c.gameKey].grade : null,
+          })),
+          streak: streak.count | 0,
+          perfect: !!s.perfect,
+          identity: ident,
+        }).then((out) => {
+          endBeat();
+          setBusy(shareBtn, false);
+          busy = false;
+          if (!out || !out.blob) {
+            shout(t('share_unavailable', 'Sharing is not available here'));
+            say('share image: the canvas would not export');
+            return;
+          }
+          const ok = deliverDownload(out.blob, shareFileName(dateLabel));
+          shout(ok
+            ? t('share_saved', 'Report card saved')
+            : t('share_unavailable', 'Sharing is not available here'));
+          if (!ok) say('share image: this host refuses downloads');
+        }).catch((e) => {
+          endBeat();
+          setBusy(shareBtn, false);
+          busy = false;
+          shout(t('share_unavailable', 'Sharing is not available here'));
+          say('share image threw: ' + ((e && e.message) || e));
+        });
+      });
+      put(imgBox);
     }
 
     /* --- out ---

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/shell.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/shell.js
@@ -99,7 +99,7 @@ import { installPaCaption } from './pacaption.js';
  * the `music` bus through the same door the beds use. The shell tells it where
  * the player is (campus, records, a class) and clearScreen tells it they left. */
 import { createOst } from './ost.js';
-import { createIdSpotlight, idReducedMotion } from './idcard.js';
+import { createIdSpotlight, idReducedMotion, studentNumber } from './idcard.js';
 import { createAccountChip, readAccount } from './accountchip.js';
 import { createAnnexReveal } from './annexreveal.js';
 /* THE SEEP - the foreshadowing layer. ONE director, and the shell's whole
@@ -1290,6 +1290,20 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
   } : null;
   reportCard = createReportCard({
     ceremonies, seep, toast: shout, log: say, onCounter: counterFromReport,
+    /* THE SLIP's two seams. `identity` is only ever CALLED when the player has
+     * ticked the box - the card is anonymous by default and the report card
+     * never reads a name it was not asked for - and `shareNamed` is where that
+     * tick lives. It is a page-owned meta key (it is not in HOST_OWNED_KEYS),
+     * so store.set write-throughs are legal and the tick survives the night. */
+    identity: () => {
+      const p = idProfile();
+      const num = studentNumber(p.selfId, p.enrolled, p.name);
+      return { name: p.name, number: num && num.no };
+    },
+    shareNamed: {
+      get: () => store.get('shareNamed', false) === true,
+      set: (v) => store.set('shareNamed', v === true),
+    },
   });
 
   /* ---------------------- helpers --------------------------------------- */

--- a/ConditioningControlPanel/Resources/web/arcademy/styles.css
+++ b/ConditioningControlPanel/Resources/web/arcademy/styles.css
@@ -362,6 +362,43 @@ kbd {
   padding:10px 12px; color:var(--ink-dim); overflow-x:auto; max-width:100%;
 }
 
+/* ---- the SLIP (shell/sharecard.js): the night drawn as a paper report card ----
+   The row is its own line under the text share, because the two are different
+   verbs and a player should never mash the wrong one. `position:relative` is
+   load-bearing: the print beat's paper is absolutely placed against this box. */
+.arc-shareimg { position:relative; margin-top:10px; }
+.arc-sharename {
+  display:inline-flex; align-items:center; gap:8px;
+  font-size:13px; color:var(--ink-dim); cursor:pointer; user-select:none;
+}
+.arc-sharename input { accent-color:var(--pink); width:15px; height:15px; cursor:pointer; }
+.arc-sharename:hover { color:var(--ink); }
+
+/* THE PRINT BEAT. A slip slides out from under the button while the canvas
+   draws. It is decoration only - aria-hidden, no text, and the toast is what
+   actually reports the outcome. */
+.arc-shareslip {
+  position:absolute; left:10px; top:calc(100% - 6px);
+  width:64px; height:84px; pointer-events:none; z-index:1;
+  border-radius:2px 2px 4px 4px;
+  background:linear-gradient(180deg, #F2EBDD 0%, #E4DAC6 100%);
+  box-shadow:0 6px 16px rgba(0,0,0,.35);
+  transform-origin:50% 0%;
+  animation:arc-shareprint 900ms cubic-bezier(.25,.9,.3,1) infinite;
+}
+@keyframes arc-shareprint {
+  0%   { transform:translateY(-84px) scaleY(.2); opacity:0; }
+  45%  { transform:translateY(0) scaleY(1); opacity:1; }
+  100% { transform:translateY(0) scaleY(1); opacity:.55; }
+}
+/* Law VI, the reduced-motion collapse: the paper is still minted and still
+   says the same thing, it just arrives instead of sliding. */
+.arc-shareslip.still { animation:arc-sharefade 120ms linear both; }
+@keyframes arc-sharefade { from { opacity:0; } to { opacity:.85; } }
+@media (prefers-reduced-motion: reduce) {
+  .arc-shareslip { animation:arc-sharefade 120ms linear both; }
+}
+
 /* ---- the fullscreen report beat (shell marks <html> arc-report-on) ----
    The stage is the night ground under a desk lamp; the report itself is a
    graded PAPER laid on it. Base .reportcard/.rcell/.grade rules above still

--- a/ConditioningControlPanel/Services/Arcademy/ArcademyHostService.cs
+++ b/ConditioningControlPanel/Services/Arcademy/ArcademyHostService.cs
@@ -1812,6 +1812,12 @@ internal static class ArcademyHostService
         ["replay_board"] = "Flip the board again",
         ["share"] = "Copy share card",
         ["shared"] = "Copied to clipboard",
+        // The SLIP (shell/sharecard.js). The drawn card is unskinnable on purpose - a
+        // paste must never name the player's mod - but its chrome is ordinary chrome.
+        ["share_image"] = "Share report card",
+        ["share_add_name"] = "Add my name",
+        ["share_saved"] = "Report card saved",
+        ["share_unavailable"] = "Sharing is not available here",
         ["done"] = "Done",
         ["retake"] = "Retake",
         ["xp"] = "XP",


### PR DESCRIPTION
Stacked on #791, which is stacked on #790. **Review in that order; do not merge ahead of the stack.**

## What

Hangs the drawn card off the report screen, and gives it the first rung of its delivery ladder.

- **Share report card.** Pressing it is a committed action, so it *prints*: a slip of paper slides out from under the button while the canvas draws, with one `paper` cue on the same frame (Law X - sound within 50ms of the sight). Under reduced motion the slip is still minted and still says the same thing, it just fades in over 120ms - the House Book's own collapse, not a beat that disappears (Law VI).
- **Add my name.** A small tick beside the button. Unticked by default, because the card is anonymous by default and the default is not a nag. Ticked, the slip carries your display name and the student number off the ID card. The tick is remembered in the meta bag under `shareNamed`.
- **Delivery.** A blob url on an `<a download>`, feature-tested through `'download' in a`, clicked once, revoked on the next turn.

The text share is **untouched**: same `SHARE_ALLOWED`, same `buildShareText`, same bytes on the clipboard. Two players comparing emoji grids across a year of pastes is a contract. The image is a second delivery of the same night, on its own row under the first.

## Anonymity, at the seam

`identity()` is a callback the shell hands in, and `reportcard.js` **does not call it on the anonymous path at all** - a card nobody named never so much as looks up a display name. `shareNamed` is a page-owned meta key (deliberately not in `HOST_OWNED_KEYS`), so the `store.set` write-through is legal and the tick survives the night.

## Delivery matrix - what this PR does and does not do

| Host | This PR | The wave after |
|------|---------|----------------|
| Desktop WebView2 | download | `navigator.clipboard.write` + a `share-image` host bridge onto the Windows clipboard |
| Desktop / laptop browser | download | clipboard `ClipboardItem` (Safari needs the promise form) |
| Phone | download | `navigator.share({files})` behind `navigator.canShare` |
| Discord Activity iframe | download **may silently no-op** - the sandbox drops navigations it did not initiate, and there is no event for that refusal | detect and say so |

That last row is why the honest-failure path exists now rather than later: a host that refuses is **told to the player** - "Sharing is not available here" - instead of left looking like it worked.

## Lexicon

Four rows: `share_image`, `share_add_name`, `share_saved`, `share_unavailable`, in `core/lexicon.js` **and** mirrored into `NeutralLexicon` in `Services/Arcademy/ArcademyHostService.cs`, so a mod can re-voice the chrome. The drawn card itself stays unskinnable - that is the point of the whole stack.

## Test evidence

- `node --check` clean on all four touched JS files.
- Node suite (the DOM double): **92 passed, 0 failed**. `canRenderCard()` returns false in the double, so the whole share row is skipped there and the report card builds exactly as before.
- `dotnet build`: **0 errors** (344 pre-existing warnings, unchanged).
- Rendered in headless Edge: `C:\Users\PC\Pictures\Screenshots\arcademy-sharecard-slip.png`

**Exercised for real:** the render, the export, the size budget, the seeded determinism, the anonymiser, the C# build.
**Not exercised:** the actual `<a download>` click on WebView2, on a phone, or inside the Activity iframe - all three need the app or a device in hand. The failure path is written to be honest about that rather than optimistic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cbafJm7hrM8qf4Fr7Wj6r



_Re-raised: #792 merged into its stack branch `feat/fold-share-paint` instead of main (the retarget call failed on GitHub's side). This PR carries only the wire commits on top of the already-merged paint._
