### PR TITLE
perf(logging): the noise diet - PR3 of the logging redesign

### DIFF
--- a/ConditioningControlPanel/AvatarTube/AvatarTubeWindow.CirceEmotes.cs
+++ b/ConditioningControlPanel/AvatarTube/AvatarTubeWindow.CirceEmotes.cs
@@ -990,7 +990,7 @@ namespace ConditioningControlPanel
                 EnsureWatchdogRunning();
                 return;
             }
-            App.Logger?.Information("[EMOTE] xfade -> {Clip} (in={In}, outOp={OutOp:F2}, talkSeq={Talk})",
+            App.Logger?.Debug("[EMOTE] xfade -> {Clip} (in={In}, outOp={OutOp:F2}, talkSeq={Talk})",
                 clip, ReferenceEquals(inImg, ImgAvatarAnimated) ? "A" : "B", outImg.Opacity, _circeTalkSeqActive);
 
             inImg.Opacity = 0;

--- a/ConditioningControlPanel/Chaos/ChaosWebViewHost.cs
+++ b/ConditioningControlPanel/Chaos/ChaosWebViewHost.cs
@@ -1337,22 +1337,22 @@ internal sealed class ChaosWebViewHost : IDisposable
     /// <summary>
     /// Map a page <c>{type:'log'}</c> envelope's <c>level</c> field onto a Serilog level.
     ///
-    /// <para>The distinction that carries the weight here is ABSENT versus DECLARED. The global
-    /// logger floor is Information and it is set unconditionally, in every build (App.OnStartup),
-    /// so a message routed to Debug is not demoted - it is DROPPED, and page logs are the only
-    /// devtools-less window a hosted surface has. Six of the ten bridges (dtrh, m2test, tunnel,
-    /// goon, intake web-shim, player) send no level field at all, so an absent field has to keep
-    /// meaning Information or those surfaces go dark. A page that declares 'debug' is opting out
-    /// on purpose: that is how the Arcademy's chatter goes quiet without silencing anybody
-    /// else.</para>
+    /// <para>ABSENT now means the same as 'debug'. It used to mean Information, for one concrete
+    /// reason: Debug was DROPPED (the logger floor is Information), and page logs are the only
+    /// devtools-less window a hosted surface has, so an absent field had to be loud or the six
+    /// bridges that predate the field went dark. That reason is gone - Debug is captured by the
+    /// in-memory flight recorder and lands in every crash/hang/bug-report dump - so an absent
+    /// field can finally mean what it always was: chatter. Nothing is lost; it just stops being
+    /// written to disk 300 times a session. A page that wants a line filed says so, with
+    /// 'warn' for a degraded surface and 'error' for a broken one.</para>
     ///
     /// <para>Case- and whitespace-insensitive. Unknown junk reads as chatter, never as loud.</para>
     /// </summary>
     internal static Serilog.Events.LogEventLevel PageLogLevel(string? level)
     {
-        // Absent or blank: the legacy contract, kept verbatim for the bridges that predate the
-        // level field entirely. Never route this to Debug: it is where six live surfaces sit.
-        if (string.IsNullOrWhiteSpace(level)) return Serilog.Events.LogEventLevel.Information;
+        // Absent or blank: chatter, same as an explicit 'debug'. Still recorded (flight recorder),
+        // just not filed.
+        if (string.IsNullOrWhiteSpace(level)) return Serilog.Events.LogEventLevel.Debug;
         return level.Trim().ToLowerInvariant() switch
         {
             "error" or "fatal" => Serilog.Events.LogEventLevel.Error,
@@ -1384,13 +1384,12 @@ internal sealed class ChaosWebViewHost : IDisposable
                     if (_opts.HostOwnedFullscreen && _isFullscreen) SetFullscreen(false);
                     break;
                 case "log":
-                    // Honour the page's own `level`. This used to write EVERY page log at
-                    // Information because that was the global logger floor and page logs were the
-                    // only devtools-less window into the page - fine for the tunnel's handful of
-                    // sites, ruinous once the Arcademy landed with 118 of them behind one funnel
-                    // and buried the real log under class chatter. Debug means DROPPED here, not
-                    // demoted (the floor is Information in every build), so the router only
-                    // silences a page that asked for it: say nothing and you are still heard.
+                    // Honour the page's own `level`, and treat silence as 'debug'. Every page log
+                    // used to be written at Information - fine for the tunnel's handful of sites,
+                    // ruinous once the Arcademy landed with 118 of them behind one funnel. Debug
+                    // is no longer a black hole (the flight recorder keeps it and dumps it with
+                    // any crash, hang or bug report), so quiet is the right default and a page
+                    // that needs a line on disk declares 'warn' or 'error'.
                     App.Logger?.Write(PageLogLevel((string?)o["level"]),
                         "{Tag}[page]: {Msg}", _opts.LogTag, (string?)o["msg"]);
                     break;

--- a/ConditioningControlPanel/MainWindow/MainWindow.Companion.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.Companion.cs
@@ -195,7 +195,7 @@ namespace ConditioningControlPanel
                     // Seed the parent-geometry cache from the main thread so the attached avatar positions
                     // correctly on first paint (CaptureParentGeom runs sync here — we ARE the parent thread).
                     _avatarTubeWindow?.CaptureParentGeom();
-                    App.Logger?.Information("Avatar Tube Window initialized (own UI thread)");
+                    App.Logger?.Debug("Avatar Tube Window initialized (own UI thread)");
                 }
                 else
                 {
@@ -215,7 +215,7 @@ namespace ConditioningControlPanel
                         _avatarTubeWindow.StartPoseAnimation();
                     }
 
-                    App.Logger?.Information("Avatar Tube Window initialized");
+                    App.Logger?.Debug("Avatar Tube Window initialized");
                 }
             }
             catch (Exception ex)

--- a/ConditioningControlPanel/MainWindow/MainWindow.Marquee.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.Marquee.cs
@@ -741,7 +741,11 @@ namespace ConditioningControlPanel
                     var result = System.Text.Json.JsonSerializer.Deserialize<MarqueeResponse>(json);
                     var newMessage = result?.message;
 
-                    if (!string.IsNullOrWhiteSpace(newMessage) && newMessage != _currentMarqueeMessage)
+                    // The animation stores an UPPERCASED copy in _currentMarqueeMessage, so the old
+                    // comparison against it never matched for a mixed-case server message: the same
+                    // marquee was re-logged and the animation restarted on every 30-minute poll.
+                    // Compare against the raw value we last accepted instead.
+                    if (!string.IsNullOrWhiteSpace(newMessage) && newMessage != App.Settings.Current.MarqueeMessage)
                     {
                         App.Logger?.Information("Marquee message updated from server: {Message}", newMessage);
                         App.Settings.Current.MarqueeMessage = newMessage;

--- a/ConditioningControlPanel/Resources/web/dtrh/boot.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/boot.js
@@ -31,11 +31,11 @@ const dom = {
 // Uncaught errors go to the host log - there are no devtools in the hosted page.
 window.addEventListener('error', (e) => {
   const src = e.filename ? ` @ ${String(e.filename).split('/').pop()}:${e.lineno}` : '';
-  bridge.log('error: ' + (e.message || 'script error') + src);
+  bridge.log('error', 'error: ' + (e.message || 'script error') + src);
 });
 window.addEventListener('unhandledrejection', (e) => {
   const r = e.reason;
-  bridge.log('promise: ' + ((r && (r.message || r.stack || r)) || 'unknown'));
+  bridge.log('error', 'promise: ' + ((r && (r.message || r.stack || r)) || 'unknown'));
 });
 
 const media = createHostMediaSource();
@@ -84,7 +84,7 @@ async function maybeStart() {
     bridge.log('engine live (game mode)');
   } catch (err) {
     bootSettled = true;
-    bridge.log('3D boot failed: ' + (err && (err.stack || err.message) || err));
+    bridge.log('error', '3D boot failed: ' + (err && (err.stack || err.message) || err));
     bridge.send({ type: 'boot-error', msg: String(err && err.message || err) });
     if (dom.loader) dom.loader.hidden = true;
     if (dom.nope) dom.nope.hidden = false;
@@ -108,7 +108,7 @@ function armBootDeadline() {
   bootDeadline = setTimeout(() => {
     if (bootSettled) return;
     bootSettled = true;
-    bridge.log('boot deadline (45s since last progress) - engine never came live'
+    bridge.log('error', 'boot deadline (45s since last progress) - engine never came live'
       + (initMsg ? '' : ' [no init]') + (haveManifest ? '' : ' [no manifest]'));
     bridge.send({ type: 'boot-error', msg: 'boot deadline: engine not live 45s after last progress' });
     if (dom.loader) dom.loader.hidden = true;

--- a/ConditioningControlPanel/Resources/web/dtrh/bridge.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/bridge.js
@@ -41,7 +41,18 @@ export function send(msg) {
   try { webview && webview.postMessage(msg); } catch (e) { /* host gone */ }
 }
 
-export function log(msg) { send({ type: 'log', msg: String(msg).slice(0, 400) }); }
+/**
+ * Serilog passthrough. `level` is optional and defaults to 'debug' (same signature as the
+ * arcademy bridge: `log(msg)` or `log(level, msg)`).
+ *
+ * The default is the QUIET one. The host files 'info' and above; 'debug' still reaches the
+ * flight recorder, so it is dumped with any crash, hang or bug report - it just stops being
+ * written to disk on every run. Say 'warn' for a degraded surface, 'error' for a broken one.
+ */
+export function log(level, msg) {
+  if (msg === undefined) { msg = level; level = 'debug'; }
+  send({ type: 'log', level: String(level), msg: String(msg).slice(0, 400) });
+}
 
 /** Announce boot completion - the host flushes its queued init/manifest on receipt. */
 export function announceReady() { send({ type: 'ready', protocol: PROTOCOL }); }

--- a/ConditioningControlPanel/Resources/web/goon/boot.js
+++ b/ConditioningControlPanel/Resources/web/goon/boot.js
@@ -100,11 +100,11 @@ if (typeof window !== 'undefined') {
   try {
     window.addEventListener('error', (e) => {
       const src = e.filename ? ' @ ' + String(e.filename).split('/').pop() + ':' + e.lineno : '';
-      bridge.log('error: ' + (e.message || 'script error') + src);
+      bridge.log('error', 'error: ' + (e.message || 'script error') + src);
     });
     window.addEventListener('unhandledrejection', (e) => {
       const r = e && e.reason;
-      bridge.log('promise: ' + ((r && (r.message || r.stack || r)) || 'unknown'));
+      bridge.log('error', 'promise: ' + ((r && (r.message || r.stack || r)) || 'unknown'));
     });
   } catch (_e) { /* never throw at import */ }
 }
@@ -213,8 +213,8 @@ function teeDebug(level, m) {
 const logger = {
   debug: (m) => { try { console.debug('[gg]', m); } catch (_e) { /* ignore */ } },
   info: (m) => { try { console.info('[gg]', m); } catch (_e) { /* ignore */ } },
-  warn: (m) => { try { console.warn('[gg]', m); } catch (_e) { /* ignore */ } bridge.log('warn: ' + m); teeDebug('warn', m); },
-  error: (m) => { try { console.error('[gg]', m); } catch (_e) { /* ignore */ } bridge.log('error: ' + m); teeDebug('error', m); },
+  warn: (m) => { try { console.warn('[gg]', m); } catch (_e) { /* ignore */ } bridge.log('warn', m); teeDebug('warn', m); },
+  error: (m) => { try { console.error('[gg]', m); } catch (_e) { /* ignore */ } bridge.log('error', m); teeDebug('error', m); },
 };
 
 /**

--- a/ConditioningControlPanel/Resources/web/goon/bridge.js
+++ b/ConditioningControlPanel/Resources/web/goon/bridge.js
@@ -95,10 +95,18 @@ export function send(msg) {
   try { if (webview) webview.postMessage(msg); } catch (_e) { /* host gone */ }
 }
 
-/** Hosted: tunnel to the C# log (400-char clamp). Standalone: console. */
-export function log(msg) {
+/**
+ * Hosted: tunnel to the C# log (400-char clamp). Standalone: console.
+ *
+ * `level` is optional and defaults to 'debug' - `log(msg)` or `log(level, msg)`, the same
+ * signature the arcademy bridge uses. The host files 'info' and above; 'debug' still reaches
+ * the flight recorder (so it lands in any crash/hang/bug-report dump) without being written to
+ * disk every run. Say 'warn' for a degraded surface, 'error' for a broken one.
+ */
+export function log(level, msg) {
+  if (msg === undefined) { msg = level; level = 'debug'; }
   const s = String(msg).slice(0, 400);
-  if (webview) send({ type: 'log', msg: s });
+  if (webview) send({ type: 'log', level: String(level), msg: s });
   else if (typeof console !== 'undefined') console.log('[goon]', s);
 }
 
@@ -362,7 +370,7 @@ export function safeServerBase(candidate) {
   if (!raw) return defaultServerBase();
   if (serverBaseAllowed(raw)) return raw;
   const fallback = defaultServerBase();
-  log('serverBase refused: "' + raw.slice(0, 120) + '" is not an allowed origin — using '
+  log('warn', 'serverBase refused: "' + raw.slice(0, 120) + '" is not an allowed origin — using '
     + (fallback || '(none)'));
   return fallback;
 }

--- a/ConditioningControlPanel/Resources/web/intake/boot.js
+++ b/ConditioningControlPanel/Resources/web/intake/boot.js
@@ -54,11 +54,11 @@ if (dom.title) dom.title.textContent = PRODUCT_NAME;
 if (typeof window !== 'undefined') {
   window.addEventListener('error', (e) => {
     const src = e.filename ? ` @ ${String(e.filename).split('/').pop()}:${e.lineno}` : '';
-    shim.log('error: ' + (e.message || 'script error') + src);
+    shim.log('error', 'error: ' + (e.message || 'script error') + src);
   });
   window.addEventListener('unhandledrejection', (e) => {
     const r = e.reason;
-    shim.log('promise: ' + ((r && (r.message || r.stack || r)) || 'unknown'));
+    shim.log('error', 'promise: ' + ((r && (r.message || r.stack || r)) || 'unknown'));
   });
   // Render-layer diagnostics (effects.js emits these instead of holding the shim).
   window.addEventListener('intake-log', (e) => {
@@ -440,7 +440,7 @@ shim.onBoot(async (config) => {
     disposePauseIfAny();   // `pause` is scoped to the try; reach it via its handle
     safeCall(subliminals, 'dispose'); subliminals = null;
     teardownCounter();
-    shim.log('boot/run failed: ' + (err && (err.stack || err.message) || err));
+    shim.log('error', 'boot/run failed: ' + (err && (err.stack || err.message) || err));
     shim.bootError(String(err && err.message || err));
     if (dom.loader) dom.loader.hidden = true;
     if (dom.stage) dom.stage.innerHTML = `<div class="intake-fatal">Something went wrong starting ${PRODUCT_NAME}.</div>`;

--- a/ConditioningControlPanel/Resources/web/intake/web-shim.js
+++ b/ConditioningControlPanel/Resources/web/intake/web-shim.js
@@ -86,9 +86,16 @@ export function send(msg) {
   } catch (_e) { /* host gone */ }
 }
 
-export function log(msg) {
+/**
+ * Host log passthrough. `level` is optional and defaults to 'debug' - `log(msg)` or
+ * `log(level, msg)`, matching the arcademy bridge. The host files 'info' and above; 'debug'
+ * still reaches the flight recorder and is dumped with any crash, hang or bug report, it just
+ * stops being written to disk on every run. Say 'warn'/'error' for anything worth a triage read.
+ */
+export function log(level, msg) {
+  if (msg === undefined) { msg = level; level = 'debug'; }
   const s = String(msg).slice(0, 400);
-  if (isHosted) send({ type: 'log', msg: s });
+  if (isHosted) send({ type: 'log', level: String(level), msg: s });
   else if (typeof console !== 'undefined') console.log('[intake]', s);
 }
 

--- a/ConditioningControlPanel/Services/AudioService.cs
+++ b/ConditioningControlPanel/Services/AudioService.cs
@@ -470,7 +470,7 @@ namespace ConditioningControlPanel.Services
                 // Check for crash recovery - restore volumes if app was killed while ducked
                 RecoverFromCrash();
 
-                App.Logger?.Information("Audio service initialized with ducking support");
+                App.Logger?.Debug("Audio service initialized with ducking support");
             }
             catch (Exception ex)
             {

--- a/ConditioningControlPanel/Services/AutonomyService.cs
+++ b/ConditioningControlPanel/Services/AutonomyService.cs
@@ -540,7 +540,7 @@ namespace ConditioningControlPanel.Services
 
             try { EnabledChanged?.Invoke(this, false); } catch { }
 
-            App.Logger?.Information("AutonomyService: Stopped");
+            App.Logger?.Debug("AutonomyService: Stopped");
         }
 
         /// <summary>
@@ -550,7 +550,7 @@ namespace ConditioningControlPanel.Services
         /// </summary>
         public void CancelActivePulses()
         {
-            App.Logger?.Information("AutonomyService: CancelActivePulses called");
+            App.Logger?.Debug("AutonomyService: CancelActivePulses called");
 
             var settings = App.Settings?.Current;
             if (settings == null) return;
@@ -808,7 +808,7 @@ namespace ConditioningControlPanel.Services
                     App.InteractionQueue?.IsBusy == true);
             };
             _heartbeatTimer.Start();
-            App.Logger?.Information("AutonomyService: Heartbeat timer started (logs every 30s)");
+            App.Logger?.Debug("AutonomyService: Heartbeat timer started (logs every 30s)");
         }
 
         /// <summary>

--- a/ConditioningControlPanel/Services/AvailableSubjectsService.cs
+++ b/ConditioningControlPanel/Services/AvailableSubjectsService.cs
@@ -95,7 +95,7 @@ namespace ConditioningControlPanel.Services
             };
             _pollTimer.Tick += async (_, _) => await RefreshAsync();
             _pollTimer.Start();
-            App.Logger?.Information("[AvailableSubjects] polling started");
+            App.Logger?.Debug("[AvailableSubjects] polling started");
         }
 
         /// <summary>

--- a/ConditioningControlPanel/Services/Awareness/AwarenessObserver.cs
+++ b/ConditioningControlPanel/Services/Awareness/AwarenessObserver.cs
@@ -358,7 +358,7 @@ namespace ConditioningControlPanel.Services.Awareness
             try { _ledger.NoteFocusEnd(_clock()); } catch { }
             _ledger.Stop();
             ResetTransientState();
-            App.Logger?.Information("AwarenessObserver: stopped");
+            App.Logger?.Debug("AwarenessObserver: stopped");
         }
 
         /// <inheritdoc />

--- a/ConditioningControlPanel/Services/BlinkTrainerService.cs
+++ b/ConditioningControlPanel/Services/BlinkTrainerService.cs
@@ -193,7 +193,7 @@ public class BlinkTrainerService : IDisposable
             IsRunning = false;
             StartedAt = null;
             Duration = null;
-            App.Logger?.Information("BlinkTrainer: stopped");
+            App.Logger?.Debug("BlinkTrainer: stopped");
         }
         try { StateChanged?.Invoke(); } catch { }
     }

--- a/ConditioningControlPanel/Services/BubbleCountService.cs
+++ b/ConditioningControlPanel/Services/BubbleCountService.cs
@@ -85,7 +85,7 @@ public class BubbleCountService : IDisposable
         CloseMessageWindows();
         CleanupTempPackFiles();
 
-        App.Logger?.Information("BubbleCountService stopped");
+        App.Logger?.Debug("BubbleCountService stopped");
     }
 
     private void ScheduleNextGame()

--- a/ConditioningControlPanel/Services/BubbleService.cs
+++ b/ConditioningControlPanel/Services/BubbleService.cs
@@ -770,7 +770,7 @@ public class BubbleService : IDisposable
         // Update Discord presence back to idle (unless another activity takes over)
         App.DiscordRpc?.SetIdleActivity();
 
-        App.Logger?.Information("BubbleService stopped");
+        App.Logger?.Debug("BubbleService stopped");
     }
 
     /// <summary>Stand up the ambient shared-host overlay + its left-click hook when BubbleSharedHost is

--- a/ConditioningControlPanel/Services/Chaos/ChaosModeService.cs
+++ b/ConditioningControlPanel/Services/Chaos/ChaosModeService.cs
@@ -849,7 +849,7 @@ public sealed class ChaosModeService
             long staticDecodes = App.Flash?.StaticDecodes ?? 0;
 
             if (App.Settings?.Current?.ChaosMemTelemetry == true)
-                App.Logger?.Information(
+                App.Logger?.Debug(
                     "[CHAOSMEM] {Phase} t={Elapsed:F0}s ws={Ws}MB priv={Priv}MB managed={Managed}MB native~={Native}MB peakNative={Peak}MB bubbles={Bubbles} gifDecodes={Gif} staticDecodes={Static} skiaFx={Skia}",
                     phase, elapsed, wsMb, privMb, managedMb, nativeMb, _peakNativeMb, bubbles,
                     gifDecodes, staticDecodes, App.Settings?.Current?.ChaosSkiaFxEnabled);
@@ -891,7 +891,7 @@ public sealed class ChaosModeService
                 if (App.Settings?.Current?.ChaosMemTelemetry == true)
                 {
                     _hitchCount++;
-                    App.Logger?.Information("[CHAOSHITCH] frame gap {Gap:F0}ms bubbles={Bubbles} (#{N} this run)",
+                    App.Logger?.Debug("[CHAOSHITCH] frame gap {Gap:F0}ms bubbles={Bubbles} (#{N} this run)",
                         gapMs, App.Bubbles?.ActiveBubbles ?? 0, _hitchCount);
                 }
             }

--- a/ConditioningControlPanel/Services/Companion/BarkService.cs
+++ b/ConditioningControlPanel/Services/Companion/BarkService.cs
@@ -1976,7 +1976,7 @@ namespace ConditioningControlPanel.Services
             }
             else
             {
-                App.Logger?.Information(
+                App.Logger?.Debug(
                     "{Tag} blocked trigger={Trigger} rule={Rule} class={Class} priority={Priority} reason={Reason}",
                     tag, trigger, rule.Id, rule.Class, rule.Priority, decision.Reason);
             }

--- a/ConditioningControlPanel/Services/Companion/CommunityPromptService.cs
+++ b/ConditioningControlPanel/Services/Companion/CommunityPromptService.cs
@@ -60,7 +60,7 @@ namespace ConditioningControlPanel.Services
             // Load cached manifest
             LoadCachedManifest();
 
-            App.Logger?.Information("CommunityPromptService initialized. Prompts folder: {Folder}", _promptsFolder);
+            App.Logger?.Debug("CommunityPromptService initialized. Prompts folder: {Folder}", _promptsFolder);
         }
 
         #region Manifest & Discovery

--- a/ConditioningControlPanel/Services/FocusGameService.cs
+++ b/ConditioningControlPanel/Services/FocusGameService.cs
@@ -131,7 +131,7 @@ namespace ConditioningControlPanel.Services
         {
             if (_disposed) return;
             _disposed = true;
-            App.Logger?.Information("FocusGameService: disposed");
+            App.Logger?.Debug("FocusGameService: disposed");
         }
     }
 }

--- a/ConditioningControlPanel/Services/GamificationBridge.cs
+++ b/ConditioningControlPanel/Services/GamificationBridge.cs
@@ -152,7 +152,7 @@ public class GamificationBridge : IDisposable
                 if (ach != null) ach.SuppressPopups = wasSuppressed;
             }
 
-            App.Logger?.Information("GamificationBridge started — achievement subscriptions wired");
+            App.Logger?.Debug("GamificationBridge started — achievement subscriptions wired");
         }
         catch (Exception ex)
         {

--- a/ConditioningControlPanel/Services/Input/GlobalHotkeyService.cs
+++ b/ConditioningControlPanel/Services/Input/GlobalHotkeyService.cs
@@ -4,6 +4,7 @@ using System.Runtime.InteropServices;
 using System.Windows;
 using System.Windows.Input;
 using System.Windows.Interop;
+using System.Windows.Threading;
 
 namespace ConditioningControlPanel.Services
 {
@@ -67,6 +68,15 @@ namespace ConditioningControlPanel.Services
         // hook stays installed as long as this has any entries.
         private static readonly Dictionary<int, Action> _callbacks = new();
 
+        // id -> "Ctrl+Alt+E", for the single summary line. Registration is spread across four
+        // callers that each fire whenever their setting changes, so each one used to file its own
+        // Information line and the log carried four near-identical lines per launch saying the
+        // hotkeys were exactly where they were last launch. Now the per-hotkey detail is Debug and
+        // one coalesced line names the whole set - and it only reappears when the set CHANGES.
+        private static readonly SortedDictionary<int, string> _armed = new();
+        private static string _lastLoggedSet = "";
+        private static DispatcherTimer? _summaryTimer;
+
         /// <summary>
         /// Registers the given combo as a system-wide hotkey under <paramref name="id"/>.
         /// Replaces any prior registration for the same id. Returns true on success;
@@ -115,7 +125,9 @@ namespace ConditioningControlPanel.Services
                 }
 
                 _callbacks[id] = onPressed;
-                App.Logger?.Information("GlobalHotkeyService: registered {Mods}+{Key} as global hotkey (id=0x{Id:X})", modifiers, key, id);
+                _armed[id] = $"{modifiers}+{key}";
+                App.Logger?.Debug("GlobalHotkeyService: registered {Mods}+{Key} as global hotkey (id=0x{Id:X})", modifiers, key, id);
+                ScheduleSummary();
                 return true;
             }
             catch (Exception ex)
@@ -145,6 +157,8 @@ namespace ConditioningControlPanel.Services
                 App.Logger?.Debug("GlobalHotkeyService: cleanup threw (id=0x{Id:X}): {Error}", id, ex.Message);
             }
             _callbacks.Remove(id);
+            _armed.Remove(id);
+            ScheduleSummary();
             if (_callbacks.Count == 0) TeardownHook();
         }
 
@@ -167,7 +181,50 @@ namespace ConditioningControlPanel.Services
                 App.Logger?.Debug("GlobalHotkeyService: cleanup-all threw: {Error}", ex.Message);
             }
             _callbacks.Clear();
+            _armed.Clear();
             TeardownHook();
+        }
+
+        /// <summary>
+        /// Coalesces a burst of Register/Unregister calls into ONE line. Registration happens once
+        /// per hotkey at startup and again whenever the user edits a combo, so a short debounce
+        /// turns "four lines, one per slot" into "one line, the whole set". Never throws; if there
+        /// is no dispatcher (unit tests, teardown) the summary is simply skipped - it is a log
+        /// line, not behaviour.
+        /// </summary>
+        private static void ScheduleSummary()
+        {
+            try
+            {
+                var dispatcher = Application.Current?.Dispatcher;
+                if (dispatcher == null || dispatcher.HasShutdownStarted) return;
+                if (_summaryTimer == null)
+                {
+                    _summaryTimer = new DispatcherTimer(DispatcherPriority.Background, dispatcher)
+                    {
+                        Interval = TimeSpan.FromMilliseconds(750),
+                    };
+                    _summaryTimer.Tick += (_, _) => { _summaryTimer?.Stop(); LogSummary(); };
+                }
+                _summaryTimer.Stop();
+                _summaryTimer.Start();
+            }
+            catch { /* swallow: a diagnostic line must never be able to break hotkey arming */ }
+        }
+
+        private static void LogSummary()
+        {
+            try
+            {
+                // Only when the SET changed: re-applying the same combos (which several settings
+                // handlers do on any settings save) must not re-file the line.
+                var set = _armed.Count == 0 ? "(none)" : string.Join(", ", _armed.Values);
+                if (set == _lastLoggedSet) return;
+                _lastLoggedSet = set;
+                App.Logger?.Information("GlobalHotkeyService: {Count} global hotkey(s) armed: {Hotkeys}",
+                    _armed.Count, set);
+            }
+            catch { /* swallow: diagnostics only */ }
         }
 
         private static void TeardownHook()

--- a/ConditioningControlPanel/Services/JustDrop/JustDropService.cs
+++ b/ConditioningControlPanel/Services/JustDrop/JustDropService.cs
@@ -238,7 +238,7 @@ namespace ConditioningControlPanel.Services.JustDrop
                 switch (type)
                 {
                     case "ready":
-                        App.Logger?.Information("JustDrop bridge: page ready");
+                        App.Logger?.Debug("JustDrop bridge: page ready");
                         break;
 
                     case "session-start":

--- a/ConditioningControlPanel/Services/KeywordTriggerService.cs
+++ b/ConditioningControlPanel/Services/KeywordTriggerService.cs
@@ -210,7 +210,7 @@ namespace ConditioningControlPanel.Services
         public KeywordTriggerService()
         {
             _audioPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Resources", "sub_audio");
-            App.Logger?.Information("KeywordTriggerService initialized");
+            App.Logger?.Debug("KeywordTriggerService initialized");
         }
 
         #endregion
@@ -231,7 +231,7 @@ namespace ConditioningControlPanel.Services
 
             _isActive = true;
             _buffer.Clear();
-            App.Logger?.Information("KeywordTriggerService started");
+            App.Logger?.Debug("KeywordTriggerService started");
         }
 
         /// <summary>
@@ -243,7 +243,7 @@ namespace ConditioningControlPanel.Services
             _isActive = false;
             _buffer.Clear();
             StopTriggerAudio();
-            App.Logger?.Information("KeywordTriggerService stopped");
+            App.Logger?.Debug("KeywordTriggerService stopped");
         }
 
         /// <summary>

--- a/ConditioningControlPanel/Services/LockCard/BrainDrainService.cs
+++ b/ConditioningControlPanel/Services/LockCard/BrainDrainService.cs
@@ -21,6 +21,8 @@ namespace ConditioningControlPanel.Services
         private double _intensity = 50; // 50% default intensity
         
         private string[]? _audioFiles;
+        // "no clips installed" is the shipped default; say it once a session, not once a scan.
+        private static bool _loggedNoAudio;
         private WaveOutEvent? _waveOut;
         private AudioFileReader? _audioReader;
         /// <summary>Bumped by every trigger and by StopCurrentAudio. A build that finishes after a
@@ -160,7 +162,7 @@ namespace ConditioningControlPanel.Services
                 var assetsFolder = EnsureAudioFolder();
                 var legacyFolder = LegacyAudioFolderPath;
 
-                App.Logger?.Information("BrainDrain: Looking for audio files in {Path} (+ legacy {Legacy})",
+                App.Logger?.Debug("BrainDrain: Looking for audio files in {Path} (+ legacy {Legacy})",
                     assetsFolder, legacyFolder);
 
                 // Assets first so its entries claim their file names; the legacy folder then only
@@ -182,8 +184,15 @@ namespace ConditioningControlPanel.Services
 
                 if (_audioFiles.Length == 0)
                 {
-                    App.Logger?.Warning("BrainDrain: No .mp3/.wav/.ogg files found in {Path} or {Legacy}",
-                        assetsFolder, legacyFolder);
+                    // Shipping with no BrainDrain clips is the DEFAULT state, not a fault: this fired at
+                    // Warning on every launch and was the single biggest source of WRN lines in the log.
+                    // Information, and only the first time per session.
+                    if (!_loggedNoAudio)
+                    {
+                        _loggedNoAudio = true;
+                        App.Logger?.Information("BrainDrain: no .mp3/.wav/.ogg files in {Path} or {Legacy} - the feature stays idle",
+                            assetsFolder, legacyFolder);
+                    }
                 }
                 else
                 {
@@ -260,7 +269,7 @@ namespace ConditioningControlPanel.Services
             // Update Discord presence back to idle
             App.DiscordRpc?.SetIdleActivity();
 
-            App.Logger?.Information("BrainDrain stopped");
+            App.Logger?.Debug("BrainDrain stopped");
         }
         
         public void UpdateSettings()

--- a/ConditioningControlPanel/Services/LockCard/LockCardService.cs
+++ b/ConditioningControlPanel/Services/LockCard/LockCardService.cs
@@ -134,7 +134,7 @@ namespace ConditioningControlPanel.Services
             _timer?.Stop();
             _timer = null;
             
-            App.Logger?.Information("LockCardService stopped");
+            App.Logger?.Debug("LockCardService stopped");
         }
 
         private void Timer_Tick(object? sender, EventArgs e)

--- a/ConditioningControlPanel/Services/LockCard/MindWipeService.cs
+++ b/ConditioningControlPanel/Services/LockCard/MindWipeService.cs
@@ -26,6 +26,8 @@ namespace ConditioningControlPanel.Services
         private double _volume = 0.5; // 50% default volume
         
         private string[]? _audioFiles;
+        // "no clips installed" is the shipped default; say it once a session, not once a scan.
+        private static bool _loggedNoAudio;
         private WaveOutEvent? _waveOut;
         private AudioFileReader? _audioReader;
         /// <summary>Bumped by every one-shot trigger and by StopCurrentAudio. A build that finishes
@@ -172,7 +174,7 @@ namespace ConditioningControlPanel.Services
 
                 var audioFolderPath = AudioFolderPath;
 
-                App.Logger?.Information("MindWipe: Looking for audio files in {Path} (and legacy {Legacy})",
+                App.Logger?.Debug("MindWipe: Looking for audio files in {Path} (and legacy {Legacy})",
                     audioFolderPath, LegacyAudioFolderPath);
                 
                 // Create the advertised folder so it exists to be found; the legacy folder is
@@ -191,7 +193,13 @@ namespace ConditioningControlPanel.Services
                 
                 if (_audioFiles.Length == 0)
                 {
-                    App.Logger?.Warning("MindWipe: No .mp3/.wav/.ogg files found in {Path}", audioFolderPath);
+                    // Normal state for anyone who never dropped clips in, so it is not a warning and
+                    // it is not worth repeating: Information, once per session.
+                    if (!_loggedNoAudio)
+                    {
+                        _loggedNoAudio = true;
+                        App.Logger?.Information("MindWipe: no .mp3/.wav/.ogg files in {Path} - the feature stays idle", audioFolderPath);
+                    }
                 }
                 else
                 {
@@ -286,7 +294,7 @@ namespace ConditioningControlPanel.Services
             // Update Discord presence back to idle
             App.DiscordRpc?.SetIdleActivity();
 
-            App.Logger?.Information("MindWipe: Stopped");
+            App.Logger?.Debug("MindWipe: Stopped");
         }
         
         public void UpdateSettings(double frequencyPerHour, double volume)
@@ -711,7 +719,7 @@ namespace ConditioningControlPanel.Services
             DisposePlayerA();
             DisposePlayerB();
 
-            App.Logger?.Information("MindWipe: Loop stopped");
+            App.Logger?.Debug("MindWipe: Loop stopped");
         }
         
         private void Timer_Tick(object? sender, EventArgs e)

--- a/ConditioningControlPanel/Services/ModService.cs
+++ b/ConditioningControlPanel/Services/ModService.cs
@@ -31,6 +31,11 @@ namespace ConditioningControlPanel.Services
     {
         private static readonly ILogger? _log = App.Logger;
 
+        /// <summary>Built-ins that adopted a bundled asset package, for the one startup summary line.
+        /// Interlocked: a downloaded pack finishes extracting on a background thread, so this is
+        /// still being incremented after the constructor has already logged its summary.</summary>
+        private int _builtInsRegistered;
+
         private ModPackage _activeMod;
         private readonly ModPackage _baseMod; // Always CCP Default — neutral fallback for missing fields
         private readonly Dictionary<string, ModPackage> _installedMods = new(StringComparer.OrdinalIgnoreCase);
@@ -113,6 +118,11 @@ namespace ConditioningControlPanel.Services
 
             // Load user-installed mods from disk
             LoadInstalledMods();
+
+            // One line for the whole roll-call. Each built-in used to file its own Information
+            // line naming an absolute extract path, so a stock install spent six identical lines
+            // per launch saying nothing had changed. The per-mod detail is still at Debug.
+            _log?.Information("Registered {Count} built-in mod(s) with bundled assets", _builtInsRegistered);
 
             // Default to base mod until Initialize is called
             _activeMod = _baseMod;
@@ -2125,7 +2135,8 @@ namespace ConditioningControlPanel.Services
                     }
                     // Keep the in-code manifest authoritative; only adopt the assets.
                     AdoptBuiltInPackage(builtInId, new ModPackage(codeManifest, extractDir, isBuiltIn: true));
-                    _log?.Information("Registered resource mod {BuiltInId} with assets at {Path}", builtInId, extractDir);
+                    System.Threading.Interlocked.Increment(ref _builtInsRegistered);
+                    _log?.Debug("Registered resource mod {BuiltInId} with assets at {Path}", builtInId, extractDir);
                     return true;
                 }
 
@@ -2157,7 +2168,8 @@ namespace ConditioningControlPanel.Services
                 manifest.Id = builtInId;
 
                 AdoptBuiltInPackage(builtInId, new ModPackage(manifest, extractDir, isBuiltIn: true));
-                _log?.Information("Registered bundled built-in mod {BuiltInId} from {Path}", builtInId, extractDir);
+                System.Threading.Interlocked.Increment(ref _builtInsRegistered);
+                _log?.Debug("Registered bundled built-in mod {BuiltInId} from {Path}", builtInId, extractDir);
                 return true;
             }
             catch (Exception ex)

--- a/ConditioningControlPanel/Services/Notifications/OverlayService.cs
+++ b/ConditioningControlPanel/Services/Notifications/OverlayService.cs
@@ -530,7 +530,7 @@ public class OverlayService : IDisposable
             App.Logger?.Error(ex, "Error during OverlayService Stop");
         }
 
-        App.Logger?.Information("OverlayService stopped");
+        App.Logger?.Debug("OverlayService stopped");
     }
 
     public void RefreshOverlays()

--- a/ConditioningControlPanel/Services/Progression/LeaderboardService.cs
+++ b/ConditioningControlPanel/Services/Progression/LeaderboardService.cs
@@ -69,7 +69,7 @@ public class LeaderboardService : IDisposable
         _refreshTimer.Tick += async (s, e) => await RefreshAsync();
         _refreshTimer.Start();
 
-        App.Logger?.Information("LeaderboardService initialized with 30-minute auto-refresh");
+        App.Logger?.Debug("LeaderboardService initialized with 30-minute auto-refresh");
     }
 
     /// <summary>
@@ -134,7 +134,7 @@ public class LeaderboardService : IDisposable
                 LastRefreshTime = DateTime.Now;
                 LastRefreshError = null;
 
-                App.Logger?.Information("Leaderboard refreshed: {Count} entries, {Total} total users, {Online} online, sorted by {SortBy}",
+                App.Logger?.Debug("Leaderboard refreshed: {Count} entries, {Total} total users, {Online} online, sorted by {SortBy}",
                     Entries.Count, TotalUsers, OnlineUsers, sortBy);
 
                 LeaderboardUpdated?.Invoke(this, EventArgs.Empty);

--- a/ConditioningControlPanel/Services/Progression/SkillTreeService.cs
+++ b/ConditioningControlPanel/Services/Progression/SkillTreeService.cs
@@ -56,7 +56,7 @@ public class SkillTreeService : IDisposable
         _pinkRushCheckTimer = new DispatcherTimer { Interval = TimeSpan.FromMinutes(10) };
         _pinkRushCheckTimer.Tick += PinkRushCheckTimer_Tick;
 
-        App.Logger?.Information("SkillTreeService initialized");
+        App.Logger?.Debug("SkillTreeService initialized");
     }
 
     #region Skill Management

--- a/ConditioningControlPanel/Services/Quiz/PopQuizService.cs
+++ b/ConditioningControlPanel/Services/Quiz/PopQuizService.cs
@@ -138,7 +138,7 @@ namespace ConditioningControlPanel.Services
             // Close any open quiz windows
             CloseAllQuizWindows();
 
-            App.Logger?.Information("PopQuizService stopped");
+            App.Logger?.Debug("PopQuizService stopped");
         }
 
         private static void CloseAllQuizWindows()

--- a/ConditioningControlPanel/Services/RemoteControlService.cs
+++ b/ConditioningControlPanel/Services/RemoteControlService.cs
@@ -311,7 +311,7 @@ namespace ConditioningControlPanel.Services
             }
 
             CleanupSession();
-            App.Logger?.Information("[RemoteControl] Session stopped");
+            App.Logger?.Debug("[RemoteControl] Session stopped");
         }
 
         private void CleanupSession()

--- a/ConditioningControlPanel/Services/RoadmapService.cs
+++ b/ConditioningControlPanel/Services/RoadmapService.cs
@@ -375,7 +375,7 @@ public class RoadmapService : IDisposable
             Save();
         }
 
-        App.Logger?.Information("RoadmapService disposed");
+        App.Logger?.Debug("RoadmapService disposed");
     }
 
     #endregion

--- a/ConditioningControlPanel/Services/ScreenOcrService.cs
+++ b/ConditioningControlPanel/Services/ScreenOcrService.cs
@@ -69,7 +69,7 @@ namespace ConditioningControlPanel.Services
                 _timer?.Dispose();
                 _timer = null;
                 _isRunning = false;
-                App.Logger?.Information("ScreenOcrService stopped");
+                App.Logger?.Debug("ScreenOcrService stopped");
             }
         }
 

--- a/ConditioningControlPanel/Services/Settings/ProfileSyncService.cs
+++ b/ConditioningControlPanel/Services/Settings/ProfileSyncService.cs
@@ -2344,7 +2344,16 @@ namespace ConditioningControlPanel.Services
             }
             catch (Exception ex)
             {
-                App.Logger?.Error(ex, "Failed to sync profile to cloud");
+                // The overwhelmingly common instance of this is the exit-time sync: the app is
+                // tearing down while the request is in flight, so the HttpClient is disposed and
+                // the task cancels. That is expected shutdown behaviour, not an error, and its
+                // 16-line TaskCanceledException stack was filed at ERR on every single quit.
+                // Anything else is a real failure and keeps the whole exception.
+                if (IsExpectedCancellation(ex))
+                    App.Logger?.Warning("Profile sync did not finish: {ExType}: {Error}",
+                        ex.GetType().Name, ex.Message);
+                else
+                    App.Logger?.Error(ex, "Failed to sync profile to cloud");
                 LastSyncError = ex.Message;
                 // Mobile streak parity: the cloud is unreachable, so a deferred streak break
                 // gets the pre-parity behavior now instead of waiting out the full timeout.
@@ -3894,6 +3903,22 @@ namespace ConditioningControlPanel.Services
         /// <summary>
         /// Adds the X-Auth-Token header to a V2 API request if an auth token is available.
         /// </summary>
+        /// <summary>
+        /// True when an exception out of a sync/backup call is the app shutting down mid-request
+        /// (or the request timing out) rather than a genuine failure. Those are expected, so they
+        /// are logged as one compact Warning line with no stack: an ERR plus a 16-line
+        /// TaskCanceledException stack on every clean exit is noise that hides real errors.
+        /// </summary>
+        private static bool IsExpectedCancellation(Exception ex)
+        {
+            // TaskCanceledException derives from OperationCanceledException, so one check covers
+            // both. HttpClient wraps a disposed-during-shutdown handler either way round depending
+            // on where the teardown caught it, so look through one level of wrapping too.
+            if (ex is OperationCanceledException || ex is ObjectDisposedException) return true;
+            var inner = ex.InnerException;
+            return inner is OperationCanceledException || inner is ObjectDisposedException;
+        }
+
         private static void AddAuthHeader(HttpRequestMessage request)
         {
             var token = App.Settings?.Current?.AuthToken;
@@ -4275,7 +4300,13 @@ namespace ConditioningControlPanel.Services
             }
             catch (Exception ex)
             {
-                App.Logger?.Warning(ex, "Settings backup failed");
+                // Same shape as the profile sync above: a backup interrupted by shutdown or a
+                // server cooldown is expected, and does not need a stack on disk.
+                if (IsExpectedCancellation(ex))
+                    App.Logger?.Warning("Settings backup did not finish: {ExType}: {Error}",
+                        ex.GetType().Name, ex.Message);
+                else
+                    App.Logger?.Warning(ex, "Settings backup failed");
                 return false;
             }
         }

--- a/ConditioningControlPanel/Services/Subliminal/SubliminalService.cs
+++ b/ConditioningControlPanel/Services/Subliminal/SubliminalService.cs
@@ -157,7 +157,7 @@ namespace ConditioningControlPanel.Services
 
             StopAudio();
 
-            App.Logger?.Information("SubliminalService stopped");
+            App.Logger?.Debug("SubliminalService stopped");
         }
 
         /// <summary>

--- a/ConditioningControlPanel/Services/UI/WindowAwarenessService.cs
+++ b/ConditioningControlPanel/Services/UI/WindowAwarenessService.cs
@@ -418,7 +418,7 @@ namespace ConditioningControlPanel.Services
 
             try { App.Awareness?.Stop(); } catch (Exception ex) { App.Logger?.Warning(ex, "WindowAwareness: v2 observer failed to stop"); }
 
-            App.Logger?.Information("WindowAwareness: Stopped monitoring");
+            App.Logger?.Debug("WindowAwareness: Stopped monitoring");
         }
 
         /// <summary>

--- a/ConditioningControlPanel/Services/Video/DualMonitorVideoService.cs
+++ b/ConditioningControlPanel/Services/Video/DualMonitorVideoService.cs
@@ -253,7 +253,7 @@ namespace ConditioningControlPanel.Services
                 });
             }
 
-            App.Logger?.Information("DualMonitorVideo: Playback stopped");
+            App.Logger?.Debug("DualMonitorVideo: Playback stopped");
         }
 
         /// <summary>
@@ -681,7 +681,7 @@ namespace ConditioningControlPanel.Services
             }
             _libVLC = null;
 
-            App.Logger?.Information("DualMonitorVideoService disposed");
+            App.Logger?.Debug("DualMonitorVideoService disposed");
         }
     }
 }

--- a/ConditioningControlPanel/Services/Video/VideoDiag.cs
+++ b/ConditioningControlPanel/Services/Video/VideoDiag.cs
@@ -47,6 +47,7 @@ namespace ConditioningControlPanel.Services
     public static class VideoDiag
     {
         private const int MaxQueued = 4000;          // hard cap; drop rather than balloon during a freeze
+        private static readonly long AliveMarkerTicks = TimeSpan.TicksPerMinute * 10; // "dispatcher alive" cadence
         private const long MaxFileBytes = 1_000_000; // ~1MB, then roll to .1 (two files kept, ever)
 
         private static readonly ConcurrentQueue<string> _queue = new();
@@ -69,6 +70,12 @@ namespace ConditioningControlPanel.Services
         // starved by higher-priority work" instead of the generic "dispatcher unresponsive", and
         // the two ages read together name the whole class from the first log.
         private static long _lastUiInputBeatTicks;
+
+        // Per-line stamps are HH:mm:ss.fff only (deliberately - the column has to stay narrow), so
+        // the file carried no date at all: a trace tailed a day later could not be placed in time.
+        // The date is written ONCE, as a header, when a file is opened empty (fresh install, after
+        // a roll) and again if the clock crosses midnight mid-session.
+        private static string _headerDate = "";
 
         /// <summary>Milliseconds since the UI thread last ran a posted callback (0 if never started).</summary>
         public static long UiStallMs
@@ -263,6 +270,12 @@ namespace ConditioningControlPanel.Services
                     using var fs = new FileStream(_path, FileMode.Append, FileAccess.Write,
                         FileShare.ReadWrite | FileShare.Delete, 4096, FileOptions.WriteThrough);
                     using var sw = new StreamWriter(fs, Encoding.UTF8);
+                    var today = DateTime.Now.ToString("yyyy-MM-dd");
+                    if (fs.Length == 0 || _headerDate != today)
+                    {
+                        _headerDate = today;
+                        sw.WriteLine($"==== {today} (local, UTC{DateTime.Now:zzz}) ====");
+                    }
                     while (_queue.TryDequeue(out var line))
                         sw.WriteLine(line);
                     int dropped = Interlocked.Exchange(ref _dropped, 0);
@@ -294,7 +307,7 @@ namespace ConditioningControlPanel.Services
 
         /// <summary>
         /// Posts a stamp to the dispatcher every second and reports the stall timeline. Escalating
-        /// thresholds keep the file quiet during normal use (one line per minute) while giving a
+        /// thresholds keep the file quiet during normal use (one line per 10 minutes) while giving a
         /// second-resolution picture of a freeze: when it began, how deep it got, whether it ever
         /// came back.
         ///
@@ -373,7 +386,11 @@ namespace ConditioningControlPanel.Services
                         }
                         // Low-rate "still alive" marker so a trace that simply ends tells us the
                         // process died, while a trace whose markers stop tells us the UI thread did.
-                        if (DateTime.UtcNow.Ticks - aliveMarkerTicks > TimeSpan.TicksPerMinute)
+                        // Every 10 minutes, not every minute: at one a minute these were 42% of the
+                        // whole file and could push a real freeze out of the 1 MB window before
+                        // anyone got to read it. The stall ladder still reports at 3s resolution,
+                        // so nothing about detecting a hang depends on this cadence.
+                        if (DateTime.UtcNow.Ticks - aliveMarkerTicks > AliveMarkerTicks)
                         {
                             aliveMarkerTicks = DateTime.UtcNow.Ticks;
                             Log("UI", "dispatcher alive");

--- a/ConditioningControlPanel/Services/Video/VideoService.cs
+++ b/ConditioningControlPanel/Services/Video/VideoService.cs
@@ -838,7 +838,7 @@ namespace ConditioningControlPanel.Services
                         if (outputs != null)
                         {
                             var names = string.Join(", ", outputs.Select(o => $"{o.Name} ({o.Description})"));
-                            App.Logger?.Information("LibVLC available aout modules: {Outputs}", names);
+                            App.Logger?.Debug("LibVLC available aout modules: {Outputs}", names);
                         }
                     }
                     catch (Exception aoutEx)
@@ -1638,7 +1638,7 @@ namespace ConditioningControlPanel.Services
             // CompleteIfCurrent never clears a claim that isn't ours.
             App.InteractionQueue?.CompleteIfCurrent(InteractionQueueService.InteractionType.Video);
 
-            App.Logger?.Information("VideoService stopped");
+            App.Logger?.Debug("VideoService stopped");
         }
 
         private void OnSessionSwitch(object? sender, Microsoft.Win32.SessionSwitchEventArgs e)
@@ -7085,7 +7085,15 @@ namespace ConditioningControlPanel.Services
             // "the panic key did nothing". Every phase is timestamped so the next report tells us
             // which phase the teardown died in instead of just going quiet.
             var closeSw = System.Diagnostics.Stopwatch.StartNew();
-            VideoDiag.Log("CLOSE", $"CloseAll begin (synchronous={synchronous}, windows={_windows.Count})");
+            // A teardown with no windows open is the common case (every panic press, every engine
+            // stop, every session end funnels here) and it produced the same four CLOSE lines as a
+            // real teardown - four lines of "nothing happened" per event, in the one trace whose
+            // whole value is a short readable timeline. Trace the phases only when there is
+            // actually a window to take down; the wedge/straggler/skip lines below stay
+            // unconditional because those only fire when something IS wrong.
+            bool traceClose = _windows.Count > 0;
+            if (traceClose)
+                VideoDiag.Log("CLOSE", $"CloseAll begin (synchronous={synchronous}, windows={_windows.Count})");
             lock (_cleanupLock)
             {
                 if (_isCleaningUp)
@@ -7125,7 +7133,12 @@ namespace ConditioningControlPanel.Services
 
                 lock (_targets)
                 {
-                    App.Logger?.Information("ATTENTION: CloseAll() called - destroying {Count} targets", _targets.Count);
+                    // Destroying nothing is the normal case and was logged at Information on every
+                    // single teardown; only a real destroy is worth a line on disk.
+                    if (_targets.Count > 0)
+                        App.Logger?.Information("ATTENTION: CloseAll() destroying {Count} target(s)", _targets.Count);
+                    else
+                        App.Logger?.Debug("ATTENTION: CloseAll() called - no targets to destroy");
                     foreach (var t in _targets.ToList()) t.Destroy();
                     _targets.Clear();
                 }
@@ -7251,7 +7264,8 @@ namespace ConditioningControlPanel.Services
                 // Now detach MediaPlayers from VideoViews (safe since players are stopped and we waited).
                 // Detaching an HwndHost surface from a player that is still presenting is the
                 // historical multi-monitor freeze; if the trace stops here, that is what happened.
-                VideoDiag.Log("CLOSE", $"detaching VideoViews at +{closeSw.ElapsedMilliseconds}ms");
+                if (traceClose)
+                    VideoDiag.Log("CLOSE", $"detaching VideoViews at +{closeSw.ElapsedMilliseconds}ms");
                 var windowsCopy = _windows.ToList();
                 foreach (var w in windowsCopy)
                 {
@@ -7284,7 +7298,8 @@ namespace ConditioningControlPanel.Services
                 }
 
                 // Close video windows AFTER media players are stopped and detached
-                VideoDiag.Log("CLOSE", $"closing {_windows.Count} video window(s) at +{closeSw.ElapsedMilliseconds}ms");
+                if (traceClose)
+                    VideoDiag.Log("CLOSE", $"closing {_windows.Count} video window(s) at +{closeSw.ElapsedMilliseconds}ms");
                 foreach (var w in _windows.ToList())
                 {
                     try
@@ -7448,7 +7463,8 @@ namespace ConditioningControlPanel.Services
 
                 // Total UI-thread block for this teardown. Anything past ~1s here is the app being
                 // unresponsive to the user (and to the low-level keyboard hook) — #616-#623.
-                VideoDiag.Log("CLOSE", $"CloseAll end after {closeSw.ElapsedMilliseconds}ms of UI-thread time");
+                if (traceClose)
+                    VideoDiag.Log("CLOSE", $"CloseAll end after {closeSw.ElapsedMilliseconds}ms of UI-thread time");
             }
         }
 

--- a/ConditioningControlPanel/Windows/EmiDesk/EmiRingWindow.xaml.cs
+++ b/ConditioningControlPanel/Windows/EmiDesk/EmiRingWindow.xaml.cs
@@ -393,7 +393,7 @@ public partial class EmiRingWindow : Window
             _closeAnnounced = false;
 
             EmiSfx.RingOpen();
-            Log.Information("[EmiDesk] ring open with {Count} cards, {Native}", _slots.Count, NativeStyle());
+            Log.Debug("[EmiDesk] ring open with {Count} cards, {Native}", _slots.Count, NativeStyle());
         }
         catch (Exception ex)
         {

--- a/Tests/ConditioningControlPanel.Tests/ArcademyDoorOpenTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/ArcademyDoorOpenTests.cs
@@ -117,20 +117,26 @@ public class ArcademyDoorOpenTests
         => Assert.Equal(LogEventLevel.Error, ChaosWebViewHost.PageLogLevel(level));
 
     [Theory]
-    [InlineData(null)]            // THE ONE THAT MATTERS: a page that sends no level field at all
-    [InlineData("")]
-    [InlineData("   ")]
     [InlineData("info")]
     [InlineData("INFO")]
     [InlineData("information")]
-    public void AnAbsentOrPlainLevelStaysAudible(string? level)
+    public void ADeclaredInfoLevelStaysAudible(string level)
+        => Assert.Equal(LogEventLevel.Information, ChaosWebViewHost.PageLogLevel(level));
+
+    [Theory]
+    [InlineData(null)]            // a page that sends no level field at all
+    [InlineData("")]
+    [InlineData("   ")]
+    public void AnAbsentLevelIsChatter(string? level)
     {
-        // The app's logger floor is Information in EVERY build (App.OnStartup, unconditional), so
-        // Debug here is not "quieter", it is GONE. Six live bridges - dtrh, m2test, tunnel, goon,
-        // the intake web-shim and player - send no level at all, and emergency-exit's bridge clamps
-        // its own to info|warn on the panic surface. If this theory ever goes red, those surfaces
-        // have just lost their only devtools-less channel and nobody will notice until triage.
-        Assert.Equal(LogEventLevel.Information, ChaosWebViewHost.PageLogLevel(level));
+        // This used to be Information for one concrete reason: Debug was DROPPED (the logger floor
+        // is Information), and page logs are the only devtools-less channel a hosted surface has,
+        // so an absent field had to be loud or the levelless bridges went dark. Debug is now kept
+        // by the in-memory flight recorder and dumped with any crash, hang or bug report, so an
+        // absent level can finally mean what it always was - chatter. Nothing is lost; it just
+        // stops being written to disk on every run. A page that wants a line filed says 'warn'
+        // or 'error', and the three loudest bridges now do (see BridgesSendALevel below).
+        Assert.Equal(LogEventLevel.Debug, ChaosWebViewHost.PageLogLevel(level));
     }
 
     [Theory]
@@ -151,6 +157,31 @@ public class ArcademyDoorOpenTests
             "the {type:'log'} case no longer routes through PageLogLevel");
         Assert.False(Mentions(src, "App.Logger?.Information(\"{Tag}[page]: {Msg}\""),
             "the flat Information page log is back");
+    }
+
+    [Theory]
+    [InlineData("dtrh")]
+    [InlineData("goon")]
+    public void TheLoudBridgesSendALevelField(string surface)
+    {
+        // With an absent level now meaning Debug, a bridge that never sends one can no longer put
+        // anything on disk. These three were the levelless bridges with real error paths, so each
+        // grew the arcademy's `log(level, msg)` signature and tags its onerror/catch handlers.
+        var bridge = File.ReadAllText(Path.Combine(AppDir(), "Resources", "web", surface, "bridge.js"));
+        Assert.True(Mentions(bridge, "type: 'log', level:"),
+            surface + " bridge.js no longer sends a level with its log frames");
+        Assert.True(Mentions(bridge, "level = 'debug';"),
+            surface + " bridge.js log() no longer defaults to the quiet level");
+    }
+
+    [Fact]
+    public void TheIntakeShimSendsALevelField()
+    {
+        var shim = File.ReadAllText(Path.Combine(AppDir(), "Resources", "web", "intake", "web-shim.js"));
+        Assert.True(Mentions(shim, "type: 'log', level:"),
+            "intake web-shim.js no longer sends a level with its log frames");
+        Assert.True(Mentions(shim, "level = 'debug';"),
+            "intake web-shim.js log() no longer defaults to the quiet level");
     }
 
     [Fact]


### PR DESCRIPTION
PR3 of the logging redesign. No new infrastructure, no new packages, no behaviour change
outside the log file (one real bug fixed on the way, see Marquee below).

The premise: a demotion to `Debug` is no longer a deletion. PR2 adds an always-on in-memory
flight recorder that keeps Debug and dumps it with every crash, hang and bug report, so
"Debug" here means "kept, just not written to disk on every run". Several sites in the tree
carry comments saying the opposite (Debug is DROPPED, so this has to be Information) - those
comments are updated where the reasoning changed, not just the level.

## What changed

| Site | Was | Now | Why |
|---|---|---|---|
| `AvatarTube/AvatarTubeWindow.CirceEmotes.cs:993` `[EMOTE] xfade -> ...` | INF | DBG | Every ~5s while the avatar is up. 22% of all bytes in the measured week. |
| `Services/Companion/BarkService.cs:1979` `[BARK] blocked ...` | INF | DBG | 12% of bytes. `[BARK] FIRE` deliberately untouched (agent C owns its line text). |
| `Services/Chaos/ChaosModeService.cs:852` `[CHAOSMEM]` | INF | DBG | Periodic telemetry sample, ~every 15s. |
| `Services/Chaos/ChaosModeService.cs:894` `[CHAOSHITCH]` | INF | DBG | Once per rendered frame with a >40ms gap. The governor input is unchanged; only the log line moved. |
| `Windows/EmiDesk/EmiRingWindow.xaml.cs:396` `[EmiDesk] ring open with N cards` | INF | DBG | Per open, no state. |
| `Services/Progression/LeaderboardService.cs:137` `Leaderboard refreshed` | INF | DBG | Every 30 minutes, forever. |
| `Services/Video/VideoService.cs:841` `LibVLC available aout modules` | INF | DBG | ~260 constant chars per launch. |
| `Services/Input/GlobalHotkeyService.cs` | 4x INF | 1x INF + DBG detail | Per-slot lines became Debug; a 750ms-debounced summary files ONE `N global hotkey(s) armed: <list>` line, and only when the set actually changes (several settings handlers re-apply the same combos on any save). |
| `Services/ModService.cs:2128,2160` `Registered ... built-in mod ... from <abs path>` | INF | DBG + 1 summary | Six lines naming absolute extract paths per launch, now one `Registered N built-in mod(s) with bundled assets`. Counter is Interlocked: a downloaded pack finishes extracting on a background thread. |
| `Services/LockCard/BrainDrainService.cs:163`, `MindWipeService.cs:175` `Looking for audio files in <abs path>` | INF | DBG | Absolute paths, constant, every launch. |
| `Services/LockCard/BrainDrainService.cs:185`, `MindWipeService.cs:194` `No .mp3/.wav/.ogg found` | **WRN** | INF, once/session | 63% of ALL warnings in the sample, for the SHIPPED DEFAULT state (no clips installed). A warning that fires on a normal condition every launch trains people to ignore warnings. |
| `Services/AutonomyService.cs:553` `CancelActivePulses called` | INF | DBG | Entry half of an always-paired log. The completion line stays at Information; that one reports the panic key actually did something. |
| `Services/AutonomyService.cs:811` `Heartbeat timer started` | INF | DBG | Constant, once per start. |
| `Services/Video/VideoService.cs:7128` `ATTENTION: CloseAll() - destroying 0 targets` | INF | INF only when >0 | The zero case is the common one and is now Debug. |
| ~25 bare `X stopped` / `X disposed` / `X initialized` lines | INF | DBG | The ~20-line shutdown fan-out plus the constant half of the startup roll-call. Only lines with NO count, mode, path, failure or fallback were touched. `Engine stopped`, `Session stopped early`, `Keyboard hook stopped - panic key disabled` and everything reporting a number or a mode were deliberately left alone. Files: AutonomyService, AwarenessObserver, BlinkTrainer, BubbleCount, Bubble, FocusGame, KeywordTrigger, BrainDrain, LockCard, MindWipe, Overlay, PopQuiz, RemoteControl, Roadmap, ScreenOcr, Subliminal, WindowAwareness, DualMonitorVideo, VideoService, SkillTree, Leaderboard, AudioService, MainWindow.Companion, CommunityPrompt, AvailableSubjects, GamificationBridge, JustDrop. |
| `Services/Settings/ProfileSyncService.cs:2347` `Failed to sync profile to cloud` | **ERR + 16-line stack, every exit** | WRN, type + message, no stack (cancellation only) | Quitting cancels the in-flight sync. That is shutdown working, not an error. A real failure still gets `Error(ex, ...)` with the whole exception. New `IsExpectedCancellation(ex)` looks through one level of wrapping (HttpClient wraps disposal either way round). |
| `Services/Settings/ProfileSyncService.cs:4278` `Settings backup failed` | WRN + stack | WRN, type + message, no stack (cancellation only) | Same shape. The HTTP-status branch above it already logged without a stack and is unchanged. |
| `MainWindow/MainWindow.Marquee.cs:744` | re-logged unchanged | logs on real change | **Bug fix, not just a log change** - see below. |

### Marquee: the log was a symptom

`RefreshMarqueeFromSettings` compared the raw server string against `_currentMarqueeMessage`,
which `StartMarqueeAnimation` stores **uppercased**. For any marquee that is not already all
caps the comparison never matched, so every 30-minute poll re-logged the same text AND
restarted the animation. It now compares against `App.Settings.Current.MarqueeMessage`, the
raw value we last accepted.

### Page log bridges

`ChaosWebViewHost.PageLogLevel`: an **absent** level mapped to Information. That was
deliberate and correct at the time. Debug was dropped, and page logs are a hosted surface's
only devtools-less channel, so the six levelless bridges had to be loud or go dark. The
flight recorder removes the constraint, so absent now maps to Debug, and the doc comment
explaining the old reasoning is rewritten rather than left lying.

To keep the loud paths loud, three bridges grew the arcademy's signature
(`log(msg)` or `log(level, msg)`; one argument still defaults to `'debug'`, so all ~100
existing call sites keep working unchanged):

- `Resources/web/dtrh/bridge.js` + `boot.js` - onerror, unhandledrejection, 3D boot failure, boot deadline promoted to `'error'`
- `Resources/web/goon/bridge.js` + `boot.js` - onerror, unhandledrejection, the shared `logger.warn`/`logger.error`, net-post failure and a refused serverBase promoted to `'warn'`/`'error'`
- `Resources/web/intake/web-shim.js` + `boot.js` - onerror, unhandledrejection, boot/run failure, onBoot callback failure promoted to `'error'`

`m2test`, `tunnel` and `player` still send no level and therefore go to Debug wholesale. They
are dev/diagnostic surfaces and their output is still in every dump; converting them was out
of scope for this PR.

### VideoDiag

- **Date.** Lines are `HH:mm:ss.fff` only (the column has to stay narrow), so the file carried no date at all and a trace read a day later could not be placed in time. A header is written once when a file opens empty (fresh install, after a roll) and again if the clock crosses midnight mid-session.
- **`UI: dispatcher alive`** went from once a minute to once per 10 minutes. It was 42% of the file, and at 1 MB with two files kept that could push a real freeze out of the window before anyone read it. The UNRESPONSIVE / RECOVERED / STARVED ladder is completely untouched and still reports at 3s resolution, so nothing about detecting a hang depends on this cadence.
- **The 4-line CLOSE block** (`CloseAll begin` / `detaching` / `closing N window(s)` / `CloseAll end`) is written only when there is actually a window to take down. Every panic press, engine stop and session end funnels through `CloseAll`, so the common case was four lines of "nothing happened" in the one trace whose whole value is a short readable timeline. The wedge / straggler / skip / fault-injection lines are unconditional, because those only fire when something IS wrong.

## Tests

`Tests/ConditioningControlPanel.Tests/ArcademyDoorOpenTests.cs`: the page-log-router theory
that asserted an absent level stays audible was split. A declared `info` is still
Information; an absent level is now Debug, with the reasoning for the flip written into the
test. Two new facts assert the three converted bridges send a `level` field and default to
the quiet one, which is what stops a future edit from silencing them by accident.

`dotnet build ConditioningControlPanel.sln -c Debug`: 0 errors.
`dotnet test Tests/ConditioningControlPanel.Tests`: **5203 passed, 0 failed**.

## Not in this PR

- `ProfileSyncService.cs:1599` (the 2.7 KB profile JSON line) - agent C.
- `Services/Browser/BrowserService.cs`, `MainWindow.Browser.cs`, `BouncingTextService.cs`, `WebcamTrackingService.cs` - each has a demotable line but is owned by C or D this wave; left to avoid conflicting edits.
- `[race-perf]` - does not exist anywhere in this tree (it lives in the unmerged Caucus Race stack).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GSSvqeYrpVG9H3EPtqikDC
