### PR TITLE
feat(logging): cap repeats at 20 a minute and report the ones dropped

### DIFF
--- a/ConditioningControlPanel/App.xaml.cs
+++ b/ConditioningControlPanel/App.xaml.cs
@@ -1512,15 +1512,13 @@ namespace ConditioningControlPanel
                 try { Directory.CreateDirectory(logPath); } catch { }
             }
 
-            Logger = new LoggerConfiguration()
-                .MinimumLevel.Information() // Security: Changed from Debug to avoid exposing sensitive data in logs
-                .WriteTo.File(Path.Combine(logPath, "app-.log"),
-                    rollingInterval: RollingInterval.Day,
-                    retainedFileCountLimit: 7,
-                    // Force a disk flush each second so the LAST lines survive a hard process death
-                    // (a native OOM kills the process with no managed unwind — see chaos OOM telemetry).
-                    flushToDiskInterval: TimeSpan.FromSeconds(1))
-                .CreateLogger();
+            // Everything about HOW a line is produced - the format, the category column, redaction,
+            // the size cap - now lives in Services/Logging/LogPipeline.cs. The floor is still
+            // Information (the "Security: changed from Debug" decision stands), but it is a switch
+            // rather than a constant, and redaction means Debug no longer implies exposure.
+            // --verbose or CCP_LOG_VERBOSE=1 puts Debug on disk for one run, for support.
+            Logger = Services.Logging.LogPipeline.Build(
+                logPath, Services.Logging.LogPipeline.VerboseRequested(e.Args));
 
             // The STATIC Serilog sink. Around 350 call sites across the app (every EmiDesk file,
             // plus Descent, Haptics, V2Auth, LocalizationManager) `using Serilog;` and write through

--- a/ConditioningControlPanel/Services/Logging/CategoryEnricher.cs
+++ b/ConditioningControlPanel/Services/Logging/CategoryEnricher.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Collections.Concurrent;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace ConditioningControlPanel.Services.Logging
+{
+    /// <summary>
+    /// Derives the <c>Cat</c> (category) column from the message template.
+    ///
+    /// <para>The app has no <c>SourceContext</c> to lean on: with 7,300 call sites written as
+    /// <c>App.Logger?.Information("[EMOTE] ...")</c> and <c>Log.Information("ProfileSync: ...")</c>,
+    /// the category is already IN the message, just in two different hand-rolled conventions. This
+    /// reads whichever one a line uses and lifts it into a real property, so the formatter can put
+    /// it in a fixed column and strip the now-duplicated prefix from the text.</para>
+    ///
+    /// <para>Derivation runs once per distinct template, not once per event: the template TEXT is a
+    /// literal from the call site, so the same string instance comes back every time. The cache is
+    /// bounded and cleared wholesale when it fills, which cannot happen with a fixed set of call
+    /// sites but can if someone builds templates by concatenation.</para>
+    /// </summary>
+    public sealed class CategoryEnricher : ILogEventEnricher
+    {
+        public const string PropertyName = "Cat";
+        private const int CacheCap = 4096;
+
+        private static readonly ConcurrentDictionary<string, string> _cache = new(StringComparer.Ordinal);
+
+        public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
+        {
+            if (logEvent == null) return;
+            // An explicit ForContext("Cat", ...) always wins.
+            if (logEvent.Properties.ContainsKey(PropertyName)) return;
+
+            var text = logEvent.MessageTemplate?.Text;
+            if (string.IsNullOrEmpty(text)) return;
+
+            if (!_cache.TryGetValue(text!, out var cat))
+            {
+                cat = Derive(text!);
+                if (_cache.Count >= CacheCap) _cache.Clear();
+                _cache[text!] = cat;
+            }
+
+            logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty(PropertyName, cat));
+        }
+
+        /// <summary>
+        /// <c>[Tag] rest</c> -> Tag; <c>Word: rest</c> or <c>Word.Method: rest</c> -> Word (a
+        /// trailing "Service" is dropped, because "ProfileSyncService" and "ProfileSync" are the
+        /// same thing to a reader); anything else -> App.
+        /// </summary>
+        public static string Derive(string text)
+        {
+            if (text.Length > 1 && text[0] == '[')
+            {
+                int close = text.IndexOf(']', 1);
+                if (close > 1 && close <= 20 && IsTagBody(text, 1, close))
+                    return Normalise(text.Substring(1, close - 1));
+                return "App";
+            }
+
+            // Scan a leading PascalCase word, optionally followed by ".Method", up to a colon.
+            if (text.Length < 2 || !IsUpper(text[0])) return "App";
+            int i = 1;
+            while (i < text.Length && IsWordChar(text[i])) i++;
+            int wordEnd = i;
+            if (i < text.Length && text[i] == '.')
+            {
+                i++;
+                int methodStart = i;
+                while (i < text.Length && IsWordChar(text[i])) i++;
+                if (i == methodStart) return "App";
+            }
+            if (i >= text.Length || text[i] != ':') return "App";
+            // "Word:" with nothing after the colon but a placeholder is still a category.
+            var word = text.Substring(0, wordEnd);
+            if (word.Length > 7 && word.EndsWith("Service", StringComparison.Ordinal))
+                word = word.Substring(0, word.Length - 7);
+            return word;
+        }
+
+        /// <summary>
+        /// SHOUTED tags are title-cased so <c>[AVATAR]</c> and <c>[Avatar]</c> land in one column
+        /// value; a tag that already carries internal case (<c>[EmiDesk]</c>) is left alone,
+        /// because lowering it would read worse than the inconsistency it fixes.
+        /// </summary>
+        private static string Normalise(string tag)
+        {
+            bool allUpper = true;
+            for (int i = 0; i < tag.Length; i++)
+            {
+                if (tag[i] >= 'a' && tag[i] <= 'z') { allUpper = false; break; }
+            }
+            if (!allUpper || tag.Length < 2) return tag;
+            return char.ToUpperInvariant(tag[0]) + tag.Substring(1).ToLowerInvariant();
+        }
+
+        private static bool IsTagBody(string s, int start, int end)
+        {
+            for (int i = start; i < end; i++)
+            {
+                if (!IsWordChar(s[i]) && s[i] != '-') return false;
+            }
+            return end > start;
+        }
+
+        private static bool IsUpper(char c) => c >= 'A' && c <= 'Z';
+
+        private static bool IsWordChar(char c) =>
+            (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_';
+    }
+}

--- a/ConditioningControlPanel/Services/Logging/CcpLineFormatter.cs
+++ b/ConditioningControlPanel/Services/Logging/CcpLineFormatter.cs
@@ -1,0 +1,195 @@
+using System;
+using System.Globalization;
+using System.IO;
+using Serilog.Events;
+using Serilog.Formatting;
+
+namespace ConditioningControlPanel.Services.Logging
+{
+    /// <summary>
+    /// The line format for every file the app writes:
+    /// <code>
+    /// HH:mm:ss.fff LVL [Category     ] message
+    /// </code>
+    ///
+    /// <para>An <see cref="ITextFormatter"/> rather than an output template, for three things a
+    /// template cannot do: strip a <c>[Category]</c> prefix that is now duplicated by the category
+    /// column, compact an exception down to the frames that are actually ours, and run the redactor
+    /// over the finished line. That last one is the safety net that matters: about half this
+    /// codebase's log calls pass an interpolated <c>$"..."</c> string, so the user's path is inside
+    /// the message TEMPLATE where the property enricher can never see it.</para>
+    ///
+    /// <para>The date is deliberately absent. It is written once in the session header; repeating
+    /// it 34,000 times a week bought nothing but bytes.</para>
+    /// </summary>
+    public sealed class CcpLineFormatter : ITextFormatter
+    {
+        /// <summary>Width of the category column. Long categories are cut, not elided: an ellipsis
+        /// would cost a character that a reader can spend on the name.</summary>
+        public const int CategoryWidth = 13;
+
+        private const int MaxAppFrames = 8;
+
+        public void Format(LogEvent logEvent, TextWriter output)
+        {
+            if (logEvent == null || output == null) return;
+            try
+            {
+                output.Write(logEvent.Timestamp.ToString("HH:mm:ss.fff", CultureInfo.InvariantCulture));
+                output.Write(' ');
+                output.Write(Abbreviate(logEvent.Level));
+                output.Write(" [");
+                var cat = Category(logEvent);
+                output.Write(cat.Length >= CategoryWidth ? cat.Substring(0, CategoryWidth) : cat.PadRight(CategoryWidth));
+                output.Write("] ");
+
+                var message = Render(logEvent);
+                int skip = PrefixLength(message, cat);
+                output.Write(LogRedactor.Redact(skip > 0 ? message.Substring(skip) : message));
+                output.WriteLine();
+
+                if (logEvent.Exception != null)
+                    WriteException(logEvent.Exception, output);
+            }
+            catch (Exception ex)
+            {
+                // swallow: a formatter that throws takes the whole sink with it, and a mangled line
+                // is worth more than a lost one.
+                try { output.WriteLine("?? formatter failed: " + ex.GetType().Name); } catch { }
+            }
+        }
+
+        public static string Abbreviate(LogEventLevel level) => level switch
+        {
+            LogEventLevel.Verbose => "VRB",
+            LogEventLevel.Debug => "DBG",
+            LogEventLevel.Information => "INF",
+            LogEventLevel.Warning => "WRN",
+            LogEventLevel.Error => "ERR",
+            _ => "FTL"
+        };
+
+        private static string Category(LogEvent e)
+        {
+            if (e.Properties.TryGetValue(CategoryEnricher.PropertyName, out var value)
+                && value is ScalarValue s && s.Value is string cat && cat.Length > 0)
+                return cat;
+            return "App";
+        }
+
+        private static string Render(LogEvent e)
+        {
+            using var sw = new StringWriter(CultureInfo.InvariantCulture);
+            e.RenderMessage(sw);
+            return sw.ToString();
+        }
+
+        /// <summary>
+        /// How many characters of the message repeat the category column. Only an EXACT repeat is
+        /// stripped ("[RES] ..." under category RES, "ProfileSyncService: ..." under ProfileSync);
+        /// anything else is left alone so that existing greps against the message keep working.
+        /// </summary>
+        public static int PrefixLength(string message, string cat)
+        {
+            if (string.IsNullOrEmpty(message) || string.IsNullOrEmpty(cat)) return 0;
+
+            if (message[0] == '[')
+            {
+                int close = message.IndexOf(']', 1);
+                if (close != cat.Length + 1) return 0;
+                if (string.Compare(message, 1, cat, 0, cat.Length, StringComparison.OrdinalIgnoreCase) != 0) return 0;
+                return SkipSpace(message, close + 1);
+            }
+
+            int i = 0;
+            while (i < message.Length && IsWordChar(message[i])) i++;
+            int wordEnd = i;
+            if (i < message.Length && message[i] == '.')
+            {
+                i++;
+                while (i < message.Length && IsWordChar(message[i])) i++;
+            }
+            if (i >= message.Length || message[i] != ':') return 0;
+
+            int len = wordEnd;
+            if (len == cat.Length + 7 &&
+                string.Compare(message, cat.Length, "Service", 0, 7, StringComparison.Ordinal) == 0)
+                len = cat.Length;
+            if (len != cat.Length) return 0;
+            if (string.Compare(message, 0, cat, 0, cat.Length, StringComparison.OrdinalIgnoreCase) != 0) return 0;
+            return SkipSpace(message, i + 1);
+        }
+
+        private static int SkipSpace(string s, int at)
+        {
+            while (at < s.Length && s[at] == ' ') at++;
+            return at;
+        }
+
+        private static bool IsWordChar(char c) =>
+            (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_';
+
+        /// <summary>
+        /// Compact the exception: every "type: message" line survives (including the inner-exception
+        /// chain), our own frames survive up to <see cref="MaxAppFrames"/> with the path cut to a
+        /// file name, and runs of framework frames collapse to a count. A WPF layout exception
+        /// carries 40+ frames of PresentationFramework that tell a reader nothing and cost a
+        /// kilobyte each time the exception repeats.
+        /// </summary>
+        private static void WriteException(Exception exception, TextWriter output)
+        {
+            var text = LogRedactor.Redact(exception.ToString());
+            int appFrames = 0, framework = 0;
+
+            foreach (var raw in text.Split('\n'))
+            {
+                var line = raw.TrimEnd('\r').Trim();
+                if (line.Length == 0) continue;
+
+                if (line.StartsWith("at ", StringComparison.Ordinal))
+                {
+                    if (IsAppFrame(line) && appFrames < MaxAppFrames)
+                    {
+                        FlushFramework(ref framework, output);
+                        appFrames++;
+                        output.Write("      ");
+                        output.WriteLine(CompactFrame(line));
+                    }
+                    else framework++;
+                    continue;
+                }
+
+                if (line.StartsWith("--- End of stack trace", StringComparison.Ordinal)) continue;
+
+                FlushFramework(ref framework, output);
+                output.Write("   ");
+                output.WriteLine(line);
+            }
+            FlushFramework(ref framework, output);
+        }
+
+        private static void FlushFramework(ref int count, TextWriter output)
+        {
+            if (count == 0) return;
+            output.Write("      ... ");
+            output.Write(count.ToString(CultureInfo.InvariantCulture));
+            output.WriteLine(" framework frames");
+            count = 0;
+        }
+
+        private static bool IsAppFrame(string frame) =>
+            frame.IndexOf("ConditioningControlPanel", StringComparison.Ordinal) >= 0 ||
+            frame.IndexOf("CCP.", StringComparison.Ordinal) >= 0;
+
+        /// <summary>" in ~\src\Services\Foo.cs:line 123" -&gt; " in Foo.cs:123".</summary>
+        private static string CompactFrame(string frame)
+        {
+            int at = frame.LastIndexOf(" in ", StringComparison.Ordinal);
+            if (at < 0) return frame;
+            var tail = frame.Substring(at + 4);
+            int slash = tail.LastIndexOfAny(new[] { '\\', '/' });
+            if (slash >= 0) tail = tail.Substring(slash + 1);
+            return frame.Substring(0, at + 4) + tail.Replace(":line ", ":");
+        }
+    }
+}

--- a/ConditioningControlPanel/Services/Logging/LogPipeline.cs
+++ b/ConditioningControlPanel/Services/Logging/LogPipeline.cs
@@ -1,0 +1,102 @@
+using System;
+using System.IO;
+using Serilog;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace ConditioningControlPanel.Services.Logging
+{
+    /// <summary>
+    /// Builds the one logger the app uses. Everything about HOW lines are produced lives here, so
+    /// the bootstrap in App.OnStartup stays a two-liner and the pipeline can be reasoned about (and
+    /// changed) without touching a 5,000-line file.
+    /// </summary>
+    public static class LogPipeline
+    {
+        /// <summary>
+        /// The global floor, held as a switch rather than a constant so the flight recorder can
+        /// drop it to Debug later without the file sink following it down.
+        /// </summary>
+        public static readonly LoggingLevelSwitch LevelSwitch = new(LogEventLevel.Information);
+
+        /// <summary>8 MB. The daily roll alone let one bad loop write an unbounded file.</summary>
+        public const long FileSizeLimitBytes = 8L * 1024 * 1024;
+
+        private static Logger? _logger;
+
+        /// <summary>
+        /// True when this run was asked for Debug on disk: <c>--verbose</c> on the command line or
+        /// <c>CCP_LOG_VERBOSE=1</c> in the environment. Support asks for one or the other depending
+        /// on whether the user can edit a shortcut, so both exist.
+        /// </summary>
+        public static bool VerboseRequested(string[]? args)
+        {
+            try
+            {
+                if (args != null)
+                {
+                    foreach (var a in args)
+                    {
+                        if (string.Equals(a, "--verbose", StringComparison.OrdinalIgnoreCase) ||
+                            string.Equals(a, "-verbose", StringComparison.OrdinalIgnoreCase) ||
+                            string.Equals(a, "/verbose", StringComparison.OrdinalIgnoreCase))
+                            return true;
+                    }
+                }
+                var env = Environment.GetEnvironmentVariable("CCP_LOG_VERBOSE");
+                return env == "1" || string.Equals(env, "true", StringComparison.OrdinalIgnoreCase);
+            }
+            catch
+            {
+                return false; // swallow: an unreadable environment must not stop logging
+            }
+        }
+
+        /// <summary>
+        /// Configure the redactor's roots and build the logger. Safe to call once per process; a
+        /// second call disposes the first logger.
+        /// </summary>
+        public static Serilog.ILogger Build(string logsDir, bool verbose)
+        {
+            LogRedactor.ConfigureRoots(App.UserDataPath, AppContext.BaseDirectory);
+            LogRedactor.AssetsRootProvider = () => App.EffectiveAssetsPath;
+
+            LevelSwitch.MinimumLevel = verbose ? LogEventLevel.Debug : LogEventLevel.Information;
+
+            var config = new LoggerConfiguration()
+                .MinimumLevel.ControlledBy(LevelSwitch)
+                // Order matters: the category is derived from the template, which redaction never
+                // touches, but the formatter needs BOTH properties present when it renders.
+                .Enrich.With(new CategoryEnricher())
+                .Enrich.With(new RedactingEnricher())
+                .WriteTo.File(
+                    new CcpLineFormatter(),
+                    Path.Combine(logsDir, "app-.log"),
+                    restrictedToMinimumLevel: verbose ? LogEventLevel.Debug : LogEventLevel.Information,
+                    rollingInterval: RollingInterval.Day,
+                    retainedFileCountLimit: 7,
+                    // A size cap as well as the daily roll: a render-loop exception writes the same
+                    // line thousands of times a minute, and "one file per day" is no cap at all
+                    // when the day has a storm in it.
+                    fileSizeLimitBytes: FileSizeLimitBytes,
+                    rollOnFileSizeLimit: true,
+                    // Force a disk flush each second so the LAST lines survive a hard process death
+                    // (a native OOM kills the process with no managed unwind - see chaos OOM telemetry).
+                    flushToDiskInterval: TimeSpan.FromSeconds(1));
+
+            var built = config.CreateLogger();
+            var previous = _logger;
+            _logger = built;
+            try { previous?.Dispose(); } catch { /* swallow: replacing a logger must not throw */ }
+            return built;
+        }
+
+        /// <summary>Flush and release the file handle. Idempotent.</summary>
+        public static void Shutdown()
+        {
+            try { Log.CloseAndFlush(); } catch { /* swallow: shutdown is best effort */ }
+            try { _logger?.Dispose(); } catch { /* swallow */ }
+            _logger = null;
+        }
+    }
+}

--- a/ConditioningControlPanel/Services/Logging/LogPipeline.cs
+++ b/ConditioningControlPanel/Services/Logging/LogPipeline.cs
@@ -23,6 +23,7 @@ namespace ConditioningControlPanel.Services.Logging
         public const long FileSizeLimitBytes = 8L * 1024 * 1024;
 
         private static Logger? _logger;
+        private static ThrottlingSink? _throttle;
 
         /// <summary>
         /// True when this run was asked for Debug on disk: <c>--verbose</c> on the command line or
@@ -63,16 +64,16 @@ namespace ConditioningControlPanel.Services.Logging
 
             LevelSwitch.MinimumLevel = verbose ? LogEventLevel.Debug : LogEventLevel.Information;
 
-            var config = new LoggerConfiguration()
-                .MinimumLevel.ControlledBy(LevelSwitch)
-                // Order matters: the category is derived from the template, which redaction never
-                // touches, but the formatter needs BOTH properties present when it renders.
-                .Enrich.With(new CategoryEnricher())
-                .Enrich.With(new RedactingEnricher())
+            // The file sink is built as its own logger so it can be WRAPPED. Serilog's Logger is an
+            // ILogEventSink, which is the only way to put the throttle between the pipeline and the
+            // file without reimplementing the rolling file sink. Its own floor is Verbose because
+            // the level decision belongs to the outer pipeline; filtering twice would mean two
+            // places to get it wrong.
+            var fileSink = new LoggerConfiguration()
+                .MinimumLevel.Verbose()
                 .WriteTo.File(
                     new CcpLineFormatter(),
                     Path.Combine(logsDir, "app-.log"),
-                    restrictedToMinimumLevel: verbose ? LogEventLevel.Debug : LogEventLevel.Information,
                     rollingInterval: RollingInterval.Day,
                     retainedFileCountLimit: 7,
                     // A size cap as well as the daily roll: a render-loop exception writes the same
@@ -82,7 +83,23 @@ namespace ConditioningControlPanel.Services.Logging
                     rollOnFileSizeLimit: true,
                     // Force a disk flush each second so the LAST lines survive a hard process death
                     // (a native OOM kills the process with no managed unwind - see chaos OOM telemetry).
-                    flushToDiskInterval: TimeSpan.FromSeconds(1));
+                    flushToDiskInterval: TimeSpan.FromSeconds(1))
+                .CreateLogger();
+
+            var throttled = new ThrottlingSink(fileSink);
+            var previousThrottle = _throttle;
+            _throttle = throttled;
+
+            var config = new LoggerConfiguration()
+                .MinimumLevel.ControlledBy(LevelSwitch)
+                // Order matters: the category is derived from the template, which redaction never
+                // touches, but the formatter needs BOTH properties present when it renders.
+                .Enrich.With(new CategoryEnricher())
+                .Enrich.With(new RedactingEnricher())
+                .WriteTo.Sink(throttled,
+                    restrictedToMinimumLevel: verbose ? LogEventLevel.Debug : LogEventLevel.Information);
+
+            try { previousThrottle?.Dispose(); } catch { /* swallow: replacing a sink must not throw */ }
 
             var built = config.CreateLogger();
             var previous = _logger;
@@ -96,7 +113,11 @@ namespace ConditioningControlPanel.Services.Logging
         {
             try { Log.CloseAndFlush(); } catch { /* swallow: shutdown is best effort */ }
             try { _logger?.Dispose(); } catch { /* swallow */ }
+            // Disposing the throttle flushes whatever the last minute suppressed and then closes
+            // the file sink underneath it.
+            try { _throttle?.Dispose(); } catch { /* swallow */ }
             _logger = null;
+            _throttle = null;
         }
     }
 }

--- a/ConditioningControlPanel/Services/Logging/RedactingEnricher.cs
+++ b/ConditioningControlPanel/Services/Logging/RedactingEnricher.cs
@@ -1,0 +1,90 @@
+using Serilog.Core;
+using Serilog.Events;
+
+namespace ConditioningControlPanel.Services.Logging
+{
+    /// <summary>
+    /// Runs <see cref="LogRedactor"/> over every string that arrives as a log PROPERTY.
+    ///
+    /// <para>Properties are the half of a log line the formatter cannot reach as text: by the time
+    /// it renders, a path is already spliced into the output. Doing it here also means a structured
+    /// sink (the flight recorder keeps events, not strings) holds redacted values too.</para>
+    ///
+    /// <para>The formatter still runs the redactor over the finished line as a safety net, because
+    /// roughly half the call sites in this app use an interpolated <c>$"..."</c> string, which puts
+    /// the content into the TEMPLATE where no enricher can see it.</para>
+    /// </summary>
+    public sealed class RedactingEnricher : ILogEventEnricher
+    {
+        public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
+        {
+            if (logEvent == null) return;
+            foreach (var kv in logEvent.Properties)
+            {
+                var replacement = Visit(kv.Value);
+                if (replacement != null)
+                    logEvent.AddOrUpdateProperty(new LogEventProperty(kv.Key, replacement));
+            }
+        }
+
+        /// <summary>
+        /// Returns a replacement value, or null when nothing in the value needed redacting.
+        /// Serilog's property values are immutable, so a change means rebuilding the container.
+        /// </summary>
+        public static LogEventPropertyValue? Visit(LogEventPropertyValue value)
+        {
+            switch (value)
+            {
+                case ScalarValue scalar when scalar.Value is string s:
+                {
+                    var redacted = LogRedactor.Redact(s);
+                    return ReferenceEquals(redacted, s) ? null : new ScalarValue(redacted);
+                }
+
+                case SequenceValue seq:
+                {
+                    LogEventPropertyValue[]? copy = null;
+                    for (int i = 0; i < seq.Elements.Count; i++)
+                    {
+                        var replaced = Visit(seq.Elements[i]);
+                        if (replaced == null) continue;
+                        copy ??= System.Linq.Enumerable.ToArray(seq.Elements);
+                        copy[i] = replaced;
+                    }
+                    return copy == null ? null : new SequenceValue(copy);
+                }
+
+                case StructureValue str:
+                {
+                    LogEventProperty[]? copy = null;
+                    for (int i = 0; i < str.Properties.Count; i++)
+                    {
+                        var replaced = Visit(str.Properties[i].Value);
+                        if (replaced == null) continue;
+                        copy ??= System.Linq.Enumerable.ToArray(str.Properties);
+                        copy[i] = new LogEventProperty(str.Properties[i].Name, replaced);
+                    }
+                    return copy == null ? null : new StructureValue(copy, str.TypeTag);
+                }
+
+                case DictionaryValue dict:
+                {
+                    System.Collections.Generic.List<System.Collections.Generic.KeyValuePair<ScalarValue, LogEventPropertyValue>>? copy = null;
+                    int i = 0;
+                    foreach (var entry in dict.Elements)
+                    {
+                        var replaced = Visit(entry.Value);
+                        if (replaced != null)
+                        {
+                            copy ??= new System.Collections.Generic.List<System.Collections.Generic.KeyValuePair<ScalarValue, LogEventPropertyValue>>(dict.Elements);
+                            copy[i] = new System.Collections.Generic.KeyValuePair<ScalarValue, LogEventPropertyValue>(entry.Key, replaced);
+                        }
+                        i++;
+                    }
+                    return copy == null ? null : new DictionaryValue(copy);
+                }
+            }
+            return null;
+        }
+    }
+}

--- a/ConditioningControlPanel/Services/Logging/ThrottlingSink.cs
+++ b/ConditioningControlPanel/Services/Logging/ThrottlingSink.cs
@@ -1,0 +1,182 @@
+using System;
+using System.Collections.Generic;
+using Serilog.Core;
+using Serilog.Events;
+using Serilog.Parsing;
+
+namespace ConditioningControlPanel.Services.Logging
+{
+    /// <summary>
+    /// Caps how many times one message can repeat inside a minute, and says so when it does.
+    ///
+    /// <para>A week of real logs is 34,500 lines, and a third of the bytes are three templates
+    /// repeating: an emote crossfade every five seconds, a blocked bark, and a profile-sync
+    /// response. Nobody reads the 400th copy, and the lines that matter are buried between them.
+    /// The first 20 per template per minute go through; the rest are counted, and the count is
+    /// written as one line the next time that template speaks:</para>
+    ///
+    /// <code>(suppressed 380 similar '[EMOTE] xfade -&gt; {Emote}' in the last 60s)</code>
+    ///
+    /// <para>Errors and Fatals are throttled by the same rule on purpose. A crash loop is exactly
+    /// the case that used to write half a gigabyte, and the count is the diagnostic - a thousand
+    /// identical stack traces are not a thousand facts.</para>
+    ///
+    /// <para>Keyed by (category, message TEMPLATE), never the rendered text: the template is the
+    /// call site, so "connected to 3 devices" and "connected to 4 devices" are one thing, which is
+    /// what makes the cap meaningful.</para>
+    /// </summary>
+    public sealed class ThrottlingSink : ILogEventSink, IDisposable
+    {
+        /// <summary>Events per key per window that pass through untouched.</summary>
+        public const int BurstLimit = 20;
+        public const int WindowMs = 60_000;
+
+        /// <summary>Distinct keys tracked. Far above the app's real template count; the eviction
+        /// path exists for templates built by concatenation, which would otherwise grow forever.</summary>
+        private const int KeyCap = 2048;
+
+        /// <summary>Joins category and template into one dictionary key; never appears in a template.</summary>
+        private const char Separator = (char)1;
+
+        private static readonly MessageTemplate SummaryTemplate =
+            new MessageTemplateParser().Parse("(suppressed {Count} similar '{Template}' in the last 60s)");
+
+        private sealed class Entry
+        {
+            public long WindowStart;
+            public int Count;
+            public int Suppressed;
+            public LogEventLevel Level;
+            public string Category = "App";
+        }
+
+        private readonly ILogEventSink _inner;
+        private readonly Dictionary<string, Entry> _keys = new(StringComparer.Ordinal);
+        private readonly object _gate = new();
+        private bool _disposed;
+
+        public ThrottlingSink(ILogEventSink inner) => _inner = inner;
+
+        public void Emit(LogEvent logEvent)
+        {
+            if (logEvent == null) return;
+            if (_inner == null) return;
+
+            bool pass = true;
+            int summarise = 0;
+            string template = string.Empty, category = "App";
+            LogEventLevel level = logEvent.Level;
+
+            try
+            {
+                category = CategoryOf(logEvent);
+                template = logEvent.MessageTemplate?.Text ?? string.Empty;
+                var key = category + Separator + template;
+                long now = Environment.TickCount64;
+
+                lock (_gate)
+                {
+                    if (!_keys.TryGetValue(key, out var entry))
+                    {
+                        if (_keys.Count >= KeyCap) EvictOldest();
+                        entry = new Entry { WindowStart = now };
+                        _keys[key] = entry;
+                    }
+
+                    if (now - entry.WindowStart >= WindowMs)
+                    {
+                        summarise = entry.Suppressed;
+                        level = entry.Level;
+                        entry.WindowStart = now;
+                        entry.Count = 0;
+                        entry.Suppressed = 0;
+                    }
+
+                    entry.Category = category;
+                    entry.Level = logEvent.Level;
+                    entry.Count++;
+                    pass = entry.Count <= BurstLimit;
+                    if (!pass) entry.Suppressed++;
+                }
+            }
+            catch
+            {
+                // swallow: a throttle that throws costs the line it was throttling. Fall through
+                // and emit.
+                pass = true;
+            }
+
+            if (summarise > 0) EmitSummary(logEvent.Timestamp, level, category, template, summarise);
+            if (pass) Safe(logEvent);
+        }
+
+        private static string CategoryOf(LogEvent e) =>
+            e.Properties.TryGetValue(CategoryEnricher.PropertyName, out var v)
+            && v is ScalarValue s && s.Value is string cat && cat.Length > 0 ? cat : "App";
+
+        private void EmitSummary(DateTimeOffset at, LogEventLevel level, string category, string template, int count)
+        {
+            try
+            {
+                // The summary keeps the suppressed line's own level so a storm of errors does not
+                // report itself as an Information note.
+                var props = new[]
+                {
+                    new LogEventProperty("Count", new ScalarValue(count)),
+                    new LogEventProperty("Template", new ScalarValue(template)),
+                    new LogEventProperty(CategoryEnricher.PropertyName, new ScalarValue(category))
+                };
+                Safe(new LogEvent(at, level < LogEventLevel.Information ? LogEventLevel.Information : level,
+                    null, SummaryTemplate, props));
+            }
+            catch { /* swallow: the summary is a courtesy, not a guarantee */ }
+        }
+
+        private void Safe(LogEvent e)
+        {
+            try { _inner.Emit(e); }
+            catch { /* swallow: never throw out of a sink */ }
+        }
+
+        /// <summary>Drop the key whose window started longest ago - the least active template.</summary>
+        private void EvictOldest()
+        {
+            string? oldestKey = null;
+            long oldest = long.MaxValue;
+            foreach (var kv in _keys)
+            {
+                if (kv.Value.WindowStart < oldest) { oldest = kv.Value.WindowStart; oldestKey = kv.Key; }
+            }
+            if (oldestKey != null) _keys.Remove(oldestKey);
+        }
+
+        /// <summary>
+        /// Flush the outstanding counts. Without this, whatever a session suppressed in its last
+        /// minute is simply lost, which is the minute a crash-loop investigation cares about.
+        /// </summary>
+        public void Flush()
+        {
+            List<(DateTimeOffset At, LogEventLevel Level, string Cat, string Template, int Count)> pending = new();
+            lock (_gate)
+            {
+                foreach (var kv in _keys)
+                {
+                    if (kv.Value.Suppressed <= 0) continue;
+                    var sep = kv.Key.IndexOf(Separator);
+                    pending.Add((DateTimeOffset.Now, kv.Value.Level, kv.Value.Category,
+                        sep >= 0 ? kv.Key.Substring(sep + 1) : kv.Key, kv.Value.Suppressed));
+                    kv.Value.Suppressed = 0;
+                }
+            }
+            foreach (var p in pending) EmitSummary(p.At, p.Level, p.Cat, p.Template, p.Count);
+        }
+
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _disposed = true;
+            try { Flush(); } catch { /* swallow */ }
+            try { (_inner as IDisposable)?.Dispose(); } catch { /* swallow */ }
+        }
+    }
+}

--- a/Tests/ConditioningControlPanel.Tests/LogFormatTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/LogFormatTests.cs
@@ -1,0 +1,136 @@
+using System;
+using System.IO;
+using ConditioningControlPanel.Services.Logging;
+using Serilog.Core;
+using Serilog.Events;
+using Serilog.Parsing;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// The line format, the category column and the two enrichers behind them.
+///
+/// <para>These exist because the format is load-bearing in a way a format usually is not: 7,300
+/// call sites already put their category in the message by hand, in two different conventions, and
+/// the bug reporter greps the result. Getting the category derivation or the prefix strip subtly
+/// wrong does not throw - it silently mangles every line in the file and breaks the marker
+/// sampling that triage runs on.</para>
+/// </summary>
+[Collection(LoggingStaticsCollection.Name)]
+public class LogFormatTests
+{
+    public LogFormatTests() =>
+        LogRedactor.ConfigureRoots(@"C:\Users\alice\AppData\Local\ConditioningControlPanel", null, null);
+
+    private sealed class Factory : ILogEventPropertyFactory
+    {
+        public LogEventProperty CreateProperty(string name, object? value, bool destructureObjects = false)
+            => new(name, new ScalarValue(value));
+    }
+
+    private static LogEvent Event(string template, Exception? ex = null, params LogEventProperty[] props) =>
+        new(new DateTimeOffset(2026, 9, 4, 12, 34, 56, 789, TimeSpan.Zero),
+            LogEventLevel.Information, ex, new MessageTemplateParser().Parse(template), props);
+
+    private static string Format(LogEvent e)
+    {
+        var factory = new Factory();
+        new CategoryEnricher().Enrich(e, factory);
+        new RedactingEnricher().Enrich(e, factory);
+        using var sw = new StringWriter();
+        new CcpLineFormatter().Format(e, sw);
+        return sw.ToString();
+    }
+
+    [Theory]
+    // A bracket tag, SHOUTED or not, lands in one column value.
+    [InlineData("[EMOTE] xfade to {A}", "Emote")]
+    [InlineData("[EmiDesk] ring open with {N} cards", "EmiDesk")]
+    // "Class:" and "Class.Method:", with the redundant "Service" suffix dropped.
+    [InlineData("GlobalHotkeyService: registered {Key}", "GlobalHotkey")]
+    [InlineData("ProfileSyncService.Sync: done in {Ms}ms", "ProfileSync")]
+    [InlineData("VideoService: opened", "Video")]
+    // Everything else is App, including a lowercase lead and a bracket that is not a tag.
+    [InlineData("Application starting v{Version}", "App")]
+    [InlineData("started 3 things", "App")]
+    [InlineData("[not a tag here, too long to be one] x", "App")]
+    public void CategoryIsDerivedFromTheMessageTemplate(string template, string expected)
+        => Assert.Equal(expected, CategoryEnricher.Derive(template));
+
+    [Fact]
+    public void ExplicitCategoryWins()
+    {
+        var e = Event("VideoService: opened", null,
+            new LogEventProperty(CategoryEnricher.PropertyName, new ScalarValue("Chaos")));
+        new CategoryEnricher().Enrich(e, new Factory());
+        Assert.Equal("Chaos", ((ScalarValue)e.Properties[CategoryEnricher.PropertyName]).Value);
+    }
+
+    [Fact]
+    public void LineShape_IsTimeLevelCategoryMessage()
+    {
+        var line = Format(Event("[EMOTE] xfade done"));
+        // The category column is fixed width so the messages line up down the page, and the prefix
+        // that is now IN that column is stripped from the message rather than printed twice.
+        Assert.Equal("12:34:56.789 INF [Emote        ] xfade done" + Environment.NewLine, line);
+    }
+
+    [Fact]
+    public void OnlyAnExactRepeatOfTheCategoryIsStripped()
+    {
+        // "Video" is the category of a "VideoService:" line, so the whole prefix goes...
+        Assert.StartsWith("12:34:56.789 INF [Video        ] opened", Format(Event("VideoService: opened")));
+        // ...but an unrelated bracket stays, because greps in the wild match on message text.
+        Assert.Contains("[queue] drained", Format(Event("[EMOTE] [queue] drained")));
+    }
+
+    [Fact]
+    public void InterpolatedMessages_AreRedactedByTheFormatter()
+    {
+        // Around half the call sites in this app pass an interpolated $"..." string, which puts the
+        // path in the TEMPLATE, where no enricher can reach it. This is the safety net.
+        var line = Format(Event(@"[FLASH] loading C:\Users\alice\Pictures\a.png"));
+        Assert.Contains(@"~\Pictures\a.png", line);
+        Assert.DoesNotContain("alice", line);
+    }
+
+    [Fact]
+    public void PropertyValues_AreRedactedByTheEnricher()
+    {
+        var e = Event("[SETTINGS] saved to {Path} for {Id}", null,
+            new LogEventProperty("Path", new ScalarValue(@"C:\Users\alice\AppData\Local\ConditioningControlPanel\settings.json")),
+            new LogEventProperty("Id", new ScalarValue("123456789012347890")));
+        var line = Format(e);
+        Assert.Contains(@"%DATA%\settings.json", line);
+        Assert.Contains("<id:…7890>", line);
+        // The template itself must survive intact - it is the throttling key and the grep target.
+        Assert.Equal("[SETTINGS] saved to {Path} for {Id}", e.MessageTemplate.Text);
+    }
+
+    [Fact]
+    public void Exceptions_AreCompactedAndRedacted()
+    {
+        Exception caught;
+        try { throw new IOException(@"cannot open C:\Users\alice\clip.mp4"); }
+        catch (Exception ex) { caught = ex; }
+
+        // Give it a real stack with a framework frame in it.
+        try { "abc".Substring(99); }
+        catch (Exception ex) { caught = new IOException(@"cannot open C:\Users\alice\clip.mp4", ex); }
+
+        var line = Format(Event("[VIDEO] open failed", caught));
+        Assert.DoesNotContain("alice", line);
+        Assert.Contains(@"~\clip.mp4", line);
+        // System.String.Substring is not our frame; it collapses to a count instead of a kilobyte
+        // of PresentationFramework.
+        Assert.Contains("framework frames", line);
+    }
+
+    [Fact]
+    public void VerboseIsOptIn()
+    {
+        Assert.False(LogPipeline.VerboseRequested(new[] { "--hidden" }));
+        Assert.True(LogPipeline.VerboseRequested(new[] { "--verbose" }));
+    }
+}

--- a/Tests/ConditioningControlPanel.Tests/LogThrottleTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/LogThrottleTests.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Collections.Generic;
+using ConditioningControlPanel.Services.Logging;
+using Serilog.Core;
+using Serilog.Events;
+using Serilog.Parsing;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// The repeat cap. A week of real logs is 34,500 lines and a third of the BYTES are three templates
+/// repeating - an emote crossfade every five seconds, a blocked bark, a profile-sync response - so
+/// the lines that matter sit buried between copies of the ones that do not.
+///
+/// <para>The cap is only useful if the count survives: silently dropping the 21st copy would turn a
+/// crash loop into a quiet log, which is worse than the noise. These pin both halves - what passes,
+/// and that the suppressed count is reported rather than lost.</para>
+/// </summary>
+public class LogThrottleTests
+{
+    private sealed class Capture : ILogEventSink
+    {
+        public readonly List<LogEvent> Events = new();
+        public void Emit(LogEvent logEvent) => Events.Add(logEvent);
+    }
+
+    private static readonly MessageTemplateParser Parser = new();
+
+    private static LogEvent Event(string template, string cat = "Emote",
+        LogEventLevel level = LogEventLevel.Information) =>
+        new(DateTimeOffset.Now, level, null, Parser.Parse(template),
+            new[] { new LogEventProperty(CategoryEnricher.PropertyName, new ScalarValue(cat)) });
+
+    [Fact]
+    public void FirstTwentyPass_TheRestAreCounted()
+    {
+        var capture = new Capture();
+        var sink = new ThrottlingSink(capture);
+
+        for (int i = 0; i < 500; i++) sink.Emit(Event("[EMOTE] xfade to {Emote}"));
+
+        Assert.Equal(ThrottlingSink.BurstLimit, capture.Events.Count);
+
+        // Nothing is lost: the 480 that did not pass are reported as one line on flush.
+        sink.Flush();
+        var summary = Assert.Single(capture.Events.GetRange(ThrottlingSink.BurstLimit,
+            capture.Events.Count - ThrottlingSink.BurstLimit));
+        Assert.Contains("suppressed", summary.MessageTemplate.Text);
+        Assert.Equal(480, ((ScalarValue)summary.Properties["Count"]).Value);
+        Assert.Equal("[EMOTE] xfade to {Emote}", ((ScalarValue)summary.Properties["Template"]).Value);
+        // The summary carries the category so it lands in the same column as the lines it counts.
+        Assert.Equal("Emote", ((ScalarValue)summary.Properties[CategoryEnricher.PropertyName]).Value);
+    }
+
+    [Fact]
+    public void TheKeyIsTheTemplate_NotTheRenderedText()
+    {
+        // "connected to 3 devices" and "connected to 4 devices" are one call site, so they share a
+        // budget. If the key were the rendered text, a template with a counter in it would never
+        // throttle at all - which is exactly the shape of the noisiest lines in the real log.
+        var capture = new Capture();
+        var sink = new ThrottlingSink(capture);
+        for (int i = 0; i < 30; i++) sink.Emit(Event("[HAPTIC] connected to {N} devices"));
+        Assert.Equal(ThrottlingSink.BurstLimit, capture.Events.Count);
+    }
+
+    [Fact]
+    public void DifferentCategoriesAndTemplatesHaveTheirOwnBudget()
+    {
+        var capture = new Capture();
+        var sink = new ThrottlingSink(capture);
+        for (int i = 0; i < 30; i++)
+        {
+            sink.Emit(Event("[EMOTE] xfade"));
+            sink.Emit(Event("[BARK] blocked", cat: "Bark"));
+        }
+        Assert.Equal(ThrottlingSink.BurstLimit * 2, capture.Events.Count);
+    }
+
+    [Fact]
+    public void ErrorsAreThrottledToo_AndTheSummaryKeepsTheirLevel()
+    {
+        // Deliberate: a crash loop is the case that once wrote half a gigabyte, and a thousand
+        // identical stack traces are not a thousand facts. But the summary must not demote itself
+        // to Information, or an error storm disappears from an error-level read of the file.
+        var capture = new Capture();
+        var sink = new ThrottlingSink(capture);
+        for (int i = 0; i < 100; i++) sink.Emit(Event("[VIDEO] open failed", level: LogEventLevel.Error));
+        sink.Flush();
+
+        Assert.Equal(ThrottlingSink.BurstLimit + 1, capture.Events.Count);
+        Assert.Equal(LogEventLevel.Error, capture.Events[^1].Level);
+    }
+
+    [Fact]
+    public void DisposeFlushesTheOutstandingCount()
+    {
+        var capture = new Capture();
+        var sink = new ThrottlingSink(capture);
+        for (int i = 0; i < 25; i++) sink.Emit(Event("[EMOTE] xfade"));
+        sink.Dispose();
+        Assert.Equal(ThrottlingSink.BurstLimit + 1, capture.Events.Count);
+        Assert.Equal(5, ((ScalarValue)capture.Events[^1].Properties["Count"]).Value);
+    }
+}


### PR DESCRIPTION
Third of the logging-redesign stack (agent A). **Base: `feat/log-format` (#829)**, which bases on
`feat/log-pipeline` (#825). Merge in that order.

## What this does

Caps how often one message can repeat, and says so when it does.

A week of real logs is 34,500 lines, and a third of the **bytes** are three templates repeating: an
emote crossfade every five seconds (22%), a blocked bark (12%), and a profile-sync response that
prints 2.7 KB of JSON per line (11%).

- First 20 events per `(category, template)` per 60 s pass through. The rest are counted.
- The count is written as one line the next time that template speaks, or on shutdown:
  `(suppressed 380 similar '[EMOTE] xfade -> {Emote}' in the last 60s)`
- Keyed by the message **template**, never the rendered text. "connected to 3 devices" and
  "connected to 4 devices" are one call site; a key that told them apart would never throttle the
  noisy lines, because nearly all of them carry a counter.
- Errors and Fatals throttle by the same rule, deliberately: a crash loop is the case that once grew
  crash.log to half a gigabyte in a single session. The summary keeps the suppressed level, so an
  error storm does not disappear from an error-level read of the file.
- Bounded at 2048 keys, oldest window evicted. Thread-safe, and every path swallows: a throttle that
  throws costs the line it was throttling.

## Wiring

The file sink is now built as its own `Logger` and wrapped, because Serilog's `Logger` is an
`ILogEventSink` and that is the only way to sit between the pipeline and the rolling file without
reimplementing the file sink. Its own floor is Verbose; the level decision stays with the outer
pipeline, so there is one place to get it wrong instead of two. `LogPipeline.Shutdown()` disposes
the throttle, which flushes the last minute's counts before closing the file.

## Verification

`dotnet build ConditioningControlPanel.sln -c Debug` 0 errors. `dotnet test` 5228 passed, 0 failed
(5 new here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GSSvqeYrpVG9H3EPtqikDC
