### PR TITLE
fix(avalonia): the nav doors' entries take clicks again

### DIFF
--- a/CCP.Avalonia/NavCheck.cs
+++ b/CCP.Avalonia/NavCheck.cs
@@ -21,6 +21,7 @@ namespace ConditioningControlPanel.Avalonia
             global::Avalonia.Threading.Dispatcher.UIThread.RunJobs();
             bool Vis(string n) => w.FindControl<Control>(n)?.IsVisible == true;
             double H(string n) => w.FindControl<Control>(n)?.Height ?? -1;
+            bool Clickable(string n) => w.FindControl<Control>(n)?.IsHitTestVisible == true;
 
             var fails = 0;
             void Check(bool ok, string what) { if (!ok) { fails++; Console.Error.WriteLine("FAIL " + what); } }
@@ -29,11 +30,19 @@ namespace ConditioningControlPanel.Avalonia
 
             w.ShowTab("quests");
             Check(Vis("QuestsTab") && !Vis("SettingsTab"), "quests shows QuestsTab and hides Settings");
-            Check(double.IsNaN(H("DoorPanelYou")) && H("DoorPanelStudio") == 0, "quests unfolds the You door only");
+            Check(w.ExpandedDoor == "you", "quests unfolds the You door only");
+            // The assertion that was missing, and the reason a real defect survived every green run:
+            // the old check asked only about Height. The markup parks each closed door at
+            // IsHitTestVisible="False", and the port never set it back, so an open door drew its
+            // entries and not one of them could be clicked. Height alone cannot see that.
+            Check(Clickable("DoorPanelYou") && !Clickable("DoorPanelStudio"),
+                  "an unfolded door's entries can actually be clicked");
 
             w.ShowTab("Haptics");                       // alias + case-insensitive
             Check(Vis("StudioTab") && !Vis("QuestsTab"), "haptics lands on StudioTab");
-            Check(double.IsNaN(H("DoorPanelStudio")) && H("DoorPanelYou") == 0, "haptics unfolds the Studio door only");
+            Check(w.ExpandedDoor == "studio", "haptics unfolds the Studio door only");
+            Check(Clickable("DoorPanelStudio") && !Clickable("DoorPanelYou"),
+                  "the door that closed stops taking clicks");
 
             w.ShowTab("no-such-tab");
             Check(Vis("StudioTab"), "unknown key keeps the current tab, never a blank page");

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.TabNavigation.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.TabNavigation.cs
@@ -55,7 +55,12 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using Avalonia.Animation;
+using Avalonia.Animation.Easings;
 using Avalonia.Controls;
+using Avalonia.Layout;
+using Avalonia.Threading;
 
 namespace ConditioningControlPanel.Avalonia.Views.Windows
 {
@@ -202,15 +207,83 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
         }
 
         /// <summary>One door open at a time. ponytail: snaps, no height tween.</summary>
+        private const int NavDoorExpandMs = 160;      // WPF MainWindow.TabNavigation.cs:653
+        private const double NavEntryRowHeight = 32;  // WPF MainWindow.TabNavigation.cs:651
+
+        private string? _expandedDoor;
+
+        /// <summary>Which door the accordion currently holds open. The panel's Height cannot answer
+        /// this: an Avalonia transition animates the property itself, so mid-tween it reads back the
+        /// in-flight value rather than the intent.</summary>
+        internal string? ExpandedDoor => _expandedDoor;
+
         private void SetExpandedDoor(string? door)
         {
+            _expandedDoor = door;
             foreach (var d in NavDoorMap)
             {
                 if (d.Panel is null) continue;
-                var panel = this.FindControl<Control>(d.Panel);
-                if (panel is not null) panel.Height = d.Door == door ? double.NaN : 0;
+                var panel = this.FindControl<Border>(d.Panel);
+                if (panel is not null) SetDoorPanelExpanded(d.Door, panel, d.Door == door);
             }
         }
+
+        /// <summary>
+        /// The accordion, ported from WPF's SetDoorPanelExpanded (MainWindow.TabNavigation.cs:872).
+        ///
+        /// The first cut of this file set Height alone. That was a real defect, not a missing
+        /// flourish: the markup parks every closed door at <c>Height="0" IsHitTestVisible="False"</c>,
+        /// and nothing ever set hit-testing back, so an opened door drew its entries and NONE of them
+        /// could be clicked. Only the Home door worked, because it is the one panel the markup does
+        /// not park. WPF line 874 is <c>panel.IsHitTestVisible = expand;</c> and it is restored here.
+        ///
+        /// The tween is WPF's too - 160ms, quadratic ease-out - as an Avalonia
+        /// <see cref="DoubleTransition"/> on Height rather than a storyboard. A transition cannot
+        /// land on <c>NaN</c>, so it runs to a measured pixel height and the panel is handed back to
+        /// layout afterwards, exactly as WPF's Completed handler does, so that a later visibility
+        /// change on one entry still resizes the door. The completion guard asks the same question
+        /// WPF asks: a faster click may already own the panel, and a tween that started on a door
+        /// the user has since left must not write its height back.
+        /// </summary>
+        private void SetDoorPanelExpanded(string door, Border panel, bool expand)
+        {
+            panel.IsHitTestVisible = expand;
+
+            var entries = this.FindControl<StackPanel>(panel.Name!.Replace("DoorPanel", "DoorEntries"));
+            var to = expand ? MeasureDoorPanel(entries) : 0d;
+
+            // Snap when there is nothing to travel - first layout, or a door already where it
+            // belongs. Clearing Transitions first stops the assignment animating to NaN.
+            if (Math.Abs(panel.Bounds.Height - to) < 0.5)
+            {
+                panel.Transitions = null;
+                panel.Height = expand ? double.NaN : 0;
+                return;
+            }
+
+            panel.Transitions ??= new Transitions
+            {
+                new DoubleTransition
+                {
+                    Property = Layoutable.HeightProperty,
+                    Duration = TimeSpan.FromMilliseconds(NavDoorExpandMs),
+                    Easing = new QuadraticEaseOut(),
+                },
+            };
+            panel.Height = to;
+
+            DispatcherTimer.RunOnce(() =>
+            {
+                var stillOwnsThePanel = string.Equals(_expandedDoor, door, StringComparison.Ordinal);
+                if (stillOwnsThePanel != expand) return;
+                panel.Transitions = null;
+                panel.Height = expand ? double.NaN : 0;
+            }, TimeSpan.FromMilliseconds(NavDoorExpandMs + 20));
+        }
+
+        /// <summary>WPF MeasureDoorPanel: one row per visible entry, nothing cleverer.</summary>
+        private static double MeasureDoorPanel(StackPanel? entries)
+            => entries is null ? 0 : entries.Children.OfType<Control>().Count(c => c.IsVisible) * NavEntryRowHeight;
 
         private void NavDoor_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e)
         {


### PR DESCRIPTION
Every entry inside an expanded nav door was unclickable, and had been since the shell
landed. The markup parks each closed door at `Height="0" IsHitTestVisible="False"`
(MainShellWindow.axaml:822 and four siblings). WPF's SetDoorPanelExpanded sets hit-testing
back on line 874; the port set Height alone. So an opened door drew its entries, looked
right, and swallowed every click on them. Only the Home door worked, because it is the one
panel the markup does not park - which is exactly the "some buttons work" a user sees.

Restores WPF line 874, and with it the 160ms quadratic ease-out the port had recorded as a
known gap. The tween is an Avalonia DoubleTransition rather than a storyboard. A transition
cannot land on NaN, so it runs to a measured pixel height and the panel is handed back to
layout afterwards, exactly as WPF's Completed handler does, so a later visibility change on
one entry still resizes the door. The completion guard asks WPF's question: a faster click
may already own the panel, and a tween that started on a door the user has since left must
not write its height back.

The reason this survived four months of green runs is the more useful half. --nav-check
asserted the door's Height. Height was never what was broken, and no proof in the repo
asked whether a control could be clicked. It does now, and the assertion is written against
the contract rather than the animation: ExpandedDoor plus IsHitTestVisible, because an
Avalonia transition animates the property itself, so mid-tween Height reads back the
in-flight value rather than the intent.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>