### PR TITLE
feat(arcademy): Back Room M4b - Prize Wheel

### DIFF
--- a/ConditioningControlPanel/Resources/web/arcademy/backroom/wheel.css
+++ b/ConditioningControlPanel/Resources/web/arcademy/backroom/wheel.css
@@ -1,0 +1,72 @@
+/* ============================================================================
+ * backroom/wheel.css - the cabinet the wheel is bolted into.
+ *
+ * Lazy-linked by wheel.js on first open, exactly like backroom.css. The FACE
+ * itself is already skinned by backroom.css (.bk-wheel, its pin, its fade),
+ * because the face is kit and the kit's skin belongs with the kit. Everything
+ * in here is the furniture around it: the button, the prize card, the table.
+ *
+ * TYPE: --disp for signage, --mono for the odds column, --body for copy.
+ * No serif (house camera law), no font host (trap 2).
+ *
+ * MOTION: nothing in here animates. The only moving thing on this machine is
+ * the face, and loomwheel.js gates its own loops in JS because the CSS freeze
+ * cannot reach one (trap 92). The diet's job here is layout: a 320px wheel and
+ * a 240px column do not sit side by side on a phone, so they stack.
+ * ==========================================================================*/
+
+.bk-pw { display: flex; flex-direction: column; gap: 12px; }
+.bk-pw-head { display: flex; align-items: baseline; gap: 10px; flex-wrap: wrap; }
+.bk-pw-head h3 { margin: 0; font-family: var(--disp); font-size: 15px; letter-spacing: .1em;
+  color: var(--bk-brass, var(--gold)); font-weight: 400; }
+.bk-pw-lede { font-size: 12px; color: var(--ink-faint); flex: 1 1 auto; }
+.bk-pw-stage { display: flex; gap: 20px; align-items: flex-start; flex-wrap: wrap; }
+
+/* ------------------------------------------------------------------ the face */
+/* The wheel wants a lane of its own: the pin overhangs the rim, so a tight box
+   clips the one part of the machine a player has to be able to read. */
+.bk-pw-face { flex: 0 0 auto; padding: 6px 4px 0; }
+
+/* ------------------------------------------------------------------ the side */
+.bk-pw-side { flex: 1 1 260px; display: flex; flex-direction: column; gap: 8px; min-width: 240px; }
+.bk-pw-spin {
+  align-self: flex-start; padding: 13px 26px; border-radius: 999px; cursor: pointer;
+  border: 1px solid var(--bk-brass, var(--gold));
+  background: color-mix(in srgb, var(--gold), transparent 82%); color: var(--gold);
+  font-family: var(--disp); font-size: 14px; letter-spacing: .14em;
+}
+.bk-pw-spin[disabled] { opacity: .45; cursor: default; }
+.bk-pw-spin:focus-visible { outline: 2px solid var(--bk-brass, var(--gold)); outline-offset: 2px; }
+.bk-pw-say { font-size: 13px; color: var(--ink-dim); min-height: 1.3em; }
+.bk-pw-say.bk-warm { color: var(--gold); }
+
+/* THE PRIZE CARD. One sentence, and it is the biggest type on the machine,
+   because it is the only thing on it a player came for. */
+.bk-pw-card { font-family: var(--disp); font-size: 19px; letter-spacing: .04em;
+  color: var(--ink); min-height: 1.2em; line-height: 1.25; }
+.bk-pw-card.bk-warm { color: var(--gold); }
+/* The note is where the prize WENT, including the honest bad news. */
+.bk-pw-note { font-size: 12px; color: var(--ink-dim); min-height: 1.2em; }
+.bk-pw-note.bk-pw-kept { color: var(--bk-neon-2, var(--lav)); }
+
+/* --------------------------------------------------------- the published table */
+.bk-pw-odds {
+  margin-top: 4px; padding: 10px 12px; border-radius: 10px; border: 1px solid var(--line);
+  background: color-mix(in srgb, var(--panel), transparent 30%);
+  font-family: var(--mono); font-size: 11px; color: var(--ink-dim); line-height: 1.75;
+}
+.bk-pw-odds-h { display: block; font-family: var(--disp); font-size: 10px; letter-spacing: .2em;
+  text-transform: uppercase; color: var(--ink-faint); margin-bottom: 4px; }
+.bk-pw-ticks { color: var(--ink-faint); margin-top: 4px; }
+
+/* --------------------------------------------------- the diet and the freeze */
+html.arc-mobile .bk-pw-stage, html.ae-lite .bk-pw-stage { gap: 12px; }
+html.arc-mobile .bk-pw-lede { display: none; }
+html.arc-mobile .bk-pw-face, html.ae-lite .bk-pw-face { padding-top: 2px; }
+/* The side keeps its column rather than being forced under the wheel. A 240px
+   face and a 200px column fit a landscape phone side by side, and a phone held
+   that way is 390 pixels TALL: stacked, the prize card lands below the fold and
+   a player has to scroll to find out what they won. Portrait still wraps. */
+html.arc-mobile .bk-pw-side, html.ae-lite .bk-pw-side { min-width: 0; flex: 1 1 200px; }
+html.arc-mobile .bk-pw-card, html.ae-lite .bk-pw-card { font-size: 17px; }
+html.arc-mobile .bk-pw-odds, html.ae-lite .bk-pw-odds { line-height: 1.55; padding: 8px 10px; }

--- a/ConditioningControlPanel/Resources/web/arcademy/backroom/wheel.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/backroom/wheel.js
@@ -1,0 +1,358 @@
+/* ============================================================================
+ * backroom/wheel.js - THE PRIZE WHEEL, the loudest thing on the floor.
+ *
+ * Five hundred chips buys one spin at seven wedges, two of which are worth
+ * waiting for. The server picks the wedge; this module only travels there.
+ *
+ * THE WIDTHS ARE THE ODDS, AND THAT IS WHY THERE ARE FIFTY SLICES. The face
+ * component draws every slice the same size (kit/loomwheel.js, `TAU /
+ * wedges.length`), so a seven-entry face would show a two-percent wedge and a
+ * thirty-six-percent wedge as identical pie slices. That is a lie a player
+ * cannot even see being told. So the face is handed FIFTY slices instead, one
+ * per two percent, in seven contiguous runs, and only the middle slice of each
+ * run carries a label (buildFace skips an empty one). The arc a wedge occupies
+ * is then exactly its published weight, and the gold rule the face strokes
+ * between slices turns into a countable odds mark: every tick is two spins in
+ * a hundred. INPUT HONESTY costs forty-three extra slices and buys a face a
+ * player can audit at a glance.
+ *
+ * WHERE IT STOPS IS NOT DECIDED HERE. `body.result.wedge` is the server's, and
+ * the only thing this file computes is which slice of that run sits under the
+ * pin. No rng, no near-miss, no nudge.
+ *
+ * NO CHIP ARITHMETIC LIVES HERE (LEDGER TRUTH). `kit.settle` folds the answer's
+ * own balances in once, when the wheel has stopped and the card has been read.
+ * ==========================================================================*/
+
+import { fill } from './lex.js';
+import { createLoomWheel } from './kit/loomwheel.js';
+
+/** Every string this cabinet prints, mirrored key for key into
+ *  `ArcademyHostService.NeutralLexicon`. Under 96 characters each, or a mod
+ *  can never re-voice the row (trap 26). No em-dashes, no raw newlines. */
+export const PW_LEX = Object.freeze({
+  bk_pw_title:     'The Prize Wheel',
+  bk_pw_lede:      'Seven wedges. The widths are the odds, so count the ticks.',
+  bk_pw_spin:      'SPIN {0} chips',                  /* {0} the stake */
+  bk_pw_spinning:  'Spinning.',
+  bk_pw_ready:     'Five hundred chips a spin.',
+  /* the face. short, because a label rides its own spoke */
+  bk_pw_w_250:     '250 chips',
+  bk_pw_w_500:     '500 chips',
+  bk_pw_w_card:    'Scratch card',
+  bk_pw_w_ins:     'Insurance',
+  bk_pw_w_1000:    '1,000 chips',
+  bk_pw_w_late:    'Late Slip',
+  bk_pw_w_visor:   "Dealer's Visor",
+  /* the card the pin caught, one whole sentence each */
+  bk_pw_chips:     '{0} chips.',                      /* {0} the payout */
+  bk_pw_it_card:   'A scratch card.',
+  bk_pw_it_ins:    'An insurance chip.',
+  bk_pw_it_late:   'A late slip.',
+  bk_pw_it_visor:  "A Dealer's Visor.",
+  bk_pw_counter:   'It is waiting at the Prize Counter.',
+  bk_pw_full:      'Your shelf is full, so the house paid {0} instead.',
+  /* the published table */
+  bk_pw_odds:      'the wheel, wedge by wedge',
+  bk_pw_odds_row:  '{0}, {1} spins in 100',           /* {0} wedge {1} weight */
+  bk_pw_ticks:     'every gold tick on the rim is two spins in a hundred.',
+  /* refusals, warm, and every one says that nothing moved */
+  bk_pw_poor:      'Not enough chips for a spin. The cage is just there.',
+  bk_pw_offline:   'The line to the counter is down. Nothing was charged.',
+  bk_pw_busy:      'The wheel is still settling for someone else.',
+  bk_pw_locked:    'The bank does not serve this account yet. Nothing was charged.',
+  bk_pw_refused:   'The house would not take that spin. Nothing moved.',
+});
+
+/** The seven wedges, in the order the server numbers them. `weight` is out of
+ *  one hundred and is the ONLY number here a status frame may overrule: the
+ *  names are copy and copy belongs to the lexicon, but the odds belong to the
+ *  wire. Colours are literals because the face is a canvas and a token cannot
+ *  reach one; they alternate so seven runs read as seven wedges. */
+const WHEEL = Object.freeze([
+  { label: 'bk_pw_w_250',   weight: 36, kind: 'chips', sku: null,           color: '#2b2450' },
+  { label: 'bk_pw_w_500',   weight: 20, kind: 'chips', sku: null,           color: '#3a2a55' },
+  { label: 'bk_pw_w_card',  weight: 18, kind: 'item',  sku: 'bk_scratcher', color: '#243f52' },
+  { label: 'bk_pw_w_ins',   weight: 12, kind: 'item',  sku: 'bk_insurance', color: '#3a2a55' },
+  { label: 'bk_pw_w_1000',  weight: 8,  kind: 'chips', sku: null,           color: '#2b2450' },
+  { label: 'bk_pw_w_late',  weight: 4,  kind: 'item',  sku: 'late_slip',    color: '#4a2f3f' },
+  { label: 'bk_pw_w_visor', weight: 2,  kind: 'item',  sku: 'bk_visor',     color: '#6b4a12' },
+]);
+/** One slice per this many percent. Two is the coarsest number that still
+ *  renders the smallest wedge as a whole slice, and fifty slices is about as
+ *  many as a 320px face can stroke before the rim goes solid gold. */
+const PER_SLICE = 2;
+/** What a sku is called once it is in the player's hands. */
+const ITEM_LINE = Object.freeze({
+  bk_scratcher: 'bk_pw_it_card', bk_insurance: 'bk_pw_it_ins',
+  late_slip: 'bk_pw_it_late', bk_visor: 'bk_pw_it_visor',
+});
+
+function el(tag, cls, text) {
+  const n = document.createElement(tag);
+  if (cls) n.className = cls;
+  if (text != null) n.textContent = String(text);
+  return n;
+}
+
+/** lab.js's lazy sheet, id-guarded so a revisit costs nothing. */
+function ensureSheet(id, rel, log) {
+  try {
+    if (document.getElementById(id)) return;
+    const link = document.createElement('link');
+    link.id = id; link.rel = 'stylesheet';
+    link.href = new URL(rel, import.meta.url).href;
+    document.head.appendChild(link);
+  } catch (e) { log('backroom: sheet failed ' + rel); }
+}
+
+/** The cabinet's own resolver. `kit.t` falls back to BK_LEX and then to the
+ *  KEY, and none of these rows are in BK_LEX, so a bare `kit.t` would paint
+ *  `bk_pw_counter` on the prize card. A host row wins; this table is the floor. */
+function makeT(kit) {
+  const base = (kit && typeof kit.t === 'function') ? kit.t : null;
+  return function pwT(key, args) {
+    let raw = PW_LEX[key] == null ? key : PW_LEX[key];
+    try { const got = base ? base(key) : null; if (got && got !== key) raw = got; }
+    catch (e) { /* a dead lexicon still prints English */ }
+    return args ? fill(raw, args) : raw;
+  };
+}
+
+/** The published weights, server first, the table above when the wire is
+ *  silent or malformed rather than a number nobody can stand behind. Only the
+ *  weights move: a paytable that renamed the wedges would be a paytable
+ *  writing copy, and copy is the lexicon's job. */
+function weights(kit) {
+  let p = null;
+  try { p = (kit.config().paytables || {}).wheel; } catch (e) { p = null; }
+  if (!Array.isArray(p) || p.length !== WHEEL.length) return WHEEL;
+  const rows = WHEEL.map((w, i) => {
+    const row = p[i];
+    const n = Math.round(Number(row && row.weight != null ? row.weight : row) || 0);
+    return n > 0 ? Object.assign({}, w, { weight: n }) : null;
+  });
+  return rows.every(Boolean) ? rows : WHEEL;
+}
+
+/**
+ * The face. Returns the fifty-odd slices AND, for each wedge, the slice that
+ * sits under the pin when that wedge wins: its run's middle, so the wedge is
+ * centred rather than caught by an edge.
+ */
+function buildSlices(rows, t) {
+  const slices = [];
+  const mid = [];
+  for (let i = 0; i < rows.length; i++) {
+    const w = rows[i];
+    const n = Math.max(1, Math.round(w.weight / PER_SLICE));
+    const start = slices.length;
+    mid.push(start + Math.floor((n - 1) / 2));
+    for (let k = 0; k < n; k++) {
+      // Only the middle slice speaks. buildFace skips an empty label, so the
+      // rest of a run is pure width, which is the whole point of them.
+      slices.push({ label: (start + k === mid[i]) ? t(w.label) : '', color: w.color });
+    }
+  }
+  return { slices, mid };
+}
+
+/** Which warm sentence a refusal gets. The server's word is never shown raw. */
+function refusalKey(status, body) {
+  if (status === 403) return 'bk_pw_locked';
+  if (!status) return 'bk_pw_offline';
+  const r = String((body && (body.reason || body.error)) || '');
+  if (r === 'insufficient_chips') return 'bk_pw_poor';
+  return r === 'busy' ? 'bk_pw_busy' : 'bk_pw_refused';
+}
+
+/** The phone diet. `kit.lite` is the ctx flag the shell projects, but the diet
+ *  ITSELF is a class on <html>, and a rig or a web host can arm one without
+ *  the other. Both count. */
+function liteMode(kit) {
+  if (kit && kit.lite) return true;
+  try { return document.documentElement.classList.contains('ae-lite'); }
+  catch (e) { return false; }
+}
+
+let live = null;   // the one mounted cabinet, for the module-level unmount()
+
+/**
+ * mount(root, kit, ctx) -> { unmount }
+ *
+ * Everything hangs off `root` and comes down with it. Nothing here binds a key:
+ * the shell owns the Esc ladder and the floor's `escapeStep` folds this cabinet
+ * away, which is how leaving mid-spin stays legal (Law VI).
+ */
+export function mount(root, kit, ctx) {
+  const t = makeT(kit);
+  const log = (typeof kit.log === 'function') ? kit.log : () => {};
+  const sfx = (typeof kit.sfx === 'function') ? kit.sfx : () => {};
+  const reduced = !!kit.reduced;
+  const lite = liteMode(kit);
+  ensureSheet('arc-bk-wheel-css', './wheel.css', log);
+
+  let dead = false;
+  let busy = false;
+  let pending = null;    // the answer body waiting to be banked
+
+  const rows = weights(kit);
+  const face = buildSlices(rows, t);
+
+  /* ------------------------------------------------------------ the cabinet */
+  const wrap = el('div', 'bk-pw');
+  // The wheel's own reflection of its face and its last landing. The odds copy
+  // reads the first, the probe reads both, and neither is a number this file
+  // decided: the slices come off the published weights and the wedge off the
+  // server.
+  wrap.dataset.slices = String(face.slices.length);
+  const head = el('div', 'bk-pw-head');
+  head.appendChild(el('h3', null, t('bk_pw_title')));
+  head.appendChild(el('span', 'bk-pw-lede', t('bk_pw_lede')));
+  const back = el('button', 'btn', kit.t('bk_back'));
+  back.type = 'button';
+  back.addEventListener('click', () => { try { kit.toFloor(); } catch (e) { /* noop */ } });
+  head.appendChild(back);
+  const stage = el('div', 'bk-pw-stage');
+  wrap.appendChild(head);
+  wrap.appendChild(stage);
+
+  const host = el('div', 'bk-pw-face');
+  stage.appendChild(host);
+
+  /* THE SIDE: the button, the receipt, the dealer, the published table. */
+  const side = el('div', 'bk-pw-side');
+  const spin = el('button', 'bk-pw-spin');
+  spin.type = 'button';
+  const say = el('div', 'bk-pw-say', t('bk_pw_ready'));
+  say.setAttribute('role', 'status');
+  const card = el('div', 'bk-pw-card');
+  const note = el('div', 'bk-pw-note');
+  const dealer = el('div', 'bk-dealer');
+  const odds = el('div', 'bk-pw-odds');
+  odds.appendChild(el('span', 'bk-pw-odds-h', t('bk_pw_odds')));
+  for (const w of rows) {
+    odds.appendChild(el('div', 'bk-pw-odds-row', t('bk_pw_odds_row', [t(w.label), String(w.weight)])));
+  }
+  odds.appendChild(el('div', 'bk-pw-ticks', t('bk_pw_ticks')));
+  side.appendChild(spin);
+  side.appendChild(say);
+  side.appendChild(card);
+  side.appendChild(note);
+  side.appendChild(dealer);
+  side.appendChild(odds);
+  stage.appendChild(side);
+  root.appendChild(wrap);
+
+  let wheel = null;
+  try {
+    wheel = createLoomWheel({
+      host, wedges: face.slices, seed: 'backroom-prize-wheel',
+      size: lite ? 240 : 320, reduced, lite, sfx, log,
+    });
+  } catch (e) { log('backroom: wheel face would not build'); }
+
+  function stake() {
+    const v = Number((kit.config().stakes || {}).wheel);
+    return v > 0 ? Math.round(v) : 500;
+  }
+
+  /** The one place the button's face is decided, so it can never disagree with
+   *  what a press is about to cost. */
+  function paintSpin() {
+    spin.disabled = busy || dead;
+    spin.textContent = busy ? t('bk_pw_spinning') : t('bk_pw_spin', [kit.fmtChips(stake())]);
+  }
+
+  /**
+   * The wheel has stopped, so NOW the receipt lands. The stake and the prize
+   * arrived on one server frame, so they are shown on one beat rather than
+   * faked as two events the server never sent.
+   */
+  function reveal(res, body) {
+    if (dead) return;
+    pending = null;
+    const paid = Math.max(0, Math.round(Number(res.amount) || 0));
+    const sku = res.sku ? String(res.sku) : '';
+    const line = ITEM_LINE[sku];
+    // A sku that paid CHIPS is the full-shelf case: the pin really did catch
+    // the item, the stack was already at its ceiling, and the house bought it
+    // back. It is named as what it was rather than quietly redrawn as a chip
+    // wedge, because a player who saw the visor go by is owed the sentence.
+    const spilled = !!sku && res.kind !== 'item';
+    say.textContent = '';
+    if (line) {
+      card.textContent = t(line);
+      note.textContent = spilled ? t('bk_pw_full', [kit.fmtChips(paid)]) : t('bk_pw_counter');
+      note.classList.toggle('bk-pw-kept', !spilled);
+    } else {
+      card.textContent = t('bk_pw_chips', [kit.fmtChips(paid)]);
+      note.textContent = '';
+    }
+    card.classList.add('bk-warm');
+    sfx('chime', 0.34);
+    dealer.textContent = kit.voice.line((sku === 'bk_visor' || paid >= 1000) ? 'big' : 'win');
+    try { kit.settle(body, paid > 0 ? host : null); }
+    catch (e) { log('backroom: wheel settle threw'); }
+    busy = false;
+    paintSpin();
+  }
+
+  /* --------------------------------------------------------------- the spin */
+  function press() {
+    if (dead || busy) return;
+    busy = true;
+    say.textContent = t('bk_pw_spinning');
+    say.classList.remove('bk-warm');
+    card.textContent = '';
+    card.classList.remove('bk-warm');
+    note.textContent = '';
+    note.classList.remove('bk-pw-kept');
+    dealer.textContent = kit.voice.line('deal');
+    paintSpin();
+    sfx('blip', 0.28);
+    kit.api.play('wheel', stake(), {}).then((r) => {
+      if (dead) return;
+      const res = (r.ok && r.body && r.body.result) || null;
+      if (!res || res.wedge == null) {
+        say.textContent = t(refusalKey(r.status, r.body));
+        say.classList.add('bk-warm');
+        dealer.textContent = '';
+        busy = false;
+        paintSpin();
+        return;
+      }
+      pending = r.body;
+      const i = Math.max(0, Math.min(rows.length - 1, Math.round(Number(res.wedge) || 0)));
+      wrap.dataset.wedge = String(i);
+      if (!wheel) { reveal(res, r.body); return; }   // a faceless wheel still pays
+      wheel.spinTo(face.mid[i], 3200).then(() => reveal(res, r.body));
+    });
+  }
+  spin.addEventListener('click', press);
+  paintSpin();
+
+  /**
+   * Down mid-spin is a legal way to leave, and the chips moved on the server
+   * already: an unrevealed spin still banks its answer on the way out, or the
+   * header would go on painting a balance the ledger has walked past.
+   */
+  function unmount() {
+    if (dead) return;
+    dead = true;
+    if (live && live.unmount === unmount) live = null;
+    const body = pending;
+    pending = null;
+    try { if (wheel) wheel.destroy(); } catch (e) { /* noop */ }
+    try { if (body) kit.settle(body, null); } catch (e) { /* noop */ }
+    try { wrap.remove(); } catch (e) { /* noop */ }
+  }
+
+  live = { unmount };
+  return live;
+}
+
+/** The floor calls this after the instance's own, and a second call is free. */
+export function unmount() { if (live) live.unmount(); }
+
+export default { key: 'wheel', title: PW_LEX.bk_pw_title, mount, unmount, PW_LEX };


### PR DESCRIPTION
Machine 5 of the Back Room: the loudest thing on the floor. Five hundred chips
buys one spin at seven wedges, two of them worth waiting for.

**Merge order: K1 (#807), then M4a (#811), then this PR, then M4c (the
fixture).** Needs server S2 for live play.

## What is in it

| File | lines | |
|---|---|---|
| `backroom/wheel.js` | 358 | the cabinet: `{ key, title, mount, unmount }` |
| `backroom/wheel.css` | 72 | the furniture around the face |

**430 lines, 2 files.** The bench that drives both machines is its own PR (M4c,
last in the stack) so that neither machine PR carries a harness.

The FACE has no skin in here on purpose. `.bk-wheel`, its pin and its fade are
already in `backroom.css` because the face is kit and the kit's skin belongs
with the kit; `wheel.css` is only the button, the prize card and the table.

## The wedge layout, and why there are fifty slices

`kit/loomwheel.js` draws every slice the same size (`const span = TAU /
wedges.length`). Hand it the seven wedges and a two-percent wedge and a
thirty-six-percent wedge come out as identical pie slices, which is a lie a
player cannot even see being told. So the face is handed **fifty slices**, one
per two percent, in seven contiguous runs, and **only the middle slice of a run
carries a label** (`buildFace` skips an empty one). Every wedge's arc is then
exactly its published weight, and the gold rule the face strokes between slices
becomes a countable odds mark: **one tick is two spins in a hundred**. INPUT
HONESTY costs forty-three extra slices and buys a face a player can audit at a
glance.

| wedge | face label | weight /100 | slices | pin lands on slice | kind | sku |
|---|---|---|---|---|---|---|
| 0 | 250 chips | 36 | 0-17 | 8 | chips | |
| 1 | 500 chips | 20 | 18-27 | 22 | chips | |
| 2 | Scratch card | 18 | 28-36 | 32 | item | `bk_scratcher` |
| 3 | Insurance | 12 | 37-42 | 39 | item | `bk_insurance` |
| 4 | 1,000 chips | 8 | 43-46 | 44 | chips | |
| 5 | Late Slip | 4 | 47-48 | 47 | item | `late_slip` |
| 6 | Dealer's Visor | 2 | 49 | 49 | item | `bk_visor` |

Fifty slices, sum 100. `spinTo` is given the run's MIDDLE slice so the wedge
sits centred under the pin rather than caught by an edge. Where it stops is not
decided here: `result.wedge` is the server's, and the only thing this file
computes is which slice of that run to travel to. No rng, no near-miss, no
nudge.

## Why it is built this way

**The card lands after the wheel stops, and only once.** The stake and the prize
arrive on one server frame, so they are shown on one beat rather than faked as
two events the server never sent. `kit.settle` folds the answer's own balances
in at that moment (LEDGER TRUTH); no chip arithmetic lives in this module.

**The full-shelf case is named, not hidden.** When a stack is already at its
ceiling the server grants nothing and buys the wedge back at 250. It would be
easy to render that as a plain chip wedge, and it would be a small lie: the
player watched the Visor go by. So the sku rides along on a `kind:'chips'`
answer, and the card still reads "A Dealer's Visor." with the note "Your shelf
is full, so the house paid 250 instead."

**Reduced motion and the diet are handled by the face, and the layout by the
sheet.** `loomwheel.js` already gates its own loops in JS (the CSS freeze cannot
reach one, trap 92): still mode crossfades to the answer instead of travelling,
and the hub stops turning under the diet. What this PR adds is the phone
LAYOUT - the side column keeps its column instead of being forced under the
wheel, because a landscape phone is 390 pixels tall and a stacked prize card
lands below the fold. A player should never have to scroll to find out what
they won. Portrait still wraps.

**Leaving mid-spin banks the spin.** Law VI: no key is bound here, the floor's
`escapeStep()` folds the cabinet, and `unmount()` destroys the face and settles
an unrevealed answer on the way out.

**Odds come off the wire.** `kit.config().paytables.wheel` overrules the
weights, and ONLY the weights: a paytable that renamed the wedges would be a
paytable writing copy, and copy is the lexicon's job. The table in the module
is the floor for a status frame that has not arrived.

## Answer fields consumed

`play('wheel', stake, {})` where `stake` is `config.stakes.wheel`, floor 500.

- `body.result.wedge` - `0..6`, the row above. Clamped, then reflected on the
  root as `data-wedge`.
- `body.result.kind` - `'chips'` or `'item'`.
- `body.result.amount` - the payout, `null` on an item wedge that granted.
- `body.result.sku` - the granted sku; **a sku present on a `kind:'chips'`
  answer is the full-shelf case** and is what flips the note.
- `body.chips` / `earnedC` / `pot` ride through `kit.settle(body, host)`.

Refusals: `insufficient_chips`, `busy`, anything else, `403` and transport
failure all map to a warm line that says nothing moved. No reason string is
ever shown raw.

## Lexicon keys (paste-ready)

```csharp
        // backroom/wheel.js - THE PRIZE WHEEL
        ["bk_pw_title"] = "The Prize Wheel",
        ["bk_pw_lede"] = "Seven wedges. The widths are the odds, so count the ticks.",
        ["bk_pw_spin"] = "SPIN {0} chips",
        ["bk_pw_spinning"] = "Spinning.",
        ["bk_pw_ready"] = "Five hundred chips a spin.",
        ["bk_pw_w_250"] = "250 chips",
        ["bk_pw_w_500"] = "500 chips",
        ["bk_pw_w_card"] = "Scratch card",
        ["bk_pw_w_ins"] = "Insurance",
        ["bk_pw_w_1000"] = "1,000 chips",
        ["bk_pw_w_late"] = "Late Slip",
        ["bk_pw_w_visor"] = "Dealer's Visor",
        ["bk_pw_chips"] = "{0} chips.",
        ["bk_pw_it_card"] = "A scratch card.",
        ["bk_pw_it_ins"] = "An insurance chip.",
        ["bk_pw_it_late"] = "A late slip.",
        ["bk_pw_it_visor"] = "A Dealer's Visor.",
        ["bk_pw_counter"] = "It is waiting at the Prize Counter.",
        ["bk_pw_full"] = "Your shelf is full, so the house paid {0} instead.",
        ["bk_pw_odds"] = "the wheel, wedge by wedge",
        ["bk_pw_odds_row"] = "{0}, {1} spins in 100",
        ["bk_pw_ticks"] = "every gold tick on the rim is two spins in a hundred.",
        ["bk_pw_poor"] = "Not enough chips for a spin. The cage is just there.",
        ["bk_pw_offline"] = "The line to the counter is down. Nothing was charged.",
        ["bk_pw_busy"] = "The wheel is still settling for someone else.",
        ["bk_pw_locked"] = "The bank does not serve this account yet. Nothing was charged.",
        ["bk_pw_refused"] = "The house would not take that spin. Nothing moved.",
```

Every row is under 96 characters so `MergeModTable` can re-voice it (trap 26).
The face labels are lexicon rows too, so a mod re-voices what is painted on the
wheel and not just what is printed beside it. As in M4a the module carries its
own resolver, because `kit.t` falls back to BK_LEX and then to the raw KEY and
none of these rows are in BK_LEX.

## Checks

The suite lives in M4c and needs all three PRs under it. Run against the M4c
tip, `bk-m4/run-checks.sh` drives `backroom/demo-machine.html` headless and
reads the dumped DOM: **43 of 43 pass, 20 of them this machine's.**

```
PASS pw: the frame opens                  PASS pw: consumables land too
PASS pw: a spin stakes 500                PASS pw: still mode still lands
PASS pw: it plays the wheel               PASS pw: lite still lands
PASS pw: seven wedges, honest widths      PASS pw: the stake is on the button
PASS pw: it lands where told              PASS pw: no chips refuses warmly
PASS pw: a chip wedge banks               PASS pw: offline refuses warmly
PASS pw: a chip wedge names the chips     PASS pw: the tier gate is standard
PASS pw: an item wedge names the item     PASS pw: leaving mid spin is legal
PASS pw: an item says where it went       PASS pw: leaving still banks the spin
PASS pw: a full shelf says so honestly    PASS pw: the odds table is published
```

"honest widths" asserts `PW slices=50` off the root's own `data-slices`, so the
proportional face is a pinned property rather than a claim in a comment. The
bench opens the cabinet by CLICKING ITS FRAME on the real floor, so what is
under test is index.js's own kit and mount contract.

## Shots

On the build machine at `C:\Users\PC\AppData\Local\Temp\claude\bk-m4-shots\`,
because a PR body cannot carry an image from a CLI and neither belongs in the
repo.

| File | What it shows |
|---|---|
| `wheel-desktop-1600x900.png` | wedge 6: the pin on the single Visor slice, the card, "It is waiting at the Prize Counter.", the seven-row table. The 36-weight run and the 2-weight run are visibly 36 and 2. |
| `wheel-phone-844x390.png` | wedge 4 at 844x390 with the diet on: 240px face, the side kept beside it, "1,000 CHIPS." and the dealer above the fold |

Reproduce: serve `Resources/web/arcademy/` statically, then
`backroom/demo-machine.html?m=wheel&auto=full` plus any of `&wedge=0..6
&fallback=1 &poor=1 &tier=1 &dark=1 &reduced=1 &lite=1 &bare=1`.

## Notes for the reviewer

- Two data attributes on the root, `data-slices` and `data-wedge`. Neither is a
  number this file decided: the slices come off the published weights and the
  wedge off the server, so they are the wheel's own reflection of its face and
  its last landing rather than a test hook.
- The odds table prints seven rows even though the face has fifty slices,
  because seven is what a player is choosing between. The slice count is in the
  ticks line instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5Gp8FA4yHguiNc46u5YDS
