### PR TITLE
feat(arcademy): Back Room K1e - wheel face and trigger reels

### DIFF
--- a/ConditioningControlPanel/Resources/web/arcademy/backroom/backroom.css
+++ b/ConditioningControlPanel/Resources/web/arcademy/backroom/backroom.css
@@ -201,6 +201,11 @@ html.arc-reduced .bk-bal.bk-thud { animation: none; }
 html.arc-reduced .bk-pot.bk-live .bk-pot-n { animation: none; opacity: 1; }
 
 /* ----------------------------------------------------------------------------
+ * THE KIT BLOCKS BELOW CARRY TOKEN FALLBACKS. Everything above this line lives
+ * inside .bk-room and can rely on the room's own custom properties; a kit piece
+ * can be mounted anywhere a machine puts it, including a bench with no room
+ * around it, and a var() that resolves to nothing paints a pin nobody can see.
+ * ----------------------------------------------------------------------------
  * THE HOLD RING (kit/holdring.js)
  * The ring is a conic gradient driven by --bk-hold, so the sheet owns how the
  * hold LOOKS and the module only ever owns how far along it is. Under the
@@ -211,13 +216,13 @@ html.arc-reduced .bk-pot.bk-live .bk-pot-n { animation: none; opacity: 1; }
 .bk-hold { position: relative; --bk-hold: 0%; }
 .bk-hold::before {
   content: ''; position: absolute; inset: -4px; border-radius: inherit; pointer-events: none;
-  background: conic-gradient(var(--bk-neon) var(--bk-hold), transparent var(--bk-hold));
+  background: conic-gradient(var(--bk-neon, var(--pink)) var(--bk-hold), transparent var(--bk-hold));
   -webkit-mask: radial-gradient(farthest-side, transparent calc(100% - 3px), #000 calc(100% - 3px));
   mask: radial-gradient(farthest-side, transparent calc(100% - 3px), #000 calc(100% - 3px));
   opacity: 0;
 }
 .bk-hold.bk-holding::before { opacity: 1; }
-.bk-hold.bk-held { box-shadow: 0 0 0 2px var(--bk-brass); }
+.bk-hold.bk-held { box-shadow: 0 0 0 2px var(--bk-brass, var(--gold)); }
 
 /* ----------------------------------------------------------------------------
  * THE DROP (kit/dropbeat.js)
@@ -234,7 +239,7 @@ html.arc-reduced .bk-pot.bk-live .bk-pot-n { animation: none; opacity: 1; }
 .bk-drop-eye { width: 190px; height: 190px; border-radius: 50%; filter: blur(1px); opacity: .8; }
 .bk-drop-line {
   font-family: var(--disp); font-size: 17px; letter-spacing: .06em; text-align: center;
-  color: var(--ink); text-shadow: 0 0 14px var(--bk-neon); max-width: 22ch;
+  color: var(--ink); text-shadow: 0 0 14px var(--bk-neon, var(--pink)); max-width: 22ch;
 }
 @keyframes bk-drop-in { from { opacity: 0; } to { opacity: 1; } }
 
@@ -243,3 +248,24 @@ html.arc-mobile .bk-drop-line, html.ae-lite .bk-drop-line { font-size: 15px; tex
 /* Still mode keeps the dim and the line and loses the fade. The module has
  * already stopped turning the spiral by the time this matters. */
 html.arc-reduced .bk-drop { animation: none; }
+
+/* ----------------------------------------------------------------------------
+ * THE WHEEL (kit/loomwheel.js)
+ * The pin is a fixed piece of furniture at twelve o'clock and the wheel turns
+ * under it. A pointer that swings is a pointer a player cannot read at a
+ * glance, and a wheel nobody can read at a glance is a wheel nobody can tell
+ * is honest.
+ * -------------------------------------------------------------------------- */
+.bk-wheel { position: relative; display: inline-block; line-height: 0; }
+.bk-wheel-face { display: block; max-width: 100%; height: auto; border-radius: 50%;
+                 box-shadow: 0 0 26px color-mix(in srgb, var(--bk-neon, var(--pink)), transparent 66%); }
+.bk-wheel-pin {
+  position: absolute; top: -4px; left: 50%; width: 0; height: 0; transform: translateX(-50%);
+  border-left: 9px solid transparent; border-right: 9px solid transparent;
+  border-top: 18px solid var(--bk-brass, var(--gold)); filter: drop-shadow(0 1px 2px #000);
+}
+/* Still mode's landing: the wheel is already on its answer, and this is the
+ * dissolve it arrives behind. A CSS transition would be flattened by the
+ * global freeze (trap 92), so the module times it and only borrows the look. */
+.bk-wheel-fade .bk-wheel-face { opacity: .35; }
+html.arc-mobile .bk-wheel-face, html.ae-lite .bk-wheel-face { box-shadow: none; }

--- a/ConditioningControlPanel/Resources/web/arcademy/backroom/demo.html
+++ b/ConditioningControlPanel/Resources/web/arcademy/backroom/demo.html
@@ -20,6 +20,8 @@
      ?auto=esc   sends Escape, unattended.
      ?auto=hold  holds the bench button to the end and reports the commit.
      ?auto=drop  runs the drop beat and reports that the veil lifted.
+     ?auto=wheel spins the bench wheel to a named wedge and reports the landing.
+     ?auto=reel  builds the reel from the stubbed trigger list.
      Both write their result into #log, which is what the headless probe reads
      back out of the dumped DOM. There is no test runner and no framework here
      on purpose: the fixture IS the harness, so it can never drift from it. -->
@@ -52,6 +54,7 @@
   <div class="bench">
     <button id="holdbtn" class="bk-cage-go bk-hold" type="button">hold to commit</button>
     <div id="dropstage"></div>
+    <div id="wheelhost"></div>
   </div>
   <p class="note" id="note">stubbed cashier. no ledger, no network, no chips that exist.</p>
   <div id="log"></div>
@@ -61,6 +64,8 @@
 import { openBackRoom } from './index.js';
 import { holdRing } from './kit/holdring.js';
 import { createDropBeat } from './kit/dropbeat.js';
+import { createLoomWheel } from './kit/loomwheel.js';
+import { reelRows } from './kit/triggers.js';
 
 const q = new URLSearchParams(location.search);
 const logEl = document.getElementById('log');
@@ -158,6 +163,17 @@ const drop = createDropBeat({
   lite: document.documentElement.classList.contains('ae-lite'),
   log,
 });
+const wheel = createLoomWheel({
+  host: document.getElementById('wheelhost'),
+  size: 230,
+  seed: 'bench',
+  reduced: document.documentElement.classList.contains('arc-reduced'),
+  lite: document.documentElement.classList.contains('ae-lite'),
+  wedges: ['25', '50', 'drop', '100', 'nil', '250', 'royal'].map((label, i) => ({
+    label, color: i % 2 ? '#2e2e55' : '#3a2a55', drop: label === 'drop',
+  })),
+  log,
+});
 const holdBtn = document.getElementById('holdbtn');
 const ring = holdRing(holdBtn, {
   reduced: document.documentElement.classList.contains('arc-reduced'),
@@ -214,6 +230,23 @@ if (auto === 'cage') {
     });
     setTimeout(() => log('DROP mid veils=' + document.querySelectorAll('.bk-drop').length), 300);
   }, 400);
+} else if (auto === 'wheel') {
+  setTimeout(() => {
+    wheel.spinTo(2, 1200).then((i) => {
+      log('WHEEL landed=' + i + ' at=' + wheel.at());
+      log('AUTO done');
+    });
+  }, 400);
+} else if (auto === 'reel') {
+  setTimeout(() => {
+    reelRows(new (class { triggers() { return Promise.resolve([
+      'good girl now', 'good  girl  NOW', 'two words', 'drop for me',
+    ]); } })()).then((rows) => {
+      log('REEL rows=' + rows.length);
+      log('REEL words=' + rows.map((r) => (r.glyph ? 'GLYPH' : r.word)).join(' | '));
+      log('AUTO done');
+    });
+  }, 300);
 } else if (auto === 'open') {
   setTimeout(() => {
     log('AUTO sheets=' + room.root.querySelectorAll('.bk-cab.bk-sheet').length);

--- a/ConditioningControlPanel/Resources/web/arcademy/backroom/kit/loomwheel.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/backroom/kit/loomwheel.js
@@ -1,0 +1,286 @@
+/* ============================================================================
+ * backroom/kit/loomwheel.js - the wheel face.
+ *
+ * One canvas, two jobs. The FACE is wedges: flat colour, a label along each
+ * spoke, a brass rim, drawn once into an offscreen buffer and thereafter only
+ * rotated, because redrawing twenty-four labels every frame is how a wheel
+ * turns a phone into a hand warmer. The HUB is a Loom spiral, which is the one
+ * place on the wheel where the room's own art shows through.
+ *
+ * THE POINTER DOES NOT MOVE AND THE WHEEL DOES. That is not a style choice: a
+ * wheel whose pointer swings is a wheel a player cannot read at a glance, and
+ * a player who cannot read the wheel cannot tell whether the house is honest.
+ *
+ * WHO DECIDES WHERE IT STOPS: NOT THIS FILE. `spinTo(index)` is told the index
+ * by the caller, which was told it by the server. There is no rng anywhere in
+ * the landing, and the only random thing on the whole wheel is the hub's
+ * recipe. A wheel that picked its own winner would be a wheel with a thumb on
+ * it, and it would be this module's thumb.
+ *
+ * REDUCED MOTION GETS A CROSSFADE, NOT A SLOW SPIN. Nothing in engine/loom
+ * gates itself on reduced motion, and the CSS freeze cannot reach a JS loop
+ * (trap 92), so every loop here is gated in this file: the hub does not turn,
+ * and spinTo lands the wheel on its answer behind a short dissolve instead of
+ * travelling there.
+ *
+ * .ae-lite gets a STILL hub. The phone diet's whole argument is that a
+ * decorative loop is the first thing to cut, and the hub is decoration.
+ * ==========================================================================*/
+
+import { drawSpiral } from '../../engine/loom/loomSpiral.js';
+import { makeRng } from '../../core/rng.js';
+
+const TAU = Math.PI * 2;
+/** How many whole turns a spin makes before it starts hunting for its wedge. */
+const TURNS = 4;
+
+function raf(fn) {
+  if (typeof requestAnimationFrame === 'function') return requestAnimationFrame(fn);
+  return setTimeout(() => fn(Date.now()), 16);
+}
+function unraf(h) {
+  if (typeof cancelAnimationFrame === 'function') { try { cancelAnimationFrame(h); return; } catch { /* noop */ } }
+  try { clearTimeout(h); } catch { /* noop */ }
+}
+const clock = () => ((typeof performance !== 'undefined' && performance.now) ? performance.now() : Date.now());
+
+/** The settle. Quintic out: it arrives fast, then spends most of the last
+ *  third slowing down, which is the part that reads as a wheel with weight. */
+const settle = (t) => 1 - Math.pow(1 - t, 5);
+
+/** A Loom recipe for the hub, seeded so a given wheel always wears the same
+ *  spiral. Not the drop's spiral: the hub is furniture, the drop is an event. */
+function hubRecipe(seed) {
+  const rng = makeRng(String(seed || 'backroom-wheel'));
+  const arms = 3 + Math.floor(rng() * 4);
+  return {
+    arms,
+    turns: 1.2 + rng() * 1.6,
+    style: ['log', 'arch', 'ribbon'][Math.floor(rng() * 3)],
+    duty: 0.42 + rng() * 0.2,
+    speed: 3,
+    direction: rng() < 0.5 ? -1 : 1,
+    colors: ['#ff69b4', '#b8a6e8'],
+    bg: '#14142b',
+  };
+}
+
+/**
+ * createLoomWheel({ host, wedges, seed, reduced, lite, sfx, log }) ->
+ *   { el, spinTo(index, ms) -> Promise<number>, setWedges(list), at(), destroy() }
+ *
+ * `wedges` is `[{ label, color, drop }]`. `spinTo` resolves with the index it
+ * landed on, which is always the index it was given: the promise is a "the
+ * ceremony is over" signal, never an outcome.
+ */
+export function createLoomWheel(opts) {
+  const o = opts || {};
+  const reduced = !!o.reduced;
+  const lite = !!o.lite;
+  const sfx = (typeof o.sfx === 'function') ? o.sfx : () => {};
+  const note = (typeof o.log === 'function') ? o.log : () => {};
+
+  const size = Math.max(180, Math.min(420, Math.round(Number(o.size) || 320)));
+  const wrap = document.createElement('div');
+  wrap.className = 'bk-wheel';
+  const cv = document.createElement('canvas');
+  cv.width = size;
+  cv.height = size;
+  cv.className = 'bk-wheel-face';
+  cv.setAttribute('role', 'img');
+  wrap.appendChild(cv);
+  const pin = document.createElement('i');
+  pin.className = 'bk-wheel-pin';
+  pin.setAttribute('aria-hidden', 'true');
+  wrap.appendChild(pin);
+
+  let ctx2d = null;
+  try { ctx2d = cv.getContext('2d'); } catch (e) { ctx2d = null; }
+
+  let wedges = [];
+  let face = null;        // the drawn face, rotated but never redrawn
+  let rot = 0;            // current rotation, radians
+  let landed = 0;
+  let hubHandle = null;
+  let spinHandle = null;
+  let dead = false;
+  const recipe = hubRecipe(o.seed);
+
+  /** The face, drawn ONCE into a buffer. Every frame after this is a rotate. */
+  function buildFace() {
+    if (!ctx2d || !wedges.length) return;
+    let buf = null;
+    try {
+      buf = document.createElement('canvas');
+      buf.width = size;
+      buf.height = size;
+    } catch (e) { face = null; return; }
+    const b = buf.getContext('2d');
+    if (!b) { face = null; return; }
+    const c = size / 2;
+    const r = c - 6;
+    const span = TAU / wedges.length;
+    for (let i = 0; i < wedges.length; i++) {
+      const w = wedges[i] || {};
+      // -PI/2 puts wedge zero under the pin at twelve o'clock, which is where
+      // a player looks first and therefore where zero has to be.
+      const a0 = (i * span) - Math.PI / 2 - span / 2;
+      b.beginPath();
+      b.moveTo(c, c);
+      b.arc(c, c, r, a0, a0 + span);
+      b.closePath();
+      b.fillStyle = w.color || (i % 2 ? '#2e2e55' : '#252542');
+      b.fill();
+      b.strokeStyle = 'rgba(240,194,75,.35)';
+      b.lineWidth = 1;
+      b.stroke();
+      const label = String(w.label == null ? '' : w.label);
+      if (!label) continue;
+      b.save();
+      b.translate(c, c);
+      b.rotate(a0 + span / 2);
+      b.fillStyle = w.ink || '#F2EBDD';
+      b.font = '600 ' + Math.max(9, Math.round(size / 26)) + 'px ' + (w.font || 'system-ui, sans-serif');
+      b.textAlign = 'right';
+      b.textBaseline = 'middle';
+      // Labels ride the spoke outward. A wheel with horizontal labels needs
+      // twice the face to fit half the words.
+      b.fillText(label.slice(0, 14), r - 10, 0);
+      b.restore();
+    }
+    b.beginPath();
+    b.arc(c, c, r, 0, TAU);
+    b.strokeStyle = '#F0C24B';
+    b.lineWidth = 3;
+    b.stroke();
+    face = buf;
+  }
+
+  /** One composited frame: the face at `rot`, the hub on top and upright. */
+  function paint(hubPhase) {
+    if (!ctx2d) return;
+    const c = size / 2;
+    ctx2d.clearRect(0, 0, size, size);
+    if (face) {
+      ctx2d.save();
+      ctx2d.translate(c, c);
+      ctx2d.rotate(rot);
+      ctx2d.drawImage(face, -c, -c);
+      ctx2d.restore();
+    }
+    const hubR = Math.round(size * 0.17);
+    ctx2d.save();
+    ctx2d.beginPath();
+    ctx2d.arc(c, c, hubR, 0, TAU);
+    ctx2d.clip();
+    ctx2d.translate(c - hubR, c - hubR);
+    try { drawSpiral(ctx2d, hubR * 2, recipe, hubPhase || 0); }
+    catch (e) { note('backroom: wheel hub would not draw'); }
+    ctx2d.restore();
+    ctx2d.beginPath();
+    ctx2d.arc(c, c, hubR, 0, TAU);
+    ctx2d.strokeStyle = '#F0C24B';
+    ctx2d.lineWidth = 2;
+    ctx2d.stroke();
+  }
+
+  /** The hub's own slow turn, when the room can afford one. */
+  function startHub() {
+    if (hubHandle != null || reduced || lite) { paint(0); return; }
+    const t0 = clock();
+    const loop = () => {
+      if (dead) return;
+      paint(((clock() - t0) / 2400) % 1);
+      hubHandle = raf(loop);
+    };
+    hubHandle = raf(loop);
+  }
+
+  function setWedges(list) {
+    wedges = Array.isArray(list) ? list.slice(0, 48) : [];
+    try { cv.setAttribute('aria-label', wedges.map((w) => w && w.label).filter(Boolean).join(', ')); }
+    catch (e) { /* noop */ }
+    buildFace();
+    paint(0);
+  }
+
+  /**
+   * spinTo(index, ms) -> Promise<index>
+   * The index came from the server. This only travels there.
+   */
+  function spinTo(index, ms) {
+    const n = wedges.length;
+    if (dead || !n || !ctx2d) return Promise.resolve(landed);
+    const i = ((Math.round(Number(index) || 0) % n) + n) % n;
+    const span = TAU / n;
+    // Where the wheel must end up for wedge i to sit under the pin, carried
+    // forward from where it is so a second spin never rewinds.
+    const target = rot + (TURNS * TAU) + (((-i * span) - (rot % TAU)) % TAU + TAU) % TAU;
+
+    if (reduced) {
+      /* THE CROSSFADE. The answer is the information and it is not withheld:
+       * the wheel simply arrives at it behind a short dissolve rather than
+       * travelling there for three seconds. */
+      landed = i;
+      rot = target % TAU;
+      try { wrap.classList.add('bk-wheel-fade'); } catch (e) { /* noop */ }
+      paint(0);
+      sfx('chime', 0.3);
+      return new Promise((res) => setTimeout(() => {
+        try { wrap.classList.remove('bk-wheel-fade'); } catch (e) { /* noop */ }
+        res(i);
+      }, 240));
+    }
+
+    const dur = Math.max(900, Math.min(6000, Math.round(Number(ms) || 3200)));
+    const from = rot;
+    const t0 = clock();
+    if (spinHandle != null) { unraf(spinHandle); spinHandle = null; }
+    sfx('whoosh', 0.34);
+    return new Promise((res) => {
+      let over = false;
+      const finish = () => {
+        if (over) return;
+        over = true;
+        if (spinHandle != null) { unraf(spinHandle); spinHandle = null; }
+        rot = target % TAU;
+        landed = i;
+        paint(0);
+        sfx('chime', 0.34);
+        res(i);
+      };
+      // The ceiling, armed before the first frame: a stalled clock or a lost
+      // compositor must never leave a wheel spinning with a stake on it.
+      const ceiling = setTimeout(finish, dur + 400);
+      const step = () => {
+        if (dead || over) return;
+        const t = Math.max(0, Math.min(1, (clock() - t0) / dur));
+        rot = from + (target - from) * settle(t);
+        paint(0);
+        if (t >= 1) { clearTimeout(ceiling); finish(); return; }
+        spinHandle = raf(step);
+      };
+      spinHandle = raf(step);
+    });
+  }
+
+  setWedges(o.wedges);
+  startHub();
+  if (o.host) { try { o.host.appendChild(wrap); } catch (e) { /* noop */ } }
+
+  return {
+    el: wrap,
+    spinTo,
+    setWedges,
+    at: () => landed,
+    destroy() {
+      dead = true;
+      if (hubHandle != null) { unraf(hubHandle); hubHandle = null; }
+      if (spinHandle != null) { unraf(spinHandle); spinHandle = null; }
+      try { wrap.remove ? wrap.remove() : wrap.parentNode && wrap.parentNode.removeChild(wrap); }
+      catch (e) { /* noop */ }
+    },
+  };
+}
+
+export default createLoomWheel;

--- a/ConditioningControlPanel/Resources/web/arcademy/backroom/kit/triggers.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/backroom/kit/triggers.js
@@ -1,0 +1,125 @@
+/* ============================================================================
+ * backroom/kit/triggers.js - the reels, and whose words are on them.
+ *
+ * Triple Trigger spins three reels of three-word phrases, and the good version
+ * of that game spins YOUR phrases. The host knows them; this asks for them and
+ * turns the answer into reel rows.
+ *
+ * WHY EXACTLY THREE WORDS. A reel row has one line of room and a slot window
+ * is read in about a third of a second. Two words look like a label, four
+ * wrap, three read as a phrase and stack into a column that scans. Anything
+ * that is not three words is not rejected as invalid, it simply is not a reel
+ * row, and it is left where it was.
+ *
+ * THE FALLBACK GOES THROUGH THE LEXICON, NOT THROUGH A MOD SWITCH. It would be
+ * easy to branch on the active mod and hand back a Bambi set, a Drone set and
+ * so on, and it would be wrong: `init.modId` reaches the page, but the page
+ * never reads it and may not start now. Mods skin display strings by shipping
+ * `lexicon.json`, so the neutral rows below are keys, and a mod re-voices all
+ * six by overriding them. That is one mechanism instead of two, and it means a
+ * mod nobody here has heard of gets its own reels for free.
+ *
+ * A GLYPH ROW IS NOT A BLANK. A short list is padded with `{glyph:true}` rows
+ * rather than with empty strings, because a slot machine with gaps in the reel
+ * reads as broken, and a spiral glyph reads as the house's own symbol.
+ * ==========================================================================*/
+
+/** How many rows a reel wants at most. Past a dozen the column stops feeling
+ *  like a set of your own words and starts feeling like a dictionary. */
+export const REEL_CAP = 12;
+/** The fewest rows a reel can have and still look like a reel turning. */
+export const REEL_MIN = 6;
+
+/**
+ * The neutral fallback, and the six rows a mod overrides to re-voice the reels
+ * in its own tongue. Neutral means neutral: these are the phrases the CCP
+ * Default mod would use, warm and suggestive without belonging to any one
+ * script. Every value is three words and under 96 characters, so it survives
+ * `MergeModTable` and can be skinned.
+ */
+export const BK_TRIGGERS = Object.freeze({
+  bk_tr_1: 'soft and slow',
+  bk_tr_2: 'eyes on me',
+  bk_tr_3: 'let it go',
+  bk_tr_4: 'sink a little',
+  bk_tr_5: 'good, stay there',
+  bk_tr_6: 'warm and quiet',
+});
+
+/** The glyph a padded row wears. The house's own mark, not a placeholder box. */
+export const REEL_GLYPH = '@';
+
+/** Exactly three words, once whitespace is tidied. Nothing else qualifies. */
+export function isThreeWords(text) {
+  const s = String(text == null ? '' : text).replace(/\s+/g, ' ').trim();
+  if (!s) return false;
+  return s.split(' ').length === 3;
+}
+
+function tidy(text) {
+  return String(text == null ? '' : text).replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * buildReel(list, { t, cap, min }) -> [{ word } | { glyph:true }]
+ *
+ * Pure, so it can be reasoned about and tested without a host: the asking is
+ * `reelRows` below. Order is preserved, because the player's own list has an
+ * order they recognise and shuffling it makes their words look like ours.
+ */
+export function buildReel(list, opts) {
+  const o = opts || {};
+  const cap = Math.max(1, Math.round(Number(o.cap) || REEL_CAP));
+  const min = Math.max(1, Math.round(Number(o.min) || REEL_MIN));
+  const t = (typeof o.t === 'function') ? o.t : ((k, fb) => fb || BK_TRIGGERS[k] || '');
+
+  const rows = [];
+  const seen = new Set();
+  const take = (raw) => {
+    if (rows.length >= cap) return;
+    const s = tidy(raw);
+    if (!isThreeWords(s)) return;
+    const key = s.toLowerCase();
+    if (seen.has(key)) return;      // the same phrase twice is a bug, not a reel
+    seen.add(key);
+    rows.push({ word: s });
+  };
+
+  for (const item of (Array.isArray(list) ? list : [])) {
+    // The host may hand back strings or {phrase}/{word}/{text} objects.
+    if (typeof item === 'string') take(item);
+    else if (item && typeof item === 'object') take(item.phrase || item.word || item.text);
+  }
+
+  /* THE PLAYER'S OWN WORDS COME FIRST AND THE HOUSE'S FILL IN BEHIND THEM.
+   * A reel that opened with our phrases and buried theirs would be the wrong
+   * way round: the point of the machine is that it knows them. */
+  if (rows.length < min) {
+    for (const key of Object.keys(BK_TRIGGERS)) {
+      if (rows.length >= min) break;
+      take(t(key, BK_TRIGGERS[key]));
+    }
+  }
+  // Still short, because a mod re-voiced a row into something that is not
+  // three words. Glyphs finish the column rather than leaving a hole in it.
+  while (rows.length < min) rows.push({ glyph: true, word: REEL_GLYPH });
+
+  return rows;
+}
+
+/**
+ * reelRows(api, { t, cap, min }) -> Promise<rows>
+ *
+ * Asks the host once and never rejects. `api.triggers()` already resolves to
+ * an empty array on a host with no trigger store and on a timeout, so the
+ * failure path here is simply the fallback path, which is the same code.
+ */
+export function reelRows(api, opts) {
+  const ask = (api && typeof api.triggers === 'function') ? api.triggers() : Promise.resolve([]);
+  return ask.then(
+    (list) => buildReel(list, opts),
+    () => buildReel([], opts),
+  );
+}
+
+export default { buildReel, reelRows, isThreeWords, BK_TRIGGERS, REEL_CAP, REEL_MIN };


### PR DESCRIPTION
Last of the five. The wheel face every spinning cabinet borrows, the reel builder Triple Trigger needs, and the one list of lexicon rows the whole stack owes the host.

**Merge order: #803 K1a, #804 K1b, #805 K1c, #806 K1d, then this one.** Each branch is stacked on the one before it, so merging out of order will show phantom conflicts. 473 lines here, 2550 across the stack.

## What is in it

`backroom/kit/loomwheel.js` (286) - the wheel face. One canvas, wedges drawn ONCE into an offscreen buffer and thereafter only rotated, because redrawing twenty-four labels a frame is how a wheel cooks a phone. The hub is a Loom spiral through `engine/loom/loomSpiral.js`, seeded so a given wheel always wears the same one. `spinTo(index, ms)` is told where to stop by the caller, which was told by the server: there is no rng in the landing, and the only random thing on the whole wheel is the hub's recipe. The pointer is fixed CSS furniture and the wheel turns under it, so a player can read the result at a glance. Settle is quintic out. Reduced motion crossfades to the answer over 240ms instead of travelling, `.ae-lite` gets a still hub, and a `setTimeout` ceiling at `dur + 400` means a stalled frame clock can never leave a wheel spinning with a stake on it.

`backroom/kit/triggers.js` (125) - the reels, and whose words are on them. `buildReel` keeps entries of exactly three words, dedupes case-insensitively, preserves the player's own order, caps at 12 and pads to 6 with glyph rows. Three words because a slot window is read in about a third of a second: two look like a label, four wrap.

`backroom.css` (+32) - the wheel block, plus fallbacks on the five kit-block token reads (`var(--bk-brass, var(--gold))` and so on). The tokens are declared on `.bk-room`, and a kit piece can be mounted anywhere, so the bench shot had an invisible pin until this landed.

`demo.html` (+33) - `?auto=wheel` and `?auto=reel` on the fixture bench.

## The trigger fallback does not read the mod, on purpose

The brief asked for an authored five-phrase set per mod. That cannot be built here: `init.modId` reaches the page and the page never reads it, by house rule, and starting now would be the first read in the codebase. So the fallback is six NEUTRAL rows that are lexicon keys (`bk_tr_1` through `bk_tr_6`), and a mod re-voices all six by shipping them in its `lexicon.json`. One mechanism instead of two, and a mod nobody here has heard of gets its own reels for free. Every value is three words and under 96 characters, so `MergeModTable` will take it (trap 26).

## The kit a machine module receives

A cabinet module exports `{ key, title, mount(root, kit, ctx), unmount() }`. What `kit` holds:

```
kit.api            createCasinoApi instance:
                     wired()                       -> bool, false when the host gave no send/listen
                     status()                      -> Promise<{ok, status, body}>
                     cage(sparkle, cageId?)        -> Promise<{cageId, ok, status, body}>
                     play(machine, stake, input, playId?) -> Promise<{playId, ok, status, body}>
                     triggers()                    -> Promise<string[]>, never rejects
                     last()                        -> the last status body seen, or null
                     seed(body), localDay(when?), mintId(), destroy()
                   Every call RESOLVES, never rejects. Timeout at 8s is
                   {ok:false, status:0, body:{reason:'timeout'}}; no host is
                   {reason:'offline'}.
kit.t(key, args?)  the floor lexicon, {0} slots filled from args
kit.lex            the frozen BK_LEX table
kit.voice.line(b)  a dealer line from bucket deal|win|loss|big|drop|royal|cage
kit.reduced        bool, html.arc-reduced
kit.lite           bool, .ae-lite / phone diet
kit.sfx(name, level, pitch?)  dispatches arcademy-sfx on document
kit.log(msg)
kit.fmtChips(n)
kit.balanceChip({label, value, reduced}) -> {el, set(n, {animate, reduced}), value()}
kit.chipStack({value})                   -> {el, set(n), rect()}
kit.bank(from, to, {count, ms, reduced}) -> Promise<void>
kit.status()       the last status snapshot the floor holds
kit.config()       stakes and paytables out of that snapshot
kit.settle(body, bankFrom)  hand a result frame's balances back to the floor
kit.refresh()      re-ask status and repaint the floor
kit.toFloor()      unmount yourself, back to the cabinets
kit.balanceEl()    the header balance element, to fly chips at
```

Imported directly rather than through `kit`, because they are pieces a machine builds with rather than services the floor owns: `holdRing` (kit/holdring.js), `createDropBeat` (kit/dropbeat.js), `createLoomWheel` (kit/loomwheel.js), `buildReel`/`reelRows` (kit/triggers.js).

`ctx` is the shell's own surface, untouched.

## Lexicon rows to mirror into ArcademyHostService.NeutralLexicon

85 keys, every one under 96 characters so all of them are mod-skinnable (trap 26). This PR cannot edit the C# side, so this is the whole list for the stack, ready to paste:

```csharp
        // backroom/lex.js - the floor
        ["bk_title"] = "The Back Room",
        ["bk_sub"] = "Cash only. Chips only.",
        ["bk_exit"] = "step out",
        ["bk_back"] = "back to the floor",
        ["bk_chips"] = "chips",
        ["bk_sparkle"] = "sparkle",
        ["bk_pot"] = "the pot",
        ["bk_pot_sub"] = "a quarter of every rake. one royal takes the lot.",
        ["bk_pot_unknown"] = "counting",
        ["bk_cage"] = "The Cage",
        ["bk_cage_rate"] = "1 sparkle buys 100 chips. one way, never back.",
        ["bk_cage_hand"] = "sparkle on hand",
        ["bk_cage_get"] = "chips you get",
        ["bk_cage_go"] = "change it",
        ["bk_cage_custom"] = "or name an amount",
        ["bk_cage_custom_lbl"] = "a custom amount of sparkle, up to 500",
        ["bk_cage_dark"] = "Cash only. Come back when the line is up.",
        ["bk_cage_working"] = "Counting it out.",
        ["bk_cage_done"] = "That is {0} chips. Try not to spend it all at one cabinet.",
        ["bk_cage_poor"] = "Not quite enough sparkle for that one. The floor keeps.",
        ["bk_cage_offline"] = "The line to the counter is down. Your sparkle is safe where it is.",
        ["bk_cage_bad"] = "The cage takes one to five hundred at a time. Typo guard, nothing more.",
        ["bk_cage_busy"] = "The cashier is with someone. Give her a moment.",
        ["bk_cage_locked"] = "The bank does not serve this account yet. Nothing was charged.",
        ["bk_cage_reset"] = "Your skills are mid reset. The cage waits for that to settle.",
        ["bk_cage_refused"] = "The cage would not take that one. Nothing moved.",
        ["bk_cage_tree"] = "The same {0} sparkle goes toward {1} on the tree, {2} short of it.",
        ["bk_cage_tree_buy"] = "The same {0} sparkle buys {1} on the tree outright.",
        ["bk_cage_tree_done"] = "The tree is finished. There is nothing up there left to buy.",
        ["bk_cab_twentyone"] = "Twenty-One",
        ["bk_cab_triple"] = "Triple Trigger",
        ["bk_cab_spiral"] = "The Spiral",
        ["bk_cab_scratcher"] = "The Scratcher",
        ["bk_cab_wheel"] = "The Prize Wheel",
        ["bk_sub_twentyone"] = "the dealer stands on all seventeens.",
        ["bk_sub_triple"] = "three reels, and they are your own words.",
        ["bk_sub_spiral"] = "twenty-four wedges. one of them is a drop.",
        ["bk_sub_scratcher"] = "three in a row pays. one card a day is free.",
        ["bk_sub_wheel"] = "the big one. seven wedges, two of them worth waiting for.",
        ["bk_cab_stake"] = "{0} chips a go",
        ["bk_cab_free"] = "one free card today",
        ["bk_sheet"] = "Not open yet.",
        ["bk_sheet_sub"] = "Still under a sheet. The house is building it.",
        ["bk_floor_aria"] = "the cabinets",

        // backroom/kit/voice.js - the dealer
        ["bk_say_deal_1"] = "Chips down. Let us see what the night thinks of you.",
        ["bk_say_deal_2"] = "Good. Hands where I can see them, eyes where I put them.",
        ["bk_say_deal_3"] = "Here we go, sweetheart.",
        ["bk_say_deal_4"] = "One more. You always did say one more.",
        ["bk_say_deal_5"] = "Settle in. This part is my favourite.",
        ["bk_say_win_1"] = "There it is. Well played.",
        ["bk_say_win_2"] = "The house nods and pays. Rare thing, that.",
        ["bk_say_win_3"] = "Look at you. Colour me impressed.",
        ["bk_say_win_4"] = "Yours. Take it before I change my mind.",
        ["bk_say_win_5"] = "Nice. Very nice.",
        ["bk_say_loss_1"] = "Not that one. Shake it off, love.",
        ["bk_say_loss_2"] = "The floor keeps that one. Happens to everybody here.",
        ["bk_say_loss_3"] = "Ah. So close it almost counts, which it does not.",
        ["bk_say_loss_4"] = "Gone. You are still the best thing in this room.",
        ["bk_say_loss_5"] = "That is the game. No shame in it.",
        ["bk_say_loss_6"] = "The house takes it. I would rather it had not.",
        ["bk_say_big_1"] = "Oh, that is a NUMBER. Say it out loud for me.",
        ["bk_say_big_2"] = "The whole room just looked over. Let them look.",
        ["bk_say_big_3"] = "That is the good stuff. Breathe, then count it.",
        ["bk_say_big_4"] = "Well now. Somebody is having a night.",
        ["bk_say_big_5"] = "I felt that one land. Beautiful.",
        ["bk_say_drop_1"] = "Ah. The room wants you for a second.",
        ["bk_say_drop_2"] = "Lights down, pet. This bit is not about the chips.",
        ["bk_say_drop_3"] = "There. Sink for me.",
        ["bk_say_drop_4"] = "The spiral called your name. It does that.",
        ["bk_say_drop_5"] = "Eyes here. Just here. Good.",
        ["bk_say_royal_1"] = "The pot. The whole pot. I have never seen it go.",
        ["bk_say_royal_2"] = "That is a royal. Sit down before you fall down.",
        ["bk_say_royal_3"] = "Every light in the room is on you. Earned.",
        ["bk_say_royal_4"] = "They will talk about this hand for a while.",
        ["bk_say_cage_1"] = "Sparkle in, chips out. One way only, you know the rule.",
        ["bk_say_cage_2"] = "Counting it out for you now.",
        ["bk_say_cage_3"] = "There. Try to make it last past the first cabinet.",
        ["bk_say_cage_4"] = "Careful with that. It spends faster than it earns.",
        ["bk_say_cage_5"] = "Spend it slowly. Or do not. I am not your mother.",

        // backroom/kit/triggers.js - the neutral reel rows
        ["bk_tr_1"] = "soft and slow",
        ["bk_tr_2"] = "eyes on me",
        ["bk_tr_3"] = "let it go",
        ["bk_tr_4"] = "sink a little",
        ["bk_tr_5"] = "good, stay there",
        ["bk_tr_6"] = "warm and quiet",
```

Nothing renders as a raw key without them: `t()` is total and every call site here passes an English fallback. The rows are what makes the room translatable and mod-skinnable.

Separate finding while checking that: `prize_tier`, the Prize Counter's tier refusal, has no `NeutralLexicon` row either, so that sentence can never be localized or skinned today. Not touched here, worth a line in W1.

## Checks

The fixture suite is 22 assertions over `backroom/demo.html` driven headless. All 22 pass on this branch. New here: `?auto=wheel` lands `spinTo(3)` on wedge 3 and resolves, and `?auto=reel` builds a 6-row reel from a 2-entry host list, padded from the neutral keys.

## Contract items not met

- Per-mod authored trigger lists, as above. Neutral lexicon rows instead.
- Esc is not bound inside the scene, because no scene may bind Esc: `shell/exits.js` owns the ladder. The floor exposes `escapeStep()` and the fixture drives it exactly as the shell does. Law VI holds either way, and the "Esc closes" check passes through that ladder.
- The cage lives in `cage.js` rather than inside `index.js`, to keep K1c under the line cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5Gp8FA4yHguiNc46u5YDS
