### PR TITLE
ios: arcademy store-safe pool + sort copy

### DIFF
--- a/ConditioningControlPanel/Resources/web/arcademy/boot.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/boot.js
@@ -805,6 +805,12 @@ bridge.on('init', guard('init', (m) => {
     return;
   }
   initMsg = m;
+  /* THE STORE-BUILD FLAG, copied onto the window before anything downstream is
+   * imported. `core/storesafe.js` is the reader and games/* are the callers; a
+   * host that never sets the field (the desktop, the web build, Android) leaves
+   * this undefined, which reads as false, which is the full school. */
+  try { window.__ccpStoreSafe = !!(m.platform && m.platform.storeSafe); }
+  catch (e) { /* noop - a page with no window is a page with no games */ }
   directGame = directLaunchKey(m);
   dressDirectLaunch();            // THE DIRECT LAUNCH: name the room on the splash
   bridge.markInitialized();       // flush anything the page queued pre-init

--- a/ConditioningControlPanel/Resources/web/arcademy/core/lexicon.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/core/lexicon.js
@@ -914,6 +914,9 @@ export const DEFAULT_LEXICON = Object.freeze({
   dt_cat_arcade: 'hometown',
   dt_cat_school: 'classroom',
   dt_cat_melt: 'melty',
+  // The store build's own band (words-answers.store.js). Never drawn on any
+  // other host, and harmless where it is not: an unused row costs nothing.
+  dt_cat_focus: 'fresh air',
   dt_cat_common: 'civilian',
 });
 

--- a/ConditioningControlPanel/Resources/web/arcademy/core/storesafe.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/core/storesafe.js
@@ -1,0 +1,47 @@
+/* ============================================================================
+ * core/storesafe.js - IS THIS PAGE RUNNING INSIDE A STORE BUILD?
+ *
+ * One question, one door, one answer for the whole page. The iOS App Store
+ * build of the mobile app is the same vendored tree as every other host, and it
+ * cannot be a different tree: one zip ships to Android and to iOS, so a
+ * build-time swap of a file is not available to us and the difference has to be
+ * a flag the page reads at runtime.
+ *
+ * WHO SETS IT. The HOST, in `init.platform.storeSafe`, and boot.js copies it
+ * onto `window.__ccpStoreSafe` the moment init lands. A host that predates the
+ * field sets nothing, which reads as false, which is the full Arcademy - so the
+ * WebView2 desktop, the web build and the Android app are all untouched by
+ * every branch that hangs off this.
+ *
+ * WHY A GLOBAL AND NOT A PARAMETER. The two callers are a game's word bank and
+ * a game's lexicon table, both of them module-scope data built at import time,
+ * three and four hops below the shell that holds `init`. Threading a boolean
+ * down that chain would mean changing the ctx contract for every game to answer
+ * a question about the building rather than about the class. The global is set
+ * once, before any game module is imported (games load lazily, on the way into
+ * a class, long after the handshake), and nothing ever writes it twice.
+ *
+ * WHAT IT IS NOT. It is not a content rating, not a tier, and not a mod. It
+ * says one thing: this page is inside a build that went through an app store
+ * review, so the adult word bands and the copy that names outside communities
+ * stay out of sight. Everything else about the school is identical.
+ * ==========================================================================*/
+
+/**
+ * True only when the host declared a store build.
+ *
+ * Read at CALL time rather than captured at import time, so a module that is
+ * imported unusually early (a test harness, a direct-launch path) still sees
+ * the answer once the handshake has set it.
+ *
+ * @returns {boolean}
+ */
+export function isStoreSafe() {
+  try {
+    return typeof window !== 'undefined' && window.__ccpStoreSafe === true;
+  } catch (e) {
+    return false;
+  }
+}
+
+export default { isStoreSafe };

--- a/ConditioningControlPanel/Resources/web/arcademy/games/daily-trigger/bank.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/daily-trigger/bank.js
@@ -18,8 +18,34 @@
  * ==========================================================================*/
 
 import { hash01, makeRng, shuffled } from '../../core/rng.js';
+import { isStoreSafe } from '../../core/storesafe.js';
 import { THEME, THEME_GROUPS, COMMON, PHRASES } from './words-answers.js';
+import {
+  THEME as STORE_THEME, THEME_GROUPS_STORE, COMMON as STORE_COMMON,
+  PHRASES as STORE_PHRASES,
+} from './words-answers.store.js';
 import { ACCEPT } from './words-accept.js';
+
+/**
+ * WHICH POOL THIS BUILD DRAWS FROM.
+ *
+ * One line, and the only thing in this file that is not a pure function of the
+ * date. An app-store build draws the narrower pool (words-answers.store.js: the
+ * five niche-neutral bands plus a calm band, 433 words); every other host draws
+ * the pool it always has. `isStoreSafe()` is a host declaration, so this is
+ * still the same for everybody who is inside the same build, which is what the
+ * global-ritual rule actually asks for: the day's word is identical for every
+ * player the same page is being served to.
+ *
+ * Read through a function rather than captured at import time because this
+ * module is imported the moment the Daily Trigger class loads, and both this
+ * and `catIndex()` memoise their first answer anyway.
+ */
+function pool() {
+  return isStoreSafe()
+    ? { theme: STORE_THEME, groups: THEME_GROUPS_STORE, common: STORE_COMMON, phrases: STORE_PHRASES }
+    : { theme: THEME, groups: THEME_GROUPS, common: COMMON, phrases: PHRASES };
+}
 
 /**
  * The puzzle-number epoch. Shared with core/timetable.js on purpose (same day 0
@@ -67,14 +93,15 @@ let cached = null;
  */
 export function bank() {
   if (cached) return cached;
-  const theme = fiveOnly(toks(THEME));
-  const common = fiveOnly(toks(COMMON));
+  const src = pool();
+  const theme = fiveOnly(toks(src.theme));
+  const common = fiveOnly(toks(src.common));
   const answers = fiveOnly(theme.concat(common));
   const accept = new Set(fiveOnly(toks(ACCEPT)));
   // Every possible answer must be guessable even if the acceptance list forgot it.
   for (const w of answers) accept.add(w);
   const phrases = [];
-  for (const p of (Array.isArray(PHRASES) ? PHRASES : [])) {
+  for (const p of (Array.isArray(src.phrases) ? src.phrases : [])) {
     if (!Array.isArray(p) || p.length < 2) continue;
     const groups = p.map((g) => String(g || '').toLowerCase()).filter((g) => ALPHA.test(g));
     if (groups.length < 2) continue;
@@ -105,7 +132,7 @@ let catCache = null;
 function catIndex() {
   if (catCache) return catCache;
   const map = Object.create(null);
-  const groups = Array.isArray(THEME_GROUPS) ? THEME_GROUPS : [];
+  const groups = Array.isArray(pool().groups) ? pool().groups : [];
   for (const g of groups) {
     const key = g && typeof g.cat === 'string' ? g.cat : '';
     if (!key) continue;

--- a/ConditioningControlPanel/Resources/web/arcademy/games/daily-trigger/index.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/daily-trigger/index.js
@@ -883,7 +883,7 @@ export default {
     const DT_CAT_FALLBACK = Object.freeze({
       trance: 'spirally', training: 'training arc', submission: "yes ma'am",
       denial: 'not yet', bimbo: 'glittery', arcade: 'hometown',
-      school: 'classroom', melt: 'melty', common: 'civilian',
+      school: 'classroom', melt: 'melty', focus: 'fresh air', common: 'civilian',
     });
 
     /** Letters nailed in place so far. Two is a player closing in, not a player

--- a/ConditioningControlPanel/Resources/web/arcademy/games/daily-trigger/words-answers.store.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/daily-trigger/words-answers.store.js
@@ -1,0 +1,102 @@
+/* ============================================================================
+ * games/daily-trigger/words-answers.store.js - THE ANSWER POOL, store edition.
+ *
+ * The same shape as words-answers.js (THEME / COMMON / PHRASES), drawn on by
+ * `bank.js` instead of that file when the host says this is an app-store build.
+ * Nothing here replaces the real pool: both files ship in every tree, the flag
+ * picks one, and off the flag the day's word is exactly the word it has always
+ * been on every host.
+ *
+ * WHY IT EXISTS. The owner's 2026-08-25 ruling stands and is not softened here:
+ * the answers are niche only, because a random English word is not what this
+ * app is about. A store build is simply a narrower version of the same idea. It
+ * keeps the bands that read as hypnosis, training and the school itself, drops
+ * the three that read as pornography, and grows one new band of ordinary calm
+ * so the pool stays big enough to be a pool.
+ *
+ * THE FIVE KEPT BANDS ARE NOT COPIED, THEY ARE DERIVED. `STORE_CATS` names them
+ * and the words come straight out of `THEME_GROUPS`, so the two pools can never
+ * drift into disagreeing about what a 'trance' word is. That cuts both ways and
+ * is worth knowing before you edit the other file: ANYTHING ADDED TO trance,
+ * training, arcade, school OR melt LANDS IN THE STORE BUILD TOO. Put a word
+ * that would not survive a review in one of those bands and it ships. The three
+ * dropped bands (submission, denial, bimbo) are the ones with the latitude.
+ *
+ * SIZE IS LOAD-BEARING, the same way it is next door: bank.js walks one shuffled
+ * pass of the whole pool before any word repeats, so the pool length IS the
+ * repeat-free horizon in days. The five kept bands are 272 words and COMMON is
+ * 46, which is under the ~400 floor on its own; the `focus` band below carries
+ * 115 more and lands the union at 433, so no word comes round inside a year.
+ * Shrink the focus band and you shorten that horizon.
+ * ==========================================================================*/
+
+import { THEME_GROUPS, COMMON as BASE_COMMON } from './words-answers.js';
+
+/**
+ * Which of the eight bands survive. Names, not indexes, because `cat` is a
+ * stable key (it is the `dt_cat_<cat>` lexicon row EMI speaks when she names the
+ * band for a stuck player) and the order of the groups is free to change.
+ *
+ * The three that are absent are absent on purpose: 'submission', 'denial' and
+ * 'bimbo'. Adding one back is a content decision, not a tidy-up.
+ */
+export const STORE_CATS = Object.freeze(['trance', 'training', 'arcade', 'school', 'melt']);
+
+/**
+ * The new band, and the only words in this file that are not next door.
+ *
+ * Ordinary calm: attention, weather, growing things, small comforts, a school
+ * day's furniture and a little music. Nothing here is a trigger word and
+ * nothing here is a euphemism, which is the whole brief. None of the 115
+ * collides with any of the eight existing bands, so every one of them is a word
+ * the pool did not already have.
+ */
+export const FOCUS_WORDS = `
+  alert aware acute clear crisp brisk lucid sober plain think recap tally recur
+  peace relax calms comfy cushy downy couch quilt duvet sheet linen towel robes
+  socks shawl scarf hands palms wrist ankle thumb lungs yawns snore
+  beach shore sands dunes hills vales woods trees ferns grass field river brook
+  creek lakes ponds marsh reeds mossy pines cedar birch maple aspen elder olive
+  lemon melon plums pears grape toast bread scone juice water
+  robin finch doves swans geese otter sheep lambs birds herds
+  piano chord hymns lyric organ flute cello harps
+  draft index shelf plans query facts logic proof chart graph
+  sunny rainy windy balmy chill frost snows gusts storm
+  hours weeks month today dates
+`;
+
+/**
+ * The store pool's bands, in the same `{cat, words}` shape `categoryOf()` reads,
+ * so a stuck-hint names a band in a store build exactly as it does anywhere
+ * else. The focus band rides last and carries its own `cat`, which needs a
+ * `dt_cat_focus` lexicon row; without one the hint falls back to the plain
+ * wording, which is the same graceful shape every other band already has.
+ */
+export const THEME_GROUPS_STORE = Object.freeze(
+  THEME_GROUPS.filter((g) => g && STORE_CATS.indexOf(g.cat) >= 0)
+    .concat([Object.freeze({ cat: 'focus', words: FOCUS_WORDS })]),
+);
+
+/** The flat pool, same contract as `THEME`: one space-joined string. */
+export const THEME = THEME_GROUPS_STORE.map((g) => g.words).join(' ');
+
+/** Unchanged. The campus / sweet shop / arcade band was already ordinary English. */
+export const COMMON = BASE_COMMON;
+
+/**
+ * Phrase days, minus the three that read as something else out of context
+ * ('good girl', 'good toy', 'open wide'). The remaining twenty five keep the
+ * same shape: two groups, a free gap, ten letters or fewer, famous enough to
+ * land as a gift rather than as a wall.
+ */
+export const PHRASES = Object.freeze([
+  ['dont', 'think'], ['sink', 'deep'], ['drop', 'down'], ['pink', 'mist'],
+  ['empty', 'head'], ['soft', 'focus'], ['deep', 'sleep'], ['blank', 'slate'],
+  ['stay', 'down'], ['melt', 'away'], ['drift', 'off'], ['thank', 'you'],
+  ['slow', 'blink'], ['heavy', 'eyes'], ['let', 'go'], ['count', 'down'],
+  ['press', 'play'], ['high', 'score'], ['game', 'over'], ['bonus', 'round'],
+  ['free', 'play'], ['quiet', 'mind'], ['sweet', 'spot'], ['keep', 'still'],
+  ['one', 'more'],
+]);
+
+export default { THEME, THEME_GROUPS: THEME_GROUPS_STORE, COMMON, PHRASES, STORE_CATS };

--- a/ConditioningControlPanel/Resources/web/arcademy/games/sort/setup-lex.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/sort/setup-lex.js
@@ -11,6 +11,8 @@
  *   - the eight noise starter subs (cats, aww, pokemon, ...) are DATA, not
  *     lexicon: they are subreddit names, and a mod re-voicing them would ask
  *     the host for a subreddit that does not exist.
+ *   - seven rows carry a store-build voice as well; see STORE_LEX at the foot
+ *     of the file for which and why
  *
  * G1 merges this table into the module's lexicon as
  *   lexicon: { ...SORT_LEX, ...SETUP_LEX }
@@ -20,7 +22,9 @@
  * alone, delete them here, not there.
  * ==========================================================================*/
 
-export const SETUP_LEX = Object.freeze({
+import { isStoreSafe } from '../../core/storesafe.js';
+
+const BASE_LEX = Object.freeze({
   /* ---- the door itself -------------------------------------------------- */
   sort_door_title: 'Set your sort',
   sort_door_sub: 'Right is yours. Left is the rest.',
@@ -113,5 +117,46 @@ export const SETUP_LEX = Object.freeze({
   sort_stamp_yes: 'YES',
   sort_stamp_no: 'NO',
 });
+
+/* ----------------------------------------------------------------------------
+ * THE STORE BUILD'S SEVEN ROWS.
+ *
+ * An app-store build has the online feed disarmed at the host, so the door
+ * offers folders and Quick Sort and never reaches a community on the web. Seven
+ * rows still SAID otherwise: they name subs and subreddits, which is a picker
+ * for a source this build does not have and a word Apple's reviewer has no
+ * reason to be shown. So they get a neutral voice and the door reads as what it
+ * actually is here, a picker over your own collections.
+ *
+ * NOT A TRANSLATION AND NOT A SECOND TABLE. Same keys, same meanings, still
+ * under 96 characters, still no em-dashes; only the source noun moves. Every row
+ * the store build does not touch stays byte-identical, which is what keeps this
+ * from becoming a second copy of the door's copy to maintain.
+ *
+ * THE HOST STILL WINS. These are FALLBACKS: `ctx.lexicon(key, fallback)` prefers
+ * whatever `init.lexicon` carries, and the desktop host mirrors this table key
+ * for key out of ArcademyHostService.NeutralLexicon. So a store build whose host
+ * ships the original rows will show the original rows, and the mobile host
+ * overrides these same seven keys on its side for exactly that reason. Both
+ * halves are needed and neither is redundant.
+ * -------------------------------------------------------------------------- */
+const STORE_LEX = Object.freeze({
+  sort_source_online_hint: 'Pictures from the online feed',
+  sort_lib_empty: 'Nothing here yet. Search for a collection below.',
+  sort_search_head: 'Add a collection',
+  sort_search_ph: 'collection name',
+  sort_probe_bad: 'That is not a collection name',
+  sort_overlap_note: 'Shared picks were dropped from the rest',
+  sort_quick_nag: 'Add a second folder for a real sort.',
+});
+
+/**
+ * What G1 merges into the module's lexicon. One table, chosen once at import
+ * time, because the door is built the moment the class loads and the flag was
+ * set at the handshake long before that.
+ */
+export const SETUP_LEX = Object.freeze(
+  isStoreSafe() ? { ...BASE_LEX, ...STORE_LEX } : BASE_LEX,
+);
 
 export default SETUP_LEX;

--- a/ConditioningControlPanel/Services/Arcademy/ArcademyHostService.cs
+++ b/ConditioningControlPanel/Services/Arcademy/ArcademyHostService.cs
@@ -3336,9 +3336,10 @@ internal static class ArcademyHostService
         ["dt_help_chip_letter_yes"] = "ok",
         ["dt_help_yes_letter"] = "boop. that one's yours now.",
         ["dt_help_no_letter"] = "ok. my letter and i will practice waiting.",
-        // The nine band names. The KEY is the contract: it is `dt_cat_` plus the `cat` of a
+        // The ten band names. The KEY is the contract: it is `dt_cat_` plus the `cat` of a
         // THEME_GROUPS band in games/daily-trigger/words-answers.js (plus `common` for the
-        // tiny ordinary-English band), so renaming a band there orphans its row here.
+        // tiny ordinary-English band and `focus` for the store pool's own band), so renaming
+        // a band there orphans its row here.
         ["dt_cat_trance"] = "spirally",
         ["dt_cat_training"] = "training arc",
         ["dt_cat_submission"] = "yes ma'am",
@@ -3347,6 +3348,11 @@ internal static class ArcademyHostService
         ["dt_cat_arcade"] = "hometown",
         ["dt_cat_school"] = "classroom",
         ["dt_cat_melt"] = "melty",
+        // The store build's band. The desktop never draws it (that pool is
+        // picked by a host flag this host does not set), but trap 123 says a
+        // key with no host row renders in English for ever, and the mobile
+        // host reads this table through the vendored lexicon.json.
+        ["dt_cat_focus"] = "fresh air",
         ["dt_cat_common"] = "civilian",
     };
 


### PR DESCRIPTION
The web-tree half of the iOS App Store work in CCP-Mobile (`docs/IOS_STORE_PLAN.md` there, PR 11). The mobile PR that reads all of this is CodeBambi/CCP-Mobile#65, and the desktop app's own behaviour does not change: every branch below hangs off a flag this host never sets.

**Why a runtime flag and not a second tree.** The mobile app vendors this tree into one zip and ships that same zip to Android and to the App Store build. There is no build-time file swap available at that layer, so the difference has to be something the page reads at runtime. `core/storesafe.js` is the one door, `boot.js` sets `window.__ccpStoreSafe` from `init.platform.storeSafe` the moment the handshake lands, and a host that predates the field (this one, the web build, the Android app) leaves it undefined, which reads as false, which is the full school.

**Daily Trigger gets a second pool, not a filter.** `words-answers.store.js` has the same `THEME` / `COMMON` / `PHRASES` shape as its neighbour and `bank.js` picks between them in one line. The owner's 2026-08-25 ruling is not softened: the answers are still niche only, because a random English word is not what this app is about. The store pool is a narrower version of the same idea. It keeps trance, training, arcade, school and melt, drops submission, denial and bimbo, and grows one new band of ordinary calm.

The five kept bands are **derived from `THEME_GROUPS`, not copied**, so the two pools cannot drift into disagreeing about what a trance word is. That cuts both ways and the new file says so at the top: anything added to those five bands from now on ships in the store build too, and the three dropped bands are where the latitude lives.

Size is the other half of the design. `cyclePick()` walks one shuffled pass before any word repeats, so pool length is the repeat-free horizon in days. Five bands plus COMMON is 318, under the ~400 floor, so the `focus` band carries 115 more and the union lands at **433**. None of those 115 collides with any of the eight existing bands.

Phrase days lose three of twenty eight ("good girl", "good toy", "open wide") and keep the rest.

**The sort door stops saying subreddit.** Seven rows in `setup-lex.js` name subs and subreddits. The store build has the online feed disarmed at the host, so the door is a picker over the player's own collections and now reads that way: "Add a collection", "collection name", "That is not a collection name", and a Quick Sort nag that stops offering an online switch there is no door to. Same keys, same meanings, under 96 characters, no em-dashes, and every untouched row is byte-identical. They are **fallbacks**, so `init.lexicon` still wins, which is why the mobile host overrides the same seven keys on its side. Both halves are needed.

**`dt_cat_focus` in three places.** The new band needs a name for EMI's stuck-hint, and trap 123 is that a key with no host row renders in English for ever with nobody noticing. So it lands in `core/lexicon.js` defaults, in the class's `DT_CAT_FALLBACK`, and in `NeutralLexicon`. The desktop never draws the band, so the row is unused here and costs nothing.

**Verification.** Both modules run under node on both sides of the flag:

```
flag off  578 answers, 28 phrases, same word on the same dates as before
          2026-09-05 carve (training)   2026-09-12 pixie (bimbo)
flag on   433 answers, 25 phrases, zero adult words in the pool
          2026-09-05 pause              sort_search_ph "collection name"
```

`dotnet build`: 0 errors, 322 pre-existing warnings.

**Diff stat**

```
 .../web/arcademy/boot.js                        |   6 +
 .../web/arcademy/core/lexicon.js                |   3 +
 .../web/arcademy/core/storesafe.js              |  48 ++++++++
 .../web/arcademy/games/daily-trigger/bank.js    |  35 +++++-
 .../web/arcademy/games/daily-trigger/index.js   |   2 +-
 .../daily-trigger/words-answers.store.js        | 105 +++++++++++++++++
 .../web/arcademy/games/sort/setup-lex.js        |  47 +++++++-
 .../Services/Arcademy/ArcademyHostService.cs    |  10 +-
 8 files changed, 244 insertions(+), 8 deletions(-)
```

252 changed lines, under the 600 cap.

**Deviations from the plan, both worth knowing**

1. **The plan's grep acceptance cannot hold, and it is the plan that is wrong.** It asks that `bimbo|sissy|goon|slut|porn|cock` match only `words-accept.js` in the extracted store tree. `words-answers.js` is a static import of `bank.js` and one zip serves both platforms, so the full pool ships in every tree whatever the flag says. What the flag guarantees is that it is never DRAWN FROM, which the node run above shows. Making the grep true would mean a per-target tree, which means the vendoring script growing a file-overlay per target, and even then Android and the store build share one target today. Flagged rather than quietly dropped.
2. `words-accept.js` is untouched on purpose. It is the list of words a player may TYPE, never a word the game shows, and narrowing it would only reject guesses a player made themselves.

**Not done here:** the re-vendor. The mobile zip is rebuilt from this repo's `origin/main`, so it waits on this PR merging rather than on any tooling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

