### PR TITLE
feat(arcademy): Back Room K1b - skin, words and dealer

### DIFF
--- a/ConditioningControlPanel/Resources/web/arcademy/backroom/backroom.css
+++ b/ConditioningControlPanel/Resources/web/arcademy/backroom/backroom.css
@@ -1,0 +1,201 @@
+/* ============================================================================
+ * backroom/backroom.css - the felt, the neon and the brass.
+ *
+ * Lazy-linked by backroom/index.js on first open, exactly like rooms.css. Every
+ * colour is a var() off the shell's tokens or a color-mix of them, so a mod
+ * palette reskins the casino for free and nothing here is a taste nobody can
+ * override. The two literals are the felt greens, and they are literals for the
+ * same reason the card hues are: a casino table is a REMEMBERED colour, not a
+ * derived one, and a violet felt reads as a bug.
+ *
+ * TYPE: --disp for signage, --body for copy, --mono for numbers. No serif
+ * anywhere (house camera law) and no font host (trap 2).
+ *
+ * MOTION: every keyframe in here is decoration and the global freeze at the
+ * bottom of styles.css already flattens it under html.arc-reduced. What this
+ * sheet adds on top is the DIET: html.arc-mobile and html.ae-lite drop the
+ * glows, the chases and the felt texture, because those are the three things a
+ * phone pays a whole frame for.
+ * ==========================================================================*/
+
+.bk-room {
+  --bk-felt:#1b3a2e;
+  --bk-felt-dark:#0f2119;
+  --bk-brass:var(--gold);
+  --bk-neon:var(--pink);
+  --bk-neon-2:var(--lav);
+  --bk-edge:color-mix(in srgb, var(--bk-felt), black 40%);
+  --bk-plate:color-mix(in srgb, var(--panel), var(--bk-felt) 30%);
+
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  min-height: 100%;
+  padding: 14px 16px 28px;
+  color: var(--ink);
+  font-family: var(--body);
+  background:
+    radial-gradient(ellipse 70% 45% at 50% -8%, color-mix(in srgb, var(--bk-neon), transparent 82%) 0%, transparent 62%),
+    linear-gradient(180deg, color-mix(in srgb, var(--bk-felt), black 26%), var(--ground) 78%);
+}
+/* The felt weave. One repeating gradient, no image, first thing the diet cuts. */
+.bk-room::before {
+  content: ''; position: absolute; inset: 0; pointer-events: none; opacity: .16;
+  background-image:
+    repeating-linear-gradient(45deg, transparent 0 3px, color-mix(in srgb, var(--bk-felt), white 12%) 3px 4px),
+    repeating-linear-gradient(-45deg, transparent 0 3px, color-mix(in srgb, var(--bk-felt-dark), black 20%) 3px 4px);
+}
+.bk-room > * { position: relative; z-index: 1; }
+
+/* ---------------------------------- header ------------------------------- */
+.bk-head {
+  display: flex; align-items: center; gap: 12px; flex-wrap: wrap;
+  padding-bottom: 10px;
+  border-bottom: 2px solid color-mix(in srgb, var(--bk-brass), transparent 62%);
+}
+.bk-title {
+  font-family: var(--disp); font-size: clamp(18px, 3.2vw, 30px); letter-spacing: .1em;
+  margin: 0; color: var(--bk-brass);
+  text-shadow: 0 0 16px color-mix(in srgb, var(--bk-brass), transparent 55%), 0 2px 0 #0008;
+}
+.bk-head-spacer { flex: 1 1 auto; }
+
+/* the balance plate + the drawn stack (kit/chips.js) */
+.bk-bal {
+  display: inline-flex; align-items: baseline; gap: 7px;
+  padding: 5px 12px; border-radius: 999px;
+  background: var(--bk-plate); border: 1px solid color-mix(in srgb, var(--bk-brass), transparent 60%);
+  font-family: var(--mono); font-variant-numeric: tabular-nums;
+}
+.bk-bal-mark {
+  width: 11px; height: 11px; border-radius: 50%; align-self: center;
+  background: radial-gradient(circle at 35% 30%, var(--bk-neon), color-mix(in srgb, var(--bk-neon), black 45%));
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--ink), transparent 78%);
+}
+.bk-bal-n { font-size: 16px; color: var(--ink); font-weight: 600; }
+.bk-bal-label { font-size: 10px; letter-spacing: .16em; text-transform: uppercase; color: var(--ink-faint); }
+.bk-bal.bk-thud { animation: bk-thud .26s ease-out 1; }
+.bk-bal.bk-thud.bk-down { animation-name: bk-thud-down; }
+@keyframes bk-thud { 0% { transform: scale(1); } 40% { transform: scale(1.09); } 100% { transform: scale(1); } }
+@keyframes bk-thud-down { 0% { transform: translateY(0); } 45% { transform: translateY(3px); } 100% { transform: translateY(0); } }
+
+.bk-stack { display: inline-flex; flex-direction: column-reverse; align-items: center; }
+.bk-disc {
+  width: 26px; height: 6px; border-radius: 3px; margin-top: -1px;
+  background: linear-gradient(180deg, color-mix(in srgb, var(--bk-neon-2), white 12%), color-mix(in srgb, var(--bk-neon-2), black 42%));
+  box-shadow: 0 1px 0 #0006;
+}
+.bk-disc-hot { background: linear-gradient(180deg, color-mix(in srgb, var(--bk-neon), white 14%), color-mix(in srgb, var(--bk-neon), black 40%)); }
+
+/* THE BANK's flight layer. Body-level and fixed, so it can cross any panel. */
+.bk-flight { position: fixed; inset: 0; z-index: 62; pointer-events: none; }
+.bk-fly {
+  position: absolute; top: 0; left: 0; width: 16px; height: 16px; margin: -8px 0 0 -8px;
+  border-radius: 50%; will-change: transform, opacity;
+  background: radial-gradient(circle at 34% 30%, var(--gold), color-mix(in srgb, var(--gold), black 48%));
+  box-shadow: 0 0 10px color-mix(in srgb, var(--gold), transparent 45%);
+}
+
+/* ---------------------------------- the pot ------------------------------ */
+.bk-pot {
+  display: flex; align-items: baseline; gap: 10px; align-self: flex-start;
+  padding: 8px 16px; border-radius: 8px;
+  background: linear-gradient(180deg, color-mix(in srgb, var(--bk-neon), black 62%), color-mix(in srgb, var(--ground), black 20%));
+  border: 2px solid color-mix(in srgb, var(--bk-neon), transparent 55%);
+  box-shadow: 0 0 24px color-mix(in srgb, var(--bk-neon), transparent 78%);
+}
+.bk-pot-label { font-family: var(--mono); font-size: 10px; letter-spacing: .22em; text-transform: uppercase; color: var(--ink-dim); }
+.bk-pot-n { font-family: var(--disp); font-size: clamp(20px, 3.6vw, 34px); color: var(--bk-brass); letter-spacing: .04em; }
+.bk-pot-sub { font-size: 11px; color: var(--ink-faint); }
+.bk-pot.bk-live .bk-pot-n { animation: bk-breathe 3.6s ease-in-out infinite; }
+@keyframes bk-breathe { 0%, 100% { opacity: 1; } 50% { opacity: .82; } }
+
+/* ---------------------------------- the cage ----------------------------- */
+.bk-cage {
+  display: grid; gap: 12px; padding: 14px 16px; border-radius: 10px;
+  background: color-mix(in srgb, var(--panel), var(--bk-felt-dark) 42%);
+  border: 1px solid color-mix(in srgb, var(--bk-brass), transparent 66%);
+}
+.bk-cage-head { display: flex; align-items: baseline; gap: 10px; flex-wrap: wrap; }
+.bk-cage h3 { margin: 0; font-family: var(--disp); font-size: 15px; letter-spacing: .1em; color: var(--bk-brass); font-weight: 400; }
+.bk-cage-rate { font-family: var(--mono); font-size: 11px; color: var(--ink-faint); letter-spacing: .08em; }
+.bk-steps { display: flex; gap: 6px; flex-wrap: wrap; }
+.bk-step {
+  min-height: 40px; min-width: 46px; padding: 6px 12px; cursor: pointer;
+  font-family: var(--mono); font-size: 13px; color: var(--ink);
+  background: var(--panel2); border: 1px solid var(--line); border-radius: 6px;
+}
+.bk-step[aria-pressed="true"] {
+  background: color-mix(in srgb, var(--bk-neon), var(--panel2) 66%);
+  border-color: var(--bk-neon); color: var(--ink);
+}
+.bk-step:focus-visible, .bk-cage-go:focus-visible, .bk-cab:focus-visible { outline: 2px solid var(--bk-brass); outline-offset: 2px; }
+.bk-custom { display: flex; align-items: center; gap: 8px; }
+.bk-custom input {
+  width: 92px; min-height: 40px; padding: 4px 10px; font-family: var(--mono); font-size: 14px;
+  color: var(--ink); background: var(--navy); border: 1px solid var(--line); border-radius: 6px;
+}
+.bk-cage-lines { display: grid; gap: 4px; font-size: 13px; color: var(--ink-dim); }
+.bk-cage-lines b { color: var(--ink); font-family: var(--mono); }
+/* THE VISIBLE CHOICE (owner ruling): what the same Sparkle buys on the tree. */
+.bk-tree { font-size: 12px; color: var(--lav); border-left: 2px solid color-mix(in srgb, var(--lav), transparent 55%); padding-left: 8px; }
+.bk-cage-go {
+  justify-self: start; min-height: 44px; padding: 8px 20px; cursor: pointer;
+  font-family: var(--disp); font-size: 14px; letter-spacing: .1em;
+  color: var(--ground); background: linear-gradient(180deg, var(--bk-brass), color-mix(in srgb, var(--bk-brass), black 26%));
+  border: none; border-radius: 8px;
+}
+.bk-cage-go[disabled] { opacity: .45; cursor: default; }
+.bk-cage-say { font-size: 12px; color: var(--ink-dim); min-height: 1.2em; }
+.bk-cage-say.bk-warm { color: var(--gold); }
+/* THE DEALER speaks under the receipt, in her colour, never over the number. */
+.bk-dealer { margin-top: 4px; color: var(--bk-neon-2); font-style: normal; }
+/* Cash only. The cage with no line to the counter. */
+.bk-cage.bk-dark { opacity: .72; border-style: dashed; }
+.bk-cage.bk-dark .bk-steps, .bk-cage.bk-dark .bk-custom, .bk-cage.bk-dark .bk-cage-go { display: none; }
+
+/* ---------------------------------- cabinets ----------------------------- */
+.bk-floor { display: grid; gap: 12px; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); }
+.bk-cab {
+  position: relative; display: flex; flex-direction: column; gap: 6px;
+  min-height: 148px; padding: 14px; text-align: left; cursor: pointer;
+  background: linear-gradient(180deg, var(--bk-plate), color-mix(in srgb, var(--ground), black 14%));
+  border: 2px solid color-mix(in srgb, var(--bk-neon-2), transparent 66%); border-radius: 10px;
+  color: var(--ink); font-family: var(--body);
+}
+.bk-cab-name { font-family: var(--disp); font-size: 15px; letter-spacing: .09em; color: var(--bk-neon); }
+.bk-cab-sub { font-size: 12px; color: var(--ink-faint); }
+.bk-cab-stake { margin-top: auto; font-family: var(--mono); font-size: 11px; letter-spacing: .1em; color: var(--ink-dim); }
+.bk-cab:hover, .bk-cab:focus-visible { border-color: var(--bk-neon); box-shadow: 0 0 22px color-mix(in srgb, var(--bk-neon), transparent 80%); }
+/* THE DUST SHEET. A cabinet whose module is not here yet, and it is furniture,
+ * never an error card - a room under a sheet still reads as a room. */
+.bk-cab.bk-sheet {
+  cursor: default; border-style: dashed; border-color: var(--line);
+  background: repeating-linear-gradient(120deg, color-mix(in srgb, var(--panel), white 4%) 0 12px, var(--panel) 12px 24px);
+  color: var(--ink-faint);
+}
+.bk-cab.bk-sheet .bk-cab-name { color: var(--slate); }
+.bk-cab.bk-sheet:hover { box-shadow: none; border-color: var(--line); }
+
+/* the mounted machine takes the whole floor over */
+.bk-stage { display: flex; flex-direction: column; gap: 12px; min-height: 320px; }
+
+/* ---------------------------------- the diet ----------------------------- */
+/* A phone pays for glow, weave and chase before it pays for anything the player
+ * came here to see. It loses all three and keeps every rect. */
+html.arc-mobile .bk-room, html.ae-lite .bk-room { padding: 10px 12px 22px; gap: 10px; }
+html.arc-mobile .bk-room::before, html.ae-lite .bk-room::before { display: none; }
+html.arc-mobile .bk-pot, html.ae-lite .bk-pot { box-shadow: none; }
+html.arc-mobile .bk-pot.bk-live .bk-pot-n, html.ae-lite .bk-pot.bk-live .bk-pot-n { animation: none; }
+html.arc-mobile .bk-title, html.ae-lite .bk-title { text-shadow: none; }
+html.arc-mobile .bk-cab:hover, html.ae-lite .bk-cab:hover { box-shadow: none; }
+html.arc-mobile .bk-floor { grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 8px; }
+html.arc-mobile .bk-cab { min-height: 104px; padding: 10px; }
+html.arc-mobile .bk-cab-sub { display: none; }
+html.arc-mobile .bk-fly, html.ae-lite .bk-fly { box-shadow: none; }
+
+/* Reduced motion: the global freeze owns the durations, so all this sheet has
+ * to do is make sure nothing is left mid-flight looking broken. */
+html.arc-reduced .bk-bal.bk-thud { animation: none; }
+html.arc-reduced .bk-pot.bk-live .bk-pot-n { animation: none; opacity: 1; }

--- a/ConditioningControlPanel/Resources/web/arcademy/backroom/kit/voice.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/backroom/kit/voice.js
@@ -1,0 +1,126 @@
+/* ============================================================================
+ * backroom/kit/voice.js - the dealer.
+ *
+ * E.M.I. works the floor down here. She is not the pit boss and she is not on
+ * the house's side: she is the one person in the room who is pleased to see
+ * you, and she says so whether the cabinet paid or not.
+ *
+ * FOUR RULES, and they are the difference between a dealer and a slot machine
+ * with subtitles.
+ *  - SYMPATHY ON LOSSES, never a jab. The house took the chips; the dealer does
+ *    not also take a swing. A loss line is warm, short, and already looking at
+ *    the next hand.
+ *  - NEVER PROMISE THE NEXT ONE. No "you are due", no "it has to hit soon".
+ *    That is the one sentence a room like this must not say out loud, and it is
+ *    a lie about how the odds work besides.
+ *  - DIEGETIC. She is a person at a table in a back room, not an assistant with
+ *    a notification. No system voice, no em-dashes, no exclamation stacks.
+ *  - THROUGH THE LEXICON. Every line is a KEY (Law VII: the accent comes from
+ *    the lexicon, never from AI), so a mod re-voices the whole dealer by
+ *    shipping `lexicon.json` rows. Nothing here reads modId; nothing may.
+ *
+ * The values are mirrored key-for-key into ArcademyHostService.NeutralLexicon.
+ * Every one is under 96 characters, because a longer row can never be skinned.
+ * ==========================================================================*/
+
+/** Every line the dealer has, by bucket. Buckets are picked, never cycled, so
+ *  two hands in a row can repeat - a dealer with a strict rotation reads like a
+ *  tape, and a dealer who occasionally says the same thing twice reads like a
+ *  person who has been on shift a while. */
+export const BK_VOICE = Object.freeze({
+  /* ---- dealing, before anything is known ---- */
+  bk_say_deal_1: 'Chips down. Let us see what the night thinks of you.',
+  bk_say_deal_2: 'Good. Hands where I can see them, eyes where I put them.',
+  bk_say_deal_3: 'Here we go, sweetheart.',
+  bk_say_deal_4: 'One more. You always did say one more.',
+  bk_say_deal_5: 'Settle in. This part is my favourite.',
+
+  /* ---- a win, ordinary size ---- */
+  bk_say_win_1: 'There it is. Well played.',
+  bk_say_win_2: 'The house nods and pays. Rare thing, that.',
+  bk_say_win_3: 'Look at you. Colour me impressed.',
+  bk_say_win_4: 'Yours. Take it before I change my mind.',
+  bk_say_win_5: 'Nice. Very nice.',
+
+  /* ---- a loss. WARM. Never a jab, never a promise about the next one. ---- */
+  bk_say_loss_1: 'Not that one. Shake it off, love.',
+  bk_say_loss_2: 'The floor keeps that one. Happens to everybody here.',
+  bk_say_loss_3: 'Ah. So close it almost counts, which it does not.',
+  bk_say_loss_4: 'Gone. You are still the best thing in this room.',
+  bk_say_loss_5: 'That is the game. No shame in it.',
+  bk_say_loss_6: 'The house takes it. I would rather it had not.',
+
+  /* ---- a big win, worth stopping the table for ---- */
+  bk_say_big_1: 'Oh, that is a NUMBER. Say it out loud for me.',
+  bk_say_big_2: 'The whole room just looked over. Let them look.',
+  bk_say_big_3: 'That is the good stuff. Breathe, then count it.',
+  bk_say_big_4: 'Well now. Somebody is having a night.',
+  bk_say_big_5: 'I felt that one land. Beautiful.',
+
+  /* ---- THE DROP: the wedge that dims the room ---- */
+  bk_say_drop_1: 'Ah. The room wants you for a second.',
+  bk_say_drop_2: 'Lights down, pet. This bit is not about the chips.',
+  bk_say_drop_3: 'There. Sink for me.',
+  bk_say_drop_4: 'The spiral called your name. It does that.',
+  bk_say_drop_5: 'Eyes here. Just here. Good.',
+
+  /* ---- the royal, the once-a-season thing that takes the pot ---- */
+  bk_say_royal_1: 'The pot. The whole pot. I have never seen it go.',
+  bk_say_royal_2: 'That is a royal. Sit down before you fall down.',
+  bk_say_royal_3: 'Every light in the room is on you. Earned.',
+  bk_say_royal_4: 'They will talk about this hand for a while.',
+
+  /* ---- the cage ---- */
+  bk_say_cage_1: 'Sparkle in, chips out. One way only, you know the rule.',
+  bk_say_cage_2: 'Counting it out for you now.',
+  bk_say_cage_3: 'There. Try to make it last past the first cabinet.',
+  bk_say_cage_4: 'Careful with that. It spends faster than it earns.',
+  bk_say_cage_5: 'Spend it slowly. Or do not. I am not your mother.',
+});
+
+/** The buckets, and how many lines each one actually has. Kept as data so a
+ *  new line is one row above and nothing else. */
+const BUCKETS = Object.freeze({
+  deal: 5, win: 5, loss: 6, big: 5, drop: 5, royal: 4, cage: 5,
+});
+
+/**
+ * createVoice({ t, rng, log }) -> { line(bucket), say(bucket), buckets }
+ *
+ * `t` is the SHELL's `t(key, fallback)`, not the floor's `bkT`: these lines
+ * carry no slots to fill, so they want the plain two-argument resolver and its
+ * mod-row-then-English fallback chain. `rng` is core/rng.js's `makeRng` output (a 0..1 function) if
+ * the caller has a seeded one; otherwise Math.random, because a dealer's small
+ * talk is the one thing on this page that does NOT need to be reproducible.
+ */
+export function createVoice(opts) {
+  const o = opts || {};
+  const t = (typeof o.t === 'function') ? o.t : ((k) => BK_VOICE[k] || '');
+  const rand = (typeof o.rng === 'function') ? o.rng : Math.random;
+  let lastKey = '';
+
+  /** One line from a bucket. Never the same key twice running, which is the
+   *  only anti-repeat this needs: the bucket is small and the ear is patient. */
+  function line(bucket) {
+    const n = BUCKETS[bucket] || 0;
+    if (!n) return '';
+    let key = '';
+    for (let tries = 0; tries < 4; tries++) {
+      const i = 1 + Math.floor(Math.max(0, Math.min(0.999999, Number(rand()) || 0)) * n);
+      key = 'bk_say_' + bucket + '_' + i;
+      if (key !== lastKey) break;
+    }
+    lastKey = key;
+    const en = BK_VOICE[key];
+    return t(key, en) || en || '';
+  }
+
+  return {
+    line,
+    buckets: Object.keys(BUCKETS),
+    /** The table, so a caller can mirror or diff it without importing twice. */
+    table: BK_VOICE,
+  };
+}
+
+export default createVoice;

--- a/ConditioningControlPanel/Resources/web/arcademy/backroom/lex.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/backroom/lex.js
@@ -1,0 +1,108 @@
+/* ============================================================================
+ * backroom/lex.js - every string the floor can print, in one table.
+ *
+ * Exported as DATA the way impulse-control/lex.js does it, for two reasons.
+ * The page's call sites are authoritative (trap 123), so this table IS the
+ * spec that `ArcademyHostService.NeutralLexicon` mirrors - copy the values,
+ * do not re-word them. And a table can be diffed against the C# side by a
+ * scratch script, where thirty scattered `t('bk_...', '...')` calls cannot.
+ *
+ * TWO RULES WHEN YOU ADD A ROW.
+ *  - Keep it under 96 characters. `MergeModTable` drops anything longer, so a
+ *    long row can never be re-voiced by a mod (trap 26). Split it in two
+ *    instead of writing one long sentence.
+ *  - No em-dashes, and no raw newlines. House prose law, both sides of the seam.
+ *
+ * The three `{...}` slots are filled by `fill()` below rather than by template
+ * literals, so a translator can move them around inside their sentence.
+ * ==========================================================================*/
+
+export const BK_LEX = Object.freeze({
+  /* ---- the room ---- */
+  bk_title:          'The Back Room',
+  bk_sub:            'Cash only. Chips only.',
+  bk_exit:           'step out',
+  bk_back:           'back to the floor',
+  bk_chips:          'chips',
+  bk_sparkle:        'sparkle',
+
+  /* ---- the pot sign ---- */
+  bk_pot:            'the pot',
+  bk_pot_sub:        'a quarter of every rake. one royal takes the lot.',
+  bk_pot_unknown:    'counting',
+
+  /* ---- the cage ---- */
+  bk_cage:           'The Cage',
+  bk_cage_rate:      '1 sparkle buys 100 chips. one way, never back.',
+  bk_cage_hand:      'sparkle on hand',
+  bk_cage_get:       'chips you get',
+  bk_cage_go:        'change it',
+  bk_cage_custom:    'or name an amount',
+  bk_cage_custom_lbl:'a custom amount of sparkle, up to 500',
+  bk_cage_dark:      'Cash only. Come back when the line is up.',
+  bk_cage_working:   'Counting it out.',
+  /* {0} chips credited */
+  bk_cage_done:      'That is {0} chips. Try not to spend it all at one cabinet.',
+  bk_cage_poor:      'Not quite enough sparkle for that one. The floor keeps.',
+  bk_cage_offline:   'The line to the counter is down. Your sparkle is safe where it is.',
+  bk_cage_bad:       'The cage takes one to five hundred at a time. Typo guard, nothing more.',
+  bk_cage_busy:      'The cashier is with someone. Give her a moment.',
+  /* THE TIER GATE, in the counter's own words. `prize_tier` is the standard
+     line the Prize Counter says when the bank answers 403 with min_tier, and
+     the two rooms must not disagree about what that means, so this row is a
+     copy of it rather than a new sentence. */
+  bk_cage_locked:    'The bank does not serve this account yet. Nothing was charged.',
+  bk_cage_reset:     'Your skills are mid reset. The cage waits for that to settle.',
+  bk_cage_refused:   'The cage would not take that one. Nothing moved.',
+
+  /* THE VISIBLE CHOICE (owner ruling): what the same sparkle buys upstairs.
+     {0} sparkle, {1} the cheapest unowned skill, {2} sparkle still needed. */
+  bk_cage_tree:      'The same {0} sparkle goes toward {1} on the tree, {2} short of it.',
+  bk_cage_tree_buy:  'The same {0} sparkle buys {1} on the tree outright.',
+  bk_cage_tree_done: 'The tree is finished. There is nothing up there left to buy.',
+
+  /* ---- the cabinets ---- */
+  bk_cab_twentyone:  'Twenty-One',
+  bk_cab_triple:     'Triple Trigger',
+  bk_cab_spiral:     'The Spiral',
+  bk_cab_scratcher:  'The Scratcher',
+  bk_cab_wheel:      'The Prize Wheel',
+  bk_sub_twentyone:  'the dealer stands on all seventeens.',
+  bk_sub_triple:     'three reels, and they are your own words.',
+  bk_sub_spiral:     'twenty-four wedges. one of them is a drop.',
+  bk_sub_scratcher:  'three in a row pays. one card a day is free.',
+  bk_sub_wheel:      'the big one. seven wedges, two of them worth waiting for.',
+  /* {0} the stake in chips */
+  bk_cab_stake:      '{0} chips a go',
+  bk_cab_free:       'one free card today',
+
+  /* ---- a cabinet with no module behind it yet ---- */
+  bk_sheet:          'Not open yet.',
+  bk_sheet_sub:      'Still under a sheet. The house is building it.',
+  bk_floor_aria:     'the cabinets',
+});
+
+/** `fill('a {0} b', ['x'])` -> 'a x b'. Slots a translator may reorder. */
+export function fill(text, args) {
+  const list = Array.isArray(args) ? args : [];
+  return String(text == null ? '' : text).replace(/\{(\d)\}/g, (m, i) => {
+    const v = list[Number(i)];
+    return v == null ? '' : String(v);
+  });
+}
+
+/**
+ * Wrap the shell's `t` so a caller cannot forget the English floor. A key with
+ * no host row behind it still renders its authored value; a missing `t`
+ * (a rig, a fixture page) renders the table straight.
+ */
+export function makeT(t) {
+  const base = (typeof t === 'function') ? t : null;
+  return function bkT(key, args) {
+    const en = BK_LEX[key];
+    const raw = base ? base(key, en == null ? key : en) : (en == null ? key : en);
+    return args ? fill(raw, args) : raw;
+  };
+}
+
+export default BK_LEX;


### PR DESCRIPTION
**Merge order: K1a (#803) -> K1b -> K1c -> K1d -> K1e.** Based on `feat/backroom-k1a`.

Everything the room says and everything it looks like, still with no room to hang it on.

### `backroom/backroom.css` (201 lines)
Dark felt under pink and violet neon, scoped entirely to `.bk-room` so it can be lazily linked and cannot leak. Borrows the page's own tokens rather than inventing colours; `--disp`/`--body`/`--mono` only, no serif, no font host; house camera law throughout. Carries the phone diet under `html.arc-mobile` and `html.ae-lite` and the kills under `html.arc-reduced`.

### `backroom/lex.js` (108 lines)
Every string the floor can print, exported as DATA the way `games/impulse-control/lex.js` does it, so `ArcademyHostService.NeutralLexicon` can be mirrored key for key by copying values rather than re-typing them.

- Every row is **under 96 characters**, because `MergeModTable` silently drops a longer one and a dropped row can never be re-voiced by a mod (trap 26).
- The `{0}` slots are filled by `fill()` rather than by template literals, so a translator can move them inside their sentence.
- `makeT(t)` wraps the shell's `t` so a caller cannot forget the English floor.

### `backroom/kit/voice.js` (126 lines)
E.M.I. dealing. 35 lines across seven buckets (`deal`, `win`, `loss`, `big`, `drop`, `royal`, `cage`), and the four rules that separate a dealer from a slot machine with subtitles:

- **Sympathy on losses, never a jab.** The house took the chips; the dealer does not also take a swing.
- **Never promise the next one.** No "you are due". That is the one sentence a room like this must not say, and it is a lie about the odds besides.
- **Diegetic.** A person at a table, not an assistant with a notification.
- **Through the lexicon.** Every line is a key, so a mod re-voices the whole dealer with `lexicon.json`. Nothing here reads `modId`, and nothing may.

### One deliberate copy
`bk_cage_locked` is `prize_tier`'s line verbatim rather than a new sentence. The Prize Counter already says *"The bank does not serve this account yet. Nothing was charged."* when the bank answers 403 with `min_tier`, and the two rooms must not disagree about what that means.

### Separate finding, not fixed here
`prize_tier` itself has **no row in `ArcademyHostService.NeutralLexicon`** (`grep -rn "prize_tier" --include=*.cs` returns zero hits) while all its siblings do. The refusal works, because the JS fallback carries it, but it can never be mod-skinned or localized. That is a live trap-123 hole in the Prize Counter and out of scope for this stack.

### LEXICON KEYS TO MIRROR
The full list of `bk_*` keys and English values for `NeutralLexicon` is in K1e's body, so the integrator has one list covering all five PRs rather than three partial ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5Gp8FA4yHguiNc46u5YDS
