### PR TITLE
refactor(logging): empty catches in ChaosModeService + App.xaml.cs -> Diag.Swallowed

### DIFF
--- a/ConditioningControlPanel/App.xaml.cs
+++ b/ConditioningControlPanel/App.xaml.cs
@@ -139,7 +139,7 @@ namespace ConditioningControlPanel
                 Directory.CreateDirectory(UserDataPath);
                 File.WriteAllText(FileOpenHandoffPath, action + "\n" + path);
             }
-            catch { /* best effort — failure just means second instance has no handoff */ }
+            catch (Exception ex) { Diag.Swallowed(ex, "file-open handoff is best effort"); }
         }
 
         private static (string? action, string? path) ConsumeFileOpenHandoff()
@@ -149,7 +149,7 @@ namespace ConditioningControlPanel
                 var p = FileOpenHandoffPath;
                 if (!File.Exists(p)) return (null, null);
                 var lines = File.ReadAllText(p).Split('\n');
-                try { File.Delete(p); } catch { }
+                try { File.Delete(p); } catch (Exception ex) { Diag.Swallowed(ex); }
                 if (lines.Length < 2) return (null, null);
                 var action = lines[0].Trim();
                 var path = ValidateMediaArgPath(lines[1].Trim());
@@ -176,7 +176,7 @@ namespace ConditioningControlPanel
                 if (!string.IsNullOrWhiteSpace(overrideDir) && Path.IsPathRooted(overrideDir))
                     return overrideDir;
             }
-            catch { }
+            catch (Exception ex) { Diag.Swallowed(ex); }
             return Path.Combine(
                 Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
                 "ConditioningControlPanel");
@@ -369,14 +369,14 @@ namespace ConditioningControlPanel
                         dirsToClean.Add(tempDir);
                 }
             }
-            catch { }
+            catch (Exception ex) { Diag.Swallowed(ex); }
 
             // System temp (fallback path)
             try
             {
                 dirsToClean.Add(Path.GetTempPath());
             }
-            catch { }
+            catch (Exception ex) { Diag.Swallowed(ex); }
 
             int deleted = 0;
             foreach (var dir in dirsToClean)
@@ -386,15 +386,15 @@ namespace ConditioningControlPanel
                     foreach (var file in Directory.GetFiles(dir, "ccp_temp_*"))
                     {
                         try { File.Delete(file); deleted++; }
-                        catch { }
+                        catch (Exception ex) { Diag.Swallowed(ex); }
                     }
                     foreach (var file in Directory.GetFiles(dir, "haptic_video_*"))
                     {
                         try { File.Delete(file); deleted++; }
-                        catch { }
+                        catch (Exception ex) { Diag.Swallowed(ex); }
                     }
                 }
-                catch { }
+                catch (Exception ex) { Diag.Swallowed(ex); }
             }
 
             // Clean up old installer downloads (each version has a different filename so they pile up)
@@ -407,7 +407,7 @@ namespace ConditioningControlPanel
                     deleted++;
                 }
             }
-            catch { }
+            catch (Exception ex) { Diag.Swallowed(ex); }
 
             if (deleted > 0)
                 Logger?.Information("Cleaned up {Count} stale temp files/folders from previous session", deleted);
@@ -946,7 +946,7 @@ namespace ConditioningControlPanel
                             var hwnd = new System.Windows.Interop.WindowInteropHelper(w).Handle;
                             if (hwnd != IntPtr.Zero) hwnds.Add(hwnd);
                         }
-                        catch { /* skip malformed window */ }
+                        catch (Exception ex) { Diag.Swallowed(ex, "skip malformed window entry"); }
                     }
 
                     // Bouncing text lives in a full-screen overlay window that
@@ -1196,10 +1196,10 @@ namespace ConditioningControlPanel
             int flashEvery  = EnvInt("CCP_STRESS_FLASH_EVERY", 6);// flash-window churn cadence (in ticks)
             int toggleEvery = EnvInt("CCP_STRESS_TOGGLE_EVERY", 40); // shared-host create/close churn cadence
 
-            try { Logger?.Warning("[STRESS] Hang-hunt stress mode ON — tick={Tick}ms spawn={Spawn} flashEvery={Flash} toggleEvery={Toggle}", tickMs, spawnPer, flashEvery, toggleEvery); } catch { }
+            try { Logger?.Warning("[STRESS] Hang-hunt stress mode ON — tick={Tick}ms spawn={Spawn} flashEvery={Flash} toggleEvery={Toggle}", tickMs, spawnPer, flashEvery, toggleEvery); } catch (Exception ex) { Diag.Swallowed(ex); }
 
             // Make sure the bubble engine is actually running so spawns render (bypass the level gate).
-            try { Bubbles?.Start(bypassLevelCheck: true); } catch { }
+            try { Bubbles?.Start(bypassLevelCheck: true); } catch (Exception ex) { Diag.Swallowed(ex); }
 
             long tick = 0;
             var timer = new System.Windows.Threading.DispatcherTimer(System.Windows.Threading.DispatcherPriority.Normal)
@@ -1212,11 +1212,11 @@ namespace ConditioningControlPanel
                 // Bubble spawns — SpawnOnce self-marshals and respects its own cap, so continuous calls
                 // keep create/destroy churn at the cap indefinitely.
                 for (int i = 0; i < spawnPer; i++)
-                    try { Bubbles?.SpawnOnce(); } catch { }
+                    try { Bubbles?.SpawnOnce(); } catch (Exception ex) { Diag.Swallowed(ex); }
 
                 // Flash windows — pool churn (create/show/hide of layered flash surfaces).
                 if (tick % flashEvery == 0)
-                    try { Flash?.TriggerFlashOnce(); } catch { }
+                    try { Flash?.TriggerFlashOnce(); } catch (Exception ex) { Diag.Swallowed(ex); }
 
                 // The prime suspect: flip the shared-host flag so the click-through host window is
                 // created and closed repeatedly — the keep-alive contract warns this deadlocks the
@@ -1228,7 +1228,7 @@ namespace ConditioningControlPanel
                         Settings.Current.BubbleSharedHost = !Settings.Current.BubbleSharedHost;
                         Settings.Current.ChaosBubbleSharedHost = Settings.Current.BubbleSharedHost;
                     }
-                    catch { }
+                    catch (Exception ex) { Diag.Swallowed(ex); }
                 }
             };
             timer.Start();
@@ -1279,7 +1279,7 @@ namespace ConditioningControlPanel
             if (e.Args.Length >= 3 && e.Args[0] == "--write-hang-dump" && int.TryParse(e.Args[1], out int hangDumpPid))
             {
                 bool dumpOk = false;
-                try { dumpOk = Services.UiHangWatchdog.TryWriteDumpOfProcess(hangDumpPid, e.Args[2]); } catch { }
+                try { dumpOk = Services.UiHangWatchdog.TryWriteDumpOfProcess(hangDumpPid, e.Args[2]); } catch (Exception ex) { Diag.Swallowed(ex); }
                 Environment.Exit(dumpOk ? 0 : 1);
                 return;
             }
@@ -1303,7 +1303,7 @@ namespace ConditioningControlPanel
                             p.PopupAnimation = System.Windows.Controls.Primitives.PopupAnimation.None;
                         }
                     }
-                    catch { }
+                    catch (Exception ex) { Diag.Swallowed(ex); }
                 }));
 
             // Show splash screen IMMEDIATELY - before anything else
@@ -1336,7 +1336,7 @@ namespace ConditioningControlPanel
                 // Write the "Open with CCP" handoff BEFORE signaling so a live primary can read it.
                 if (_pendingFileOpenAction != null && _pendingFileOpenPath != null)
                 {
-                    try { WriteFileOpenHandoff(_pendingFileOpenAction, _pendingFileOpenPath); } catch { }
+                    try { WriteFileOpenHandoff(_pendingFileOpenAction, _pendingFileOpenPath); } catch (Exception ex) { Diag.Swallowed(ex); }
                 }
 
                 EventWaitHandle? ackWait = null;
@@ -1357,12 +1357,12 @@ namespace ConditioningControlPanel
                         signal.Set();
                         signal.Dispose();
                     }
-                    catch { }
+                    catch (Exception ex) { Diag.Swallowed(ex); }
 
                     bool tookOver = false;
                     try { tookOver = _mutex.WaitOne(TimeSpan.FromSeconds(8)); }
                     catch (AbandonedMutexException) { tookOver = true; } // old build died holding it — we own it now
-                    catch { }
+                    catch (Exception ex) { Diag.Swallowed(ex); }
 
                     if (!tookOver)
                     {
@@ -1372,25 +1372,25 @@ namespace ConditioningControlPanel
                     }
 
                     _mutexOwned = true;
-                    try { ConsumeFileOpenHandoff(); } catch { }
+                    try { ConsumeFileOpenHandoff(); } catch (Exception ex) { Diag.Swallowed(ex); }
                     // Fall through — the legacy primary is gone; this instance is now the primary.
                 }
                 else
                 {
                     // Clear any stale ack from a prior handshake, poke the primary, then wait for it
                     // to confirm liveness from its UI thread.
-                    try { ackWait.Reset(); } catch { }
+                    try { ackWait.Reset(); } catch (Exception ex) { Diag.Swallowed(ex); }
                     try
                     {
                         var signal = EventWaitHandle.OpenExisting(ShowSignalName);
                         signal.Set();
                         signal.Dispose();
                     }
-                    catch { }
+                    catch (Exception ex) { Diag.Swallowed(ex); }
 
                     bool acknowledged = false;
-                    try { acknowledged = ackWait.WaitOne(ShowAckTimeoutMs); } catch { }
-                    try { ackWait.Dispose(); } catch { }
+                    try { acknowledged = ackWait.WaitOne(ShowAckTimeoutMs); } catch (Exception ex) { Diag.Swallowed(ex); }
+                    try { ackWait.Dispose(); } catch (Exception ex) { Diag.Swallowed(ex); }
 
                     if (acknowledged)
                     {
@@ -1414,11 +1414,11 @@ namespace ConditioningControlPanel
                     // the mutex, WaitOne throws AbandonedMutexException but we DO acquire it.
                     try { if (_mutex!.WaitOne(TimeSpan.FromSeconds(3))) _mutexOwned = true; }
                     catch (AbandonedMutexException) { _mutexOwned = true; }
-                    catch { }
+                    catch (Exception ex) { Diag.Swallowed(ex); }
 
                     // We kept the parsed _pendingFileOpen* fields and will fulfill them ourselves, so
                     // drop any on-disk handoff to avoid a spurious re-open on a later signal.
-                    try { ConsumeFileOpenHandoff(); } catch { }
+                    try { ConsumeFileOpenHandoff(); } catch (Exception ex) { Diag.Swallowed(ex); }
 
                     // Fall through — this instance is now the primary.
                 }
@@ -1445,7 +1445,7 @@ namespace ConditioningControlPanel
                             // this thread frozen too, so takeover still catches real zombies.)
                             if (_startupPhase)
                             {
-                                try { _showAckSignal?.Set(); } catch { }
+                                try { _showAckSignal?.Set(); } catch (Exception ex) { Diag.Swallowed(ex); }
                             }
 
                             Dispatcher.BeginInvoke(() =>
@@ -1471,7 +1471,7 @@ namespace ConditioningControlPanel
                                 // waiting second instance so it exits instead of killing us. Sent
                                 // even when mainWin is null (still starting): a responsive
                                 // dispatcher is proof enough that we are not wedged.
-                                try { _showAckSignal?.Set(); } catch { }
+                                try { _showAckSignal?.Set(); } catch (Exception ex) { Diag.Swallowed(ex); }
                             });
                         }
                     }
@@ -1940,7 +1940,7 @@ namespace ConditioningControlPanel
             catch (Exception exDesk) { Logger?.Warning(exDesk, "[EmiDesk] service construction failed; EMI Desk is unavailable this run"); }
             if (_engineCrashRecovered)
             {
-                try { EmiDesk?.Fire("crashRecovered", null); } catch { }
+                try { EmiDesk?.Fire("crashRecovered", null); } catch (Exception ex) { Diag.Swallowed(ex); }
             }
             QuestDefinitions = new QuestDefinitionService();
             _ = QuestDefinitions.InitializeAsync(); // Fire and forget - will load from cache first
@@ -2030,7 +2030,7 @@ namespace ConditioningControlPanel
             // No-op for cloud users; silent on failure (Ollama may not be running).
             if (Ai is AiServiceStrategy aiStrategy)
             {
-                _ = Task.Run(async () => { try { await aiStrategy.WarmUpLocalAsync(); } catch { } });
+                _ = Task.Run(async () => { try { await aiStrategy.WarmUpLocalAsync(); } catch (Exception ex) { Diag.Swallowed(ex); } });
             }
 
             WindowAwareness = new WindowAwarenessService();
@@ -2138,7 +2138,7 @@ namespace ConditioningControlPanel
                 // pipeline is still there and still works. Detach so the legacy mouth is not left
                 // suppressed by a half-built v2 that can never speak.
                 Awareness = null;
-                try { Services.Awareness.AwarenessV2Routing.Detach(); } catch { }
+                try { Services.Awareness.AwarenessV2Routing.Detach(); } catch (Exception exIgnored) { Diag.Swallowed(exIgnored); }
                 Services.Awareness.AwarenessLive.Ledger = null;
                 Services.Awareness.AwarenessLive.Memory = null;
                 Services.Awareness.AwarenessLive.ResetObserverState = null;
@@ -2214,12 +2214,12 @@ namespace ConditioningControlPanel
             KeywordHighlight = new KeywordHighlightService();
             RemoteControl = new RemoteControlService();
             // Quest credit: each remote-control command received (Patreon-exclusive quest category).
-            RemoteControl.CommandReceived += (_, _) => { try { Quests?.TrackRemoteCommand(); } catch { } };
+            RemoteControl.CommandReceived += (_, _) => { try { Quests?.TrackRemoteCommand(); } catch (Exception ex) { Diag.Swallowed(ex); } };
             // Quest credit for the GIVING side: each command this user issues to ANOTHER subject
             // as a Controller (take_the_reins_d, free for every tier). Raised by
             // RemoteControlService.ReportCommandIssued - read its remarks for why the giving side
             // is reported in rather than dispatched here.
-            RemoteControl.CommandIssued += (_, e) => { try { Quests?.TrackRemoteCommandIssued(e.TargetUnifiedId); } catch { } };
+            RemoteControl.CommandIssued += (_, e) => { try { Quests?.TrackRemoteCommandIssued(e.TargetUnifiedId); } catch (Exception ex) { Diag.Swallowed(ex); } };
             // (No app-level GoonGameService singleton: the Goon Game's clients build their own
             // facade — the browser client via GoonHostService, the dev cockpit via GoonTestPanel —
             // so an always-constructed idle singleton owned nothing and was never read.)
@@ -2405,7 +2405,7 @@ namespace ConditioningControlPanel
             LockdownDose = new Services.Haptics.LockdownDoseKeeper(Lockdown);
             LockdownDose.Install();
             // Quest credit: each completed lockdown (Patreon-exclusive quest category).
-            Lockdown.LockdownDeactivated += () => { try { Quests?.TrackLockdownCompleted(); } catch { } };
+            Lockdown.LockdownDeactivated += () => { try { Quests?.TrackLockdownCompleted(); } catch (Exception ex) { Diag.Swallowed(ex); } };
 
             // Initialize mantra lab service
             Mantra = new MantraService();
@@ -2524,7 +2524,7 @@ namespace ConditioningControlPanel
             catch (Exception ex)
             {
                 Logger?.Error(ex, "Failed to create main window");
-                try { splash?.CloseImmediate(); } catch { }
+                try { splash?.CloseImmediate(); } catch (Exception exIgnored) { Diag.Swallowed(exIgnored); }
                 _splash = null;
                 throw; // Re-throw to let DispatcherUnhandledException show the error
             }
@@ -2780,8 +2780,8 @@ namespace ConditioningControlPanel
             {
                 Task.Run(() =>
                 {
-                    try { _ = Speech?.IsAvailable; } catch { }                                   // warm Vosk off-UI
-                    try { if (Settings?.Current?.SpeechWakeWordEnabled == true) _ = WakeWord?.IsAvailable; } catch { } // warm KWS off-UI
+                    try { _ = Speech?.IsAvailable; } catch (Exception ex) { Diag.Swallowed(ex); }                                   // warm Vosk off-UI
+                    try { if (Settings?.Current?.SpeechWakeWordEnabled == true) _ = WakeWord?.IsAvailable; } catch (Exception ex) { Diag.Swallowed(ex); } // warm KWS off-UI
                 }).ContinueWith(_ =>
                 {
                     Dispatcher.BeginInvoke(new Action(() =>
@@ -2927,7 +2927,7 @@ namespace ConditioningControlPanel
                         // Process may have exited on its own, or we lack rights to end it.
                         NoteStaleInstanceDecision($"[LIFECYCLE] Takeover could not act on pid {otherId}: {ex.GetType().Name} {ex.Message}");
                     }
-                    finally { try { proc.Dispose(); } catch { } }
+                    finally { try { proc.Dispose(); } catch (Exception ex) { Diag.Swallowed(ex); } }
                 }
             }
             catch (Exception ex)
@@ -2958,10 +2958,10 @@ namespace ConditioningControlPanel
                         if (QueryFullProcessImageName(handle, 0, buffer, ref size) && size > 0)
                             return buffer.ToString();
                     }
-                    finally { try { CloseHandle(handle); } catch { } }
+                    finally { try { CloseHandle(handle); } catch (Exception ex) { Diag.Swallowed(ex); } }
                 }
             }
-            catch { }
+            catch (Exception ex) { Diag.Swallowed(ex); }
 
             try { return proc.MainModule?.FileName; }
             catch { return null; }
@@ -2988,7 +2988,7 @@ namespace ConditioningControlPanel
                         _staleInstanceDecisions.Add(message);
                 }
             }
-            catch { }
+            catch (Exception ex) { Diag.Swallowed(ex); }
         }
 
         private const int PROCESS_QUERY_LIMITED_INFORMATION = 0x1000;
@@ -3064,7 +3064,7 @@ namespace ConditioningControlPanel
                         else if (t.IsCanceled || !t.Result)
                             Logger?.Warning("Achievement '{Name}' did NOT post to Discord (see preceding warning for cause)", achievement.Name);
                     }
-                    catch { /* diagnostics only — never let logging fault the continuation */ }
+                    catch (Exception ex) { Diag.Swallowed(ex, "diagnostics only, must not fault the continuation"); }
                 }, TaskContinuationOptions.ExecuteSynchronously);
             }
             else
@@ -3903,7 +3903,7 @@ namespace ConditioningControlPanel
                     var avatarWindow = Current.Windows.OfType<Window>().FirstOrDefault(w => w.GetType().Name == "AvatarTubeWindow");
                     avatarWindow?.Hide();
                 }
-                catch { }
+                catch (Exception ex) { Diag.Swallowed(ex); }
 
                 progressDialog = new UpdateProgressDialog();
                 progressDialog.Topmost = true;
@@ -3927,10 +3927,10 @@ namespace ConditioningControlPanel
                                     dialog.SetProgress(progress);
                                 }
                             }
-                            catch { }
+                            catch (Exception ex) { Diag.Swallowed(ex); }
                         });
                     }
-                    catch { }
+                    catch (Exception ex) { Diag.Swallowed(ex); }
                 };
 
                 Update.DownloadProgressChanged += progressHandler;
@@ -4008,7 +4008,7 @@ namespace ConditioningControlPanel
             {
                 Logger?.Error(ex, "Failed to download installer for fresh install");
 
-                try { progressDialog?.Close(); } catch { }
+                try { progressDialog?.Close(); } catch (Exception exIgnored) { Diag.Swallowed(exIgnored); }
 
                 // Restore the main window if update failed
                 RestoreHiddenWindows();
@@ -4202,7 +4202,7 @@ namespace ConditioningControlPanel
                                 UseShellExecute = true
                             });
                         }
-                        catch { }
+                        catch (Exception exIgnored) { Diag.Swallowed(exIgnored); }
                     }
                     return false;
                 }
@@ -4538,7 +4538,7 @@ Application State:
                                 migratedCount++;
                                 Logger?.Debug("Migrated spiral: {File} from {Source}", fileName, basePath);
                             }
-                            catch { }
+                            catch (Exception ex) { Diag.Swallowed(ex); }
                         }
                     }
                 }
@@ -4650,7 +4650,7 @@ Application State:
                     foreach (var file in Directory.EnumerateFiles(logDir))
                     {
                         try { Consider(File.GetCreationTimeUtc(file)); }
-                        catch { /* one unreadable log file must not lose the other candidates */ }
+                        catch (Exception ex) { Diag.Swallowed(ex, "one unreadable log file must not lose the others"); }
                     }
                 }
             }
@@ -4743,19 +4743,19 @@ Application State:
 
             // EMI Desk (MOMENTS 4.B / 3.8): the wordless flinch. appClosing is a HOLD with no pool
             // and never gets one - she does not get a goodbye speech while the app is going away.
-            try { EmiDesk?.Fire("appClosing", null); } catch { }
+            try { EmiDesk?.Fire("appClosing", null); } catch (Exception ex) { Diag.Swallowed(ex); }
 
-            try { SystemEvents.DisplaySettingsChanged -= OnDisplaySettingsChanged; } catch { }
+            try { SystemEvents.DisplaySettingsChanged -= OnDisplaySettingsChanged; } catch (Exception ex) { Diag.Swallowed(ex); }
 
             // A clean shutdown — even mid-run — is NOT a crash. Clear both dirty-shutdown
             // sentinels so the next launch doesn't false-report an abnormal exit.
-            try { Services.Chaos.ChaosCrashSentinel.Clear(); } catch { }
-            try { Services.EngineCrashSentinel.Clear(); } catch { }
-            try { Services.CornerGifService.ClearSentinelOnCleanExit(); } catch { }
+            try { Services.Chaos.ChaosCrashSentinel.Clear(); } catch (Exception ex) { Diag.Swallowed(ex); }
+            try { Services.EngineCrashSentinel.Clear(); } catch (Exception ex) { Diag.Swallowed(ex); }
+            try { Services.CornerGifService.ClearSentinelOnCleanExit(); } catch (Exception ex) { Diag.Swallowed(ex); }
             // A shutdown that takes >13s (video teardown, haptics stop, WebView2 dispose) can trip
             // the watchdog on the way out. That is not the freeze we are hunting — disarm it so the
             // next launch doesn't cry hang over a clean, if slow, exit.
-            try { Services.UiHangWatchdog.ClearSentinelOnCleanExit(); } catch { }
+            try { Services.UiHangWatchdog.ClearSentinelOnCleanExit(); } catch (Exception ex) { Diag.Swallowed(ex); }
 
             // Haptics FIRST and synchronously (bounded ~2s): a Lovense level has no server-side
             // watchdog, so a toy we don't countermand keeps running after the app is gone. This
@@ -4771,19 +4771,19 @@ Application State:
             try { EmiDesk?.Dispose(); } catch (Exception ex) { Logger?.Debug(ex, "[EmiDesk] shutdown failed"); }
 
             // DtRH browser game: dispose the WebView2 window/process if it's up.
-            try { Services.Chaos.DtrhHostService.CloseActive(); } catch { }
+            try { Services.Chaos.DtrhHostService.CloseActive(); } catch (Exception ex) { Diag.Swallowed(ex); }
 
             // The Arcademy: same reason - a WebView2 process outliving the app is a leak, and its
             // meta store has a debounced write that must be flushed before we go. ShutdownFlush, NOT
             // CloseActive: the graceful close waits on a 1200ms DispatcherTimer for the page's
             // exit-done, and that timer can never tick from inside OnExit - so the flush it guards
             // never happened and the last class's grades/streak went with the process.
-            try { Services.Arcademy.ArcademyHostService.ShutdownFlush(); } catch { }
+            try { Services.Arcademy.ArcademyHostService.ShutdownFlush(); } catch (Exception ex) { Diag.Swallowed(ex); }
 
             // The Emergency Exit's friction door: a WebView2 process outliving the app is a leak, and
             // Close() is safe from here - it has no state to flush and never touches the lockdown (any
             // verdict was applied the moment it was rolled).
-            try { Services.EmergencyExit.EmergencyExitHostService.Close(); } catch { }
+            try { Services.EmergencyExit.EmergencyExitHostService.Close(); } catch (Exception ex) { Diag.Swallowed(ex); }
 
             // If the companion is on its own UI thread (AvatarOwnThread), shut its Dispatcher down so the
             // STA thread's Dispatcher.Run() returns and the thread exits cleanly. Background thread, so it
@@ -4843,13 +4843,13 @@ Application State:
             Compositor?.Dispose(); // after effect services so their layers deactivate first
             // Before the window goes: Dispose runs the crash-safe UndoAll so no haunt is left painted on
             // a control (or, worse, left mid-transform in a saved layout).
-            try { Possession?.Dispose(); } catch { }
+            try { Possession?.Dispose(); } catch (Exception ex) { Diag.Swallowed(ex); }
             ScreenShake?.Dispose();
-            try { Chaos?.ForceShutdown(); } catch { }
+            try { Chaos?.ForceShutdown(); } catch (Exception ex) { Diag.Swallowed(ex); }
             // Standalone corner-GIF overlays are unowned topmost windows (#709) - close them here
             // as well as from MainWindow.Closing, since a Shutdown() that bypasses the main
             // window's close path would otherwise leave them alive.
-            try { CornerGif?.StopAll(); } catch { }
+            try { CornerGif?.StopAll(); } catch (Exception ex) { Diag.Swallowed(ex); }
             // Each guarded individually (#1071). These were a bare unguarded run of calls, so a
             // throw in ANY of them skipped every line after it - including the achievement flush,
             // which is the last write of the user's progress before OnExit reaches TerminateProcess.
@@ -4865,7 +4865,7 @@ Application State:
             // Before WindowAwareness: its Dispose runs Stop(), which also stops the observer — and the
             // observer's own Stop is what closes the open visit and flushes the ledger to disk.
             // Detach first so nothing can route a line into a half-disposed arbiter on the way down.
-            try { Services.Awareness.AwarenessV2Routing.Detach(); } catch { }
+            try { Services.Awareness.AwarenessV2Routing.Detach(); } catch (Exception ex) { Diag.Swallowed(ex); }
             Awareness?.Dispose();
             Services.Awareness.AwarenessLive.ResetObserverState = null;
             Services.Awareness.AwarenessLive.Ledger = null;
@@ -4941,7 +4941,7 @@ Application State:
             // Dispose the single-instance ack gate
             var ackSignal = _showAckSignal;
             _showAckSignal = null;
-            try { ackSignal?.Dispose(); } catch { }
+            try { ackSignal?.Dispose(); } catch (Exception ex) { Diag.Swallowed(ex); }
 
             // Release single instance mutex (only if we own it)
             if (_mutexOwned && _mutex != null)
@@ -4952,8 +4952,7 @@ Application State:
                 }
                 catch (ApplicationException)
                 {
-                    // Mutex was not owned by this thread - ignore
-                }
+                } // swallow: mutex was not owned by this thread
             }
             _mutex?.Dispose();
 

--- a/ConditioningControlPanel/Services/Chaos/ChaosModeService.cs
+++ b/ConditioningControlPanel/Services/Chaos/ChaosModeService.cs
@@ -218,7 +218,7 @@ public sealed class ChaosModeService
                 ChaosPopText.Show(BubbleService.ChaosLastPopXDip, BubbleService.ChaosLastPopYDip - 30,
                     $"+{amount} {ChaosGlyphs.Drops} {label}", Color.FromRgb(0xC8, 0xA8, 0xFF));
             }
-            catch { }
+            catch (Exception ex) { Diag.Swallowed(ex); }
         }));
     }
 
@@ -239,7 +239,7 @@ public sealed class ChaosModeService
                 _lastRevealToastUtc = DateTime.UtcNow;
                 _state.PushEvent("something new in the dollhouse.");
             }
-            catch { }
+            catch (Exception ex) { Diag.Swallowed(ex); }
         }));
     }
 
@@ -607,7 +607,7 @@ public sealed class ChaosModeService
     /// <summary>Close the Warren-phase sidebar (hub closed or a run is taking over).</summary>
     public void CloseLoadoutSidebar()
     {
-        try { _preHud?.Close(); } catch { }
+        try { _preHud?.Close(); } catch (Exception ex) { Diag.Swallowed(ex); }
         _preHud = null;
         _preState = null;
     }
@@ -745,30 +745,30 @@ public sealed class ChaosModeService
         // would fight them bringing a browser/work window forward.
         if (!ChaosWindowZ.PinTopmost) return;
         // Bottom of the gameplay band: ambient FX that read fine UNDER the bubbles.
-        try { ChaosFieldFxOverlay.RaiseActive(); } catch { }
-        try { ChaosSkiaFxOverlay.RaiseActive(); } catch { }
+        try { ChaosFieldFxOverlay.RaiseActive(); } catch (Exception ex) { Diag.Swallowed(ex); }
+        try { ChaosSkiaFxOverlay.RaiseActive(); } catch (Exception ex) { Diag.Swallowed(ex); }
         // The shared bubble host (when enabled) sits just above the ambient FX, below the chrome.
-        try { ChaosBubbleHostOverlay.RaiseActive(); } catch { }
-        try { ChaosPopText.RaiseActive(); } catch { }
-        try { ChaosDvdOverlay.RaiseActive(); } catch { }
-        try { ChaosEffectBannerOverlay.RaiseActive(); } catch { }
-        try { ChaosAnnouncerOverlay.RaiseActive(); } catch { }
-        try { ChaosCursorGlowOverlay.RaiseActive(); } catch { }
-        try { ChaosEStimOverlay.RaiseActive(); } catch { }
-        try { ChaosVibeTrailOverlay.RaiseActive(); } catch { }
+        try { ChaosBubbleHostOverlay.RaiseActive(); } catch (Exception ex) { Diag.Swallowed(ex); }
+        try { ChaosPopText.RaiseActive(); } catch (Exception ex) { Diag.Swallowed(ex); }
+        try { ChaosDvdOverlay.RaiseActive(); } catch (Exception ex) { Diag.Swallowed(ex); }
+        try { ChaosEffectBannerOverlay.RaiseActive(); } catch (Exception ex) { Diag.Swallowed(ex); }
+        try { ChaosAnnouncerOverlay.RaiseActive(); } catch (Exception ex) { Diag.Swallowed(ex); }
+        try { ChaosCursorGlowOverlay.RaiseActive(); } catch (Exception ex) { Diag.Swallowed(ex); }
+        try { ChaosEStimOverlay.RaiseActive(); } catch (Exception ex) { Diag.Swallowed(ex); }
+        try { ChaosVibeTrailOverlay.RaiseActive(); } catch (Exception ex) { Diag.Swallowed(ex); }
         // Run chrome sits BELOW the bubbles so the player can always pop what's drifting over the
         // sidebar / boon ribbon / active-skill buttons instead of the chrome stealing the click.
-        try { _fx?.RaiseToTopmost(); } catch { }
-        try { ChaosWaveTimerOverlay.RaiseActive(); } catch { }
-        try { ChaosBoonBarOverlay.RaiseActive(); } catch { }
-        try { _hud?.RaiseToTopmost(); } catch { }
-        foreach (var b in _toyButtons) { try { b.RaiseToTopmost(); } catch { } }
+        try { _fx?.RaiseToTopmost(); } catch (Exception ex) { Diag.Swallowed(ex); }
+        try { ChaosWaveTimerOverlay.RaiseActive(); } catch (Exception ex) { Diag.Swallowed(ex); }
+        try { ChaosBoonBarOverlay.RaiseActive(); } catch (Exception ex) { Diag.Swallowed(ex); }
+        try { _hud?.RaiseToTopmost(); } catch (Exception ex) { Diag.Swallowed(ex); }
+        foreach (var b in _toyButtons) { try { b.RaiseToTopmost(); } catch (Exception ex) { Diag.Swallowed(ex); } }
         // Bubbles ride ABOVE the chrome...
         App.Bubbles?.BringAllToFront();
         // ...and the big attention assets (gif cascades + flashes) ride ABOVE the bubbles.
-        try { ChaosGifCascadeOverlay.RaiseActive(); } catch { }
-        try { ChaosFlashOverlay.RaiseActive(); } catch { }
-        try { App.Flash?.RaiseAllToFront(); } catch { }
+        try { ChaosGifCascadeOverlay.RaiseActive(); } catch (Exception ex) { Diag.Swallowed(ex); }
+        try { ChaosFlashOverlay.RaiseActive(); } catch (Exception ex) { Diag.Swallowed(ex); }
+        try { App.Flash?.RaiseAllToFront(); } catch (Exception ex) { Diag.Swallowed(ex); }
     }
 
     /// <summary>
@@ -788,17 +788,17 @@ public sealed class ChaosModeService
         // avoids BringAllToFront yanking the bubbles back over the foreground app).
         if (!ChaosWindowZ.PinTopmost) return;
         // Chrome first (lowest of the pinned set).
-        try { _hud?.RaiseToTopmost(); } catch { }
-        try { _fx?.RaiseToTopmost(); } catch { }
-        try { ChaosWaveTimerOverlay.RaiseActive(); } catch { }
-        try { ChaosBoonBarOverlay.RaiseActive(); } catch { }
-        foreach (var b in _toyButtons) { try { b.RaiseToTopmost(); } catch { } }
+        try { _hud?.RaiseToTopmost(); } catch (Exception ex) { Diag.Swallowed(ex); }
+        try { _fx?.RaiseToTopmost(); } catch (Exception ex) { Diag.Swallowed(ex); }
+        try { ChaosWaveTimerOverlay.RaiseActive(); } catch (Exception ex) { Diag.Swallowed(ex); }
+        try { ChaosBoonBarOverlay.RaiseActive(); } catch (Exception ex) { Diag.Swallowed(ex); }
+        foreach (var b in _toyButtons) { try { b.RaiseToTopmost(); } catch (Exception ex) { Diag.Swallowed(ex); } }
         // Bubbles above the chrome so they stay poppable over the sidebar / boons / active buttons.
         App.Bubbles?.BringAllToFront();
         // Attention assets above the bubbles.
-        try { ChaosGifCascadeOverlay.RaiseActive(); } catch { }
-        try { ChaosFlashOverlay.RaiseActive(); } catch { }
-        try { App.Flash?.RaiseAllToFront(); } catch { }
+        try { ChaosGifCascadeOverlay.RaiseActive(); } catch (Exception ex) { Diag.Swallowed(ex); }
+        try { ChaosFlashOverlay.RaiseActive(); } catch (Exception ex) { Diag.Swallowed(ex); }
+        try { App.Flash?.RaiseAllToFront(); } catch (Exception ex) { Diag.Swallowed(ex); }
     }
 
     /// <summary>
@@ -814,8 +814,8 @@ public sealed class ChaosModeService
         var disp = Application.Current?.Dispatcher;
         if (disp == null) return;
         // A fullscreen video fully covers the tunnel — pause its render loop (0% tunnel GPU).
-        try { disp.BeginInvoke((Action)(() => ChaosTunnelService.SetVideoPlaying(true))); } catch { }
-        try { disp.BeginInvoke((Action)RaiseGameLayerAboveVideo); } catch { }
+        try { disp.BeginInvoke((Action)(() => ChaosTunnelService.SetVideoPlaying(true))); } catch (Exception ex) { Diag.Swallowed(ex); }
+        try { disp.BeginInvoke((Action)RaiseGameLayerAboveVideo); } catch (Exception ex) { Diag.Swallowed(ex); }
         System.Threading.Tasks.Task.Delay(60).ContinueWith(_ =>
         {
             if (Application.Current?.Dispatcher == null) return;
@@ -1721,7 +1721,7 @@ public sealed class ChaosModeService
         if (first)
         {
             _state?.PushEvent($"{ChaosGlyphs.Gold} gold. she takes it at her bench.");
-            try { App.Bark?.NotifyChaosGoldFirst(); } catch { }
+            try { App.Bark?.NotifyChaosGoldFirst(); } catch (Exception ex) { Diag.Swallowed(ex); }
         }
     }
 
@@ -2180,14 +2180,14 @@ public sealed class ChaosModeService
         if (e.PropertyName != nameof(ChaosRunState.Combo)) return;
         var st = _state;
         if (st == null) return;
-        try { ChaosTunnelService.SetStreak(st.Combo, st.ComboMult); } catch { }
+        try { ChaosTunnelService.SetStreak(st.Combo, st.ComboMult); } catch (Exception ex) { Diag.Swallowed(ex); }
     }
 
     /// <summary>Any video ending during a run (natural end, attention-check retry, cap) starts
     /// the teardown quarantine so no cascade rises into the LibVLC disposal churn.</summary>
     private void OnVideoEndedDuringRun(object? sender, EventArgs e)
     {
-        try { Application.Current?.Dispatcher?.BeginInvoke((Action)(() => ChaosTunnelService.SetVideoPlaying(false))); } catch { }
+        try { Application.Current?.Dispatcher?.BeginInvoke((Action)(() => ChaosTunnelService.SetVideoPlaying(false))); } catch (Exception ex) { Diag.Swallowed(ex); }
         ExtendHeavyQuarantine(VIDEO_TEARDOWN_QUARANTINE_SEC);
     }
 
@@ -2404,7 +2404,7 @@ public sealed class ChaosModeService
     private void CloseToyButtons()
     {
         foreach (var b in _toyButtons.ToArray())
-            try { b.Close(); } catch { }
+            try { b.Close(); } catch (Exception ex) { Diag.Swallowed(ex); }
         _toyButtons.Clear();
     }
 
@@ -2461,7 +2461,7 @@ public sealed class ChaosModeService
                 _keyHook.Dispose();
             }
         }
-        catch { }
+        catch (Exception ex) { Diag.Swallowed(ex); }
         _keyHook = null;
     }
 
@@ -2483,7 +2483,7 @@ public sealed class ChaosModeService
 
     private void StopRippleHook()
     {
-        try { _rippleHook?.Dispose(); } catch { }
+        try { _rippleHook?.Dispose(); } catch (Exception ex) { Diag.Swallowed(ex); }
         _rippleHook = null;
     }
 
@@ -2752,7 +2752,7 @@ public sealed class ChaosModeService
                 if (enabled.Count > 0) return enabled[Random.Shared.Next(enabled.Count)];
             }
         }
-        catch { }
+        catch (Exception ex) { Diag.Swallowed(ex); }
         return "GIVE IN";
     }
 
@@ -3088,33 +3088,33 @@ public sealed class ChaosModeService
         _paused = false;
         _runTimer?.Stop();
         _spawnTimer?.Stop();
-        try { App.Bubbles?.EndChaosMode(); } catch { }
-        try { App.Bubbles?.Resume(); } catch { }
+        try { App.Bubbles?.EndChaosMode(); } catch (Exception ex) { Diag.Swallowed(ex); }
+        try { App.Bubbles?.Resume(); } catch (Exception ex) { Diag.Swallowed(ex); }
         StopKeyHook();
         CloseToyButtons();
         EndSlowMo(); EndFreeze();
-        try { ChaosFlashOverlay.CloseActive(); } catch { }
-        try { ChaosGifCascadeOverlay.CloseActive(); } catch { }
-        try { ChaosAnnouncerOverlay.CloseActive(); } catch { }
-        try { ChaosUnlockCardOverlay.CloseActive(); } catch { }
-        try { ChaosDvdOverlay.CloseActive(); } catch { }
-        try { ChaosEffectBannerOverlay.CloseActive(); } catch { }
-        try { ChaosWaveTimerOverlay.CloseActive(); } catch { }
-        try { ChaosBoonBarOverlay.CloseActive(); } catch { }
-        try { DisarmRabbitCall(); ChaosCursorGlowOverlay.CloseActive(); } catch { }
-        try { ChaosVibeTrailOverlay.CloseActive(); } catch { }
-        try { ChaosEStimOverlay.CloseActive(); } catch { }
-        try { ChaosFieldFxOverlay.CloseActive(); } catch { }
-        try { ChaosSkiaFxOverlay.CloseActive(); } catch { }
-        try { ChaosPopText.ShutdownPool(); } catch { }
-        try { _fx?.Close(); } catch { }
+        try { ChaosFlashOverlay.CloseActive(); } catch (Exception ex) { Diag.Swallowed(ex); }
+        try { ChaosGifCascadeOverlay.CloseActive(); } catch (Exception ex) { Diag.Swallowed(ex); }
+        try { ChaosAnnouncerOverlay.CloseActive(); } catch (Exception ex) { Diag.Swallowed(ex); }
+        try { ChaosUnlockCardOverlay.CloseActive(); } catch (Exception ex) { Diag.Swallowed(ex); }
+        try { ChaosDvdOverlay.CloseActive(); } catch (Exception ex) { Diag.Swallowed(ex); }
+        try { ChaosEffectBannerOverlay.CloseActive(); } catch (Exception ex) { Diag.Swallowed(ex); }
+        try { ChaosWaveTimerOverlay.CloseActive(); } catch (Exception ex) { Diag.Swallowed(ex); }
+        try { ChaosBoonBarOverlay.CloseActive(); } catch (Exception ex) { Diag.Swallowed(ex); }
+        try { DisarmRabbitCall(); ChaosCursorGlowOverlay.CloseActive(); } catch (Exception ex) { Diag.Swallowed(ex); }
+        try { ChaosVibeTrailOverlay.CloseActive(); } catch (Exception ex) { Diag.Swallowed(ex); }
+        try { ChaosEStimOverlay.CloseActive(); } catch (Exception ex) { Diag.Swallowed(ex); }
+        try { ChaosFieldFxOverlay.CloseActive(); } catch (Exception ex) { Diag.Swallowed(ex); }
+        try { ChaosSkiaFxOverlay.CloseActive(); } catch (Exception ex) { Diag.Swallowed(ex); }
+        try { ChaosPopText.ShutdownPool(); } catch (Exception ex) { Diag.Swallowed(ex); }
+        try { _fx?.Close(); } catch (Exception ex) { Diag.Swallowed(ex); }
         if (_overlay != null)
         {
             _overlay.OnDismissed = null;   // avoid re-entrant cleanup
             _overlay.OnRunAgain = null;
-            try { _overlay.Close(); } catch { }
+            try { _overlay.Close(); } catch (Exception ex) { Diag.Swallowed(ex); }
         }
-        try { _hud?.Close(); } catch { }
+        try { _hud?.Close(); } catch (Exception ex) { Diag.Swallowed(ex); }
         CleanupAfterRun();
     }
 
@@ -3123,7 +3123,7 @@ public sealed class ChaosModeService
         if (!_spawning || _state == null) return;
         LogMemSample("run-end");
         ChaosCrashSentinel.Clear();   // the field is coming down — a vanish after here isn't a run crash
-        try { System.Windows.Media.CompositionTarget.Rendering -= OnChaosRendering; } catch { }
+        try { System.Windows.Media.CompositionTarget.Rendering -= OnChaosRendering; } catch (Exception ex) { Diag.Swallowed(ex); }
         bool ranFullCourse = _state.ElapsedSec >= _state.RunDurationSec;
         // The final loop ends at the run clock, not a wave boundary — its tip lands here
         // (full-course descents only; a quit mid-fall forfeits the loop's tip).
@@ -3142,21 +3142,21 @@ public sealed class ChaosModeService
         CloseToyButtons();
         App.Bubbles?.EndChaosMode();
         EndSlowMo(); EndFreeze();
-        try { ChaosFlashOverlay.CloseActive(); } catch { }
-        try { ChaosGifCascadeOverlay.CloseActive(); } catch { }
-        try { ChaosAnnouncerOverlay.CloseActive(); } catch { }
-        try { ChaosUnlockCardOverlay.CloseActive(); } catch { }
-        try { ChaosDvdOverlay.CloseActive(); } catch { }
-        try { ChaosEffectBannerOverlay.CloseActive(); } catch { }
-        try { ChaosWaveTimerOverlay.CloseActive(); } catch { }
-        try { ChaosBoonBarOverlay.CloseActive(); } catch { }
-        try { DisarmRabbitCall(); ChaosCursorGlowOverlay.CloseActive(); } catch { }
-        try { ChaosVibeTrailOverlay.CloseActive(); } catch { }
-        try { ChaosEStimOverlay.CloseActive(); } catch { }
-        try { ChaosFieldFxOverlay.CloseActive(); } catch { }
-        try { ChaosSkiaFxOverlay.CloseActive(); } catch { }
-        try { ChaosPopText.ShutdownPool(); } catch { }
-        try { _fx?.Close(); } catch { }
+        try { ChaosFlashOverlay.CloseActive(); } catch (Exception ex) { Diag.Swallowed(ex); }
+        try { ChaosGifCascadeOverlay.CloseActive(); } catch (Exception ex) { Diag.Swallowed(ex); }
+        try { ChaosAnnouncerOverlay.CloseActive(); } catch (Exception ex) { Diag.Swallowed(ex); }
+        try { ChaosUnlockCardOverlay.CloseActive(); } catch (Exception ex) { Diag.Swallowed(ex); }
+        try { ChaosDvdOverlay.CloseActive(); } catch (Exception ex) { Diag.Swallowed(ex); }
+        try { ChaosEffectBannerOverlay.CloseActive(); } catch (Exception ex) { Diag.Swallowed(ex); }
+        try { ChaosWaveTimerOverlay.CloseActive(); } catch (Exception ex) { Diag.Swallowed(ex); }
+        try { ChaosBoonBarOverlay.CloseActive(); } catch (Exception ex) { Diag.Swallowed(ex); }
+        try { DisarmRabbitCall(); ChaosCursorGlowOverlay.CloseActive(); } catch (Exception ex) { Diag.Swallowed(ex); }
+        try { ChaosVibeTrailOverlay.CloseActive(); } catch (Exception ex) { Diag.Swallowed(ex); }
+        try { ChaosEStimOverlay.CloseActive(); } catch (Exception ex) { Diag.Swallowed(ex); }
+        try { ChaosFieldFxOverlay.CloseActive(); } catch (Exception ex) { Diag.Swallowed(ex); }
+        try { ChaosSkiaFxOverlay.CloseActive(); } catch (Exception ex) { Diag.Swallowed(ex); }
+        try { ChaosPopText.ShutdownPool(); } catch (Exception ex) { Diag.Swallowed(ex); }
+        try { _fx?.Close(); } catch (Exception ex) { Diag.Swallowed(ex); }
         _fx = null;
 
         double durMin = Math.Max(1, _state.RunDurationSec) / 60.0;
@@ -3177,7 +3177,7 @@ public sealed class ChaosModeService
         catch (Exception ex) { App.Logger?.Debug("Chaos meta award: {E}", ex.Message); }
 
         // RunsCompleted just moved — queue any freshly crossed reveals for the next dollhouse open.
-        try { RevealService.Sync("run_end"); } catch { }
+        try { RevealService.Sync("run_end"); } catch (Exception ex) { Diag.Swallowed(ex); }
 
         // Rank spine: did this descent push the rank past the last card shown? Only the
         // HIGHEST new rank gets a card (a debug fast-forward skips the ones in between).
@@ -3187,7 +3187,7 @@ public sealed class ChaosModeService
             var nowRank = ChaosRanks.For(ChaosMeta.State.RunsCompleted);
             if ((int)nowRank > ChaosMeta.State.LastRankSeen) rankUp = nowRank;
         }
-        catch { }
+        catch (Exception ex) { Diag.Swallowed(ex); }
 
         string diff = _state.Config.Difficulty.ToString();
         App.Bark?.NotifyChaosRunCompleted((int)finalXp, diff);
@@ -3219,31 +3219,31 @@ public sealed class ChaosModeService
             App.Bubbles?.EndChaosMode();
             App.Bubbles?.Resume();
         }
-        try { _hud?.Close(); } catch { }
+        try { _hud?.Close(); } catch (Exception ex) { Diag.Swallowed(ex); }
         CleanupAfterRun();
     }
 
     private void CleanupAfterRun()
     {
         ChaosCrashSentinel.Clear();   // every run teardown path funnels through here — disarm the sentinel
-        try { System.Windows.Media.CompositionTarget.Rendering -= OnChaosRendering; } catch { }
+        try { System.Windows.Media.CompositionTarget.Rendering -= OnChaosRendering; } catch (Exception ex) { Diag.Swallowed(ex); }
         if (App.Video != null) App.Video.VideoStarted -= OnVideoStartedDuringRun;   // belt-and-suspenders (mid-run close)
         if (App.Video != null) App.Video.VideoEnded -= OnVideoEndedDuringRun;
         StopKeyHook();   // idempotent; covers the overlay-closed-mid-run path
         StopRippleHook();
         CloseToyButtons();
-        try { ChaosDvdOverlay.CloseActive(); } catch { }
-        try { ChaosEffectBannerOverlay.CloseActive(); } catch { }
-        try { ChaosWaveTimerOverlay.CloseActive(); } catch { }
-        try { ChaosBoonBarOverlay.CloseActive(); } catch { }
-        try { DisarmRabbitCall(); ChaosCursorGlowOverlay.CloseActive(); } catch { }
-        try { ChaosVibeTrailOverlay.CloseActive(); } catch { }
-        try { ChaosEStimOverlay.CloseActive(); } catch { }
-        try { ChaosFieldFxOverlay.CloseActive(); } catch { }
-        try { ChaosSkiaFxOverlay.CloseActive(); } catch { }
-        try { ChaosBackdropService.CloseActive(); } catch { }
-        try { ChaosTunnelService.CloseActive(); } catch { }
-        try { ChaosPopText.ShutdownPool(); } catch { }
+        try { ChaosDvdOverlay.CloseActive(); } catch (Exception ex) { Diag.Swallowed(ex); }
+        try { ChaosEffectBannerOverlay.CloseActive(); } catch (Exception ex) { Diag.Swallowed(ex); }
+        try { ChaosWaveTimerOverlay.CloseActive(); } catch (Exception ex) { Diag.Swallowed(ex); }
+        try { ChaosBoonBarOverlay.CloseActive(); } catch (Exception ex) { Diag.Swallowed(ex); }
+        try { DisarmRabbitCall(); ChaosCursorGlowOverlay.CloseActive(); } catch (Exception ex) { Diag.Swallowed(ex); }
+        try { ChaosVibeTrailOverlay.CloseActive(); } catch (Exception ex) { Diag.Swallowed(ex); }
+        try { ChaosEStimOverlay.CloseActive(); } catch (Exception ex) { Diag.Swallowed(ex); }
+        try { ChaosFieldFxOverlay.CloseActive(); } catch (Exception ex) { Diag.Swallowed(ex); }
+        try { ChaosSkiaFxOverlay.CloseActive(); } catch (Exception ex) { Diag.Swallowed(ex); }
+        try { ChaosBackdropService.CloseActive(); } catch (Exception ex) { Diag.Swallowed(ex); }
+        try { ChaosTunnelService.CloseActive(); } catch (Exception ex) { Diag.Swallowed(ex); }
+        try { ChaosPopText.ShutdownPool(); } catch (Exception ex) { Diag.Swallowed(ex); }
         App.AvatarWindow?.SetChaosRunActive(false);   // restore the avatar's normal attached z-order
         ChaosHappyPath.OnRunEnded();   // the script never outlives its run (idempotent)
         ChaosNarrativeHooks.OnRunEnded();   // drop the Madam's run-scoped state + any duck


### PR DESCRIPTION
**Logging redesign, swallow lane PR 2 of 5.** Base: `feat/log-swallow-helper` (#824). Merge that first.

Converts the empty catch bodies in the two worst offenders. `catch { }` becomes `catch (Exception ex) { Diag.Swallowed(ex); }`.

## Counts

| file | empty catches before | after | to `Diag.Swallowed` | typed `// swallow:` | left for another agent |
|---|---|---|---|---|---|
| `Services/Chaos/ChaosModeService.cs` | 91 | 2 | 89 | 0 | 2 (lines 840-900, agent B's `[CHAOSHITCH]`/`[CHAOSMEM]` block) |
| `App.xaml.cs` | 82 | 18 | 64 | 1 | 17 (lines 1490-1700 and 4230-4400, agent A's Serilog bootstrap, global handlers and crash writer) |
| **total** | **173** | **20** | **153** | **1** | **19** |

The finder re-run over both files reports exactly those 19 unconverted sites plus the 1 marked `// swallow:`, and nothing else.

Four sites read `exIgnored` rather than `ex` because an enclosing scope already binds `ex` (CS0136): `App.xaml.cs` at the awareness detach, the splash close, the installer progress-dialog close, and one update-path cleanup.

## Judgement calls

- **The one typed swallow** is `App.OnExit`'s `_mutex.ReleaseMutex()`. `ApplicationException` there means "this thread never owned it", which is exactly the expected case on a handoff exit, so it stays a typed empty catch with `// swallow: mutex was not owned by this thread` instead of logging.
- **Four notes carried over from comments**, with the comment dropped: `"file-open handoff is best effort"`, `"skip malformed window entry"`, `"diagnostics only, must not fault the continuation"`, `"one unreadable log file must not lose the others"`.
- **Nothing was narrowed.** Widening or narrowing a blanket catch changes what escapes, and none of these sites made the case for it clearly enough to be worth a behaviour change in a shipping build.

## Hot call sites

Two clusters here run often enough to be worth naming, and both are bounded by the helper's ten-per-site cap:

- `RaiseGameLayerAboveVideo` / the z-order pass (`ChaosModeService.cs` ~748-771 and ~791-801) - about 20 sites, re-driven whenever the layer is pinned and a video starts.
- `OnStateChangedForTunnel` (~2183) fires on every combo change during a run.

The rest are startup, teardown and run-end paths that fire once.

## Verification

```
dotnet build ConditioningControlPanel.sln -c Debug   0 errors
dotnet test Tests/ConditioningControlPanel.Tests     5207 passed, 0 failed
```

No control flow changed: no catch removed, no `throw` added, no `when` clause touched, no surrounding code reformatted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GSSvqeYrpVG9H3EPtqikDC
