### PR TITLE
ios: arcademy portrait notice for a window that cannot turn

### DIFF
--- a/ConditioningControlPanel/Resources/web/arcademy/boot.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/boot.js
@@ -811,6 +811,11 @@ bridge.on('init', guard('init', (m) => {
    * this undefined, which reads as false, which is the full school. */
   try { window.__ccpStoreSafe = !!(m.platform && m.platform.storeSafe); }
   catch (e) { /* noop - a page with no window is a page with no games */ }
+  /* AND WHETHER THIS WINDOW CAN EVER TURN. `core/device.js viewportCanRotate`
+   * is the reader and shell/orientgate.js is the only caller; a host that never
+   * sets the field leaves this undefined, which reads as "it can rotate". */
+  try { window.__ccpOrientationLocked = !!(m.platform && m.platform.orientationLocked); }
+  catch (e) { /* noop */ }
   directGame = directLaunchKey(m);
   dressDirectLaunch();            // THE DIRECT LAUNCH: name the room on the splash
   bridge.markInitialized();       // flush anything the page queued pre-init

--- a/ConditioningControlPanel/Resources/web/arcademy/core/device.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/core/device.js
@@ -134,6 +134,36 @@ export function orientationOk(want) {
   return orientation() === want;
 }
 
+/**
+ * CAN THIS VIEWPORT EVER TURN? A device fact, and the only one on this page that
+ * the page cannot work out for itself.
+ *
+ * Everything else in this module is measured: a viewport is wide or it is tall,
+ * and if the phone turns the numbers change. But "this window will never be any
+ * shape but the one it is" is not measurable from inside the frame, because it
+ * looks exactly like a phone somebody simply has not turned yet. Only the host
+ * knows, so the host says: `init.platform.orientationLocked`, copied onto the
+ * window by boot.js the moment init lands.
+ *
+ * The one host that sets it today is the iOS App Store build, whose plist lists
+ * portrait alone, so no amount of asking rotates it. The Discord Activity iframe
+ * is the same shape of problem and may set it later. Every other host leaves it
+ * undefined, which reads as "it can rotate", which is what a phone does.
+ *
+ * WHAT READS IT: shell/orientgate.js, and nothing else. A requirement that
+ * cannot be satisfied is not a requirement, it is a locked door, so the gate
+ * stops asking and says something useful instead.
+ *
+ * @returns {boolean} false only when the host declared the viewport locked
+ */
+export function viewportCanRotate() {
+  try {
+    return !(typeof window !== 'undefined' && window.__ccpOrientationLocked === true);
+  } catch (e) {
+    return true;
+  }
+}
+
 /* ----------------------------------------------------------------------------
  * THE SEAM
  * One listener pair for the whole page, however many callers there are. iOS

--- a/ConditioningControlPanel/Resources/web/arcademy/core/lexicon.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/core/lexicon.js
@@ -225,6 +225,12 @@ export const DEFAULT_LEXICON = Object.freeze({
      iframe hands the page whatever it likes), and a requirement nobody can
      satisfy has to carry a door. */
   rotate_stuck_note: 'Phone not turning? Some are told to hold still. Pick a way in below.',
+  /* THE SAME CARD ON A WINDOW THAT CANNOT TURN AT ALL (orientgate second coda).
+     A host that knows says so, and then the card stops asking for a quarter turn
+     it will never get and offers the way in straight away instead. */
+  rotate_locked_title: 'This one plays wide',
+  rotate_locked_body: 'This room was drawn for a wide screen and this app stays upright, so the board comes in a little tighter than it was built for. Everything works. Nothing is running while you decide.',
+  rotate_locked_note: 'Pick a way in below.',
   rotate_play_anyway: 'Play it upright anyway',
   rotate_leave_class: 'Leave the class',
   /* The splash's knock line (boot.js). boot runs before this module loads, so

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/orientgate.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/orientgate.js
@@ -33,6 +33,15 @@
  *      had turned), or leave the class (the caller's own door, via `onLeave`).
  *      The campus card is untouched - the campus is not a room you can be stuck
  *      inside, and its way out is the phone.
+ *      SECOND CODA (2026-09-04, the iOS store build): some hosts KNOW the
+ *      window can never turn, and say so in `init.platform.orientationLocked`.
+ *      Waiting out a grace period to offer a way in is then just seven seconds
+ *      of asking a player to do something impossible, so a locked viewport gets
+ *      the class card AT ONCE, worded as a notice rather than as an instruction
+ *      ("this one plays wide, here is the way in") with both buttons already on
+ *      screen. The campus card is not built at all on a locked viewport: it has
+ *      no buttons by Law 2, so a card that could never lift would be the locked
+ *      door this whole coda exists to prevent.
  *   3. ONE CARD, EVER. `requireOrientation` is idempotent and the node is
  *      REMOVED rather than hidden (trap 27), so a screen that repaints while the
  *      card is up cannot stack two of them.
@@ -52,7 +61,9 @@
  * ==========================================================================*/
 
 import { t } from '../core/lexicon.js';
-import { isMobile, orientation, orientationOk, onDeviceChange } from '../core/device.js';
+import {
+  isMobile, orientation, orientationOk, onDeviceChange, viewportCanRotate,
+} from '../core/device.js';
 
 function el(tag, cls, text) {
   const n = document.createElement(tag);
@@ -67,7 +78,20 @@ function el(tag, cls, text) {
  * the device. Lexicon rows with English fallbacks, same as every other string
  * the shell renders, so a mod can re-voice all six.
  * -------------------------------------------------------------------------- */
-function copyFor(want, reason) {
+function copyFor(want, reason, locked) {
+  /* A LOCKED VIEWPORT IS TOLD, NOT ASKED. Same card, same buttons, different
+   * sentence: nothing here says "turn your phone", because on this host that is
+   * an instruction the player cannot carry out and every second they spend
+   * trying is a second we wasted for them. */
+  if (locked) {
+    return {
+      title: t('rotate_locked_title', 'This one plays wide'),
+      body: t('rotate_locked_body',
+        'This room was drawn for a wide screen and this app stays upright, so the'
+        + ' board comes in a little tighter than it was built for. Everything works.'
+        + ' Nothing is running while you decide.'),
+    };
+  }
   if (want === 'portrait') {
     return {
       title: t('rotate_portrait_title', 'Stand it back up'),
@@ -122,10 +146,11 @@ function standDown() {
 }
 
 /** Build the card. Called only when one is actually going up. */
-function build(want, reason) {
-  const words = copyFor(want, reason);
+function build(want, reason, locked) {
+  const words = copyFor(want, reason, locked);
 
-  const root = el('div', 'arc-orientgate arc-orientgate-' + want);
+  const root = el('div', 'arc-orientgate arc-orientgate-' + want
+    + (locked ? ' arc-orientgate-locked' : ''));
   root.setAttribute('role', 'dialog');
   root.setAttribute('aria-modal', 'true');
   root.setAttribute('aria-live', 'assertive');
@@ -155,10 +180,15 @@ function build(want, reason) {
    * yet never sees them - and `visibility` rides the same keyframe so they are
    * out of the tab order until they are on screen. */
   if (want === 'landscape' && reason === 'class') {
-    const acts = el('div', 'arc-orientgate-actions');
+    /* `arc-orientgate-now` skips the grace-period keyframe (second coda): the
+     * wait exists to let a phone that CAN turn turn first, and this one cannot. */
+    const acts = el('div', 'arc-orientgate-actions'
+      + (locked ? ' arc-orientgate-now' : ''));
     acts.appendChild(el('p', 'arc-note arc-orientgate-stuck',
-      t('rotate_stuck_note',
-        'Phone not turning? Some are told to hold still. Pick a way in below.')));
+      locked
+        ? t('rotate_locked_note', 'Pick a way in below.')
+        : t('rotate_stuck_note',
+          'Phone not turning? Some are told to hold still. Pick a way in below.')));
 
     const row = el('div', 'arc-orientgate-actionrow');
 
@@ -192,11 +222,18 @@ function build(want, reason) {
 
 /** Put the card up, take it down, or leave it exactly as it is. */
 function reconcile() {
-  const blocking = !!wanted && isMobile() && !orientationOk(wanted);
+  /* A HOST THAT SAYS THE WINDOW CANNOT TURN (second coda). The campus asks for
+   * width with a card that has no buttons, so on a locked viewport it is not
+   * built at all and the campus simply runs upright - which it has done since
+   * the floor plan stopped requiring landscape. A class still gets its card,
+   * because the card is now the notice and the two buttons are the point. */
+  const locked = !viewportCanRotate();
+  const blocking = !!wanted && isMobile() && !orientationOk(wanted)
+    && (!locked || wantedReason === 'class');
 
   if (blocking && !node) {
     try {
-      node = build(wanted, wantedReason);
+      node = build(wanted, wantedReason, locked);
       document.body.appendChild(node);
     } catch (e) { node = null; }
   } else if (!blocking && node) {
@@ -209,7 +246,7 @@ function reconcile() {
     try {
       if (!node.classList.contains(cls)) {
         node.remove();
-        node = build(wanted, wantedReason);
+        node = build(wanted, wantedReason, locked);
         document.body.appendChild(node);
       }
     } catch (e) { /* noop */ }
@@ -271,7 +308,10 @@ export function clearOrientation() {
 
 /** Test seam - never read by the shell. */
 export function diagnostics() {
-  return { wanted, reason: wantedReason, up: !!node, mobile: isMobile(), orientation: orientation() };
+  return {
+    wanted, reason: wantedReason, up: !!node, mobile: isMobile(),
+    orientation: orientation(), canRotate: viewportCanRotate(),
+  };
 }
 
 export default { requireOrientation, clearOrientation, isBlocking, diagnostics };

--- a/ConditioningControlPanel/Resources/web/arcademy/styles.css
+++ b/ConditioningControlPanel/Resources/web/arcademy/styles.css
@@ -5338,6 +5338,18 @@ html.arc-mobile .arc-rs-close { top:8px; right:10px; }
   0%   { opacity:0; visibility:hidden; pointer-events:none; }
   100% { opacity:1; visibility:visible; pointer-events:auto; }
 }
+/* AND SO DOES A LOCKED VIEWPORT (orientgate second coda). The delay is there to
+   let a phone that can turn turn first; a window that can never turn has nothing
+   to wait for, so the way in is on screen with the sentence that offers it. The
+   two-class selector out-specifies the base rule above. */
+.arc-orientgate-actions.arc-orientgate-now {
+  animation:none; opacity:1; visibility:visible; pointer-events:auto;
+}
+/* The glyph is a phone tipping a quarter turn, which on a locked window is a
+   picture of something that will not happen. The card keeps its shape without
+   it. */
+.arc-orientgate-locked .arc-orientgate-art { display:none; }
+
 /* REDUCED MOTION SHOWS THEM AT ONCE. The freeze at the bottom of this file runs
    every animation at .001s with no delay, which would technically land the same
    end state - but relying on a blanket freeze to deliver the only way out of a


### PR DESCRIPTION
The web-tree half of `ios/orientation` in CCP-Mobile (PR 12 of that stack, owner decision 2, option A). Stacked on **#821**, and like it, the desktop app's own behaviour does not change: every branch below hangs off a field this host never sets, and the gate itself is phones only, so a WebView2 window cannot reach any of it.

**The problem is a card that cannot be satisfied.** `shell/orientgate.js` asks a player to turn the phone, and it lifts when they do. Its 2026-08-31 coda already knew some phones never can (an iOS system portrait lock has no in-page override, and the Discord Activity iframe hands the page whatever shape it likes), so a class card grows two buttons after a grace period: play it upright anyway, or leave. Seven seconds, so a phone that was merely slow to turn never sees them.

The iOS App Store build is the case where that wait buys nothing. Its plist lists portrait alone and UIKit will not rotate past it, so the phone in the picture is never going to turn and the player spends seven seconds finding that out, being asked all the while to do something they cannot do.

**So the host says, because the page cannot tell.** From inside the frame, a window that will never rotate looks exactly like a phone nobody has turned yet. `init.platform.orientationLocked` is the fact, `boot.js` copies it onto the window at the handshake next to the store flag, `core/device.js viewportCanRotate()` is the reader, and orientgate is its only caller.

- **A class gets its card at once**, worded as a notice rather than an instruction: "This one plays wide", the room was drawn for a wide screen and this app stays upright, everything works, nothing is running while you decide. Both buttons are on screen from the first paint (`arc-orientgate-now` skips the grace keyframe) and the turning-phone glyph is hidden, because it is a picture of something that will not happen.
- **The campus card is not built at all.** By Law 2 it has no buttons, on the grounds that the campus is not a room you can be stuck inside and the way out is the phone. On a locked window the phone is not a way out, so a card with no dismiss that can never lift would be precisely the locked door the coda exists to prevent. The campus runs upright instead, which it has done anyway since the floor plan stopped requiring landscape.

**Off by default, everywhere.** No host sets the field today. Undefined reads as "it can rotate", which is what a phone does, so the desktop, the web build, the Discord Activity and the Android app all keep the gate exactly as it is.

**Acceptance**

Exercised for real, not read: `shell/orientgate.js` was imported into node over a minimal DOM stub and driven through five states.

| state | card | copy | actions |
|---|---|---|---|
| unlocked, class, portrait phone | up | Turn it sideways | after the grace period |
| **locked**, class, portrait phone | up | **This one plays wide** | **on screen at once** |
| **locked**, campus | **none** | - | - |
| unlocked, campus | up | Turn it sideways | none (Law 2) |
| locked, portrait want, portrait phone | none | - | - |

And the way in still works on a locked card: pressing "play it upright anyway" fired `onChange(true)` then `onChange(false)` and removed the node, which is the signal the shell restarts the class on. `clearOrientation()` leaves the body empty. `dotnet build` 0 errors, 322 pre-existing warnings.

**Diff stat**

```
 Resources/web/arcademy/boot.js            |  5 ++
 Resources/web/arcademy/core/device.js     | 30 ++++++++++
 Resources/web/arcademy/core/lexicon.js    |  6 ++
 Resources/web/arcademy/shell/orientgate.js| 64 +++++++++++++++++----
 Resources/web/arcademy/styles.css         | 12 ++++
 5 files changed, 105 insertions(+), 12 deletions(-)
```

117 changed lines against `ios/arcademy-sfw`, well under the cap.

**Deviations**

- The three new rows land in `core/lexicon.js` only. `ArcademyHostService.cs` carries no `rotate_*` row today (the desktop can never see this card), so adding the first one there would put a row in the host table that only a phone host will ever render.
- Nothing in the mobile app renders any of this until the campus zip is re-vendored from this repo's main, which is its own mechanical PR over there. The mobile PR ships the field regardless: it is inert against today's tree, and the class card's existing waiver is still the way through in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
