### PR TITLE
feat(arcademy): Back Room M1b - Twenty-One skin and bench

### DIFF
--- a/ConditioningControlPanel/Resources/web/arcademy/backroom/twentyone.css
+++ b/ConditioningControlPanel/Resources/web/arcademy/backroom/twentyone.css
@@ -1,0 +1,170 @@
+/* ============================================================================
+ * backroom/twentyone.css - THE TABLE'S SKIN.
+ *
+ * Lazy-linked by twentyone.js the first time the cabinet is opened, the same
+ * way backroom/index.js links the floor's sheet, so a player who never walks
+ * to this table never pays for it.
+ *
+ * IT BORROWS, IT DOES NOT REDECLARE. --bk-felt, --bk-neon, --bk-brass and the
+ * rest are declared on .bk-room in backroom.css, and every read here carries a
+ * fallback because a machine can be mounted on a bench with no room around it
+ * (the K1 lesson: an unfallen var() paints furniture nobody can see).
+ *
+ * NO SERIF ANYWHERE (house camera law). Display for the name, mono for
+ * numbers, body for the dealer's sentences, and nothing else.
+ *
+ * The still-mode and phone blocks sit at the bottom. The global freeze at the
+ * end of styles.css already flattens CSS animation under html.arc-reduced; the
+ * blocks here are for the things a flattened duration still leaves looking
+ * wrong, and for the glow a phone should not be paying for.
+ * ==========================================================================*/
+
+.bk21 { display: flex; flex-direction: column; gap: 10px; }
+
+/* ------------------------------------------------------------------- the hud */
+/* min-width:0 on every child is not tidiness, it is the fix: a flex item's
+   default min-width is auto, so the odds sentence refused to shrink and pushed
+   the whole page wider than a phone (the CLAUDE.md phone-shot gate catches it
+   as a horizontal scrollbar). Allowed to shrink, it simply wraps. */
+.bk21-hud { display: flex; align-items: baseline; gap: 10px; flex-wrap: wrap; }
+.bk21-hud > * { min-width: 0; }
+.bk21-name {
+  margin: 0; font-family: var(--disp); font-size: 16px; letter-spacing: .1em;
+  font-weight: 400; color: var(--bk-neon, var(--pink));
+}
+.bk21-sub { font-size: 12px; color: var(--ink-faint); }
+.bk21-spacer { flex: 1 1 auto; }
+.bk21-odds {
+  font-family: var(--mono); font-size: 11px; letter-spacing: .06em;
+  color: var(--bk-brass, var(--gold));
+}
+
+/* ------------------------------------------------------------------ the felt */
+.bk21-felt {
+  position: relative; display: flex; flex-direction: column; gap: 10px;
+  /* A table is a table, not a wall. Past about seven hundred pixels the felt
+     stops reading as furniture and starts reading as a background. */
+  max-width: 700px; padding: 14px 16px 18px;
+  border: 2px solid var(--bk-edge, var(--line));
+  border-radius: 70px 70px var(--radius, 10px) var(--radius, 10px);
+  background:
+    radial-gradient(120% 90% at 50% 0%, color-mix(in srgb, var(--bk-felt, #1b3a2e), white 8%), transparent 70%),
+    var(--bk-felt, #1b3a2e);
+  box-shadow: inset 0 0 40px #0008;
+}
+
+/* ---------------------------------------------------------------- the dealer */
+.bk21-dealer { display: flex; align-items: center; gap: 12px; }
+.bk21-crt {
+  position: relative; flex: none; width: 74px; height: 58px;
+  background: #0d0916; border: 4px solid var(--bk-neon-2, var(--lav));
+  border-radius: 12px 12px 10px 10px;
+  box-shadow: 0 0 14px color-mix(in srgb, var(--bk-neon-2, var(--lav)), transparent 60%);
+}
+/* the aerial and its bead, so she reads as a set rather than as a rectangle */
+.bk21-crt::before {
+  content: ''; position: absolute; top: -14px; left: 50%; width: 2px; height: 14px;
+  background: var(--bk-neon-2, var(--lav)); transform: rotate(18deg); transform-origin: bottom;
+}
+.bk21-crt::after {
+  content: ''; position: absolute; top: -18px; left: calc(50% + 5px);
+  width: 8px; height: 8px; border-radius: 50%; background: var(--bk-neon, var(--pink));
+  box-shadow: 0 0 8px var(--bk-neon, var(--pink));
+}
+.bk21-eyes { position: absolute; left: 14px; right: 14px; top: 17px; display: flex; justify-content: space-between; }
+.bk21-eyes i {
+  width: 11px; height: 11px; background: var(--bk-neon, var(--pink));
+  box-shadow: 0 0 8px var(--bk-neon, var(--pink)); animation: bk21-blink 4.4s infinite;
+}
+.bk21-mouth {
+  position: absolute; left: 25px; right: 25px; bottom: 12px; height: 3px;
+  background: var(--bk-neon, var(--pink));
+}
+/* While the real mascot is standing at the plate, the drawn screen steps back.
+   It never leaves: she is on loan and the table keeps its own dealer. */
+.bk21-crt.bk21-lent { opacity: .25; }
+@keyframes bk21-blink { 0%, 92%, 100% { transform: scaleY(1); } 96% { transform: scaleY(.1); } }
+
+.bk21-say { font-size: 13px; color: var(--ink); min-height: 1.2em; }
+.bk21-dealer-line { margin-top: 3px; font-size: 12px; color: var(--bk-neon-2, var(--lav)); }
+
+/* ----------------------------------------------------------------- the hands */
+.bk21-row { display: flex; flex-direction: column; gap: 4px; }
+.bk21-cap {
+  display: flex; align-items: baseline; gap: 8px;
+  font-family: var(--mono); font-size: 10px; letter-spacing: .2em; text-transform: uppercase;
+  color: var(--ink-dim);
+}
+.bk21-count { font-size: 14px; letter-spacing: .06em; color: var(--ink); }
+.bk21-hand { display: flex; gap: 6px; min-height: 82px; flex-wrap: wrap; }
+
+.bk21-card {
+  width: 56px; height: 80px; padding: 5px; border-radius: 7px;
+  display: grid; grid-template-rows: auto 1fr auto; justify-items: start;
+  background: #fdf6f0; color: #2a1b44;
+  font-family: var(--mono); font-weight: 700; font-size: 13px;
+  box-shadow: 0 4px 10px #0006;
+}
+.bk21-card.bk21-hot { color: #d6357c; }
+.bk21-r { line-height: 1; }
+.bk21-r-low { justify-self: end; transform: rotate(180deg); }
+.bk21-suit { justify-self: center; align-self: center; color: currentColor; opacity: .9; }
+.bk21-card.bk21-back {
+  background: repeating-linear-gradient(45deg,
+    var(--bk-neon, var(--pink)) 0 6px, var(--bk-neon-2, var(--lav)) 6px 12px);
+  border: 3px solid #fdf6f0;
+}
+/* THE DEAL. Added by the module only when motion is allowed, so still mode
+   never has a flattened spring to sit inside. */
+.bk21-card.bk21-in { animation: bk21-deal .3s cubic-bezier(.2, 1.4, .4, 1) 1; }
+@keyframes bk21-deal {
+  from { opacity: 0; transform: translate3d(28px, -34px, 0) rotate(9deg) scale(.9); }
+  to   { opacity: 1; transform: none; }
+}
+
+/* ----------------------------------------------------------------- the verbs */
+.bk21-verbs { display: flex; gap: 8px; flex-wrap: wrap; align-items: center; }
+.bk21-btn {
+  font-family: var(--mono); font-size: 12px; letter-spacing: .14em; text-transform: uppercase;
+  padding: 9px 14px; border-radius: 8px; cursor: pointer;
+  color: var(--ink); background: var(--bk-plate, var(--panel));
+  border: 1px solid var(--bk-neon, var(--pink));
+}
+.bk21-btn.bk21-gold { border-color: var(--bk-brass, var(--gold)); color: var(--bk-brass, var(--gold)); }
+.bk21-btn.bk21-ghost { border-color: var(--line); color: var(--ink-dim); }
+.bk21-btn.bk21-back { margin-left: auto; }
+.bk21-btn:focus-visible { outline: 2px solid var(--bk-brass, var(--gold)); outline-offset: 2px; }
+.bk21-btn[disabled] { opacity: .45; cursor: default; }
+.bk21-btn[hidden] { display: none; }
+
+/* A table with no line to the counter says so and stops pretending to deal. */
+.bk21-dark .bk21-felt { opacity: .7; border-style: dashed; }
+
+/* The blackjack beat: the felt lifts for a moment. A beat, never a fanfare. */
+.bk21-beat .bk21-felt {
+  box-shadow: inset 0 0 40px #0008, 0 0 30px color-mix(in srgb, var(--bk-brass, var(--gold)), transparent 55%);
+}
+
+/* ------------------------------------------------------------------ the diet */
+/* A phone pays for glow and springs before it pays for the cards. It loses
+   both and keeps every rect, which is the only rule that matters here. */
+html.arc-mobile .bk21-felt, html.ae-lite .bk21-felt { padding: 10px 12px 14px; border-radius: 44px 44px 10px 10px; }
+html.arc-mobile .bk21-card, html.ae-lite .bk21-card { width: 42px; height: 60px; font-size: 11px; box-shadow: 0 2px 5px #0006; }
+html.arc-mobile .bk21-card.bk21-in, html.ae-lite .bk21-card.bk21-in { animation: none; }
+html.arc-mobile .bk21-hand, html.ae-lite .bk21-hand { min-height: 62px; }
+html.arc-mobile .bk21-crt, html.ae-lite .bk21-crt { width: 52px; height: 42px; box-shadow: none; }
+html.arc-mobile .bk21-eyes, html.ae-lite .bk21-eyes { top: 12px; }
+html.arc-mobile .bk21-eyes i, html.ae-lite .bk21-eyes i { width: 8px; height: 8px; box-shadow: none; animation: none; }
+html.arc-mobile .bk21-mouth, html.ae-lite .bk21-mouth { left: 17px; right: 17px; bottom: 9px; }
+html.arc-mobile .bk21-sub, html.ae-lite .bk21-sub { display: none; }
+/* The odds line takes the whole second row on a phone, and the way out stops
+   being pushed to the far edge where a thumb cannot reach it. */
+html.arc-mobile .bk21-odds, html.ae-lite .bk21-odds { flex: 1 0 100%; font-size: 10px; }
+html.arc-mobile .bk21-btn.bk21-back, html.ae-lite .bk21-btn.bk21-back { margin-left: 0; }
+html.arc-mobile .bk21-btn, html.ae-lite .bk21-btn { padding: 10px 11px; letter-spacing: .08em; }
+html.arc-mobile .bk21-beat .bk21-felt, html.ae-lite .bk21-beat .bk21-felt { box-shadow: inset 0 0 40px #0008; }
+
+/* Still mode. The freeze owns the durations; these are the two things a
+   flattened duration would otherwise leave looking like a fault. */
+html.arc-reduced .bk21-card.bk21-in { animation: none; }
+html.arc-reduced .bk21-eyes i { animation: none; }

--- a/ConditioningControlPanel/Resources/web/arcademy/backroom/twentyone.demo.html
+++ b/ConditioningControlPanel/Resources/web/arcademy/backroom/twentyone.demo.html
@@ -1,0 +1,268 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Twenty-One - table fixture</title>
+<!-- The REAL twentyone.js under a STUBBED kit. No shell, no floor, no bridge,
+     no server and not a chip that exists anywhere. The stub is the point: the
+     table's whole job is to render frames somebody else resolved, so the way
+     to test it is to hand it frames and read what it drew.
+
+     ?script=  which canned hand the pretend dealer is holding:
+                 deal      one deal, the felt goes live
+                 bust      deal then DEEPER into twenty-four
+                 win       deal then HOLD, the dealer breaks
+                 push      deal then HOLD, both on nineteen
+                 bj        twenty-one on the deal, pays 3 to 2
+                 double    deal then DOUBLE DOWN, one card and stand
+                 poor      the table refuses for want of chips
+                 offline   the line is down, nothing was staked
+                 resume    an open hand is already on the felt at mount
+     ?slow=1   the dealer takes 1200ms, so the LOCK can be watched
+     ?dark=1   no line at all: kit.api.wired() is false
+     ?reduced=1 arms html.arc-reduced, the global still mode
+     ?lite=1   arms html.ae-lite + html.arc-mobile, the phone diet
+     ?w=390    caps the column at 390 CSS pixels and drops the bench padding.
+               Headless Chrome will not open a window narrower than about 504
+               on Windows, so a phone WIDTH has to be a container, not a
+               viewport. Nothing in the table reads vw or a media query, so a
+               capped column is the same layout a phone gets.
+     ?auto=    the unattended driver: deal|bust|win|push|bj|double|poor|
+               offline|resume|lock|unmount|open|floor
+               (floor drives the REAL backroom/index.js instead of the stub)
+     Every driver writes AUTO lines into #log, which is what the headless probe
+     reads back out of the dumped DOM. No framework, no runner in the page: the
+     fixture IS the harness, so it can never drift from it. -->
+<link rel="stylesheet" href="../styles.css">
+<link rel="stylesheet" href="./backroom.css">
+<style>
+  body { margin: 0; padding: 16px 14px 60px; background: var(--ground); color: var(--ink); font-family: var(--body); }
+  .wrap { max-width: 900px; margin: 0 auto; }
+  header.fx { display: flex; align-items: baseline; gap: 12px; flex-wrap: wrap;
+              border-bottom: 3px solid var(--pink); padding-bottom: 8px; margin-bottom: 14px; }
+  header.fx h1 { font-family: var(--disp); font-size: 20px; margin: 0; letter-spacing: .08em; }
+  .eyebrow { font-family: var(--mono); font-size: 10px; letter-spacing: .2em; color: var(--ink-dim); }
+  #log { font-family: var(--mono); font-size: 11px; color: var(--ink-dim); white-space: pre-wrap;
+         margin-top: 12px; max-height: 200px; overflow: auto; }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <header class="fx">
+    <h1>TWENTY-ONE</h1>
+    <span class="eyebrow">backroom/twentyone.js &middot; table fixture</span>
+  </header>
+  <!-- .bk-room is where backroom.css declares the room's tokens, and a machine
+       is always mounted inside one. The bench wears it for the same reason. -->
+  <div class="bk-room"><div id="stage" class="bk-stage"></div></div>
+  <div id="log"></div>
+</div>
+
+<script type="module">
+import twentyone from './twentyone.js';
+import { fmtChips, balanceChip, chipStack, bank } from './kit/chips.js';
+
+const q = new URLSearchParams(location.search);
+const logEl = document.getElementById('log');
+const log = (m) => { logEl.textContent += m + '\n'; };
+window.addEventListener('error', (e) => log('THREW ' + (e.message || e)));
+
+if (q.has('reduced')) document.documentElement.classList.add('arc-reduced');
+if (q.has('lite')) document.documentElement.classList.add('ae-lite', 'arc-mobile');
+if (q.has('w')) {
+  document.body.style.padding = '0';
+  const w = document.querySelector('.wrap');
+  w.style.maxWidth = Math.max(240, Number(q.get('w')) || 390) + 'px';
+  w.style.margin = '0';
+}
+
+/* ------------------------------------------------------------------------
+ * THE CANNED DEALER. One plan per script, an answer per verb. Nothing here
+ * decides anything: these are frames a server already resolved, written down.
+ * ---------------------------------------------------------------------- */
+const C = (r, s) => ({ r, s });
+const purse = { chips: 2000 };
+
+/** `delta` is what the frame does to the balance (the stake has already left);
+ *  `payout` is what the table paid, which is the number the felt prints. */
+function frame(result, delta, payout, extra) {
+  purse.chips += (delta || 0);
+  return Object.assign({
+    machine: 'twentyone', chips: purse.chips, earnedC: 0, pot: 41800,
+    stake: 25, payout: payout || 0, result,
+  }, extra || {});
+}
+const ok = (body) => ({ ok: true, status: 200, body });
+const no = (reason, status) => ({ ok: false, status: status == null ? 200 : status, body: { reason } });
+
+const OPEN = { player: [C('K', 0), C('5', 3)], dealer: [C('6', 1)], dealerHidden: true, status: 'playing', canDouble: true };
+
+const PLANS = {
+  deal:   { deal: () => ok(frame(OPEN, -25, 0)) },
+  bust:   { deal: () => ok(frame(OPEN, -25, 0)),
+            hit: () => ok(frame({ player: [C('K', 0), C('5', 3), C('9', 2)], dealer: [C('6', 1), C('T', 0)],
+                                  dealerHidden: false, status: 'lost', canDouble: false }, 0, 0)) },
+  win:    { deal: () => ok(frame(OPEN, -25, 0)),
+            stand: () => ok(frame({ player: [C('K', 0), C('5', 3)], dealer: [C('6', 1), C('T', 0), C('8', 2)],
+                                    dealerHidden: false, status: 'won', canDouble: false }, 50, 50)) },
+  push:   { deal: () => ok(frame(OPEN, -25, 0)),
+            stand: () => ok(frame({ player: [C('K', 0), C('9', 3)], dealer: [C('9', 1), C('T', 0)],
+                                    dealerHidden: false, status: 'push', canDouble: false }, 25, 25)) },
+  bj:     { deal: () => ok(frame({ player: [C('A', 3), C('K', 0)], dealer: [C('6', 1), C('7', 2)],
+                                   dealerHidden: false, status: 'blackjack', canDouble: false }, 37, 62)) },
+  double: { deal: () => ok(frame(OPEN, -25, 0)),
+            double: () => ok(frame({ player: [C('K', 0), C('5', 3), C('6', 1)], dealer: [C('6', 1), C('T', 0), C('9', 2)],
+                                     dealerHidden: false, status: 'won', canDouble: false }, 75, 100)) },
+  poor:   { deal: () => no('insufficient_chips') },
+  offline:{ deal: () => no('offline', 0) },
+  resume: {},
+};
+
+const script = q.get('script') || q.get('auto') || 'deal';
+const plan = PLANS[script] || PLANS.deal;
+const delay = q.has('slow') ? 1200 : 90;
+const wired = !q.has('dark');
+const wait = (v) => new Promise((r) => setTimeout(() => r(v), delay));
+
+const snap = {
+  chips: purse.chips, earnedC: 0, sparkle: 27, rate: 100, pot: 41800,
+  hand: script === 'resume' ? { player: [C('A', 0), C('7', 2)], dealer: [C('9', 1)], dealerHidden: true, status: 'playing', canDouble: true } : null,
+  config: { stakes: { twentyone: 25 }, paytables: { twentyone: { blackjack: '3:2', stand: 17 } } },
+};
+
+/* ------------------------------------------------------------------------
+ * THE STUBBED KIT. The same surface backroom/index.js hands a machine, with
+ * the money replaced by a counter and the seam replaced by the table above.
+ * ---------------------------------------------------------------------- */
+const bal = balanceChip({ label: 'chips', value: purse.chips });
+const kit = {
+  api: {
+    wired: () => wired,
+    status: () => wait(wired ? ok(snap) : { ok: false, status: 0, body: { reason: 'offline' } }),
+    play(machine, stake, input) {
+      log('PLAY ' + JSON.stringify({ machine, stake, action: input && input.action }));
+      const fn = plan[(input && input.action) || ''];
+      return wait(fn ? fn() : no('invalid_input'));
+    },
+  },
+  t: (key) => key,             // the floor's bkT answers a bk_t1_ key with the key
+  voice: { line: (b) => 'she says something ' + b + '.' },
+  reduced: q.has('reduced'),
+  lite: q.has('lite'),
+  log,
+  sfx: (name, level) => log('SFX ' + name + ' ' + level),
+  fmtChips, balanceChip, chipStack, bank,
+  status: () => snap,
+  config: () => snap.config,
+  settle: (body, from) => {
+    if (!body || body.chips == null) return;
+    bal.set(body.chips);
+    log('SETTLE chips=' + body.chips + ' bank=' + (from ? 'yes' : 'no'));
+  },
+  refresh: () => Promise.resolve({ ok: true }),
+  toFloor: () => log('TOFLOOR'),
+  balanceEl: () => bal.el,
+};
+
+const stage = document.getElementById('stage');
+
+/* ?auto=floor is the one drive that does NOT use the stub: it opens the REAL
+ * floor with no line to a counter at all and presses the cabinet, because
+ * "backroom/index.js can mount this module and fold it again" is the single
+ * assertion neither file can make on its own. */
+if (q.get('auto') === 'floor') {
+  const mod = await import('./index.js');
+  const room = mod.openBackRoom({ log, t: (key, fb) => fb || key });
+  document.querySelector('.bk-room').appendChild(room.root);
+  setTimeout(() => {
+    const cab = room.root.querySelector('.bk-cab');
+    log('AUTO cabSheet=' + cab.classList.contains('bk-sheet') + ' name=' + cab.textContent.slice(0, 10));
+    cab.click();
+    setTimeout(() => {
+      log('AUTO mounted=' + (room.root.querySelector('.bk21') ? 'yes' : 'no'));
+      log('AUTO folded=' + room.escapeStep());
+      log('AUTO gone=' + (room.root.querySelector('.bk21') ? 'no' : 'yes'));
+      log('AUTO done');
+    }, 600);
+  }, 900);
+} else {
+  twentyone.mount(stage, kit, { log, exits: null });
+}
+
+/* ------------------------------------------------------------------------
+ * THE UNATTENDED DRIVER. It presses the same buttons a player does and then
+ * writes down what it saw. Nothing reaches inside the module.
+ * ---------------------------------------------------------------------- */
+const btn = (act) => stage.querySelector('.bk21-btn[data-act="' + act + '"]');
+const felt = () => stage.querySelector('.bk21-say').textContent;
+const count = (side) => stage.querySelector('.bk21-row-' + side + ' .bk21-count').textContent;
+const cards = (side) => stage.querySelectorAll('.bk21-row-' + side + ' .bk21-card').length;
+const backs = () => stage.querySelectorAll('.bk21-card.bk21-back').length;
+
+function report(tag) {
+  log(tag + ' you=' + count('player') + ' dealer=' + count('dealer'));
+  log(tag + ' cards=' + cards('player') + '/' + cards('dealer') + ' backs=' + backs());
+  log(tag + ' say=' + felt());
+}
+
+const auto = q.get('auto');
+const press = (act, then) => { const b = btn(act); log('PRESS ' + act + ' hidden=' + b.hidden + ' disabled=' + b.disabled); b.click(); setTimeout(then, delay + 260); };
+
+if (auto === 'open') {
+  setTimeout(() => {
+    log('AUTO odds=' + stage.querySelector('.bk21-odds').textContent);
+    log('AUTO dealLabel=' + btn('deal').textContent);
+    log('AUTO dark=' + (stage.querySelector('.bk21').classList.contains('bk21-dark') ? 'yes' : 'no'));
+    // THE PHONE GATE, measured rather than eyeballed: a room whose scrollWidth
+    // is wider than its client width has a sideways scrollbar on a phone, and
+    // CLAUDE.md treats that as a bug rather than as a taste.
+    const room = document.querySelector('.bk-room');
+    log('AUTO room=' + room.clientWidth
+      + ' overflow=' + Math.max(0, room.scrollWidth - room.clientWidth));
+    report('AUTO');
+    log('AUTO done');
+  }, delay + 400);
+} else if (auto === 'resume') {
+  setTimeout(() => {
+    report('AUTO');
+    log('AUTO hitShown=' + !btn('hit').hidden + ' dealShown=' + !btn('deal').hidden);
+    log('AUTO done');
+  }, delay + 400);
+} else if (auto === 'lock') {
+  setTimeout(() => {
+    btn('deal').click();
+    // Mid flight: every verb is dead and the felt says the shoe is moving.
+    setTimeout(() => {
+      log('AUTO lockedDeal=' + btn('deal').disabled + ' lockedHit=' + btn('hit').disabled
+        + ' lockedStand=' + btn('stand').disabled);
+      log('AUTO midSay=' + felt());
+      // A SECOND PRESS MID FLIGHT MUST NOT STAKE AGAIN.
+      btn('deal').click();
+    }, 200);
+    setTimeout(() => { log('AUTO plays=' + (logEl.textContent.match(/PLAY /g) || []).length); log('AUTO done'); }, delay + 700);
+  }, delay + 400);
+} else if (auto === 'unmount') {
+  setTimeout(() => {
+    press('deal', () => {
+      report('AUTO');
+      // LEAVING MID HAND. The server stands the hand; the page just stops.
+      twentyone.unmount();
+      twentyone.unmount();                       // twice, from any road
+      log('AUTO attached=' + (stage.querySelector('.bk21') ? 'yes' : 'no'));
+      log('AUTO done');
+    });
+  }, delay + 400);
+} else if (auto && auto !== 'floor') {
+  const second = { bust: 'hit', win: 'stand', push: 'stand', double: 'double' }[auto];
+  setTimeout(() => {
+    press('deal', () => {
+      report('AUTO deal');
+      if (!second) { log('AUTO done'); return; }
+      press(second, () => { report('AUTO ' + second); log('AUTO done'); });
+    });
+  }, delay + 400);
+}
+</script>
+</body>
+</html>


### PR DESCRIPTION
## What

The second half of Back Room M1, split off so each PR stays under the 600 line cap. Based on `feat/backroom-m1-twentyone` (M1a, the module). Two new files, both in `backroom/`:

- `twentyone.css` (170) - the table's skin, lazy-linked by the module.
- `twentyone.demo.html` (268) - the bench that deals canned hands at the real module.

## Why

**The skin borrows, it never redeclares.** `--bk-felt`, `--bk-neon`, `--bk-neon-2`, `--bk-brass`, `--bk-edge` and `--bk-plate` are declared on `.bk-room` in `backroom.css`; every read here carries a fallback, because a machine can be mounted on a bench with no room around it and an unfallen `var()` paints furniture nobody can see. Display face for the name, mono for numbers, body for her sentences, no serif anywhere.

The phone rules are not decoration. A flex item's default `min-width` is `auto`, so the odds sentence refused to shrink and pushed the whole page sideways at 390; `min-width: 0` on the hud children lets it wrap instead, the odds line takes its own row under the diet, and the way out stops being pushed to the far edge where a thumb cannot reach it. The felt is capped at 700px so it reads as furniture rather than as a wall.

**The bench mounts the real module** under a stubbed `kit`, so the tests exercise the shipping code and not a copy of it. `?auto=` plays one scripted script and prints what landed into a log div the runner reads:

`deal, bust, win, push, bj, double, poor, offline, resume, lock, unmount, open, floor`

plus `?dark=1` (no line), `?reduced=1`, `?lite=1`, `?slow=1` (hold the answer so the lock is observable), and `?w=` which caps the bench width. `?w=` exists because headless Chrome on Windows will not open a window narrower than about 500 CSS px; nothing in the table's own CSS reads `vw` or a media query, so a capped bench is the same layout a phone gets. `?auto=floor` imports the real `./index.js` and drives the cabinet through the actual floor.

`demo.html` in this folder set the precedent for a fixture living in the repo.

## Tests

Runner lives outside the repo (`scratchpad/bk-m1/run-checks.sh`, K1 harness shape, headless Chrome against a local static server):

```
PASS table opens, odds off config          PASS blackjack rings the jackpot
PASS stake label off config                PASS DOUBLE DOWN shows and pays
PASS no line: the table reads dark         PASS double is offered on the deal
PASS deal sends the right frame            PASS no chips reads warmly
PASS deal paints both hands                PASS offline says nothing was taken
PASS hole card hides the count             PASS an open hand resumes at mount
PASS deal settles the balance              PASS resumed hand shows the verbs
PASS DEEPER into a bust reads warm         PASS every verb locks mid answer
PASS bust reveals the hole card            PASS a second press cannot stake
PASS HOLD into a win pays                  PASS unmount mid hand is silent
PASS a win banks out of the felt           PASS still mode deals the same hand
PASS a push comes home untouched           PASS phone diet deals the same hand
PASS blackjack is a beat                   PASS the floor mounts the cabinet
PASS the cabinet is no dust sheet          PASS the ladder folds it back home
PASS no sideways scroll at 390             PASS no sideways scroll at 360

---- 30 passed, 0 failed
```

## Shots

Off this bench, in `C:/Users/PC/AppData/Local/Temp/claude/bk-m1-shots/`:

- `table-desktop-hand.png`, `table-desktop-blackjack.png`
- `table-phone-390-lite.png`, `table-phone-360-win.png`

## Merge note

**Stacked on K1 (#807); needs server S2 for live play.** Merge this in the same wave as M1a, which is unskinned without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5Gp8FA4yHguiNc46u5YDS
