### PR TITLE
feat(arcademy): Back Room M3 - the Spiral's skin and fixture

### DIFF
--- a/ConditioningControlPanel/Resources/web/arcademy/backroom/spiral-demo.html
+++ b/ConditioningControlPanel/Resources/web/arcademy/backroom/spiral-demo.html
@@ -1,0 +1,274 @@
+<!DOCTYPE html>
+<html lang="en"><head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>The Spiral - cabinet fixture</title>
+<!-- No shell, no bridge, no host. The REAL floor and the REAL cabinet under a
+     STUBBED pit: send and listen are a little pretend croupier at the bottom of
+     this file, so the wheel can be looked at, shot and driven by a headless
+     probe without a server and without a penny of real ledger near it.
+
+     The driver goes through the FLOOR, not around it: it clicks the Spiral
+     cabinet the way a player does, so the mount contract in index.js is under
+     test too and not just the module.
+
+     ?kind=pink|violet|word|drop   what the pit's next answer lands on
+     ?wedge=N        land on this exact wedge instead (0..23)
+     ?bet=pink|violet|word|number  which bet the driver places
+     ?pick=N         which wedge, when the bet is a number
+     ?stake=N        which stake button the driver presses
+     ?poor=1         the pit refuses for want of chips
+     ?bad=1          the pit refuses the stake
+     ?insured=1      the answer carries insured:true
+     ?tier=1         the pit refuses with the tier gate (403)
+     ?dark=1         NO send/listen at all: the wheel must go covered, not throw
+     ?reduced=1      arms html.arc-reduced, the global still mode
+     ?lite=1         arms html.ae-lite + html.arc-mobile, the phone diet
+     ?shot=1         folds the fixture chrome and the cage away, for a screenshot
+     ?auto=open|spin|stakes|refuse|leave
+     Everything is written into #log, which is what the headless probe reads
+     back out of the dumped DOM. There is no test runner and no framework here
+     on purpose: the fixture IS the harness, so it can never drift from it. -->
+<link rel="stylesheet" href="../styles.css">
+<style>
+  body { margin: 0; padding: 16px 14px 60px; background: var(--ground); color: var(--ink);
+         font-family: var(--body); }
+  .wrap { max-width: 1100px; margin: 0 auto; }
+  header.fx { display: flex; align-items: baseline; gap: 12px; flex-wrap: wrap;
+              border-bottom: 3px solid var(--pink); padding-bottom: 8px; margin-bottom: 14px; }
+  header.fx h1 { font-family: var(--disp); font-size: 20px; margin: 0; letter-spacing: .08em; }
+  .eyebrow { font-family: var(--mono); font-size: 10px; letter-spacing: .2em; color: var(--ink-dim); }
+  .note { color: var(--ink-faint); font-size: 12px; font-family: var(--mono); margin-top: 14px; }
+  #log { font-family: var(--mono); font-size: 11px; color: var(--ink-dim); white-space: pre-wrap;
+         margin-top: 10px; max-height: 200px; overflow: auto; }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <header class="fx">
+    <h1>THE SPIRAL</h1>
+    <span class="eyebrow">backroom/spiral.js · cabinet fixture</span>
+  </header>
+  <div id="host"></div>
+  <p class="note" id="note">stubbed pit. no ledger, no network, no chips that exist.</p>
+  <div id="log"></div>
+</div>
+
+<script type="module">
+import { openBackRoom } from './index.js';
+import { SPIRAL_LAYOUT } from './spiral.js';
+
+const q = new URLSearchParams(location.search);
+const logEl = document.getElementById('log');
+const log = (m) => { logEl.textContent += m + '\n'; };
+window.addEventListener('error', (e) => log('THREW ' + (e && e.message)));
+window.addEventListener('unhandledrejection', (e) => log('THREW ' + ((e && e.reason && e.reason.message) || e.reason)));
+
+if (q.has('reduced')) document.documentElement.classList.add('arc-reduced');
+if (q.has('lite')) document.documentElement.classList.add('ae-lite', 'arc-mobile');
+
+/* ------------------------------------------------------------------------
+ * THE PRETEND PIT. It answers the same frames the host will and it is the only
+ * thing in this fixture that knows a number. It holds a purse so a spin
+ * visibly moves the balance, which is what the shot is of.
+ * ---------------------------------------------------------------------- */
+const purse = { chips: 2000, sparkle: 27, pot: 41800 };
+const listeners = new Map();
+const delay = 160;
+const WORD = 'GOOD GIRL';
+
+function fire(type, msg) {
+  const set = listeners.get(type);
+  if (!set) return;
+  for (const fn of Array.from(set)) { try { fn(msg); } catch (e) { log('listener threw: ' + e.message); } }
+}
+
+function statusBody() {
+  return {
+    chips: purse.chips, sparkle: purse.sparkle, pot: purse.pot, rate: 100, earnedC: 0,
+    word: WORD,
+    tree: { cheapest_unowned: { id: 'soft_focus', cost: 40 }, owned: 6, total: 21 },
+    config: {
+      stakes: { twentyone: 25, triple: 10, spiral: 25, scratcher: 50, wheel: 500 },
+      paytables: { spiral: { stakes: [25, 50, 100], colour: 1, word: 20, number: 20 } },
+    },
+  };
+}
+
+/** The pit's answer for one spin. The WEDGE is picked from the query, never by
+ *  the page, which is the whole point: the cabinet must land where it is told. */
+function playBody(msg) {
+  const stake = Math.round(Number(msg.body.stake) || 0);
+  const bet = msg.body.input && msg.body.input.bet;
+  let wedge = q.has('wedge') ? Number(q.get('wedge')) : null;
+  if (wedge == null) {
+    const kind = q.get('kind') || 'pink';
+    wedge = SPIRAL_LAYOUT.indexOf(kind);
+    if (wedge < 0) wedge = 0;
+  }
+  const kind = SPIRAL_LAYOUT[wedge];
+  let payout = 0;
+  if (kind !== 'drop') {
+    if ((bet === 'pink' || bet === 'violet') && bet === kind) payout = stake * 2;
+    else if (bet === 'word' && kind === 'word') payout = stake * 21;
+    else if (typeof bet === 'number' && bet === wedge) payout = stake * 21;
+  }
+  let insured = false;
+  if (payout === 0 && q.has('insured')) { payout = stake; insured = true; }
+  purse.chips += payout - stake;
+  log('PIT wedge=' + wedge + ' kind=' + kind + ' payout=' + payout);
+  return Object.assign(statusBody(), {
+    machine: 'spiral', stake, payout, insured,
+    result: { wedge, kind, word: kind === 'word' ? WORD : null },
+  });
+}
+
+const ctx = {
+  log,
+  // The host sets BOTH: the html class is the CSS diet, ctx.lite is the JS one.
+  // Only arming the class was how the first phone shot came back with a
+  // desktop-sized wheel on it.
+  lite: q.has('lite'),
+  t: (key, fallback) => fallback || key,
+  words: ['GOOD GIRL', 'EMPTY', 'SOFT'],
+  send(msg) {
+    log('up   ' + JSON.stringify(msg));
+    if (msg.type !== 'casino-request') return;
+    setTimeout(() => {
+      let ok = true; let status = 200; let body = statusBody();
+      if (msg.op === 'play') {
+        if (q.has('tier')) { ok = false; status = 403; body = { code: 'arcademy_locked', min_tier: 2 }; }
+        else if (q.has('poor')) { ok = false; status = 200; body = { reason: 'insufficient_chips' }; }
+        else if (q.has('bad')) { ok = false; status = 200; body = { reason: 'invalid_stake' }; }
+        else body = playBody(msg);
+      }
+      fire('casino-result', { type: 'casino-result', reqId: msg.reqId, ok, status, body });
+      log('down casino-result ' + (ok ? 'ok' : status));
+    }, delay);
+  },
+  listen(type, fn) {
+    if (!listeners.has(type)) listeners.set(type, new Set());
+    listeners.get(type).add(fn);
+    return () => { const s = listeners.get(type); if (s) s.delete(fn); };
+  },
+};
+
+/* ?dark=1 pulls the line out from under the room. The wheel must still paint. */
+if (q.has('dark')) { delete ctx.send; delete ctx.listen; }
+
+const room = openBackRoom(ctx);
+document.getElementById('host').appendChild(room.root);
+window.__room = room;
+
+/* THE LADDER, exactly the way the shell holds it. Nothing in the cabinet binds
+ * Esc: the scene folds a step, and with none left the room leaves. */
+document.addEventListener('keydown', (e) => {
+  if (e.key !== 'Escape') return;
+  if (room.escapeStep()) { log('esc: folded the cabinet'); return; }
+  room.close();
+  log('esc: room closed');
+});
+
+/* ------------------------------------------------------------------------
+ * THE UNATTENDED DRIVER. It presses the same buttons a player does and then
+ * writes down what it saw. Nothing here reaches inside the cabinet.
+ * ---------------------------------------------------------------------- */
+const sp = () => room.root.querySelector('.bk-sp');
+const pick = (sel) => room.root.querySelector(sel);
+const esc = () => document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+
+function openCabinet() {
+  const btns = Array.from(room.root.querySelectorAll('.bk-cab'));
+  const cab = btns[2];   // the floor's third frame is the Spiral
+  log('CAB sheet=' + (cab.classList.contains('bk-sheet') ? 'yes' : 'no'));
+  cab.click();
+  log('CAB mounted=' + (sp() ? 'yes' : 'no'));
+  // ?shot puts the cabinet at the top of a phone viewport by folding away the
+  // fixture's own furniture and the counter above it. Presentation only: not one
+  // element inside .bk-sp is touched, so a shot is of the real thing.
+  if (q.has('shot')) {
+    for (const sel of ['header.fx', '#note', '#log', '.bk-pot', '.bk-cage']) {
+      const n = document.querySelector(sel);
+      if (n) n.style.display = 'none';
+    }
+  }
+}
+
+function placeBet() {
+  const want = q.get('bet') || 'pink';
+  if (want === 'number') {
+    const n = Math.max(0, Math.min(23, Number(q.get('pick') || 6)));
+    room.root.querySelectorAll('.bk-sp-cell')[n].click();
+    log('BET number=' + n);
+  } else {
+    const map = { pink: 0, violet: 1, word: 2 };
+    room.root.querySelectorAll('.bk-sp-bet')[map[want] || 0].click();
+    log('BET ' + want);
+  }
+  if (q.has('stake')) {
+    const want2 = String(q.get('stake'));
+    for (const b of room.root.querySelectorAll('.bk-sp-stakebtn')) {
+      if (b.textContent === want2) { b.click(); log('STAKE ' + want2); break; }
+    }
+  }
+}
+
+function report(tag) {
+  log(tag + ' say=' + pick('.bk-sp-say').textContent);
+  log(tag + ' balance=' + pick('.bk-bal-n').textContent);
+  log(tag + ' goDisabled=' + pick('.bk-sp-go').disabled);
+  log(tag + ' veils=' + document.querySelectorAll('.bk-drop').length);
+}
+
+const auto = q.get('auto');
+if (auto === 'open') {
+  setTimeout(() => {
+    openCabinet();
+    log('OPEN cells=' + room.root.querySelectorAll('.bk-sp-cell').length);
+    log('OPEN bets=' + room.root.querySelectorAll('.bk-sp-bet').length);
+    log('OPEN stakes=' + Array.from(room.root.querySelectorAll('.bk-sp-stakebtn')).map((b) => b.textContent).join('/'));
+    log('OPEN odds=' + pick('.bk-sp-odds').textContent);
+    log('OPEN wordwedge=' + pick('.bk-wheel-face').getAttribute('aria-label').split(', ')[6]);
+    setTimeout(() => { report('OPEN'); log('AUTO done'); }, 1800);
+  }, 800);
+} else if (auto === 'spin' || auto === 'refuse') {
+  setTimeout(() => {
+    openCabinet();
+    placeBet();
+    pick('.bk-sp-go').click();
+    log('SPIN locked=' + pick('.bk-sp-go').disabled);
+    // The wheel takes 3.2s to travel, so the veil can only be up after it.
+    setTimeout(() => log('SPIN mid veils=' + document.querySelectorAll('.bk-drop').length), 4000);
+    setTimeout(() => { report('SPIN'); log('AUTO done'); }, 6600);
+  }, 800);
+} else if (auto === 'stakes') {
+  setTimeout(() => {
+    openCabinet();
+    const list = Array.from(room.root.querySelectorAll('.bk-sp-stakebtn'));
+    list[2].click();
+    log('STAKES list=' + list.map((b) => b.textContent).join('/'));
+    log('STAKES pressed=' + list.map((b) => b.getAttribute('aria-pressed')).join('/'));
+    log('AUTO done');
+  }, 800);
+} else if (auto === 'leave') {
+  /* UNMOUNT MID-SPIN. The stake is up the seam, the wheel is turning, and the
+   * player walks. Nothing may throw and nothing may come back afterwards. */
+  setTimeout(() => {
+    openCabinet();
+    placeBet();
+    pick('.bk-sp-go').click();
+    setTimeout(() => {
+      esc();
+      log('LEAVE cabinet=' + (sp() ? 'still up' : 'gone'));
+      log('LEAVE floorBack=' + (room.root.querySelector('.bk-floor').hidden ? 'no' : 'yes'));
+    }, delay + 500);
+    setTimeout(() => {
+      log('LEAVE afterSpin cabinet=' + (sp() ? 'still up' : 'gone'));
+      log('LEAVE veils=' + document.querySelectorAll('.bk-drop').length);
+      log('AUTO done');
+    }, 5200);
+  }, 800);
+}
+</script>
+</body>
+</html>

--- a/ConditioningControlPanel/Resources/web/arcademy/backroom/spiral.css
+++ b/ConditioningControlPanel/Resources/web/arcademy/backroom/spiral.css
@@ -1,0 +1,153 @@
+/* ============================================================================
+ * backroom/spiral.css - the wheel's corner of the felt.
+ *
+ * Lazy-linked by backroom/spiral.js on first open, the way backroom.css is
+ * linked by the floor. Everything here sits INSIDE .bk-sp, so a cabinet can
+ * never reach out and restyle the room around it.
+ *
+ * The palette is backroom.css's: --bk-brass, --bk-neon, --bk-neon-2, --bk-plate
+ * are already declared on .bk-room, and this sheet only ever reads them. The
+ * two exceptions are the pink and violet chips on the board, which carry the
+ * WHEEL's literal hues rather than the mod palette's, because the board and the
+ * face have to be the same two colours or the bet stops meaning anything.
+ *
+ * TYPE: --disp for the signage, --mono for numbers, --body for copy. No serif.
+ *
+ * MOTION: the only loops in here are the word-hit pulse and the pearl's knock,
+ * both decoration, both flattened under html.arc-reduced and both cut outright
+ * by the phone diet along with the glows.
+ * ==========================================================================*/
+
+.bk-sp {
+  --bk-sp-pink: #a83a6b;
+  --bk-sp-violet: #4f3f86;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  font-family: var(--body);
+}
+
+/* ---------------------------------- header ------------------------------- */
+.bk-sp-head { display: flex; align-items: baseline; gap: 10px; flex-wrap: wrap; }
+.bk-sp-name {
+  margin: 0; font-family: var(--disp); font-size: 16px; letter-spacing: .12em;
+  font-weight: 400; color: var(--bk-brass, var(--gold));
+}
+.bk-sp-sub { font-size: 12px; color: var(--ink-faint); }
+.bk-sp-spacer { flex: 1 1 auto; }
+.bk-sp-back {
+  font-family: var(--mono); font-size: 11px; letter-spacing: .1em;
+  padding: 6px 12px; border-radius: 999px; cursor: pointer;
+  color: var(--ink); background: transparent;
+  border: 1px solid color-mix(in srgb, var(--bk-brass, var(--gold)), transparent 55%);
+}
+.bk-sp-back:hover { border-color: var(--bk-brass, var(--gold)); }
+
+/* ----------------------------------- body -------------------------------- */
+.bk-sp-body { display: flex; gap: 18px; align-items: flex-start; flex-wrap: wrap; }
+.bk-sp-wheelbox { position: relative; flex: 0 0 auto; line-height: 0; }
+.bk-sp-board { flex: 1 1 300px; display: flex; flex-direction: column; gap: 10px; min-width: 260px; }
+.bk-sp-legend {
+  font-family: var(--mono); font-size: 10px; letter-spacing: .22em;
+  text-transform: uppercase; color: var(--ink-dim);
+}
+
+/* THE PEARL sits on the pin at twelve o'clock and never travels. It knocks once
+ * when the wheel arrives, which is the whole of its job. */
+.bk-sp-pearl {
+  position: absolute; top: 2px; left: 50%; width: 13px; height: 13px;
+  margin-left: -6.5px; border-radius: 50%; pointer-events: none; z-index: 2;
+  background: radial-gradient(circle at 34% 28%, #fff, #cfc6e4 55%, #7b7196);
+  box-shadow: 0 1px 3px #000a;
+}
+.bk-sp-pearl.bk-sp-pearl-hit { animation: bk-sp-knock .3s ease-out 1; }
+@keyframes bk-sp-knock {
+  0% { transform: translateY(0); } 45% { transform: translateY(4px); } 100% { transform: translateY(0); }
+}
+/* The word wedge announces itself for a beat when it pays. */
+.bk-wheel.bk-sp-wordhit .bk-wheel-face {
+  box-shadow: 0 0 26px color-mix(in srgb, var(--bk-brass, var(--gold)), transparent 25%);
+}
+
+/* ---------------------------------- the board ---------------------------- */
+.bk-sp-bets { display: grid; gap: 8px; grid-template-columns: repeat(auto-fit, minmax(128px, 1fr)); }
+.bk-sp-bet {
+  display: flex; flex-direction: column; gap: 3px; align-items: flex-start;
+  padding: 9px 11px; border-radius: 8px; cursor: pointer; text-align: left;
+  background: var(--bk-plate, var(--panel)); color: var(--ink);
+  border: 1px solid var(--line);
+}
+.bk-sp-bet-name { font-family: var(--disp); font-size: 13px; letter-spacing: .1em; }
+.bk-sp-bet-odds { font-family: var(--mono); font-size: 10px; color: var(--ink-faint); letter-spacing: .04em; }
+.bk-sp-bet-pink .bk-sp-bet-name { color: color-mix(in srgb, var(--bk-sp-pink), white 42%); }
+.bk-sp-bet-violet .bk-sp-bet-name { color: color-mix(in srgb, var(--bk-sp-violet), white 46%); }
+.bk-sp-bet-word .bk-sp-bet-name { color: var(--bk-brass, var(--gold)); }
+.bk-sp-bet[aria-pressed="true"] {
+  border-color: var(--bk-brass, var(--gold));
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--bk-brass, var(--gold)), transparent 60%);
+}
+.bk-sp-bet[disabled], .bk-sp-cell[disabled], .bk-sp-stakebtn[disabled] { opacity: .5; cursor: default; }
+
+/* THE WEDGE GRID. Every cell wears its own wedge's colour, so backing 6 or 18
+ * is backing the word or the drop with the eyes open. */
+.bk-sp-grid { display: grid; gap: 4px; grid-template-columns: repeat(12, 1fr); }
+.bk-sp-cell {
+  padding: 6px 0; border-radius: 5px; cursor: pointer; border: 1px solid transparent;
+  font-family: var(--mono); font-size: 11px; color: #fff;
+  background: var(--bk-sp-pink);
+}
+.bk-sp-cell.bk-sp-violet { background: var(--bk-sp-violet); }
+.bk-sp-cell.bk-sp-word { background: var(--bk-brass, var(--gold)); color: #231a06; }
+.bk-sp-cell.bk-sp-drop { background: #101024; color: #8f8fb8; }
+.bk-sp-cell[aria-pressed="true"] { border-color: var(--bk-brass, var(--gold)); transform: translateY(-1px); }
+
+/* --------------------------------- the stakes ---------------------------- */
+.bk-sp-stakes { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; }
+.bk-sp-stakebtn {
+  min-width: 48px; padding: 6px 10px; border-radius: 999px; cursor: pointer;
+  font-family: var(--mono); font-size: 12px; color: var(--ink);
+  background: var(--bk-plate, var(--panel)); border: 1px solid var(--line);
+}
+.bk-sp-stakebtn[aria-pressed="true"] { border-color: var(--bk-neon, var(--pink)); color: var(--bk-neon, var(--pink)); }
+.bk-sp-stake-unit { font-family: var(--mono); font-size: 10px; letter-spacing: .12em; color: var(--ink-faint); }
+
+.bk-sp-odds {
+  margin: 0; font-size: 11.5px; color: var(--lav); line-height: 1.45;
+  border-left: 2px solid color-mix(in srgb, var(--lav), transparent 55%); padding-left: 8px;
+}
+
+.bk-sp-go {
+  align-self: flex-start; padding: 10px 26px; border-radius: 999px; cursor: pointer;
+  font-family: var(--disp); font-size: 14px; letter-spacing: .16em;
+  color: #201703; border: 0;
+  background: linear-gradient(180deg, color-mix(in srgb, var(--bk-brass, var(--gold)), white 16%), var(--bk-brass, var(--gold)));
+}
+.bk-sp-go[disabled] { opacity: .45; cursor: default; }
+.bk-sp-bet:focus-visible, .bk-sp-cell:focus-visible, .bk-sp-stakebtn:focus-visible,
+.bk-sp-go:focus-visible, .bk-sp-back:focus-visible { outline: 2px solid var(--bk-brass, var(--gold)); outline-offset: 2px; }
+
+.bk-sp-say { font-size: 13px; color: var(--ink); min-height: 1.3em; }
+.bk-sp .bk-dealer { font-size: 12px; min-height: 1.2em; }
+
+/* The wheel with no line behind it is COVERED, and it says so rather than
+ * pretending it is about to take a bet. */
+.bk-sp-dark .bk-sp-bets, .bk-sp-dark .bk-sp-grid, .bk-sp-dark .bk-sp-stakes, .bk-sp-dark .bk-sp-go { opacity: .5; }
+
+/* ------------------------------- the phone diet -------------------------- */
+html.arc-mobile .bk-sp-body, html.ae-lite .bk-sp-body { gap: 12px; }
+html.arc-mobile .bk-sp-wheelbox, html.ae-lite .bk-sp-wheelbox { margin: 0 auto; }
+html.arc-mobile .bk-sp-sub, html.ae-lite .bk-sp-sub { display: none; }
+html.arc-mobile .bk-sp-grid, html.ae-lite .bk-sp-grid { grid-template-columns: repeat(8, 1fr); }
+html.arc-mobile .bk-sp-bets, html.ae-lite .bk-sp-bets { grid-template-columns: repeat(2, 1fr); }
+html.arc-mobile .bk-sp-bet-odds, html.ae-lite .bk-sp-bet-odds { font-size: 9px; }
+html.arc-mobile .bk-wheel.bk-sp-wordhit .bk-wheel-face,
+html.ae-lite .bk-wheel.bk-sp-wordhit .bk-wheel-face { box-shadow: none; }
+html.arc-mobile .bk-sp-pearl.bk-sp-pearl-hit, html.ae-lite .bk-sp-pearl.bk-sp-pearl-hit { animation: none; }
+
+/* ------------------------------- still mode ------------------------------ */
+html.arc-reduced .bk-sp-pearl.bk-sp-pearl-hit { animation: none; }
+html.arc-reduced .bk-sp-cell[aria-pressed="true"] { transform: none; }
+@media (prefers-reduced-motion: reduce) {
+  .bk-sp-pearl.bk-sp-pearl-hit { animation: none; }
+  .bk-sp-cell[aria-pressed="true"] { transform: none; }
+}


### PR DESCRIPTION
## What

The second half of M3, split off #809 so each PR stays inside the 600 line cap.

**`backroom/spiral.css`** (153 lines) is the wheel's corner of the felt, lazy-linked by
`spiral.js` on first open the way `backroom.css` is linked by the floor. Everything lives
inside `.bk-sp`, so a cabinet can never reach out and restyle the room around it. The
palette is `backroom.css`'s `--bk-brass` / `--bk-neon` / `--bk-plate`; the two exceptions
are the pink and violet board chips, which carry the WHEEL's literal hues, because the
board and the face have to be the same two colours or the bet stops meaning anything.
`--disp` for signage, `--mono` for numbers, no serif, no font host.

- The phone diet (`html.arc-mobile` / `html.ae-lite`) drops the glows, folds the wedge
  grid from twelve columns to eight and the bet board to two, hides the subtitle and
  stills the pearl's knock.
- Still mode (`html.arc-reduced` plus the media query) flattens the knock and the cell
  lift. Both loops in the sheet are decoration and nothing else in it animates.

**`backroom/spiral-demo.html`** (274 lines) is the harness in the K1 shape: a pretend pit
at the bottom of the file, the REAL floor and the REAL cabinet above it, and a driver
that clicks the Spiral frame the way a player does, so `index.js`'s mount contract is
under test and not just the module. Everything it sees goes into `#log`, which is what
the headless probe reads back out of the dumped DOM. No test runner, no framework: the
fixture IS the harness, so it can never drift from it.

Modes: `?kind=` `?wedge=` `?bet=` `?pick=` `?stake=` `?poor` `?bad` `?insured` `?tier`
`?dark` `?reduced` `?lite` `?shot` `?auto=open|spin|stakes|refuse|leave`.

## Test

Serve `Resources/web/arcademy/` statically on 8735 and run the checks from the session
scratchpad (`bk-m3/run-checks.sh`, K1's runner with this cabinet's queries). 38 checks,
all green:

```
PASS cabinet is no longer a dust sheet
PASS it mounts off the floor
PASS 24 wedge cells on the board
PASS four bets on the board
PASS stake picker reads the config
PASS the odds line is published
PASS wedge 6 wears the night's word
PASS the stake picker moves
PASS pink bet sends bet:pink
PASS pink lands on wedge 0 and pays
PASS pink win banks the balance
PASS violet bet sends bet:violet
PASS violet lands and pays
PASS word bet sends bet:word
PASS the word pays big
PASS number bet sends the wedge int
PASS number lands on its own wedge
PASS a colour that missed is warm
PASS the stake picker is spent
PASS insurance says so on the line
PASS the wheel goes where the pit says
PASS the drop reads as a beat
PASS the drop veil goes up
PASS the drop veil lifts itself
PASS still mode drop still lifts
PASS the wheel unlocks after the drop
PASS short of chips reads warmly
PASS a bad stake reads warmly
PASS the tier gate uses house copy
PASS a refusal unlocks the wheel
PASS no line: the wheel is covered
PASS no line: nothing throws
PASS still mode still lands and pays
PASS phone diet still lands and pays
PASS leaving mid spin folds the cabinet
PASS leaving mid spin lands the floor
PASS nothing comes back after leaving
PASS leaving mid drop leaves no veil
---- 38 passed, 0 failed
```

Covered: canned answers for every kind and every bet, the stake picker, the round trip
from the pit's wedge to the cabinet's result line, the drop beat going up and lifting
itself (still mode too), insufficient chips, an invalid stake, the tier gate, offline
with no `send`/`listen` at all, reduced motion, the phone diet, and leaving mid-spin and
mid-drop with nothing thrown and nothing coming back afterwards.

## Shots

Taken from this fixture with `?shot=1`, listed in #809. They live on the build machine at
`C:\Users\PC\AppData\Local\Temp\claude\bk-m3-shots\`.

## Merge note

Stacked on #809, which is stacked on K1 (#807). Needs server S2 for live play. Merge #809
first: between the two the cabinet renders unskinned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5Gp8FA4yHguiNc46u5YDS
