### PR TITLE
feat(arcademy): Back Room W1 - the door on the campus + chips at the counter

### DIFF
--- a/ConditioningControlPanel/Resources/web/arcademy/core/lexicon.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/core/lexicon.js
@@ -763,6 +763,34 @@ export const DEFAULT_LEXICON = Object.freeze({
   locker_open: 'Open Locker',
 
   /* ------------------------------------------------------------------------
+   * THE BACK ROOM (the casino wing, W1: the door and the chips).
+   *
+   * The fifth window in the service alley, and the only one that is not a
+   * counter. The voice drops a register again: the shop is warm, the locker is
+   * private, and this one is CALM - a house does not need to raise its voice.
+   * Every row is a NeutralLexicon candidate under the 96-character mod cap
+   * (trap 26), and the same rows are mirrored in the C# host or a host that
+   * ships without them falls back to English in silence (trap 123).
+   *
+   * The CHIP itself is a third currency and it sits with the other two: the
+   * counter reads `wallet.c` off the same echo the tickets and tokens ride.
+   * Chip PRICES and prize names are the host's, never this file's.
+   * ---------------------------------------------------------------------- */
+  campus_room_backroom: 'The Back Room',
+  campus_desc_backroom: 'Cash only. Chips only. The house always has time for you.',
+  backroom_sign: 'Back Room',
+  campus_backroom_status: 'Always open',
+  /* The dust sheet: the door is painted on the plan whether or not the room
+   * behind it has been built, because a landmark that comes and goes is a menu
+   * item. This is what it says on a host that has no room to open. */
+  backroom_dust: 'Not open yet.',
+  backroom_dust_line: 'Sheets over the tables and the lights off at the wall. Another night.',
+  /* the third shelf at the Prize Counter */
+  wallet_chips: 'Chips',
+  prize_shelf_chips: 'The Back Room shelf',
+  prize_shelf_chips_hint: 'Chips only. What you carried out of the Back Room buys these.',
+
+  /* ------------------------------------------------------------------------
    * THE PUBLIC ADDRESS SYSTEM (Counter Stock `pa_pack`, captions 2026-08-28).
    *
    * Thirty-six announcements. The recordings shipped first and were audio only;

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/campus.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/campus.js
@@ -741,6 +741,27 @@ export const FACILITIES = Object.freeze({
   locker: Object.freeze({
     rect: [1260, 668, 108, 84], side: 'w', door: 710, stop: [1250, 710], rm: '004',
   }),
+  /* THE BACK ROOM (the casino wing, 2026-09-04). FIFTH WINDOW IN THE ALLEY,
+   * and it is the only one that is not a counter. Last door before the alley
+   * runs out of school: you walk past what you can buy and past what you
+   * already own, and then there is one more door. Same width, same west door,
+   * same three-step walk down the alley the other four take.
+   *
+   * TWELVE UNITS DOWN AND SIXTY-FOUR DEEP, not the ninety-six-by-eighty-four
+   * the pairs above it keep, and that is a MEASUREMENT rather than a taste:
+   * the plan's bottom band is where `.campus-hint` sits on a desktop (bottom
+   * 14px, the school's one line of instruction), and a fifth full-height
+   * window would have put this room's dressing under that sentence. The rig
+   * caught the last two pixels of a 72-deep window under the hint at 1366x768,
+   * so the window came in to 64 and the room now ends at plan y 828: eleven
+   * clear pixels at 1600x900 and just under five at 1366x768.
+   *
+   * FURNITURE, NEVER A CLASS. No ROOMS row, no registry, no timetable, nothing
+   * in campusState - the plan paints a door and the shell decides what is
+   * behind it. */
+  backroom: Object.freeze({
+    rect: [1260, 764, 108, 64], side: 'w', door: 796, stop: [1250, 796], rm: '005',
+  }),
 });
 
 /** ROOMS first, the two counters second. Pure; undefined for anything else. */
@@ -2168,6 +2189,60 @@ export function createCampus({ state, gameName, banner, stats, reducedMotion, on
     facPut(lockerG, svg('line', { x1: x + 4, y1: 744, x2: x + 14, y2: 744 }, 'campus-furn'));
   });
   stag(lockerG, 900);
+
+  /* THE BACK ROOM. RM 005, FIFTH WINDOW IN THE ALLEY, AND IT IS ALWAYS THERE.
+   *
+   * Drawn on every host, exactly like the Prize Counter and for the counter's
+   * own reason: a landmark that comes and goes is not a landmark, it is a menu
+   * item. What CHANGES is whether the door opens. A shell that can open it
+   * hands `on.backroom` and the door walks; a shell that cannot (an older page,
+   * a host with the wing switched off) gets the dust sheet below, which is the
+   * sealed card every other shut door on this campus already raises.
+   *
+   * Drawn through the SAME facility() helper as the other four, with the
+   * alley's grammar (compact plate, west door, neon over the name) carried down
+   * to the short window's offsets. Nothing in the helper is touched for it.
+   */
+  function backroomDustCard() {
+    openFacilityCard({
+      name: t('campus_room_backroom', 'The Back Room'),
+      status: t('backroom_dust', 'Not open yet.'),
+      desc: t('backroom_dust_line',
+        'Sheets over the tables and the lights off at the wall. Another night.'),
+      sealed: true,
+    });
+  }
+  const backroomG = facility({
+    rect: FACILITIES.backroom.rect, door: FACILITIES.backroom.door,
+    side: FACILITIES.backroom.side, compact: true,
+    neonY: 768, nameY: 796, furnBox: [1276, 815, 76, 11],
+    sign: t('backroom_sign', 'Back Room'),
+    name: t('campus_room_backroom', 'The Back Room'),
+    rm: FACILITIES.backroom.rm,
+    onClick: () => {
+      if (handlers.backroom) { handlers.backroom(); return; }
+      backroomDustCard();
+    },
+    tip: () => ({
+      name: t('campus_room_backroom', 'The Back Room'),
+      status: t('campus_backroom_status', 'Always open'),
+      desc: t('campus_desc_backroom',
+        'Cash only. Chips only. The house always has time for you.'),
+    }),
+  });
+  backroomG.setAttribute('class', 'campus-room facility backroom');
+  /* THE CHIP RACK behind the glass - the parcels and the locker doors' opposite
+   * number one window down. Three chips on the rail instead of three boxes, so
+   * the shapes say what is played in there without a word on the plate.
+   *
+   * SMALLER DISCS AND A HIGHER RAIL than the drawers next door, because this
+   * window is twenty units shorter and the rig measured the old rack climbing
+   * into the RM plate. The rail keeps the drawers' four units of floor under
+   * it, so the shelf still reads as a shelf and not as the wall. */
+  [1288, 1304, 1320].forEach((x) => facPut(backroomG,
+    svg('circle', { cx: x, cy: 820.5, r: 2.8 }, 'campus-furnf')));
+  facPut(backroomG, svg('line', { x1: 1280, y1: 824, x2: 1348, y2: 824 }, 'campus-furn'));
+  stag(backroomG, 940);
 
   /* Entrance hall dressing (notice board, trophy case, admissions desk, crest) */
   const hall = svg('g', null, 'campus-halldress');
@@ -3600,8 +3675,18 @@ export function createCampus({ state, gameName, banner, stats, reducedMotion, on
       if (key === 'records') return recordsG;
       if (key === 'registrar') return regG;
       if (key === 'annex') return annexG;
+      if (key === 'backroom') return backroomG;
       return null;
     },
+    /**
+     * THE DUST SHEET, raised from outside. The Back Room's module is loaded on
+     * the click and only the SHELL can know that the load failed, but the card
+     * that says so belongs to the plan: every other shut door on this campus is
+     * refused with this exact card, and a second refusal surface would be a
+     * second voice. Safe to call at any time - it is the sealed card and
+     * nothing else.
+     */
+    backroomDust: backroomDustCard,
     /**
      * A viewBox point -> page coordinates, for a FLIP that has to start at a
      * place on the plan (ORIENTATION.md §3.4's handover). Fully guarded: the

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/prizecounter.css
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/prizecounter.css
@@ -90,6 +90,7 @@
 }
 .pc-chip-t .pc-chip-n { color:var(--pink); }
 .pc-chip-k .pc-chip-n { color:var(--gold); }
+.pc-chip-c .pc-chip-n { color:var(--lav); }
 
 /* ------------------------------------------------------------- the payday */
 
@@ -184,6 +185,25 @@
 }
 .pc-root.is-lite .pc-sect-k::after { display:none; }
 
+/* THE BACK ROOM SHELF: green baize is the one thing a casino table is, and
+   there is no green in the token plan (see .arc-chipmark in styles.css). So the
+   felt is drawn in the school's secondary instead - a flat lavender weave, no
+   strip light, no glass. It is the DULLEST of the three surfaces on purpose:
+   the shelf is timber under a lamp and the case is lit glass because somebody
+   is selling you something, and this shelf is just where the chips end up. */
+.pc-sect-c {
+  background:
+    repeating-linear-gradient(45deg,
+      color-mix(in srgb, var(--lav), transparent 95%) 0 3px,
+      transparent 3px 6px),
+    linear-gradient(180deg,
+      color-mix(in srgb, var(--navy), black 10%),
+      color-mix(in srgb, var(--navy), black 26%));
+  border-color:color-mix(in srgb, var(--line), var(--lav) 18%);
+  box-shadow:inset 0 0 0 1px color-mix(in srgb, var(--ink), transparent 94%);
+}
+.pc-sect-c .pc-sect-title { color:var(--lav); }
+
 /* ------------------------------------------------------------- the goods */
 
 .pc-goods {
@@ -228,6 +248,7 @@
 }
 .pc-glyph { font-size:20px; line-height:1; color:var(--lav); }
 .pc-item-k .pc-glyph { color:var(--gold); }
+.pc-item-c .pc-glyph { color:var(--lav); }
 /* THE SPRITE SITS ON THE GLYPH. Absolute, so the bed underneath keeps the box's
    size whether or not the png ever arrives; `pixelated` both ways because the
    art is pixel art and a smoothed sprite is a different drawing. */
@@ -267,6 +288,7 @@
 .pc-price-n { font-family:var(--mono); font-size:14px; line-height:1; }
 .pc-price-t .pc-price-n { color:var(--pink); }
 .pc-price-k .pc-price-n { color:var(--gold); }
+.pc-price-c .pc-price-n { color:var(--lav); }
 
 .pc-badge {
   font-family:var(--disp); font-size:10.5px; letter-spacing:.16em;

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/prizecounter.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/prizecounter.js
@@ -52,8 +52,26 @@ import {
  * THE TABLE
  * -------------------------------------------------------------------------- */
 
-/** The two shop surfaces, in the order the room reads left to right. */
-export const SURFACES = Object.freeze(['t', 'k']);
+/** The shop's surfaces, top to bottom. CHIPS COME LAST because the Back Room
+ *  is last: you walk past the shelf and the case to reach it, and this is that
+ *  walk sat down. No chip rows in the catalog draws no third shelf, which is
+ *  the same nothing an empty token case has always drawn. */
+export const SURFACES = Object.freeze(['t', 'k', 'c']);
+
+/**
+ * WHICH SURFACE A ROW BELONGS TO, and this is the only place that decides.
+ * Eight callers each asked `row.cur === 'k' ? 'k' : 't'` in their own words,
+ * which was fine at two surfaces and quietly wrong at three - a chip row filed
+ * on the ticket shelf and priced with a stub. The old fallback is kept on
+ * purpose: a currency this build never heard of is a TICKET row, which is what
+ * all eight already assumed and the safest thing an unknown row can be.
+ * @param {*} row a catalog row, or anything at all
+ * @returns {'t'|'k'|'c'}
+ */
+export function curOf(row) {
+  const cur = row && row.cur;
+  return (cur === 'k' || cur === 'c') ? cur : 't';
+}
 
 /** How long a pressed row waits for the counter before it wakes back up. The
  *  host answers a prize-buy in the same tick it receives it, so six seconds is
@@ -100,9 +118,18 @@ export const HOLD_FROM = 1000;
  */
 export const HOLD_FROM_K = 2;
 
+/** The chip floor: the ticket floor's own reasoning in the Back Room's money.
+ *  A hundred chips is one Sparkle (BACKROOM-CONTRACT §1), so this is twenty-five
+ *  Sparkle of table time in one press - the same "a week of good nights should
+ *  not leave on one stray click". Nothing on the shelf reaches it yet; chip
+ *  rows arrive with the catalog wave, so re-audit it the day prices land. */
+export const HOLD_FROM_C = 2500;
+
 /** The floor this row has to clear to be worth holding down. */
 export function holdFloor(cur) {
-  return (cur === 'k') ? HOLD_FROM_K : HOLD_FROM;
+  if (cur === 'k') return HOLD_FROM_K;
+  if (cur === 'c') return HOLD_FROM_C;
+  return HOLD_FROM;
 }
 
 /**
@@ -113,6 +140,15 @@ export function holdFloor(cur) {
  * saves toward. The token case is dear by definition - there is no cheap token.
  */
 export const BEAT_DEAR_T = 200;
+/** The chip shelf's waist: five Sparkle. Enough that the row was saved toward,
+ *  not so much that only the top of the shelf ever gets the full party.
+ *  Re-audit with real prices, exactly like HOLD_FROM_C. */
+export const BEAT_DEAR_C = 500;
+
+/** The price a row has to clear on its own surface to be worth the full beat. */
+export function dearFloor(cur) {
+  return (cur === 'c') ? BEAT_DEAR_C : BEAT_DEAR_T;
+}
 export const BEAT_MS_SMALL = 1000;
 export const BEAT_MS_FULL = 1600;
 export const BEAT_MS_STILL = 1200;
@@ -144,18 +180,22 @@ export function shortfallBand(cost) {
  * night just because the ticket shelf is out of reach.
  *
  * @param {Array} catalog rows as the host sent them
- * @param {{t:number,k:number}} purse
+ * @param {{t:number,k:number,c:number}} purse
  * @returns {number} 0.2 .. 0.55
  */
 export function marqueeHeat(catalog, purse) {
   const rows = Array.isArray(catalog) ? catalog : [];
-  const have = { t: Number(purse && purse.t) || 0, k: Number(purse && purse.k) || 0 };
+  const have = {
+    t: Number(purse && purse.t) || 0,
+    k: Number(purse && purse.k) || 0,
+    c: Number(purse && purse.c) || 0,
+  };
   let best = 0;
   for (const cur of SURFACES) {
     let top = 0;      // the dearest row on this surface
     let reach = 0;    // the dearest one this purse covers
     for (const r of rows) {
-      if (!r || (r.cur === 'k' ? 'k' : 't') !== cur) continue;
+      if (!r || curOf(r) !== cur) continue;
       if (r.locked === true) continue;
       const cost = Math.max(0, Math.round(Number(r.cost) || 0));
       if (cost > top) top = cost;
@@ -592,8 +632,8 @@ export function createPrizeCounter(caps) {
   /* THE MOVES' OWN BOOKKEEPING, and every line of it is PRESENTATION. Not one
    * of these is a fact about the player, not one of them outlives a destroy,
    * and not one of them is ever read to decide what a purchase did. */
-  const chipEls = { t: null, k: null };   // the two wallet chips, re-seated each render
-  const chipNums = { t: null, k: null };  // the <b> inside each, for the bank's ticking
+  const chipEls = { t: null, k: null, c: null };   // the wallet chips, re-seated each render
+  const chipNums = { t: null, k: null, c: null };  // the <b> inside each, for the bank's ticking
   const holds = [];                       // live charge-hold handles, torn down each render
   let refreshTimer = null;                // a repaint waiting for a finger to lift
   let lastSig = '';                       // what the shelf on screen is painted FROM
@@ -607,9 +647,16 @@ export function createPrizeCounter(caps) {
   function readBalance() {
     try {
       const b = (typeof c.balance === 'function') ? c.balance() : null;
-      const tt = Number(b && b.t); const kk = Number(b && b.k);
-      return { t: Number.isFinite(tt) ? tt : 0, k: Number.isFinite(kk) ? kk : 0 };
-    } catch (e) { return { t: 0, k: 0 }; }
+      const tt = Number(b && b.t); const kk = Number(b && b.k); const cc = Number(b && b.c);
+      return {
+        t: Number.isFinite(tt) ? tt : 0,
+        k: Number.isFinite(kk) ? kk : 0,
+        /* A SHELL THAT PREDATES THE WING sends no `c` at all, and a purse that
+         * has never held a chip reads zero either way. Neither is an error and
+         * neither draws a third shelf - the CATALOG decides that. */
+        c: Number.isFinite(cc) ? cc : 0,
+      };
+    } catch (e) { return { t: 0, k: 0, c: 0 }; }
   }
 
   function readInv() {
@@ -654,7 +701,10 @@ export function createPrizeCounter(caps) {
    * "cheaper" than `60` on a ticket row in any sense a player would recognise.
    * The shelf is the everyday surface, so the shelf is where the room beckons,
    * and the case only gets the breath when nothing on the shelf is within
-   * reach at all.
+   * reach at all. CHIPS ARE LAST for the same reason one step further out: a
+   * chip is money that was won at a table rather than earned in a class, and a
+   * shop that beckons you toward the thing you gambled for before the thing you
+   * studied for is a shop with an opinion nobody asked it to have.
    */
   function cheapestAffordable(catalog) {
     let pick = null;
@@ -662,11 +712,11 @@ export function createPrizeCounter(caps) {
       let best = Infinity;
       for (const item of (catalog || [])) {
         if (!item || !item.sku) continue;
-        if ((item.cur === 'k' ? 'k' : 't') !== cur) continue;
+        if (curOf(item) !== cur) continue;
         if (item.locked === true) continue;
         if (isOwned(item)) continue;
         const cost = Math.max(0, Math.round(Number(item.cost) || 0));
-        const purse = (cur === 'k') ? wallet.k : wallet.t;
+        const purse = Number(wallet[cur]) || 0;
         if (purse < cost) continue;
         if (item.kind === 'consumable') {
           const cap = stackMaxFor(item.sku);
@@ -710,41 +760,58 @@ export function createPrizeCounter(caps) {
 
   /* ------------------------------------------------------------ the chrome */
 
+  /** The icon a currency wears: a drawn ticket stub, the token's mark, or the
+   *  Back Room's drawn disc. DRAWN, not typed - a third unicode mark would be a
+   *  third font risk on a page that may not fetch one (trap 2), and the stub
+   *  already proved that a shape in the stylesheet reads better than a glyph. */
+  function curIcon(cur) {
+    if (cur === 'k') return el('i', 'arc-tok', TOKEN_MARK);
+    if (cur === 'c') return el('i', 'arc-chipmark');
+    return el('i', 'arc-tick');
+  }
+
+  /** What a currency is called, in the school's own words. */
+  function curLabel(cur) {
+    if (cur === 'k') return t('wallet_tokens', 'Tokens');
+    if (cur === 'c') return t('wallet_chips', 'Chips');
+    return t('wallet_tickets', 'Tickets');
+  }
+
   /**
-   * A currency chip. Tickets get a drawn stub, tokens get the mark, and both
-   * carry the number FIRST because the number is the thing a player came to
-   * read. `cur` is 't' or 'k'.
+   * A currency chip. Tickets get a drawn stub, tokens get the mark, chips get
+   * the disc, and all three carry the number FIRST because the number is the
+   * thing a player came to read. `cur` is 't', 'k' or 'c'.
    */
   function chip(cur) {
     const box = el('span', 'pc-chip pc-chip-' + cur);
-    const ico = el('i', cur === 'k' ? 'arc-tok' : 'arc-tick', cur === 'k' ? TOKEN_MARK : null);
+    const ico = curIcon(cur);
     attr(ico, 'aria-hidden', 'true');
     box.appendChild(ico);
-    const num = el('b', 'pc-chip-n', String(cur === 'k' ? wallet.k : wallet.t));
+    const num = el('b', 'pc-chip-n', String(Number(wallet[cur]) || 0));
     box.appendChild(num);
-    box.appendChild(el('span', 'pc-chip-lbl', cur === 'k'
-      ? t('wallet_tokens', 'Tokens')
-      : t('wallet_tickets', 'Tickets')));
+    box.appendChild(el('span', 'pc-chip-lbl', curLabel(cur)));
     /* THE BANK spends FROM here, so the chip and its number are kept by hand.
      * They are re-seated on every render and read through thunks, so a repaint
      * landing mid-flight retargets the ticking instead of orphaning it. */
-    const key = (cur === 'k') ? 'k' : 't';
-    chipEls[key] = box;
-    chipNums[key] = num;
+    chipEls[cur] = box;
+    chipNums[cur] = num;
     return box;
   }
 
-  /** The price flag on a row. Tickets read as a plain count beside a stub;
-   *  tokens read as the contract's ◉N, which is short enough to sit on glass. */
+  /** The price flag on a row. Tickets read as a plain count beside a stub,
+   *  tokens read as the contract's ◉N, which is short enough to sit on glass,
+   *  and chips read as a count beside the disc - a chip price is a four-figure
+   *  number and a mark in front of it would only make it longer. */
   function priceTag(item) {
-    const flag = el('span', 'pc-price pc-price-' + (item.cur === 'k' ? 'k' : 't'));
+    const cur = curOf(item);
+    const flag = el('span', 'pc-price pc-price-' + cur);
     const cost = Math.max(0, Math.round(Number(item.cost) || 0));
-    if (item.cur === 'k') {
+    if (cur === 'k') {
       flag.appendChild(el('b', 'pc-price-n', TOKEN_MARK + String(cost)));
     } else {
-      const stub = el('i', 'arc-tick');
-      attr(stub, 'aria-hidden', 'true');
-      flag.appendChild(stub);
+      const mark = curIcon(cur);
+      attr(mark, 'aria-hidden', 'true');
+      flag.appendChild(mark);
       flag.appendChild(el('b', 'pc-price-n', String(cost)));
     }
     return flag;
@@ -851,7 +918,7 @@ export function createPrizeCounter(caps) {
     const cap = item.kind === 'consumable' ? stackMaxFor(item.sku) : 0;
     const locked = item.locked === true;
     const cost = Math.max(0, Math.round(Number(item.cost) || 0));
-    const purse = item.cur === 'k' ? wallet.k : wallet.t;
+    const purse = Number(wallet[curOf(item)]) || 0;
     const poor = !locked && !owned && purse < cost;
     const full = !!(cap && held >= cap);
     const short = cost - purse;
@@ -868,7 +935,7 @@ export function createPrizeCounter(caps) {
      * you look at it, and "you are twenty short" was always the truer one. */
     const almost = poor && short > 0 && short <= shortfallBand(cost);
 
-    let cls = 'pc-item pc-item-' + (item.cur === 'k' ? 'k' : 't');
+    let cls = 'pc-item pc-item-' + curOf(item);
     if (owned) cls += ' is-owned';
     if (locked) cls += ' is-locked';
     if (poor) cls += ' is-poor';
@@ -990,7 +1057,7 @@ export function createPrizeCounter(caps) {
       if (almost) ghostGold(rows.get(item.sku) || btn, { reduced: reduced(), lite: !!c.lite });
       propose(item);
     };
-    if (HOLD_TO_BUY && cost >= holdFloor(item.cur === 'k' ? 'k' : 't')) {
+    if (HOLD_TO_BUY && cost >= holdFloor(curOf(item))) {
       let h = null;
       try {
         h = chargeHold(btn, {
@@ -1036,7 +1103,7 @@ export function createPrizeCounter(caps) {
    * then pretended it had not.
    */
   function shelfSig() {
-    let s = wallet.t + '/' + wallet.k + '|' + (pending || '');
+    let s = wallet.t + '/' + wallet.k + '/' + wallet.c + '|' + (pending || '');
     try {
       const keys = Object.keys(inv || {}).sort();
       for (const k of keys) {
@@ -1088,15 +1155,27 @@ export function createPrizeCounter(caps) {
     }, 220);
   }
 
+  /** What each shelf is called and what it says under its own name. */
+  function surfaceWords(cur) {
+    if (cur === 'k') {
+      return [t('prize_case', 'Token Case'),
+        t('prize_case_hint', 'Tokens only. Your first S of the day drops one in the tray.')];
+    }
+    if (cur === 'c') {
+      return [t('prize_shelf_chips', 'The Back Room shelf'),
+        t('prize_shelf_chips_hint',
+          'Chips only. What you carried out of the Back Room buys these.')];
+    }
+    return [t('prize_shelf', 'Ticket Shelf'),
+      t('prize_shelf_hint', 'Every graded class pays tickets. This is where they go.')];
+  }
+
   function surface(cur, items) {
     const sect = el('section', 'pc-sect pc-sect-' + cur);
     const head = el('div', 'pc-sect-head');
-    head.appendChild(el('h3', 'pc-sect-title', cur === 'k'
-      ? t('prize_case', 'Token Case')
-      : t('prize_shelf', 'Ticket Shelf')));
-    head.appendChild(el('p', 'pc-sect-hint', cur === 'k'
-      ? t('prize_case_hint', 'Tokens only. Your first S of the day drops one in the tray.')
-      : t('prize_shelf_hint', 'Every graded class pays tickets. This is where they go.')));
+    const words = surfaceWords(cur);
+    head.appendChild(el('h3', 'pc-sect-title', words[0]));
+    head.appendChild(el('p', 'pc-sect-hint', words[1]));
     sect.appendChild(head);
 
     const goods = el('div', 'pc-goods');
@@ -1151,15 +1230,17 @@ export function createPrizeCounter(caps) {
      * bank's only use for this is knowing which digits to count down through on
      * the way there. If the two ever disagree the frame wins and the next
      * render says so. */
-    const before = { t: wallet.t, k: wallet.k };
+    const before = { t: wallet.t, k: wallet.k, c: wallet.c };
 
     /* The host's numbers win outright. A missing bag means "unchanged", never
      * "empty" - a refusal frame is allowed to carry only the reason. */
     if (r.wallet && typeof r.wallet === 'object') {
       const tt = Number(r.wallet.t); const kk = Number(r.wallet.k);
+      const cc = Number(r.wallet.c);
       wallet = {
         t: Number.isFinite(tt) ? tt : wallet.t,
         k: Number.isFinite(kk) ? kk : wallet.k,
+        c: Number.isFinite(cc) ? cc : wallet.c,
       };
     }
     if (r.inv && typeof r.inv === 'object') inv = r.inv;
@@ -1200,7 +1281,7 @@ export function createPrizeCounter(caps) {
       if (row) shiver(row, { reduced: red });
       if (String(r.reason || '') === 'poor') {
         const item = catalogRow(missed);
-        warmGlow(chipEls[(item && item.cur === 'k') ? 'k' : 't'], { reduced: red });
+        warmGlow(chipEls[curOf(item)], { reduced: red });
       }
     }
     return !!was && (!r.sku || r.sku === was);
@@ -1240,7 +1321,7 @@ export function createPrizeCounter(caps) {
    */
   function spendBank(sku, before) {
     const item = catalogRow(sku);
-    const cur = (item && item.cur === 'k') ? 'k' : 't';
+    const cur = curOf(item);
     const cost = Math.max(0, Math.round(Number(item && item.cost) || 0));
     const red = reduced();
 
@@ -1295,11 +1376,14 @@ export function createPrizeCounter(caps) {
    */
   function winChime(sku, hintCost) {
     const item = catalogRow(sku);
-    const cur = (item && item.cur === 'k') ? 'k' : 't';
+    const cur = curOf(item);
     const cost = Math.max(0, Math.round(Number(
       (item && item.cost) != null ? item.cost : hintCost) || 0));
     if (cur === 'k') { sfx('chime', 0.55, { pitch: 1.1225 }); return; }
-    sfx('chime', cost >= BEAT_DEAR_T ? 0.55 : 0.4);
+    /* A CHIP ROW IS NOT A TOKEN ROW. The third rung belongs to the day's one
+     * token and would be a lie over money that was won at a table, so chips
+     * take the shelf's own two-step ladder against their own waist. */
+    sfx('chime', cost >= dearFloor(cur) ? 0.55 : 0.4);
   }
 
   /* -------------------------------------------------------- THE TRAY BEAT */
@@ -1341,7 +1425,7 @@ export function createPrizeCounter(caps) {
    */
   function beatHold(cost, cur, still) {
     if (still) return BEAT_MS_STILL;
-    const dear = (cur === 'k') || (Number(cost) || 0) >= BEAT_DEAR_T;
+    const dear = (cur === 'k') || (Number(cost) || 0) >= dearFloor(cur);
     if (!dear || buys > BEAT_FULL_RUNS) return BEAT_MS_SMALL;
     return BEAT_MS_FULL;
   }
@@ -1351,7 +1435,7 @@ export function createPrizeCounter(caps) {
     clearBeat();
     const still = reduced();
     const item = catalogRow(sku);
-    const cur = (item && item.cur === 'k') ? 'k' : 't';
+    const cur = curOf(item);
     const cost = Math.max(0, Math.round(Number(item && item.cost) || 0));
     /* `is-lite` rides the BEAT rather than the root, because the beat does not
      * always hang off the root any more (see beatHost). The old
@@ -1431,8 +1515,7 @@ export function createPrizeCounter(caps) {
      * a charge-hold still holding a timer for a node that has left the document
      * is a ring that fills in the dark and fires into nothing. */
     dropHolds();
-    chipEls.t = null; chipEls.k = null;
-    chipNums.t = null; chipNums.k = null;
+    for (const cur of SURFACES) { chipEls[cur] = null; chipNums[cur] = null; }
     try { root.textContent = ''; } catch (e) { /* noop */ }
 
     /* THE SHELF IS READ FIRST NOW. Both of the room's new judgements - how hot
@@ -1472,6 +1555,12 @@ export function createPrizeCounter(caps) {
     purse.appendChild(label);
     purse.appendChild(chip('t'));
     purse.appendChild(chip('k'));
+    /* THE THIRD CHIP IS ALWAYS THERE, even at zero, and that is deliberate. A
+     * purse that hides an empty currency teaches a player that the currency
+     * does not exist; a purse that shows a zero teaches them there is somewhere
+     * they have not been yet. The two above it have always read zero on a first
+     * night for exactly the same reason. */
+    purse.appendChild(chip('c'));
     marquee.appendChild(purse);
     root.appendChild(marquee);
 
@@ -1487,7 +1576,7 @@ export function createPrizeCounter(caps) {
         'Shelf is bare tonight. Come back when the truck has been.')));
     } else {
       for (const cur of SURFACES) {
-        const items = catalog.filter((r) => (r.cur === 'k' ? 'k' : 't') === cur);
+        const items = catalog.filter((r) => curOf(r) === cur);
         if (items.length) root.appendChild(surface(cur, items));
       }
     }
@@ -1566,7 +1655,7 @@ export function createPrizeCounter(caps) {
     /** The last line the counter said (test seam). */
     get note() { return note; },
     /** What the room believes it can spend (test seam). Never authored here. */
-    get balance() { return { t: wallet.t, k: wallet.k }; },
+    get balance() { return { t: wallet.t, k: wallet.k, c: wallet.c }; },
     /** One painted row by sku, or null (test seam). */
     rowFor(sku) { return rows.get(sku) || null; },
     /** The tray beat currently on screen, or null (test seam). */

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/shell.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/shell.js
@@ -182,13 +182,24 @@ function docEvent(name, detail) {
  * booth now (the Records Office's arrangement, one alley over), so `prizes` is
  * not a screen this router can ever be on. A depth for a screen that cannot
  * exist is a line that reads as a route somebody could still take. */
-const SCREEN_DEPTH = Object.freeze({ board: 0, room: 1, records: 1, prizebooth: 1, locker: 1, annex: 2, report: 2, settings: 3, class: 4 });
+const SCREEN_DEPTH = Object.freeze({ board: 0, room: 1, records: 1, prizebooth: 1, locker: 1, backroom: 1, annex: 2, report: 2, settings: 3, class: 4 });
 
 /** Walk targets EMI never remarks on arriving at. The three office doors are
  *  voice.js's geofence read from the other end: she is silent on the Records
  *  side of them anyway, so a `campus.walkArrived` there would be a line spent
  *  on the last step before she is switched off (heartbeat wave, 2026-08-25). */
 const SILENT_WALK_TARGETS = new Set(['records', 'registrar', 'annex']);
+
+/* THE BACK ROOM'S WIRE, AND EXACTLY THIS MUCH OF IT (BACKROOM-CONTRACT §3).
+ * The wing is a page like any other page in this bundle and it is under the
+ * annex's law: it imports no bridge, so it cannot post a frame the shell has
+ * not agreed to carry. These two lists ARE the agreement. A room that asks for
+ * anything else is not refused quietly - it is logged and dropped, because the
+ * only reason a room would ask is that somebody has widened its contract
+ * without widening this line, and that should be visible in the console rather
+ * than at a bank balance. */
+const BACKROOM_SENDS = Object.freeze(['casino-request', 'triggers-request']);
+const BACKROOM_HEARS = Object.freeze(['casino-result', 'triggers-result']);
 
 /* ----------------------------------------------------------------------------
  * DECK V - THE RAKE (house-rules.txt). Built ONCE here so all ten classes wear
@@ -1017,6 +1028,13 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
   /** THE ROOM SCENE (shell/room.js). Built fresh per visit, destroyed on every
    *  path out via clearScreen - the annex's lifecycle without the bracket. */
   let roomPage = null;
+  /** THE BACK ROOM (backroom/index.js, loaded on the click and never before).
+   *  The one page in this bundle the shell does not import at the top: the wing
+   *  is a whole floor of tables and it may not cost a boot on a phone that is
+   *  never going to open the door. `backRoomMod` is the module once it has
+   *  landed, so a second visit is a call and not a second fetch. */
+  let backRoomPage = null;
+  let backRoomMod = null;
   /** The one in-flight annex stats request ({promise, resolve, timer}|null). */
   let annexStatsWait = null;
   /* THE PUNCH-CARD CEREMONY. `punchStage` is the live overlay; `punchArm` is
@@ -1575,6 +1593,23 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
       const lr = lockerRoom;
       lockerRoom = null;
       try { lr.destroy(); } catch (e) { /* noop */ }
+    }
+    /* AND THE BACK ROOM, which is torn down here for every reason the four
+     * rooms above it are AND one nobody else on this floor has: it is the only
+     * page holding a live subscription to the host. A handler left on
+     * `casino-result` would paint a cage that has been thrown away, and worse,
+     * would keep doing it for the rest of the night. The room's own destroy()
+     * drops the ones it took out; the sweep after it is the safety net, because
+     * a page that forgets one must not be able to leak it into the next screen. */
+    if (backRoomPage) {
+      const br = backRoomPage;
+      backRoomPage = null;
+      try { br.destroy(); } catch (e) { /* noop */ }
+    }
+    if (backRoomOffs.length) {
+      const offs = backRoomOffs;
+      backRoomOffs = [];
+      offs.forEach((off) => { try { off(); } catch (e) { /* noop */ } });
     }
     extrasBox = null;
     /* THE ROTATE GATE BELONGS TO A SCREEN, NOT TO THE PAGE. Every screen change
@@ -2203,6 +2238,11 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
            * the right way round. Never shuttered - nothing is sold in there, so
            * there is no closing time to keep and no sealed card to raise. */
           locker: () => walkThen('locker', () => showLockerScreen()),
+          /* THE BACK ROOM'S DOOR, the last one in the alley and the only one
+           * whose room is fetched rather than imported. It walks like every
+           * other door here; what happens at the end of the walk depends on
+           * whether the module is on this host at all (see showBackRoom). */
+          backroom: () => walkThen('backroom', () => showBackRoom()),
           /* THE PURSE IN THE CHROME. The wallet chip is the shortcut half of
            * the same split the gear and the Front Office door already run: no
            * walk, no antechamber, straight to the shelf - because the chip is a
@@ -2904,6 +2944,14 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
       const tt = Number(f.wallet.t); const kk = Number(f.wallet.k);
       if (Number.isFinite(tt)) { next.t = tt; moved = true; }
       if (Number.isFinite(kk)) { next.k = kk; moved = true; }
+      /* CHIPS RIDE THE SAME ECHO (the Back Room, W1). `c` is what is on the
+       * player and `earnedC` is what they have ever won, and both are the
+       * HOST's numbers on the host's frame - the page banks neither. A host
+       * that has never heard of the wing sends neither field and this reads
+       * exactly as it read before the wing existed. */
+      const cc = Number(f.wallet.c); const ec = Number(f.wallet.earnedC);
+      if (Number.isFinite(cc)) { next.c = cc; moved = true; }
+      if (Number.isFinite(ec)) { next.earnedC = ec; moved = true; }
     }
     if (f.inv && typeof f.inv === 'object') { next.inv = f.inv; moved = true; }
     if (f.unlocks && typeof f.unlocks === 'object') { next.unlocks = f.unlocks; moved = true; }
@@ -2922,11 +2970,16 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
     return walletEcho ? Object.assign({}, base, walletEcho) : base;
   }
 
-  /** {t, k}: what is on the player right now. */
+  /** {t, k, c}: what is on the player right now. A purse that has never held a
+   *  chip reads zero, which is the same nothing an empty ticket purse reads. */
   function walletBalance() {
     const w = walletBag();
-    const tt = Number(w.t); const kk = Number(w.k);
-    return { t: Number.isFinite(tt) && tt > 0 ? tt : 0, k: Number.isFinite(kk) && kk > 0 ? kk : 0 };
+    const tt = Number(w.t); const kk = Number(w.k); const cc = Number(w.c);
+    return {
+      t: Number.isFinite(tt) && tt > 0 ? tt : 0,
+      k: Number.isFinite(kk) && kk > 0 ? kk : 0,
+      c: Number.isFinite(cc) && cc > 0 ? cc : 0,
+    };
   }
 
   function walletInv() {
@@ -3831,6 +3884,161 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
     setStage('arc-report-on');
     if (typeof lockerRoom.fit === 'function') lockerRoom.fit();
     docEvent('arcademy-locker-opened', { from: from === 'prizebooth' ? 'counter' : from });
+  }
+
+  /* ========================= THE BACK ROOM =============================
+   * BACKROOM-CONTRACT §4. The fifth window in the alley, and the one room in
+   * this bundle the shell does not import at the top of the file.
+   *
+   * WHY IT IS A DYNAMIC IMPORT. Every other screen here is a page that most
+   * players open on most nights. The casino wing is a floor of tables, a cage
+   * and a cabinet, and a player who never opens that door should not pay for
+   * any of it on a phone that is already the slowest thing in the room. So the
+   * module is fetched on the CLICK, cached once it lands, and a host that does
+   * not ship the directory at all simply never resolves it - which is not an
+   * error, it is a school with one door still boarded up.
+   *
+   * AND THE SCREEN DOES NOT MOVE UNTIL IT LANDS. showBackRoom is called at the
+   * end of the walk with the campus still standing, and it stays standing while
+   * the import is in the air: a failure raises the plan's own dust sheet over a
+   * quad that never went anywhere, so there is nothing to "return" to and no
+   * empty screen for a player to be stranded on.
+   *
+   * THE CTX (documented here because the module is not in this repo yet):
+   *   t(key, fallback)      the lexicon, already merged with the mod skin
+   *   lite / reduced        the phone's cut-down flag, the motion setting
+   *   log(line)             the shell's console channel
+   *   subject               init.subject, read-only
+   *   localDay              'yyyy-mm-dd', the LOCAL day the cage counts by
+   *   gameName(key)         a class's display name
+   *   balance()             {t, k, c} - the purse, host-owned
+   *   earnedC()             lifetime chips won, host-owned
+   *   state() / save(patch) one page-owned blob in the meta store
+   *   send(msg)             casino-request / triggers-request, and nothing else
+   *   listen(type, fn)      casino-result / triggers-result; returns unsubscribe
+   *   onExit()              the way out, and the way out is the quad
+   * ==================================================================== */
+
+  /** Every live `listen` the room took out, so a room that forgets to drop one
+   *  cannot leave a handler painting into a page that has been torn down. */
+  let backRoomOffs = [];
+
+  /** The module, fetched once. A FAILURE IS NOT CACHED - a fetch that lost the
+   *  network is worth trying again the next time somebody tries the door. */
+  function loadBackRoom() {
+    if (backRoomMod) return Promise.resolve(backRoomMod);
+    return import('../backroom/index.js').then((mod) => {
+      backRoomMod = mod;
+      return mod;
+    });
+  }
+
+  /** The dust sheet, and it is the PLAN's card - every other shut door on this
+   *  campus is refused with that same card, and a second refusal surface here
+   *  would be the school speaking in two voices about one locked room. */
+  function refuseBackRoom(why) {
+    say('the Back Room did not open: ' + why);
+    if (campus && typeof campus.backroomDust === 'function') {
+      try { campus.backroomDust(); return; } catch (e) { /* fall through to a line */ }
+    }
+    try {
+      shout(t('backroom_dust_line',
+        'Sheets over the tables and the lights off at the wall. Another night.'));
+    } catch (e) { /* a toast may never hold a door */ }
+  }
+
+  /** NARROW CAPS, THE ANNEX'S LAW, plus the two wire verbs the contract adds. */
+  function backRoomCaps() {
+    return {
+      t,
+      lite: shellLite(),
+      reduced: reducedMotion,
+      log: say,
+      subject: src.subject || {},
+      localDay: localDate,
+      gameName,
+      balance: () => walletBalance(),
+      /* LIFETIME CHIPS, off the same echo the balance rides. It is a READ of
+       * what the host banked and never a count this page keeps. */
+      earnedC: () => {
+        const n = Number(walletBag().earnedC);
+        return Number.isFinite(n) && n > 0 ? n : 0;
+      },
+      // ONE page-owned blob, not N keys (the meta-store headroom law).
+      state: () => store.get('backroom') || {},
+      save: (patch) => {
+        try { store.merge('backroom', patch); }
+        catch (e) { say('backroom merge failed: ' + ((e && e.message) || e)); }
+      },
+      /* THE WIRE. Two verbs, two whitelists, and the room never sees `bridge`. */
+      send: (msg) => {
+        const type = String((msg && msg.type) || '');
+        if (BACKROOM_SENDS.indexOf(type) < 0) {
+          say('backroom send refused: ' + (type || '(no type)'));
+          return false;
+        }
+        try { bridge.send(msg); return true; }
+        catch (e) { say('backroom send failed: ' + ((e && e.message) || e)); return false; }
+      },
+      listen: (type, fn) => {
+        const key = String(type || '');
+        if (BACKROOM_HEARS.indexOf(key) < 0 || typeof fn !== 'function') {
+          say('backroom listen refused: ' + (key || '(no type)'));
+          return () => {};
+        }
+        let off = () => {};
+        try { off = bridge.on(key, fn) || (() => {}); }
+        catch (e) { say('backroom listen failed: ' + ((e && e.message) || e)); return () => {}; }
+        backRoomOffs.push(off);
+        return () => {
+          const i = backRoomOffs.indexOf(off);
+          if (i >= 0) backRoomOffs.splice(i, 1);
+          try { off(); } catch (e) { /* noop */ }
+        };
+      },
+      onExit: () => showBoard(),
+    };
+  }
+
+  function showBackRoom() {
+    /* THE QUAD STAYS UP while the module is in the air. See the header. */
+    loadBackRoom().then((mod) => {
+      if (destroyed) return;
+      /* The player walked out while the fetch was running (Esc, a toast's Back,
+       * a suspend). A room minted into a screen that has moved on is exactly
+       * the class-into-a-dead-screen bug the walk funnel is written to avoid. */
+      if (screen !== 'board') return;
+      if (!mod || typeof mod.openBackRoom !== 'function') {
+        refuseBackRoom('the module has no openBackRoom');
+        return;
+      }
+      screen = 'backroom';
+      dismissEndCard();
+      dismissPunchStage();
+      dismissAnnexStage();
+      clearScreen();
+      renderTopbar();
+      let page = null;
+      try { page = mod.openBackRoom(backRoomCaps()); }
+      catch (e) { page = null; say('the Back Room threw on open: ' + ((e && e.message) || e)); }
+      if (!page || !page.root) {
+        /* It refused to build AFTER the quad came down, which is the one path
+         * that can strand somebody. The board is the honest place to put them
+         * back, and the dust sheet is raised on the campus that comes with it. */
+        backRoomPage = null;
+        showBoard();
+        refuseBackRoom('the room would not mount');
+        return;
+      }
+      backRoomPage = page;
+      if (dom && dom.screen) dom.screen.appendChild(page.root);
+      setStage('arc-report-on');
+      if (typeof page.fit === 'function') page.fit();
+      docEvent('arcademy-backroom-opened', {});
+    }).catch((e) => {
+      if (destroyed) return;
+      refuseBackRoom('module load failed: ' + ((e && e.message) || e));
+    });
   }
 
   /* IS THE BOOT SPLASH STILL THE THING ON SCREEN? `#arc-toast` is z 60 and
@@ -6948,6 +7156,17 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
         try { if (lockerRoom.escapeStep()) return true; } catch (e) { /* noop */ }
       }
       if (screen === 'locker') { showBoard(); return true; }
+      /* THE BACK ROOM FOLDS INWARD-OUT like everything else on this floor: the
+       * room's own rungs first (a table it has dealt, a cage it has opened),
+       * then FALSE, and the rung below walks out to the quad. A wing that is
+       * not on this host has no rung at all - the door never opened, so `screen`
+       * never moved and this line is never reached. */
+      if (screen === 'backroom' && backRoomPage) {
+        try {
+          if (typeof backRoomPage.escapeStep === 'function' && backRoomPage.escapeStep()) return true;
+        } catch (e) { /* noop */ }
+      }
+      if (screen === 'backroom') { showBoard(); return true; }
       // THE ANNEX folds inward-out (trap 48's shape, one ladder both sides of
       // the seam): the lab's own rungs first - paper down, OS window shut,
       // laptop closed, close-up stepped back - then the stairs walk home to

--- a/ConditioningControlPanel/Resources/web/arcademy/styles.css
+++ b/ConditioningControlPanel/Resources/web/arcademy/styles.css
@@ -590,6 +590,31 @@ html.arc-reduced .arc-endcard-actions .arc-retake { animation:none; box-shadow:0
   box-shadow:inset 0 -1px 2px rgba(0,0,0,.45);
 }
 
+/* THE CHIP is the Back Room's money and it is a struck disc with an inset ring
+   and a bite of edge spots, which is what a casino chip is and what nothing
+   else in this school looks like. DRAWN, like the stub and the coin beside it:
+   a third glyph would have been a third font to fetch, and this page fetches
+   none (trap 2).
+
+   LAVENDER, NOT GREEN. Every colour in this school comes out of the token plan
+   at the top of this file and there is no green in it - the one brand colour
+   that ever appears here is the ID card's 6px Discord LED. So the chip takes
+   the school's SECONDARY, which reads cool against the shelf's pink and the
+   case's gold and says "after hours" without a new hue in the palette. */
+.arc-chipmark {
+  flex:none; display:inline-block; width:16px; height:16px;
+  border-radius:50%; font-style:normal;
+  background:
+    radial-gradient(circle at 50% 50%, transparent 0 4.4px,
+      color-mix(in srgb, var(--lav), white 22%) 4.5px 5.6px, transparent 5.7px),
+    conic-gradient(from 20deg,
+      var(--lav) 0 12%, color-mix(in srgb, var(--lav), black 34%) 12% 25%,
+      var(--lav) 25% 37%, color-mix(in srgb, var(--lav), black 34%) 37% 50%,
+      var(--lav) 50% 62%, color-mix(in srgb, var(--lav), black 34%) 62% 75%,
+      var(--lav) 75% 87%, color-mix(in srgb, var(--lav), black 34%) 87% 100%);
+  box-shadow:inset 0 -1px 2px rgba(0,0,0,.45);
+}
+
 /* THE TILL on the report card: the night's tickets counted out, and on a rare
    night the token beside them. One row, two chips, the shell's chip primitive. */
 .arc-till { gap:10px; flex-wrap:wrap; }

--- a/ConditioningControlPanel/Services/Arcademy/ArcademyHostService.cs
+++ b/ConditioningControlPanel/Services/Arcademy/ArcademyHostService.cs
@@ -3302,6 +3302,21 @@ internal static class ArcademyHostService
         ["locker_signpost_go"] = "Open The Locker",
         ["locker_unlock_hint"] = "{tok}2 at the counter",
         ["locker_open"] = "Open Locker",
+        // ---- THE BACK ROOM (casino wing W1: the door and the chips) ------------------
+        // The fifth window in the service alley. The desktop host ships these so a page
+        // running against it says the same words the web build does: a key the host does
+        // not carry falls back to English in silence and nobody ever sees the gap.
+        // Every value is under the 96-character mod-skin cap and none of them prices
+        // anything - chip costs ride the catalog, like every other row on that shelf.
+        ["campus_room_backroom"] = "The Back Room",
+        ["campus_desc_backroom"] = "Cash only. Chips only. The house always has time for you.",
+        ["backroom_sign"] = "Back Room",
+        ["campus_backroom_status"] = "Always open",
+        ["backroom_dust"] = "Not open yet.",
+        ["backroom_dust_line"] = "Sheets over the tables and the lights off at the wall. Another night.",
+        ["wallet_chips"] = "Chips",
+        ["prize_shelf_chips"] = "The Back Room shelf",
+        ["prize_shelf_chips_hint"] = "Chips only. What you carried out of the Back Room buys these.",
         // ---- EMI's stuck-hints (Daily Trigger, 2026-08-30) ----------------------------
         // The owner amended the "no mid-class mascot speech" law (arcademy/CLAUDE.md traps
         // 90 and 97) for one narrow channel: when the board says the player is beaten, EMI


### PR DESCRIPTION
## What

Back Room W1, per `BACKROOM-CONTRACT.md` §3 and §4: the **door on the campus** and **chips at the Prize Counter**. Nothing behind the door yet.

1. **`shell/campus.js`** - `FACILITIES.backroom`, RM 005, the fifth window down the service alley, drawn through the same `facility()` helper as Records / Front Office / Prize Counter / The Locker. Compact plate, west door, neon sign reading BACK ROOM, the alley's twelve units of wall above it, a chip rack behind the glass. **Furniture, never a class**: no `ROOMS` row, no registry entry, no timetable involvement, nothing in `campusState`.
2. **`shell/shell.js`** - entering `backroom` walks the alley and then **dynamically imports `../backroom/index.js`** and calls `openBackRoom(ctx)`. Import failure raises the plan's dust sheet.
3. **`shell/prizecounter.js` + `.css`** - a third purse chip and a third shelf for `c`, read off the wallet echo.
4. **`core/lexicon.js` + `ArcademyHostService.cs`** - nine keys in both tables.

## Why the import is dynamic, and why the quad stays up

The casino wing is a floor of tables, a cage and a cabinet. A player who never opens that door should not pay for any of it on the slowest phone in the room, so the module is fetched on the click and cached once it lands. A host that does not ship the directory never resolves it, which is not an error, it is a school with one door still boarded up.

`showBackRoom()` is called at the end of the walk **with the campus still standing**, and it stays standing while the import is in the air. A failure raises the plan's own sealed card over a quad that never went anywhere, so there is nothing to "return" to and no empty screen to be stranded on. The dust sheet is `openFacilityCard({ sealed: true })` - the same card every other shut door on this campus already raises, reached through a new `campus.backroomDust()` seam because only the shell can know the import failed. The one path that *can* strand somebody (a module that lands and then refuses to mount) puts the player back on the board first.

A failure is **not** cached: a fetch that lost the network is worth trying again next time somebody tries the door.

## The ctx passed to `openBackRoom(ctx)`

The Annex's narrow surface plus the contract's two wire verbs. `backroom/index.js` is **not** in this PR (K1 owns that directory); this is the shape it will be handed.

| field | type | notes |
|---|---|---|
| `t(key, fallback)` | `(string, string) => string` | the lexicon, already merged with the mod skin |
| `lite` | `boolean` | the phone's cut-down flag |
| `reduced` | `boolean` | the motion setting |
| `log(line)` | `(string) => void` | the shell's console channel |
| `subject` | `object` | `init.subject`, read-only |
| `localDay` | `string` | `yyyy-mm-dd`, the LOCAL day the cage counts by |
| `gameName(key)` | `(string) => string` | a class's display name |
| `balance()` | `() => {t, k, c}` | the purse, host-owned |
| `earnedC()` | `() => number` | lifetime chips won, host-owned, off the same echo |
| `state()` | `() => object` | one page-owned blob in the meta store |
| `save(patch)` | `(object) => void` | merges into that one blob (headroom law) |
| `send(msg)` | `(object) => boolean` | see below |
| `listen(type, fn)` | `(string, fn) => () => void` | see below |
| `onExit()` | `() => void` | the way out, and the way out is the quad |

**`send(msg) -> boolean`** routes through the shell's existing `bridge.send` seam. Only `casino-request` and `triggers-request` go out; anything else returns `false` with a line in the log and no frame on the wire. The room never sees `bridge`.

**`listen(type, fn) -> unsubscribe`** subscribes through `bridge.on`. Only `casino-result` and `triggers-result` are accepted; anything else returns a no-op unsubscribe. Every live subscription is also tracked by the shell, so `clearScreen()` sweeps anything the room forgets to drop - the Back Room is the only screen on this floor holding a live host subscription, and a handler left on `casino-result` would paint a cage that has been thrown away.

The Esc ladder folds inward-out: `backRoomPage.escapeStep()` first, then out to the quad.

## Chips at the counter

- `SURFACES` is now `['t','k','c']`; chips come last because the Back Room is last in the alley.
- New exported **`curOf(row)`** replaces eight hand-written `row.cur === 'k' ? 'k' : 't'` ternaries. Those were fine at two surfaces and quietly wrong at three: a chip row would have been filed on the ticket shelf and priced with a stub. Unknown currencies still degrade to tickets, which is what all eight already assumed.
- The third purse chip is drawn **even at zero** - a purse that hides an empty currency teaches a player the currency does not exist.
- The chip shelf is only drawn when the catalog actually has `cur: 'c'` rows (the same nothing an empty token case has always drawn). **No chip rows exist in the vendored catalog yet**; D2 adds them. Verified here against a fixture.
- The chip glyph `.arc-chipmark` is **drawn**, not typed: a struck disc with an inset ring and a bite of edge spots, beside the ticket stub and the token coin in the shell's own primitives. A third unicode mark would be a third font risk on a page that fetches none (trap 2). Lavender rather than green because there is no green in the token plan, and the shelf's felt follows it: flat weave, no strip light, no glass.
- `HOLD_FROM_C = 2500` and `BEAT_DEAR_C = 500` (100 chips = 1 Sparkle, so 25 and 5 Sparkle). Worth re-auditing the day real chip prices land.
- Buying is unchanged: chip rows go out on the existing `prize-buy` send.

## Lexicon keys added (both tables)

`campus_room_backroom`, `campus_desc_backroom`, `backroom_sign`, `campus_backroom_status`, `backroom_dust`, `backroom_dust_line`, `wallet_chips`, `prize_shelf_chips`, `prize_shelf_chips_hint`.

All nine are in `core/lexicon.js` **and** `ArcademyHostService.cs` `NeutralLexicon` (a key the host does not ship falls back to English silently, and `MergeModTable` can only override a key the neutral table already knows). All under the 96-char mod cap.

## Verification

Headless-Chrome CDP rig against the page over a local static server, with a web shim standing in for the C# host (fixture catalog carrying three `cur: 'c'` rows, wallet `c: 2450 / earnedC: 18600`). **Measured, not eyeballed**: every shot dumps the Back Room's painted box, every piece of chrome that shares the plan with it, and the box intersection of each pair.

**15 shots, 9 viewports, zero clashes, zero page errors.**

Campus, `__RS.campus()` - the `clash` map is empty at every one of:

| viewport | Back Room box | clash |
|---|---|---|
| 390x844 portrait | 340,110 32x52 | none |
| 375x667 portrait | 311,107 27x44 | none |
| 360x640 portrait | 298,106 26x42 | none |
| 844x390 landscape | 682,341 52x31 | none |
| 1600x900 | 1400,788 120x71 | none |
| 1366x768 | 1195,672 102x61 | none |
| 1280x800 | 1173,700 107x63 | none |
| 1024x768 | clipped by the horizontal safe band, as all four alley windows are at 4:3 | none |
| 1920x1080 | 1680,945 144x85 | none |

Checked against the ID card, the post row, the top-right cluster, the desktop hint, the mail chip, the board and EMI. In portrait at 390x844 the room sits at x 340..372, y 110..162: the top-right cluster ends at y 94 (16px of air), the ID card starts at y 778, the mail chip at y 786, and the Prize Counter and Locker windows are the two windows above it in the same alley band.

**The 72 to 64 depth change was the rig's finding, not a taste.** A 72-deep window put its last two pixels under `.campus-hint` at 1366x768; the second pass caught the chip rack climbing into the RM plate. Both fixed and re-measured.

Door, `__RS.tryBackRoom()` at 390x844 and 1600x900 - tapping the window walks the alley, the shell's dynamic import fails on a host with no `backroom/` directory, and the plan raises: **THE BACK ROOM / NOT OPEN YET. / "Sheets over the tables and the lights off at the wall. Another night." / SEALED (disabled)**. `screen` never moved off the board.

Counter, `__RS.counter()` at 390x844 and 1600x900 - three purse chips (`5000 Tickets`, `500 Tokens`, `2450 Chips`, all three with their glyph), section order `pc-sect-t, pc-sect-k, pc-sect-c`, the third headed **The Back Room shelf** / "Chips only. What you carried out of the Back Room buys these.", and three chip-priced rows (400 / 1200 / 3200) each carrying `.arc-chipmark`.

Shots and per-shot logs: `C:/Users/PC/AppData/Local/Temp/claude/bk-w1-shots/` - `bk-{p390,p375,p360,l844,d1024,d1280,d1366,d1600,d1920}-campus.png`, `bk-{p390,d1600}-door.png`, `bk-{p390,d1600}-counter.png`, `bk-{p390,d1600}-chipshelf.png`.

`node --check` clean on all four JS files. No JS suite exists in this repo for the shell, so the fixture run above is the suite.

## Merge note

**Independent of the other Back Room PRs. The door shows a dust sheet until K1 lands.** Chip rows on the shelf show up when D2's catalog rows land; until then the shelf simply is not drawn and the purse reads a zero.

## Known gaps

- The campus top-right wallet chip and the Prize Counter booth's sill tray still show tickets and tokens only. Out of W1's scope; worth a follow-up once chips are actually earnable.
- `prize_counter_sub` still reads "Tickets on the shelf, tokens in the case". Leaving it: on the shipped catalog there are no chip rows yet, so a third clause would be the marquee lying.
- 597 changed lines (540 + 57), inside the ~600 cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5Gp8FA4yHguiNc46u5YDS
