### PR TITLE
feat(arcademy): Back Room K1a - the cashier's line and the money

### DIFF
--- a/ConditioningControlPanel/Resources/web/arcademy/backroom/kit/api.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/backroom/kit/api.js
@@ -1,0 +1,223 @@
+/* ============================================================================
+ * backroom/kit/api.js - the cashier's telephone.
+ *
+ * The page never dials the proxy. It says one thing up the seam and waits for
+ * one thing back (BACKROOM-CONTRACT §3):
+ *
+ *   up    { type:'casino-request', reqId, op:'status'|'cage'|'play', body, localDay }
+ *   down  { type:'casino-result',  reqId, ok, status, body }
+ *
+ * Every answer this module hands back has the SAME shape, win or lose or never
+ * arrived: `{ ok, status, body }`. A caller therefore never has to write a
+ * try/catch around a promise that might reject, and the floor can render a dark
+ * cage instead of throwing. That is the whole reason this file exists: a room
+ * with no line to the counter is still a room.
+ *
+ * There is no client-side chip arithmetic here on purpose (LEDGER TRUTH). The
+ * server resolves; this file only carries the question and the receipt.
+ * ==========================================================================*/
+
+/** Every request gets this long before the cage goes dark. Eight seconds is the
+ *  wallet's own patience: long enough for a cold server, short enough that a
+ *  player standing at the counter does not think the app has died. */
+const TIMEOUT_MS = 8000;
+
+/** The trigger list is a smaller favour and a host that has no trigger store
+ *  answers instantly or not at all, so it waits a shorter beat. */
+const TRIGGER_TIMEOUT_MS = 2500;
+
+/** The offline answer, minted fresh each time so nobody can mutate a shared one. */
+function offline(reason) {
+  return { ok: false, status: 0, body: { reason: reason || 'offline' } };
+}
+
+/**
+ * The wire's id shape, and it is not a taste: `ArcademyWalletSyncService.IdShape`
+ * is `^[A-Za-z0-9_-]{8,64}$` and every id the host mints is a GUID in "N" form,
+ * i.e. 32 hex characters. A cageId or playId is an IDEMPOTENCY KEY - the server
+ * remembers it and replays the original result - so it has to be unguessable
+ * and it has to survive a retry unchanged. `crypto.randomUUID` where there is
+ * one, `getRandomValues` where there is not, and a clock+counter floor so a
+ * hardened webview with neither still mints something legal rather than
+ * throwing at the counter.
+ */
+let idSeq = 0;
+export function mintId() {
+  const c = (typeof globalThis !== 'undefined') ? globalThis.crypto : null;
+  try {
+    if (c && typeof c.randomUUID === 'function') return c.randomUUID().replace(/-/g, '');
+  } catch { /* fall through */ }
+  try {
+    if (c && typeof c.getRandomValues === 'function') {
+      const b = new Uint8Array(16);
+      c.getRandomValues(b);
+      let s = '';
+      for (let i = 0; i < b.length; i++) s += b[i].toString(16).padStart(2, '0');
+      return s;
+    }
+  } catch { /* fall through */ }
+  idSeq += 1;
+  const rnd = Math.floor(Math.random() * 0xFFFFFFFF).toString(16).padStart(8, '0');
+  return ('bk' + Date.now().toString(16) + rnd + idSeq.toString(16)).slice(0, 32);
+}
+
+/** 'yyyy-mm-dd' in LOCAL time. The same six lines shell/bugle.js and
+ *  shell/corkboard.js carry, copied rather than imported because the kit does
+ *  not reach into the shell (vendoring law) - and a date STAMP on this page is
+ *  always local (trap 8), which is what the free scratcher's day is bounded by. */
+export function localDay(when) {
+  const d = (when instanceof Date) ? when : new Date();
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return y + '-' + m + '-' + day;
+}
+
+/**
+ * createCasinoApi({ send, listen, log }) -> the counter's line.
+ *
+ * `send(msg)` and `listen(type, fn) -> unsubscribe` are the two things the
+ * shell hands down. EITHER ONE MISSING is not an error: every call answers
+ * `offline` on the next tick and the floor draws the cage dark. Rigs stub ctx
+ * without them, and so does a web host that has not shipped the relay yet.
+ */
+export function createCasinoApi(opts) {
+  const o = opts || {};
+  const send = (typeof o.send === 'function') ? o.send : null;
+  const listen = (typeof o.listen === 'function') ? o.listen : null;
+  const say = (typeof o.log === 'function') ? o.log : () => {};
+  const timeoutMs = Number(o.timeoutMs) > 0 ? Number(o.timeoutMs) : TIMEOUT_MS;
+  const wired = !!(send && listen);
+
+  let dead = false;
+  let lastStatus = null;            // the last ok `status` body, for a cheap re-read
+  const pending = new Map();        // reqId -> { resolve, timer }
+  let offResult = null;
+  let triggerWait = null;           // one in-flight triggers-request, shared
+
+  if (wired) {
+    try {
+      offResult = listen('casino-result', (m) => {
+        if (dead || !m) return;
+        const rec = pending.get(m.reqId);
+        if (!rec) return;                       // a stale or foreign receipt is not ours
+        pending.delete(m.reqId);
+        try { clearTimeout(rec.timer); } catch { /* noop */ }
+        const answer = {
+          ok: m.ok === true,
+          status: Number(m.status) || 0,
+          body: (m.body && typeof m.body === 'object') ? m.body : {},
+        };
+        if (answer.ok && rec.op === 'status') lastStatus = answer.body;
+        rec.resolve(answer);
+      });
+    } catch (e) { say('backroom: casino-result listen failed: ' + ((e && e.message) || e)); }
+  }
+
+  /** One question, one receipt, never a rejection. */
+  function ask(op, body) {
+    if (dead || !wired) return Promise.resolve(offline('offline'));
+    const reqId = mintId();
+    return new Promise((resolve) => {
+      const timer = setTimeout(() => {
+        pending.delete(reqId);
+        // A timeout is NOT a refusal. The stake may well have landed, which is
+        // why every id is minted once and reused on a retry: the server answers
+        // the original result and nothing moves twice.
+        resolve(offline('timeout'));
+      }, timeoutMs);
+      pending.set(reqId, { resolve, timer, op });
+      try {
+        send({ type: 'casino-request', reqId, op, body: body || {}, localDay: localDay() });
+      } catch (e) {
+        pending.delete(reqId);
+        try { clearTimeout(timer); } catch { /* noop */ }
+        say('backroom: casino-request send failed: ' + ((e && e.message) || e));
+        resolve(offline('offline'));
+      }
+    });
+  }
+
+  return {
+    /** Is there a line at all? The floor asks this before it dresses the cage. */
+    wired: () => wired && !dead,
+
+    /** The whole floor in one frame: chips, sparkle, pot, tree, config, hand. */
+    status: () => ask('status', {}),
+
+    /**
+     * Sparkle in, chips out, one way. `cageId` is minted here so a caller
+     * cannot forget it, and it is handed back on the answer so a retry can
+     * carry the SAME one (idempotency, contract §1).
+     */
+    cage(sparkle, cageId) {
+      const n = Math.round(Number(sparkle) || 0);
+      const id = cageId ? String(cageId) : mintId();
+      return ask('cage', { sparkle: n, cageId: id }).then((r) => Object.assign({ cageId: id }, r));
+    },
+
+    /** A stake at a machine. Same idempotency story as the cage. */
+    play(machine, stake, input, playId) {
+      const id = playId ? String(playId) : mintId();
+      return ask('play', {
+        machine: String(machine || ''),
+        stake: Math.round(Number(stake) || 0),
+        playId: id,
+        input: (input && typeof input === 'object') ? input : {},
+      }).then((r) => Object.assign({ playId: id }, r));
+    },
+
+    /** The last `status` body that came back ok, or null. Read, never written to. */
+    last: () => lastStatus,
+
+    /** Remember a status body the floor already has (the open frame), so a
+     *  machine mounted a second later does not have to ask again. */
+    seed(body) { if (body && typeof body === 'object') lastStatus = body; },
+
+    /**
+     * The player's own trigger phrases, raw. A host with no trigger store
+     * answers `[]` and the kit's authored list takes over - which is why this
+     * resolves to an array and never to an error.
+     */
+    triggers() {
+      if (dead || !wired) return Promise.resolve([]);
+      if (triggerWait) return triggerWait;
+      triggerWait = new Promise((resolve) => {
+        let off = null;
+        let done = false;
+        const finish = (list) => {
+          if (done) return;
+          done = true;
+          try { if (off) off(); } catch { /* noop */ }
+          try { clearTimeout(timer); } catch { /* noop */ }
+          resolve(Array.isArray(list) ? list : []);
+        };
+        const timer = setTimeout(() => finish([]), TRIGGER_TIMEOUT_MS);
+        try { off = listen('triggers-result', (m) => finish(m && m.triggers)); }
+        catch { finish([]); return; }
+        try { send({ type: 'triggers-request' }); }
+        catch (e) { say('backroom: triggers-request failed: ' + ((e && e.message) || e)); finish([]); }
+      });
+      return triggerWait;
+    },
+
+    localDay,
+    mintId,
+
+    /** Every timer cleared, every waiter answered. Safe from any road, twice. */
+    destroy() {
+      if (dead) return;
+      dead = true;
+      for (const [, rec] of pending) {
+        try { clearTimeout(rec.timer); } catch { /* noop */ }
+        try { rec.resolve(offline('closed')); } catch { /* noop */ }
+      }
+      pending.clear();
+      try { if (offResult) offResult(); } catch { /* noop */ }
+      offResult = null;
+      triggerWait = null;
+    },
+  };
+}
+
+export default createCasinoApi;

--- a/ConditioningControlPanel/Resources/web/arcademy/backroom/kit/chips.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/backroom/kit/chips.js
@@ -1,0 +1,261 @@
+/* ============================================================================
+ * backroom/kit/chips.js - the money, and how it moves.
+ *
+ * Three things, and every machine on the floor uses all three:
+ *   balanceChip()  the little "chips: 2,000" plate in a header
+ *   chipStack()    the drawn stack in front of the player
+ *   bank()         THE BANK: chips arcing from one place to another
+ *
+ * BANK GOES BOTH WAYS on purpose. A stake leaving for the table is the same
+ * ceremony as a win coming home, played backwards, because a room where money
+ * only ever arrives with a flourish is a room that is lying about what it is.
+ *
+ * REDUCED MOTION IS INSTANT, not slow (trap 66/92). Every animation in here is
+ * driven by requestAnimationFrame rather than CSS, so the global freeze at the
+ * bottom of styles.css cannot reach it - which means this file has to check
+ * `reduced` itself and simply land on the final number. It does, on every path.
+ * ==========================================================================*/
+
+const nf = (typeof Intl !== 'undefined' && Intl.NumberFormat) ? new Intl.NumberFormat('en-US') : null;
+
+/** 2000 -> "2,000". The one place a chip count becomes text. */
+export function fmtChips(n) {
+  const v = Math.round(Number(n) || 0);
+  try { return nf ? nf.format(v) : String(v); } catch { return String(v); }
+}
+
+function el(tag, cls, text) {
+  const n = document.createElement(tag);
+  if (cls) n.className = cls;
+  if (text != null) n.textContent = String(text);
+  return n;
+}
+
+/** rAF that still ticks in node and in a headless probe with no frame clock -
+ *  a missing rAF must never mean "the number never lands" (trap 36's lesson). */
+function raf(fn) {
+  if (typeof requestAnimationFrame === 'function') return requestAnimationFrame(fn);
+  return setTimeout(() => fn(Date.now()), 16);
+}
+function unraf(h) {
+  if (typeof cancelAnimationFrame === 'function') { try { cancelAnimationFrame(h); return; } catch { /* noop */ } }
+  try { clearTimeout(h); } catch { /* noop */ }
+}
+
+const easeOut = (t) => 1 - Math.pow(1 - t, 3);
+
+/**
+ * countUp(node, from, to, {ms, reduced}) -> stop()
+ *
+ * Walks the printed number. Reduced motion writes the destination on the first
+ * tick and stops - the count-up is decoration, the NUMBER is the information,
+ * and the information must never be withheld for a second and a half.
+ */
+export function countUp(node, from, to, opts) {
+  const o = opts || {};
+  const end = Math.round(Number(to) || 0);
+  if (!node) return () => {};
+  const write = (v) => { node.textContent = fmtChips(v); };
+  if (o.reduced || !(Number(o.ms) > 0)) { write(end); return () => {}; }
+  const start = Math.round(Number(from) || 0);
+  if (start === end) { write(end); return () => {}; }
+  const ms = Number(o.ms);
+  /* ONE CLOCK, READ THE SAME WAY AT BOTH ENDS. The stamp requestAnimationFrame
+   * hands its callback is NOT always on the same origin as performance.now (a
+   * headless probe on a virtual-time budget is the case that caught this), and
+   * mixing the two made `t` land outside 0..1 - which painted a MINUS BALANCE
+   * for a frame. A balance may never read wrong, not even for one frame. */
+  const clock = () => ((typeof performance !== 'undefined' && performance.now) ? performance.now() : Date.now());
+  const t0 = clock();
+  let handle = null;
+  let belt = null;
+  let stopped = false;
+  let frames = 0;
+  const land = () => { if (!stopped) { stopped = true; write(end); } };
+  const step = () => {
+    if (stopped) return;
+    frames += 1;
+    /* THE FRAME FLOOR, and it is not belt-and-braces, it is the brace itself.
+     * A clock that does not move (a headless probe on a virtual-time budget is
+     * the one that caught this) leaves a pure clock-driven rAF loop spinning
+     * for ever, which ALSO starves the setTimeout below it, because a renderer
+     * with a frame permanently pending never goes idle. Counting frames as a
+     * second, slower hand means the count always finishes: whichever hand has
+     * gone further wins, so a real clock still drives a real animation. */
+    const byClock = (clock() - t0) / ms;
+    const byFrame = (frames * 16) / ms;
+    const t = Math.max(0, Math.min(1, Math.max(byClock, byFrame)));
+    write(Math.round(start + (end - start) * easeOut(t)));
+    if (t < 1) handle = raf(step); else stopped = true;
+  };
+  handle = raf(step);
+  // The belt: no frame clock, a backgrounded tab, a probe that never paints -
+  // the NUMBER still arrives, because the number was the information.
+  belt = setTimeout(land, ms + 240);
+  return function stop() {
+    stopped = true;
+    write(end);
+    if (handle != null) unraf(handle);
+    try { clearTimeout(belt); } catch { /* noop */ }
+  };
+}
+
+/**
+ * balanceChip({ label, value, reduced }) -> { el, set(n, {animate}), value() }
+ *
+ * The header plate. `set` count-ups by default and thuds the plate so a change
+ * is felt even when the eye was elsewhere.
+ */
+export function balanceChip(opts) {
+  const o = opts || {};
+  const root = el('span', 'bk-bal');
+  const name = el('i', 'bk-bal-mark');
+  name.setAttribute('aria-hidden', 'true');
+  const num = el('b', 'bk-bal-n', fmtChips(o.value));
+  const cap = el('span', 'bk-bal-label', o.label == null ? '' : String(o.label));
+  root.appendChild(name);
+  root.appendChild(num);
+  root.appendChild(cap);
+  root.setAttribute('role', 'status');
+
+  let value = Math.round(Number(o.value) || 0);
+  let stop = () => {};
+  return {
+    el: root,
+    value: () => value,
+    set(n, setOpts) {
+      const s = setOpts || {};
+      const next = Math.round(Number(n) || 0);
+      const prev = value;
+      value = next;
+      try { stop(); } catch { /* noop */ }
+      const reduced = s.reduced != null ? !!s.reduced : !!o.reduced;
+      stop = countUp(num, prev, next, { ms: s.animate === false ? 0 : 520, reduced });
+      // The thud is a CLASS the sheet animates, so the global reduced freeze
+      // already flattens it - no second guard needed here.
+      if (next !== prev) {
+        root.classList.remove('bk-thud');
+        void root.offsetWidth;
+        root.classList.add('bk-thud');
+        root.classList.toggle('bk-down', next < prev);
+      }
+      root.setAttribute('aria-label', (o.label || '') + ' ' + fmtChips(next));
+    },
+  };
+}
+
+/** How many drawn chips a count is worth. A stack that grew one disc per chip
+ *  would be a thousand nodes; the floor reads the NUMBER and the stack is the
+ *  feeling, so it saturates at ten discs and says the rest in the plate. */
+function discsFor(n) {
+  const v = Math.max(0, Math.round(Number(n) || 0));
+  if (!v) return 0;
+  return Math.max(1, Math.min(10, Math.round(Math.log10(v + 1) * 3.2)));
+}
+
+/**
+ * chipStack({ value, reduced }) -> { el, set(n), rect() }
+ * The drawn pile. Purely decorative and never authoritative.
+ */
+export function chipStack(opts) {
+  const o = opts || {};
+  const root = el('span', 'bk-stack');
+  root.setAttribute('aria-hidden', 'true');
+  let discs = -1;
+  function set(n) {
+    const want = discsFor(n);
+    if (want === discs) return;
+    discs = want;
+    root.textContent = '';
+    for (let i = 0; i < want; i++) {
+      const d = el('i', 'bk-disc' + (i % 3 === 0 ? ' bk-disc-hot' : ''));
+      d.style.setProperty('--bk-i', String(i));
+      root.appendChild(d);
+    }
+  }
+  set(o.value);
+  return {
+    el: root,
+    set,
+    rect: () => (root.getBoundingClientRect ? root.getBoundingClientRect() : null),
+  };
+}
+
+function centreOf(target) {
+  if (!target) return null;
+  const r = (typeof target.getBoundingClientRect === 'function')
+    ? target.getBoundingClientRect()
+    : (target.el && typeof target.el.getBoundingClientRect === 'function' ? target.el.getBoundingClientRect() : null);
+  if (!r) return null;
+  return { x: r.left + r.width / 2, y: r.top + r.height / 2 };
+}
+
+/**
+ * bank(from, to, { count, ms, reduced, host }) -> Promise<void>
+ *
+ * THE BANK. Arcs a handful of discs from one node to another and resolves when
+ * the last one lands, so a caller can chain the number onto the arrival.
+ *
+ * It resolves IMMEDIATELY and draws nothing when motion is reduced, when either
+ * end cannot be measured (a detached node, a node double in a test) or when
+ * there is no document to hang the flight layer on. The caller's `.then` still
+ * runs, so a room can never be left waiting on a beat that was refused.
+ */
+export function bank(from, to, opts) {
+  const o = opts || {};
+  const a = centreOf(from);
+  const b = centreOf(to);
+  if (o.reduced || !a || !b || typeof document === 'undefined' || !document.body) return Promise.resolve();
+
+  const count = Math.max(1, Math.min(9, Math.round(Number(o.count) || 5)));
+  const ms = Math.max(180, Math.min(1200, Number(o.ms) || 620));
+  const layer = el('div', 'bk-flight');
+  layer.setAttribute('aria-hidden', 'true');
+  document.body.appendChild(layer);
+
+  return new Promise((resolve) => {
+    let landed = 0;
+    let handle = null;
+    let killed = false;
+    const nodes = [];
+    for (let i = 0; i < count; i++) {
+      const d = el('i', 'bk-fly');
+      // A little scatter so five discs do not read as one disc drawn five times.
+      d.__lift = 40 + (i % 3) * 26;
+      d.__wobble = ((i % 2) ? 1 : -1) * (8 + i * 3);
+      d.__delay = i * 42;
+      layer.appendChild(d);
+      nodes.push(d);
+    }
+    const t0 = (typeof performance !== 'undefined' && performance.now) ? performance.now() : Date.now();
+    const done = () => {
+      if (killed) return;
+      killed = true;
+      if (handle != null) unraf(handle);
+      try { layer.remove ? layer.remove() : layer.parentNode && layer.parentNode.removeChild(layer); } catch { /* noop */ }
+      resolve();
+    };
+    const step = (now) => {
+      if (killed) return;
+      const el0 = (now || Date.now()) - t0;
+      landed = 0;
+      for (const d of nodes) {
+        const t = Math.max(0, Math.min(1, (el0 - d.__delay) / ms));
+        if (t >= 1) landed += 1;
+        const e = easeOut(t);
+        const x = a.x + (b.x - a.x) * e + d.__wobble * Math.sin(t * Math.PI);
+        const y = a.y + (b.y - a.y) * e - d.__lift * Math.sin(t * Math.PI);
+        d.style.transform = 'translate3d(' + x.toFixed(1) + 'px,' + y.toFixed(1) + 'px,0) scale(' + (1 - t * 0.25).toFixed(3) + ')';
+        d.style.opacity = t >= 1 ? '0' : '1';
+      }
+      if (landed >= nodes.length) { done(); return; }
+      handle = raf(step);
+    };
+    handle = raf(step);
+    // A belt for the brace: if a frame clock never ticks (a backgrounded tab,
+    // a headless probe), the flight still ends and the caller still continues.
+    setTimeout(done, ms + count * 42 + 400);
+  });
+}
+
+export default { fmtChips, countUp, balanceChip, chipStack, bank };


### PR DESCRIPTION
**Merge order: K1a -> K1b -> K1c -> K1d -> K1e.** This is the first of five and the only one based on `main`. Nothing here is wired into the shell yet; PR W1 imports `backroom/index.js`'s `openBackRoom(ctx)`, which lands in K1c.

The two pieces every machine on the casino floor will share, and nothing else. No room, no cage, no cabinets.

### `backroom/kit/api.js` (223 lines)
The promise wrapper over the shell's `send`/`listen`.

- Every answer has the same `{ok, status, body}` shape whether the server said yes, said no, or never answered. No caller needs a try/catch around a rejection, and the floor can draw a dark cage instead of throwing.
- **Missing `send` or `listen` is not an error.** It resolves `offline` on the next tick, which is what a rig, a fixture page and a web host without the relay should see.
- 8s timeout resolves `{ok:false, status:0, body:{reason:'timeout'}}`. A timeout is not a refusal, which is why every id is minted once and reused on a retry.
- Ids are 32 hex characters, inside `ArcademyWalletSyncService.IdShape` (`^[A-Za-z0-9_-]{8,64}$`), because a `cageId` is an idempotency key. `crypto.randomUUID`, then `getRandomValues`, then a clock+counter floor so a hardened webview still mints something legal.
- `localDay()` is `shell/bugle.js`'s six lines copied rather than imported (the kit does not reach into the shell).

### `backroom/kit/chips.js` (261 lines)
The balance plate, the drawn stack and THE BANK, which goes both ways on purpose: a stake leaving is the same ceremony as a win arriving, played backwards. A room where money only ever arrives with a flourish is lying about what it is.

All of it is rAF driven, so the global reduced-motion freeze at the bottom of `styles.css` cannot reach it and every path checks the flag itself and lands on the final number instantly (trap 92).

**Two guards the headless probe earned**, both live bugs it caught:

1. `countUp` reads **one clock at both ends**. The stamp rAF hands its callback is not always on `performance.now`'s origin, and mixing them made `t` land outside 0..1, which painted a **minus balance** for a frame. A balance may never read wrong, not even for one frame.
2. Progress has a **frame-count floor** as well as a clock. A clock that never moves left the loop spinning for ever, which also starved the `setTimeout` belt underneath it: a renderer with a frame permanently pending never goes idle.

### Ledger truth
No chip arithmetic anywhere in either file. The server resolves; these carry the question and the receipt.

### Verification
Both files are exercised by the fixture that lands in K1d (22 checks, all passing on the tip of the stack).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5Gp8FA4yHguiNc46u5YDS
