### PR TITLE
feat(arcademy): Back Room D1 - chips shape, casino bridge, cage adoption

### DIFF
--- a/ConditioningControlPanel/Services/Arcademy/ArcademyEconomy.cs
+++ b/ConditioningControlPanel/Services/Arcademy/ArcademyEconomy.cs
@@ -24,7 +24,7 @@ namespace ConditioningControlPanel.Services.Arcademy;
 /// for the same reason the streak does: a stale or edited page must never be able to mint currency.
 /// Shape (all fields ensured by <see cref="EnsureShape"/>):</para>
 /// <code>
-/// { "t":0, "k":0, "earnedT":0, "earnedK":0,
+/// { "t":0, "k":0, "c":0, "earnedT":0, "earnedK":0, "earnedC":0,
 ///   "tokenDays":["yyyy-MM-dd"],
 ///   "payDays":{ "yyyy-MM-dd": { "&lt;gameKey&gt;": 2 } },
 ///   "inv":{ "late_slip": { "n":2, "at":"yyyy-MM-dd" } },
@@ -236,6 +236,16 @@ internal static class ArcademyEconomy
     public const string CurTickets = "t";
     public const string CurTokens = "k";
 
+    /// <summary>CHIPS, the Back Room's third purse. Bought one way at the cage with Sparkle Points
+    /// and spendable only on the Back Room shelf: chips never cash out and nothing else ever mints
+    /// them, so the school's two earned currencies keep their meaning.</summary>
+    public const string CurChips = "c";
+
+    /// <summary>The cage's one and only rate. One number, here, because the page prints it, the
+    /// counter quotes it and the server debits by it, and a rate that disagrees across those three
+    /// is a player watching Sparkle vanish into the wrong pile.</summary>
+    public const int ChipsPerSparkle = 100;
+
     public const string SkuLateSlip = "late_slip";
 
     /// <summary>How many Tardy Slips the desk will hold — and therefore the longest absence one
@@ -420,8 +430,13 @@ internal static class ArcademyEconomy
         var wallet = w ?? new JObject();
         EnsureInt(wallet, "t");
         EnsureInt(wallet, "k");
+        // The Back Room's purse rides the same bag as the other two so one adopt carries the lot.
+        // A build that has never heard of chips still round-trips them: the field is ensured here
+        // and nothing local ever mints it, so an older desk cannot zero what the server holds.
+        EnsureInt(wallet, "c");
         EnsureInt(wallet, "earnedT");
         EnsureInt(wallet, "earnedK");
+        EnsureInt(wallet, "earnedC");
         if (wallet["tokenDays"] is not JArray) wallet["tokenDays"] = new JArray();
         if (wallet["payDays"] is not JObject) wallet["payDays"] = new JObject();
         if (wallet["inv"] is not JObject) wallet["inv"] = new JObject();
@@ -660,7 +675,16 @@ internal static class ArcademyEconomy
     public static JObject BalanceJson(JObject w)
     {
         var wallet = EnsureShape(w);
-        return new JObject { ["t"] = (int?)wallet["t"] ?? 0, ["k"] = (int?)wallet["k"] ?? 0 };
+        return new JObject
+        {
+            ["t"] = (int?)wallet["t"] ?? 0,
+            ["k"] = (int?)wallet["k"] ?? 0,
+            // Chips carry their lifetime total on the same frame because the Back Room's floor
+            // shows both at once (balance on the chip, "won so far" on the cage sign) and a second
+            // round trip for the second number would repaint the room a beat late.
+            ["c"] = (int?)wallet["c"] ?? 0,
+            ["earnedC"] = (int?)wallet["earnedC"] ?? 0,
+        };
     }
 
     // ============================ dates ============================

--- a/ConditioningControlPanel/Services/Arcademy/ArcademyHostService.cs
+++ b/ConditioningControlPanel/Services/Arcademy/ArcademyHostService.cs
@@ -594,6 +594,12 @@ internal static class ArcademyHostService
             case "prize-buy":
                 OnPrizeBuy(o);
                 break;
+            case "casino-request":
+                OnCasinoRequest(o);
+                break;
+            case "triggers-request":
+                OnTriggersRequest();
+                break;
             case "class-left":
                 // The closing bracket for `class-started`. Leaving a class with Esc ends no class,
                 // so without this the mid-class heartbeat limit (12s vs 20s) stayed armed for the
@@ -4199,6 +4205,183 @@ internal static class ArcademyHostService
         }
         catch (Exception ex) { App.Logger?.Debug("ArcademyHost.PostWalletResult: {E}", ex.Message); }
     }
+
+    // ============================ the back room ============================
+
+    /// <summary>
+    /// <c>casino-request {reqId, op, body, localDay}</c> -> the Back Room, and exactly one
+    /// <c>casino-result</c> back. The page never fetches the proxy itself, so every stake, every
+    /// cage press and every status poll comes through here on the same token door the counter uses.
+    ///
+    /// <para>THE REPLY IS UNCONDITIONAL, refusals included. The floor settles nothing optimistically
+    /// past the frame the server corrects, so a swallowed answer would leave a cabinet holding a
+    /// spinner it could never put down. An unknown op and a shut door both answer <c>offline</c>,
+    /// which is the one word the room already has a line for.</para>
+    /// </summary>
+    private static void OnCasinoRequest(JObject o)
+    {
+        var reqId = ReadString(o, "reqId") ?? "";
+        try
+        {
+            var op = (ReadString(o, "op") ?? "").Trim();
+            if (op is not ("status" or "cage" or "play"))
+            {
+                App.Logger?.Debug("ArcademyHost: casino op '{Op}' is not one of ours", op);
+                PostCasinoResult(reqId, false, 0, Offline());
+                return;
+            }
+
+            // THE BACK ROOM IS AN ACCOUNT ROOM. Chips live on the server the way tickets do, and
+            // there is no local casino to fall back on: with no identity the floor stays dark
+            // rather than dealing a hand nothing could ever settle.
+            if (!ArcademyWalletSyncService.DoorOpen)
+            {
+                PostCasinoResult(reqId, false, 0, Offline());
+                return;
+            }
+
+            var body = o["body"] as JObject ?? new JObject();
+            var localDay = ReadString(o, "localDay") ?? "";
+            int epoch = Volatile.Read(ref _generation);
+            ArcademyWalletSyncService.Casino(op, body, localDay,
+                outcome => SettleCasino(epoch, reqId, op, outcome));
+        }
+        catch (Exception ex)
+        {
+            App.Logger?.Warning("ArcademyHost.OnCasinoRequest: {E}", ex.Message);
+            PostCasinoResult(reqId, false, 0, Offline());
+        }
+    }
+
+    /// <summary>The Back Room answered (or did not). Same dispatcher-and-generation hop
+    /// <see cref="SettleBuy"/> takes, and the same rule about a reply that outlived its window.</summary>
+    private static void SettleCasino(int epoch, string reqId, string op,
+        ArcademyWalletSyncService.CasinoOutcome outcome)
+    {
+        try
+        {
+            var disp = Application.Current?.Dispatcher;
+            if (disp == null || disp.HasShutdownStarted) return;
+            if (Volatile.Read(ref _generation) != epoch) return;
+            disp.BeginInvoke(() =>
+            {
+                try
+                {
+                    if (_host == null || Volatile.Read(ref _generation) != epoch) return;
+                    if (!outcome.Answered)
+                    {
+                        PostCasinoResult(reqId, false, 0, Offline());
+                        return;
+                    }
+
+                    // A game refusal is a 200 carrying `ok:false` and rides back verbatim; so does
+                    // the tier wall's 403 body, which the room turns into its own sentence. Only a
+                    // 2xx that actually says `ok:true` is allowed to move a number on this desk.
+                    var body = outcome.Body ?? new JObject();
+                    bool ok = outcome.Status is >= 200 and < 300 && (bool?)body["ok"] == true;
+                    if (ok) AdoptCasinoAnswer(op, body);
+                    PostCasinoResult(reqId, ok, outcome.Status, body);
+                }
+                catch (Exception ex) { App.Logger?.Warning("ArcademyHost.SettleCasino: {E}", ex.Message); }
+            });
+        }
+        catch (Exception ex) { App.Logger?.Debug("ArcademyHost.SettleCasino dispatch: {E}", ex.Message); }
+    }
+
+    /// <summary>
+    /// Take what the server just moved. Two different numbers live in two different places and both
+    /// have to land here or the desk goes on showing the old one.
+    ///
+    /// <para>SPARKLE IS ADOPTED, NEVER SUBTRACTED. The cage debits <c>skill_points</c> inside the
+    /// same lock the skill tree buys under, so this reads the answer exactly the way
+    /// <c>PurchaseSkillAsync</c> reads <c>result.SkillPoints</c>. Subtracting locally instead would
+    /// be undone the moment any sync merged a higher number back over it.</para>
+    ///
+    /// <para>CHIPS go into the wallet cache so the Prize Counter, the balance chip and the cage sign
+    /// all repaint from one meta push, exactly like a purchase.</para>
+    /// </summary>
+    private static void AdoptCasinoAnswer(string op, JObject body)
+    {
+        try
+        {
+            if (string.Equals(op, "cage", StringComparison.Ordinal))
+            {
+                var settings = App.Settings?.Current;
+                int sparkle = ReadInt(body, "sparkle", -1);
+                if (settings != null && sparkle >= 0 && settings.SkillPoints != sparkle)
+                {
+                    settings.SkillPoints = sparkle;
+                    App.Settings?.Save();
+                }
+
+                // The cage answers in CHIPS credited, and the prestige counter counts SPARKLE spent,
+                // so the rate is the one honest way across. Integer division is exact here: the
+                // server only ever credits whole Sparkle at 100 chips each.
+                int credited = ReadInt(body, "credited", 0);
+                if (credited >= ArcademyEconomy.ChipsPerSparkle)
+                    App.Achievements?.TrackSkillPointsSpent(credited / ArcademyEconomy.ChipsPerSparkle);
+            }
+
+            if (_meta == null) return;
+            // -1 is "the answer did not carry this one": a cage press moves the balance and never
+            // the lifetime-won total, so the two are written independently.
+            int chips = ReadInt(body, "chips", -1);
+            int earned = ReadInt(body, "earnedC", -1);
+            if (chips < 0 && earned < 0) return;
+            _meta.NoteChips(chips >= 0 ? chips : null, earned >= 0 ? earned : null);
+            _host?.Post(_meta.SnapshotMessage());
+        }
+        catch (Exception ex) { App.Logger?.Warning("ArcademyHost.AdoptCasinoAnswer: {E}", ex.Message); }
+    }
+
+    /// <summary>The <c>casino-result</c> frame. <c>body</c> is the server's own JSON whenever there
+    /// was one, so the room reads its refusals off the same words the server used.</summary>
+    private static void PostCasinoResult(string reqId, bool ok, int status, JObject body)
+    {
+        try { _host?.Post(new { type = "casino-result", reqId, ok, status, body }); }
+        catch (Exception ex) { App.Logger?.Debug("ArcademyHost.PostCasinoResult: {E}", ex.Message); }
+    }
+
+    /// <summary>Nobody answered. One shape, one word, so the floor has a single thing to match on.</summary>
+    private static JObject Offline() => new() { ["reason"] = "offline" };
+
+    /// <summary>
+    /// <c>triggers-request</c> -> <c>triggers-result {triggers}</c>: this player's own trigger
+    /// phrases, so the reels and the Spiral's WORD wedge land on words that mean something to them
+    /// rather than a stock list. RAW text, trimmed and bounded and nothing else: a host that filtered
+    /// here would quietly change what the wheel promised.
+    ///
+    /// <para>A page with no trigger store gets an empty list and falls back to its authored one, so
+    /// an empty answer is a normal answer and never a failure.</para>
+    /// </summary>
+    private static void OnTriggersRequest()
+    {
+        var triggers = new JArray();
+        try
+        {
+            var list = App.Settings?.Current?.CustomTriggers;
+            if (list != null)
+            {
+                foreach (var raw in list)
+                {
+                    var t = (raw ?? "").Trim();
+                    if (t.Length == 0) continue;
+                    if (t.Length > MaxTriggerChars) t = t[..MaxTriggerChars];
+                    triggers.Add(t);
+                    if (triggers.Count >= MaxTriggers) break;
+                }
+            }
+        }
+        catch (Exception ex) { App.Logger?.Debug("ArcademyHost.OnTriggersRequest read: {E}", ex.Message); }
+
+        try { _host?.Post(new { type = "triggers-result", triggers }); }
+        catch (Exception ex) { App.Logger?.Debug("ArcademyHost.OnTriggersRequest post: {E}", ex.Message); }
+    }
+
+    /// <summary>How much of a trigger list crosses the seam. Enough for any real list, small enough
+    /// that a settings file somebody pasted a novel into cannot wedge a reel.</summary>
+    private const int MaxTriggers = 64;
+    private const int MaxTriggerChars = 64;
 
     // ============================ enrollment-done: the first-run punches ============================
 

--- a/ConditioningControlPanel/Services/Arcademy/ArcademyMetaStore.cs
+++ b/ConditioningControlPanel/Services/Arcademy/ArcademyMetaStore.cs
@@ -657,6 +657,23 @@ internal sealed class ArcademyMetaStore
         }
     }
 
+    /// <summary>
+    /// Write the Back Room's two numbers back after the server moved them. A TARGETED write rather
+    /// than <see cref="AdoptServerWallet"/> because a casino answer carries balances and nothing
+    /// else: adopting one whole would blank the tickets, the shelf and the two lever rungs.
+    /// </summary>
+    public void NoteChips(int? chips, int? earnedChips)
+    {
+        if (chips == null && earnedChips == null) return;
+        lock (_lock)
+        {
+            var wallet = WalletUnlocked();
+            if (chips.HasValue) wallet["c"] = Math.Max(0, chips.Value);
+            if (earnedChips.HasValue) wallet["earnedC"] = Math.Max(0, earnedChips.Value);
+            Touch();
+        }
+    }
+
     /// <summary>The parked mint frames, oldest first - a clone, and only the rows still carrying a
     /// <c>mintId</c> (a frame without one cannot be paid idempotently, so it is not a frame).</summary>
     public JArray PendingMints()

--- a/ConditioningControlPanel/Services/Arcademy/ArcademyWalletSyncService.cs
+++ b/ConditioningControlPanel/Services/Arcademy/ArcademyWalletSyncService.cs
@@ -65,6 +65,13 @@ internal static class ArcademyWalletSyncService
     private const string ClassEndedPath = "/v2/arcademy/class-ended";
     private const string PrizeBuyPath = "/v2/arcademy/prize-buy";
 
+    /// <summary>THE BACK ROOM. Three routes behind one call, because they share every rule that
+    /// matters here: the same token door, the same 5s page wait, the same tier gate, and the same
+    /// "the server resolved it, this desk only renders it" posture the counter already has.</summary>
+    private const string CasinoPath = "/v2/arcademy/casino";
+    private const string CasinoCagePath = "/v2/arcademy/casino/cage";
+    private const string CasinoPlayPath = "/v2/arcademy/casino/play";
+
     /// <summary>How long a call the PAGE is waiting on may take. The Prize Counter puts its own
     /// watchdog down at 6s (<c>shell/prizecounter.js</c> ECHO_WAIT_MS) and answers "the counter
     /// went quiet" when it fires, so a request that has not landed by 5s has to be turned into a
@@ -79,6 +86,9 @@ internal static class ArcademyWalletSyncService
     /// <summary>The wire's id shape for both <c>deviceId</c> and <c>mintId</c>. A GUID in "N" form
     /// is 32 hex characters, comfortably inside it.</summary>
     private static readonly Regex IdShape = new("^[A-Za-z0-9_-]{8,64}$", RegexOptions.Compiled);
+
+    /// <summary>The wire's date shape, used to sanity-check a <c>localDay</c> the page sent up.</summary>
+    private static readonly Regex DayShape = new("^[0-9]{4}-[0-9]{2}-[0-9]{2}$", RegexOptions.Compiled);
 
     /// <summary>The launch pull can take its time (nobody is watching it); the two page-facing
     /// calls carry their own shorter cancellation instead.</summary>
@@ -191,6 +201,12 @@ internal static class ArcademyWalletSyncService
     /// counter refuses and the local wallet is left exactly as it was.</summary>
     internal readonly record struct BuyOutcome(bool Answered, bool Ok, string? Reason, JObject? Wallet);
 
+    /// <summary>What came back from one Back Room call. <c>Answered</c> false is the offline case
+    /// and carries <c>Status</c> 0; anything the server actually said rides back whole, status code
+    /// and body together, because the room reads its own refusals off that body and this class has
+    /// no business deciding what a stake meant.</summary>
+    internal readonly record struct CasinoOutcome(bool Answered, int Status, JObject? Body);
+
     /// <summary>
     /// Bank one graded finish. Fire-and-forget with a guaranteed single callback on a background
     /// thread - the caller owns marshalling it to the dispatcher, exactly like the mirror's
@@ -233,6 +249,29 @@ internal static class ArcademyWalletSyncService
             try { settled(outcome); }
             catch (Exception ex) { App.Logger?.Debug("ArcademyWallet.Buy callback: {E}", ex.Message); }
         }, "buy");
+    }
+
+    /// <summary>
+    /// One Back Room call: <c>status</c>, <c>cage</c> or <c>play</c>. Same shape as <see cref="Buy"/>
+    /// (fire and forget, exactly one callback, on a background thread), and ONLINE ONLY for the same
+    /// reason: the chips live on the server, so a stake this desk settled by itself would be
+    /// overwritten by the next answer and the player would watch a win turn back into nothing.
+    /// </summary>
+    public static void Casino(string op, JObject body, string localDay, Action<CasinoOutcome> settled)
+    {
+        int generation = Volatile.Read(ref _generation);
+        Run(async () =>
+        {
+            CasinoOutcome outcome;
+            try { outcome = await PostCasinoAsync(op, body, localDay, generation).ConfigureAwait(false); }
+            catch (Exception ex)
+            {
+                App.Logger?.Information("[ArcademyWallet] casino '{Op}' failed: {E}", op, ex.Message);
+                outcome = new CasinoOutcome(false, 0, null);
+            }
+            try { settled(outcome); }
+            catch (Exception ex) { App.Logger?.Debug("ArcademyWallet.Casino callback: {E}", ex.Message); }
+        }, "casino");
     }
 
     // ============================ launch ============================
@@ -704,6 +743,95 @@ internal static class ArcademyWalletSyncService
         {
             App.Logger?.Information("[ArcademyWallet] buy failed: {E}", ex.Message);
             return new BuyOutcome(false, false, "offline", null);
+        }
+    }
+
+    // ============================ the back room ============================
+
+    /// <summary>
+    /// Send one Back Room call and hand the server's answer back untouched. Nothing is adopted
+    /// here: the casino answers with balances rather than a whole wallet, so the host writes the
+    /// two chip fields into the cache itself and this lane stays a pure courier.
+    ///
+    /// <para>The refusal mapping is <see cref="PostBuyAsync"/>'s, deliberately. A game refusal
+    /// (not enough chips, a hand already open) arrives as a 200 with <c>ok:false</c> and rides
+    /// back whole. The tier wall and the account lock keep their own status codes so the room can
+    /// say the right sentence. The identity door and a dead token are the offline answer, because
+    /// there is nothing a player can do about either from inside a cabinet.</para>
+    /// </summary>
+    private static async Task<CasinoOutcome> PostCasinoAsync(string op, JObject body, string localDay,
+        int generation)
+    {
+        if (!Identity(out var unifiedId, out var token)) return new CasinoOutcome(false, 0, null);
+
+        // THE PLAYER'S DAY, CHECKED RATHER THAN TRUSTED. The free scratcher is bounded by it, so a
+        // page that sent nothing readable gets this desk's own date instead of a free card a day.
+        var day = DayShape.IsMatch(localDay ?? "")
+            ? localDay!
+            : DateTime.Now.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+
+        using var cts = new CancellationTokenSource(PageWait);
+        try
+        {
+            HttpRequestMessage request;
+            if (string.Equals(op, "status", StringComparison.Ordinal))
+            {
+                request = new HttpRequestMessage(HttpMethod.Get,
+                    $"{ProxyBaseUrl}{CasinoPath}?unified_id={Uri.EscapeDataString(unifiedId)}" +
+                    $"&localDay={Uri.EscapeDataString(day)}");
+            }
+            else
+            {
+                bool cage = string.Equals(op, "cage", StringComparison.Ordinal);
+                var payload = (JObject)(body ?? new JObject()).DeepClone();
+                payload["unified_id"] = unifiedId;
+                // Only a play is dated: the cage takes Sparkle whatever the clock says, and an
+                // extra field on that route is one more thing for the server to have to ignore.
+                if (!cage) payload["localDay"] = day;
+                request = new HttpRequestMessage(HttpMethod.Post,
+                    ProxyBaseUrl + (cage ? CasinoCagePath : CasinoPlayPath))
+                {
+                    Content = new StringContent(payload.ToString(Formatting.None), Encoding.UTF8, "application/json"),
+                };
+            }
+
+            using (request)
+            {
+                request.Headers.Add("X-Auth-Token", token);
+                using var response = await Http.SendAsync(request, cts.Token).ConfigureAwait(false);
+                var text = await response.Content.ReadAsStringAsync(cts.Token).ConfigureAwait(false);
+                var reply = Parse(text);
+                int status = (int)response.StatusCode;
+
+                if (response.StatusCode == HttpStatusCode.Forbidden && !IsTierRefusal(reply))
+                {
+                    App.Logger?.Information("[ArcademyWallet] casino refused at the identity door: {Body}", Truncate(text));
+                    return new CasinoOutcome(false, 0, null);
+                }
+                if (response.StatusCode == HttpStatusCode.Unauthorized)
+                {
+                    App.Logger?.Information("[ArcademyWallet] casino refused at the token door: {Body}", Truncate(text));
+                    return new CasinoOutcome(false, 0, null);
+                }
+
+                if (!response.IsSuccessStatusCode)
+                    App.Logger?.Information("[ArcademyWallet] casino '{Op}' answered {Status}: {Body}",
+                        op, status, Truncate(text));
+                else if (Retired(generation))
+                    App.Logger?.Debug("[ArcademyWallet] casino '{Op}' landed after the window closed", op);
+
+                return new CasinoOutcome(true, status, reply);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            App.Logger?.Information("[ArcademyWallet] the back room did not answer inside {S}s", PageWait.TotalSeconds);
+            return new CasinoOutcome(false, 0, null);
+        }
+        catch (Exception ex)
+        {
+            App.Logger?.Information("[ArcademyWallet] casino '{Op}' failed: {E}", op, ex.Message);
+            return new CasinoOutcome(false, 0, null);
         }
     }
 

--- a/ConditioningControlPanel/Services/Settings/ProfileSyncService.cs
+++ b/ConditioningControlPanel/Services/Settings/ProfileSyncService.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
@@ -1637,18 +1637,26 @@ namespace ConditioningControlPanel.Services
                         }
                         else if (v2Result?.SkillPoints.HasValue == true)
                         {
-                            // Take max of server/local — skill points only increase (level-ups, bubble
-                            // pops) and are NEVER reset by seasons (policy: the balance is permanent,
-                            // and since the Descent so is the tree it buys), so the higher value is
-                            // always correct.
-                            // This also shields the balance from an older server that still zeroes
-                            // skill_points at rollover.
-                            var maxPoints = Math.Max(v2Result.SkillPoints.Value, settings.SkillPoints);
-                            if (maxPoints != settings.SkillPoints)
+                            // ADOPT THE SERVER'S BALANCE. It is the only side that sees the whole
+                            // story: it AWARDS from the level delta and the bubble delta carried up
+                            // by this very sync, and it DEBITS at the skill tree and now at the Back
+                            // Room cage. A max-merge was safe while nothing could ever go down; with
+                            // a debit in the picture it resurrects spent points the first time a
+                            // second desk syncs its older, higher number, which would mean chips
+                            // bought for free.
+                            // An offline level-up is still not lost. The award for it is computed
+                            // server-side FROM the level this same request just carried up, so the
+                            // number being adopted here already contains it.
+                            // Seasons still never reset the balance (policy: it is permanent, and
+                            // since the Descent so is the tree it buys) - that rule now lives with
+                            // the server, and force_skills_reset above stays the one path that
+                            // deliberately rewrites the balance from outside.
+                            var serverPoints = Math.Max(0, v2Result.SkillPoints.Value);
+                            if (serverPoints != settings.SkillPoints)
                             {
-                                App.Logger?.Information("V2 Sync: Skill points server={Server}, local={Local} — taking max ({Max})",
-                                    v2Result.SkillPoints.Value, settings.SkillPoints, maxPoints);
-                                settings.SkillPoints = maxPoints;
+                                App.Logger?.Information("V2 Sync: Skill points server={Server}, local={Local} - adopting the server's",
+                                    v2Result.SkillPoints.Value, settings.SkillPoints);
+                                settings.SkillPoints = serverPoints;
                                 App.Settings?.Save();
                             }
                         }
@@ -2942,7 +2950,10 @@ namespace ConditioningControlPanel.Services
                 }
             }
 
-            // Merge skill tree data - take max of server/local (skill points only increase)
+            // Merge skill tree data - take max of server/local (skill points only increase).
+            // LEGACY PATH ONLY: the v2 sync above ADOPTS the server's balance instead, because that
+            // is the side that debits the tree and the Back Room cage. This older endpoint knows
+            // about no debit at all, so max is still the right answer down here.
             if (cloudProfile.SkillPoints.HasValue)
             {
                 var maxPoints = Math.Max(cloudProfile.SkillPoints.Value, settings.SkillPoints);


### PR DESCRIPTION
The desktop half of "The Back Room" wave 1: the chips currency exists in the wallet shape, the host can talk to the casino routes, and a cage press moves Sparkle Points for real. No UI, no cabinets, no catalog rows here (PR D2 owns the shelf, W1 the door, K1 the kit).

Built to `BACKROOM-CONTRACT.md` v1, sections 1, 3 and the C# side of 6.

## What and why

**`ArcademyEconomy`** gains `CurChips = "c"` and `ChipsPerSparkle = 100`. `EnsureShape` now ensures integer `c` and `earnedC` beside `t`/`earnedT`, and `BalanceJson` emits both. Chips ride the existing wallet blob so one adopt carries all three purses, and an older build that has never heard of chips still round-trips them rather than zeroing what the server holds. No catalog rows and `CurrentWave` is untouched.

**`ArcademyWalletSyncService`** gains one generic call:

```csharp
public static void Casino(string op, JObject body, string localDay, Action<CasinoOutcome> settled)
```

- `status` -> `GET /v2/arcademy/casino?unified_id=&localDay=`
- `cage` -> `POST /v2/arcademy/casino/cage`
- `play` -> `POST /v2/arcademy/casino/play` (body gains `localDay`)

Same `X-Auth-Token` + `unified_id` door, same 5s `PageWait`, same generation guard and the same tier-refusal mapping `PostBuyAsync` uses. `CasinoOutcome(bool Answered, int Status, JObject? Body)`; a transport failure, the identity door and a dead token are all `Answered false / Status 0`. Nothing is adopted in that lane: a casino answer carries balances, not a wallet, so it stays a pure courier and the host decides what landed. The page's `localDay` is shape-checked against `yyyy-MM-dd` and falls back to this desk's own date, because the free scratcher is bounded by it.

**`ArcademyHostService`** handles the two new page messages. **`ArcademyMetaStore`** gains `NoteChips(int? chips, int? earnedChips)`, a targeted write: adopting a balances-only answer as a whole wallet would blank the tickets, the shelf and the two lever rungs.

**`ProfileSyncService`** stops max-merging skill points on the v2 path. Explained below.

## Bridge message shapes

Up, from the page:

- `{ type: 'casino-request', reqId, op: 'status'|'cage'|'play', body, localDay }`
- `{ type: 'triggers-request' }`

Down, from the host, exactly one per request:

- `{ type: 'casino-result', reqId, ok, status, body }`
  - offline / unknown op / no account: `ok:false, status:0, body:{ reason:'offline' }`
  - tier refusal: `ok:false, status:403`, and the server's own 403 body passes through verbatim
  - a game refusal is the server's 200 with `ok:false` and rides back whole
  - `ok` is true only for a 2xx whose body says `ok:true`
- `{ type: 'triggers-result', triggers: [...] }` from `AppSettings.CustomTriggers`, raw text, empties dropped, max 64 entries each trimmed to 64 chars

On `op:'cage'` with `ok`, the host adopts `body.sparkle` into `App.Settings.Current.SkillPoints` and calls `TrackSkillPointsSpent(body.credited / 100)` (the cage answers in chips credited, the prestige counter counts Sparkle spent). On `cage` and `play` alike it writes the answer's `chips` / `earnedC` into the wallet cache and posts the meta snapshot, so the balance chip, the cage sign and the Prize Counter repaint from one frame.

## The ProfileSync change

`/v2/user/sync` used `Math.Max(server, local)` for skill points, with a comment saying the balance only ever increases. That was true while nothing could spend it outside the server's own purchase route being immediately adopted. It is not true now: the cage DEBITS `skill_points` server side, and a max-merge would resurrect every debit the moment a second desk synced its older, higher number. That is chips bought for free, and the skill tree has the same hole today.

So the v2 path now ADOPTS what the server sent. This is safe for the offline level-up case that motivated max in the first place: the server computes the level award and the bubble award FROM the deltas carried up by that same request, so the number being adopted already contains them. `force_skills_reset` keeps its own branch untouched. The legacy path keeps `Math.Max` and now carries a comment saying why the two differ (that endpoint knows about no debit at all).

## Build

`dotnet build` from `ConditioningControlPanel/`: **0 errors**, 322 warnings, all pre-existing (CA1416 platform, CS8602 nullable, WFAC010 manifest). No warning from any file this PR touches. App not run.

Changed lines: 378 added / 15 removed across 5 files, inside the ~600 cap.

## Merge note

**Needs server S1 on the wire first.** Until `/v2/arcademy/casino*` exists, every `casino-request` answers `{ok:false, status:404}` or the offline shape, which is exactly what the page is built to survive but is not something to ship as a working room. Contract merge order: cclabs-web parser and host relay, then server S1, then this. The `ProfileSyncService` adoption is independently correct and can land at any time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5Gp8FA4yHguiNc46u5YDS
