### PR TITLE
feat(arcademy): the slip, part 4 - the delivery ladder

### DIFF
--- a/ConditioningControlPanel/Resources/web/arcademy/boot.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/boot.js
@@ -867,6 +867,9 @@ bridge.on('profile', guard('profile', (m) => {
 }));
 bridge.on('meta', guard('meta', (m) => { if (shell) shell.onMeta(m); }));
 bridge.on('annex-stats', guard('annex-stats', (m) => { if (shell && shell.onAnnexStats) shell.onAnnexStats(m); }));
+bridge.on('share-image-result', guard('share-image-result', (m) => {
+  if (shell && shell.onShareImageResult) shell.onShareImageResult(m);
+}));
 bridge.on('fullscreen', guard('fullscreen', (m) => { fullscreen = !!m.on; }));
 bridge.on('ping', guard('ping', (m) => bridge.send({ type: 'pong', t: m && m.t })));
 bridge.on('end-run', guard('end-run', () => shutdown('host asked')));

--- a/ConditioningControlPanel/Resources/web/arcademy/core/lexicon.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/core/lexicon.js
@@ -87,6 +87,8 @@ export const DEFAULT_LEXICON = Object.freeze({
   share_image: 'Share report card',
   share_add_name: 'Add my name',
   share_saved: 'Report card saved',
+  share_copied: 'Report card copied',
+  share_shared: 'Report card shared',
   share_unavailable: 'Sharing is not available here',
   done: 'Done',
   xp: 'XP',

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/reportcard.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/reportcard.js
@@ -35,6 +35,7 @@ import { t, gradeLabel, tierLabel } from '../core/lexicon.js';
 import { gradeKey } from '../core/grades.js';
 import { exitBar, sign as signExit, campusPillRow } from './exits.js';
 import { canRenderCard, renderShareCard } from './sharepaint.js';
+import { deliverShareCard, DELIVERED } from './sharedeliver.js';
 
 /** Mod-anonymous, name-only, no URL. Do not "improve" this. */
 export const SHARE_HEADER = 'The Arcademy';
@@ -274,7 +275,7 @@ function printBeat(host, reduced) {
  *                                 preference with nowhere to live.
  */
 export function createReportCard({
-  ceremonies, seep, toast, log, onCounter, identity, shareNamed,
+  ceremonies, seep, toast, log, onCounter, identity, shareNamed, shareToHost,
 } = {}) {
   const say = typeof log === 'function' ? log : () => {};
   const shout = typeof toast === 'function' ? toast : () => {};
@@ -290,6 +291,10 @@ export function createReportCard({
   const readIdentity = typeof identity === 'function' ? identity : null;
   const namedGet = (shareNamed && typeof shareNamed.get === 'function') ? shareNamed.get : null;
   const namedSet = (shareNamed && typeof shareNamed.set === 'function') ? shareNamed.set : null;
+  /* The desktop app's clipboard, reached the only way the page is allowed to
+   * reach anything: a round trip the SHELL owns. A web build hands in nothing
+   * and that rung of the ladder simply is not there. */
+  const toHost = typeof shareToHost === 'function' ? shareToHost : null;
   let namedLocal = false;    // the sitting's answer when there is nowhere to save one
   const isNamed = () => (namedGet ? namedGet() === true : namedLocal);
   const setNamed = (v) => {
@@ -708,25 +713,33 @@ export function createReportCard({
           perfect: !!s.perfect,
           identity: ident,
         }).then((out) => {
-          endBeat();
-          setBusy(shareBtn, false);
-          busy = false;
           if (!out || !out.blob) {
             shout(t('share_unavailable', 'Sharing is not available here'));
             say('share image: the canvas would not export');
-            return;
+            return null;
           }
-          const ok = deliverDownload(out.blob, shareFileName(dateLabel));
-          shout(ok
-            ? t('share_saved', 'Report card saved')
-            : t('share_unavailable', 'Sharing is not available here'));
-          if (!ok) say('share image: this host refuses downloads');
+          return deliverShareCard(out.blob, shareFileName(dateLabel), {
+            toHost, download: deliverDownload,
+          }).then((how) => {
+            if (how === DELIVERED.SHARED) { shout(t('share_shared', 'Report card shared')); return; }
+            if (how === DELIVERED.COPIED) { shout(t('share_copied', 'Report card copied')); return; }
+            if (how === DELIVERED.SAVED) { shout(t('share_saved', 'Report card saved')); return; }
+            /* EVERY RUNG REFUSED. Say so. The Activity iframe can take the
+             * download without taking it, and a beat that looks like it
+             * worked is the one outcome worse than not sharing. */
+            shout(t('share_unavailable', 'Sharing is not available here'));
+            say('share image: no delivery this host will accept');
+          });
         }).catch((e) => {
+          shout(t('share_unavailable', 'Sharing is not available here'));
+          say('share image threw: ' + ((e && e.message) || e));
+        }).then(() => {
+          /* ONE owner for the latch, on every path. The ladder is two awaits
+           * deep now and a beat left running because a rung threw is a button
+           * nobody can press again tonight. */
           endBeat();
           setBusy(shareBtn, false);
           busy = false;
-          shout(t('share_unavailable', 'Sharing is not available here'));
-          say('share image threw: ' + ((e && e.message) || e));
         });
       });
       put(imgBox);

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/sharedeliver.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/sharedeliver.js
@@ -1,0 +1,174 @@
+/* ============================================================================
+ * shell/sharedeliver.js - THE SLIP, handed over.
+ *
+ * `shell/sharecard.js` decides where the marks go, `shell/sharepaint.js` puts
+ * ink on the paper, and this file gets the finished PNG out of the school and
+ * into wherever the player wanted to post it.
+ *
+ * THE LADDER, in the order a player would want it:
+ *
+ *   1. navigator.share({files})  - a phone. The OS sheet is the right answer
+ *                                  there and nothing else comes close, so it
+ *                                  goes first, but ONLY when canShare says
+ *                                  files are actually supported: canShare
+ *                                  exists on hosts that will then throw.
+ *   2. clipboard ClipboardItem   - a desktop browser. Paste straight into
+ *                                  Discord. Safari needs the PROMISE form of
+ *                                  ClipboardItem, so the promise form is what
+ *                                  everyone gets - Chrome takes it too.
+ *   3. the host                  - WebView2 has no async clipboard image write
+ *                                  worth the name, so the desktop app carries
+ *                                  the PNG over the bridge and C# puts it on
+ *                                  the Windows clipboard itself.
+ *   4. <a download>              - the universal floor, and the rung the
+ *                                  Discord Activity iframe can silently
+ *                                  refuse (its sandbox drops navigations it
+ *                                  did not start, and there is no event for
+ *                                  that). Which is why rung 5 exists.
+ *   5. nothing                   - and the player is TOLD so, out loud. A
+ *                                  share that quietly did not happen is the
+ *                                  worst of the five outcomes, not the least.
+ *
+ * Every rung is feature-tested before it is tried and every rung is wrapped:
+ * a host that has the API and refuses anyway simply falls to the next one.
+ * ==========================================================================*/
+
+/** What actually happened. The caller turns one of these into a toast. */
+export const DELIVERED = Object.freeze({
+  SHARED: 'shared',
+  COPIED: 'copied',
+  SAVED: 'saved',
+  NONE: 'none',
+});
+
+/** Biggest PNG we will push across the host bridge, as raw bytes. */
+export const MAX_BRIDGE_BYTES = 3 * 1024 * 1024;
+
+/** A File, when this host has one. Some webviews ship Blob and not File. */
+function asFile(blob, fileName) {
+  try {
+    if (typeof File !== 'function') return null;
+    return new File([blob], String(fileName || 'report.png'), { type: 'image/png' });
+  } catch (e) { return null; }
+}
+
+/**
+ * RUNG 1. The OS share sheet, files and all.
+ *
+ * `canShare` is the gate rather than `share`: every host that can share TEXT
+ * has `navigator.share`, and handing one of those a file list is how you get a
+ * rejected promise instead of a sheet.
+ */
+export async function shareFile(blob, fileName) {
+  try {
+    const nav = (typeof navigator !== 'undefined') ? navigator : null;
+    if (!nav || typeof nav.share !== 'function' || typeof nav.canShare !== 'function') return false;
+    const file = asFile(blob, fileName);
+    if (!file) return false;
+    if (!nav.canShare({ files: [file] })) return false;
+    await nav.share({ files: [file] });
+    return true;
+  } catch (e) {
+    /* AbortError is the player closing the sheet, which is not a failure of
+     * this rung - but it is also not a share, and falling through to the
+     * clipboard after someone deliberately backed out would be rude. */
+    if (e && e.name === 'AbortError') return true;
+    return false;
+  }
+}
+
+/**
+ * RUNG 2. The clipboard, as an image.
+ *
+ * The PROMISE form of ClipboardItem on purpose: Safari only honours a
+ * clipboard write that was issued in the user gesture, and it accepts a
+ * pending promise as the payload precisely so a slow encode does not lose the
+ * gesture. Chrome accepts the same shape, so there is one code path.
+ */
+export async function copyImage(blob) {
+  try {
+    if (typeof ClipboardItem !== 'function') return false;
+    const nav = (typeof navigator !== 'undefined') ? navigator : null;
+    if (!nav || !nav.clipboard || typeof nav.clipboard.write !== 'function') return false;
+    const item = new ClipboardItem({ 'image/png': Promise.resolve(blob) });
+    await nav.clipboard.write([item]);
+    return true;
+  } catch (e) { return false; }
+}
+
+/**
+ * The PNG as bare base64 (no `data:` prefix), or null.
+ *
+ * `arrayBuffer()` + `btoa` first because it is the shorter road and it works
+ * everywhere this page runs; FileReader is the fallback for an older webview
+ * that has Blob but not Blob.arrayBuffer. Chunked through fromCharCode because
+ * spreading 300,000 bytes into one call blows the argument limit.
+ */
+export async function blobToBase64(blob) {
+  try {
+    if (!blob) return null;
+    if (typeof blob.arrayBuffer === 'function' && typeof btoa === 'function') {
+      const bytes = new Uint8Array(await blob.arrayBuffer());
+      let bin = '';
+      for (let i = 0; i < bytes.length; i += 8192) {
+        bin += String.fromCharCode.apply(null, bytes.subarray(i, i + 8192));
+      }
+      return btoa(bin);
+    }
+  } catch (e) { /* fall through to the reader */ }
+  return new Promise((resolve) => {
+    try {
+      if (typeof FileReader !== 'function') { resolve(null); return; }
+      const fr = new FileReader();
+      fr.onerror = () => resolve(null);
+      fr.onload = () => {
+        const s = String(fr.result || '');
+        const comma = s.indexOf(',');
+        resolve(comma >= 0 ? s.slice(comma + 1) : null);
+      };
+      fr.readAsDataURL(blob);
+    } catch (e) { resolve(null); }
+  });
+}
+
+/**
+ * RUNG 3. Over the bridge, onto the Windows clipboard.
+ *
+ * `toHost` is the shell's own round trip (it owns the bridge; this module must
+ * not). Size-capped before the encode, because a base64 string is a third
+ * bigger again and the message channel is not a file transfer.
+ */
+export async function copyViaHost(blob, toHost) {
+  try {
+    if (typeof toHost !== 'function' || !blob) return false;
+    if (!blob.size || blob.size > MAX_BRIDGE_BYTES) return false;
+    const png = await blobToBase64(blob);
+    if (!png) return false;
+    return (await toHost(png)) === true;
+  } catch (e) { return false; }
+}
+
+/**
+ * Walk the ladder and report which rung caught.
+ *
+ * @param {Blob} blob
+ * @param {string} fileName
+ * @param {Object} opts  {toHost, download} - both optional; a missing one is
+ *                       simply a rung this host does not have.
+ * @returns {Promise<string>} one of DELIVERED
+ */
+export async function deliverShareCard(blob, fileName, opts) {
+  const o = opts || {};
+  if (!blob) return DELIVERED.NONE;
+  if (await shareFile(blob, fileName)) return DELIVERED.SHARED;
+  if (await copyImage(blob)) return DELIVERED.COPIED;
+  if (await copyViaHost(blob, o.toHost)) return DELIVERED.COPIED;
+  try {
+    if (typeof o.download === 'function' && o.download(blob, fileName) === true) {
+      return DELIVERED.SAVED;
+    }
+  } catch (e) { /* the floor is allowed to give way; rung 5 catches */ }
+  return DELIVERED.NONE;
+}
+
+export default deliverShareCard;

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/shell.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/shell.js
@@ -1016,6 +1016,7 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
   let roomPage = null;
   /** The one in-flight annex stats request ({promise, resolve, timer}|null). */
   let annexStatsWait = null;
+  let shareImageWait = null;
   /* THE PUNCH-CARD CEREMONY. `punchStage` is the live overlay; `punchArm` is
    * what the shell is WAITING for while the host answers `class-ended`.
    * Both are null the rest of the time. */
@@ -1304,6 +1305,10 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
       get: () => store.get('shareNamed', false) === true,
       set: (v) => store.set('shareNamed', v === true),
     },
+    /* The app only. On the web `src.mediaControls` is true and there is no
+     * host behind the bridge to ask, so that rung of the ladder is absent
+     * rather than present-and-broken. */
+    shareToHost: src.mediaControls === true ? null : shareImageToHost,
   });
 
   /* ---------------------- helpers --------------------------------------- */
@@ -4185,6 +4190,30 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
     return w.promise;
   }
 
+  /* THE SHARE CARD'S LAST RUNG BEFORE THE FLOOR. WebView2 has no async
+   * clipboard image write the page can use, so the desktop app carries the PNG
+   * over the bridge and C# puts it on the Windows clipboard itself. Same shape
+   * as the registry link above: one request in flight, a deadline, and every
+   * failure resolves FALSE rather than hanging a button forever. A web build
+   * never gets here - reportcard.js is handed this only on the app. */
+  function shareImageToHost(png) {
+    if (typeof png !== 'string' || !png) return Promise.resolve(false);
+    if (shareImageWait) return Promise.resolve(false);
+    const w = {};
+    w.promise = new Promise((resolve) => {
+      w.resolve = resolve;
+      w.timer = setTimeout(() => { shareImageWait = null; resolve(false); }, 8000);
+    });
+    shareImageWait = w;
+    try { bridge.send({ type: 'share-image', png }); }
+    catch (e) {
+      clearTimeout(w.timer);
+      shareImageWait = null;
+      return Promise.resolve(false);
+    }
+    return w.promise;
+  }
+
   /* ============================ THE PUNCH CARD ==========================
    * PUNCHCARD §4. The ceremony is the ONLY place the page draws a hole, and it
    * draws the one the HOST minted: `punchcard-result` carries the post-mint
@@ -6413,6 +6442,17 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
       annexStatsWait = null;
       try { clearTimeout(w.timer); } catch (e) { /* noop */ }
       w.resolve(m && m.body && typeof m.body === 'object' ? m.body : null);
+    },
+
+    /** {type:'share-image-result'} - the host either put the PNG on the
+     *  Windows clipboard or it did not. Resolves the one pending request;
+     *  an unsolicited frame is dropped on the floor. */
+    onShareImageResult(m) {
+      const w = shareImageWait;
+      if (!w) return;
+      shareImageWait = null;
+      try { clearTimeout(w.timer); } catch (e) { /* noop */ }
+      w.resolve(!!(m && m.ok));
     },
 
     /** {type:'setting'} post-clamp echo. THE only path that moves a setting. */

--- a/ConditioningControlPanel/Services/Arcademy/ArcademyHostService.cs
+++ b/ConditioningControlPanel/Services/Arcademy/ArcademyHostService.cs
@@ -10,6 +10,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
+using System.Windows.Media.Imaging;
 using System.Windows.Threading;
 using Microsoft.Web.WebView2.Core;
 using Newtonsoft.Json;
@@ -614,6 +615,11 @@ internal static class ArcademyHostService
                 // discordLinked is false - a linked account moves the rung with an ordinary
                 // set-setting instead (contract trap 1).
                 OnLinkDiscord();
+                break;
+            case "share-image":
+                // The report card's PNG, on its way to the Windows clipboard. Fire-and-forget
+                // from the page's side; exactly one reply always comes back.
+                OnShareImage((string?)o["png"]);
                 break;
             case "annex-stats":
                 // The registry link downstairs. Fire-and-forget: exactly one reply comes back,
@@ -1817,6 +1823,8 @@ internal static class ArcademyHostService
         ["share_image"] = "Share report card",
         ["share_add_name"] = "Add my name",
         ["share_saved"] = "Report card saved",
+        ["share_copied"] = "Report card copied",
+        ["share_shared"] = "Report card shared",
         ["share_unavailable"] = "Sharing is not available here",
         ["done"] = "Done",
         ["retake"] = "Retake",
@@ -5338,6 +5346,92 @@ internal static class ArcademyHostService
             });
         }
         catch (Exception ex) { App.Logger?.Debug("ArcademyHost.PostAnnexStats: {E}", ex.Message); }
+    }
+
+    /// <summary>Biggest base64 payload the share card may push over the bridge: about 4.4 MB of
+    /// text, which is roughly 3.3 MB of PNG. The page caps itself well under this; the wall is
+    /// here because a page is a page and the bridge is not a file transfer.</summary>
+    private const int MaxShareImageChars = 4_400_000;
+
+    /// <summary>THE SHARE CARD'S LAST RUNG BEFORE THE FLOOR.
+    ///
+    /// WebView2 gives the page no async clipboard image write worth the name, so the page draws
+    /// the report card, hands the finished PNG over as base64, and C# puts it on the Windows
+    /// clipboard itself. Exactly ONE reply always goes back - <c>ok</c> true or false - because a
+    /// missing reply leaves a button spinning until its own deadline, and a share that quietly did
+    /// not happen is the worst outcome the whole feature has.
+    ///
+    /// The decode and the clipboard write both happen on the UI thread: WPF's clipboard is STA and
+    /// a BitmapImage handed across threads unfrozen is a crash waiting for a slow night.</summary>
+    private static void OnShareImage(string? png)
+    {
+        try
+        {
+            var epoch = Volatile.Read(ref _generation);
+            var win = _host?.Window;
+            if (win == null) return;
+            win.Dispatcher.BeginInvoke(() =>
+            {
+                var ok = false;
+                try
+                {
+                    if (_host == null || Volatile.Read(ref _generation) != epoch) return;
+                    ok = PutPngOnClipboard(png);
+                }
+                catch (Exception ex) { App.Logger?.Debug("ArcademyHost.share-image: {E}", ex.Message); }
+                try { _host?.Post(new { type = "share-image-result", ok }); }
+                catch (Exception ex) { App.Logger?.Debug("ArcademyHost.share-image reply: {E}", ex.Message); }
+            });
+        }
+        catch (Exception ex) { App.Logger?.Debug("ArcademyHost.OnShareImage: {E}", ex.Message); }
+    }
+
+    /// <summary>Decode a base64 PNG and put it on the clipboard. UI thread only. Never throws:
+    /// every refusal - junk base64, something that is not a PNG, a clipboard another process is
+    /// holding open - is a plain false, and the page falls to its download rung.</summary>
+    private static bool PutPngOnClipboard(string? png)
+    {
+        if (string.IsNullOrEmpty(png) || png!.Length > MaxShareImageChars) return false;
+
+        byte[] bytes;
+        try { bytes = Convert.FromBase64String(png); }
+        catch (FormatException) { return false; }
+
+        // The PNG signature, checked before anything is asked to decode it. The page is our own
+        // and the bytes are still validated: a share card is never anything but a share card.
+        if (bytes.Length < 8 || bytes[0] != 0x89 || bytes[1] != 0x50 || bytes[2] != 0x4E || bytes[3] != 0x47)
+            return false;
+
+        BitmapImage img;
+        try
+        {
+            using var ms = new MemoryStream(bytes, writable: false);
+            img = new BitmapImage();
+            img.BeginInit();
+            img.CacheOption = BitmapCacheOption.OnLoad;   // the stream is gone the moment we leave
+            img.StreamSource = ms;
+            img.EndInit();
+            img.Freeze();
+        }
+        catch (Exception ex)
+        {
+            App.Logger?.Debug("ArcademyHost: share image would not decode: {E}", ex.Message);
+            return false;
+        }
+
+        // CLIPBRD_E_CANT_OPEN: another process is holding the clipboard for a moment. One retry is
+        // what every other app on this machine does, and it is nearly always enough.
+        for (var attempt = 0; attempt < 2; attempt += 1)
+        {
+            try { Clipboard.SetImage(img); return true; }
+            catch (System.Runtime.InteropServices.COMException) { Thread.Sleep(60); }
+            catch (Exception ex)
+            {
+                App.Logger?.Debug("ArcademyHost: clipboard refused the share image: {E}", ex.Message);
+                return false;
+            }
+        }
+        return false;
     }
 
     /// <summary>True when remote media may appear anywhere in the app. Copied verbatim from


### PR DESCRIPTION
Stacked on #792 -> #791 -> #790. **Review in that order; do not merge ahead of the stack.**

## What

#792 gave the card a button and a download. This gives it the rungs that should be tried *before* the floor.

| # | Rung | Who it is for | Why it is gated the way it is |
|---|------|---------------|-------------------------------|
| 1 | `navigator.share({files})` | phone | Gated on **`canShare({files})`**, not on `share`. Every host that can share text has `navigator.share`; handing one of those a file list gets you a rejected promise instead of a sheet. A closed sheet is an `AbortError` and counts as **done** - falling through to the clipboard after someone deliberately backed out would be rude. |
| 2 | `ClipboardItem` | desktop browser | The **promise form** on purpose: Safari only honours a clipboard write issued inside the gesture, and takes a pending promise precisely so a slow encode does not lose it. Chrome accepts the same shape, so there is one code path. |
| 3 | the host bridge | desktop app | WebView2 gives the page no async clipboard image write worth the name, so the PNG goes over the bridge as base64 and C# puts it on the Windows clipboard itself. |
| 4 | `<a download>` | everyone | The universal floor - and the rung the Discord Activity iframe can **silently refuse**: its sandbox drops navigations it did not start, and there is no event for that. |
| 5 | nothing, **said out loud** | the Activity, mostly | "Sharing is not available here". A share that quietly did not happen is the worst of the five outcomes, not the least. |

Every rung is feature-tested before it is tried and every rung is wrapped, so a host that *has* an API and refuses anyway falls to the next one rather than taking the button down with it.

The busy latch now has **one owner on every path** - the ladder is two awaits deep, and a beat left running because a rung threw is a button nobody can press again tonight.

## Host side

`share-image` decodes the base64, checks the PNG signature before anything is asked to decode it, and does both the decode and the `Clipboard.SetImage` **on the UI thread** - WPF's clipboard is STA, and an unfrozen `BitmapImage` handed across threads is a crash waiting for a slow night. One retry on `CLIPBRD_E_CANT_OPEN`, which is what every other app on the machine does. Payload capped at ~4.4 MB of text (the page caps itself well under that; this is the wall behind it). **Exactly one reply always goes back**, `ok` true or false, because a missing reply is a spinning button.

`shareToHost` is handed to the report card only on the app - on the web that rung is *absent*, not present-and-broken.

## Test evidence

- Node suite: **104 passed, 0 failed** (12 new, covering the ladder's ordering, the throw-through, the oversized-payload refusal, the missing-bridge case, and that the module carries no strings of its own).
- `node --check` clean on all five touched JS files.
- `dotnet build`: **0 errors**.

**Exercised for real:** the ladder's ordering and every refusal path, in node against stubs; the C# compiles.
**Not exercised:** an actual `navigator.share` sheet on a phone, an actual `ClipboardItem` write in Safari or Chrome, an actual round trip to `Clipboard.SetImage` through WebView2, and the Activity iframe's behaviour. All four need a device or the running app in hand. Every one of them is written to fail *down the ladder* rather than sideways, and rung 5 exists so the last failure is spoken rather than silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cbafJm7hrM8qf4Fr7Wj6r



_Re-raised from #793, whose base branch went away when part 3 merged with `--delete-branch`; GitHub refuses to retarget it. Same commits, base main. Parts 1 to 3 are already on main (#790, #795, #796)._
