### PR TITLE
feat(arcademy): Back Room K1d - hold ring, drop beat and the floor fixture

### DIFF
--- a/ConditioningControlPanel/Resources/web/arcademy/backroom/backroom.css
+++ b/ConditioningControlPanel/Resources/web/arcademy/backroom/backroom.css
@@ -199,3 +199,47 @@ html.arc-mobile .bk-fly, html.ae-lite .bk-fly { box-shadow: none; }
  * to do is make sure nothing is left mid-flight looking broken. */
 html.arc-reduced .bk-bal.bk-thud { animation: none; }
 html.arc-reduced .bk-pot.bk-live .bk-pot-n { animation: none; opacity: 1; }
+
+/* ----------------------------------------------------------------------------
+ * THE HOLD RING (kit/holdring.js)
+ * The ring is a conic gradient driven by --bk-hold, so the sheet owns how the
+ * hold LOOKS and the module only ever owns how far along it is. Under the
+ * global reduced freeze the module steps the value in fifths instead of
+ * sweeping it, which is why there is no transition on it here: a transition
+ * would be flattened by the freeze and the ring would simply jump (trap 92).
+ * -------------------------------------------------------------------------- */
+.bk-hold { position: relative; --bk-hold: 0%; }
+.bk-hold::before {
+  content: ''; position: absolute; inset: -4px; border-radius: inherit; pointer-events: none;
+  background: conic-gradient(var(--bk-neon) var(--bk-hold), transparent var(--bk-hold));
+  -webkit-mask: radial-gradient(farthest-side, transparent calc(100% - 3px), #000 calc(100% - 3px));
+  mask: radial-gradient(farthest-side, transparent calc(100% - 3px), #000 calc(100% - 3px));
+  opacity: 0;
+}
+.bk-hold.bk-holding::before { opacity: 1; }
+.bk-hold.bk-held { box-shadow: 0 0 0 2px var(--bk-brass); }
+
+/* ----------------------------------------------------------------------------
+ * THE DROP (kit/dropbeat.js)
+ * pointer-events:none is the load-bearing line in this whole block. The veil
+ * lies over the cabinet and the way out stays clickable underneath it for the
+ * entire beat, which is what keeps a ceremony from becoming a modal (Law VI).
+ * -------------------------------------------------------------------------- */
+.bk-drop {
+  position: absolute; inset: 0; z-index: 40; pointer-events: none;
+  display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 14px;
+  background: color-mix(in srgb, var(--ground), transparent 22%);
+  animation: bk-drop-in 220ms ease-out both;
+}
+.bk-drop-eye { width: 190px; height: 190px; border-radius: 50%; filter: blur(1px); opacity: .8; }
+.bk-drop-line {
+  font-family: var(--disp); font-size: 17px; letter-spacing: .06em; text-align: center;
+  color: var(--ink); text-shadow: 0 0 14px var(--bk-neon); max-width: 22ch;
+}
+@keyframes bk-drop-in { from { opacity: 0; } to { opacity: 1; } }
+
+html.arc-mobile .bk-drop-eye, html.ae-lite .bk-drop-eye { width: 120px; height: 120px; filter: none; }
+html.arc-mobile .bk-drop-line, html.ae-lite .bk-drop-line { font-size: 15px; text-shadow: none; }
+/* Still mode keeps the dim and the line and loses the fade. The module has
+ * already stopped turning the spiral by the time this matters. */
+html.arc-reduced .bk-drop { animation: none; }

--- a/ConditioningControlPanel/Resources/web/arcademy/backroom/demo.html
+++ b/ConditioningControlPanel/Resources/web/arcademy/backroom/demo.html
@@ -1,0 +1,228 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>The Back Room - floor fixture</title>
+<!-- No shell, no bridge, no host. The REAL modules under a STUBBED ctx: send
+     and listen are a little pretend cashier at the bottom of this file, so the
+     floor can be looked at, shot and driven by a headless probe without a
+     server and without a penny of real ledger anywhere near it.
+
+     ?dark=1     opens with NO send/listen at all (the cage must go dark and
+                 nothing may throw). This is the fixture's most important mode.
+     ?slow=1     the cashier takes 9s, so the 8s timeout can be watched.
+     ?poor=1     the cashier refuses for want of sparkle.
+     ?tier=1     the cashier refuses with the tier gate (403).
+     ?reduced=1  arms html.arc-reduced, the global still mode.
+     ?lite=1     arms html.ae-lite + html.arc-mobile, the phone diet.
+     ?auto=cage  presses the cage for ?n= sparkle, unattended.
+     ?auto=esc   sends Escape, unattended.
+     ?auto=hold  holds the bench button to the end and reports the commit.
+     ?auto=drop  runs the drop beat and reports that the veil lifted.
+     Both write their result into #log, which is what the headless probe reads
+     back out of the dumped DOM. There is no test runner and no framework here
+     on purpose: the fixture IS the harness, so it can never drift from it. -->
+<link rel="stylesheet" href="../styles.css">
+<style>
+  body { margin: 0; padding: 16px 14px 60px; background: var(--ground); color: var(--ink);
+         font-family: var(--body); }
+  .wrap { max-width: 1100px; margin: 0 auto; }
+  header.fx { display: flex; align-items: baseline; gap: 12px; flex-wrap: wrap;
+              border-bottom: 3px solid var(--pink); padding-bottom: 8px; margin-bottom: 14px; }
+  header.fx h1 { font-family: var(--disp); font-size: 20px; margin: 0; letter-spacing: .08em; }
+  .eyebrow { font-family: var(--mono); font-size: 10px; letter-spacing: .2em; color: var(--ink-dim); }
+  .note { color: var(--ink-faint); font-size: 12px; font-family: var(--mono); margin-top: 14px; }
+  .bench { display: flex; align-items: center; gap: 18px; margin-top: 18px; }
+  #dropstage { position: relative; flex: 1; min-height: 210px; border: 2px solid var(--line);
+               border-radius: var(--radius); background: var(--panel); }
+  #log { font-family: var(--mono); font-size: 11px; color: var(--ink-dim); white-space: pre-wrap;
+         margin-top: 10px; max-height: 160px; overflow: auto; }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <header class="fx">
+    <h1>THE BACK ROOM</h1>
+    <span class="eyebrow">backroom/index.js &middot; floor fixture</span>
+  </header>
+  <div id="host"></div>
+  <!-- THE KIT BENCH. The two pieces with no cabinet to live in yet, so they
+       can still be driven, shot and asserted on before a machine exists. -->
+  <div class="bench">
+    <button id="holdbtn" class="bk-cage-go bk-hold" type="button">hold to commit</button>
+    <div id="dropstage"></div>
+  </div>
+  <p class="note" id="note">stubbed cashier. no ledger, no network, no chips that exist.</p>
+  <div id="log"></div>
+</div>
+
+<script type="module">
+import { openBackRoom } from './index.js';
+import { holdRing } from './kit/holdring.js';
+import { createDropBeat } from './kit/dropbeat.js';
+
+const q = new URLSearchParams(location.search);
+const logEl = document.getElementById('log');
+const log = (m) => { logEl.textContent += m + '\n'; };
+
+if (q.has('reduced')) document.documentElement.classList.add('arc-reduced');
+if (q.has('lite')) document.documentElement.classList.add('ae-lite', 'arc-mobile');
+
+/* ------------------------------------------------------------------------
+ * THE PRETEND CASHIER. It answers the same frames the host will, and it is
+ * the ONLY place in this fixture that knows any numbers. It holds a purse so
+ * a cage pull visibly moves both balances, which is the thing the shot is of.
+ * ---------------------------------------------------------------------- */
+const purse = { chips: 1250, sparkle: 27, pot: 41800 };
+const listeners = new Map();
+const delay = q.has('slow') ? 9000 : 220;
+
+function fire(type, msg) {
+  const set = listeners.get(type);
+  if (!set) return;
+  for (const fn of Array.from(set)) { try { fn(msg); } catch (e) { log('listener threw: ' + e.message); } }
+}
+
+function statusBody() {
+  return {
+    chips: purse.chips,
+    sparkle: purse.sparkle,
+    pot: purse.pot,
+    rate: 100,
+    free_scratch_available: true,
+    tree: { cheapest_unowned: { id: 'soft_focus', cost: 40 }, owned: 6, total: 21 },
+    config: { stakes: { twentyone: 25, triple: 10, spiral: 25, scratcher: 50, wheel: 500 } },
+  };
+}
+
+const ctx = {
+  root: document.getElementById('host'),
+  log,
+  t: (key, fallback) => fallback || key,
+  send(msg) {
+    // The WHOLE frame, because "did the cage send the right body" is the one
+    // assertion a dumped DOM has to be able to answer on its own.
+    log('up   ' + JSON.stringify(msg));
+    if (msg.type === 'triggers-request') {
+      setTimeout(() => fire('triggers-result', { type: 'triggers-result', triggers: [
+        'good girl now', 'drop for me', 'empty and warm', 'sleep sweet thing',
+      ] }), 120);
+      return;
+    }
+    if (msg.type !== 'casino-request') return;
+    setTimeout(() => {
+      let ok = true; let status = 200; let body = statusBody();
+      if (msg.op === 'cage') {
+        const n = Math.round(Number(msg.body.sparkle) || 0);
+        if (q.has('tier')) { ok = false; status = 403; body = { code: 'arcademy_locked', min_tier: 2 }; }
+        else if (q.has('poor') || n > purse.sparkle) { ok = false; status = 400; body = { reason: 'insufficient_sparkle' }; }
+        else {
+          purse.sparkle -= n;
+          purse.chips += n * 100;
+          body = Object.assign(statusBody(), { credited: n * 100, cageId: msg.body.cageId });
+        }
+      }
+      fire('casino-result', { type: 'casino-result', reqId: msg.reqId, ok, status, body });
+      log('down casino-result ' + (ok ? 'ok' : status));
+    }, delay);
+  },
+  listen(type, fn) {
+    if (!listeners.has(type)) listeners.set(type, new Set());
+    listeners.get(type).add(fn);
+    return () => { const s = listeners.get(type); if (s) s.delete(fn); };
+  },
+};
+
+/* ?dark=1 pulls the line out from under the room. It must still open. */
+if (q.has('dark')) { delete ctx.send; delete ctx.listen; }
+
+const room = openBackRoom(ctx);
+ctx.root.appendChild(room.root);
+window.__room = room;   // the headless probe drives this
+
+/* THE LADDER, exactly the way the shell holds it: the scene folds a step, and
+ * when it has none left the room leaves. Nothing inside the scene binds Esc. */
+document.addEventListener('keydown', (e) => {
+  if (e.key !== 'Escape') return;
+  if (room.escapeStep()) { log('esc: folded a cabinet'); return; }
+  room.close();
+  log('esc: room closed');
+});
+
+/* The bench pieces, wired to the same dealer the room uses. */
+const drop = createDropBeat({
+  host: document.getElementById('dropstage'),
+  voice: { line: () => 'The room wants you for a second.' },
+  reduced: document.documentElement.classList.contains('arc-reduced'),
+  lite: document.documentElement.classList.contains('ae-lite'),
+  log,
+});
+const holdBtn = document.getElementById('holdbtn');
+const ring = holdRing(holdBtn, {
+  reduced: document.documentElement.classList.contains('arc-reduced'),
+  onCommit: () => log('HOLD committed'),
+  onCancel: () => log('HOLD cancelled'),
+});
+
+/* ------------------------------------------------------------------------
+ * THE UNATTENDED DRIVER. Nothing here reaches inside the scene: it presses the
+ * same buttons and sends the same key a player would, then writes down what it
+ * saw, which is the only kind of test worth having on a room.
+ * ---------------------------------------------------------------------- */
+const auto = q.get('auto');
+if (auto === 'cage') {
+  setTimeout(() => {
+    const n = String(q.get('n') || '10');
+    const input = room.root.querySelector('.bk-custom input');
+    const go = room.root.querySelector('.bk-cage-go');
+    input.value = n;
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    log('AUTO amount=' + n + ' goDisabled=' + go.disabled);
+    go.click();
+    setTimeout(() => {
+      log('AUTO balance=' + room.root.querySelector('.bk-bal-n').textContent);
+      log('AUTO say=' + room.root.querySelector('.bk-cage-say').textContent);
+      log('AUTO done');
+    }, delay + 2800);
+  }, 700);
+} else if (auto === 'esc') {
+  setTimeout(() => {
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    log('AUTO attached=' + (room.root.isConnected ? 'yes' : 'no'));
+    log('AUTO done');
+  }, 700);
+} else if (auto === 'hold') {
+  setTimeout(() => {
+    holdBtn.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, button: 0 }));
+    setTimeout(() => log('HOLD armed=' + ring.holding()), 200);
+    setTimeout(() => {
+      log('HOLD holding=' + ring.holding());
+      // LETTING GO IS FREE, and that is the half worth asserting: a second
+      // press released early must cancel and cost nothing.
+      holdBtn.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, button: 0 }));
+      setTimeout(() => holdBtn.dispatchEvent(new PointerEvent('pointerup', { bubbles: true })), 120);
+      setTimeout(() => log('AUTO done'), 400);
+    }, 1500);
+  }, 400);
+} else if (auto === 'drop') {
+  setTimeout(() => {
+    log('DROP veils=' + document.querySelectorAll('.bk-drop').length);
+    drop.run({ ms: 1200 }).then(() => {
+      log('DROP lifted veils=' + document.querySelectorAll('.bk-drop').length);
+      log('AUTO done');
+    });
+    setTimeout(() => log('DROP mid veils=' + document.querySelectorAll('.bk-drop').length), 300);
+  }, 400);
+} else if (auto === 'open') {
+  setTimeout(() => {
+    log('AUTO sheets=' + room.root.querySelectorAll('.bk-cab.bk-sheet').length);
+    log('AUTO balance=' + room.root.querySelector('.bk-bal-n').textContent);
+    log('AUTO tree=' + room.root.querySelector('.bk-tree').textContent);
+    log('AUTO dark=' + (room.root.querySelector('.bk-cage').classList.contains('bk-dark') ? 'yes' : 'no'));
+    log('AUTO done');
+  }, 2200);
+}
+</script>
+</body>
+</html>

--- a/ConditioningControlPanel/Resources/web/arcademy/backroom/kit/dropbeat.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/backroom/kit/dropbeat.js
@@ -1,0 +1,161 @@
+/* ============================================================================
+ * backroom/kit/dropbeat.js - THE DROP.
+ *
+ * One wedge on the Spiral is not a payout. The room dims, a spiral turns over
+ * the felt for a moment, the dealer says one thing, and then the lights come
+ * back up and you are still standing at the cabinet. That is the whole beat.
+ *
+ * FOUR HARD LIMITS, and every one of them is a promise to the player rather
+ * than a taste.
+ *  - IT NEVER LASTS LONGER THAN 1.6 SECONDS. There is a ceiling in code, not a
+ *    convention in a comment: `run()` always ends, and it ends on a timer that
+ *    was armed before the first frame was drawn.
+ *  - IT NEVER BLOCKS THE EXIT (Law VI). The veil is pointer-events:none and
+ *    takes no focus, so the way out stays clickable underneath it the whole
+ *    time. Nothing here is a modal, and nothing here waits for a click.
+ *  - IT NEVER ARRIVES WHILE ONE IS RUNNING. A second drop over the first is
+ *    two celebrations talking over each other, so a call during a drop is
+ *    dropped, not queued.
+ *  - REDUCED MOTION GETS THE SAME EVENT WITHOUT THE SPIN. One still frame, one
+ *    line, out. The Loom modules carry no reduced-motion handling of their own
+ *    (nothing in engine/loom does), so the rAF loop is gated HERE.
+ *
+ * The dim is deliberately gentle. This room already asks for a lot of a
+ * player's attention and the drop should read as a hand on the shoulder, not
+ * as the screen being taken away.
+ * ==========================================================================*/
+
+import { drawSpiral } from '../../engine/loom/loomSpiral.js';
+
+/** The ceiling. Nothing in this file may take longer, on any path. */
+export const DROP_MAX_MS = 1600;
+/** The floor, so a drop is felt at all rather than flickering past. */
+const DROP_MIN_MS = 700;
+
+function raf(fn) {
+  if (typeof requestAnimationFrame === 'function') return requestAnimationFrame(fn);
+  return setTimeout(() => fn(Date.now()), 16);
+}
+function unraf(h) {
+  if (typeof cancelAnimationFrame === 'function') { try { cancelAnimationFrame(h); return; } catch { /* noop */ } }
+  try { clearTimeout(h); } catch { /* noop */ }
+}
+const clock = () => ((typeof performance !== 'undefined' && performance.now) ? performance.now() : Date.now());
+
+/** The spiral the drop wears. Fixed rather than seeded: the drop should be the
+ *  same shape every time so that seeing it is recognising it. */
+const DROP_LOOM = Object.freeze({
+  arms: 5, turns: 2.4, style: 'log', duty: 0.55, speed: 4, direction: 1,
+  colors: ['#ff69b4', '#b8a6e8'], bg: '#14142b',
+});
+
+/**
+ * createDropBeat({ host, voice, sfx, reduced, lite, log }) ->
+ *   { run(opts) -> Promise<void>, running(), destroy() }
+ *
+ * `host` is the element the veil is laid over, normally the machine's stage.
+ * `run()` resolves when the beat is over, always, including when it refused to
+ * play at all, so a caller can always chain the next thing onto it.
+ */
+export function createDropBeat(opts) {
+  const o = opts || {};
+  const host = o.host || null;
+  const sfx = (typeof o.sfx === 'function') ? o.sfx : () => {};
+  const note = (typeof o.log === 'function') ? o.log : () => {};
+  const reduced = !!o.reduced;
+  const lite = !!o.lite;
+
+  let dead = false;
+  let live = false;
+
+  function makeVeil() {
+    const veil = document.createElement('div');
+    veil.className = 'bk-drop';
+    veil.setAttribute('aria-hidden', 'true');   // the LINE is the announcement, not the veil
+    const cv = document.createElement('canvas');
+    cv.className = 'bk-drop-eye';
+    // A small canvas scaled up by CSS. The spiral is a blur behind a dim, so
+    // pixels spent on it are pixels wasted, and a phone notices.
+    const px = lite ? 96 : 168;
+    cv.width = px;
+    cv.height = px;
+    veil.appendChild(cv);
+    const line = document.createElement('div');
+    line.className = 'bk-drop-line';
+    line.setAttribute('role', 'status');
+    veil.appendChild(line);
+    return { veil, cv, line };
+  }
+
+  /**
+   * run({ ms, text }) -> Promise<void>
+   * `text` overrides the dealer's line, for a machine with something specific
+   * to say. Otherwise she picks one from her drop bucket.
+   */
+  function run(runOpts) {
+    const r = runOpts || {};
+    // A drop over a drop is two ceremonies talking over each other.
+    if (dead || live || !host || typeof document === 'undefined') return Promise.resolve();
+    live = true;
+
+    const ms = Math.max(DROP_MIN_MS, Math.min(DROP_MAX_MS, Math.round(Number(r.ms) || 1200)));
+    let text = r.text;
+    if (text == null) { try { text = o.voice ? o.voice.line('drop') : ''; } catch (e) { text = ''; } }
+
+    const { veil, cv, line } = makeVeil();
+    if (text) line.textContent = String(text);
+    let ctx2d = null;
+    try { ctx2d = cv.getContext('2d'); } catch (e) { ctx2d = null; }
+    try { host.appendChild(veil); } catch (e) { live = false; return Promise.resolve(); }
+    sfx('spiral_hum', 0.3);
+
+    return new Promise((resolve) => {
+      let handle = null;
+      let over = false;
+      const end = () => {
+        if (over) return;
+        over = true;
+        live = false;
+        if (handle != null) { unraf(handle); handle = null; }
+        try { veil.remove ? veil.remove() : veil.parentNode && veil.parentNode.removeChild(veil); }
+        catch (e) { note('backroom: drop veil would not lift'); }
+        sfx('lift', 0.22);
+        resolve();
+      };
+
+      // THE CEILING IS ARMED BEFORE THE FIRST FRAME. Whatever happens to the
+      // frame clock, to the canvas, to the tab, the room comes back up.
+      const ceiling = setTimeout(end, ms);
+
+      if (!ctx2d) { /* no canvas: the dim and the line are still the beat */ }
+      else if (reduced) {
+        // ONE STILL FRAME. Phase 0, drawn once, never animated. The player is
+        // told the same thing; they are simply not spun while being told it.
+        try { drawSpiral(ctx2d, cv.width, DROP_LOOM, 0); } catch (e) { note('backroom: still spiral failed'); }
+      } else {
+        const t0 = clock();
+        let frames = 0;
+        const step = () => {
+          if (over) return;
+          frames += 1;
+          const elapsed = Math.max(clock() - t0, frames * 16);
+          if (elapsed >= ms) { clearTimeout(ceiling); end(); return; }
+          // phase 0..1 twice over the beat: two turns reads as motion, more
+          // reads as a machine, fewer reads as a stutter.
+          try { drawSpiral(ctx2d, cv.width, DROP_LOOM, ((elapsed / ms) * 2) % 1); }
+          catch (e) { clearTimeout(ceiling); end(); return; }
+          handle = raf(step);
+        };
+        handle = raf(step);
+      }
+    });
+  }
+
+  return {
+    run,
+    running: () => live,
+    destroy() { dead = true; },
+  };
+}
+
+export default createDropBeat;

--- a/ConditioningControlPanel/Resources/web/arcademy/backroom/kit/holdring.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/backroom/kit/holdring.js
@@ -1,0 +1,166 @@
+/* ============================================================================
+ * backroom/kit/holdring.js - press and HOLD.
+ *
+ * A casino needs one gesture that costs a beat of your attention. A tap is
+ * free and a tap is what a habit does; nine hundred milliseconds of holding a
+ * button down while a ring closes around it is a decision, and the ring is
+ * there so you can watch yourself make it.
+ *
+ * THE RULE THAT MAKES IT SAFE: LETTING GO IS ALWAYS FREE. Leaving the button,
+ * lifting the finger, Escape, the page hiding, a pointer the browser takes
+ * away - every one of those cancels and nothing is spent. The only way to
+ * commit is to hold it to the end on purpose. That is also why there is no
+ * confirm dialog anywhere in this room: this IS the confirm, and unlike a
+ * dialog it never stands between the player and the way out (Law VI).
+ *
+ * REDUCED MOTION KEEPS THE HOLD AND DROPS THE SWEEP. The hold is unchanged -
+ * same nine hundred milliseconds, same commit, same free release - and the
+ * ring simply does not sweep: it sits empty and then reads full. The sweep was
+ * the part that moved, and the CSS freeze in styles.css cannot reach a JS loop
+ * (trap 92), so the loop is not started rather than being flattened.
+ * ==========================================================================*/
+
+/** The hold, in milliseconds. Long enough to be a decision, short enough that
+ *  a player who meant it does not start wondering whether the button works. */
+export const HOLD_MS = 900;
+
+/** rAF with a timer floor, the same pair kit/chips.js uses. Here it only ever
+ *  paints: the decision itself hangs off a setTimeout, see `commit` below. */
+function raf(fn) {
+  if (typeof requestAnimationFrame === 'function') return requestAnimationFrame(fn);
+  return setTimeout(() => fn(Date.now()), 16);
+}
+function unraf(h) {
+  if (typeof cancelAnimationFrame === 'function') { try { cancelAnimationFrame(h); return; } catch { /* noop */ } }
+  try { clearTimeout(h); } catch { /* noop */ }
+}
+const clock = () => ((typeof performance !== 'undefined' && performance.now) ? performance.now() : Date.now());
+
+/**
+ * holdRing(btn, { ms, reduced, sfx, onCommit, onProgress, onCancel }) ->
+ *   { cancel(), destroy(), holding() }
+ *
+ * `btn` is any element that can take focus. The ring itself is a CSS conic
+ * gradient driven by the --bk-hold custom property, so the sheet owns how it
+ * looks and this file only ever owns how far along it is.
+ *
+ * BOTH ROADS IN. Pointer down starts it and pointer up or leave cancels it;
+ * Space or Enter held down does exactly the same thing, because a keyboard
+ * player is not a second-class player and a hold that only works with a mouse
+ * is a hold half the room cannot use.
+ */
+export function holdRing(btn, opts) {
+  const o = opts || {};
+  const ms = Math.max(200, Math.round(Number(o.ms) || HOLD_MS));
+  const reduced = !!o.reduced;
+  const sfx = (typeof o.sfx === 'function') ? o.sfx : () => {};
+  const onCommit = (typeof o.onCommit === 'function') ? o.onCommit : () => {};
+  const onProgress = (typeof o.onProgress === 'function') ? o.onProgress : () => {};
+  const onCancel = (typeof o.onCancel === 'function') ? o.onCancel : () => {};
+
+  let handle = null;
+  let commitTimer = null;
+  let t0 = 0;
+  let live = false;
+  let dead = false;
+  let keyDown = false;
+
+  function paint(p) {
+    try { btn.style.setProperty('--bk-hold', (p * 100).toFixed(1) + '%'); } catch (e) { /* noop */ }
+    onProgress(p);
+  }
+
+  /** Down tools. `committed` only says whether to announce a cancel, because a
+   *  commit has already announced itself by the time this runs. */
+  function stop(committed) {
+    if (!live) return;
+    live = false;
+    if (handle != null) { unraf(handle); handle = null; }
+    if (commitTimer != null) { try { clearTimeout(commitTimer); } catch (e) { /* noop */ } commitTimer = null; }
+    try { btn.classList.remove('bk-holding'); } catch (e) { /* noop */ }
+    paint(0);
+    if (!committed) { sfx('slide', 0.18); onCancel(); }
+  }
+
+  /* THE COMMIT IS A TIMER, THE RING IS ONLY PAINT. Hanging the decision off
+   * requestAnimationFrame made it hostage to a frame clock: a tab with no
+   * compositor (a headless probe is the honest case, a heavily throttled
+   * background tab is the real one) simply never finished the hold, and a
+   * gesture that silently stops working is worse than one that never existed.
+   * A setTimeout keeps the promise the copy makes - hold it for nine hundred
+   * milliseconds and it commits - and cancelling clears the timer, so letting
+   * go is still free, which is the half that has to be exactly right. */
+  function commit() {
+    commitTimer = null;
+    if (!live || dead) return;
+    live = false;
+    if (handle != null) { unraf(handle); handle = null; }
+    paint(1);
+    try { btn.classList.remove('bk-holding'); } catch (e) { /* noop */ }
+    try { btn.classList.add('bk-held'); } catch (e) { /* noop */ }
+    sfx('commit', 0.42);
+    onCommit();
+  }
+
+  function tick() {
+    if (!live || dead) return;
+    paint(Math.max(0, Math.min(1, (clock() - t0) / ms)));
+    handle = raf(tick);
+  }
+
+  function start() {
+    if (dead || live || btn.disabled) return;
+    live = true;
+    t0 = clock();
+    try { btn.classList.remove('bk-held'); } catch (e) { /* noop */ }
+    try { btn.classList.add('bk-holding'); } catch (e) { /* noop */ }
+    sfx('tell', 0.2);
+    commitTimer = setTimeout(commit, ms);
+    // The ring is decoration and says so: reduced motion never starts the loop
+    // at all, and the fifths the module would have stepped through are simply
+    // the empty ring and then the full one.
+    if (!reduced) handle = raf(tick);
+  }
+
+  const onDown = (e) => { if (e && e.button != null && e.button !== 0) return; start(); };
+  const onUp = () => stop(false);
+  const onKeyDown = (e) => {
+    if (e.key !== ' ' && e.key !== 'Enter' && e.key !== 'Spacebar') return;
+    // A held key repeats; only the first one starts the ring.
+    if (keyDown) { e.preventDefault(); return; }
+    keyDown = true;
+    e.preventDefault();
+    start();
+  };
+  const onKeyUp = (e) => {
+    if (e.key !== ' ' && e.key !== 'Enter' && e.key !== 'Spacebar') return;
+    keyDown = false;
+    stop(false);
+  };
+
+  btn.addEventListener('pointerdown', onDown);
+  btn.addEventListener('pointerup', onUp);
+  btn.addEventListener('pointerleave', onUp);
+  btn.addEventListener('pointercancel', onUp);
+  btn.addEventListener('keydown', onKeyDown);
+  btn.addEventListener('keyup', onKeyUp);
+  btn.addEventListener('blur', onUp);
+
+  return {
+    holding: () => live,
+    cancel: () => stop(false),
+    destroy() {
+      dead = true;
+      stop(false);
+      btn.removeEventListener('pointerdown', onDown);
+      btn.removeEventListener('pointerup', onUp);
+      btn.removeEventListener('pointerleave', onUp);
+      btn.removeEventListener('pointercancel', onUp);
+      btn.removeEventListener('keydown', onKeyDown);
+      btn.removeEventListener('keyup', onKeyUp);
+      btn.removeEventListener('blur', onUp);
+    },
+  };
+}
+
+export default holdRing;


### PR DESCRIPTION
**Merge order: K1a (#803) -> K1b (#804) -> K1c (#805) -> K1d -> K1e.** Based on `feat/backroom-k1c`.

Two kit pieces with no cabinet to live in yet, and the fixture that finally lets all of it be driven.

### `backroom/kit/holdring.js` (166 lines)
The one gesture in the room that costs a beat of your attention. A tap is free and a tap is what a habit does; 900ms of holding while a ring closes is a decision.

**Letting go is always free**, on every road out: leaving the button, lifting, blurring, `pointercancel`, releasing the key. Pointer and keyboard both, because a hold that only works with a mouse is a hold half the room cannot use. This is also why the room has no confirm dialog anywhere - **this is the confirm**, and unlike a dialog it never stands between the player and the way out.

**The commit is a `setTimeout` and the ring is only paint.** Hanging the decision off rAF made it hostage to a frame clock, and a tab with no compositor never finished the hold at all. A gesture that silently stops working is worse than one that never existed. Cancelling clears the timer, so the free-release half stays exactly right. Reduced motion keeps the hold and simply does not start the sweep.

### `backroom/kit/dropbeat.js` (161 lines)
The wedge that is not a payout: the room dims, a Loom spiral turns over the felt, the dealer says one thing, the lights come up.

- **The 1.6s ceiling is armed before the first frame is drawn**, so it is enforced rather than intended.
- **The veil is `pointer-events: none`** and takes no focus, so the way out stays clickable underneath it for the whole beat. A ceremony never becomes a modal (Law VI).
- A drop during a drop is **refused, not queued** - two celebrations talking over each other cancel each other.
- Reduced motion draws **one still frame**. Nothing in `engine/loom` carries reduced-motion handling of its own, so the caller has to gate the loop, and this file does.

### `backroom/demo.html` (228 lines) - the fixture
The real modules under a stubbed cashier. No shell, no bridge, no host, no network.

`?dark=1` (no `send`/`listen` at all), `?slow=1`, `?poor=1`, `?tier=1`, `?reduced=1`, `?lite=1`, and an unattended `?auto=` driver (`open` / `cage&n=N` / `esc` / `hold` / `drop`) that presses the same buttons a player would and writes what it saw into a log a headless dump can read back. Unhandled errors and rejections land in that log too, so **a throw is a failing test, not a line in a console nobody dumps**.

### Verification
A scratch runner drives Chrome headless against this page. **22 checks, all passing** on the tip of the stack.

Two live bugs the fixture caught are already fixed in the branches below it, which is the argument for it existing at all:

1. `countUp` painted a **minus balance** for a frame when the rAF stamp and `performance.now` disagreed (fixed in K1a).
2. The count-up's rAF loop **never terminated** under a frozen clock, and starved its own timer belt while doing it (fixed in K1a).

Shots (desktop 1600x900, phone 844x390 and 667x375, plus the paid cage and the dark cage) are attached in a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5Gp8FA4yHguiNc46u5YDS
