### PR TITLE
feat(logging): redact on the write path, not just at upload

### DIFF
--- a/ConditioningControlPanel/App.xaml.cs
+++ b/ConditioningControlPanel/App.xaml.cs
@@ -4385,7 +4385,12 @@ Application State:
 - Dispatcher Shutdown: {(Current?.Dispatcher?.HasShutdownStarted ?? true)}
 ================================================================================
 ";
-                File.AppendAllText(crashLogPath, crashInfo);
+                // Redact BEFORE the text touches the disk. crash.log is the one file users open
+                // by hand and paste into Discord, and it carried the full "C:\Users\<name>" of
+                // every frame in the stack plus whatever ids and paths the exception message
+                // happened to quote. LogScrubber only cleaned that up at bug-report upload time,
+                // which is far too late for a file that is already sitting in the logs folder.
+                File.AppendAllText(crashLogPath, Services.Logging.LogRedactor.Redact(crashInfo));
             }
             catch
             {

--- a/ConditioningControlPanel/Services/LogScrubber.cs
+++ b/ConditioningControlPanel/Services/LogScrubber.cs
@@ -22,58 +22,19 @@ namespace ConditioningControlPanel.Services
     /// </summary>
     public static class LogScrubber
     {
-        // C:\Users\<name>\...  or  C:/Users/<name>/...
-        // Matches both backslash and forward-slash forms. The username is whatever
-        // appears between Users\ and the next path separator.
-        private static readonly Regex UserPathRegex = new(
-            @"(?i)([A-Z]:[\\/])Users[\\/]([^\\/\r\n""']+)",
-            RegexOptions.Compiled);
-
-        // /home/<name>/... and /Users/<name>/... — the POSIX and macOS home shapes.
-        //
-        // This class only knew the Windows shape while Core ran exclusively inside the WPF
-        // process, so on a Linux head the username went into crash.log verbatim. Found by
-        // actually executing Core on Linux (CCP.LinuxSmoke), not by any compile-time gate:
-        // a Windows path redacted correctly while "/home/alice/..." passed straight through.
-        //
-        // "root" is deliberately kept: it identifies no one and dropping it would obscure that
-        // the app ran elevated, which matters when reading a crash report.
-        //
-        // The leading boundary is a zero-width lookbehind, not a captured group: a consumed
-        // delimiter belongs to one match and is then missing for the next, so the second half
-        // of "/home/alice,/home/bob" would leak. The name class stops short of trailing
-        // punctuation for the same reason, and the "root" guard mirrors that class so that
-        // "root," is still recognised as root. Case-sensitive on purpose — the real shapes are
-        // lowercase "/home/" and capital-U "/Users/"; a lowercase "/users/" is an HTTP route
-        // ("GET /users/alice HTTP/1.1"), not a home directory.
-        private static readonly Regex PosixHomePathRegex = new(
-            @"(?<=^|[\s""'(\[=:,;])(/home/|/Users/)(?!root(?![^/\r\n""'\s,;)\]]))([^/\r\n""'\s,;)\]]+)",
-            RegexOptions.Compiled);
-
-        // Email addresses (RFC-ish — good enough for log scrubbing).
-        private static readonly Regex EmailRegex = new(
-            @"\b[A-Z0-9._%+\-]+@[A-Z0-9.\-]+\.[A-Z]{2,}\b",
-            RegexOptions.IgnoreCase | RegexOptions.Compiled);
-
-        // OAuth-style tokens in JSON or key=value form: "access_token": "...", refresh_token=..., etc.
-        private static readonly Regex JsonTokenRegex = new(
-            @"(?i)(""?(?:access_token|refresh_token|auth_token|api_key|apikey|authorization|bearer_token|x-auth-token|x-admin-token|client_secret|patreon_token|discord_token)""?\s*[:=]\s*)""?[A-Z0-9._~+/=\-]{8,}""?",
-            RegexOptions.Compiled);
-
-        // Bearer <token>
-        private static readonly Regex BearerRegex = new(
-            @"(?i)\bBearer\s+[A-Z0-9._~+/=\-]{16,}\b",
-            RegexOptions.Compiled);
-
-        // Discord bot tokens (standard format: three dot-separated base64 segments, ~24.6.27+ chars)
-        private static readonly Regex DiscordBotTokenRegex = new(
-            @"\b[MNO][A-Za-z0-9_\-]{23,25}\.[A-Za-z0-9_\-]{6}\.[A-Za-z0-9_\-]{27,}\b",
-            RegexOptions.Compiled);
-
-        // %LOCALAPPDATA%, %APPDATA%, %USERPROFILE% — both literal expansions and variable forms.
-        private static readonly Regex AppDataLiteralRegex = new(
-            @"(?i)%(?:LOCALAPPDATA|APPDATA|USERPROFILE)%",
-            RegexOptions.Compiled);
+        // The path, email and token rules are the SHARED primitives in
+        // Services/Logging/LogRedactor.cs. They used to be declared here, which meant the upload
+        // path (this class) and the write path (the redactor) each carried their own copy of the
+        // same seven regexes - two places for one rule to be fixed in, and the reason a rule fixed
+        // for a bug report could silently stay broken for the log file itself. The aliases keep the
+        // rest of this class, and its output shapes, exactly as they were.
+        private static readonly Regex UserPathRegex = Logging.LogRedactor.UserPathRegex;
+        private static readonly Regex PosixHomePathRegex = Logging.LogRedactor.PosixHomePathRegex;
+        private static readonly Regex EmailRegex = Logging.LogRedactor.EmailRegex;
+        private static readonly Regex JsonTokenRegex = Logging.LogRedactor.JsonTokenRegex;
+        private static readonly Regex BearerRegex = Logging.LogRedactor.BearerRegex;
+        private static readonly Regex DiscordBotTokenRegex = Logging.LogRedactor.DiscordBotTokenRegex;
+        private static readonly Regex AppDataLiteralRegex = Logging.LogRedactor.AppDataLiteralRegex;
 
         // Expanded forms: C:\Users\<name>\AppData\Local\... and ...\AppData\Roaming\...
         // Handled indirectly via UserPathRegex (which captures the username) — we leave

--- a/ConditioningControlPanel/Services/Logging/LogRedactor.cs
+++ b/ConditioningControlPanel/Services/Logging/LogRedactor.cs
@@ -1,0 +1,244 @@
+using System;
+using System.Text.RegularExpressions;
+
+namespace ConditioningControlPanel.Services.Logging
+{
+    /// <summary>
+    /// The single redaction rule set for everything the app writes to disk.
+    ///
+    /// <para><b>Why this exists next to <see cref="LogScrubber"/>.</b> The scrubber runs once, at
+    /// bug-report upload time, over text that is already on disk: by then a week of
+    /// <c>C:\Users\&lt;name&gt;\...</c> lines (1,763 of them in a one-week sample) has already been
+    /// written to app-.log and crash.log, where anyone who opens the folder can read it. This class
+    /// runs on the WRITE path instead, so the identifying text never reaches the file at all. The
+    /// two share their regexes (below) so a rule can only be fixed in one place, but they differ in
+    /// output: the scrubber keeps the shape (<c>Users\&lt;redacted&gt;</c>) because its output is
+    /// read by a human triaging a report, while this one collapses whole known roots to short
+    /// tokens (<c>%DATA%</c>) because it runs on every line and shorter is cheaper.</para>
+    ///
+    /// <para>All rules are ordinal and allocation-light on the common path: a line with no
+    /// separator, no <c>@</c> and no long digit run returns the same reference it was handed.</para>
+    /// </summary>
+    public static class LogRedactor
+    {
+        // ---- Shared primitives (LogScrubber uses these too; do not duplicate them there) ----
+
+        /// <summary>C:\Users\name\... and C:/Users/name/... - group 1 is the drive+separator.</summary>
+        internal static readonly Regex UserPathRegex = new(
+            @"(?i)([A-Z]:[\\/])Users[\\/]([^\\/\r\n""']+)",
+            RegexOptions.Compiled);
+
+        /// <summary>
+        /// /home/name/... and /Users/name/... See LogScrubber for the boundary reasoning: the
+        /// leading delimiter is a zero-width lookbehind so adjacent paths both match, "root" is
+        /// deliberately preserved, and the match is case-sensitive so an HTTP route "/users/alice"
+        /// is left alone.
+        /// </summary>
+        internal static readonly Regex PosixHomePathRegex = new(
+            @"(?<=^|[\s""'(\[=:,;])(/home/|/Users/)(?!root(?![^/\r\n""'\s,;)\]]))([^/\r\n""'\s,;)\]]+)",
+            RegexOptions.Compiled);
+
+        internal static readonly Regex EmailRegex = new(
+            @"\b[A-Z0-9._%+\-]+@[A-Z0-9.\-]+\.[A-Z]{2,}\b",
+            RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+        internal static readonly Regex JsonTokenRegex = new(
+            @"(?i)(""?(?:access_token|refresh_token|auth_token|api_key|apikey|authorization|bearer_token|x-auth-token|x-admin-token|client_secret|patreon_token|discord_token)""?\s*[:=]\s*)""?[A-Z0-9._~+/=\-]{8,}""?",
+            RegexOptions.Compiled);
+
+        internal static readonly Regex BearerRegex = new(
+            @"(?i)\bBearer\s+[A-Z0-9._~+/=\-]{16,}\b",
+            RegexOptions.Compiled);
+
+        internal static readonly Regex DiscordBotTokenRegex = new(
+            @"\b[MNO][A-Za-z0-9_\-]{23,25}\.[A-Za-z0-9_\-]{6}\.[A-Za-z0-9_\-]{27,}\b",
+            RegexOptions.Compiled);
+
+        internal static readonly Regex AppDataLiteralRegex = new(
+            @"(?i)%(?:LOCALAPPDATA|APPDATA|USERPROFILE)%",
+            RegexOptions.Compiled);
+
+        /// <summary>
+        /// Snowflake-shaped ids (Discord ids are 17-19 digits; 20 covers headroom). Last four are
+        /// kept so two lines about the same user can still be correlated during triage.
+        /// </summary>
+        private static readonly Regex LongIdRegex = new(
+            @"(?<![0-9])[0-9]{17,20}(?![0-9])",
+            RegexOptions.Compiled);
+
+        /// <summary>Server-side user handles, e.g. <c>u_9f2a71bc</c>.</summary>
+        private static readonly Regex UserHandleRegex = new(
+            @"\bu_[a-z0-9]{8,}\b",
+            RegexOptions.Compiled);
+
+        // ---- Known roots ----
+
+        private static string? _dataRoot;
+        private static string? _appRoot;
+        private static string? _assetsRoot;
+        private static long _assetsStamp;
+        private static bool _rootsResolved;
+
+        /// <summary>
+        /// Resolves the assets root on demand. Set by the pipeline; the assets folder is settings
+        /// driven and settings load after the logger, so it cannot be captured once at startup.
+        /// </summary>
+        public static Func<string?>? AssetsRootProvider { get; set; }
+
+        /// <summary>
+        /// Point the root rules at explicit folders. Called by the pipeline at startup and by tests.
+        /// Nulls leave a root unresolved (that rule is then skipped).
+        /// </summary>
+        public static void ConfigureRoots(string? dataRoot, string? appRoot = null, string? assetsRoot = null)
+        {
+            _dataRoot = Trim(dataRoot);
+            _appRoot = Trim(appRoot);
+            _assetsRoot = Trim(assetsRoot);
+            _assetsStamp = Environment.TickCount64;
+            _rootsResolved = true;
+        }
+
+        /// <summary>
+        /// The crash writer redacts before the pipeline has configured anything (a crash during
+        /// startup is exactly when that happens), so fall back to the app's own folders once.
+        /// </summary>
+        private static void EnsureRoots()
+        {
+            if (_rootsResolved) return;
+            _rootsResolved = true;
+            try { _dataRoot = Trim(App.UserDataPath); } catch { /* swallow: defaults are optional */ }
+            try { _appRoot = Trim(AppContext.BaseDirectory); } catch { /* swallow */ }
+        }
+
+        private static string? Trim(string? path) =>
+            string.IsNullOrWhiteSpace(path) ? null : path!.TrimEnd('\\', '/');
+
+        private static string? AssetsRoot()
+        {
+            // Re-ask the provider at most once a minute: the user can repoint the assets folder at
+            // runtime, but asking on every log line would mean a Directory.Exists per line.
+            var provider = AssetsRootProvider;
+            if (provider != null && (_assetsRoot == null || Environment.TickCount64 - _assetsStamp > 60_000))
+            {
+                _assetsStamp = Environment.TickCount64;
+                try { _assetsRoot = Trim(provider()); }
+                catch { /* swallow: a broken provider must never break logging */ }
+            }
+            return _assetsRoot;
+        }
+
+        /// <summary>
+        /// Apply every rule, in order. Returns the input unchanged (same reference) when nothing
+        /// matched, which is the overwhelmingly common case.
+        /// </summary>
+        public static string Redact(string? input)
+        {
+            if (string.IsNullOrEmpty(input)) return input ?? string.Empty;
+            if (!MightContainSecrets(input!)) return input!;
+
+            var s = input!;
+            try
+            {
+                EnsureRoots();
+
+                // 1. Known roots first: %DATA% lives under C:\Users\<name>, so collapsing it here
+                //    keeps the more useful token instead of falling through to the "~" rule.
+                s = ReplaceRoot(s, _dataRoot, "%DATA%");
+                s = ReplaceRoot(s, _appRoot, "%APP%");
+                s = ReplaceRoot(s, AssetsRoot(), "%ASSETS%");
+
+                // 2. Any remaining home directory.
+                //    Both regexes consume only the "root + username" span and leave the following
+                //    separator in place, so the replacement is a bare "~".
+                s = UserPathRegex.Replace(s, "~");
+                s = PosixHomePathRegex.Replace(s, "~");
+
+                // 3-4. Contact details and credentials.
+                s = EmailRegex.Replace(s, "<email>");
+                s = JsonTokenRegex.Replace(s, m => m.Groups[1].Value + "<token>");
+                s = BearerRegex.Replace(s, "Bearer <token>");
+                s = DiscordBotTokenRegex.Replace(s, "<token>");
+
+                // 5. Identifiers: keep the last four so lines stay correlatable.
+                s = LongIdRegex.Replace(s, m => "<id:…" + m.Value.Substring(m.Value.Length - 4) + ">");
+                s = UserHandleRegex.Replace(s, m => "u_…" + m.Value.Substring(m.Value.Length - 4));
+            }
+            catch
+            {
+                // swallow: redaction is best effort, but a partially redacted line is still better
+                // than throwing out of a sink and losing the log.
+            }
+            return s;
+        }
+
+        /// <summary>
+        /// Cheap pre-filter. Every rule needs at least one of: a path separator, an "@", an "_",
+        /// a "%", or a run of 17+ digits. Most log lines have none of those and skip 10 regexes.
+        /// </summary>
+        private static bool MightContainSecrets(string s)
+        {
+            int digits = 0, run = 0;
+            bool runDigit = false, runAlpha = false;
+            for (int i = 0; i < s.Length; i++)
+            {
+                char c = s[i];
+                if (c == '\\' || c == '/' || c == '@' || c == '_' || c == '%') return true;
+
+                bool isDigit = c >= '0' && c <= '9';
+                if (isDigit)
+                {
+                    if (++digits >= 17) return true;   // snowflake-shaped id
+                }
+                else digits = 0;
+
+                // A long unbroken base64-ish run carrying both letters and digits. This is what a
+                // bearer token or a Discord bot token looks like when the "Bearer " prefix is the
+                // only separator on the line; without this arm those two rules would never run,
+                // because the token itself contains none of the characters checked above.
+                bool isAlpha = (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
+                if (isDigit || isAlpha || c == '.' || c == '-' || c == '+' || c == '=' || c == '~')
+                {
+                    run++;
+                    runDigit |= isDigit;
+                    runAlpha |= isAlpha;
+                    if (run >= 20 && runDigit && runAlpha) return true;
+                }
+                else
+                {
+                    run = 0;
+                    runDigit = runAlpha = false;
+                }
+            }
+            return false;
+        }
+
+        private static string ReplaceRoot(string s, string? root, string token)
+        {
+            if (root == null || root.Length == 0 || s.Length < root.Length) return s;
+            if (s.IndexOf(root, StringComparison.OrdinalIgnoreCase) < 0)
+            {
+                // Same folder written with the other slash style - one normalised retry, no regex.
+                var alt = root.IndexOf('\\') >= 0 ? root.Replace('\\', '/') : root.Replace('/', '\\');
+                if (ReferenceEquals(alt, root) || s.IndexOf(alt, StringComparison.OrdinalIgnoreCase) < 0) return s;
+                root = alt;
+            }
+            return Replace(s, root, token);
+        }
+
+        private static string Replace(string s, string find, string token)
+        {
+            var sb = new System.Text.StringBuilder(s.Length);
+            int at = 0;
+            while (true)
+            {
+                int hit = s.IndexOf(find, at, StringComparison.OrdinalIgnoreCase);
+                if (hit < 0) break;
+                sb.Append(s, at, hit - at).Append(token);
+                at = hit + find.Length;
+            }
+            if (at == 0) return s;
+            sb.Append(s, at, s.Length - at);
+            return sb.ToString();
+        }
+    }
+}

--- a/Tests/ConditioningControlPanel.Tests/LogRedactorTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/LogRedactorTests.cs
@@ -1,0 +1,109 @@
+using ConditioningControlPanel.Services.Logging;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// Serialises every suite that configures <see cref="LogRedactor"/>'s PROCESS-WIDE roots. The
+/// roots are static because the redactor runs on every log line and cannot afford an instance
+/// lookup per call; that is right for the app and hostile to xUnit's default parallelism, so the
+/// logging suites share one collection instead of racing each other's %DATA% folder.
+/// </summary>
+[CollectionDefinition(Name, DisableParallelization = true)]
+public sealed class LoggingStaticsCollection
+{
+    public const string Name = "LoggingStatics";
+}
+
+/// <summary>
+/// The write-path redaction rules. Until now the only redaction in the app ran at bug-report
+/// UPLOAD time (<see cref="ConditioningControlPanel.Services.LogScrubber"/>), so a week of logs
+/// carried the user's home folder 1,763 times and crash.log carried it in every stack frame -
+/// readable by anyone who opened the folder, whether or not a report was ever filed. These pin the
+/// rules that now run before the text reaches the disk.
+/// </summary>
+[Collection(LoggingStaticsCollection.Name)]
+public class LogRedactorTests
+{
+    private const string Data = @"C:\Users\alice\AppData\Local\ConditioningControlPanel";
+    private const string AppDir = @"C:\Program Files\ConditioningControlPanel";
+    private const string Assets = @"D:\ccp-assets";
+
+    public LogRedactorTests() => LogRedactor.ConfigureRoots(Data, AppDir, Assets);
+
+    [Fact]
+    public void KnownRoots_CollapseToTokens()
+    {
+        Assert.Equal(@"%DATA%\settings.json", LogRedactor.Redact(Data + @"\settings.json"));
+        Assert.Equal(@"%APP%\ccp.exe", LogRedactor.Redact(AppDir + @"\ccp.exe"));
+        Assert.Equal(@"%ASSETS%\images\a.png", LogRedactor.Redact(Assets + @"\images\a.png"));
+    }
+
+    [Fact]
+    public void KnownRoots_AreCaseAndSlashInsensitive()
+    {
+        // Paths reach the log from three places that disagree about case and separators: Path.Combine,
+        // WebView2 file URIs, and hand-built strings.
+        Assert.Equal("%DATA%/logs/app.log", LogRedactor.Redact(Data.ToUpperInvariant().Replace('\\', '/') + "/logs/app.log"));
+    }
+
+    [Fact]
+    public void DataRoot_WinsOverTheHomeFolderRule()
+    {
+        // %DATA% lives under C:\Users\<name>, so rule order matters: the more useful token has to
+        // be applied first or every data path degrades to "~\AppData\Local\...".
+        Assert.StartsWith("%DATA%", LogRedactor.Redact(Data + @"\mods"));
+    }
+
+    [Fact]
+    public void OtherHomeFolders_BecomeTilde()
+    {
+        Assert.Equal(@"~\Desktop\clip.mp4", LogRedactor.Redact(@"C:\Users\alice\Desktop\clip.mp4"));
+        Assert.Equal("reading ~/app/log.txt", LogRedactor.Redact("reading /home/alice/app/log.txt"));
+    }
+
+    [Fact]
+    public void EmailsAndTokens_AreRemoved()
+    {
+        Assert.Equal("mail <email> failed", LogRedactor.Redact("mail alice@example.com failed"));
+
+        // A bearer header carries no path separator and no long digit run, so it only survives the
+        // cheap pre-filter thanks to the base64-run arm. That arm is the point of this assertion.
+        Assert.Equal("Bearer <token>", LogRedactor.Redact("Bearer abcdefghijklmnopqrstuvwxyz012345"));
+        Assert.Equal(@"{""access_token"": <token>", LogRedactor.Redact(@"{""access_token"": ""abcdef0123456789"""));
+    }
+
+    [Fact]
+    public void LongIds_KeepOnlyTheLastFour()
+    {
+        // Discord ids are 17-19 digits. The tail stays so two lines about the same account can
+        // still be correlated during triage without naming the account.
+        Assert.Equal("user <id:…7890>", LogRedactor.Redact("user 123456789012347890"));
+        Assert.Equal("u_…9bc0", LogRedactor.Redact("u_4f2a71bc9bc0"));
+
+        // Shorter runs are timestamps, sizes and counts, and must survive untouched.
+        Assert.Equal("took 1234567890 ms", LogRedactor.Redact("took 1234567890 ms"));
+    }
+
+    [Fact]
+    public void OrdinaryLines_ArePassedThroughUnchanged()
+    {
+        // The cheap pre-filter is the whole reason this is affordable per line: a line with no
+        // separator, no "@" and no long digit run must not touch a single regex.
+        const string line = "Flash shown (count 12, level 4)";
+        Assert.Same(line, LogRedactor.Redact(line));
+    }
+
+    [Fact]
+    public void Scrubber_StillRedactsAfterSharingTheRuleSet()
+    {
+        // LogScrubber now aliases the redactor's regexes rather than owning copies. Its OUTPUT
+        // shape is different on purpose (a human reads it), so pin that it did not drift.
+        var (scrubbed, counts) = ConditioningControlPanel.Services.LogScrubber.Scrub(
+            @"crash in C:\Users\alice\app.exe for bob@example.com");
+        Assert.Contains(@"Users\<redacted>", scrubbed);
+        Assert.Contains("[email redacted]", scrubbed);
+        Assert.Equal(1, counts.Paths);
+        Assert.Equal(1, counts.Emails);
+    }
+}


### PR DESCRIPTION
First of the logging-redesign stack (agent A). **Stacked PRs, merge in order:** this one, then
`feat/log-format`, then `feat/log-throttle`, then the flight recorder and the per-session files.

## What this does

Moves redaction from the bug-report **upload** path to the **write** path.

Today the only redaction in the app is `LogScrubber`, and it runs when a bug report is uploaded. By
then the text has been on disk for a week: a one-week sample of `app-.log` carried
`C:\Users\<name>` 1,763 times, and `crash.log` carries it in every frame of every stack trace,
readable by anyone who opens the logs folder whether or not a report is ever filed.

- New `Services/Logging/LogRedactor.cs` owns the seven shared path/email/token regexes.
  `LogScrubber` now aliases them instead of holding its own copies, so a rule can only be fixed in
  one place. Output shapes are deliberately different: the scrubber keeps `Users\<redacted>` (a
  human reads it), the redactor collapses known roots to `%DATA%` / `%APP%` / `%ASSETS%` (it runs
  per line).
- Rule order matters and is pinned by a test: `%DATA%` lives under `C:\Users\<name>`, so roots are
  collapsed before the home-folder rule can degrade them to `~`.
- Ids: 17-20 digit runs become `<id:…1234>` and `u_…` handles keep their last four, so two lines
  about one account stay correlatable without naming the account.
- `App.LogCrashDetails` runs the crash block through `LogRedactor.Redact` before
  `File.AppendAllText`. crash.log's format is otherwise untouched (the bug reporter parses it).

## Cost

One pass of character checks per line; a line with no separator, no `@` and no long digit run
returns the same string reference. The base64-run arm of that pre-filter is load-bearing rather
than decorative: a bearer token and a Discord bot token contain none of the characters the other
arms look for, so without it those two rules would never fire on the line that actually carries a
credential. There is a test for exactly that.

## Not in this PR

The formatter, enrichers and pipeline (`feat/log-format`), the throttling sink
(`feat/log-throttle`), the flight recorder and per-session files. Level floor is still Information
and the file sink is untouched here, so the only behaviour change is redacted crash blocks.

## Verification

`dotnet build ConditioningControlPanel.sln -c Debug` 0 errors. `dotnet test` 5208 passed, 0 failed
(8 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GSSvqeYrpVG9H3EPtqikDC
