### PR TITLE
feat(arcademy): Back Room K1c - the floor and THE CAGE

### DIFF
--- a/ConditioningControlPanel/Resources/web/arcademy/backroom/cage.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/backroom/cage.js
@@ -1,0 +1,224 @@
+/* ============================================================================
+ * backroom/cage.js - THE CAGE, and the choice it makes you look at.
+ *
+ * Sparkle in, chips out, one hundred to one, ONE WAY. Nothing on this page can
+ * turn chips back into sparkle, and the cage says so on the wall rather than
+ * letting you discover it at the worst possible moment.
+ *
+ * THE TREE LINE IS THE POINT OF THIS FILE (owner ruling). The same sparkle that
+ * buys chips down here buys skills upstairs, and a casino that quietly competes
+ * with a progression tree for the same scarce currency is running a confidence
+ * trick. So the counter prints the other price too, every time, in the same
+ * breath: "the same 25 sparkle goes toward soft focus on the tree, 15 short of
+ * it". The player then chooses, which is the only version of this worth
+ * shipping.
+ *
+ * ONE PRESS COMMITS. There is no confirm dialog, because a modal over a casino
+ * counter is a modal over the way out (Law VI). The guard is that the button
+ * stays dead until the number is both sane and affordable, and the receipt
+ * afterwards says exactly what moved.
+ *
+ * IT OWNS NO NUMBERS. `paint(snap)` is fed the server's last status frame and
+ * `onSettled` hands the answer back up. Nothing in here adds a chip to anything.
+ * ==========================================================================*/
+
+import { fmtChips } from './kit/chips.js';
+
+/** The stepper. 500 is a TYPO GUARD on one press, not a lid on the evening. */
+export const STEPS = Object.freeze([1, 5, 10, 25, 50]);
+export const CAGE_MAX = 500;
+const RATE_FLOOR = 100;
+
+function el(tag, cls, text) {
+  const n = document.createElement(tag);
+  if (cls) n.className = cls;
+  if (text != null) n.textContent = String(text);
+  return n;
+}
+
+/** 'soft_focus' -> 'soft focus'. A skill id is the only name the tree frame
+ *  carries, and a raw snake_case id in a sentence reads like a bug. */
+function prettyId(id) {
+  return String(id == null ? '' : id).replace(/[_-]+/g, ' ').trim();
+}
+
+/**
+ * createCage({ t, api, voice, sfx, log, onSettled }) ->
+ *   { el, paint(snap), amount(), destroy() }
+ *
+ * `onSettled(body, fromNode)` is called with the answer's body when a pull
+ * lands, and `fromNode` is the counter itself, so the floor can fly the chips
+ * out of it. The cage never reaches for the header plate directly.
+ */
+export function createCage(opts) {
+  const o = opts || {};
+  const t = o.t;
+  const api = o.api;
+  const note = (typeof o.log === 'function') ? o.log : () => {};
+  const sfx = (typeof o.sfx === 'function') ? o.sfx : () => {};
+  const onSettled = (typeof o.onSettled === 'function') ? o.onSettled : () => {};
+
+  let snap = null;
+  let amount = STEPS[0];
+  let busy = false;
+  let dead = false;
+
+  const root = el('div', 'bk-cage bk-dark');
+  const head = el('div', 'bk-cage-head');
+  head.appendChild(el('h3', null, t('bk_cage')));
+  head.appendChild(el('span', 'bk-cage-rate', t('bk_cage_rate')));
+  root.appendChild(head);
+
+  const steps = el('div', 'bk-steps');
+  steps.setAttribute('role', 'group');
+  steps.setAttribute('aria-label', t('bk_cage'));
+  const stepBtns = [];
+  root.appendChild(steps);
+
+  const custom = el('div', 'bk-custom');
+  const customIn = el('input');
+  customIn.type = 'number';
+  customIn.min = '1';
+  customIn.max = String(CAGE_MAX);
+  customIn.setAttribute('aria-label', t('bk_cage_custom_lbl'));
+  custom.appendChild(el('span', 'bk-cage-rate', t('bk_cage_custom')));
+  custom.appendChild(customIn);
+  root.appendChild(custom);
+
+  const lines = el('div', 'bk-cage-lines');
+  const lineHand = el('div');
+  const lineGet = el('div');
+  const lineTree = el('div', 'bk-tree');
+  lines.appendChild(lineHand);
+  lines.appendChild(lineGet);
+  lines.appendChild(lineTree);
+  root.appendChild(lines);
+
+  const go = el('button', 'bk-cage-go', t('bk_cage_go'));
+  go.type = 'button';
+  root.appendChild(go);
+
+  const receipt = el('div', 'bk-cage-say');
+  receipt.setAttribute('role', 'status');
+  root.appendChild(receipt);
+
+  for (const n of STEPS) {
+    const b = el('button', 'bk-step', String(n));
+    b.type = 'button';
+    b.setAttribute('aria-pressed', n === amount ? 'true' : 'false');
+    b.addEventListener('click', () => { customIn.value = ''; setAmount(n); sfx('pip', 0.22); });
+    steps.appendChild(b);
+    stepBtns.push({ n, b });
+  }
+  customIn.addEventListener('input', () => setAmount(Number(customIn.value) || 0));
+
+  function setAmount(n) {
+    amount = Math.max(0, Math.min(CAGE_MAX, Math.round(Number(n) || 0)));
+    for (const s of stepBtns) s.b.setAttribute('aria-pressed', s.n === amount ? 'true' : 'false');
+    paint();
+  }
+
+  /** Everything the counter shows, from the last frame and the current number.
+   *  Pure: it asks the server nothing and it moves nothing. */
+  function paint(next) {
+    if (next !== undefined) snap = next;
+    const sparkle = snap ? Math.max(0, Math.round(Number(snap.sparkle) || 0)) : 0;
+    const rate = (snap && Number(snap.rate) > 0) ? Math.round(Number(snap.rate)) : RATE_FLOOR;
+
+    lineHand.textContent = '';
+    lineHand.appendChild(el('span', null, t('bk_cage_hand') + ': '));
+    lineHand.appendChild(el('b', null, fmtChips(sparkle)));
+    lineGet.textContent = '';
+    lineGet.appendChild(el('span', null, t('bk_cage_get') + ': '));
+    lineGet.appendChild(el('b', null, fmtChips(amount * rate)));
+
+    const tree = (snap && snap.tree && typeof snap.tree === 'object') ? snap.tree : null;
+    const cheap = tree && tree.cheapest_unowned;
+    if (!tree) lineTree.textContent = '';
+    else if (!cheap) lineTree.textContent = t('bk_cage_tree_done');
+    else {
+      const cost = Math.max(0, Math.round(Number(cheap.cost) || 0));
+      const name = prettyId(cheap.id);
+      lineTree.textContent = (amount >= cost)
+        ? t('bk_cage_tree_buy', [fmtChips(amount), name])
+        : t('bk_cage_tree', [fmtChips(amount), name, fmtChips(cost - amount)]);
+    }
+
+    const wired = !!(api && api.wired && api.wired());
+    root.classList.toggle('bk-dark', !wired);
+    if (!wired) { receipt.textContent = t('bk_cage_dark'); receipt.classList.remove('bk-warm'); }
+    go.disabled = dead || !wired || busy || amount < 1 || amount > CAGE_MAX || amount > sparkle;
+  }
+
+  /** One press, one id, one receipt. */
+  function pull() {
+    if (dead || busy || !(api && api.wired && api.wired())) return;
+    const n = amount;
+    if (!(n >= 1 && n <= CAGE_MAX)) { warm(t('bk_cage_bad')); return; }
+    busy = true;
+    go.disabled = true;
+    receipt.classList.remove('bk-warm');
+    receipt.textContent = t('bk_cage_working');
+    sfx('commit', 0.36);
+    api.cage(n).then((r) => {
+      if (dead) return;
+      busy = false;
+      if (r.ok) {
+        const credited = Math.max(0, Math.round(Number(r.body.credited) || (n * RATE_FLOOR)));
+        // The floor folds the new balances in and flies the chips out of HERE,
+        // so the money is seen to come from the cashier rather than to appear.
+        onSettled(r.body, root);
+        warm(t('bk_cage_done', [fmtChips(credited)]));
+        dealer();
+        sfx('jackpot', 0.3);
+      } else {
+        receipt.textContent = refusal(r);
+        receipt.classList.remove('bk-warm');
+        sfx('bump', 0.28);
+        paint();
+      }
+    });
+  }
+  go.addEventListener('click', pull);
+
+  function warm(text) { receipt.textContent = text; receipt.classList.add('bk-warm'); }
+
+  /** The dealer speaks UNDER the receipt. The number is what the player came to
+   *  read; she talks over the top of it, never instead of it. */
+  function dealer() {
+    try {
+      const line = o.voice ? o.voice.line('cage') : '';
+      if (line) receipt.appendChild(el('div', 'bk-dealer', line));
+    } catch (e) { note('backroom: dealer line failed'); }
+  }
+
+  /** Every refusal reads warmly. The house never scolds a player for being poor. */
+  function refusal(r) {
+    const body = (r && r.body) || {};
+    const reason = String(body.reason || body.code || '');
+    if (r && r.status === 403) return t('bk_cage_locked');
+    switch (reason) {
+      case 'insufficient_sparkle': return t('bk_cage_poor');
+      case 'invalid_amount': return t('bk_cage_bad');
+      case 'busy': return t('bk_cage_busy');
+      case 'force_skills_reset': return t('bk_cage_reset');
+      case 'arcademy_locked': return t('bk_cage_locked');
+      case 'offline':
+      case 'timeout':
+      case 'closed': return t('bk_cage_offline');
+      default: return t('bk_cage_refused');
+    }
+  }
+
+  paint(null);
+
+  return {
+    el: root,
+    paint,
+    amount: () => amount,
+    /** Goes dead and stays dead. Safe from any road, and safe twice. */
+    destroy() { dead = true; go.disabled = true; },
+  };
+}
+
+export default createCage;

--- a/ConditioningControlPanel/Resources/web/arcademy/backroom/index.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/backroom/index.js
@@ -1,0 +1,335 @@
+/* ============================================================================
+ * backroom/index.js - THE FLOOR.
+ *
+ * The Back Room is a SCENE, like the Annex and the Records Office: no registry
+ * row, no timetable deal, no grade, no punch card. The shell walks the student
+ * to a door and calls `openBackRoom(ctx)`; this file paints the room behind it
+ * and hands back the same `{root, escapeStep, destroy, fit}` handle every other
+ * scene answers with, plus `close()` for the caller that asked for one.
+ *
+ * WHAT IS ON THE FLOOR: a header with the chip balance and a lit way out, the
+ * pot sign, THE CAGE (backroom/cage.js) and five cabinet frames. A cabinet
+ * whose module has not shipped yet is a dust sheet, not an error.
+ *
+ * THREE LAWS THIS FILE IS WRITTEN AROUND.
+ *  - EXITS SACRED (Law VI). The sign leaves mid-anything and is never covered
+ *    by a modal. `escapeStep()` folds a mounted machine first and then answers
+ *    false so the shell can walk home. Nothing here binds a key: the shell owns
+ *    the ladder, which is exits.js's wiring law.
+ *  - LEDGER TRUTH. Not one chip is added or taken away on this page. Every
+ *    number painted here arrived on a server frame, and the only optimism is
+ *    the BANK animation, which plays while the real balance is being written.
+ *  - IT NEVER THROWS. No `send`, no `listen`, a dead module, a host that never
+ *    answers: each one is a thing the room DRAWS, never a thing it dies of.
+ * ==========================================================================*/
+
+import { createCasinoApi } from './kit/api.js';
+import { balanceChip, chipStack, bank, fmtChips } from './kit/chips.js';
+import { makeT, BK_LEX } from './lex.js';
+import { createVoice } from './kit/voice.js';
+import { createCage } from './cage.js';
+
+/** The five cabinets, in the order the room reads left to right. The stakes
+ *  here are a FLOOR for the frames only: the live numbers arrive on the status
+ *  frame's `config.stakes`, so the page never publishes odds of its own. */
+const CABINETS = Object.freeze([
+  { key: 'twentyone', nameKey: 'bk_cab_twentyone', subKey: 'bk_sub_twentyone', stake: 25 },
+  { key: 'triple', nameKey: 'bk_cab_triple', subKey: 'bk_sub_triple', stake: 10 },
+  { key: 'spiral', nameKey: 'bk_cab_spiral', subKey: 'bk_sub_spiral', stake: 25 },
+  { key: 'scratcher', nameKey: 'bk_cab_scratcher', subKey: 'bk_sub_scratcher', stake: 50 },
+  { key: 'wheel', nameKey: 'bk_cab_wheel', subKey: 'bk_sub_wheel', stake: 500 },
+]);
+
+function el(tag, cls, text) {
+  const n = document.createElement(tag);
+  if (cls) n.className = cls;
+  if (text != null) n.textContent = String(text);
+  return n;
+}
+
+/** The scene sfx door, copied rather than imported (the kit does not reach into
+ *  the shell), in exits.js's defensive shape so the module still loads under a
+ *  DOM double that has no CustomEvent. */
+function sfx(name, level, extra) {
+  try {
+    if (typeof document === 'undefined' || typeof document.dispatchEvent !== 'function') return;
+    const Ctor = (typeof CustomEvent === 'function') ? CustomEvent : null;
+    if (!Ctor) return;
+    document.dispatchEvent(new Ctor('arcademy-sfx', {
+      detail: Object.assign({ name: String(name || 'blip'), level: Number(level) || 0.4, bus: 'fx' }, extra || {}),
+    }));
+  } catch (e) { /* a cue must never be the thing that throws */ }
+}
+
+/** lab.js's lazy sheet, id-guarded so a revisit costs nothing. */
+function ensureSheet(id, rel, log) {
+  try {
+    if (document.getElementById(id)) return;
+    const link = document.createElement('link');
+    link.id = id;
+    link.rel = 'stylesheet';
+    link.href = new URL(rel, import.meta.url).href;
+    document.head.appendChild(link);
+  } catch (e) { log('backroom sheet failed: ' + rel); }
+}
+
+/** os.js's three-test still mode. Every rAF loop in the kit gates on this,
+ *  because the CSS freeze at the bottom of styles.css cannot reach JS. */
+function stillMode(ctx) {
+  try { if (ctx && ctx.motion && ctx.motion.reducedMotion) return true; } catch (e) { /* noop */ }
+  try {
+    if (typeof matchMedia === 'function' && matchMedia('(prefers-reduced-motion: reduce)').matches) return true;
+  } catch (e) { /* noop */ }
+  try { return document.documentElement.classList.contains('arc-reduced'); } catch (e) { return false; }
+}
+
+/**
+ * openBackRoom(ctx) -> { root, close, destroy, escapeStep, fit }
+ *
+ * `ctx` is the scene surface plus `send(msg)` and `listen(type, fn)`. EVERY
+ * field is optional. A ctx with no send/listen opens a room whose cage is dark
+ * and whose cabinets are honest about it, which is exactly what a rig, a
+ * fixture page and a web host without the relay should see.
+ */
+export function openBackRoom(ctx) {
+  const c = ctx || {};
+  const log = (typeof c.log === 'function') ? c.log : () => {};
+  const t = makeT(c.t || c.lexicon);
+  const reduced = stillMode(c);
+  const api = createCasinoApi({ send: c.send, listen: c.listen, log });
+  // The dealer takes the SHELL's plain t(key, fallback), not the floor's bkT:
+  // her lines carry no slots, and a mod re-voices her with lexicon rows alone.
+  const voice = createVoice({ t: c.t, rng: (c.rng && c.rng.next) || null });
+
+  ensureSheet('arc-backroom-css', './backroom.css', log);
+
+  let dead = false;
+  let snap = null;        // the last ok status body
+  let mounted = null;     // { key, handle, mod }
+
+  /* --------------------------------------------------------------- the room */
+  const root = el('div', 'bk-room' + (c.lite ? ' bk-lite' : ''));
+  root.setAttribute('role', 'region');
+  root.setAttribute('aria-label', t('bk_title'));
+
+  const head = el('div', 'bk-head');
+  const chips = balanceChip({ label: t('bk_chips'), value: 0, reduced });
+  const stack = chipStack({ value: 0 });
+  head.appendChild(el('h2', 'bk-title', t('bk_title')));
+  head.appendChild(el('span', 'bk-pot-sub', t('bk_sub')));
+  head.appendChild(el('span', 'bk-head-spacer'));
+  head.appendChild(stack.el);
+  head.appendChild(chips.el);
+
+  /* THE WAY OUT, LIT, AND IT IS THE FIRST THING BUILT. Law VI is not a feature
+   * that gets added at the end: the sign exists before the cage does, it is
+   * never disabled, and it never waits on a request in flight. */
+  const exitBtn = el('button', 'btn primary', t('bk_exit'));
+  exitBtn.type = 'button';
+  exitBtn.addEventListener('click', () => leave());
+  try {
+    if (c.exits && typeof c.exits.sign === 'function') c.exits.sign(exitBtn, { dir: 'back' });
+  } catch (e) { /* an undressed button still leaves */ }
+  head.appendChild(exitBtn);
+  root.appendChild(head);
+
+  /* ---------------------------------------------------------- the pot sign */
+  const pot = el('div', 'bk-pot');
+  const potN = el('b', 'bk-pot-n', t('bk_pot_unknown'));
+  pot.appendChild(el('span', 'bk-pot-label', t('bk_pot')));
+  pot.appendChild(potN);
+  pot.appendChild(el('span', 'bk-pot-sub', t('bk_pot_sub')));
+  root.appendChild(pot);
+
+  /* -------------------------------------------------------------- the cage */
+  const cage = createCage({
+    t, api, voice, sfx, log,
+    onSettled: (body, from) => takeStatus(Object.assign({}, snap || {}, body || {}), from),
+  });
+  root.appendChild(cage.el);
+
+  /* ---------------------------------------------------------- the cabinets */
+  const floor = el('div', 'bk-floor');
+  floor.setAttribute('role', 'group');
+  floor.setAttribute('aria-label', t('bk_floor_aria'));
+  root.appendChild(floor);
+  const stage = el('div', 'bk-stage');
+  stage.hidden = true;
+  root.appendChild(stage);
+
+  const frames = new Map();
+  for (const cab of CABINETS) {
+    const btn = el('button', 'bk-cab');
+    btn.type = 'button';
+    btn.appendChild(el('span', 'bk-cab-name', t(cab.nameKey)));
+    btn.appendChild(el('span', 'bk-cab-sub', t(cab.subKey)));
+    const stakeEl = el('span', 'bk-cab-stake', t('bk_cab_stake', [fmtChips(cab.stake)]));
+    btn.appendChild(stakeEl);
+    btn.addEventListener('click', () => openCabinet(cab.key));
+    floor.appendChild(btn);
+    frames.set(cab.key, { cab, btn, stakeEl, mod: null });
+  }
+
+  /** Paint the balances a frame carried. `bankFrom` runs THE BANK on the way. */
+  function paintBalances(body, bankFrom) {
+    if (!body || typeof body !== 'object') return;
+    const next = Math.max(0, Math.round(Number(body.chips) || 0));
+    const land = () => { chips.set(next, { reduced }); stack.set(next); };
+    if (bankFrom) {
+      sfx('bank', 0.4);
+      bank(bankFrom, chips.el, { count: 6, reduced }).then(land, land);
+    } else land();
+    if (body.pot != null) {
+      const p = Math.max(0, Math.round(Number(body.pot) || 0));
+      potN.textContent = fmtChips(p);
+      pot.classList.toggle('bk-live', p > 0);
+    }
+  }
+
+  /** One status frame, folded in. The only writer of `snap`. */
+  function takeStatus(body, bankFrom) {
+    if (!body || typeof body !== 'object') return;
+    snap = body;
+    api.seed(body);
+    paintBalances(body, bankFrom);
+    if (body.config && body.config.stakes && typeof body.config.stakes === 'object') {
+      for (const [key, f] of frames) {
+        const v = Number(body.config.stakes[key]);
+        if (v > 0) f.stakeEl.textContent = t('bk_cab_stake', [fmtChips(Math.round(v))]);
+      }
+    }
+    const scr = frames.get('scratcher');
+    if (scr && scr.mod && body.free_scratch_available === true) scr.stakeEl.textContent = t('bk_cab_free');
+    cage.paint(snap);
+  }
+
+  /** What a machine module is handed. One object, built once, shared by all. */
+  const kit = {
+    api,
+    t,
+    voice,
+    lex: BK_LEX,
+    reduced,
+    lite: !!c.lite,
+    log,
+    sfx,
+    fmtChips,
+    balanceChip,
+    chipStack,
+    bank,
+    /** The last status body, or null. Machines read it, never write it. */
+    status: () => snap,
+    /** The live stake table off the status frame. */
+    config: () => (snap && snap.config) || {},
+    /** Fold a play answer's balances back into the room, optionally banking. */
+    settle: (body, bankFrom) => takeStatus(Object.assign({}, snap || {}, body || {}), bankFrom),
+    /** Ask the counter again, when a machine could not fold an answer in. */
+    refresh: () => api.status().then((r) => { if (r.ok) takeStatus(r.body); return r; }),
+    /** Put the cabinet away and stand on the floor again. */
+    toFloor: () => unmountMachine(),
+    /** The header's chip plate, so a machine can BANK into the real thing. */
+    balanceEl: () => chips.el,
+  };
+
+  /**
+   * A cabinet's module, imported the first time the floor is painted. A module
+   * that has not shipped yet is not a bug and not a console error a player can
+   * see: the frame becomes a DUST SHEET and stops being a button.
+   */
+  function probeCabinet(f) {
+    return import('./' + f.cab.key + '.js').then((m) => {
+      const mod = (m && (m.default || m[f.cab.key] || m.machine)) || null;
+      if (!mod || typeof mod.mount !== 'function') throw new Error('no mount()');
+      f.mod = mod;
+    }).catch(() => {
+      f.mod = null;
+      dustSheet(f);
+    });
+  }
+
+  function dustSheet(f) {
+    f.btn.classList.add('bk-sheet');
+    f.btn.disabled = true;
+    f.btn.textContent = '';
+    f.btn.appendChild(el('span', 'bk-cab-name', t(f.cab.nameKey)));
+    f.btn.appendChild(el('span', 'bk-cab-sub', t('bk_sheet_sub')));
+    f.btn.appendChild(el('span', 'bk-cab-stake', t('bk_sheet')));
+  }
+
+  function openCabinet(key) {
+    const f = frames.get(key);
+    if (dead || !f || !f.mod || mounted) return;
+    sfx('door', 0.3);
+    floor.hidden = true;
+    stage.hidden = false;
+    stage.textContent = '';
+    let handle = null;
+    try { handle = f.mod.mount(stage, kit, c) || null; }
+    catch (e) {
+      // A machine that throws on the way in leaves the player on the floor,
+      // never on a blank stage.
+      log('backroom: ' + key + ' failed to mount: ' + ((e && e.message) || e));
+      stage.hidden = true;
+      floor.hidden = false;
+      dustSheet(f);
+      return;
+    }
+    mounted = { key, handle, mod: f.mod };
+  }
+
+  function unmountMachine() {
+    if (!mounted) return false;
+    const m = mounted;
+    mounted = null;
+    try { if (m.handle && typeof m.handle.unmount === 'function') m.handle.unmount(); }
+    catch (e) { log('backroom: ' + m.key + ' unmount threw'); }
+    try { if (typeof m.mod.unmount === 'function') m.mod.unmount(); }
+    catch (e) { /* a module-level unmount is optional */ }
+    stage.textContent = '';
+    stage.hidden = true;
+    floor.hidden = false;
+    sfx('slide', 0.26);
+    return true;
+  }
+
+  /* ------------------------------------------------------------- the doors */
+  function leave() {
+    sfx('door', 0.32);
+    try { if (typeof c.onExit === 'function') { c.onExit(); return; } } catch (e) { /* noop */ }
+    close();
+  }
+
+  /** The shell's ladder asks; this binds no key of its own (exits.js law). */
+  function escapeStep() {
+    if (dead) return false;
+    return unmountMachine();
+  }
+
+  function close() {
+    if (dead) return;
+    dead = true;
+    unmountMachine();
+    try { cage.destroy(); } catch (e) { /* noop */ }
+    try { api.destroy(); } catch (e) { /* noop */ }
+    try { root.remove(); } catch (e) { /* noop */ }
+  }
+
+  /* --------------------------------------------------------------- opening */
+  for (const [, f] of frames) probeCabinet(f);
+  api.status().then((r) => {
+    if (dead) return;
+    if (r.ok) takeStatus(r.body);
+    else cage.paint(null);
+  });
+
+  return {
+    root,
+    close,
+    destroy: close,
+    escapeStep,
+    /** Nothing here is a fixed stage, so a refit is a no-op. The shell calls it. */
+    fit() { /* the floor is a flow layout: it fits itself */ },
+  };
+}
+
+export default openBackRoom;


### PR DESCRIPTION
**Merge order: K1a (#803) -> K1b (#804) -> K1c -> K1d -> K1e.** Based on `feat/backroom-k1b`.

**This is the PR that PR W1 needs.** `openBackRoom(ctx)` exists after this one.

### `backroom/index.js` (335 lines) - the floor
A SCENE, like the Annex and the Records Office: no registry row, no timetable deal, no grade, no punch card. Returns `{ root, close, destroy, escapeStep, fit }`, a superset of the `{close()}` the contract asks for, so the shell can hold it the way it holds every other scene.

Paints the header with the chip balance and a lit way out, the pot sign, the cage, and five cabinet frames (`twentyone`, `triple`, `spiral`, `scratcher`, `wheel`).

- Each frame dynamically imports `./<key>.js` at open. Nothing behind it means a **DUST SHEET** that stops being a button, not a console error a player can see. A machine that throws on the way in puts the player back on the floor rather than on a blank stage.
- **Every field of `ctx` is optional**, `send` and `listen` included. A rig, a fixture and a host with no relay all get a room rather than an exception.
- Live stakes come off `status.config.stakes`; the constants in the file are frame placeholders only, so the page never publishes odds of its own.

**Law VI is built first, literally.** The sign exists before the cage does, it is never disabled, and it never waits on a request in flight. `escapeStep()` folds a mounted machine and then answers `false` so the shell walks home. **Nothing here binds a key** - the shell owns the ladder, per `shell/exits.js`'s wiring law. (The fixture in K1d wires Esc the way the shell does and asserts the room detaches.)

### `backroom/cage.js` (224 lines) - THE CAGE
Sparkle in, chips out, 1:100, one way, with the stepper (1 / 5 / 10 / 25 / 50 / custom to 500).

**The tree line is the whole reason this is its own file.** The same sparkle buys skills upstairs, and a casino that quietly competes with the progression tree for the same scarce currency is running a confidence trick. So the counter prints the other price too, every time, in the same breath:

> The same 25 sparkle goes toward soft focus on the tree, 15 short of it.

with `bk_cage_tree_buy` when the amount already covers it and `bk_cage_tree_done` when the tree is finished.

**One press commits.** No confirm dialog, because a modal over a casino counter is a modal over the way out. The guard is a button that stays dead until the number is both sane and affordable. Refusals read warmly and map every reason the contract lists (`insufficient_sparkle`, `invalid_amount`, `busy`, `force_skills_reset`, `arcademy_locked`, offline/timeout/closed) plus any 403 to the standard tier copy. The house never scolds a player for being poor.

### Ledger truth
Neither file adds a chip to anything. The cage hands the answer up and the floor flies it into the plate **from the counter**, so the money is seen to come from the cashier rather than to appear.

### Verification
The fixture lands in K1d. On the tip of the stack, 22 checks pass, including: floor renders with 5 dust sheets, cage sends `{"op":"cage","body":{"sparkle":10,"cageId":"<32 hex>"}}` with `localDay`, the answer banks 1,250 -> 2,250, an unaffordable amount leaves the button dead and sends nothing, the tier refusal prints the standard copy, Esc detaches the room, and **with `send`/`listen` deleted the floor still renders and the cage goes dark without throwing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5Gp8FA4yHguiNc46u5YDS
