### PR TITLE
feat(spiral): per-day feature usage log synced as stats.feature_day_log

### DIFF
--- a/ConditioningControlPanel/App.xaml.cs
+++ b/ConditioningControlPanel/App.xaml.cs
@@ -474,6 +474,9 @@ namespace ConditioningControlPanel
         private static bool _engineCrashRecovered;
         public static QuestDefinitionService QuestDefinitions { get; private set; } = null!;
         public static QuestService Quests { get; private set; } = null!;
+        /// <summary>Spiral rail: per-day feature use, snapshotted off the lifetime counters
+        /// (see FeatureDayLogService). Null only if its construction failed.</summary>
+        public static FeatureDayLogService? FeatureDayLog { get; private set; }
         /// <summary>Weekly free-tier pass for the Graded Intake (see IntakePassService).</summary>
         public static IntakePassService IntakePass { get; private set; } = null!;
         /// <summary>The ? box's daily free premium feature (see DailyFreeService).</summary>
@@ -1950,6 +1953,10 @@ namespace ConditioningControlPanel
                 // When server definitions change, re-check quests (regenerates if definition was removed)
                 Quests?.CheckAndGenerateQuests();
             };
+            // Spiral rail day log. Needs Achievements and Settings (both up by now); reads them on
+            // a 60 s timer and on sync, never hooks a feature. Its loss must not cost the launch.
+            try { FeatureDayLog = new FeatureDayLogService(); }
+            catch (Exception exDayLog) { Logger?.Warning(exDayLog, "[FeatureDayLog] service construction failed; per-day feature use is not recorded this run"); }
             // Intake onboarding. Both are cheap and synchronous (the pass reads AppSettings; the
             // punch card loads one small json), and both must exist before MainWindow paints the
             // Exclusives gate or the Dashboard tile. Neither may touch App.Notifications from its
@@ -4861,6 +4868,8 @@ Application State:
             try { BouncingText?.Dispose(); } catch (Exception ex) { Logger?.Debug(ex, "BouncingText dispose failed"); }
             try { MindWipe?.Dispose(); } catch (Exception ex) { Logger?.Debug(ex, "MindWipe dispose failed"); }
             try { BrainDrain?.Dispose(); } catch (Exception ex) { Logger?.Debug(ex, "BrainDrain dispose failed"); }
+            // Before the achievement flush: the day log's last tick reads the counters that flush writes.
+            try { FeatureDayLog?.Dispose(); } catch (Exception ex) { Logger?.Debug(ex, "FeatureDayLog flush on shutdown failed"); }
             try { Achievements?.Dispose(); } catch (Exception ex) { Logger?.Error(ex, "Achievement progress flush on shutdown FAILED"); }
             // Before WindowAwareness: its Dispose runs Stop(), which also stops the observer — and the
             // observer's own Stop is what closes the open visit and flushes the ledger to disk.

--- a/ConditioningControlPanel/Models/FeatureDayLog.cs
+++ b/ConditioningControlPanel/Models/FeatureDayLog.cs
@@ -1,0 +1,145 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json;
+using System.Text.Json.Serialization;
+
+namespace ConditioningControlPanel.Models;
+
+/// <summary>
+/// One calendar day of feature use, as whole numbers. <c>D</c> is the same local day key
+/// (yyyy-MM-dd, invariant) <see cref="QuestLogEntry.D"/> uses, so a day here lines up with the
+/// quest log and the streak calendar. The short names are the wire names of
+/// <c>stats.feature_day_log</c> (Spiral rail wire contract 1); both serializer attributes are here
+/// because the local file goes through System.Text.Json and the sync body through Newtonsoft.
+/// </summary>
+public class FeatureDayEntry
+{
+    /// <summary>The 11 counter keys, in contract order. <c>d</c> is not a counter.</summary>
+    public static readonly string[] CounterKeys = { "xp", "cm", "fl", "bb", "pf", "sp", "vd", "lk", "ac", "bc", "ss" };
+
+    [JsonProperty("d")]
+    [JsonPropertyName("d")]
+    public string D { get; set; } = "";
+
+    /// <summary>XP earned.</summary>
+    [JsonProperty("xp")] [JsonPropertyName("xp")] public int Xp { get; set; }
+    /// <summary>Conditioning minutes.</summary>
+    [JsonProperty("cm")] [JsonPropertyName("cm")] public int Cm { get; set; }
+    /// <summary>Flash images shown.</summary>
+    [JsonProperty("fl")] [JsonPropertyName("fl")] public int Fl { get; set; }
+    /// <summary>Bubbles popped.</summary>
+    [JsonProperty("bb")] [JsonPropertyName("bb")] public int Bb { get; set; }
+    /// <summary>Pink filter minutes.</summary>
+    [JsonProperty("pf")] [JsonPropertyName("pf")] public int Pf { get; set; }
+    /// <summary>Spiral minutes.</summary>
+    [JsonProperty("sp")] [JsonPropertyName("sp")] public int Sp { get; set; }
+    /// <summary>Video minutes.</summary>
+    [JsonProperty("vd")] [JsonPropertyName("vd")] public int Vd { get; set; }
+    /// <summary>Lock cards completed.</summary>
+    [JsonProperty("lk")] [JsonPropertyName("lk")] public int Lk { get; set; }
+    /// <summary>Attention checks passed.</summary>
+    [JsonProperty("ac")] [JsonPropertyName("ac")] public int Ac { get; set; }
+    /// <summary>Bubble-count games played.</summary>
+    [JsonProperty("bc")] [JsonPropertyName("bc")] public int Bc { get; set; }
+    /// <summary>Sessions started.</summary>
+    [JsonProperty("ss")] [JsonPropertyName("ss")] public int Ss { get; set; }
+
+    public FeatureDayEntry() { }
+
+    public FeatureDayEntry(string day) { D = day; }
+
+    public int Get(string key) => key switch
+    {
+        "xp" => Xp, "cm" => Cm, "fl" => Fl, "bb" => Bb, "pf" => Pf, "sp" => Sp,
+        "vd" => Vd, "lk" => Lk, "ac" => Ac, "bc" => Bc, "ss" => Ss,
+        _ => 0
+    };
+
+    /// <summary>Add <paramref name="amount"/> (never negative) to one counter.</summary>
+    public void Add(string key, int amount)
+    {
+        if (amount <= 0) return;
+        switch (key)
+        {
+            case "xp": Xp += amount; break;
+            case "cm": Cm += amount; break;
+            case "fl": Fl += amount; break;
+            case "bb": Bb += amount; break;
+            case "pf": Pf += amount; break;
+            case "sp": Sp += amount; break;
+            case "vd": Vd += amount; break;
+            case "lk": Lk += amount; break;
+            case "ac": Ac += amount; break;
+            case "bc": Bc += amount; break;
+            case "ss": Ss += amount; break;
+        }
+    }
+
+    /// <summary>True when every counter is zero: such a day is never put on the wire.</summary>
+    [Newtonsoft.Json.JsonIgnore]
+    [System.Text.Json.Serialization.JsonIgnore]
+    public bool IsEmpty => CounterKeys.All(k => Get(k) <= 0);
+
+    /// <summary>
+    /// The wire shape: <c>d</c> always, then only the counters that are above zero. Zero-valued
+    /// keys are ABSENT, not 0, which is what the server's normaliser expects.
+    /// </summary>
+    public Dictionary<string, object> ToWire()
+    {
+        var wire = new Dictionary<string, object> { ["d"] = D };
+        foreach (var key in CounterKeys)
+        {
+            var v = Get(key);
+            if (v > 0) wire[key] = v;
+        }
+        return wire;
+    }
+}
+
+/// <summary>
+/// Per-day feature usage, kept beside the lifetime counters rather than fed by per-feature hooks.
+/// <see cref="Baseline"/> holds, per counter key, the lifetime value as of the last time the day
+/// log was credited (a running snapshot, so a re-baseline after a cloud merge or a reset never
+/// loses what today had already banked); today's entry grows by the whole units the lifetime
+/// counter moved since then. Persisted to feature_day_log.json, never inside AppSettings, and
+/// pruned to <see cref="MaxDays"/> like the quest log cutoff.
+/// </summary>
+public class FeatureDayLog
+{
+    public const int MaxDays = 400;
+
+    /// <summary>Lifetime counter value per key at the last credit. Missing key = not yet baselined.</summary>
+    [JsonProperty("baseline")]
+    [JsonPropertyName("baseline")]
+    public Dictionary<string, double> Baseline { get; set; } = new();
+
+    [JsonProperty("days")]
+    [JsonPropertyName("days")]
+    public List<FeatureDayEntry> Days { get; set; } = new();
+
+    /// <summary>The entry for <paramref name="dayKey"/>, created on first use.</summary>
+    public FeatureDayEntry GetOrAddDay(string dayKey)
+    {
+        var entry = Days.FirstOrDefault(e => e != null && e.D == dayKey);
+        if (entry == null)
+        {
+            entry = new FeatureDayEntry(dayKey);
+            Days.Add(entry);
+        }
+        return entry;
+    }
+
+    /// <summary>
+    /// Drop days older than <paramref name="cutoffKey"/> (ordinal day-key compare, same as the
+    /// quest log) and anything beyond the newest <see cref="MaxDays"/>.
+    /// </summary>
+    public void Prune(string cutoffKey)
+    {
+        Days.RemoveAll(e => e == null || string.IsNullOrEmpty(e.D) || string.CompareOrdinal(e.D, cutoffKey) < 0);
+        if (Days.Count > MaxDays)
+        {
+            Days = Days.OrderBy(e => e.D, StringComparer.Ordinal).Skip(Days.Count - MaxDays).ToList();
+        }
+    }
+}

--- a/ConditioningControlPanel/Services/Progression/FeatureDayLogService.cs
+++ b/ConditioningControlPanel/Services/Progression/FeatureDayLogService.cs
@@ -1,0 +1,257 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Threading;
+using ConditioningControlPanel.Models;
+
+namespace ConditioningControlPanel.Services;
+
+/// <summary>
+/// Keeps <see cref="FeatureDayLog"/> current (Spiral rail, desktop lane). It never hooks a
+/// feature: every 60 s, at start, and whenever the profile sync asks via <see cref="Flush"/>, it
+/// reads the lifetime counters the app already keeps (AchievementProgress.Total* and the total
+/// conditioning minutes in settings), credits today's entry with the whole units each one moved
+/// since the last credit, and moves the baseline forward. Fractions of a minute stay in the
+/// baseline until they add up to one, so slow counters are never floored away. A counter that
+/// went DOWN (reset, profile restore) re-baselines instead of writing a negative. No network.
+/// </summary>
+public class FeatureDayLogService : IDisposable
+{
+    private readonly string _path;
+    private readonly object _lock = new();
+    private readonly DispatcherTimer _timer;
+    private bool _dirty;
+    private bool _disposed;
+
+    public FeatureDayLog Log { get; private set; }
+
+    public FeatureDayLogService()
+    {
+        _path = Path.Combine(App.UserDataPath, "feature_day_log.json");
+        Log = LoadLog();
+
+        try { Tick(); } catch (Exception ex) { App.Logger?.Debug(ex, "[FeatureDayLog] initial tick failed"); }
+
+        _timer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(60) };
+        _timer.Tick += OnTimerTick;
+        _timer.Start();
+    }
+
+    private void OnTimerTick(object? sender, EventArgs e)
+    {
+        if (Application.Current?.Dispatcher == null || Application.Current.Dispatcher.HasShutdownStarted) return;
+        try
+        {
+            Tick();
+            SaveIfDirtyAsync();
+        }
+        catch (Exception ex)
+        {
+            App.Logger?.Debug(ex, "[FeatureDayLog] tick failed");
+        }
+    }
+
+    /// <summary>The local day key, identical to the quest log's (QuestService.DayKey).</summary>
+    private static string DayKey(DateTime day) =>
+        day.ToString("yyyy-MM-dd", System.Globalization.CultureInfo.InvariantCulture);
+
+    /// <summary>Current lifetime values keyed by wire name. Null when the sources are not up yet.</summary>
+    private static Dictionary<string, double>? ReadCounters()
+    {
+        var p = App.Achievements?.Progress;
+        var settings = App.Settings?.Current;
+        if (p == null || settings == null) return null;
+        return new Dictionary<string, double>
+        {
+            ["xp"] = p.TotalXPEarned,
+            ["cm"] = settings.TotalConditioningMinutes,
+            ["fl"] = p.TotalFlashImages,
+            ["bb"] = p.TotalBubblesPopped,
+            ["pf"] = p.TotalPinkFilterMinutes,
+            ["sp"] = p.TotalSpiralMinutes,
+            ["vd"] = p.TotalVideoMinutes,
+            ["lk"] = p.TotalLockCardsCompleted,
+            ["ac"] = p.TotalAttentionChecksPassed,
+            ["bc"] = p.TotalBubbleCountGames,
+            ["ss"] = p.TotalSessionsStarted,
+        };
+    }
+
+    /// <summary>
+    /// Credit today with whatever the lifetime counters gained since the last credit. Safe from
+    /// any thread; cheap enough for a 60 s timer.
+    /// </summary>
+    public void Tick()
+    {
+        var current = ReadCounters();
+        if (current == null) return;
+
+        lock (_lock)
+        {
+            var today = DateTime.Today;
+            var todayKey = DayKey(today);
+            FeatureDayEntry? entry = null;
+
+            foreach (var key in FeatureDayEntry.CounterKeys)
+            {
+                var now = current[key];
+                if (double.IsNaN(now) || double.IsInfinity(now)) continue;
+
+                if (!Log.Baseline.TryGetValue(key, out var prev) || now < prev)
+                {
+                    // First sight of this counter, or it dropped: start counting from here.
+                    Log.Baseline[key] = now;
+                    _dirty = true;
+                    continue;
+                }
+
+                var whole = (int)Math.Floor(now - prev);
+                if (whole <= 0) continue;
+
+                entry ??= Log.GetOrAddDay(todayKey);
+                entry.Add(key, whole);
+                Log.Baseline[key] = prev + whole;
+                _dirty = true;
+            }
+
+            if (entry != null)
+            {
+                Log.Prune(DayKey(today.AddDays(-FeatureDayLog.MaxDays)));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Move every baseline to the current lifetime value without crediting the difference. For
+    /// the moment a cloud merge lifts the local counters to what another device banked: that
+    /// gain belongs to other days, not to today.
+    /// </summary>
+    public void Rebaseline(string reason)
+    {
+        var current = ReadCounters();
+        if (current == null) return;
+        lock (_lock)
+        {
+            foreach (var key in FeatureDayEntry.CounterKeys)
+            {
+                var now = current[key];
+                if (double.IsNaN(now) || double.IsInfinity(now)) continue;
+                Log.Baseline[key] = now;
+            }
+            _dirty = true;
+        }
+        App.Logger?.Debug("[FeatureDayLog] re-baselined ({Reason})", reason);
+        SaveIfDirtyAsync();
+    }
+
+    /// <summary>Tick and write to disk now. The profile sync calls this before building its body.</summary>
+    public void Flush()
+    {
+        try
+        {
+            Tick();
+            SaveNow();
+        }
+        catch (Exception ex)
+        {
+            App.Logger?.Debug(ex, "[FeatureDayLog] flush failed");
+        }
+    }
+
+    /// <summary>
+    /// Outbound <c>stats.feature_day_log</c>: newest <paramref name="cap"/> non-empty days, each
+    /// with <c>d</c> and only its non-zero counters.
+    /// </summary>
+    public List<Dictionary<string, object>> BuildWirePayload(int cap)
+    {
+        lock (_lock)
+        {
+            return Log.Days
+                .Where(e => e != null && !string.IsNullOrEmpty(e.D) && !e.IsEmpty)
+                .OrderByDescending(e => e.D, StringComparer.Ordinal)
+                .Take(cap)
+                .OrderBy(e => e.D, StringComparer.Ordinal)
+                .Select(e => e.ToWire())
+                .ToList();
+        }
+    }
+
+    #region Persistence
+
+    private FeatureDayLog LoadLog()
+    {
+        try
+        {
+            if (File.Exists(_path))
+            {
+                var json = File.ReadAllText(_path);
+                var log = JsonSerializer.Deserialize<FeatureDayLog>(json);
+                if (log != null)
+                {
+                    log.Baseline ??= new Dictionary<string, double>();
+                    log.Days ??= new List<FeatureDayEntry>();
+                    return log;
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            App.Logger?.Warning(ex, "[FeatureDayLog] feature_day_log.json unreadable, starting a fresh log");
+        }
+        return new FeatureDayLog();
+    }
+
+    private string? SerializeIfDirty()
+    {
+        lock (_lock)
+        {
+            if (!_dirty) return null;
+            _dirty = false;
+            return JsonSerializer.Serialize(Log, new JsonSerializerOptions { WriteIndented = true });
+        }
+    }
+
+    private void WriteFile(string json)
+    {
+        var dir = Path.GetDirectoryName(_path);
+        if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir)) Directory.CreateDirectory(dir);
+        var tmp = _path + ".tmp";
+        File.WriteAllText(tmp, json);
+        File.Move(tmp, _path, overwrite: true);
+    }
+
+    private void SaveIfDirtyAsync()
+    {
+        var json = SerializeIfDirty();
+        if (json == null) return;
+        _ = Task.Run(() =>
+        {
+            try { WriteFile(json); }
+            catch (Exception ex) { App.Logger?.Error(ex, "[FeatureDayLog] save failed"); }
+        });
+    }
+
+    /// <summary>Synchronous save of any pending change (shutdown, sync flush).</summary>
+    public void SaveNow()
+    {
+        var json = SerializeIfDirty();
+        if (json == null) return;
+        try { WriteFile(json); }
+        catch (Exception ex) { App.Logger?.Error(ex, "[FeatureDayLog] save failed"); }
+    }
+
+    #endregion
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        try { _timer.Stop(); } catch { }
+        try { Tick(); } catch { }
+        SaveNow();
+    }
+}

--- a/ConditioningControlPanel/Services/Settings/ProfileSyncService.cs
+++ b/ConditioningControlPanel/Services/Settings/ProfileSyncService.cs
@@ -1424,6 +1424,10 @@ namespace ConditioningControlPanel.Services
                     achievementProgress?.TotalVideoMinutes ?? 0,
                     achievementProgress?.TotalLockCardsCompleted ?? 0);
 
+                // Spiral rail: bank the last few seconds of feature use into today's day-log
+                // entry before either body below reads it (a local write, no network).
+                App.FeatureDayLog?.Flush();
+
                 // Use V2 sync if user has unified_id (new v5.5 system)
                 var unifiedId = App.Settings?.Current?.UnifiedId;
                 if (!string.IsNullOrEmpty(unifiedId))
@@ -1467,6 +1471,9 @@ namespace ConditioningControlPanel.Services
                             // Spiral W1: the same days, but with the quest ids that filled them.
                             // Rides beside the dates and gets the same union merge coming back.
                             ["quest_completion_log"] = BuildQuestCompletionLogPayload(questProgress),
+                            // Spiral rail: which features were used on which day. Server-side
+                            // only; nothing comes back down for it (see BuildFeatureDayLogPayload).
+                            ["feature_day_log"] = BuildFeatureDayLogPayload(),
                             ["total_daily_quests_completed"] = questProgress?.TotalDailyQuestsCompleted ?? 0,
                             ["total_weekly_quests_completed"] = questProgress?.TotalWeeklyQuestsCompleted ?? 0,
                             ["total_xp_from_quests"] = questProgress?.TotalXPFromQuests ?? 0,
@@ -1863,6 +1870,9 @@ namespace ConditioningControlPanel.Services
                                 App.Achievements?.Progress?.SyncCurrentStreak();
                                 App.Settings?.Save();
                                 App.Achievements?.Save();
+                                // Same rule as the legacy path: a lifted lifetime counter is
+                                // another device's history, not today's use.
+                                App.FeatureDayLog?.Rebaseline("v2 cloud merge");
                             }
                         }
 
@@ -2278,6 +2288,7 @@ namespace ConditioningControlPanel.Services
                         ["quest_completion_dates"] = legacyQuestProgress?.DailyQuestCompletionDates?
                             .Select(d => d.ToString("yyyy-MM-dd", System.Globalization.CultureInfo.InvariantCulture)).ToList() ?? new List<string>(),
                         ["quest_completion_log"] = BuildQuestCompletionLogPayload(legacyQuestProgress),
+                        ["feature_day_log"] = BuildFeatureDayLogPayload(),
                         ["total_daily_quests_completed"] = legacyQuestProgress?.TotalDailyQuestsCompleted ?? 0,
                         ["total_weekly_quests_completed"] = legacyQuestProgress?.TotalWeeklyQuestsCompleted ?? 0,
                         ["total_xp_from_quests"] = legacyQuestProgress?.TotalXPFromQuests ?? 0
@@ -3049,6 +3060,9 @@ namespace ConditioningControlPanel.Services
             {
                 App.Settings?.Save();
                 achievements?.Save();
+                // A take-higher merge just lifted lifetime counters to what another device
+                // banked. That gain is not today's: move the day log's baseline past it.
+                App.FeatureDayLog?.Rebaseline("legacy cloud merge");
             }
 
             // Handle force_streak_override for legacy path (profile includes the flag)
@@ -3154,6 +3168,29 @@ namespace ConditioningControlPanel.Services
                 .Reverse()
                 .Select(e => new Dictionary<string, string> { ["d"] = e.D, ["q"] = e.Q })
                 .ToList();
+        }
+
+        /// <summary>Newest days the feature day log may carry over the wire (same cap as the quest log).</summary>
+        private const int FeatureDayLogWireCap = 400;
+
+        /// <summary>
+        /// Spiral rail: the outbound stats.feature_day_log. Each day is <c>d</c> plus only the
+        /// counters above zero; days with nothing in them are left out. Like quest_completion_log
+        /// it is NOT a stat: the server lifts it off the payload before the stats merge, and no
+        /// cloud-to-local path here reads it back (the day log is built from the local lifetime
+        /// counters, so there is nothing to pull down).
+        /// </summary>
+        private static List<Dictionary<string, object>> BuildFeatureDayLogPayload()
+        {
+            try
+            {
+                return App.FeatureDayLog?.BuildWirePayload(FeatureDayLogWireCap) ?? new List<Dictionary<string, object>>();
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Debug(ex, "[FeatureDayLog] wire payload failed, sending none");
+                return new List<Dictionary<string, object>>();
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
## The Spiral rail, desktop lane: per-day feature usage log

Wire contract 1 of the Spiral rail build plan. The server archive knows per banked day the vat fill, the quest tick and (since 6.9) the quest ids, but not which features were used. This PR captures that on the desktop and sends it as `stats.feature_day_log` beside `stats.quest_completion_log`.

**Single PR, 448 changed lines (4 files), no lockfile churn. No version bump.**

### What it adds
- `Models/FeatureDayLog.cs`
  `FeatureDayEntry`: `d` + the 11 int counters with the wire names `xp cm fl bb pf sp vd lk ac bc ss`, Newtonsoft and STJ attributes like `QuestLogEntry`. `FeatureDayLog`: a running baseline of the lifetime counters plus the day list, pruned to 400 days.
- `Services/Progression/FeatureDayLogService.cs`
  No per-feature hooks. On start, every 60 s (DispatcherTimer, dispatcher-null and shutdown guarded) and on `Flush()` it reads `AchievementProgress.Total*` plus `settings.TotalConditioningMinutes`, credits today with the whole units each counter moved since the last credit and moves the baseline forward. Fractions of a minute stay in the baseline until they add up to one, so slow counters are never floored to zero. A counter that drops (reset, restore) re-baselines instead of writing a negative. Persists to `feature_day_log.json` in the user data folder (tmp + move, like quests.json), never in AppSettings. No network of its own.
- `ProfileSyncService`
  `Flush()` before the body is built; `["feature_day_log"]` beside `["quest_completion_log"]` on both the V2 and legacy bodies; cap 400 days; zero counters and empty days omitted (`d` always present). After a take-higher cloud merge lifts the lifetime counters, the log is re-baselined so another device's history is not booked as today. No cloud-to-local path reads it back: the merge code only reads named keys, so the server-side field is ignored on the way down.
- `App.xaml.cs`
  `App.FeatureDayLog` static, constructed right after `QuestService` (Achievements and Settings are up by then, construction failure is caught and logged), disposed (final tick + save) just before the achievement flush in `OnExit`.

### Day key
Local calendar day, `yyyy-MM-dd` invariant, exactly what `QuestService.DayKey` uses for the quest log. Same key convention on the wire.

### Wire shape
```
"feature_day_log": [ { "d": "2026-09-04", "xp": 1082, "cm": 2, "fl": 102 }, ... ]
```
Integers only, zero keys absent, empty days absent, newest 400 days.

### Privacy wording
Grepped `Localization/Languages/*.json` and the XAML/code-behind for "telemetry", "analytics", "no data", "collect" style claims. The desktop carries none that is app-wide; the hits are feature-specific notices (window awareness, bug report, suggestion, webcam) that stay true. No language-file change in this PR. The site privacy policy and the web cookie notice are other lanes.

### Verified
- `dotnet build` in the worktree: 0 errors.
- Launched the worktree build, started the engine via UI Automation for ~2.5 minutes. `feature_day_log.json` appeared with the baseline and an empty `days` list (first sight credits nothing), then today's entry read `fl 102, xp 1082, cm 2` with the baseline moved by exactly those amounts and the minute fraction preserved. The app then went through a normal shutdown and the entry survived the `OnExit` flush.

### Not tested
- The actual sync body on the wire (the server side of this contract is a separate lane; the field is built by the same helper pattern as `quest_completion_log`).
- Day rollover at local midnight, the 400 day prune, the re-baseline after a cloud merge that lifts counters, and the drop-re-baseline. All are straight-line code but were not exercised at runtime.
- `ss`/`bc`/`lk`/`ac`/`pf`/`sp`/`vd` deltas (nothing moved them in the short run).

### Merge order
Standalone. Server ingest (`descent.normalizeFeatureLog`) should be live before a release that carries this so the field is not dropped as an unknown stat, but merging this first is harmless: the server's stats merge already rejects unknown keys.

Worktree: `C:\wt-spiral-desktop` (delete after merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MXhCHtCRSQ3adPLEzS743B
