### PR TITLE
refactor(logging): empty catches in the Deeper editor + player -> Diag.Swallowed

### DIFF
--- a/ConditioningControlPanel/Views/Deeper/DeeperEditorWindow.xaml.cs
+++ b/ConditioningControlPanel/Views/Deeper/DeeperEditorWindow.xaml.cs
@@ -255,7 +255,7 @@ namespace ConditioningControlPanel.Views.Deeper
 
             // Legacy bus event kept for any other listeners; tutorial Part 2
             // start is dispatched from PendingPart2Tutorial below.
-            try { TutorialEventBus.Emit("WindowLoaded:DeeperEditorWindow"); } catch { }
+            try { TutorialEventBus.Emit("WindowLoaded:DeeperEditorWindow"); } catch (Exception ex) { Diag.Swallowed(ex); }
 
             // Interactive tutorial Part 2 dispatch. The dialog finished Part 1
             // (clicked Create with a valid source) and queued a TutorialType to
@@ -294,7 +294,7 @@ namespace ConditioningControlPanel.Views.Deeper
                             if (Application.Current.MainWindow == null) return;
                             if (!thisWindow.IsLoaded) return;
 
-                            try { if (App.Tutorial.IsActive) App.Tutorial.Skip(); } catch { }
+                            try { if (App.Tutorial.IsActive) App.Tutorial.Skip(); } catch (Exception ex) { Diag.Swallowed(ex); }
                             App.Tutorial.Start(pendingType);
                             var overlay = new ConditioningControlPanel.TutorialOverlay(thisWindow, App.Tutorial);
                             overlay.Show();
@@ -306,7 +306,7 @@ namespace ConditioningControlPanel.Views.Deeper
                     };
                     // Stop the timer if the editor goes away before it fires —
                     // covers the case where the user closes mid-delay.
-                    void StopIfEditorClosing(object? s, EventArgs ev) { try { startTimer.Stop(); } catch { } }
+                    void StopIfEditorClosing(object? s, EventArgs ev) { try { startTimer.Stop(); } catch (Exception ex) { Diag.Swallowed(ex); } }
                     thisWindow.Closing += (s, ev) => StopIfEditorClosing(s, ev);
                     thisWindow.Closed += StopIfEditorClosing;
                     startTimer.Start();
@@ -683,16 +683,16 @@ namespace ConditioningControlPanel.Views.Deeper
                     // the temp window says we're not clean, retry cleanup.
                     if (_isPreviewFullscreen || _previewFullscreenWindow != null)
                     {
-                        Dispatcher.BeginInvoke(() => { try { ExitPreviewFullscreen(); } catch { } });
+                        Dispatcher.BeginInvoke(() => { try { ExitPreviewFullscreen(); } catch (Exception ex) { Diag.Swallowed(ex); } });
                     }
                 }
                 else if (msg == "ccp_zoom_in")
                 {
-                    Dispatcher.BeginInvoke(() => { try { AdjustPreviewZoom(+0.10); } catch { } });
+                    Dispatcher.BeginInvoke(() => { try { AdjustPreviewZoom(+0.10); } catch (Exception ex) { Diag.Swallowed(ex); } });
                 }
                 else if (msg == "ccp_zoom_out")
                 {
-                    Dispatcher.BeginInvoke(() => { try { AdjustPreviewZoom(-0.10); } catch { } });
+                    Dispatcher.BeginInvoke(() => { try { AdjustPreviewZoom(-0.10); } catch (Exception ex) { Diag.Swallowed(ex); } });
                 }
             }
             catch (Exception ex)
@@ -772,7 +772,7 @@ namespace ConditioningControlPanel.Views.Deeper
                         hadFsSubscription = true;
                     }
                 }
-                catch { }
+                catch (Exception ex) { Diag.Swallowed(ex); }
 
                 var screen = System.Windows.Forms.Screen.FromHandle(
                     new System.Windows.Interop.WindowInteropHelper(this).Handle);
@@ -846,8 +846,8 @@ namespace ConditioningControlPanel.Views.Deeper
                     // capture so timeline PreviewMouseWheel works too — wheel
                     // events are hit-test based, so focus on the WebView
                     // doesn't steal them when the cursor is over the timeline.
-                    try { Mouse.Capture(null); } catch { }
-                    try { BrowserPreview?.Focus(); } catch { }
+                    try { Mouse.Capture(null); } catch (Exception ex) { Diag.Swallowed(ex); }
+                    try { BrowserPreview?.Focus(); } catch (Exception ex) { Diag.Swallowed(ex); }
                 };
 
                 _previewFullscreenWindow = built;
@@ -858,7 +858,7 @@ namespace ConditioningControlPanel.Views.Deeper
                 // Flag the page so dblclick / click-pair handlers fire even
                 // when HTML5 fullscreen state was lost during reparent.
                 try { _ = BrowserPreview.CoreWebView2.ExecuteScriptAsync("window._ccpForcedFs = true;"); }
-                catch { }
+                catch (Exception ex) { Diag.Swallowed(ex); }
 
                 // Commit state only after reparent is fully in place.
                 _isPreviewFullscreen = true;
@@ -873,11 +873,11 @@ namespace ConditioningControlPanel.Views.Deeper
                 {
                     if (built != null)
                     {
-                        try { built.Content = null; } catch { }
-                        try { built.Close(); } catch { }
+                        try { built.Content = null; } catch (Exception exIgnored) { Diag.Swallowed(exIgnored); }
+                        try { built.Close(); } catch (Exception exIgnored) { Diag.Swallowed(exIgnored); }
                     }
                 }
-                catch { }
+                catch (Exception exIgnored) { Diag.Swallowed(exIgnored); }
                 _previewFullscreenWindow = null;
                 SafeRestoreBrowserPreviewToHost();
                 try
@@ -888,7 +888,7 @@ namespace ConditioningControlPanel.Views.Deeper
                             "window._ccpForcedFs = false; try { if (document.exitFullscreen && document.fullscreenElement) document.exitFullscreen(); } catch (_) {}");
                     }
                 }
-                catch { }
+                catch (Exception exIgnored) { Diag.Swallowed(exIgnored); }
                 // _isPreviewFullscreen was never flipped, so no further unwind.
             }
             finally
@@ -900,7 +900,7 @@ namespace ConditioningControlPanel.Views.Deeper
                         if (BrowserPreview?.CoreWebView2 != null)
                             BrowserPreview.CoreWebView2.ContainsFullScreenElementChanged += OnPreviewFullscreenChanged;
                     }
-                    catch { }
+                    catch (Exception ex) { Diag.Swallowed(ex); }
                 }
                 _fsTransitionInFlight = false;
             }
@@ -943,7 +943,7 @@ namespace ConditioningControlPanel.Views.Deeper
                         hadFsSubscription = true;
                     }
                 }
-                catch { }
+                catch (Exception ex) { Diag.Swallowed(ex); }
 
                 // Commit state up front — we're past the point where Enter
                 // could win the race, and downstream code should immediately
@@ -957,7 +957,7 @@ namespace ConditioningControlPanel.Views.Deeper
                             "window._ccpForcedFs = false; try { if (document.exitFullscreen && document.fullscreenElement) document.exitFullscreen(); } catch (_) {}");
                     }
                 }
-                catch { }
+                catch (Exception ex) { Diag.Swallowed(ex); }
                 if (_previewFullscreenWindow != null)
                 {
                     try { _previewFullscreenWindow.Close(); }
@@ -977,7 +977,7 @@ namespace ConditioningControlPanel.Views.Deeper
                         if (BrowserPreview?.CoreWebView2 != null)
                             BrowserPreview.CoreWebView2.ContainsFullScreenElementChanged += OnPreviewFullscreenChanged;
                     }
-                    catch { }
+                    catch (Exception ex) { Diag.Swallowed(ex); }
                 }
                 _fsTransitionInFlight = false;
             }
@@ -1094,12 +1094,12 @@ namespace ConditioningControlPanel.Views.Deeper
             EventHandler<EventArgs>? pauseOnce = null;
             pauseOnce = (_, _) =>
             {
-                try { _mediaPlayer?.Pause(); } catch { }
+                try { _mediaPlayer?.Pause(); } catch (Exception ex) { Diag.Swallowed(ex); }
                 Dispatcher.InvokeAsync(() =>
                 {
-                    try { BtnPlayPause.Content = "▶"; } catch { }
+                    try { BtnPlayPause.Content = "▶"; } catch (Exception ex) { Diag.Swallowed(ex); }
                 });
-                try { if (_mediaPlayer != null && pauseOnce != null) _mediaPlayer.Playing -= pauseOnce; } catch { }
+                try { if (_mediaPlayer != null && pauseOnce != null) _mediaPlayer.Playing -= pauseOnce; } catch (Exception ex) { Diag.Swallowed(ex); }
             };
             _mediaPlayer.Playing += pauseOnce;
 
@@ -1149,7 +1149,7 @@ namespace ConditioningControlPanel.Views.Deeper
             // bare Play() is a no-op. Stop()+seek-to-zero means the next Play
             // (whether from Space or BtnPlayPause) actually replays — the
             // "replay-after-stop" promise from bb6f503.
-            try { _mediaPlayer?.Stop(); } catch { }
+            try { _mediaPlayer?.Stop(); } catch (Exception ex) { Diag.Swallowed(ex); }
             Dispatcher.InvokeAsync(() =>
             {
                 if (Dispatcher.HasShutdownStarted) return;
@@ -1345,7 +1345,7 @@ namespace ConditioningControlPanel.Views.Deeper
             else if (_audioReader != null)
             {
                 try { _audioReader.CurrentTime = TimeSpan.FromSeconds(_currentSeconds); }
-                catch { /* unsupported on some streams */ }
+                catch (Exception ex) { Diag.Swallowed(ex, "seek unsupported on some streams"); }
             }
             UpdatePlayheadPosition();
         }
@@ -1723,12 +1723,12 @@ namespace ConditioningControlPanel.Views.Deeper
         {
             if (_rubberBandRect != null)
             {
-                try { TimelineCanvas.Children.Remove(_rubberBandRect); } catch { }
+                try { TimelineCanvas.Children.Remove(_rubberBandRect); } catch (Exception ex) { Diag.Swallowed(ex); }
                 _rubberBandRect = null;
             }
             if (_dragCreatePreview != null)
             {
-                try { TimelineCanvas.Children.Remove(_dragCreatePreview); } catch { }
+                try { TimelineCanvas.Children.Remove(_dragCreatePreview); } catch (Exception ex) { Diag.Swallowed(ex); }
                 _dragCreatePreview = null;
             }
             _dragMode = DragMode.None;
@@ -4202,7 +4202,7 @@ namespace ConditioningControlPanel.Views.Deeper
             // Close here without committing leaves Committed=false → no apply.
             if (_gazePickerWindow == null) return;
             try { _gazePickerWindow.Close(); }
-            catch { }
+            catch (Exception ex) { Diag.Swallowed(ex); }
             _gazePickerWindow = null;
         }
 
@@ -4392,7 +4392,7 @@ namespace ConditioningControlPanel.Views.Deeper
                     TutorialEventBus.LastSavedEnhancementPath = path;
                     TutorialEventBus.Emit("FileSaved");
                 }
-                catch { }
+                catch (Exception ex) { Diag.Swallowed(ex); }
             }
             catch (Exception ex)
             {
@@ -4431,7 +4431,7 @@ namespace ConditioningControlPanel.Views.Deeper
                         || currentSrc.StartsWith("https://", StringComparison.OrdinalIgnoreCase);
             if (!srcIsUrl && EnhancementMediaBundler.IsSupportedExtension(currentSrc))
             {
-                try { if (File.Exists(currentSrc)) sourcePath = currentSrc; } catch { }
+                try { if (File.Exists(currentSrc)) sourcePath = currentSrc; } catch (Exception ex) { Diag.Swallowed(ex); }
             }
 
             if (sourcePath == null)
@@ -4566,7 +4566,7 @@ namespace ConditioningControlPanel.Views.Deeper
             else
             {
                 var exists = false;
-                try { exists = File.Exists(src); } catch { }
+                try { exists = File.Exists(src); } catch (Exception ex) { Diag.Swallowed(ex); }
                 TxtLinkedMediaStatus.Text = exists ? "✓" : "⚠";
                 TxtLinkedMediaStatus.ToolTip = exists
                     ? Loc.Get("deeper_editor_linked_status_local_ok")
@@ -4665,7 +4665,7 @@ namespace ConditioningControlPanel.Views.Deeper
                     e.Effects = DragDropEffects.Copy;
                 }
             }
-            catch { }
+            catch (Exception ex) { Diag.Swallowed(ex); }
             e.Handled = true;
         }
 
@@ -4999,7 +4999,7 @@ namespace ConditioningControlPanel.Views.Deeper
         public void ForceClose()
         {
             _suppressDirtyPromptOnClose = true;
-            try { Close(); } catch { }
+            try { Close(); } catch (Exception ex) { Diag.Swallowed(ex); }
         }
 
         private void Window_Closing(object sender, System.ComponentModel.CancelEventArgs e)
@@ -5020,11 +5020,11 @@ namespace ConditioningControlPanel.Views.Deeper
             }
 
             EndGazePick(commit: false);
-            try { _htFetchCts?.Cancel(); _htFetchCts?.Dispose(); _htFetchCts = null; } catch { }
+            try { _htFetchCts?.Cancel(); _htFetchCts?.Dispose(); _htFetchCts = null; } catch (Exception ex) { Diag.Swallowed(ex); }
             // Force the tutorial overlay closed so its OnClosed teardown runs;
             // otherwise its static TutorialEventBus.Event subscription would
             // outlive the editor and pin the closed window.
-            try { _editorTutorialOverlay?.Close(); } catch { }
+            try { _editorTutorialOverlay?.Close(); } catch (Exception ex) { Diag.Swallowed(ex); }
             _editorTutorialOverlay = null;
 
             // Exit preview fullscreen synchronously so the reparent-on-Closed
@@ -5033,7 +5033,7 @@ namespace ConditioningControlPanel.Views.Deeper
             // Check the window reference too — a partial prior exit can leave
             // the borderless host alive with the flag already cleared, and
             // skipping cleanup here would orphan it past the editor's death.
-            try { if (_isPreviewFullscreen || _previewFullscreenWindow != null) ExitPreviewFullscreen(); } catch { }
+            try { if (_isPreviewFullscreen || _previewFullscreenWindow != null) ExitPreviewFullscreen(); } catch (Exception ex) { Diag.Swallowed(ex); }
 
             DisposePlayback();
         }
@@ -5049,35 +5049,35 @@ namespace ConditioningControlPanel.Views.Deeper
                 if (_mediaPlayer != null)
                 {
                     if (VideoPreview != null) VideoPreview.MediaPlayer = null;
-                    try { if (_vlcLengthChanged != null) _mediaPlayer.LengthChanged -= _vlcLengthChanged; } catch { }
-                    try { if (_vlcTimeChanged != null) _mediaPlayer.TimeChanged -= _vlcTimeChanged; } catch { }
-                    try { if (_vlcEndReached != null) _mediaPlayer.EndReached -= _vlcEndReached; } catch { }
+                    try { if (_vlcLengthChanged != null) _mediaPlayer.LengthChanged -= _vlcLengthChanged; } catch (Exception ex) { Diag.Swallowed(ex); }
+                    try { if (_vlcTimeChanged != null) _mediaPlayer.TimeChanged -= _vlcTimeChanged; } catch (Exception ex) { Diag.Swallowed(ex); }
+                    try { if (_vlcEndReached != null) _mediaPlayer.EndReached -= _vlcEndReached; } catch (Exception ex) { Diag.Swallowed(ex); }
                     _vlcLengthChanged = null;
                     _vlcTimeChanged = null;
                     _vlcEndReached = null;
-                    try { _mediaPlayer.Stop(); } catch { }
-                    try { _mediaPlayer.Dispose(); } catch { }
+                    try { _mediaPlayer.Stop(); } catch (Exception ex) { Diag.Swallowed(ex); }
+                    try { _mediaPlayer.Dispose(); } catch (Exception ex) { Diag.Swallowed(ex); }
                     _mediaPlayer = null;
                 }
                 if (_vlcMedia != null)
                 {
-                    try { _vlcMedia.Dispose(); } catch { }
+                    try { _vlcMedia.Dispose(); } catch (Exception ex) { Diag.Swallowed(ex); }
                     _vlcMedia = null;
                 }
                 if (_waveOut != null)
                 {
-                    try { if (_waveOutStopped != null) _waveOut.PlaybackStopped -= _waveOutStopped; } catch { }
+                    try { if (_waveOutStopped != null) _waveOut.PlaybackStopped -= _waveOutStopped; } catch (Exception ex) { Diag.Swallowed(ex); }
                     _waveOutStopped = null;
-                    try { _waveOut.Stop(); } catch { }
-                    try { _waveOut.Dispose(); } catch { }
+                    try { _waveOut.Stop(); } catch (Exception ex) { Diag.Swallowed(ex); }
+                    try { _waveOut.Dispose(); } catch (Exception ex) { Diag.Swallowed(ex); }
                     _waveOut = null;
                 }
                 _audioReader?.Dispose();
                 _audioReader = null;
                 if (_browserSource != null)
                 {
-                    try { _browserSource.PlaybackTimeChanged -= OnBrowserTimeChanged; } catch { }
-                    try { _browserSource.Dispose(); } catch { }
+                    try { _browserSource.PlaybackTimeChanged -= OnBrowserTimeChanged; } catch (Exception ex) { Diag.Swallowed(ex); }
+                    try { _browserSource.Dispose(); } catch (Exception ex) { Diag.Swallowed(ex); }
                     _browserSource = null;
                 }
                 _totalSeconds = 0;
@@ -5099,9 +5099,9 @@ namespace ConditioningControlPanel.Views.Deeper
                 if (_mediaPlayer != null)
                 {
                     if (VideoPreview != null) VideoPreview.MediaPlayer = null;
-                    try { if (_vlcLengthChanged != null) _mediaPlayer.LengthChanged -= _vlcLengthChanged; } catch { }
-                    try { if (_vlcTimeChanged != null) _mediaPlayer.TimeChanged -= _vlcTimeChanged; } catch { }
-                    try { if (_vlcEndReached != null) _mediaPlayer.EndReached -= _vlcEndReached; } catch { }
+                    try { if (_vlcLengthChanged != null) _mediaPlayer.LengthChanged -= _vlcLengthChanged; } catch (Exception ex) { Diag.Swallowed(ex); }
+                    try { if (_vlcTimeChanged != null) _mediaPlayer.TimeChanged -= _vlcTimeChanged; } catch (Exception ex) { Diag.Swallowed(ex); }
+                    try { if (_vlcEndReached != null) _mediaPlayer.EndReached -= _vlcEndReached; } catch (Exception ex) { Diag.Swallowed(ex); }
                     _vlcLengthChanged = null;
                     _vlcTimeChanged = null;
                     _vlcEndReached = null;
@@ -5111,15 +5111,15 @@ namespace ConditioningControlPanel.Views.Deeper
                 }
                 if (_vlcMedia != null)
                 {
-                    try { _vlcMedia.Dispose(); } catch { }
+                    try { _vlcMedia.Dispose(); } catch (Exception ex) { Diag.Swallowed(ex); }
                     _vlcMedia = null;
                 }
 
                 if (_waveOut != null)
                 {
-                    try { if (_waveOutStopped != null) _waveOut.PlaybackStopped -= _waveOutStopped; } catch { }
+                    try { if (_waveOutStopped != null) _waveOut.PlaybackStopped -= _waveOutStopped; } catch (Exception ex) { Diag.Swallowed(ex); }
                     _waveOutStopped = null;
-                    try { _waveOut.Stop(); } catch { }
+                    try { _waveOut.Stop(); } catch (Exception ex) { Diag.Swallowed(ex); }
                     _waveOut.Dispose();
                     _waveOut = null;
                 }
@@ -5134,7 +5134,7 @@ namespace ConditioningControlPanel.Views.Deeper
                         BrowserPreview.CoreWebView2.WebMessageReceived -= OnPreviewWebMessageReceived;
                     }
                 }
-                catch { }
+                catch (Exception ex) { Diag.Swallowed(ex); }
 
                 if (_browserSource != null)
                 {
@@ -5147,8 +5147,8 @@ namespace ConditioningControlPanel.Views.Deeper
                     if (BrowserPreview?.CoreWebView2 != null)
                         BrowserPreview.CoreWebView2.NavigationStarting -= OnBrowserNavigationStarting;
                 }
-                catch { }
-                try { BrowserPreview?.Dispose(); } catch { }
+                catch (Exception ex) { Diag.Swallowed(ex); }
+                try { BrowserPreview?.Dispose(); } catch (Exception ex) { Diag.Swallowed(ex); }
             }
             catch (Exception ex)
             {

--- a/ConditioningControlPanel/Views/Deeper/EnhancementPlayerWindow.xaml.cs
+++ b/ConditioningControlPanel/Views/Deeper/EnhancementPlayerWindow.xaml.cs
@@ -207,7 +207,7 @@ namespace ConditioningControlPanel.Views.Deeper
                     e.Effects = DragDropEffects.Copy;
                 }
             }
-            catch { }
+            catch (Exception ex) { Diag.Swallowed(ex); }
             e.Handled = true;
         }
 
@@ -466,7 +466,7 @@ namespace ConditioningControlPanel.Views.Deeper
                 };
                 _promotedClearTimer.Start();
             }
-            catch { }
+            catch (Exception ex) { Diag.Swallowed(ex); }
         }
 
         private void BtnCreateNewEnhancement_Click(object sender, RoutedEventArgs e)
@@ -691,7 +691,7 @@ namespace ConditioningControlPanel.Views.Deeper
         {
             if (_videoSource != null)
             {
-                try { _videoSource.Pause(); _videoSource.Seek(0); } catch { }
+                try { _videoSource.Pause(); _videoSource.Seek(0); } catch (Exception ex) { Diag.Swallowed(ex); }
                 BtnPlayPause.Content = "▶";
                 TxtCurrent.Text = "0:00";
                 TxtStatus.Text = Loc.Get("deeper_player_status_stopped");
@@ -838,7 +838,7 @@ namespace ConditioningControlPanel.Views.Deeper
         {
             var svc = App.Webcam;
             if (svc == null || _onWebcamStateChanged == null) return;
-            try { svc.OnTrackingStateChanged -= _onWebcamStateChanged; } catch { }
+            try { svc.OnTrackingStateChanged -= _onWebcamStateChanged; } catch (Exception ex) { Diag.Swallowed(ex); }
             _onWebcamStateChanged = null;
         }
 
@@ -932,7 +932,7 @@ namespace ConditioningControlPanel.Views.Deeper
                 if (totalSec <= 0) totalSec = _miniTotalSeconds;
                 TxtMiniTimelineReadout.Text = $"{FormatTime(curSec)} / {FormatTime(totalSec)}";
             }
-            catch { }
+            catch (Exception ex) { Diag.Swallowed(ex); }
         }
 
         // -- Waveform render + scrub ------------------------------------------
@@ -1185,7 +1185,7 @@ namespace ConditioningControlPanel.Views.Deeper
             var src = _videoSource;
             _host.Bind(src,
                 attach: () => src?.Attach(),
-                detach: () => { try { src?.Detach(); } catch { } });
+                detach: () => { try { src?.Detach(); } catch (Exception ex) { Diag.Swallowed(ex); } });
         }
 
         // Single hardened WebView2 init for the Player. Mirrors
@@ -1400,16 +1400,16 @@ namespace ConditioningControlPanel.Views.Deeper
                     // the flag, but Close() left the window alive.
                     if (_isVideoFullscreen || _videoFullscreenWindow != null)
                     {
-                        Dispatcher.BeginInvoke(() => { try { ExitVideoFullscreen(); } catch { } });
+                        Dispatcher.BeginInvoke(() => { try { ExitVideoFullscreen(); } catch (Exception ex) { Diag.Swallowed(ex); } });
                     }
                 }
                 else if (msg == "ccp_zoom_in")
                 {
-                    Dispatcher.BeginInvoke(() => { try { AdjustVideoZoom(+0.10); } catch { } });
+                    Dispatcher.BeginInvoke(() => { try { AdjustVideoZoom(+0.10); } catch (Exception ex) { Diag.Swallowed(ex); } });
                 }
                 else if (msg == "ccp_zoom_out")
                 {
-                    Dispatcher.BeginInvoke(() => { try { AdjustVideoZoom(-0.10); } catch { } });
+                    Dispatcher.BeginInvoke(() => { try { AdjustVideoZoom(-0.10); } catch (Exception ex) { Diag.Swallowed(ex); } });
                 }
             }
             catch (Exception ex)
@@ -1642,7 +1642,7 @@ namespace ConditioningControlPanel.Views.Deeper
                     if (!_isVideoFullscreen) return;
                     if (_isPlayerDualMonitorActive)
                     {
-                        try { App.ScreenMirror?.DisableMirror(); } catch { }
+                        try { App.ScreenMirror?.DisableMirror(); } catch (Exception ex) { Diag.Swallowed(ex); }
                         _isPlayerDualMonitorActive = false;
                     }
                     ExitVideoFullscreen();
@@ -1701,7 +1701,7 @@ namespace ConditioningControlPanel.Views.Deeper
                         hadFsSubscription = true;
                     }
                 }
-                catch { }
+                catch (Exception ex) { Diag.Swallowed(ex); }
 
                 // Find which monitor this Player is currently on so the fullscreen
                 // window lands on the same screen the user was looking at.
@@ -1769,18 +1769,18 @@ namespace ConditioningControlPanel.Views.Deeper
                 EventHandler deactivatedHandler = (_, _) =>
                 {
                     try { if (_videoFullscreenWindow != null) _videoFullscreenWindow.Topmost = false; }
-                    catch { }
+                    catch (Exception ex) { Diag.Swallowed(ex); }
                 };
                 EventHandler activatedHandler = (_, _) =>
                 {
                     try { if (_videoFullscreenWindow != null) _videoFullscreenWindow.Topmost = true; }
-                    catch { }
+                    catch (Exception ex) { Diag.Swallowed(ex); }
                     // Re-taking the claim re-raises this window to the FRONT of the topmost band,
                     // which is exactly what buried the pink tint / spiral / flashes for the rest of
                     // the run (#1041/#1051/#1052). Put them straight back on top instead of waiting
                     // out the reconcile tick.
                     try { App.Overlay?.RequestForcedZOrderReassert(); }
-                    catch { }
+                    catch (Exception ex) { Diag.Swallowed(ex); }
                 };
 
                 EventHandler? closedHandler = null;
@@ -1798,18 +1798,18 @@ namespace ConditioningControlPanel.Views.Deeper
                         App.Logger?.Debug("EnhancementPlayer: WebView re-parent on close failed: {Error}", ex.Message);
                     }
 
-                    try { built!.KeyDown -= keyHandler; } catch { }
-                    try { built!.Closing -= closingHandler; } catch { }
-                    try { built!.Deactivated -= deactivatedHandler; } catch { }
-                    try { built!.Activated -= activatedHandler; } catch { }
-                    try { built!.Closed -= closedHandler!; } catch { }
+                    try { built!.KeyDown -= keyHandler; } catch (Exception ex) { Diag.Swallowed(ex); }
+                    try { built!.Closing -= closingHandler; } catch (Exception ex) { Diag.Swallowed(ex); }
+                    try { built!.Deactivated -= deactivatedHandler; } catch (Exception ex) { Diag.Swallowed(ex); }
+                    try { built!.Activated -= activatedHandler; } catch (Exception ex) { Diag.Swallowed(ex); }
+                    try { built!.Closed -= closedHandler!; } catch (Exception ex) { Diag.Swallowed(ex); }
 
                     _videoFullscreenWindow = null;
                     // Release the z-order registration on the window's OWN teardown too, so a close
                     // that did not come through ExitVideoFullscreen can't strand the forced-tick
                     // flag on (SetFullscreenBrowserActive is idempotent per owner).
                     try { App.Overlay?.SetFullscreenBrowserActive(built, false); }
-                    catch { }
+                    catch (Exception ex) { Diag.Swallowed(ex); }
 
                     // After reparent the underlying Chromium HWND is in a state
                     // where the page no longer receives input events (mouse
@@ -1818,8 +1818,8 @@ namespace ConditioningControlPanel.Views.Deeper
                     // inner HWND back up so the HT page is scrollable on
                     // return. Mouse.Capture(null) clears any stuck capture
                     // from the fullscreen click sequence.
-                    try { Mouse.Capture(null); } catch { }
-                    try { VideoBrowser?.Focus(); } catch { }
+                    try { Mouse.Capture(null); } catch (Exception ex) { Diag.Swallowed(ex); }
+                    try { VideoBrowser?.Focus(); } catch (Exception ex) { Diag.Swallowed(ex); }
                 };
 
                 built.KeyDown += keyHandler;
@@ -1843,7 +1843,7 @@ namespace ConditioningControlPanel.Views.Deeper
                 // user can always exit our WPF "forced fullscreen" by
                 // double-clicking the video, regardless of page state.
                 try { FireScript("window._ccpForcedFs = true;"); }
-                catch { }
+                catch (Exception ex) { Diag.Swallowed(ex); }
 
                 // Commit state only after reparent is fully in place.
                 _isVideoFullscreen = true;
@@ -1861,11 +1861,11 @@ namespace ConditioningControlPanel.Views.Deeper
                 {
                     if (built != null)
                     {
-                        try { built.Content = null; } catch { }
-                        try { built.Close(); } catch { }
+                        try { built.Content = null; } catch (Exception exIgnored) { Diag.Swallowed(exIgnored); }
+                        try { built.Close(); } catch (Exception exIgnored) { Diag.Swallowed(exIgnored); }
                     }
                 }
-                catch { }
+                catch (Exception exIgnored) { Diag.Swallowed(exIgnored); }
                 _videoFullscreenWindow = null;
                 SafeRestoreVideoBrowserToPane();
                 try
@@ -1876,7 +1876,7 @@ namespace ConditioningControlPanel.Views.Deeper
                             "window._ccpForcedFs = false; try { if (document.exitFullscreen && document.fullscreenElement) document.exitFullscreen(); } catch (_) {}");
                     }
                 }
-                catch { }
+                catch (Exception exIgnored) { Diag.Swallowed(exIgnored); }
                 // _isVideoFullscreen never flipped, so no further unwind.
             }
             finally
@@ -1888,7 +1888,7 @@ namespace ConditioningControlPanel.Views.Deeper
                         if (VideoBrowser?.CoreWebView2 != null)
                             VideoBrowser.CoreWebView2.ContainsFullScreenElementChanged += OnVideoFullscreenChanged;
                     }
-                    catch { }
+                    catch (Exception ex) { Diag.Swallowed(ex); }
                 }
                 _fsTransitionInFlight = false;
             }
@@ -1929,7 +1929,7 @@ namespace ConditioningControlPanel.Views.Deeper
                     t => { _ = t.Exception; },
                     TaskContinuationOptions.OnlyOnFaulted);
             }
-            catch { }
+            catch (Exception ex) { Diag.Swallowed(ex); }
         }
 
         private void ExitVideoFullscreen()
@@ -1951,7 +1951,7 @@ namespace ConditioningControlPanel.Views.Deeper
                         hadFsSubscription = true;
                     }
                 }
-                catch { }
+                catch (Exception ex) { Diag.Swallowed(ex); }
 
                 _isVideoFullscreen = false;
                 // Clear the JS flag and best-effort exit any HTML5 fullscreen
@@ -1965,11 +1965,11 @@ namespace ConditioningControlPanel.Views.Deeper
                             "window._ccpForcedFs = false; try { if (document.exitFullscreen && document.fullscreenElement) document.exitFullscreen(); } catch (_) {}");
                     }
                 }
-                catch { }
+                catch (Exception ex) { Diag.Swallowed(ex); }
                 if (_videoFullscreenWindow != null)
                 {
                     try { App.Overlay?.SetFullscreenBrowserActive(_videoFullscreenWindow, false); }
-                    catch { }
+                    catch (Exception ex) { Diag.Swallowed(ex); }
                     try { _videoFullscreenWindow.Close(); }
                     catch (Exception ex) { App.Logger?.Debug("EnhancementPlayer: fullscreen window close failed: {Error}", ex.Message); }
                 }
@@ -1977,7 +1977,7 @@ namespace ConditioningControlPanel.Views.Deeper
                 // the fullscreen window was up, so re-seat everything one last time now that the
                 // forced-tick flag is off.
                 try { App.Overlay?.RequestForcedZOrderReassert(); }
-                catch { }
+                catch (Exception ex) { Diag.Swallowed(ex); }
                 App.Logger?.Information("EnhancementPlayer: exited fullscreen");
             }
             catch (Exception ex)
@@ -1993,7 +1993,7 @@ namespace ConditioningControlPanel.Views.Deeper
                         if (VideoBrowser?.CoreWebView2 != null)
                             VideoBrowser.CoreWebView2.ContainsFullScreenElementChanged += OnVideoFullscreenChanged;
                     }
-                    catch { }
+                    catch (Exception ex) { Diag.Swallowed(ex); }
                 }
                 _fsTransitionInFlight = false;
             }
@@ -2031,7 +2031,7 @@ namespace ConditioningControlPanel.Views.Deeper
                 if (Dispatcher.CheckAccess()) IngestActionLine(line);
                 else Dispatcher.BeginInvoke(() => IngestActionLine(line));
             }
-            catch { }
+            catch (Exception ex) { Diag.Swallowed(ex); }
         }
 
         private void OnHostDiagnostic(string line)
@@ -2041,7 +2041,7 @@ namespace ConditioningControlPanel.Views.Deeper
                 if (Dispatcher.CheckAccess()) IngestDiagnosticLine(line);
                 else Dispatcher.BeginInvoke(() => IngestDiagnosticLine(line));
             }
-            catch { }
+            catch (Exception ex) { Diag.Swallowed(ex); }
         }
 
         private void OnHostLoadFailed(string reason)
@@ -2058,7 +2058,7 @@ namespace ConditioningControlPanel.Views.Deeper
                 if (Dispatcher.CheckAccess()) Apply();
                 else Dispatcher.BeginInvoke(Apply);
             }
-            catch { }
+            catch (Exception ex) { Diag.Swallowed(ex); }
         }
 
         // -- Cleanup -----------------------------------------------------------
@@ -2074,14 +2074,14 @@ namespace ConditioningControlPanel.Views.Deeper
             // means an early throw (e.g. ScreenMirror NRE) skips _uiTimer.Stop
             // and leaves dead delegates pinned on the App.* singletons. Stop
             // the tick timer first so no UI work is queued onto a dying window.
-            try { _uiTimer?.Stop(); } catch { }
-            try { if (_uiTimer != null) _uiTimer.Tick -= UiTimer_Tick; } catch { }
+            try { _uiTimer?.Stop(); } catch (Exception ex) { Diag.Swallowed(ex); }
+            try { if (_uiTimer != null) _uiTimer.Tick -= UiTimer_Tick; } catch (Exception ex) { Diag.Swallowed(ex); }
             _uiTimer = null;
 
             // DispatcherTimer is rooted by the Dispatcher while running; if the
             // banner is mid-display when the window closes, the timer's lambda
             // captures `this` and briefly pins the window until the 6s tick.
-            try { _promotedClearTimer?.Stop(); } catch { }
+            try { _promotedClearTimer?.Stop(); } catch (Exception ex) { Diag.Swallowed(ex); }
             _promotedClearTimer = null;
 
             // Exit fullscreen synchronously so the reparent-on-Closed lambda
@@ -2089,7 +2089,7 @@ namespace ConditioningControlPanel.Views.Deeper
             // Check the window reference too — a partial prior exit can leave
             // the borderless host alive with the flag already cleared, and
             // skipping cleanup here would orphan it past the player's death.
-            try { if (_isVideoFullscreen || _videoFullscreenWindow != null) ExitVideoFullscreen(); } catch { }
+            try { if (_isVideoFullscreen || _videoFullscreenWindow != null) ExitVideoFullscreen(); } catch (Exception ex) { Diag.Swallowed(ex); }
 
             // Safety net: ExitVideoFullscreen() early-returns while a fullscreen transition
             // is in flight (_fsTransitionInFlight) — and EnterVideoFullscreen pumps the
@@ -2105,29 +2105,29 @@ namespace ConditioningControlPanel.Views.Deeper
                 catch (Exception ex) { App.Logger?.Debug("EnhancementPlayer: forced fullscreen window close failed: {Error}", ex.Message); }
                 _videoFullscreenWindow = null;
                 _isVideoFullscreen = false;
-                try { SafeRestoreVideoBrowserToPane(); } catch { }
+                try { SafeRestoreVideoBrowserToPane(); } catch (Exception ex) { Diag.Swallowed(ex); }
             }
 
             try
             {
                 if (_isPlayerDualMonitorActive)
                 {
-                    try { App.ScreenMirror?.DisableMirror(); } catch { }
+                    try { App.ScreenMirror?.DisableMirror(); } catch (Exception ex) { Diag.Swallowed(ex); }
                     _isPlayerDualMonitorActive = false;
                 }
             }
-            catch { }
+            catch (Exception ex) { Diag.Swallowed(ex); }
 
             // Unsubscribe singleton-service events. Each in its own try so a
             // throw on one (e.g. _player already disposed) doesn't strand the
             // others as dead delegates on the app-lifetime singletons.
-            try { _player.Loaded -= OnPlayerLoaded; } catch { }
-            try { _player.Ended -= OnPlayerEnded; } catch { }
-            try { _host.Loaded -= OnHostLoaded; } catch { }
-            try { _host.LoadFailed -= OnHostLoadFailed; } catch { }
-            try { _host.ActionLogged -= OnHostActionLogged; } catch { }
-            try { _host.Diagnostic -= OnHostDiagnostic; } catch { }
-            try { UnsubscribeWebcamStateForButton(); } catch { }
+            try { _player.Loaded -= OnPlayerLoaded; } catch (Exception ex) { Diag.Swallowed(ex); }
+            try { _player.Ended -= OnPlayerEnded; } catch (Exception ex) { Diag.Swallowed(ex); }
+            try { _host.Loaded -= OnHostLoaded; } catch (Exception ex) { Diag.Swallowed(ex); }
+            try { _host.LoadFailed -= OnHostLoadFailed; } catch (Exception ex) { Diag.Swallowed(ex); }
+            try { _host.ActionLogged -= OnHostActionLogged; } catch (Exception ex) { Diag.Swallowed(ex); }
+            try { _host.Diagnostic -= OnHostDiagnostic; } catch (Exception ex) { Diag.Swallowed(ex); }
+            try { UnsubscribeWebcamStateForButton(); } catch (Exception ex) { Diag.Swallowed(ex); }
             // If THIS player session turned the webcam on (via the pre-play
             // prompt), turn it off on the way out so we leave the system the
             // way we found it. Webcams the user had running before opening
@@ -2138,8 +2138,8 @@ namespace ConditioningControlPanel.Views.Deeper
                     App.Webcam.Stop();
             }
             catch (Exception ex) { App.Logger?.Debug("Player webcam auto-stop failed: {Error}", ex.Message); }
-            try { UnbindEngineIfRunning(); } catch { }
-            try { _player.Stop(); } catch { }
+            try { UnbindEngineIfRunning(); } catch (Exception ex) { Diag.Swallowed(ex); }
+            try { _player.Stop(); } catch (Exception ex) { Diag.Swallowed(ex); }
 
             try
             {
@@ -2151,17 +2151,17 @@ namespace ConditioningControlPanel.Views.Deeper
                 var cw = VideoBrowser?.CoreWebView2;
                 if (cw != null)
                 {
-                    try { cw.NavigationStarting -= OnVideoNavStarting; } catch { }
-                    try { cw.NavigationCompleted -= OnVideoNavCompleted; } catch { }
-                    try { cw.ContainsFullScreenElementChanged -= OnVideoFullscreenChanged; } catch { }
-                    try { cw.WebMessageReceived -= OnVideoWebMessageReceived; } catch { }
+                    try { cw.NavigationStarting -= OnVideoNavStarting; } catch (Exception ex) { Diag.Swallowed(ex); }
+                    try { cw.NavigationCompleted -= OnVideoNavCompleted; } catch (Exception ex) { Diag.Swallowed(ex); }
+                    try { cw.ContainsFullScreenElementChanged -= OnVideoFullscreenChanged; } catch (Exception ex) { Diag.Swallowed(ex); }
+                    try { cw.WebMessageReceived -= OnVideoWebMessageReceived; } catch (Exception ex) { Diag.Swallowed(ex); }
                 }
             }
-            catch { }
+            catch (Exception ex) { Diag.Swallowed(ex); }
 
-            try { _videoSource?.Dispose(); } catch { }
+            try { _videoSource?.Dispose(); } catch (Exception ex) { Diag.Swallowed(ex); }
             _videoSource = null;
-            try { VideoBrowser?.Dispose(); } catch { }
+            try { VideoBrowser?.Dispose(); } catch (Exception ex) { Diag.Swallowed(ex); }
         }
 
         private static string FormatTime(double seconds)


### PR DESCRIPTION
**Logging redesign, swallow lane PR 3 of 5.** Base: `feat/log-swallow-catches-1` (#827). Merge #824 then #827 first.

## Counts

| file | empty catches before | after | to `Diag.Swallowed` | typed `// swallow:` |
|---|---|---|---|---|
| `Views/Deeper/EnhancementPlayerWindow.xaml.cs` | 60 | 0 | 60 | 0 |
| `Views/Deeper/DeeperEditorWindow.xaml.cs` | 54 | 0 | 54 | 0 |
| **total** | **114** | **0** | **114** | **0** |

The finder re-run over both files reports zero remaining empty or comment-only catch bodies.

Eight sites read `exIgnored` rather than `ex` because an enclosing scope already binds `ex` (CS0136): the fullscreen host-window teardown blocks in both files.

## Judgement calls

- **One note carried over from a comment**, with the comment dropped: `"seek unsupported on some streams"` on the NAudio `CurrentTime` setter in `DeeperEditorWindow`.
- **Nothing was narrowed.** These are dense teardown paths (VLC `LengthChanged`/`TimeChanged`/`EndReached` unhooks, `WaveOut` stop and dispose, browser-source detach, fullscreen window close, timer stops). The blanket catch there is load-bearing: teardown must finish even when one step is already dead, and each step can fail for a different reason. Logging the exception is the whole win; narrowing it would risk aborting the rest of the teardown.

## Hot call sites

None per-frame. The busiest are the fullscreen enter/exit paths (`ExitVideoFullscreen`, `ExitPreviewFullscreen`) and the zoom key handlers, all user-driven; the rest run once per window close. The helper's ten-per-site cap bounds them regardless.

## Verification

```
dotnet build ConditioningControlPanel.sln -c Debug   0 errors
dotnet test Tests/ConditioningControlPanel.Tests     5207 passed, 0 failed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GSSvqeYrpVG9H3EPtqikDC
