### PR TITLE
feat(arcademy): Back Room M2a - Triple Trigger reel window and skin

### DIFF
--- a/ConditioningControlPanel/Resources/web/arcademy/backroom/triple-reel.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/backroom/triple-reel.js
@@ -1,0 +1,309 @@
+/* ============================================================================
+ * backroom/triple-reel.js - the three reels, and nothing else.
+ *
+ * The window of TRIPLE TRIGGER: three columns of words that turn, and stop
+ * where they are told to stop. It knows nothing about chips, stakes, holds as
+ * a PRICE, odds or the dealer. Hand it a list of trigger rows and it paints
+ * three reels; hand it three indices and it lands on them. That is the whole
+ * surface, and keeping it that small is what makes the cabinet on top of it
+ * readable and this half testable on a bench with no cashier anywhere near it.
+ *
+ * FOUR THINGS THIS FILE IS BUILT AROUND.
+ *
+ *  - THE REELS ARE THEATRE (LEDGER TRUTH). The server drew the outcome before
+ *    the first frame turned. Every road through `settle()` ends on the indices
+ *    it was given, and no road anywhere in here picks one.
+ *
+ *  - IT ALWAYS COMES TO REST. The ceiling is armed BEFORE the first frame, the
+ *    way kit/dropbeat.js arms its own: a frame clock that stops, a tab that
+ *    sleeps, an answer that never lands, and the reels still park and the
+ *    cabinet still gets told. A slot machine that spins forever has eaten
+ *    somebody's stake and is lying about it.
+ *
+ *  - REDUCED MOTION IS A DIFFERENT MACHINE, NOT A SLOWER ONE. Still mode never
+ *    starts the loop at all: the reels dim, and then they CROSSFADE onto the
+ *    answer. The global freeze at the bottom of styles.css cannot reach a rAF
+ *    (trap 92), so the gate is here in the JS and the crossfade is an opacity
+ *    class this module times rather than a transition the freeze would flatten.
+ *
+ *  - NO PIXEL IS EVER MEASURED. A reel is parked by writing
+ *    `translateY(calc(var(--bk-tt-cell) * -n))`, so the sheet owns the cell
+ *    height, the phone diet can shorten it, and nothing here has to know or
+ *    care. Measuring would also mean measuring during a roll, which is the
+ *    classic way to make a phone drop frames.
+ * ==========================================================================*/
+
+import { REEL_GLYPH } from './kit/triggers.js';
+
+/** Three reels. It is in the name. */
+export const REELS = 3;
+/** Copies of the strip stacked in each column, so there is always one above
+ *  and one below the window and the wrap is never seen. */
+const COPIES = 3;
+/** Cells a reel travels per second while it turns. Each one is a hair quicker
+ *  than the last, so three reels never read as one wide reel. */
+const SPEED = Object.freeze([15.5, 17, 18.5]);
+/** The roll is never shorter than this, however fast the server answers. A
+ *  slot that resolves instantly reads as a button, not as a machine. */
+export const MIN_ROLL_MS = 620;
+/** Reel to reel, on the way down. Long enough to count, short enough to want. */
+const SETTLE_GAP_MS = 300;
+/** The ceiling. Nothing in this file may turn for longer, on any path. */
+export const ROLL_CEILING_MS = 9500;
+
+function el(tag, cls, text) {
+  const n = document.createElement(tag);
+  if (cls) n.className = cls;
+  if (text != null) n.textContent = String(text);
+  return n;
+}
+
+function raf(fn) {
+  if (typeof requestAnimationFrame === 'function') return requestAnimationFrame(fn);
+  return setTimeout(() => fn(Date.now()), 16);
+}
+function unraf(h) {
+  if (typeof cancelAnimationFrame === 'function') { try { cancelAnimationFrame(h); return; } catch { /* noop */ } }
+  try { clearTimeout(h); } catch { /* noop */ }
+}
+const clock = () => ((typeof performance !== 'undefined' && performance.now) ? performance.now() : Date.now());
+
+/**
+ * createReelWindow({ reduced, lite, sfx, log, labels, onCeiling }) ->
+ *   { el, setRows, rows, at, wordAt, sentence, rolling,
+ *     startRoll, settle, park, stop, destroy }
+ *
+ * `labels` is `{ window, reel(i) }` and it is passed IN rather than looked up
+ * here on purpose: the strings of this machine live in the cabinet's own table
+ * (they are `bk_tt_*` rows the host mirrors), and a component with its own
+ * private lexicon would be a second place for a translator to find.
+ *
+ * `onCeiling()` fires when the ceiling parks the reels without an answer. The
+ * cabinet uses it to hand the buttons back, which is the only thing that can
+ * still be done for a player at that point.
+ */
+export function createReelWindow(opts) {
+  const o = opts || {};
+  const reduced = !!o.reduced;
+  const sfx = (typeof o.sfx === 'function') ? o.sfx : () => {};
+  const note = (typeof o.log === 'function') ? o.log : () => {};
+  const labels = o.labels || {};
+  const onCeiling = (typeof o.onCeiling === 'function') ? o.onCeiling : () => {};
+
+  let dead = false;
+  let rows = [];                       // the reel list, from kit/triggers.js
+  let at = [0, 0, 0];                  // where each reel is parked, an index into `rows`
+  let rollingFlags = [false, false, false];
+  let loop = null;
+  let ceiling = null;
+  let rollT0 = 0;
+  const timers = new Set();
+
+  const win = el('div', 'bk-tt-window');
+  win.setAttribute('role', 'group');
+  win.setAttribute('aria-label', String(labels.window || 'the three reels'));
+
+  const cols = [];
+  for (let i = 0; i < REELS; i++) {
+    const reel = el('div', 'bk-tt-reel');
+    reel.setAttribute('role', 'img');
+    reel.setAttribute('aria-label', String((typeof labels.reel === 'function' ? labels.reel(i + 1) : '') || ('reel ' + (i + 1))));
+    const strip = el('div', 'bk-tt-strip');
+    reel.appendChild(strip);
+    win.appendChild(reel);
+    cols.push({ reel, strip, off: 0 });
+  }
+
+  function later(fn, ms) {
+    const h = setTimeout(() => { timers.delete(h); if (!dead) fn(); }, ms);
+    timers.add(h);
+    return h;
+  }
+
+  /* ----------------------------------------------------------------- paint */
+
+  /** The word reel `r` shows for row `i`. The server's blank is `-1` and a
+   *  padded row carries its own glyph flag, so both roads reach the same cell. */
+  function wordAt(r, i) {
+    if (i < 0 || i >= rows.length) return null;
+    const row = rows[i];
+    if (!row || row.glyph) return null;
+    const parts = String(row.word || '').split(' ');
+    return parts[r] || null;
+  }
+
+  /** Every cell of one strip, COPIES times over. The extra row on the end is
+   *  the server's `-1`: a blank needs somewhere to stop, and a blank is the
+   *  house's spiral rather than an empty box. */
+  function buildStrip(r) {
+    const strip = cols[r].strip;
+    strip.textContent = '';
+    const n = rows.length + 1;
+    for (let copy = 0; copy < COPIES; copy++) {
+      for (let i = 0; i < n; i++) {
+        const w = (i === rows.length) ? null : wordAt(r, i);
+        strip.appendChild(el('div', 'bk-tt-cell' + (w ? '' : ' bk-tt-glyph'), w || REEL_GLYPH));
+      }
+    }
+  }
+
+  /** The offset that puts row `i` on the payline, inside the middle copy. The
+   *  window is three cells tall and the payline is the middle one, hence the
+   *  minus one: `off` counts the cells that have gone past the TOP. */
+  function posFor(i) {
+    const n = rows.length + 1;
+    const idx = (i < 0 || i >= rows.length) ? rows.length : i;
+    return n + idx - 1;
+  }
+
+  function place(col, off) {
+    col.off = off;
+    try { col.strip.style.transform = 'translateY(calc(var(--bk-tt-cell) * ' + (-off).toFixed(3) + '))'; }
+    catch (e) { /* a strip that will not move still reports its parked index */ }
+  }
+
+  /** New words on the reels. The opening positions are deliberately spread, so
+   *  a cabinet that has never been pulled does not open on three of a kind and
+   *  read as a machine that has already paid. */
+  function setRows(list) {
+    rows = Array.isArray(list) ? list : [];
+    if (!rows.length) return;
+    at = [0, 1 % rows.length, 2 % rows.length];
+    for (let i = 0; i < REELS; i++) { buildStrip(i); place(cols[i], posFor(at[i])); }
+  }
+
+  /* ------------------------------------------------------------------ roll */
+
+  /** `held` is three booleans. A held reel does not turn: that is exactly what
+   *  the player paid five chips for, and it has to be visible. */
+  function startRoll(held) {
+    if (dead || !rows.length) return;
+    const keep = Array.isArray(held) ? held : [];
+    rollT0 = clock();
+    for (let i = 0; i < REELS; i++) {
+      rollingFlags[i] = !keep[i];
+      cols[i].reel.classList.remove('bk-tt-land');
+      if (rollingFlags[i]) cols[i].reel.classList.add(reduced ? 'bk-tt-fade' : 'bk-tt-rolling');
+    }
+    // ARMED BEFORE THE FIRST FRAME, always, on both roads.
+    ceiling = later(() => { stop(); park(); onCeiling(); }, ROLL_CEILING_MS);
+    if (reduced) return;
+
+    let last = clock();
+    const step = () => {
+      if (dead) return;
+      const now = clock();
+      const dt = Math.min(0.05, Math.max(0, (now - last) / 1000));
+      last = now;
+      const n = rows.length + 1;
+      for (let i = 0; i < REELS; i++) {
+        if (!rollingFlags[i]) continue;
+        let off = cols[i].off + (SPEED[i] * dt);
+        while (off >= n * 2) off -= n;
+        place(cols[i], off);
+      }
+      loop = raf(step);
+    };
+    loop = raf(step);
+  }
+
+  function stop() {
+    if (loop != null) { unraf(loop); loop = null; }
+    if (ceiling != null) {
+      try { clearTimeout(ceiling); } catch (e) { /* noop */ }
+      timers.delete(ceiling);
+      ceiling = null;
+    }
+    for (let i = 0; i < REELS; i++) {
+      rollingFlags[i] = false;
+      cols[i].reel.classList.remove('bk-tt-rolling', 'bk-tt-fade');
+    }
+  }
+
+  /** Every reel back where it was. The road out of a refusal and out of the
+   *  ceiling: a machine that could not take a pull must at least look like it
+   *  never took one. */
+  function park() {
+    for (let i = 0; i < REELS; i++) place(cols[i], posFor(at[i]));
+  }
+
+  function land(i, idx) {
+    const moved = rollingFlags[i];
+    at[i] = (idx < 0 || idx >= rows.length) ? -1 : idx;
+    rollingFlags[i] = false;
+    const col = cols[i];
+    col.reel.classList.remove('bk-tt-rolling', 'bk-tt-fade');
+    place(col, posFor(idx));
+    // The parked index, on the element, because a headless probe reading a
+    // dumped DOM cannot see a transform but can always read an attribute.
+    try { col.reel.dataset.at = String(at[i]); } catch (e) { /* noop */ }
+    // Three thuds, each a semitone up, so the ear counts the reels down. A reel
+    // that never turned makes no sound: you paid for it to stay still.
+    if (!moved) return;
+    sfx('pip', 0.34, { pitch: 1 + (i * 0.12) });
+    if (reduced) return;
+    col.reel.classList.add('bk-tt-land');
+    later(() => col.reel.classList.remove('bk-tt-land'), 220);
+  }
+
+  /**
+   * settle([i,i,i]) -> Promise, resolved when the third reel is down.
+   *
+   * Left to right with a beat between, and never before the roll has had its
+   * minimum, however quickly the server answered. It resolves even when the
+   * window is torn down underneath it, so the cabinet's `.then` is never the
+   * thing left hanging.
+   */
+  function settle(list) {
+    const want = Array.isArray(list) ? list : [];
+    const wait = Math.max(0, MIN_ROLL_MS - (clock() - rollT0));
+    return new Promise((done) => {
+      let i = 0;
+      const next = () => {
+        if (dead) { done(); return; }
+        if (i >= REELS) { stop(); done(); return; }
+        const which = i;
+        i += 1;
+        land(which, Math.round(Number(want[which])));
+        later(next, SETTLE_GAP_MS);
+      };
+      later(wait > 0 ? next : next, wait);
+    });
+  }
+
+  return {
+    el: win,
+    setRows,
+    rows: () => rows,
+    at: () => at.slice(),
+    wordAt,
+    /** The three words on the payline right now, in reel order. On a scramble
+     *  this is a sentence nobody wrote, which is the point of the machine. */
+    sentence() {
+      const out = [];
+      for (let i = 0; i < REELS; i++) out.push(wordAt(i, at[i]) || REEL_GLYPH);
+      return out.join(' ').toUpperCase();
+    },
+    /** The whole trigger row a reel is sitting on, for reading a royal out. */
+    phraseAt(i) {
+      const row = rows[at[i]];
+      return (row && !row.glyph) ? String(row.word || '') : '';
+    },
+    rolling: () => rollingFlags.some(Boolean),
+    startRoll,
+    settle,
+    park,
+    stop,
+    /** Safe from any road, and safe twice: mid roll, mid settle, mid nothing. */
+    destroy() {
+      if (dead) return;
+      dead = true;
+      stop();
+      for (const h of timers) { try { clearTimeout(h); } catch (e) { /* noop */ } }
+      timers.clear();
+      try { win.remove(); } catch (e) { note('backroom: reel window would not lift'); }
+    },
+  };
+}
+
+export default createReelWindow;

--- a/ConditioningControlPanel/Resources/web/arcademy/backroom/triple.css
+++ b/ConditioningControlPanel/Resources/web/arcademy/backroom/triple.css
@@ -1,0 +1,202 @@
+/* ============================================================================
+ * backroom/triple.css - TRIPLE TRIGGER, the cabinet with your own words in it.
+ *
+ * Lazy-linked by backroom/triple.js on mount, the same way backroom.css is
+ * linked by the floor. Every colour is a var() off the room's own tokens with
+ * a shell token behind it, so the cabinet paints correctly on the felt AND on
+ * a bare fixture bench with no .bk-room around it.
+ *
+ * TYPE: --disp for the reel words, --mono for numbers and the odds sheet. No
+ * serif anywhere (house camera law), no font host (trap 2).
+ *
+ * THE CELL HEIGHT IS A CUSTOM PROPERTY AND THAT IS LOAD-BEARING. The module
+ * parks a reel by writing `translateY(calc(var(--bk-tt-cell) * -n))`, so it
+ * never measures a pixel and never has to know what the diet did to the
+ * layout. Change the height here and the reels still land on the payline.
+ *
+ * MOTION: the roll is a JS transform loop, gated in the module, because the
+ * global freeze at the bottom of styles.css cannot reach a rAF (trap 92). What
+ * this sheet owns is the LOOK of the window, and the still-mode crossfade is
+ * an opacity CLASS the module times rather than a transition the freeze would
+ * flatten (the same trick kit/loomwheel.js lands its wheel with).
+ * ==========================================================================*/
+
+.bk-tt {
+  --bk-tt-cell: 54px;
+  --bk-tt-gold: var(--bk-brass, var(--gold));
+  --bk-tt-neon: var(--bk-neon, var(--pink));
+  --bk-tt-glass: color-mix(in srgb, var(--panel, #252542), black 42%);
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  font-family: var(--body);
+  color: var(--ink);
+}
+
+/* ---------------------------------- head --------------------------------- */
+.bk-tt-head { display: flex; align-items: baseline; gap: 10px; flex-wrap: wrap; }
+.bk-tt-title {
+  margin: 0; font-family: var(--disp); font-size: 17px; letter-spacing: .11em;
+  font-weight: 400; color: var(--bk-tt-gold);
+}
+.bk-tt-sub { font-size: 12px; color: var(--ink-faint); }
+.bk-tt-spacer { flex: 1 1 auto; }
+.bk-tt-back {
+  border: 1px solid color-mix(in srgb, var(--bk-tt-gold), transparent 58%);
+  background: transparent; color: var(--ink-dim); cursor: pointer;
+  border-radius: var(--radius, 8px); padding: 6px 12px;
+  font-family: var(--mono); font-size: 11px; letter-spacing: .1em;
+}
+.bk-tt-back:hover { color: var(--ink); border-color: var(--bk-tt-gold); }
+
+/* The cabinet on the left, the odds sheet on the right. One column the moment
+ * the room is narrower than a laptop, because the sheet is reading matter and
+ * reading matter under the machine beats reading matter squeezed beside it. */
+.bk-tt-stage { display: grid; grid-template-columns: minmax(0, 1fr) 262px; gap: 14px; align-items: start; }
+@media (max-width: 760px) { .bk-tt-stage { grid-template-columns: minmax(0, 1fr); } }
+
+/* -------------------------------- the cabinet ---------------------------- */
+.bk-tt-cab {
+  position: relative;
+  display: flex; flex-direction: column; gap: 10px;
+  padding: 12px; border-radius: var(--radius, 8px);
+  border: 3px solid color-mix(in srgb, var(--bk-tt-neon), black 42%);
+  background: var(--bk-plate, var(--panel, #252542));
+  box-shadow: inset 0 0 34px #000a;
+}
+
+/* THE WINDOW. Three cells tall with the payline in the middle, and the strips
+ * clipped to it: the reel is a column of words the machine drags past a slot,
+ * which is the one bit of a slot machine that has to look right. */
+.bk-tt-window { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 8px; }
+.bk-tt-reel {
+  position: relative; overflow: hidden;
+  height: calc(var(--bk-tt-cell) * 3);
+  border-radius: 6px;
+  border: 1px solid color-mix(in srgb, var(--bk-tt-gold), transparent 68%);
+  background: var(--bk-tt-glass);
+}
+/* The glass: dark at the top and the bottom so the words that are not on the
+ * payline read as being behind something. */
+.bk-tt-reel::before {
+  content: ''; position: absolute; inset: 0; z-index: 2; pointer-events: none;
+  background: linear-gradient(180deg, #000c, transparent 30%, transparent 70%, #000c);
+}
+/* The payline itself, two brass rules across the middle cell. */
+.bk-tt-reel::after {
+  content: ''; position: absolute; z-index: 3; pointer-events: none;
+  left: 0; right: 0; top: var(--bk-tt-cell); height: var(--bk-tt-cell);
+  border-top: 2px solid var(--bk-tt-gold); border-bottom: 2px solid var(--bk-tt-gold);
+  box-shadow: inset 0 0 16px color-mix(in srgb, var(--bk-tt-gold), transparent 66%);
+}
+.bk-tt-strip { will-change: transform; }
+.bk-tt-cell {
+  height: var(--bk-tt-cell); display: flex; align-items: center; justify-content: center;
+  font-family: var(--disp); font-size: 15px; letter-spacing: .08em; text-transform: uppercase;
+  color: var(--ink); text-align: center; padding: 0 4px; overflow: hidden;
+}
+.bk-tt-cell.bk-tt-glyph { color: var(--bk-tt-neon); font-size: 22px; letter-spacing: 0; opacity: .8; }
+
+/* Rolling. It is an OPACITY, not a blur: a `filter` on an element that is
+ * transformed every frame repaints the whole layer every frame, which is the
+ * cost trap 36 is about, and a phone pays it first. Opacity composites for
+ * free and reads the same at speed. Still mode never gets here at all, because
+ * the module does not start the loop and never adds this class. */
+.bk-tt-reel.bk-tt-rolling .bk-tt-strip { opacity: .78; }
+/* The landing nudge. A hair of overshoot so a reel reads as having stopped
+ * rather than as having been switched. */
+.bk-tt-reel.bk-tt-land { animation: bk-tt-land .18s ease-out 1; }
+@keyframes bk-tt-land { 0% { transform: translateY(-3px); } 100% { transform: translateY(0); } }
+/* Still mode's crossfade. An opacity CLASS the module times, never a
+ * transition: the global freeze would flatten a transition and the words would
+ * simply snap, which is the one thing still mode was asking us not to do. */
+.bk-tt-reel.bk-tt-fade .bk-tt-strip { opacity: .22; }
+
+/* A win lights the window. The royal lights it harder and holds it. */
+.bk-tt-window.bk-tt-hit .bk-tt-reel { border-color: var(--bk-tt-gold); }
+.bk-tt-window.bk-tt-royal .bk-tt-reel {
+  border-color: var(--bk-tt-gold);
+  box-shadow: 0 0 26px color-mix(in srgb, var(--bk-tt-gold), transparent 52%);
+}
+
+/* --------------------------------- the holds ----------------------------- */
+.bk-tt-holds { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 8px; }
+.bk-tt-hold-btn {
+  border: 1px solid var(--line, #3a3a5c); background: transparent; color: var(--ink-dim);
+  border-radius: 6px; padding: 6px 4px; cursor: pointer;
+  font-family: var(--mono); font-size: 10px; letter-spacing: .16em; text-transform: uppercase;
+}
+.bk-tt-hold-btn[aria-pressed="true"] {
+  border-color: var(--bk-tt-gold); color: var(--bk-tt-gold);
+  background: color-mix(in srgb, var(--bk-tt-gold), transparent 88%);
+}
+.bk-tt-hold-btn[disabled] { opacity: .4; cursor: default; }
+
+/* --------------------------------- the price ----------------------------- */
+.bk-tt-price { display: flex; gap: 10px; flex-wrap: wrap; align-items: baseline;
+               font-size: 12px; color: var(--ink-dim); }
+.bk-tt-price b { font-family: var(--mono); color: var(--ink); font-variant-numeric: tabular-nums; }
+.bk-tt-note { font-size: 11px; color: var(--ink-faint); }
+
+/* --------------------------------- the lever ----------------------------- */
+.bk-tt-pull {
+  align-self: flex-start;
+  border: 1px solid var(--bk-tt-gold); border-radius: 999px;
+  background: color-mix(in srgb, var(--bk-tt-neon), transparent 82%);
+  color: var(--ink); cursor: pointer; padding: 10px 22px;
+  font-family: var(--disp); font-size: 14px; letter-spacing: .14em; text-transform: uppercase;
+}
+.bk-tt-pull[disabled] { opacity: .45; cursor: default; }
+.bk-tt-pull:focus-visible, .bk-tt-hold-btn:focus-visible, .bk-tt-back:focus-visible {
+  outline: 2px solid var(--bk-tt-gold); outline-offset: 2px;
+}
+
+/* --------------------------------- what she said ------------------------- */
+.bk-tt-say { font-size: 12px; color: var(--ink-dim); min-height: 2.4em; }
+.bk-tt-say.bk-warm { color: var(--gold); }
+.bk-tt-say .bk-dealer { margin-top: 4px; color: var(--bk-neon-2, var(--lav)); }
+/* The scramble line is the machine reading a sentence you have never heard
+ * before, so it gets the display face and a little room around it. */
+.bk-tt-say .bk-tt-read {
+  display: block; margin-top: 5px;
+  font-family: var(--disp); font-size: 15px; letter-spacing: .08em;
+  color: var(--bk-tt-neon);
+}
+
+/* -------------------------------- the odds sheet ------------------------- */
+.bk-tt-odds {
+  padding: 10px 12px; border-radius: var(--radius, 8px);
+  border: 1px solid color-mix(in srgb, var(--bk-tt-gold), transparent 66%);
+  background: color-mix(in srgb, var(--panel, #252542), transparent 22%);
+}
+.bk-tt-odds h4 {
+  margin: 0 0 8px; font-family: var(--disp); font-size: 12px; letter-spacing: .16em;
+  text-transform: uppercase; font-weight: 400; color: var(--bk-tt-gold);
+}
+.bk-tt-odds table { width: 100%; border-collapse: collapse; font-family: var(--mono); font-size: 11px; }
+.bk-tt-odds th, .bk-tt-odds td { padding: 3px 2px; text-align: right; color: var(--ink-dim);
+  /* A price that wraps onto two lines reads as two prices. The sheet is the
+   * one thing in this room that has to be unmistakable, so it never wraps. */
+  white-space: nowrap; }
+.bk-tt-odds th { color: var(--ink-faint); font-weight: 400; letter-spacing: .08em; }
+.bk-tt-odds th:first-child, .bk-tt-odds td:first-child { text-align: left; }
+.bk-tt-odds tbody tr.bk-tt-now td { color: var(--ink); background: color-mix(in srgb, var(--bk-tt-gold), transparent 90%); }
+.bk-tt-odds p { margin: 8px 0 0; font-size: 11px; color: var(--ink-faint); }
+
+/* ----------------------------------------------------------------------------
+ * THE PHONE DIET. Shorter cells, no smear, no glow. The three reels stay three
+ * reels: a slot machine that reflows into a column is not a slot machine.
+ * -------------------------------------------------------------------------- */
+html.arc-mobile .bk-tt, html.ae-lite .bk-tt { --bk-tt-cell: 40px; }
+html.arc-mobile .bk-tt-cell, html.ae-lite .bk-tt-cell { font-size: 12px; letter-spacing: .04em; }
+html.arc-mobile .bk-tt-reel.bk-tt-rolling .bk-tt-strip,
+html.ae-lite .bk-tt-reel.bk-tt-rolling .bk-tt-strip { opacity: 1; }
+html.arc-mobile .bk-tt-window.bk-tt-royal .bk-tt-reel,
+html.ae-lite .bk-tt-window.bk-tt-royal .bk-tt-reel { box-shadow: none; }
+html.arc-mobile .bk-tt-cab, html.ae-lite .bk-tt-cab { box-shadow: none; padding: 9px; }
+html.arc-mobile .bk-tt-sub, html.ae-lite .bk-tt-sub { display: none; }
+
+/* Still mode: the landing nudge is decoration and the freeze already stops it.
+ * Saying so here keeps the frozen state at rest rather than at frame one. */
+html.arc-reduced .bk-tt-reel.bk-tt-land { animation: none; }


### PR DESCRIPTION
## What

The mechanical half of TRIPLE TRIGGER, the Back Room slot machine whose reels are the player's own three word triggers. This part is the reel window and the skin only. The cabinet that drives it is M2b, stacked on this.

**`backroom/triple-reel.js`** (309) exports `createReelWindow(opts)` and `REELS`. It owns the three strips, the roll and the settle, and nothing else.

**`backroom/triple.css`** (202) is the skin, in the backroom palette. No serif.

## Why it is split

M2 as one file was 932 lines. The reel is transform maths and the cabinet is copy and rules, and they were not helping each other read. Splitting on that seam puts this part at 511 changed lines and the cabinet at 592, both under the cap.

## The parts that are load bearing

**The cell height is a custom property.** A reel parks at `translateY(calc(var(--bk-tt-cell) * -n))`, so the module never measures a pixel and the phone diet can shorten the cells (54px to 40px) without a reel missing the payline.

**The roll is a rAF loop and it gates itself.** The global freeze at the bottom of `styles.css` kills animation and transition but cannot reach a rAF (trap 92), so `startRoll` returns before the first frame under reduced motion and the still mode path is an opacity class the module times instead.

**The blank has somewhere to land.** Every strip carries one extra glyph cell past the end of the list, and `posFor()` maps the server's `-1` onto it. The reels are three copies of the list so a roll never runs off the top.

**The landed index is in the DOM.** `land()` writes `dataset.at`, which is how the M2c fixture asserts "the reels settled where the server said" out of a dumped DOM with no instrumentation inside the module.

**A held reel gets no thud.** `land()` skips its sfx if the reel never turned. You paid five chips for it to stay still and it should sound like it stayed still.

**A roll cannot spin forever.** `ROLL_CEILING_MS` is armed before the first frame, and the cabinet's `onCeiling` unlocks the buttons and says so. A machine that has taken your chips and gone quiet is the worst thing this room could do.

**No filter on the smear.** The rolling look is `opacity: .78`, not a blur. A `filter` on a layer that is transformed every frame repaints the whole layer every frame (trap 36) and a phone pays that first.

## Merge note

Stacked on K1 (#807). Nothing imports this yet, so it is inert until M2b lands. Needs server S2 for live play.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5Gp8FA4yHguiNc46u5YDS
