### PR TITLE
fix(logging): stop writing personal content at the known call sites

### DIFF
--- a/ConditioningControlPanel/AvatarTube/AvatarTubeWindow.Reactions.cs
+++ b/ConditioningControlPanel/AvatarTube/AvatarTubeWindow.Reactions.cs
@@ -302,7 +302,7 @@ namespace ConditioningControlPanel
                 if (doubleBounce) PlayDoubleBounce();
                 GigglePriority(text, aiGenerated: true);
 
-                App.Logger?.Debug("Awareness v2 line delivered (rare={Rare}): {Text}", doubleBounce, text);
+                App.Logger?.Debug("Awareness v2 line delivered (rare={Rare}, {Chars} chars)", doubleBounce, (text ?? "").Length);
             }
             catch (Exception ex)
             {
@@ -447,7 +447,7 @@ namespace ConditioningControlPanel
             // (audio will play but text won't show - prevents text/audio desync)
             if (_isGiggling)
             {
-                App.Logger?.Debug("Flash audio speech skipped (bubble showing): {Text}", e.Text);
+                App.Logger?.Debug("Flash audio speech skipped, bubble showing ({Chars} chars)", (e.Text ?? "").Length);
                 return;
             }
 
@@ -464,7 +464,7 @@ namespace ConditioningControlPanel
                 // Show immediately WITHOUT playing sound (FlashService already plays the audio)
                 ShowGiggle(e.Text, playSound: false, source: SpeechSource.Preset);
 
-                App.Logger?.Debug("Flash audio speech: {Text}", e.Text);
+                App.Logger?.Debug("Flash audio speech ({Chars} chars)", (e.Text ?? "").Length);
             });
         }
 

--- a/ConditioningControlPanel/AvatarTube/AvatarTubeWindow.Speech.cs
+++ b/ConditioningControlPanel/AvatarTube/AvatarTubeWindow.Speech.cs
@@ -17,6 +17,7 @@ using System.Windows.Navigation;
 using System.Windows.Threading;
 using ConditioningControlPanel.Models;
 using ConditioningControlPanel.Services;
+using ConditioningControlPanel.Services.Logging;
 using ConditioningControlPanel.Services.Moderation;
 using XamlAnimatedGif;
 using ConditioningControlPanel.Helpers;
@@ -185,7 +186,8 @@ namespace ConditioningControlPanel
             }
 
             var (nextText, source, nextEmotionLineId, nextMood) = _speechQueue.Dequeue();
-            App.Logger?.Debug("Dequeued speech ({Source}): {Text}", source, nextText);
+            App.Logger?.Debug("Dequeued speech ({Source}, line={LineId}, {Chars} chars)",
+                source, nextEmotionLineId ?? "-", (nextText ?? "").Length);
 
             // Calculate how long since last speech ended (delay based on PREVIOUS speech properties)
             double timeSinceLastSpeech = (DateTime.Now - _lastSpeechEndTime).TotalSeconds;
@@ -242,14 +244,14 @@ namespace ConditioningControlPanel
             // Block if waiting for AI response
             if (_isWaitingForAi)
             {
-                App.Logger?.Debug("Giggle blocked - waiting for AI: {Text}", text);
+                App.Logger?.Debug("Giggle blocked - waiting for AI ({Chars} chars)", (text ?? "").Length);
                 return;
             }
 
             // Block (discard) preset phrases while AI bubble is visible - don't queue them
             if (_isShowingAiBubble)
             {
-                App.Logger?.Debug("Giggle discarded - AI bubble visible: {Text}", text);
+                App.Logger?.Debug("Giggle discarded - AI bubble visible ({Chars} chars)", (text ?? "").Length);
                 return;
             }
 
@@ -265,14 +267,14 @@ namespace ConditioningControlPanel
                 // Double-check AI bubble state on UI thread
                 if (_isShowingAiBubble)
                 {
-                    App.Logger?.Debug("Giggle discarded (UI thread) - AI bubble visible: {Text}", text);
+                    App.Logger?.Debug("Giggle discarded (UI thread) - AI bubble visible ({Chars} chars)", (text ?? "").Length);
                     return;
                 }
 
                 if (_isGiggling)
                 {
                     _speechQueue.Enqueue((text, SpeechSource.Preset, emotionLineId, mood));
-                    App.Logger?.Debug("Queued preset speech: {Text}", text);
+                    App.Logger?.Debug("Queued preset speech (line={LineId}, {Chars} chars)", emotionLineId ?? "-", (text ?? "").Length);
                     return;
                 }
 
@@ -354,7 +356,7 @@ namespace ConditioningControlPanel
                 ShowGiggle(text, playSound: playSound, source: SpeechSource.AI, aiGenerated: aiGenerated,
                     phraseAudioPath: phraseAudioPath, barkVoice: barkVoice, emotionLineId: emotionLineId, mood: mood);
 
-                App.Logger?.Debug("Priority speech (queue cleared): {Text}", text);
+                App.Logger?.Debug("Priority speech, queue cleared (line={LineId}, {Chars} chars)", emotionLineId ?? "-", (text ?? "").Length);
             });
         }
 
@@ -603,8 +605,8 @@ namespace ConditioningControlPanel
                 // Reset idle timer when speaking
                 ResetIdleTimer();
 
-                App.Logger?.Debug("Companion says ({Source}, {Chars} chars, {Duration:F1}s): {Text}",
-                    source, (text ?? "").Length, displayDuration, text);
+                App.Logger?.Debug("Companion says ({Source}, {Chars} chars, {Duration:F1}s)",
+                    source, (text ?? "").Length, displayDuration);
             };
 
             _speechLeadInTimer?.Stop();
@@ -1224,7 +1226,8 @@ namespace ConditioningControlPanel
                     };
                     hyperlink.RequestNavigate += SpeechBubbleHyperlink_RequestNavigate;
                     target.Add(hyperlink);
-                    App.Logger?.Information("Auto-linked video: '{Name}' -> {Url}", displayText, url);
+                    App.Logger?.Information("Auto-linked video on {Host} ({Chars} chars of link text)",
+                        UrlLog.Host(url), (displayText ?? "").Length);
                 }
                 catch
                 {
@@ -1271,7 +1274,7 @@ namespace ConditioningControlPanel
                 }
 
                 var url = e.Uri.AbsoluteUri;
-                App.Logger?.Information("Speech bubble link clicked - Raw URI: {Uri}, AbsoluteUri: {Url}", e.Uri, url);
+                App.Logger?.Information("Speech bubble link clicked: {Host}", UrlLog.Host(url));
 
                 // Find MainWindow - it might not be Application.Current.MainWindow if AvatarTube is detached
                 var mainWindow = _parentWindow as MainWindow
@@ -1286,7 +1289,7 @@ namespace ConditioningControlPanel
 
                 if (mainWindow?.NavigateToUrlInBrowser(url, autoPlayFullscreen: true) == true)
                 {
-                    App.Logger?.Information("Speech bubble link routed to embedded browser: {Url}", url);
+                    App.Logger?.Information("Speech bubble link routed to embedded browser: {Host}", UrlLog.Host(url));
                 }
                 else
                 {
@@ -1298,7 +1301,7 @@ namespace ConditioningControlPanel
                     // Fallback: open in external browser (HTTPS only for safety)
                     if (Uri.TryCreate(url, UriKind.Absolute, out var fallbackUri) && fallbackUri.Scheme == "https")
                     {
-                        App.Logger?.Warning("Embedded browser unavailable, opening externally: {Url}", url);
+                        App.Logger?.Warning("Embedded browser unavailable, opening externally: {Host}", UrlLog.Host(url));
                         System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(url) { UseShellExecute = true });
                     }
                 }
@@ -1814,7 +1817,8 @@ namespace ConditioningControlPanel
                 // (alluring/dreamy/entrancing/teasing), pose count scaled to the line's audio length.
                 PlayEmotionForLine(System.IO.Path.GetFileNameWithoutExtension(filePath), filePath, text);
 
-                App.Logger?.Information("VoiceLine: Displayed '{Text}'", text);
+                App.Logger?.Information("VoiceLine: Displayed {Line} ({Chars} chars)",
+                    System.IO.Path.GetFileNameWithoutExtension(filePath), (text ?? "").Length);
 
                 // Calculate display duration based on text length
                 double baseDuration = 5.0;

--- a/ConditioningControlPanel/MainWindow/MainWindow.Browser.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.Browser.cs
@@ -18,6 +18,7 @@ using System.Windows.Media.Animation;
 using System.Windows.Media.Effects;
 using System.Windows.Media.Imaging;
 using System.Windows.Threading;
+using ConditioningControlPanel.Services.Logging;
 using Rectangle = System.Windows.Shapes.Rectangle;
 using NAudio.Wave;
 using ConditioningControlPanel.Localization;
@@ -136,8 +137,8 @@ namespace ConditioningControlPanel
                         var hapticsConnected = App.Haptics?.IsConnected == true;
                         var isHypnotube = url.Contains("hypnotube", StringComparison.OrdinalIgnoreCase);
 
-                        App.Logger?.Information("AudioSync check: Enabled={Enabled}, HapticsConnected={Connected}, IsHypnotube={IsHT}, URL={Url}",
-                            audioSyncEnabled, hapticsConnected, isHypnotube, url);
+                        App.Logger?.Information("AudioSync check: Enabled={Enabled}, HapticsConnected={Connected}, IsHypnotube={IsHT}, Host={Host}",
+                            audioSyncEnabled, hapticsConnected, isHypnotube, UrlLog.Host(url));
 
                         if (audioSyncEnabled && hapticsConnected && isHypnotube)
                         {
@@ -449,7 +450,7 @@ namespace ConditioningControlPanel
                 return;
             }
 
-            App.Logger?.Warning("Browser never finished initializing - opening externally: {Url}", url);
+            App.Logger?.Warning("Browser never finished initializing - opening externally: {Host}", UrlLog.Host(url));
             OpenUrlExternallyAfterBrowserFailure(url);
         }
 
@@ -462,12 +463,12 @@ namespace ConditioningControlPanel
             try
             {
                 if (!Uri.TryCreate(url, UriKind.Absolute, out var uri) || uri.Scheme != Uri.UriSchemeHttps) return;
-                App.Logger?.Warning("Embedded browser init failed, opening externally: {Url}", url);
+                App.Logger?.Warning("Embedded browser init failed, opening externally: {Host}", UrlLog.Host(url));
                 System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(url) { UseShellExecute = true });
             }
             catch (Exception ex)
             {
-                App.Logger?.Warning(ex, "Failed to open URL externally: {Url}", url);
+                App.Logger?.Warning(ex, "Failed to open URL externally: {Host}", UrlLog.Host(url));
             }
         }
 
@@ -630,7 +631,7 @@ namespace ConditioningControlPanel
             // Block navigation in offline mode.
             if (App.Settings?.Current?.OfflineMode == true)
             {
-                App.Logger?.Debug("Browser navigation blocked in offline mode: {Url}", url);
+                App.Logger?.Debug("Browser navigation blocked in offline mode: {Host}", UrlLog.Host(url));
                 if (userInitiated) NotifyBrowserBlockedOffline();
                 return false;
             }
@@ -656,8 +657,8 @@ namespace ConditioningControlPanel
                 }
                 if (_browserInitialized)
                 {
-                    App.Logger?.Warning("Browser flagged ready but is not usable (service init={Init}, core={HasCore}) - re-initializing for {Url}",
-                        _browser?.IsInitialized == true, _browser?.WebView?.CoreWebView2 != null, url);
+                    App.Logger?.Warning("Browser flagged ready but is not usable (service init={Init}, core={HasCore}) - re-initializing for {Host}",
+                        _browser?.IsInitialized == true, _browser?.WebView?.CoreWebView2 != null, UrlLog.Host(url));
                     _browserInitialized = false; // let InitializeBrowserAsync tear down and rebuild
                 }
                 _ = InitAndNavigateAsync(url, autoPlayFullscreen);
@@ -666,7 +667,7 @@ namespace ConditioningControlPanel
 
             if (_browser == null)
             {
-                App.Logger?.Warning("Browser not available for navigation: {Url}", url);
+                App.Logger?.Warning("Browser not available for navigation: {Host}", UrlLog.Host(url));
                 return false;
             }
 
@@ -724,7 +725,7 @@ namespace ConditioningControlPanel
                 }
                 else if (autoPlayFullscreen)
                 {
-                    App.Logger?.Warning("Auto-play/fullscreen requested but CoreWebView2 is null - takeover skipped: {Url}", url);
+                    App.Logger?.Warning("Auto-play/fullscreen requested but CoreWebView2 is null - takeover skipped: {Host}", UrlLog.Host(url));
                 }
 
                 // Navigate. A dropped Navigate must surface as failure: reporting success here is
@@ -735,18 +736,18 @@ namespace ConditioningControlPanel
                     if (navCompletedHandler != null && _browser.WebView?.CoreWebView2 != null)
                         _browser.WebView.CoreWebView2.NavigationCompleted -= navCompletedHandler;
 
-                    App.Logger?.Warning("Speech link navigation dropped by browser service: {Url}", url);
+                    App.Logger?.Warning("Speech link navigation dropped by browser service: {Host}", UrlLog.Host(url));
                     return false;
                 }
 
-                App.Logger?.Information("Speech link navigated to: {Url} (Site: {Site}, AutoPlay: {AutoPlay})",
-                    url, lowerUrl.Contains("bambicloud") ? "BambiCloud" : "HypnoTube", autoPlayFullscreen);
+                App.Logger?.Information("Speech link navigated to {Host} (Site: {Site}, AutoPlay: {AutoPlay})",
+                    UrlLog.Host(url), lowerUrl.Contains("bambicloud") ? "BambiCloud" : "HypnoTube", autoPlayFullscreen);
 
                 return true;
             }
             catch (Exception ex)
             {
-                App.Logger?.Error(ex, "Browser navigation failed for URL: {Url}", url);
+                App.Logger?.Error(ex, "Browser navigation failed for host: {Host}", UrlLog.Host(url));
                 return false;
             }
         }
@@ -983,11 +984,12 @@ namespace ConditioningControlPanel
                 // Log audio sync messages at Information level for debugging
                 if (message.Contains("audioSync"))
                 {
-                    App.Logger?.Information("AudioSync message received: {Message}", message);
+                    // Page messages carry the page title and video URL. Shape only.
+                    App.Logger?.Information("AudioSync message received ({Bytes} bytes)", message?.Length ?? 0);
                 }
                 else
                 {
-                    App.Logger?.Debug("Browser web message received: {Message}", message);
+                    App.Logger?.Debug("Browser web message received ({Bytes} bytes)", message?.Length ?? 0);
                 }
 
                 // Force-exit our WPF "forced fullscreen" surface — sent by the
@@ -1120,7 +1122,7 @@ namespace ConditioningControlPanel
                 if (urlMatch.Success)
                 {
                     var videoUrl = urlMatch.Groups[1].Value;
-                    App.Logger?.Information("AudioSync: Starting processing for video URL: {Url}", videoUrl);
+                    App.Logger?.Information("AudioSync: Starting processing for video on {Host}", UrlLog.Host(videoUrl));
 
                     // Wire up progress events
                     void OnProgress(object? sender, Services.Audio.ChunkProgressEventArgs e)
@@ -1593,7 +1595,7 @@ namespace ConditioningControlPanel
                         UseShellExecute = false
                     };
                     System.Diagnostics.Process.Start(startInfo);
-                    App.Logger?.Information("Opened Discord profile for user: {DiscordId}", discordId);
+                    App.Logger?.Information("Opened Discord profile for a leaderboard entry");
                 }
                 catch (Exception ex)
                 {
@@ -2413,7 +2415,7 @@ namespace ConditioningControlPanel
                             }
                             catch (Exception ex)
                             {
-                                App.Logger?.Warning(ex, "Failed to load profile avatar from {Url}", avatarUrl);
+                                App.Logger?.Warning(ex, "Failed to load profile avatar from {Host}", UrlLog.Host(avatarUrl));
                                 DiscordTab.ProfileViewerAvatar.ImageSource = null;
                                 SetProfilePictureLoad(ProfilePictureLoad.None);
                             }
@@ -3123,7 +3125,7 @@ namespace ConditioningControlPanel
                 var isBambiCloud = SettingsTab.RbBambiCloud?.IsChecked == true;
                 var url = isBambiCloud ? "https://bambicloud.com/" : "https://hypnotube.com/";
                 _browser.Navigate(url);
-                App.Logger?.Information("Browser navigated to current site home: {Url}", url);
+                App.Logger?.Information("Browser navigated to current site home: {Host}", UrlLog.Host(url));
             }
             catch (Exception ex)
             {

--- a/ConditioningControlPanel/MainWindow/MainWindow.Leaderboard.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.Leaderboard.cs
@@ -922,7 +922,7 @@ namespace ConditioningControlPanel
                 }
                 catch (Exception ex)
                 {
-                    App.Logger?.Warning(ex, "Failed to open Discord profile for user {DiscordId}", discordId);
+                    App.Logger?.Warning(ex, "Failed to open Discord profile for a leaderboard entry");
                 }
             }
         }

--- a/ConditioningControlPanel/MainWindow/MainWindow.UiUpdates.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.UiUpdates.cs
@@ -23,6 +23,7 @@ using NAudio.Wave;
 using ConditioningControlPanel.Localization;
 using ConditioningControlPanel.Models;
 using ConditioningControlPanel.Helpers;
+using ConditioningControlPanel.Services.Logging;
 using ConditioningControlPanel.Services;
 
 namespace ConditioningControlPanel
@@ -2603,8 +2604,8 @@ namespace ConditioningControlPanel
                 // Disconnect all network services
                 DisconnectNetworkServices();
 
-                App.Logger?.Information("Offline mode enabled with username '{Username}'",
-                    App.Settings.Current.OfflineUsername);
+                App.Logger?.Information("Offline mode enabled with a local username ({Chars} chars)",
+                    App.Settings.Current.OfflineUsername?.Length ?? 0);
             }
             else
             {
@@ -2757,7 +2758,7 @@ namespace ConditioningControlPanel
                                 ? "https://bambicloud.com/"
                                 : "https://hypnotube.com/";
                             _browser.Navigate(url);
-                            App.Logger?.Information("Browser reloaded after exiting offline mode: {Url}", url);
+                            App.Logger?.Information("Browser reloaded after exiting offline mode: {Host}", UrlLog.Host(url));
                         }
                         catch (Exception ex)
                         {

--- a/ConditioningControlPanel/MainWindow/MainWindow.xaml.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.xaml.cs
@@ -2058,8 +2058,8 @@ namespace ConditioningControlPanel
 
                 App.Settings.Current.OfflineMode = true;
                 DisconnectNetworkServices();
-                App.Logger?.Information("Offline mode enabled with username '{Username}'",
-                    App.Settings.Current.OfflineUsername);
+                App.Logger?.Information("Offline mode enabled with a local username ({Chars} chars)",
+                    App.Settings.Current.OfflineUsername?.Length ?? 0);
             }
             else
             {

--- a/ConditioningControlPanel/Services/Account/AccountService.cs
+++ b/ConditioningControlPanel/Services/Account/AccountService.cs
@@ -158,8 +158,10 @@ public static class AccountService
                     App.Discord.CustomDisplayName = lookupResult.DisplayName;
                 }
 
-                App.Logger?.Information("AccountService: Returning user found - {DisplayName} ({UnifiedId})",
-                    lookupResult.DisplayName, lookupResult.UnifiedId);
+                // Unified id only. The display name is the handle the user picked and is the
+                // single most identifying string we hold (logging policy: ids, counts, enums).
+                App.Logger?.Information("AccountService: Returning user found ({UnifiedId})",
+                    lookupResult.UnifiedId);
 
                 // Load profile and start sync
                 await App.ProfileSync?.LoadProfileAsync();
@@ -171,8 +173,8 @@ public static class AccountService
             // Step 4: Check for auto-link opportunity (same email as existing account)
             if (lookupResult.CanAutoLink && !string.IsNullOrEmpty(lookupResult.AutoLinkUnifiedId))
             {
-                App.Logger?.Information("AccountService: Auto-link opportunity found for {Provider} -> {DisplayName}",
-                    provider, lookupResult.AutoLinkDisplayName);
+                App.Logger?.Information("AccountService: Auto-link opportunity found for {Provider} -> {UnifiedId}",
+                    provider, lookupResult.AutoLinkUnifiedId);
 
                 // Auto-link the provider to existing account
                 var linkResult = await LinkProviderAsync(provider, accessToken, lookupResult.AutoLinkUnifiedId);
@@ -365,8 +367,9 @@ public static class AccountService
                     App.Discord.CustomDisplayName = authResponse.User.DisplayName;
                 }
 
-                App.Logger?.Information("AccountService: V2 auth complete - {DisplayName} ({UnifiedId}), OG={IsOg}",
-                    authResponse.User.DisplayName, authResponse.User.UnifiedId, authResponse.User.IsSeason0Og);
+                App.Logger?.Information("AccountService: V2 auth complete ({UnifiedId}), OG={IsOg}, named={HasName}",
+                    authResponse.User.UnifiedId, authResponse.User.IsSeason0Og,
+                    !string.IsNullOrWhiteSpace(authResponse.User.DisplayName));
 
                 // Start profile sync heartbeat
                 App.ProfileSync?.StartHeartbeat();
@@ -488,7 +491,8 @@ public static class AccountService
 
             if (!response.IsSuccessStatusCode)
             {
-                App.Logger?.Warning("AccountService: Lookup failed - {Status}: {Body}", response.StatusCode, json);
+                App.Logger?.Warning("AccountService: Lookup failed - {Status} (body {Bytes} bytes)",
+                    (int)response.StatusCode, json?.Length ?? 0);
                 return null;
             }
 
@@ -683,8 +687,8 @@ public static class AccountService
                         App.Discord.CustomDisplayName = result.DisplayName;
                     }
 
-                    App.Logger?.Information("AccountService: Registered new user {DisplayName} ({UnifiedId})",
-                        result.DisplayName, result.UnifiedId);
+                    App.Logger?.Information("AccountService: Registered new user ({UnifiedId})",
+                        result.UnifiedId);
 
                     nameSet = true;
 
@@ -720,8 +724,8 @@ public static class AccountService
                                 App.Discord.CustomDisplayName = trimmedName;
                             }
 
-                            App.Logger?.Information("AccountService: Claimed account {DisplayName} ({UnifiedId})",
-                                trimmedName, claimResponse.UnifiedId);
+                            App.Logger?.Information("AccountService: Claimed account ({UnifiedId})",
+                                claimResponse.UnifiedId);
 
                             nameSet = true;
 

--- a/ConditioningControlPanel/Services/Account/DiscordRichPresenceService.cs
+++ b/ConditioningControlPanel/Services/Account/DiscordRichPresenceService.cs
@@ -87,7 +87,7 @@ public class DiscordRichPresenceService : IDisposable
 
             _client.OnReady += (sender, e) =>
             {
-                App.Logger?.Information("Discord RPC connected: {Username}", e.User.Username);
+                App.Logger?.Information("Discord RPC connected");
             };
 
             _client.OnError += (sender, e) =>

--- a/ConditioningControlPanel/Services/Account/DiscordService.cs
+++ b/ConditioningControlPanel/Services/Account/DiscordService.cs
@@ -738,12 +738,14 @@ namespace ConditioningControlPanel.Services
 
                 if (response.IsSuccessStatusCode)
                 {
-                    App.Logger?.Information("Achievement shared to community: {Name} - Response: {Response}", achievement.Name, responseText);
+                    App.Logger?.Information("Achievement shared to community: {Achievement} ({Status}, {Bytes} bytes)",
+                        achievement.Id, (int)response.StatusCode, responseText?.Length ?? 0);
                     return true;
                 }
                 else
                 {
-                    App.Logger?.Warning("Achievement share failed: {Status} - {Response}", response.StatusCode, responseText);
+                    App.Logger?.Warning("Achievement share failed: {Status} (body {Bytes} bytes)",
+                        (int)response.StatusCode, responseText?.Length ?? 0);
                     return false;
                 }
             }
@@ -802,12 +804,14 @@ namespace ConditioningControlPanel.Services
 
                 if (response.IsSuccessStatusCode)
                 {
-                    App.Logger?.Information("Level up shared to community: Level {Level} - Response: {Response}", level, responseText);
+                    App.Logger?.Information("Level up shared to community: Level {Level} ({Status}, {Bytes} bytes)",
+                        level, (int)response.StatusCode, responseText?.Length ?? 0);
                     return true;
                 }
                 else
                 {
-                    App.Logger?.Warning("Level up share failed: {Status} - {Response}", response.StatusCode, responseText);
+                    App.Logger?.Warning("Level up share failed: {Status} (body {Bytes} bytes)",
+                        (int)response.StatusCode, responseText?.Length ?? 0);
                     return false;
                 }
             }
@@ -855,7 +859,7 @@ namespace ConditioningControlPanel.Services
                 _tokenStorage.StoreCachedState(cachedState);
             }
 
-            App.Logger?.Information("Custom display name set to: {DisplayName} (claimed: {Claimed})", CustomDisplayName, claimExisting);
+            App.Logger?.Information("Custom display name set ({Chars} chars, claimed: {Claimed})", CustomDisplayName?.Length ?? 0, claimExisting);
             return (true, null, false);
         }
 
@@ -982,7 +986,7 @@ namespace ConditioningControlPanel.Services
                             cachedState.CustomDisplayName = CustomDisplayName;
                             _tokenStorage.StoreCachedState(cachedState);
                         }
-                        App.Logger?.Information("Loaded display name from server: {Name}", CustomDisplayName);
+                        App.Logger?.Information("Loaded display name from server ({Chars} chars)", CustomDisplayName?.Length ?? 0);
                         return;
                     }
                 }
@@ -998,7 +1002,7 @@ namespace ConditioningControlPanel.Services
                         cachedState.CustomDisplayName = CustomDisplayName;
                         _tokenStorage.StoreCachedState(cachedState);
                     }
-                    App.Logger?.Information("Adopted display name from Patreon: {Name}", CustomDisplayName);
+                    App.Logger?.Information("Adopted display name from Patreon ({Chars} chars)", CustomDisplayName?.Length ?? 0);
                 }
             }
             catch (Exception ex)

--- a/ConditioningControlPanel/Services/Account/PatreonService.cs
+++ b/ConditioningControlPanel/Services/Account/PatreonService.cs
@@ -692,7 +692,7 @@ namespace ConditioningControlPanel.Services
                 {
                     // Adopt Discord's display name if Patreon doesn't have one
                     DisplayName = discordDisplayName;
-                    App.Logger?.Information("Adopted display name from Discord: {Name}", DisplayName);
+                    App.Logger?.Information("Adopted display name from Discord ({Chars} chars)", DisplayName.Length);
                 }
 
                 // Cache result for 24 hours (use effective values for whitelisted users)
@@ -828,7 +828,7 @@ namespace ConditioningControlPanel.Services
             var checkResult = await CheckDisplayNameAvailableAsync(trimmedName);
             if (!checkResult.Available)
             {
-                App.Logger?.Warning("Display name '{Name}' is already taken", trimmedName);
+                App.Logger?.Warning("Display name is already taken ({Chars} chars)", trimmedName.Length);
                 return (false, checkResult.Error ?? "This name is already taken. Please choose another.");
             }
 
@@ -845,7 +845,7 @@ namespace ConditioningControlPanel.Services
             // Save to server so it syncs across devices
             await SaveDisplayNameToServerAsync(DisplayName);
 
-            App.Logger?.Information("Display name set to: {DisplayName}", DisplayName);
+            App.Logger?.Information("Display name set ({Chars} chars)", DisplayName?.Length ?? 0);
             NeedsDisplayNameMigration = false;
             return (true, null);
         }
@@ -861,13 +861,13 @@ namespace ConditioningControlPanel.Services
                 return (true, null); // Nothing to migrate
             }
 
-            App.Logger?.Information("Attempting to migrate local display name to server: {Name}", DisplayName);
+            App.Logger?.Information("Attempting to migrate local display name to server ({Chars} chars)", DisplayName?.Length ?? 0);
 
             // Check if the name is available
             var checkResult = await CheckDisplayNameAvailableAsync(DisplayName);
             if (!checkResult.Available)
             {
-                App.Logger?.Warning("Migration failed - name '{Name}' is already taken", DisplayName);
+                App.Logger?.Warning("Migration failed - display name is already taken ({Chars} chars)", DisplayName?.Length ?? 0);
                 // Clear the local name so user can pick a new one
                 DisplayName = null;
                 var cachedState = _tokenStorage.RetrieveCachedState();
@@ -883,7 +883,7 @@ namespace ConditioningControlPanel.Services
             // Name is available - sync to server
             await SaveDisplayNameToServerAsync(DisplayName);
             NeedsDisplayNameMigration = false;
-            App.Logger?.Information("Successfully migrated display name to server: {Name}", DisplayName);
+            App.Logger?.Information("Successfully migrated display name to server");
             return (true, null);
         }
 

--- a/ConditioningControlPanel/Services/AudioSyncService.cs
+++ b/ConditioningControlPanel/Services/AudioSyncService.cs
@@ -103,12 +103,12 @@ namespace ConditioningControlPanel.Services
 
             if (!VideoDownloader.IsLikelyVideoUrl(videoUrl))
             {
-                Log.Debug("AudioSyncService: URL doesn't look like a video: {Url}", videoUrl);
+                Log.Debug("AudioSyncService: URL doesn't look like a video: {Host}", Logging.UrlLog.Host(videoUrl));
                 ProcessingCompleted?.Invoke(this, EventArgs.Empty);
                 return;
             }
 
-            Log.Information("AudioSyncService: Video detected, starting processing: {Url}", videoUrl);
+            Log.Information("AudioSyncService: Video detected on {Host}, starting processing", Logging.UrlLog.Host(videoUrl));
 
             try
             {

--- a/ConditioningControlPanel/Services/Browser/BrowserService.cs
+++ b/ConditioningControlPanel/Services/Browser/BrowserService.cs
@@ -7,6 +7,7 @@ using System.Windows;
 using System.Windows.Controls;
 using Microsoft.Web.WebView2.Core;
 using Microsoft.Web.WebView2.Wpf;
+using ConditioningControlPanel.Services.Logging;
 
 namespace ConditioningControlPanel.Services
 {
@@ -477,7 +478,7 @@ namespace ConditioningControlPanel.Services
 
                 // Navigate to URL
                 var url = _pendingUrl ?? _defaultUrl;
-                App.Logger?.Information("Navigating to: {Url}", url);
+                App.Logger?.Information("Navigating to: {Host}", UrlLog.Host(url));
                 _webView.CoreWebView2.Navigate(url);
 
                 _isInitialized = true;
@@ -537,7 +538,7 @@ namespace ConditioningControlPanel.Services
                 // Check if it's an ad popup (no user gesture or suspicious URL)
                 if (IsAdUrl(e.Uri))
                 {
-                    App.Logger?.Debug("Blocked ad popup: {Url}", e.Uri);
+                    App.Logger?.Debug("Blocked ad popup: {Host}", UrlLog.Host(e.Uri));
                     e.Handled = true;
                     return;
                 }
@@ -1198,8 +1199,8 @@ namespace ConditioningControlPanel.Services
         {
             if (_disposed || !_isInitialized || _webView?.CoreWebView2 == null)
             {
-                App.Logger?.Warning("Navigate dropped - browser not ready (disposed={Disposed}, init={Init}, core={HasCore}): {Url}",
-                    _disposed, _isInitialized, _webView?.CoreWebView2 != null, url);
+                App.Logger?.Warning("Navigate dropped - browser not ready (disposed={Disposed}, init={Init}, core={HasCore}): {Host}",
+                    _disposed, _isInitialized, _webView?.CoreWebView2 != null, UrlLog.Host(url));
                 return false;
             }
 
@@ -1215,7 +1216,10 @@ namespace ConditioningControlPanel.Services
                     lowerUrl.StartsWith("data:") ||
                     lowerUrl.StartsWith("vbscript:"))
                 {
-                    App.Logger?.Warning("Blocked potentially dangerous URL scheme: {Url}", url);
+                    // Scheme only: the rest of a javascript:/data: URL is a payload, and for
+                    // file: it is a local path.
+                    App.Logger?.Warning("Blocked potentially dangerous URL scheme: {Scheme}",
+                        lowerUrl.Substring(0, lowerUrl.IndexOf(':') + 1));
                     return false;
                 }
 
@@ -1230,19 +1234,19 @@ namespace ConditioningControlPanel.Services
                 if (url.StartsWith("http://", StringComparison.OrdinalIgnoreCase))
                 {
                     url = "https://" + url.Substring(7);
-                    App.Logger?.Debug("Upgraded HTTP to HTTPS: {Url}", url);
+                    App.Logger?.Debug("Upgraded HTTP to HTTPS: {Host}", UrlLog.Host(url));
                 }
 
                 // Validate URL format
                 if (!Uri.TryCreate(url, UriKind.Absolute, out var uri) ||
                     (uri.Scheme != Uri.UriSchemeHttps))
                 {
-                    App.Logger?.Warning("Invalid URL rejected: {Url}", url);
+                    App.Logger?.Warning("Invalid URL rejected ({Chars} chars)", url.Length);
                     return false;
                 }
 
                 _webView.CoreWebView2.Navigate(url);
-                App.Logger?.Debug("Navigating to: {Url}", url);
+                App.Logger?.Debug("Navigating to: {Host}", UrlLog.Host(url));
                 return true;
             }
             catch (Exception ex)
@@ -1379,7 +1383,7 @@ namespace ConditioningControlPanel.Services
 
                 if (Uri.TryCreate(url, UriKind.Absolute, out _))
                 {
-                    App.Logger?.Information("Extracted video URL: {Url}", url);
+                    App.Logger?.Information("Extracted video URL from {Host}", UrlLog.Host(url));
                     return url;
                 }
 

--- a/ConditioningControlPanel/Services/Companion/BarkService.cs
+++ b/ConditioningControlPanel/Services/Companion/BarkService.cs
@@ -1962,17 +1962,20 @@ namespace ConditioningControlPanel.Services
         private void LogDecision(string trigger, BarkRule rule, GateDecision decision)
         {
             var pool = ResolvePool(rule);
-            string preview = decision.VariantIndex >= 0 && decision.VariantIndex < pool.Count
-                ? Truncate(pool[decision.VariantIndex].Text, 48)
-                : "(n/a)";
+            // Length, not the line. The bark text is the companion talking to the user and is
+            // the sort of thing that ends up pasted into a support thread; rule + variant index
+            // identify the line exactly for anyone with the pack in front of them.
+            int lineChars = decision.VariantIndex >= 0 && decision.VariantIndex < pool.Count
+                ? (pool[decision.VariantIndex].Text ?? "").Length
+                : -1;
             string tag = DryRun ? "[BARK dry-run]" : "[BARK]";
 
             if (decision.WouldFire)
             {
                 string verb = DryRun ? "WOULD FIRE" : "FIRE";
                 App.Logger?.Information(
-                    "{Tag} {Verb} trigger={Trigger} rule={Rule} class={Class} mood={Mood} priority={Priority} variant#={Idx} line=\"{Preview}\"",
-                    tag, verb, trigger, rule.Id, rule.Class, rule.Mood, rule.Priority, decision.VariantIndex, preview);
+                    "{Tag} {Verb} trigger={Trigger} rule={Rule} class={Class} mood={Mood} priority={Priority} variant#={Idx} lineChars={Chars}",
+                    tag, verb, trigger, rule.Id, rule.Class, rule.Mood, rule.Priority, decision.VariantIndex, lineChars);
             }
             else
             {
@@ -1981,8 +1984,5 @@ namespace ConditioningControlPanel.Services
                     tag, trigger, rule.Id, rule.Class, rule.Priority, decision.Reason);
             }
         }
-
-        private static string Truncate(string s, int n) =>
-            string.IsNullOrEmpty(s) ? "" : (s.Length <= n ? s : s.Substring(0, n) + "…");
     }
 }

--- a/ConditioningControlPanel/Services/Deeper/BrowserEnhancementBridge.cs
+++ b/ConditioningControlPanel/Services/Deeper/BrowserEnhancementBridge.cs
@@ -120,7 +120,7 @@ namespace ConditioningControlPanel.Services.Deeper
                 // Bark hook: an enhancement was applied to the current page. Identify it by name
                 // (enhancements have no id/slug field — name is the stable human key authors match on).
                 try { App.Bark?.NotifyEnhancementApplied(match.Name); } catch { /* never break playback for a bark */ }
-                App.Logger?.Information("BrowserEnhancementBridge: bound {Name} for {Url}", match.Name, UrlSafety.RedactUrl(url));
+                App.Logger?.Information("BrowserEnhancementBridge: bound {Name} for {Host}", match.Name, Logging.UrlLog.Host(url));
             }
             catch (Exception ex)
             {

--- a/ConditioningControlPanel/Services/Haptics/LovenseProvider.cs
+++ b/ConditioningControlPanel/Services/Haptics/LovenseProvider.cs
@@ -6,6 +6,7 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Serilog;
+using ConditioningControlPanel.Services.Logging;
 
 namespace ConditioningControlPanel.Services.Haptics
 {
@@ -73,7 +74,7 @@ namespace ConditioningControlPanel.Services.Haptics
         {
             try
             {
-                App.Logger?.Information("Connecting to Lovense in {Mode} mode at {Url}", _mode, _baseUrl);
+                App.Logger?.Information("Connecting to Lovense in {Mode} mode at {Host}", _mode, UrlLog.Host(_baseUrl));
                 
                 string content;
                 if (_mode == LovenseConnectionMode.Lan)
@@ -90,7 +91,9 @@ namespace ConditioningControlPanel.Services.Haptics
                     content = await response.Content.ReadAsStringAsync();
                 }
 
-                App.Logger?.Information("Lovense response: {Content}", content);
+                // The GetToys body carries the toy nicknames the user typed and the LAN address
+                // of their phone. Shape only.
+                App.Logger?.Information("Lovense GetToys response ({Bytes} bytes)", content?.Length ?? 0);
                 using var doc = JsonDocument.Parse(content);
                 var root = doc.RootElement;
 
@@ -140,7 +143,8 @@ namespace ConditioningControlPanel.Services.Haptics
                     
                 ConnectedDevices.Add(displayName);
                 DeviceDiscovered?.Invoke(this, displayName);
-                App.Logger?.Information("Found toy: {Id} - {Name}", _toyId, displayName);
+                App.Logger?.Information("Found toy: {Id} ({Type}, battery {Battery}%, nicknamed={HasNick})",
+                    _toyId, toyType, battery, !string.IsNullOrEmpty(nickName));
             }
             if (ConnectedDevices.Count > 0) 
             { 
@@ -231,21 +235,21 @@ namespace ConditioningControlPanel.Services.Haptics
                     // Lovense Remote API requires timeSec parameter
                     var sec = Math.Max(1, durationMs / 1000);
                     var cmdJson = $"{{\"command\":\"Function\",\"action\":\"Vibrate:{i}\",\"timeSec\":{sec},\"apiVer\":1}}";
-                    App.Logger?.Information("Lovense sending: {Json}", cmdJson);
+                    App.Logger?.Information("Lovense sending Vibrate:{Level} for {Seconds}s (LAN)", i, sec);
                     var json = new StringContent(cmdJson, Encoding.UTF8, "application/json");
                     var response = await _client.PostAsync($"{_baseUrl}/command", json);
                     var responseContent = await response.Content.ReadAsStringAsync();
-                    App.Logger?.Information("Lovense response: {Status} - {Content}", response.StatusCode, responseContent);
+                    App.Logger?.Information("Lovense response: {Status} ({Bytes} bytes)", (int)response.StatusCode, responseContent?.Length ?? 0);
                 }
                 else
                 {
                     // For Lovense Connect (Local mode), use simpler command without timeSec
                     // The device maintains vibration until next command
                     var url = $"{_baseUrl}/command?command=Vibrate&action=Vibrate&intensity={i}&toy={_toyId}";
-                    App.Logger?.Debug("Lovense sending GET: {Url} (level {Level})", url, i);
+                    App.Logger?.Debug("Lovense sending GET Vibrate to {Host} (level {Level})", UrlLog.Host(url), i);
                     var response = await _client.GetAsync(url);
                     var responseContent = await response.Content.ReadAsStringAsync();
-                    App.Logger?.Debug("Lovense response: {Status} - {Content}", response.StatusCode, responseContent);
+                    App.Logger?.Debug("Lovense response: {Status} ({Bytes} bytes)", (int)response.StatusCode, responseContent?.Length ?? 0);
                 }
             }
             catch (Exception ex) { App.Logger?.Warning(ex, "Vibrate failed"); }
@@ -321,11 +325,11 @@ namespace ConditioningControlPanel.Services.Haptics
                 {
                     // Use standard Vibrate command with longer duration
                     var cmdJson = $"{{\"command\":\"Function\",\"action\":\"Vibrate:{levelToSend}\",\"timeSec\":{durationSec},\"apiVer\":1}}";
-                    App.Logger?.Information("Lovense sending: {Json}", cmdJson);
+                    App.Logger?.Information("Lovense sending Vibrate:{Level} for {Seconds}s (LAN pattern)", levelToSend, durationSec);
                     var json = new StringContent(cmdJson, Encoding.UTF8, "application/json");
                     var response = await _client.PostAsync($"{_baseUrl}/command", json);
                     var responseContent = await response.Content.ReadAsStringAsync();
-                    App.Logger?.Information("Lovense response: {Status} - {Content}", response.StatusCode, responseContent);
+                    App.Logger?.Information("Lovense response: {Status} ({Bytes} bytes)", (int)response.StatusCode, responseContent?.Length ?? 0);
                 }
                 else
                 {

--- a/ConditioningControlPanel/Services/Logging/UrlLog.cs
+++ b/ConditioningControlPanel/Services/Logging/UrlLog.cs
@@ -1,0 +1,67 @@
+using System;
+
+namespace ConditioningControlPanel.Services.Logging
+{
+    /// <summary>
+    /// Turns a URL into the only part of it that is safe to write to a log file: the host.
+    ///
+    /// Everything after the host is content. A HypnoTube path is the title of the video the
+    /// user was watching, a query string carries session tokens and signed asset URLs, and a
+    /// fragment can carry either. The logging policy (CLAUDE.md) allows ids, counts, enums and
+    /// status codes only, so every log line that used to interpolate a URL now interpolates
+    /// <see cref="Host"/> instead.
+    ///
+    /// Never throws and never returns null: a log call must not be able to take the app down,
+    /// and a caller must never be tempted to fall back to the raw URL on failure.
+    /// </summary>
+    public static class UrlLog
+    {
+        /// <summary>Placeholder for a URL that will not parse. Deliberately not the raw
+        /// string: an unparseable "URL" is exactly the case most likely to be a pasted
+        /// blob of user text.</summary>
+        public const string Invalid = "<invalid>";
+
+        /// <summary>Placeholder for a null/empty/whitespace URL.</summary>
+        public const string Empty = "<none>";
+
+        /// <summary>
+        /// Host of <paramref name="url"/> (for example <c>hypnotube.com</c>), lower-cased.
+        /// Returns <see cref="Empty"/> for null/blank input and <see cref="Invalid"/> when the
+        /// string is not an absolute URI or carries no host (relative paths, <c>data:</c>,
+        /// <c>about:blank</c>, <c>javascript:</c>). For a non-default port the port is kept
+        /// (<c>127.0.0.1:20010</c>) because local haptics/dev endpoints are identified by it.
+        /// </summary>
+        public static string Host(string? url)
+        {
+            if (string.IsNullOrWhiteSpace(url)) return Empty;
+            try
+            {
+                if (!Uri.TryCreate(url.Trim(), UriKind.Absolute, out var uri)) return Invalid;
+                return Host(uri);
+            }
+            catch
+            {
+                return Invalid;
+            }
+        }
+
+        /// <summary>Overload for callers that already hold a <see cref="Uri"/> (WebView2
+        /// navigation args, HttpRequestMessage.RequestUri).</summary>
+        public static string Host(Uri? uri)
+        {
+            if (uri == null) return Empty;
+            try
+            {
+                if (!uri.IsAbsoluteUri) return Invalid;
+                var host = uri.Host;
+                if (string.IsNullOrEmpty(host)) return Invalid;
+                host = host.ToLowerInvariant();
+                return uri.IsDefaultPort ? host : host + ":" + uri.Port.ToString(System.Globalization.CultureInfo.InvariantCulture);
+            }
+            catch
+            {
+                return Invalid;
+            }
+        }
+    }
+}

--- a/ConditioningControlPanel/Services/Moderation/ModerationLog.cs
+++ b/ConditioningControlPanel/Services/Moderation/ModerationLog.cs
@@ -36,11 +36,13 @@ namespace ConditioningControlPanel.Services.Moderation
         public ModerationLog(ModerationSession session)
         {
             _session = session;
-            // App.UserDataPath is %APPDATA%/ConditioningControlPanel by convention.
-            // We cannot reference App here without a circular dependency at startup,
-            // so duplicate the path computation. Matches App.UserDataPath exactly.
-            var appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
-            _logDir = Path.Combine(appData, "ConditioningControlPanel", "logs");
+            // App.UserDataPath is %LOCALAPPDATA%/ConditioningControlPanel (and honours the
+            // CCP_USERDATA_DIR override). This used to hand-roll the path off
+            // SpecialFolder.ApplicationData - Roaming - which is NOT where the app keeps
+            // anything else, so moderation.log landed in a directory nothing reads and the
+            // bug reporter never picked it up. Any pre-existing Roaming file is left where it
+            // is; there is nothing in it worth migrating.
+            _logDir = Path.Combine(App.UserDataPath, "logs");
             _logPath = Path.Combine(_logDir, "moderation.log");
         }
 

--- a/ConditioningControlPanel/Services/Settings/ProfileSyncService.cs
+++ b/ConditioningControlPanel/Services/Settings/ProfileSyncService.cs
@@ -1577,7 +1577,10 @@ namespace ConditioningControlPanel.Services
                         }
                         await HandleUnauthorizedAsync(v2Response);
                         var error = await v2Response.Content.ReadAsStringAsync();
-                        App.Logger?.Warning("V2 Profile sync failed: {Status} - {Error}", v2Response.StatusCode, error);
+                        // Status + size only: the error body echoes fields from the profile we
+                        // just posted, and logs get pasted into Discord support threads.
+                        App.Logger?.Warning("V2 Profile sync failed: {Status} (error body {Bytes} bytes)",
+                            (int)v2Response.StatusCode, error?.Length ?? 0);
                         LastSyncError = $"Sync failed: {v2Response.StatusCode}";
                         // Settle a deferred streak break only on a DEFINITIVE rejection (4xx) —
                         // retrying cannot change those answers. A 5xx is transient like the 429
@@ -1596,12 +1599,20 @@ namespace ConditioningControlPanel.Services
                     PendingCosmeticsClear = false;
 
                     var v2Json = await v2Response.Content.ReadAsStringAsync();
-                    App.Logger?.Information("V2 Profile synced successfully: {Response}", v2Json);
+                    // The response is the user's whole profile (~2.7 KB of JSON, and 11% of every
+                    // log file we ever received). Size here; the fields we actually act on are
+                    // summarised at Debug once the payload is deserialised, just below.
+                    App.Logger?.Information("V2 Profile synced successfully ({Bytes} bytes)", v2Json?.Length ?? 0);
 
                     // Check for server-side flags in V2 sync response
                     try
                     {
                         var v2Result = JsonConvert.DeserializeObject<V2SyncResponse>(v2Json);
+                        App.Logger?.Debug(
+                            "V2 Sync response: ok={Success} sp={SkillPoints} skills={SkillCount} xp={TotalXp} mins={Minutes} cosmetics={HasCosmetics} webXp={HasWebXp}",
+                            v2Result?.Success, v2Result?.SkillPoints, v2Result?.UnlockedSkills?.Count ?? 0,
+                            v2Result?.TotalXpEarned, v2Result?.TotalConditioningMinutes,
+                            v2Result?.Cosmetics != null, v2Result?.WebXp != null);
                         if (v2Result?.ResetWeeklyQuest == true)
                         {
                             App.Logger?.Information("V2 Sync: Server requested weekly quest reset");

--- a/ConditioningControlPanel/Services/Subliminal/BouncingTextService.cs
+++ b/ConditioningControlPanel/Services/Subliminal/BouncingTextService.cs
@@ -201,8 +201,10 @@ public class BouncingTextService : IDisposable
             if (App.Video.IsPlaying) OnVideoStartedPause(null, EventArgs.Empty);
         }
 
-        App.Logger?.Information("BouncingTextService started - Logos: {Count}, Text: {Text}, ColorMode: {Mode}",
-            _logos.Count, _logos[0].Text, settings.BouncingTextColorMode);
+        // The mantra is the user's own text on their own screen, but it is still content and
+        // logs get shared: count and length only.
+        App.Logger?.Information("BouncingTextService started - Logos: {Count}, TextChars: {Chars}, ColorMode: {Mode}",
+            _logos.Count, (_logos[0].Text ?? "").Length, settings.BouncingTextColorMode);
     }
 
     public void Stop()

--- a/Tests/ConditioningControlPanel.Tests/UrlLogHostTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/UrlLogHostTests.cs
@@ -1,0 +1,127 @@
+using System;
+using ConditioningControlPanel.Services.Logging;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// Contract tests for <see cref="UrlLog.Host"/>, the helper every log line now goes through
+/// instead of interpolating a URL.
+///
+/// The point of the helper is what it throws away. A HypnoTube path is the title of the video
+/// the user was watching, a query string carries session tokens and signed asset URLs, and a
+/// fragment can carry either - none of that may reach a log file that gets pasted into a
+/// support thread. So the tests here mostly assert absence: whatever comes out must not
+/// contain the path, the query, or the fragment of what went in.
+///
+/// The other half of the contract is that a log call can never take the app down: no input,
+/// however malformed, may throw, and no failure path may hand the caller back the raw URL.
+/// </summary>
+public class UrlLogHostTests
+{
+    [Theory]
+    [InlineData("https://hypnotube.com/video/12345/some-very-revealing-title/", "hypnotube.com")]
+    [InlineData("https://www.bambicloud.com/watch?v=abc&token=secret", "www.bambicloud.com")]
+    [InlineData("http://example.org/a/b/c#fragment", "example.org")]
+    [InlineData("https://EXAMPLE.ORG/Path", "example.org")]
+    [InlineData("  https://example.org/path  ", "example.org")]
+    public void Host_keeps_only_the_host(string url, string expected)
+    {
+        Assert.Equal(expected, UrlLog.Host(url));
+    }
+
+    [Fact]
+    public void Host_drops_path_query_and_fragment()
+    {
+        const string url = "https://hypnotube.com/videos/999/deep-trance-title?token=abcdef123456#t=90";
+        var host = UrlLog.Host(url);
+
+        Assert.Equal("hypnotube.com", host);
+        Assert.DoesNotContain("deep-trance-title", host, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("token", host, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("abcdef123456", host, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("90", host, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Host_keeps_a_non_default_port()
+    {
+        // Local haptics and dev endpoints are identified by their port, so it survives.
+        Assert.Equal("127.0.0.1:20010", UrlLog.Host("http://127.0.0.1:20010/command?command=GetToys"));
+        Assert.Equal("192.168.1.5:30010", UrlLog.Host("https://192.168.1.5:30010/command"));
+    }
+
+    [Fact]
+    public void Host_drops_a_default_port()
+    {
+        Assert.Equal("example.org", UrlLog.Host("https://example.org:443/x"));
+        Assert.Equal("example.org", UrlLog.Host("http://example.org:80/x"));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Host_reports_blank_input_as_none(string? url)
+    {
+        Assert.Equal(UrlLog.Empty, UrlLog.Host(url));
+    }
+
+    [Theory]
+    // Relative paths, schemes with no host, and pasted junk are all "not a URL we can name".
+    [InlineData("/videos/some-title")]
+    [InlineData("not a url at all")]
+    [InlineData("javascript:alert(document.cookie)")]
+    [InlineData("data:text/html;base64,PHNjcmlwdD4=")]
+    [InlineData("about:blank")]
+    public void Host_reports_unparseable_input_as_invalid(string url)
+    {
+        Assert.Equal(UrlLog.Invalid, UrlLog.Host(url));
+    }
+
+    [Fact]
+    public void Host_never_echoes_the_input_back_on_failure()
+    {
+        // The failure path is exactly the case most likely to be a blob of pasted user text,
+        // so it must not fall back to returning what it was given.
+        const string junk = "this is a sentence the user typed into the address bar";
+        Assert.Equal(UrlLog.Invalid, UrlLog.Host(junk));
+        Assert.DoesNotContain("sentence", UrlLog.Host(junk), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Host_accepts_a_uri_overload()
+    {
+        Assert.Equal("example.org", UrlLog.Host(new Uri("https://example.org/path?q=1")));
+        Assert.Equal(UrlLog.Empty, UrlLog.Host((Uri?)null));
+        Assert.Equal(UrlLog.Invalid, UrlLog.Host(new Uri("/relative/path", UriKind.Relative)));
+    }
+
+    [Fact]
+    public void Host_never_throws()
+    {
+        // A log call must not be able to take the app down.
+        var nasty = new[]
+        {
+            "http://",
+            "https://[::1",
+            @"file://C:\Users\alice\Videos\clip.mp4",
+            "\u0000\u0001\u0002",
+            new string('x', 70000),
+            "https://" + new string('a', 5000) + ".com/p",
+        };
+        foreach (var s in nasty)
+        {
+            var result = UrlLog.Host(s);
+            Assert.NotNull(result);
+        }
+    }
+
+    [Fact]
+    public void Host_of_a_file_url_does_not_leak_the_local_path()
+    {
+        var host = UrlLog.Host("file:///C:/Users/alice/Videos/private-clip.mp4");
+        Assert.DoesNotContain("alice", host, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("private-clip", host, StringComparison.OrdinalIgnoreCase);
+    }
+}


### PR DESCRIPTION
PR5 of the logging redesign wave. Base `main`. A stacked follow-up (`feat/log-pii-sweep`) does the wider grep sweep; this one is the list of sites we already knew about.

## Why

Log files leave the machine. Users paste them into support threads, the bug reporter uploads a tail of them, and from PR2 a flight recorder keeps Debug lines too. Today those files contain the user's whole profile, their display name, every URL they browsed, the lines the companion spoke to them, their mantra text, and raw haptics request/response bodies. None of it is needed to diagnose anything.

Policy for the whole wave: **ids, counts, enums, status codes only.**

## New: `Services/Logging/UrlLog.cs`

`UrlLog.Host(url)` returns the host and nothing else.

- `<none>` for blank input, `<invalid>` for anything that will not parse - never the raw string back, so no caller can be tempted into a fallback.
- Never throws. A log call must not be able to take the app down.
- A non-default port survives (`127.0.0.1:20010`) because local haptics and dev endpoints are identified by it.

A HypnoTube path is the title of the video the user was watching and a query string carries session tokens, so the host is the only part of a URL a log line may keep. 20 tests cover the absence guarantees (path/query/fragment gone, no echo on failure, no local path out of a `file:` URL) and the never-throws contract.

## What changed, by kind

**Profile JSON.** `ProfileSyncService` wrote the whole sync response - ~2.7 KB per sync, and 11% of the bytes in every log file we have ever received. Now a byte count, with the fields the app actually branches on summarised at Debug once the payload is deserialised. Sync-failed and lookup-failed bodies became status + size.

**Names and ids.** `AccountService`, `PatreonService`, `DiscordService`, `DiscordRichPresenceService`, `MainWindow.Browser/.Leaderboard/.UiUpdates/.xaml.cs` no longer write display names, offline usernames or Discord ids. The unified id stays where it was already logged: it is what support looks users up by, and the write-time redactor (PR1) shortens it.

**Spoken and on-screen text.** `VoiceLine: Displayed '{Text}'` becomes line id + length. The Debug speech sites in `Speech.cs` / `Reactions.cs` become lengths - Debug is no longer a place content can hide, because the flight recorder keeps it. `BarkService`'s `[BARK] FIRE` line drops the preview and keeps rule + variant index, which identify the line exactly for anyone holding the pack. `BouncingTextService` logs the mantra's length.

**Device and page traffic.** `LovenseProvider` no longer writes raw bodies: the GetToys reply carries the nicknames the user typed for their toys and the LAN address of their phone. Status + byte count now, and "Found toy" reports type / battery / whether a nickname exists. `MainWindow.Browser`'s AudioSync and web-message lines log a size, not the message (which carries the page title and video URL).

## Drive-by bug

`ModerationLog` hand-rolled its path off `SpecialFolder.ApplicationData` (Roaming) under a comment claiming it matched `App.UserDataPath`. It did not - `App.UserDataPath` is `LocalApplicationData`. `moderation.log` has been landing in a directory nothing else reads and the bug reporter never collected. Now uses `App.UserDataPath` directly, which also picks up the `CCP_USERDATA_DIR` override. Any pre-existing Roaming file is left where it is; there is nothing in it worth migrating.

## Left alone deliberately

- `DiscordService:556` logs the raw Discord user id at Information. It is a 17-20 digit run, which the PR1 write-time redactor collapses to `<id:...last4>`; double-redacting here would only add noise.
- `KeywordTriggerService` logs the user's own configured trigger keywords at Debug. Those are user-configured settings, not screen or chat content.
- Our own server API paths (e.g. `ProfileSyncService`'s "Request to {Uri} cannot be signed") stay whole: they are constants, and the signature rides in a header rather than the query.

## Coordination

`Services/Companion/BarkService.cs` also holds the `[BARK] blocked` line that the noise-diet PR lowers to Debug. This PR touches only the FIRE branch and the `preview` local it fed; the two hunks are adjacent, so whichever lands second may need a trivial rebase.

## Verification

- `dotnet build ConditioningControlPanel.sln -c Debug` - 0 errors.
- `dotnet test Tests/ConditioningControlPanel.Tests` - 5220 passed, 0 failed (20 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GSSvqeYrpVG9H3EPtqikDC
