### PR TITLE
feat(arcademy): Back Room D2 - the chip shelf (catalog wave 3 rows)

### DIFF
--- a/ConditioningControlPanel/Services/Arcademy/ArcademyEconomy.cs
+++ b/ConditioningControlPanel/Services/Arcademy/ArcademyEconomy.cs
@@ -235,6 +235,7 @@ internal static class ArcademyEconomy
 
     public const string CurTickets = "t";
     public const string CurTokens = "k";
+    public const string CurChips = "c"; // chips: the Back Room's currency, bought one way at the cage
 
     public const string SkuLateSlip = "late_slip";
 
@@ -392,6 +393,96 @@ internal static class ArcademyEconomy
             "prize_tube_midnight_blurb",
             "A darker glass for the tube back home. It ships to the whole app, not just the school.",
             Wave: 3),
+
+        // ============================ THE BACK ROOM (2026-09-04) ============================
+        // Thirteen rows that spend CHIPS, not tickets and not tokens. Chips are bought one way at
+        // the cage with Sparkle and they never cash out, so this is the ONLY shelf they buy from
+        // and everything on it is dressing: two consumables the machines hand back, three looks,
+        // one door onto the Spiral's word wedge, and a title nobody can buy.
+        //
+        // WHY THEY LIVE HERE AND NOT IN A SECOND TABLE. The counter is one counter. The Back Room
+        // sells through the SAME prize-buy path the shelf already has, so a chip row that drifted
+        // out of this list is a row the host could not price, and that is the one bug down here
+        // that would cost a player money.
+        //
+        // NOTHING ON SAFETY IS FOR SALE HERE EITHER, and nothing on this shelf buys a better
+        // outcome at a table: the published odds are the real odds and no row moves them.
+        //
+        // WAVE 3 - built and priced, and NOT on the wire (CurrentWave is still 2). The bump is a
+        // separate one-line PR, because it also releases the three wave-3 rows above.
+        new("bk_scratcher", CurChips, 50, "consumable",
+            "prize_bk_scratcher", "SCRATCH CARD",
+            "prize_bk_scratcher_blurb",
+            "A fresh card off the pad. Scratch it at the machine and see what the row says.",
+            StackMax: 20, Wave: 3),
+        new("bk_insurance", CurChips, 100, "consumable",
+            "prize_bk_insurance", "INSURANCE CHIP",
+            "prize_bk_insurance_blurb",
+            "Lay it on the rail. The next small hand you lose gets handed straight back to you.",
+            StackMax: 5, Wave: 3),
+        new("bk_visor", CurChips, 3000, "cosmetic",
+            "prize_bk_visor", "DEALER'S VISOR",
+            "prize_bk_visor_blurb",
+            "Green celluloid, low over the eyes. She wears it at the table and deals like she means it.",
+            Wave: 3),
+        new("bk_felt_teal", CurChips, 6000, "cosmetic",
+            "prize_bk_felt_teal", "TEAL NIGHT FELT",
+            "prize_bk_felt_teal_blurb",
+            "New felt on every table down here. Deep teal, the kind that keeps a room quiet.",
+            Wave: 3),
+        new("bk_frame_highroller", CurChips, 10000, "cosmetic",
+            "prize_bk_frame_highroller", "HIGH ROLLER FRAME",
+            "prize_bk_frame_highroller_blurb",
+            "A heavy gold edge around your ID photo. The desk pretends not to notice you now.",
+            Wave: 3),
+        new("bk_your_word", CurChips, 30000, "unlock",
+            "prize_bk_your_word", "YOUR WORD ON THE WHEEL",
+            "prize_bk_your_word_blurb",
+            "The WORD wedge on the Spiral stops being ours and starts being one of yours.",
+            Wave: 3),
+        // THE ONE ROW WITH NO PRICE. Cost 0 and Locked together, which is how the case says
+        // "won, never sold": the buy path refuses it `locked` at any balance, and the house hands
+        // it over the first time the reels come up royal. Free would otherwise mean free.
+        new("bk_house_favorite", CurChips, 0, "cosmetic",
+            "prize_bk_house_favorite", "HOUSE FAVORITE",
+            "prize_bk_house_favorite_blurb",
+            "Not for sale at any price. The house gives it the first time your reels go royal.",
+            Locked: true, Wave: 3),
+
+        // WAVE 4 - on the shelf list, on NO wire, and nothing behind them is built yet. They are
+        // here so the ladder above the first six prices is visible to whoever balances the cage
+        // next, and so a later PR adds an EFFECT rather than a row. The two stack sizes are the
+        // desk's own guess and the only numbers on these six the contract does not pin.
+        new("bk_double_payday", CurChips, 1000, "consumable",
+            "prize_bk_double_payday", "DOUBLE PAYDAY",
+            "prize_bk_double_payday_blurb",
+            "Hand it over before you stake and the desk marks the card. One play pays twice.",
+            StackMax: 5, Wave: 4),
+        new("bk_boon", CurChips, 4000, "consumable",
+            "prize_bk_boon", "HOUSE BOON",
+            "prize_bk_boon_blurb",
+            "The house owes you a favor. Spend it and the night leans your way for one hand.",
+            StackMax: 3, Wave: 4),
+        new("bk_pitboss", CurChips, 15000, "unlock",
+            "prize_bk_pitboss", "PIT BOSS",
+            "prize_bk_pitboss_blurb",
+            "Somebody stands behind your table all night and keeps the count for you.",
+            Wave: 4),
+        new("bk_mantra", CurChips, 20000, "unlock",
+            "prize_bk_mantra", "THE HOUSE MANTRA",
+            "prize_bk_mantra_blurb",
+            "The room learns a line of yours and says it back between hands. Softly, all night.",
+            Wave: 4),
+        new("bk_dealers_cut", CurChips, 50000, "unlock",
+            "prize_bk_dealers_cut", "DEALER'S CUT",
+            "prize_bk_dealers_cut_blurb",
+            "A standing share of the rake. Every play drops a little back in your pocket.",
+            Wave: 4),
+        new("bk_vault_key", CurChips, 250000, "unlock",
+            "prize_bk_vault_key", "THE VAULT KEY",
+            "prize_bk_vault_key_blurb",
+            "The door behind the cage. Nobody at the desk will say what is on the far side of it.",
+            Wave: 4),
     };
 
     public static CatalogItem? Find(string? sku) =>
@@ -590,7 +681,12 @@ internal static class ArcademyEconomy
         }
         else if (held > 0) return new BuyResult(false, "owned", item);
 
-        var purse = item.Cur == CurTokens ? "k" : "t";
+        // THREE PURSES NOW, and the row picks its own. Anything unrecognised falls to tickets,
+        // which is the cheapest purse and therefore the one a mangled row can do least harm in.
+        // `c` is not ensured by EnsureShape yet (the cage PR owns the wallet shape), and it does
+        // not need to be tonight: a missing field reads 0, so a chip row would be refused `poor`
+        // rather than paid for out of thin air, and no chip row is on the wire at wave 2 anyway.
+        var purse = item.Cur switch { CurTokens => "k", CurChips => "c", _ => "t" };
         var have = (int?)wallet[purse] ?? 0;
         if (have < item.Cost) return new BuyResult(false, "poor", item);
 

--- a/ConditioningControlPanel/Services/Arcademy/ArcademyHostService.cs
+++ b/ConditioningControlPanel/Services/Arcademy/ArcademyHostService.cs
@@ -1888,6 +1888,38 @@ internal static class ArcademyHostService
         ["prize_emi_varsity_blurb"] = "She found it in lost and found and it fits perfectly. Every one of her poses, re-dressed.",
         ["prize_tube_midnight"] = "TUBE GLASS: MIDNIGHT",
         ["prize_tube_midnight_blurb"] = "A darker glass for the tube back home. It ships to the whole app, not just the school.",
+        // THE BACK ROOM SHELF (2026-09-04). Thirteen chip rows, waves 3 and 4, and every one of
+        // them is carried here the night the row lands rather than the night it goes on sale, for
+        // the same reason the restock's were: a lexicon row costs nothing until something asks for
+        // it, and shipping the wing should be one const bump and not a second trip through nine
+        // language files. The blurbs are the catalog's own words, trimmed to the 96-char bar the
+        // counter card reads comfortably.
+        ["prize_bk_scratcher"] = "SCRATCH CARD",
+        ["prize_bk_scratcher_blurb"] = "A fresh card off the pad. Scratch it at the machine and see what the row says.",
+        ["prize_bk_insurance"] = "INSURANCE CHIP",
+        ["prize_bk_insurance_blurb"] = "Lay it on the rail. The next small hand you lose gets handed straight back.",
+        ["prize_bk_visor"] = "DEALER'S VISOR",
+        ["prize_bk_visor_blurb"] = "Green celluloid, low over the eyes. She deals like she means it in that thing.",
+        ["prize_bk_felt_teal"] = "TEAL NIGHT FELT",
+        ["prize_bk_felt_teal_blurb"] = "New felt on every table down here. Deep teal, the kind that keeps a room quiet.",
+        ["prize_bk_frame_highroller"] = "HIGH ROLLER FRAME",
+        ["prize_bk_frame_highroller_blurb"] = "A heavy gold edge around your ID photo. The desk pretends not to notice you.",
+        ["prize_bk_your_word"] = "YOUR WORD ON THE WHEEL",
+        ["prize_bk_your_word_blurb"] = "The WORD wedge on the Spiral stops being ours and starts being one of yours.",
+        ["prize_bk_house_favorite"] = "HOUSE FAVORITE",
+        ["prize_bk_house_favorite_blurb"] = "Not for sale at any price. The house gives it the first time you go royal.",
+        ["prize_bk_double_payday"] = "DOUBLE PAYDAY",
+        ["prize_bk_double_payday_blurb"] = "Hand it over before you stake and the desk marks the card. One play pays twice.",
+        ["prize_bk_boon"] = "HOUSE BOON",
+        ["prize_bk_boon_blurb"] = "The house owes you a favor. Spend it and the night leans your way for a hand.",
+        ["prize_bk_pitboss"] = "PIT BOSS",
+        ["prize_bk_pitboss_blurb"] = "Somebody stands behind your table all night and keeps the count for you.",
+        ["prize_bk_mantra"] = "THE HOUSE MANTRA",
+        ["prize_bk_mantra_blurb"] = "The room learns a line of yours and says it back between hands. Softly.",
+        ["prize_bk_dealers_cut"] = "DEALER'S CUT",
+        ["prize_bk_dealers_cut_blurb"] = "A standing share of the rake. Every play drops a little back in your pocket.",
+        ["prize_bk_vault_key"] = "THE VAULT KEY",
+        ["prize_bk_vault_key_blurb"] = "The door behind the cage. Nobody at the desk will say what is on the far side.",
         // ---- the Extra Credit lever ----------------------------------------------------
         // shell/lever.js owns the words on BOTH class-start surfaces (the door card and the
         // painted room's apron), so every rung is one key and one locked line, no more.

--- a/Tests/ConditioningControlPanel.Tests/ArcademyBackRoomShelfTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/ArcademyBackRoomShelfTests.cs
@@ -1,0 +1,174 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using ConditioningControlPanel.Services.Arcademy;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// THE BACK ROOM SHELF (wire contract v1, 2026-09-04). Thirteen rows that spend CHIPS, priced at
+/// the cage and sold through the counter the Arcademy already has.
+///
+/// <para>Prices and stack sizes are the contract's, and they are pinned here rather than reviewed,
+/// because the same table is regenerated into the server catalog and parsed again by the web sync:
+/// a price that moves in one place and not the other two is the one bug down here that costs a
+/// player money. Everything runs for real against <see cref="ArcademyEconomy"/>, which is free of
+/// WPF on purpose; the lexicon half is a source tripwire because the table it checks is private.</para>
+/// </summary>
+public class ArcademyBackRoomShelfTests
+{
+    // =====================================================================================
+    //  the contract table
+    // =====================================================================================
+
+    /// <summary>sku, cost, kind, stack, locked, wave. Contract section 6, verbatim.</summary>
+    public static IEnumerable<object[]> Rows() => new[]
+    {
+        new object[] { "bk_scratcher", 50, "consumable", 20, false, 3 },
+        new object[] { "bk_insurance", 100, "consumable", 5, false, 3 },
+        new object[] { "bk_visor", 3000, "cosmetic", 0, false, 3 },
+        new object[] { "bk_felt_teal", 6000, "cosmetic", 0, false, 3 },
+        new object[] { "bk_frame_highroller", 10000, "cosmetic", 0, false, 3 },
+        new object[] { "bk_your_word", 30000, "unlock", 0, false, 3 },
+        new object[] { "bk_house_favorite", 0, "cosmetic", 0, true, 3 },
+        new object[] { "bk_double_payday", 1000, "consumable", 5, false, 4 },
+        new object[] { "bk_boon", 4000, "consumable", 3, false, 4 },
+        new object[] { "bk_pitboss", 15000, "unlock", 0, false, 4 },
+        new object[] { "bk_mantra", 20000, "unlock", 0, false, 4 },
+        new object[] { "bk_dealers_cut", 50000, "unlock", 0, false, 4 },
+        new object[] { "bk_vault_key", 250000, "unlock", 0, false, 4 },
+    };
+
+    private static IReadOnlyList<ArcademyEconomy.CatalogItem> ChipRows() =>
+        ArcademyEconomy.Catalog.Where(c => c.Cur == ArcademyEconomy.CurChips).ToList();
+
+    [Theory]
+    [MemberData(nameof(Rows))]
+    public void EveryChipRowIsPricedExactlyAsTheContractSaid(
+        string sku, int cost, string kind, int stack, bool locked, int wave)
+    {
+        var row = ArcademyEconomy.Catalog.Single(c => c.Sku == sku);
+        Assert.Equal(ArcademyEconomy.CurChips, row.Cur);
+        Assert.Equal(cost, row.Cost);
+        Assert.Equal(kind, row.Kind);
+        Assert.Equal(stack, row.StackMax);
+        Assert.Equal(locked, row.Locked);
+        Assert.Equal(wave, row.Wave);
+    }
+
+    [Fact]
+    public void TheChipShelfIsThirteenRowsAndNothingElseSpendsChips()
+    {
+        var expected = Rows().Select(r => (string)r[0]).ToList();
+        Assert.Equal(expected.OrderBy(s => s, StringComparer.Ordinal),
+            ChipRows().Select(c => c.Sku).OrderBy(s => s, StringComparer.Ordinal));
+    }
+
+    [Fact]
+    public void ChipsAreTheirOwnPurseAndSpelledC()
+    {
+        // The identifier is read by name out of this file by two external parsers (the server's
+        // arcademy-catalog.mjs and cclabs-web's sync-arcademy.mjs), and the letter is the wallet
+        // field. Neither can move without both of those moving first.
+        Assert.Equal("c", ArcademyEconomy.CurChips);
+        Assert.NotEqual(ArcademyEconomy.CurTickets, ArcademyEconomy.CurChips);
+        Assert.NotEqual(ArcademyEconomy.CurTokens, ArcademyEconomy.CurChips);
+    }
+
+    // =====================================================================================
+    //  still behind the truck
+    // =====================================================================================
+
+    [Fact]
+    public void NoChipRowIsOnTheWireTonight()
+    {
+        // The wave bump is a separate PR on purpose: it also releases the three ticket and token
+        // rows already sitting at wave 3, so it is an owner call rather than a side effect of
+        // adding a shelf.
+        Assert.Equal(2, ArcademyEconomy.CurrentWave);
+        Assert.All(ChipRows(), c => Assert.False(ArcademyEconomy.InStock(c)));
+
+        var projected = ArcademyEconomy.CatalogJson().OfType<JObject>()
+            .Where(r => (string?)r["cur"] == ArcademyEconomy.CurChips)
+            .ToList();
+        Assert.Empty(projected);
+    }
+
+    [Fact]
+    public void TheCounterDoesNotKnowAChipRowYetAndChargesNothing()
+    {
+        var w = new JObject { ["t"] = 5000, ["k"] = 5, ["c"] = 100000 };
+        foreach (var sku in Rows().Select(r => (string)r[0]))
+        {
+            var r = ArcademyEconomy.Buy(w, sku, "2026-09-04");
+            Assert.False(r.Ok);
+            // "unknown" rather than "locked": naming an unreleased prize in a refusal spoils it.
+            Assert.Equal("unknown", r.Reason);
+        }
+        Assert.Equal(100000, (int?)w["c"]);
+        Assert.Equal(5000, (int?)w["t"]);
+        Assert.Equal(5, (int?)w["k"]);
+    }
+
+    [Fact]
+    public void TheHouseFavoriteIsWonAndNeverSold()
+    {
+        var row = ArcademyEconomy.Catalog.Single(c => c.Sku == "bk_house_favorite");
+        Assert.Equal(0, row.Cost);
+        Assert.True(row.Locked);
+    }
+
+    // =====================================================================================
+    //  the words on the card (source tripwire - NeutralLexicon is private)
+    // =====================================================================================
+
+    private static string HostSource()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir != null && !Directory.Exists(Path.Combine(dir.FullName, "ConditioningControlPanel", "Resources")))
+            dir = dir.Parent;
+        Assert.True(dir != null, "could not locate the repo root from " + AppContext.BaseDirectory);
+        return File.ReadAllText(Path.Combine(dir!.FullName, "ConditioningControlPanel",
+            "Services", "Arcademy", "ArcademyHostService.cs"));
+    }
+
+    [Fact]
+    public void EveryChipRowHasItsNameAndBlurbInTheLexicon()
+    {
+        var source = HostSource();
+        var table = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (Match m in Regex.Matches(source, "\\[\"(prize_bk_[a-z_]+)\"\\] = \"([^\"]*)\""))
+            table[m.Groups[1].Value] = m.Groups[2].Value;
+
+        foreach (var row in ChipRows())
+        {
+            Assert.True(table.ContainsKey(row.NameKey), "lexicon is missing " + row.NameKey);
+            Assert.True(table.ContainsKey(row.BlurbKey), "lexicon is missing " + row.BlurbKey);
+        }
+        Assert.Equal(ChipRows().Count * 2, table.Count);
+    }
+
+    [Fact]
+    public void NoChipRowStringRunsPastTheCardOrCarriesALineBreak()
+    {
+        var source = HostSource();
+        foreach (Match m in Regex.Matches(source, "\\[\"(prize_bk_[a-z_]+)\"\\] = \"([^\"]*)\""))
+        {
+            var key = m.Groups[1].Value;
+            var value = m.Groups[2].Value;
+            Assert.True(value.Length < 96, key + " runs to " + value.Length + " chars");
+            Assert.DoesNotContain("\\n", value, StringComparison.Ordinal);
+        }
+        // House rule: no em-dash or en-dash anywhere a player can read it.
+        foreach (var row in ChipRows())
+        {
+            var words = row.NameEn + " " + row.BlurbEn;
+            Assert.False(words.Contains('\u2014'), row.Sku + " carries an em-dash");
+            Assert.False(words.Contains('\u2013'), row.Sku + " carries an en-dash");
+        }
+    }
+}


### PR DESCRIPTION
## What

PR **D2** of The Back Room (the Arcademy's casino wing): the shelf rows.

- `ArcademyEconomy.CurChips = "c"` beside `CurTickets` / `CurTokens`.
- Thirteen catalog rows that spend chips: seven at wave 3, six at wave 4.
- `Buy` picks its purse from the row (`k` / `c` / `t`) instead of a two-way
  ternary, so a chip row debits `c` and is refused `poor` on an empty pocket
  exactly the way a ticket row is.
- Twenty-six lexicon rows in `ArcademyHostService.NeutralLexicon`, all under
  the 96-char card bar, no literal line breaks.
- A test class that pins the whole table to the contract.

## Why

The counter is one counter. The Back Room sells through the same `prize-buy`
path the shelf already has, so a chip row that lived in a second table would
be a row the host could not price. The C# file stays the single source: the
server catalog is regenerated from it and cclabs-web parses it again.

## The rows

| sku | cur | price | kind | stack | locked | wave |
|---|---|---|---|---|---|---|
| `bk_scratcher` | c | 50 | consumable | 20 | | 3 |
| `bk_insurance` | c | 100 | consumable | 5 | | 3 |
| `bk_visor` | c | 3,000 | cosmetic | | | 3 |
| `bk_felt_teal` | c | 6,000 | cosmetic | | | 3 |
| `bk_frame_highroller` | c | 10,000 | cosmetic | | | 3 |
| `bk_your_word` | c | 30,000 | unlock | | | 3 |
| `bk_house_favorite` | c | 0 | cosmetic | | yes | 3 |
| `bk_double_payday` | c | 1,000 | consumable | 5 | | 4 |
| `bk_boon` | c | 4,000 | consumable | 3 | | 4 |
| `bk_pitboss` | c | 15,000 | unlock | | | 4 |
| `bk_mantra` | c | 20,000 | unlock | | | 4 |
| `bk_dealers_cut` | c | 50,000 | unlock | | | 4 |
| `bk_vault_key` | c | 250,000 | unlock | | | 4 |

`bk_house_favorite` is cost 0 AND `Locked`, which is how the case says "won,
never sold": the buy path refuses it at any balance and the house hands it
over on the player's first royal.

Two numbers here are NOT in the contract and are the desk's own guess: the
wave-4 stack sizes (`bk_double_payday` 5, `bk_boon` 3). Nothing is built
behind those rows yet, so either is a one-word change.

## Parser note (READ BEFORE MERGING)

Two external parsers read `new("sku", CurTickets, ...)` rows out of this file
by hand-rolled parsing. Both **reject `c` today**, and both must accept it
before this merges:

1. `ccp-server` `proxy/scripts/arcademy-catalog.mjs`
2. `cclabs-web` `scripts/sync-arcademy.mjs` (the same parser, lifted; its
   sync Action fails on a bad row)

The `CurChips` **identifier** resolves fine in both: `parseCsConsts` picks up
any `public const string`, so no regex needs teaching. The single blocker is
the currency whitelist:

```js
if (row.cur !== 't' && row.cur !== 'k') die('... has currency "' + row.cur + '", expected "t" or "k".')
```

Verified against `origin/main`'s copy of the server generator, read-only:

```
ERROR: CATALOG PARSE FAILED: in ...\ArcademyEconomy.cs (row 23) has currency "c", expected "t" or "k".
```

With `&& row.cur !== 'c'` added to that one line (patched in a scratch copy,
nothing in `ccp-server` touched), the file parses clean:

```
Wrote data/arcademy-catalog.json: 35 rows, wave 2 (18 on the wire tonight)
```

All thirteen chip rows come out with the prices in the table above.

## Build and test

```
dotnet build      322 Warning(s), 0 Error(s)   (CA1416 / CS8602 pre-existing)
dotnet test --filter FullyQualifiedName~Arcademy
                  Passed! - Failed: 0, Passed: 112, Total: 112
dotnet test --filter Locker|Wardrobe|Catalog|Prize
                  Passed! - Failed: 0, Passed: 81, Total: 81
```

No existing assertion was removed.

## Merge note

`CurrentWave` **stays 2**. Nothing in this PR is on the wire: the projection
drops every chip row and `Buy` answers `unknown` for all thirteen. The bump
to 3 is a separate one-line PR at the end of the stack, because it also
releases the three ticket/token rows already sitting at wave 3.

`EnsureShape` is deliberately **not** touched: PR D1 (the cage) owns the
wallet shape and adds `c` / `earnedC`. A missing `c` reads 0, which refuses a
chip buy rather than paying for one out of thin air, and no chip row is
reachable at wave 2 anyway.

The web lexicon (`Resources/web/arcademy/core/lexicon.js`) needs **no** change:
prize names and blurbs are not kept there, they ride `init.economy.catalog`
from the host, which is what this PR feeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5Gp8FA4yHguiNc46u5YDS
