### PR TITLE
feat(arcademy): Back Room G1 - no door until the house says open

### DIFF
--- a/ConditioningControlPanel/Resources/web/arcademy/backroom/cage.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/backroom/cage.js
@@ -196,6 +196,7 @@ export function createCage(opts) {
   function refusal(r) {
     const body = (r && r.body) || {};
     const reason = String(body.reason || body.code || '');
+    if (reason === 'casino_closed') return t('bk_closed');   // a 403 too, but the house's, not the account's
     if (r && r.status === 403) return t('bk_cage_locked');
     switch (reason) {
       case 'insufficient_sparkle': return t('bk_cage_poor');

--- a/ConditioningControlPanel/Resources/web/arcademy/backroom/lex.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/backroom/lex.js
@@ -52,6 +52,7 @@ export const BK_LEX = Object.freeze({
      the two rooms must not disagree about what that means, so this row is a
      copy of it rather than a new sentence. */
   bk_cage_locked:    'The bank does not serve this account yet. Nothing was charged.',
+  bk_closed:         'The house is closed tonight. Your chips keep. Come back when the sign is lit.',
   bk_cage_reset:     'Your skills are mid reset. The cage waits for that to settle.',
   bk_cage_refused:   'The cage would not take that one. Nothing moved.',
 

--- a/ConditioningControlPanel/Resources/web/arcademy/backroom/scratcher.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/backroom/scratcher.js
@@ -130,9 +130,10 @@ function oddsRows(kit) {
 
 /** Which warm sentence a refusal gets. The server's word is never shown raw. */
 function refusalKey(status, body) {
+  const r = String((body && (body.reason || body.error)) || '');
+  if (r === 'casino_closed') return 'bk_closed';   // a 403 too, but the house's, not the account's
   if (status === 403) return 'bk_sc_locked';
   if (!status) return 'bk_sc_offline';
-  const r = String((body && (body.reason || body.error)) || '');
   if (r === 'insufficient_chips') return 'bk_sc_poor';
   return r === 'busy' ? 'bk_sc_busy' : 'bk_sc_refused';
 }

--- a/ConditioningControlPanel/Resources/web/arcademy/backroom/spiral.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/backroom/spiral.js
@@ -376,6 +376,7 @@ function mount(root, kit, ctx) {
   function refusal(r) {
     const b = (r && r.body) || {};
     const reason = String(b.reason || b.code || '');
+    if (reason === 'casino_closed') return t('bk_closed');   // a 403 too, but the house's, not the account's
     if (r && r.status === 403) return t('bk_sp_locked');
     switch (reason) {
       case 'insufficient_chips': return t('bk_sp_poor');

--- a/ConditioningControlPanel/Resources/web/arcademy/backroom/triple.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/backroom/triple.js
@@ -527,6 +527,7 @@ export function mount(root, kit, ctx) {
   function refusal(r) {
     const body = (r && r.body) || {};
     const reason = String(body.reason || body.code || '');
+    if (reason === 'casino_closed') return t('bk_closed');   // a 403 too, but the house's, not the account's
     if (r && r.status === 403) return t('bk_tt_locked');
     switch (reason) {
       case 'insufficient_chips': return t('bk_tt_poor');

--- a/ConditioningControlPanel/Resources/web/arcademy/backroom/twentyone.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/backroom/twentyone.js
@@ -431,6 +431,7 @@ function mountTable(root, kit, ctx) {
   function refusal(r) {
     const body = (r && r.body) || {};
     const reason = String(body.reason || body.code || '');
+    if (reason === 'casino_closed') return t('bk_closed');   // a 403 too, but the house's, not the account's
     if (r && r.status === 403) return t('bk_t1_locked');
     switch (reason) {
       case 'insufficient_chips': return t('bk_t1_poor');

--- a/ConditioningControlPanel/Resources/web/arcademy/backroom/wheel.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/backroom/wheel.js
@@ -159,9 +159,10 @@ function buildSlices(rows, t) {
 
 /** Which warm sentence a refusal gets. The server's word is never shown raw. */
 function refusalKey(status, body) {
+  const r = String((body && (body.reason || body.error)) || '');
+  if (r === 'casino_closed') return 'bk_closed';   // a 403 too, but the house's, not the account's
   if (status === 403) return 'bk_pw_locked';
   if (!status) return 'bk_pw_offline';
-  const r = String((body && (body.reason || body.error)) || '');
   if (r === 'insufficient_chips') return 'bk_pw_poor';
   return r === 'busy' ? 'bk_pw_busy' : 'bk_pw_refused';
 }

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/campus.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/campus.js
@@ -1019,7 +1019,7 @@ function idCrestGlyph() {
  */
 export function createCampus({ state, gameName, banner, stats, reducedMotion, on, log,
   dateSeed, attractIdleMs, boardPulse, idCardMode, holdAttract, post, seep, annex,
-  capsule, account, economy, idFrame } = {}) {
+  capsule, account, economy, idFrame, backroomOpen } = {}) {
   const say = typeof log === 'function' ? log : () => {};
   const handlers = on || {};
   /* THE ACCOUNT CHIP (shell/accountchip.js): a host slot in the top-right
@@ -2243,6 +2243,17 @@ export function createCampus({ state, gameName, banner, stats, reducedMotion, on
     svg('circle', { cx: x, cy: 820.5, r: 2.8 }, 'campus-furnf')));
   facPut(backroomG, svg('line', { x1: 1280, y1: 824, x2: 1348, y2: 824 }, 'campus-furn'));
   stag(backroomG, 940);
+  /* THE SIGN OVER THE DOOR (the soft launch). No door until the house says
+   * open: `backroomOpen` is the server's word, relayed by the shell, and it is
+   * false on every host that has not asked yet or was not answered. The group
+   * is hidden rather than unbuilt so the shell can light it the moment the
+   * answer lands, without a rebuild. Hidden, the alley is the four-window
+   * alley it was before the wing: the plate, the rack and the neon all ride
+   * this one group. */
+  function setBackroomOpen(open) {
+    try { backroomG.style.display = (open === true) ? '' : 'none'; } catch (e) { /* noop */ }
+  }
+  setBackroomOpen(backroomOpen);
 
   /* Entrance hall dressing (notice board, trophy case, admissions desk, crest) */
   const hall = svg('g', null, 'campus-halldress');
@@ -3687,6 +3698,9 @@ export function createCampus({ state, gameName, banner, stats, reducedMotion, on
      * nothing else.
      */
     backroomDust: backroomDustCard,
+    /** The sign over the Back Room door, from outside: true draws the door,
+     *  anything else is a wall. Safe to call at any time. */
+    setBackroomOpen,
     /**
      * A viewBox point -> page coordinates, for a FLIP that has to start at a
      * place on the plan (ORIENTATION.md §3.4's handover). Fully guarded: the

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/shell.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/shell.js
@@ -2319,9 +2319,13 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
          * show different frames - and it is the getter and not a value because
          * the campus outlives an equip made in the Locker. */
         idFrame,
+        // THE SIGN OVER THE BACK ROOM DOOR: the last answer, and false until
+        // there is one. askBackRoomOpen below lights it when the server says so.
+        backroomOpen: backRoomOpen,
         log: say,
       });
       campus.noteDescriptors(campusDescriptors());
+      askBackRoomOpen();
       /* THE CARD KNOWS WHO YOU ARE BEFORE IT IS EVER SEEN. The campus is torn
        * down and rebuilt on every visit, so the profile is handed over here
        * rather than held by the card - and an in-flight chip keeps its look
@@ -3942,6 +3946,47 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
    *  cannot leave a handler painting into a page that has been torn down. */
   let backRoomOffs = [];
 
+  /* THE SIGN OVER THE DOOR (the soft launch). The door is drawn ONLY when the
+   * server says the house is open for this player: a `casino-request` for
+   * status answers `body.open`, and anything else - offline, a 403, a timeout,
+   * a server that predates the flag - is a wall with no door in it. Asked on
+   * the campus build, throttled, and never blocking: the quad stands first
+   * and the door is lit when the answer lands. The ask is the shell's own and
+   * filters by its own reqId, so it can never eat a receipt the room is
+   * waiting on. No host change: both hosts already carry this frame. */
+  let backRoomOpen = false;
+  let backRoomAskedAt = 0;
+  const BACKROOM_ASK_EVERY_MS = 5 * 60 * 1000;
+  const BACKROOM_ASK_TIMEOUT_MS = 4000;
+  function setBackRoomOpen(open) {
+    backRoomOpen = open === true;
+    if (campus && typeof campus.setBackroomOpen === 'function') {
+      try { campus.setBackroomOpen(backRoomOpen); } catch (e) { /* noop */ }
+    }
+  }
+  function askBackRoomOpen() {
+    const now = Date.now();
+    if (now - backRoomAskedAt < BACKROOM_ASK_EVERY_MS) { setBackRoomOpen(backRoomOpen); return; }
+    backRoomAskedAt = now;
+    const reqId = 'bkgate' + now.toString(16)
+      + Math.floor(Math.random() * 0xFFFFFFFF).toString(16).padStart(8, '0');
+    let off = () => {};
+    const timer = setTimeout(() => { try { off(); } catch (e) { /* noop */ } }, BACKROOM_ASK_TIMEOUT_MS);
+    off = bridge.on('casino-result', (m) => {
+      if (!m || m.reqId !== reqId) return;
+      clearTimeout(timer);
+      try { off(); } catch (e) { /* noop */ }
+      setBackRoomOpen(m.ok === true && !!m.body && m.body.open === true);
+    });
+    try {
+      bridge.send({ type: 'casino-request', reqId, op: 'status', body: {}, localDay: localDate });
+    } catch (e) {
+      clearTimeout(timer);
+      try { off(); } catch (e2) { /* noop */ }
+      say('backroom gate ask failed: ' + ((e && e.message) || e));
+    }
+  }
+
   /** The module, fetched once. A FAILURE IS NOT CACHED - a fetch that lost the
    *  network is worth trying again the next time somebody tries the door. */
   function loadBackRoom() {
@@ -4020,6 +4065,9 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
   }
 
   function showBackRoom() {
+    // A door that is not drawn cannot be walked to, but a keybind or a stale
+    // handle could still ask. The sealed card, same as any other shut door.
+    if (!backRoomOpen) { refuseBackRoom('the house is closed'); return; }
     /* THE QUAD STAYS UP while the module is in the air. See the header. */
     loadBackRoom().then((mod) => {
       if (destroyed) return;

--- a/ConditioningControlPanel/Services/Arcademy/ArcademyHostService.cs
+++ b/ConditioningControlPanel/Services/Arcademy/ArcademyHostService.cs
@@ -3405,6 +3405,7 @@ internal static class ArcademyHostService
         ["bk_cage_bad"] = "The cage takes one to five hundred at a time. Typo guard, nothing more.",
         ["bk_cage_busy"] = "The cashier is with someone. Give her a moment.",
         ["bk_cage_locked"] = "The bank does not serve this account yet. Nothing was charged.",
+        ["bk_closed"] = "The house is closed tonight. Your chips keep. Come back when the sign is lit.",
         ["bk_cage_reset"] = "Your skills are mid reset. The cage waits for that to settle.",
         ["bk_cage_refused"] = "The cage would not take that one. Nothing moved.",
         ["bk_cage_tree"] = "The same {0} sparkle goes toward {1} on the tree, {2} short of it.",


### PR DESCRIPTION
## The rule

**No door until the house says open.** The Back Room window in the alley is drawn only when `GET /v2/arcademy/casino` (server PR CC-Labs-llc/CCP-Server#139) answers `open: true` for this player. The shell asks once per campus build through the existing `casino-request` frame with its own `reqId`, throttled to one ask per five minutes, with a four second timeout. The campus builds first and the door is lit when the answer lands, so a slow server never holds the quad.

Anything else leaves the alley as it was before the wing, four windows and no hole: offline (status 0), a 403, a timeout, a server that has no `open` field yet, or `open: false`.

**No host change.** Desktop (D1) and the web relay already forward `casino-request` and answer `casino-result`. The shell's ask filters on its own `reqId`, so it can never eat a receipt the room is waiting on.

## Mid-session close

If the flag closes while a player is at a table, the next cage or play answer is `403 casino_closed`. All six refusal maps (cage, Spiral, Triple Trigger, Twenty-One, Scratcher, Prize Wheel) now check that reason **before** the 403 branch and print `bk_closed`: "The house is closed tonight. Your chips keep. Come back when the sign is lit." The exit stays lit as always. Without the reorder the 403 branch would have printed "the bank does not serve this account", which is the wrong story. `bk_closed` is mirrored into `NeutralLexicon`.

`showBackRoom` also refuses with the plan's sealed card when the door is not lit, for a keybind or stale handle that asks anyway.

## Harness

Copied shots rig (scratchpad `bk-g1/shots`, the shim gains `?bk=open|closed|silent`), run headless through the real shell on this branch:

| case | door | campus | result |
|---|---|---|---|
| `open:false` desktop 1600 | no | built, 17 rooms | pass |
| `open:true` desktop 1600 | yes | floor mounts 5 cabinets, 0 sheets | pass |
| never answers, 5.6 s | no | built, no exception | pass |
| `open:false` phone 390 lite | no | built | pass |

Zero exceptions in any log. `dotnet build`: 0 errors (322 standing warnings).

Shot of the closed alley: `C:\Users\PC\AppData\Local\Temp\claude\bk-g1-shots\g1-closed-d1600.png`

## Merge order

After #820 (integration). Pairs with server #139, which must deploy before the flag means anything; until then every client sees no door, which is the intended default.

Operator steps to open (env var names only): set `CASINO_TESTERS` to a comma list of account ids for the tester wave, or `CASINO_OPEN=on` for everyone. Server #139 documents both in `proxy/docs/env-vars.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018oDQzrDxMaHFUuXnnY8c8W
