### PR TITLE
refactor(logging): empty catches in bubble/tutorial/flash/video/DtRH -> Diag.Swallowed

### DIFF
--- a/ConditioningControlPanel/Services/BubbleService.cs
+++ b/ConditioningControlPanel/Services/BubbleService.cs
@@ -96,7 +96,7 @@ public class BubbleService : IDisposable
                 if (hwnd != IntPtr.Zero) handles.Add(hwnd);
             }
         }
-        catch { /* a diagnostic/reconciler accessor must never throw */ }
+        catch (Exception ex) { Diag.Swallowed(ex, "diagnostic accessor must never throw"); }
         return handles;
     }
 
@@ -418,7 +418,7 @@ public class BubbleService : IDisposable
             hop.Tick += (_, _) =>
             {
                 hop.Stop();
-                try { if (t.IsAlive) t.Pop(); } catch { }
+                try { if (t.IsAlive) t.Pop(); } catch (Exception ex) { Diag.Swallowed(ex); }
             };
             hop.Start();
         }
@@ -456,7 +456,7 @@ public class BubbleService : IDisposable
             hop.Tick += (_, _) =>
             {
                 hop.Stop();
-                try { if (target.IsAlive) target.Pop(); } catch { }
+                try { if (target.IsAlive) target.Pop(); } catch (Exception ex) { Diag.Swallowed(ex); }
             };
             hop.Start();
         }
@@ -688,7 +688,7 @@ public class BubbleService : IDisposable
             // thread wedged in CWGXBitmapLockState::LockRead) — give the surge a beat to pass.
             await Task.Delay(2500, ct);
         }
-        catch (OperationCanceledException) { /* run ended / shutdown mid-egg */ }
+        catch (OperationCanceledException) { } // swallow: run ended or shutdown mid-egg
         catch (Exception ex) { App.Logger?.Debug("Avatar bubble egg failed: {E}", ex.Message); }
         finally
         {
@@ -696,7 +696,7 @@ public class BubbleService : IDisposable
             // 4) send the companion home (re-attach or restore coords); swallow if we're tearing down
             try { if (avatar != null && Application.Current?.Dispatcher?.HasShutdownStarted != true)
                       await avatar.ReturnFromBubbleAsync(CancellationToken.None); }
-            catch { }
+            catch (Exception ex) { Diag.Swallowed(ex); }
             _avatarEggActive = false;
             _avatarEggCooldownUntil = DateTime.UtcNow + TimeSpan.FromSeconds(AVATAR_EGG_COOLDOWN_SEC);
         }
@@ -706,7 +706,7 @@ public class BubbleService : IDisposable
     /// the claimed bubble can actually be cleared (the claim-pop guard would otherwise strand it).</summary>
     private void CancelAvatarEgg()
     {
-        try { _eggCts?.Cancel(); } catch { }
+        try { _eggCts?.Cancel(); } catch (Exception ex) { Diag.Swallowed(ex); }
         foreach (var b in _bubbles) if (b.ClaimedByAvatar) b.ReleaseAvatarClaim();
         _avatarEggActive = false;
     }
@@ -744,7 +744,7 @@ public class BubbleService : IDisposable
                 return (int)Math.Clamp(r.TotalTime.TotalMilliseconds + 900, 1500, 6000);
             }
         }
-        catch { }
+        catch (Exception ex) { Diag.Swallowed(ex); }
         return (int)Math.Clamp((text?.Length ?? 0) * 55 + 600, 1500, 4500);
     }
 
@@ -809,7 +809,7 @@ public class BubbleService : IDisposable
         if (!_ambientHost) return;
         _ambientHost = false;
         Bubble.AmbientHostActive = false;
-        try { _ambientHook?.Dispose(); } catch { }
+        try { _ambientHook?.Dispose(); } catch (Exception ex) { Diag.Swallowed(ex); }
         _ambientHook = null;
         ChaosBubbleHostOverlay.CloseActive();
         if (ChaosClickDiscsSnapshot.Length > 0) ChaosClickDiscsSnapshot = Array.Empty<(double, double, double, bool)>();
@@ -1781,7 +1781,7 @@ public class BubbleService : IDisposable
             foreach (var b in _bubbles)
                 if (b.HintKey == key) b.HideHint();
         }
-        catch { }
+        catch (Exception ex) { Diag.Swallowed(ex); }
     }
 
     /// <summary>Drop every tether + window (field cleared / run over).</summary>
@@ -1854,7 +1854,7 @@ public class BubbleService : IDisposable
                 hop.Tick += (_, _) =>
                 {
                     hop.Stop();
-                    try { if (target.IsAlive) target.Pop(); } catch { }
+                    try { if (target.IsAlive) target.Pop(); } catch (Exception ex) { Diag.Swallowed(ex); }
                 };
                 hop.Start();
             }
@@ -2116,7 +2116,7 @@ public class BubbleService : IDisposable
                 // Direct cleanup without dispatcher - force destroy
                 foreach (var bubble in _bubbles.ToArray())
                 {
-                    try { bubble.ForceDestroy(); } catch { }
+                    try { bubble.ForceDestroy(); } catch (Exception ex) { Diag.Swallowed(ex); }
                 }
                 _bubbles.Clear();
                 return;
@@ -2156,7 +2156,7 @@ public class BubbleService : IDisposable
         Stop();
 
         // Close pooled bubble window shells (static pool holds hidden HWNDs for the process life).
-        try { DispatcherHelper.RunOnUI(Bubble.DrainWindowPool); } catch { }
+        try { DispatcherHelper.RunOnUI(Bubble.DrainWindowPool); } catch (Exception ex) { Diag.Swallowed(ex); }
 
         // Audio devices are no longer pooled here — AudioService owns every one-shot device
         // and disposes it deterministically (#778/#779).
@@ -2252,7 +2252,7 @@ internal class Bubble
         if (w == null) return;
         // Restore the topmost default: a Free Desktop chaos bubble may have set this false, and the
         // pool is shared with ambient bubbles that must always ride on top.
-        try { w.Effect = null; w.Content = null; w.Opacity = 0; w.Topmost = true; w.Hide(); } catch { }
+        try { w.Effect = null; w.Content = null; w.Opacity = 0; w.Topmost = true; w.Hide(); } catch (Exception ex) { Diag.Swallowed(ex); }
         if (_windowPoolCount < WINDOW_POOL_MAX)
         {
             if (!_windowPool.TryGetValue(bucket, out var stack))
@@ -2263,7 +2263,7 @@ internal class Bubble
             stack.Push(w);
             _windowPoolCount++;
         }
-        else { try { w.Close(); } catch { } }
+        else { try { w.Close(); } catch (Exception ex) { Diag.Swallowed(ex); } }
     }
 
     /// <summary>Close every pooled shell (service Dispose / app shutdown) — the pool is static
@@ -2274,7 +2274,7 @@ internal class Bubble
         {
             while (stack.Count > 0)
             {
-                try { stack.Pop()?.Close(); } catch { }
+                try { stack.Pop()?.Close(); } catch (Exception ex) { Diag.Swallowed(ex); }
             }
         }
         _windowPool.Clear();
@@ -2579,7 +2579,7 @@ internal class Bubble
             _bubbleImage.Effect = new DropShadowEffect
             { Color = Color.FromRgb(0xFF, 0x2D, 0x2D), BlurRadius = 30, ShadowDepth = 0, Opacity = 0.95 };
         }
-        catch { }
+        catch (Exception ex) { Diag.Swallowed(ex); }
         ShowChaosLabel("ENRAGED", Color.FromRgb(0xFF, 0x5A, 0x5A));
     }
     // ---- prism shadow pop ("Look at the bright colors...") ----
@@ -3238,7 +3238,7 @@ internal class Bubble
                         Opacity = 0.85
                     };
                 }
-                catch { }
+                catch (Exception ex) { Diag.Swallowed(ex); }
             }
         }
 
@@ -3248,7 +3248,7 @@ internal class Bubble
         {
             _isSpanked = true;
             _spankGrowth = 1.0;
-            try { _bubbleImage.Effect = new DropShadowEffect { Color = Color.FromRgb(0xFF, 0x8A, 0x14), BlurRadius = 36, ShadowDepth = 0, Opacity = 1.0 }; } catch { }
+            try { _bubbleImage.Effect = new DropShadowEffect { Color = Color.FromRgb(0xFF, 0x8A, 0x14), BlurRadius = 36, ShadowDepth = 0, Opacity = 1.0 }; } catch (Exception ex) { Diag.Swallowed(ex); }
         }
 
         // Show + alt-tab hide (per-window mode only — the host/layer is already shown). A recycled shell
@@ -3356,7 +3356,7 @@ internal class Bubble
                             Canvas.SetTop(sp.Shape, sp.Y - sp.Size / 2);
                             sp.Shape.Opacity = Math.Max(0, sp.Alpha);
                         }
-                        catch { }
+                        catch (Exception ex) { Diag.Swallowed(ex); }
                     }
 
                     _sparkles[i] = sp;
@@ -3889,7 +3889,7 @@ internal class Bubble
                     Opacity = 0.8
                 };
             }
-            catch { }
+            catch (Exception ex) { Diag.Swallowed(ex); }
         }
 
         // Spawn sparkle particles if sparkle boost is unlocked
@@ -4064,7 +4064,7 @@ internal class Bubble
             BubbleService.ChaosLastPopXPx = popPx.X;
             BubbleService.ChaosLastPopYPx = popPx.Y;
         }
-        catch { }
+        catch (Exception ex) { Diag.Swallowed(ex); }
         ShowChaosLabel("SNAP", SnapColor);
         // First-contact verb hints: a completed hold is the lesson (per-variant key). Bound
         // pairs learn on the PAIR clearing (OnBoundHalfResolved) — one half held isn't enough.
@@ -4137,7 +4137,7 @@ internal class Bubble
                 if (ChaosSkiaFxOverlay.Enabled)
                     ChaosSkiaFxOverlay.Burst(popPx, _spec.IsLive ? SnapColor : _spec.Tint, _spec.IsLive ? 1.3 : 1.0);
             }
-            catch { }
+            catch (Exception ex) { Diag.Swallowed(ex); }
             // Mimic prism: the shadow pop — the copied bubble ghosts out underneath the burst.
             if (_spec.IsPrism && _prismGhost != null)
             {
@@ -4147,7 +4147,7 @@ internal class Bubble
                     _prismGhost.BeginAnimation(UIElement.OpacityProperty,
                         new System.Windows.Media.Animation.DoubleAnimation(0.6, 0, TimeSpan.FromMilliseconds(650)));
                 }
-                catch { }
+                catch (Exception ex) { Diag.Swallowed(ex); }
             }
             // Chaos bubble: a live bubble clicked in time is a DEFUSE (reward, no payload);
             // a darter caught is its own reward path; a benign bubble is a treat.
@@ -4198,7 +4198,7 @@ internal class Bubble
             // steer and hurry it — no compounding back up to comedy size.
             _spankGrowth = Math.Max(1.0, BubbleService.ChaosSpankGrowNow);
             // It changes color: the chase-glow deepens to a hot ally-pink.
-            try { _bubbleImage.Effect = new DropShadowEffect { Color = Color.FromRgb(0xFF, 0x14, 0x93), BlurRadius = 34, ShadowDepth = 0, Opacity = 1.0 }; } catch { }
+            try { _bubbleImage.Effect = new DropShadowEffect { Color = Color.FromRgb(0xFF, 0x14, 0x93), BlurRadius = 34, ShadowDepth = 0, Opacity = 1.0 }; } catch (Exception ex) { Diag.Swallowed(ex); }
             ShowChaosLabel("SPANKED", Color.FromRgb(0xFF, 0x4D, 0xC4));
         }
     }
@@ -4226,7 +4226,7 @@ internal class Bubble
         {
             _isSpanked = true;
             _spankGrowth = 1.0;   // no Spanker swell — the wave only throws it
-            try { _bubbleImage.Effect = new DropShadowEffect { Color = Color.FromRgb(0xFF, 0x14, 0x93), BlurRadius = 34, ShadowDepth = 0, Opacity = 1.0 }; } catch { }
+            try { _bubbleImage.Effect = new DropShadowEffect { Color = Color.FromRgb(0xFF, 0x14, 0x93), BlurRadius = 34, ShadowDepth = 0, Opacity = 1.0 }; } catch (Exception ex) { Diag.Swallowed(ex); }
             ShowChaosLabel("FLUNG", Color.FromRgb(0x7A, 0xE0, 0xFF));
         }
     }
@@ -4247,7 +4247,7 @@ internal class Bubble
             if (ChaosSkiaFxOverlay.Enabled)
                 ChaosSkiaFxOverlay.Burst(px, Color.FromRgb(0xFF, 0x3D, 0x5A), 1.4);   // risk-red detonation
         }
-        catch { }
+        catch (Exception ex) { Diag.Swallowed(ex); }
         ShowChaosLabel("✖", Color.FromRgb(0xFF, 0x3D, 0x5A));
         _onTeaseTouched?.Invoke(this);
     }
@@ -4267,7 +4267,7 @@ internal class Bubble
             BubbleService.ChaosLastPopXPx = px.X;
             BubbleService.ChaosLastPopYPx = px.Y;
         }
-        catch { }
+        catch (Exception ex) { Diag.Swallowed(ex); }
         if (_prismGhost != null)
         {
             try
@@ -4276,7 +4276,7 @@ internal class Bubble
                 _prismGhost.BeginAnimation(UIElement.OpacityProperty,
                     new System.Windows.Media.Animation.DoubleAnimation(0.6, 0, TimeSpan.FromMilliseconds(650)));
             }
-            catch { }
+            catch (Exception ex) { Diag.Swallowed(ex); }
         }
         ShowChaosLabel("SHATTER", Color.FromRgb(0xCF, 0xEC, 0xFF));
         _onBrittleShattered?.Invoke(this);
@@ -4335,7 +4335,7 @@ internal class Bubble
             BubbleService.ChaosLastPopXPx = detPx.X;
             BubbleService.ChaosLastPopYPx = detPx.Y;
         }
-        catch { }
+        catch (Exception ex) { Diag.Swallowed(ex); }
         ShowChaosEffectLabel();   // the live effect is firing → flash its color-coded word at the bubble
         _onDetonate?.Invoke(this);
         // Pop/burst animation + Destroy handled by AnimateFrame().
@@ -4366,7 +4366,7 @@ internal class Bubble
             double cy = _posY + _size / 2.0;
             ChaosPopText.Show(cx, cy + yOffsetDip, word, color);
         }
-        catch { }
+        catch (Exception ex) { Diag.Swallowed(ex); }
     }
 
     /// <summary>Builds the chaos-only visual layers (tint, label, fuse ring). No-op for ambient bubbles.</summary>
@@ -4622,7 +4622,7 @@ internal class Bubble
             _hintEl.BeginAnimation(UIElement.OpacityProperty, null);
             _hintEl.Visibility = Visibility.Collapsed;
         }
-        catch { }
+        catch (Exception ex) { Diag.Swallowed(ex); }
         _hintEl = null;
     }
 
@@ -4677,7 +4677,7 @@ internal class Bubble
                 && _teaseAnimatedAlive < PerformanceProfile.MaxAnimatedTeaseBubbles(PerformanceProfile.CurrentTier))
             {
                 long len = 0;
-                try { len = new FileInfo(path).Length; } catch { }
+                try { len = new FileInfo(path).Length; } catch (Exception ex) { Diag.Swallowed(ex); }
                 animate = len > 0 && len <= ChaosTuning.TEASE_ANIMATED_MAX_BYTES;
             }
             if (animate)
@@ -4719,9 +4719,9 @@ internal class Bubble
                                 if (_teaseStillCache.Count > 12) _teaseStillCache.Clear();
                                 _teaseStillCache[file] = bmp;
                             }
-                            Application.Current?.Dispatcher.BeginInvoke(() => { try { img.Source = bmp; } catch { } });
+                            Application.Current?.Dispatcher.BeginInvoke(() => { try { img.Source = bmp; } catch (Exception ex) { Diag.Swallowed(ex); } });
                         }
-                        catch { }
+                        catch (Exception ex) { Diag.Swallowed(ex); }
                     });
                 }
             }
@@ -4846,24 +4846,24 @@ internal class Bubble
             // leaving it on a recycled pooled window would root this dead bubble forever.
             if (_winClickHandler != null)
             {
-                try { _window.MouseLeftButtonDown -= _winClickHandler; } catch { }
-                try { _window.MouseRightButtonDown -= _winClickHandler; } catch { }
+                try { _window.MouseLeftButtonDown -= _winClickHandler; } catch (Exception ex) { Diag.Swallowed(ex); }
+                try { _window.MouseRightButtonDown -= _winClickHandler; } catch (Exception ex) { Diag.Swallowed(ex); }
                 _winClickHandler = null;
             }
             _grid.Children.Clear();
         }
-        catch { }
+        catch (Exception ex) { Diag.Swallowed(ex); }
 
         if (_useLayer)
         {
             // Layer mode: drop the draw item (disposes its owned tease frames) — no window, no Canvas child.
-            try { if (_layerItem != null) s_layer?.Remove(_layerItem); } catch { }
+            try { if (_layerItem != null) s_layer?.Remove(_layerItem); } catch (Exception ex) { Diag.Swallowed(ex); }
             _layerItem = null;
         }
         else if (_useHost)
         {
             // Host mode: pull the grid off the shared Canvas — there's no per-bubble window to recycle.
-            try { ChaosBubbleHostOverlay.Remove(_grid); } catch { }
+            try { ChaosBubbleHostOverlay.Remove(_grid); } catch (Exception ex) { Diag.Swallowed(ex); }
         }
         else
         {
@@ -4874,7 +4874,7 @@ internal class Bubble
         }
 
         // Notify service to remove from list (after animation completed)
-        try { _onDestroy?.Invoke(this); } catch { }
+        try { _onDestroy?.Invoke(this); } catch (Exception ex) { Diag.Swallowed(ex); }
     }
 
     /// <summary>
@@ -4892,7 +4892,7 @@ internal class Bubble
             if (hwnd == IntPtr.Zero) return;
             SetWindowPos(hwnd, HWND_TOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
         }
-        catch { }
+        catch (Exception ex) { Diag.Swallowed(ex); }
     }
 
     /// <summary>
@@ -4914,7 +4914,7 @@ internal class Bubble
             int side = (int)Math.Round(_winDim * _dpiScale);
             SetWindowPos(hwnd, IntPtr.Zero, px, py, side, side, SWP_NOZORDER | SWP_NOACTIVATE);
         }
-        catch { }
+        catch (Exception ex) { Diag.Swallowed(ex); }
     }
 
     #region Win32
@@ -4979,7 +4979,7 @@ internal class Bubble
             if (hwnd == IntPtr.Zero) return;
             SetWindowLong(hwnd, GWL_EXSTYLE, GetWindowLong(hwnd, GWL_EXSTYLE) | WS_EX_TRANSPARENT);
         }
-        catch { }
+        catch (Exception ex) { Diag.Swallowed(ex); }
     }
 
     private void HideFromAltTab()
@@ -4999,7 +4999,7 @@ internal class Bubble
                 flags |= WS_EX_TRANSPARENT;
             SetWindowLong(hwnd, GWL_EXSTYLE, flags);
         }
-        catch { }
+        catch (Exception ex) { Diag.Swallowed(ex); }
     }
 
     private const int GWL_EXSTYLE = -20;

--- a/ConditioningControlPanel/Services/Chaos/DtrhHostService.cs
+++ b/ConditioningControlPanel/Services/Chaos/DtrhHostService.cs
@@ -79,8 +79,8 @@ internal static class DtrhHostService
         try
         {
             // EMI Desk: the ring learns from every open, not just its own cards.
-            try { App.EmiDesk?.NoteOpen("dtrh"); } catch { }
-            try { App.EmiDesk?.Fire("dtrhOpened", null); } catch { }
+            try { App.EmiDesk?.NoteOpen("dtrh"); } catch (Exception ex) { Diag.Swallowed(ex); }
+            try { App.EmiDesk?.Fire("dtrhOpened", null); } catch (Exception ex) { Diag.Swallowed(ex); }
             _emiOpenedUtc = DateTime.UtcNow;
 
             // The descent's audio (bubbles sfx, vn shared, drone bed) ships as the lazy audio-web
@@ -296,10 +296,10 @@ internal static class DtrhHostService
                 var diff = (string?)o["difficulty"] ?? "Gentle";
                 if (!_testMode)
                 {
-                    try { ChaosCrashSentinel.Mark($"mode=dtrh-web diff={diff}"); } catch { }
-                    try { App.Bark?.NotifyChaosRunStarted(diff); } catch { }
+                    try { ChaosCrashSentinel.Mark($"mode=dtrh-web diff={diff}"); } catch (Exception ex) { Diag.Swallowed(ex); }
+                    try { App.Bark?.NotifyChaosRunStarted(diff); } catch (Exception ex) { Diag.Swallowed(ex); }
                 }
-                try { Haptics.DtrhHapticDirector.OnRunStarted(); } catch { }
+                try { Haptics.DtrhHapticDirector.OnRunStarted(); } catch (Exception ex) { Diag.Swallowed(ex); }
                 App.Logger?.Information("DtrhHost: run started (diff={D}, mode={M})", diff, (string?)o["mode"]);
                 break;
             }
@@ -309,13 +309,13 @@ internal static class DtrhHostService
             case "bark":
                 // Haptics tap FIRST: the moment happened whether or not a voice line plays
                 // over it (the vn-speaking gate below only guards the audio mix).
-                try { Haptics.DtrhHapticDirector.OnGameEvent(o); } catch { }
+                try { Haptics.DtrhHapticDirector.OnGameEvent(o); } catch (Exception ex) { Diag.Swallowed(ex); }
                 if (_vnSpeaking) break;   // don't let a bark talk over her VN line
                 RouteBark(o);
                 break;
             case "haptic-state":
                 // page's ~2s depth/melt feed for the haptic director's ambient floor
-                try { Haptics.DtrhHapticDirector.OnHapticState(o); } catch { }
+                try { Haptics.DtrhHapticDirector.OnHapticState(o); } catch (Exception ex) { Diag.Swallowed(ex); }
                 break;
             case "heartbeat":
                 _lastHeartbeatUtc = DateTime.UtcNow;
@@ -323,7 +323,7 @@ internal static class DtrhHostService
             case "asset-stats":
                 // per-asset engagement delta (weighted attention + paddle interactions);
                 // summed into dtrh_asset_stats.json for future media-selection features
-                try { DtrhAssetStatsStore.Merge(o); } catch { }
+                try { DtrhAssetStatsStore.Merge(o); } catch (Exception ex) { Diag.Swallowed(ex); }
                 break;
             case "loom-save":
             {
@@ -462,7 +462,7 @@ internal static class DtrhHostService
                 // one would deal a second classroom. Persist + rebroadcast so JS agrees.
                 ChaosMeta.State.ForceScriptedRun = false;
                 ChaosMeta.Save();
-                try { _meta?.Rebroadcast(); } catch { }
+                try { _meta?.Rebroadcast(); } catch (Exception ex) { Diag.Swallowed(ex); }
             }
             _host?.Post(new { type = "run-config", runConfig = BuildRunConfig(cfg) });
             App.Logger?.Information("DtrhHost: dealt run config (diff={D}, scripted={S})", cfg.Difficulty, scripted);
@@ -574,7 +574,7 @@ internal static class DtrhHostService
     private static void OnRunEnded(JObject o)
     {
         _runActive = false;
-        try { Haptics.DtrhHapticDirector.OnRunEnded(); } catch { }
+        try { Haptics.DtrhHapticDirector.OnRunEnded(); } catch (Exception ex) { Diag.Swallowed(ex); }
         ApplyWorldFreeze(false);   // a run ending mid-freeze must resume native video + voice, not wedge them through the hub
         try
         {
@@ -623,18 +623,18 @@ internal static class DtrhHostService
                     if (bubblesPopped > 0) App.Achievements?.TrackBubblesPopped(bubblesPopped);
                 }
                 catch (Exception ex) { App.Logger?.Debug("DtrhHost bubble credit: {E}", ex.Message); }
-                try { RevealService.Sync("run_end"); } catch { }
+                try { RevealService.Sync("run_end"); } catch (Exception ex) { Diag.Swallowed(ex); }
                 try
                 {
                     var nowRank = ChaosRanks.For(ChaosMeta.State.RunsCompleted);
                     if ((int)nowRank > ChaosMeta.State.LastRankSeen) rankUp = nowRank;
                 }
-                catch { }
-                try { App.Bark?.NotifyChaosRunCompleted((int)finalXp, diff); } catch { }
-                try { ChaosCrashSentinel.Clear(); } catch { }
+                catch (Exception ex) { Diag.Swallowed(ex); }
+                try { App.Bark?.NotifyChaosRunCompleted((int)finalXp, diff); } catch (Exception ex) { Diag.Swallowed(ex); }
+                try { ChaosCrashSentinel.Clear(); } catch (Exception ex) { Diag.Swallowed(ex); }
                 // RevealService.Sync mutated pendingReveals BEHIND the bridge - push a fresh
                 // snapshot so the Warren's flash pass sees the new pendings on return.
-                try { _meta?.Rebroadcast(); } catch { }
+                try { _meta?.Rebroadcast(); } catch (Exception ex) { Diag.Swallowed(ex); }
             }
 
             // Local-only session telemetry: fold the host-measured natives + payout into the
@@ -761,7 +761,7 @@ internal static class DtrhHostService
     {
         if (on == _worldFrozen) return;
         _worldFrozen = on;
-        try { Haptics.DtrhHapticDirector.OnWorldFreeze(on); } catch { }
+        try { Haptics.DtrhHapticDirector.OnWorldFreeze(on); } catch (Exception ex) { Diag.Swallowed(ex); }
         var disp = Application.Current?.Dispatcher;
         if (disp == null) return;
         disp.BeginInvoke(() =>
@@ -807,13 +807,13 @@ internal static class DtrhHostService
                 _videoHooked = false;
             }
         }
-        catch { }
+        catch (Exception ex) { Diag.Swallowed(ex); }
     }
 
     private static void OnVideoStarted(object? sender, EventArgs e)
     {
         if (_runActive) _runVideosShown++;   // session telemetry: a video was shown this run
-        try { Haptics.DtrhHapticDirector.OnVideoCovering(true); } catch { }
+        try { Haptics.DtrhHapticDirector.OnVideoCovering(true); } catch (Exception ex) { Diag.Swallowed(ex); }
         var disp = Application.Current?.Dispatcher;
         if (disp == null || _host == null) return;
         disp.BeginInvoke(() => _host?.Post(new { type = "payload-state", kind = "video", on = true }));
@@ -852,7 +852,7 @@ internal static class DtrhHostService
 
     private static void OnVideoEnded(object? sender, EventArgs e)
     {
-        try { Haptics.DtrhHapticDirector.OnVideoCovering(false); } catch { }
+        try { Haptics.DtrhHapticDirector.OnVideoCovering(false); } catch (Exception ex) { Diag.Swallowed(ex); }
         var disp = Application.Current?.Dispatcher;
         if (disp == null || _host == null) return;
         disp.BeginInvoke(() =>
@@ -929,7 +929,7 @@ internal static class DtrhHostService
 
     private static void StopHeartbeatWatch()
     {
-        try { _heartbeatWatch?.Stop(); } catch { }
+        try { _heartbeatWatch?.Stop(); } catch (Exception ex) { Diag.Swallowed(ex); }
         _heartbeatWatch = null;
     }
 
@@ -970,7 +970,7 @@ internal static class DtrhHostService
 
     private static void CancelExitWatchdog()
     {
-        try { _exitWatchdog?.Stop(); } catch { }
+        try { _exitWatchdog?.Stop(); } catch (Exception ex) { Diag.Swallowed(ex); }
         _exitWatchdog = null;
     }
 
@@ -988,7 +988,7 @@ internal static class DtrhHostService
         {
             int emiMinutes = Math.Max(0, (int)(DateTime.UtcNow - _emiOpenedUtc).TotalMinutes);
             _emiOpenedUtc = DateTime.MinValue;
-            try { App.EmiDesk?.Fire("dtrhClosed", new { minutes = emiMinutes }); } catch { }
+            try { App.EmiDesk?.Fire("dtrhClosed", new { minutes = emiMinutes }); } catch (Exception ex) { Diag.Swallowed(ex); }
         }
 
         try
@@ -997,20 +997,20 @@ internal static class DtrhHostService
         StopHeartbeatWatch();
         HookVideoEvents(false);
         // Never leave the toy running after the window dies (crash, watchdog, clean exit alike).
-        try { Haptics.DtrhHapticDirector.OnClosed(); } catch { }
+        try { Haptics.DtrhHapticDirector.OnClosed(); } catch (Exception ex) { Diag.Swallowed(ex); }
         // Never leave a video or voiceline wedged paused if the window dies mid-freeze.
-        if (_worldFrozen) { _worldFrozen = false; try { App.Video?.PlayPrimary(); } catch { } try { App.AvatarWindow?.ResumeSpokenAudio(); } catch { } }
+        if (_worldFrozen) { _worldFrozen = false; try { App.Video?.PlayPrimary(); } catch (Exception ex) { Diag.Swallowed(ex); } try { App.AvatarWindow?.ResumeSpokenAudio(); } catch (Exception ex) { Diag.Swallowed(ex); } }
         // ...and never leave every video silent because the dive ended while muted.
-        if (_diveMuted) { _diveMuted = false; try { App.Video?.SetExternalMute(false); } catch { } }
-        try { _meta?.FlushSave(); } catch { }
+        if (_diveMuted) { _diveMuted = false; try { App.Video?.SetExternalMute(false); } catch (Exception ex) { Diag.Swallowed(ex); } }
+        try { _meta?.FlushSave(); } catch (Exception ex) { Diag.Swallowed(ex); }
         if (_runActive && !_testMode)
         {
             // The window died mid-run (crash/force close): leave the sentinel armed only for
             // genuine process death; a deliberate close is a clean end.
-            try { ChaosCrashSentinel.Clear(); } catch { }
+            try { ChaosCrashSentinel.Clear(); } catch (Exception ex) { Diag.Swallowed(ex); }
         }
         _runActive = false;
-        try { _host?.Dispose(); } catch { }
+        try { _host?.Dispose(); } catch (Exception ex) { Diag.Swallowed(ex); }
         _host = null;
         _meta = null;
         _exiting = false;
@@ -1018,7 +1018,7 @@ internal static class DtrhHostService
         if (_minimizedMainWindow)
         {
             _minimizedMainWindow = false;
-            try { (Application.Current?.MainWindow as MainWindow)?.ShowFromTray(); } catch { }
+            try { (Application.Current?.MainWindow as MainWindow)?.ShowFromTray(); } catch (Exception ex) { Diag.Swallowed(ex); }
         }
         App.Logger?.Information("DtrhHostService: closed");
         }
@@ -1055,7 +1055,7 @@ internal static class DtrhHostService
                 if (pool != null)
                     foreach (var kv in pool) if (kv.Value) thoughts.Add(kv.Key);
             }
-            catch { }
+            catch (Exception ex) { Diag.Swallowed(ex); }
 
             return new
             {

--- a/ConditioningControlPanel/Services/Flash/FlashService.cs
+++ b/ConditioningControlPanel/Services/Flash/FlashService.cs
@@ -93,7 +93,7 @@ namespace ConditioningControlPanel.Services
                 catch (Exception ex)
                 {
                     try { App.Logger?.Debug("FlashService unduck failed: {Error}", ex.Message); }
-                    catch { }
+                    catch (Exception exIgnored) { Diag.Swallowed(exIgnored); }
                 }
             });
         }
@@ -282,7 +282,7 @@ namespace ConditioningControlPanel.Services
                             NativeMethods.SetWindowPos(hostHwnd, NativeMethods.HWND_TOPMOST, 0, 0, 0, 0,
                                 NativeMethods.SWP_NOMOVE | NativeMethods.SWP_NOSIZE | NativeMethods.SWP_NOACTIVATE);
                     }
-                    catch { }
+                    catch (Exception ex) { Diag.Swallowed(ex); }
                 }
             });
         }
@@ -314,7 +314,7 @@ namespace ConditioningControlPanel.Services
                     }
                 }
             }
-            catch { /* a diagnostic/reconciler accessor must never throw */ }
+            catch (Exception ex) { Diag.Swallowed(ex, "diagnostic accessor must never throw"); }
             return handles;
         }
 
@@ -455,7 +455,7 @@ namespace ConditioningControlPanel.Services
             App.Logger.Information("FlashService started, images path: {Path}", _imagesPath);
 
             // EMI Desk (MOMENTS 4.B). Fire last: nothing about her may sit in front of the start.
-            try { App.EmiDesk?.Fire("flashesStarted", null); } catch { }
+            try { App.EmiDesk?.Fire("flashesStarted", null); } catch (Exception ex) { Diag.Swallowed(ex); }
         }
 
         public void Stop()
@@ -471,9 +471,9 @@ namespace ConditioningControlPanel.Services
             var retiredCts = _cancellationSource;
             _cancellationSource = null;
             try { retiredCts?.Cancel(); }
-            catch (ObjectDisposedException) { }
+            catch (ObjectDisposedException) { } // swallow: retired CTS already disposed
             try { retiredCts?.Dispose(); }
-            catch (ObjectDisposedException) { }
+            catch (ObjectDisposedException) { } // swallow: retired CTS already disposed
             StopHeartbeat();
             _schedulerTimer?.Stop();
 
@@ -489,7 +489,7 @@ namespace ConditioningControlPanel.Services
             App.DiscordRpc?.SetIdleActivity();
 
             // EMI Desk (MOMENTS 4.B): how long it ran, read before the start stamp is cleared.
-            try { App.EmiDesk?.Fire("flashesStopped", new { minutes = RunMinutes }); } catch { }
+            try { App.EmiDesk?.Fire("flashesStopped", new { minutes = RunMinutes }); } catch (Exception ex) { Diag.Swallowed(ex); }
             _runStartedUtc = null;
 
             App.Logger.Information("FlashService stopped");
@@ -818,7 +818,7 @@ namespace ConditioningControlPanel.Services
                     // same two destinations, and the moment's launch/1 limit is what keeps the
                     // three sites that can reach this beat (here, the wallpaper, the summon) to
                     // exactly one line.
-                    try { EmiDesk.EmiOffers.AnnounceEmptyLibrary(); } catch { }
+                    try { EmiDesk.EmiOffers.AnnounceEmptyLibrary(); } catch (Exception ex) { Diag.Swallowed(ex); }
 
                     _isBusy = false;
                     return;
@@ -914,7 +914,7 @@ namespace ConditioningControlPanel.Services
             // Drain any stragglers so unobserved exceptions don't linger.
             if (pending.Count > 0)
             {
-                try { await Task.WhenAll(pending); } catch { /* individual tasks are already guarded */ }
+                try { await Task.WhenAll(pending); } catch (Exception ex) { Diag.Swallowed(ex, "individual tasks are already guarded"); }
             }
 
             return loaded;
@@ -998,7 +998,7 @@ namespace ConditioningControlPanel.Services
                                 BitmapCreateOptions.DelayCreation, BitmapCacheOption.None);
                             srcW = probe.PixelWidth; srcH = probe.PixelHeight;
                         }
-                        catch { }
+                        catch (Exception ex) { Diag.Swallowed(ex); }
 
                         var bmp = new BitmapImage();
                         bmp.BeginInit();
@@ -1183,7 +1183,7 @@ namespace ConditioningControlPanel.Services
                         BitmapCreateOptions.DelayCreation, BitmapCacheOption.None);
                     srcW = probe.PixelWidth; srcH = probe.PixelHeight;
                 }
-                catch { }
+                catch (Exception ex) { Diag.Swallowed(ex); }
 
                 var bmp = new BitmapImage();
                 bmp.BeginInit();
@@ -1326,7 +1326,7 @@ namespace ConditioningControlPanel.Services
                             }
                         });
                     }
-                    catch { }
+                    catch (Exception ex) { Diag.Swallowed(ex); }
                 }, TaskContinuationOptions.NotOnCanceled);
             }
 
@@ -1361,7 +1361,7 @@ namespace ConditioningControlPanel.Services
                                     SpawnFlashWindow(capturedData, settings, capturedLifetime, capturedGeneration, capturedSuppressHaptic, capturedOneShotGen);
                             });
                         }
-                        catch { }
+                        catch (Exception ex) { Diag.Swallowed(ex); }
                     }, TaskContinuationOptions.NotOnCanceled);
                 }
             }
@@ -1498,7 +1498,7 @@ namespace ConditioningControlPanel.Services
                             window.IsFadingOut = true;
                         });
                     }
-                    catch { }
+                    catch (Exception ex) { Diag.Swallowed(ex); }
                 });
 
                 // Create image control (layer mode has no WPF visual tree at all - the layer
@@ -1768,8 +1768,8 @@ namespace ConditioningControlPanel.Services
             {
                 // If anything fails before the window is tracked, dispose the CTS so it doesn't leak~ 🧹
                 App.Logger?.Debug("SpawnFlashWindow failed: {Error}", ex.Message);
-                try { windowCts.Cancel(); } catch { }
-                try { windowCts.Dispose(); } catch { }
+                try { windowCts.Cancel(); } catch (Exception exIgnored) { Diag.Swallowed(exIgnored); }
+                try { windowCts.Dispose(); } catch (Exception exIgnored) { Diag.Swallowed(exIgnored); }
                 if (window != null)
                 {
                     try
@@ -1790,7 +1790,7 @@ namespace ConditioningControlPanel.Services
                         if (window.UsesLayer) CloseStateBagWindow(window);
                         else if (!window.UsesHost) window.Close();
                     }
-                    catch { }
+                    catch (Exception exIgnored) { Diag.Swallowed(exIgnored); }
                 }
                 return;
             }
@@ -1811,7 +1811,7 @@ namespace ConditioningControlPanel.Services
                     if (App.Achievements?.Progress?.TotalFlashImages == 1)
                         App.EmiDesk?.Fire("firstFlashEver", null);
                 }
-                catch { }
+                catch (Exception ex) { Diag.Swallowed(ex); }
             }
         }
 
@@ -2040,7 +2040,7 @@ namespace ConditioningControlPanel.Services
             if (frames == null) return;
             foreach (var f in frames)
             {
-                try { f?.Dispose(); } catch { }
+                try { f?.Dispose(); } catch (Exception ex) { Diag.Swallowed(ex); }
             }
         }
 
@@ -2058,7 +2058,7 @@ namespace ConditioningControlPanel.Services
         private void ReleaseLayerHook()
         {
             if (_layerHook == null) return;
-            try { _layerHook.Dispose(); } catch { }
+            try { _layerHook.Dispose(); } catch (Exception ex) { Diag.Swallowed(ex); }
             _layerHook = null;
             _layerHits = Array.Empty<LayerHit>();
         }
@@ -2141,7 +2141,7 @@ namespace ConditioningControlPanel.Services
                         exclude = new float[] { r.Left, r.Top, r.Right - r.Left, r.Bottom - r.Top };
                 }
             }
-            catch { }
+            catch (Exception ex) { Diag.Swallowed(ex); }
             _layerVideoExcludePx = exclude;
 
             if (!anyLayer) ReleaseLayerHook();
@@ -2151,7 +2151,7 @@ namespace ConditioningControlPanel.Services
         private void OnFlashClicked(FlashWindow window, AppSettings settings, bool fromGaze = false)
         {
             // Cancel only THIS window's lifetime — other windows keep living~ ✨
-            try { window.LifetimeCts?.Cancel(); } catch { }
+            try { window.LifetimeCts?.Cancel(); } catch (Exception ex) { Diag.Swallowed(ex); }
 
             lock (_lockObj)
             {
@@ -3316,7 +3316,7 @@ namespace ConditioningControlPanel.Services
                     App.Logger?.Information("FlashService: warmed {Warmed} remote still(s), {Ready} ready", warmed, ready);
                 }
             }
-            catch (OperationCanceledException) { /* teardown */ }
+            catch (OperationCanceledException) { } // swallow: teardown
             catch (Exception ex)
             {
                 App.Logger?.Debug("FlashService: remote prefetch failed (non-fatal): {Error}", ex.Message);
@@ -3450,7 +3450,7 @@ namespace ConditioningControlPanel.Services
                 return LooksLikeGif(header.Slice(0, read));
             }
             catch { return false; }
-            finally { try { if (stream.CanSeek) stream.Position = 0; } catch { } }
+            finally { try { if (stream.CanSeek) stream.Position = 0; } catch (Exception ex) { Diag.Swallowed(ex); } }
         }
 
         /// <param name="allowAnimated">False for the single-bitmap overlay caller, which only ever
@@ -3482,7 +3482,7 @@ namespace ConditioningControlPanel.Services
                 {
                     App.Logger?.Debug("FlashService: remote GIF {Url} frame decode failed, falling back to still: {Error}", url, ex.Message);
                 }
-                finally { try { if (stream.CanSeek) stream.Position = 0; } catch { } }
+                finally { try { if (stream.CanSeek) stream.Position = 0; } catch (Exception ex) { Diag.Swallowed(ex); } }
             }
 
             // WIC first - same decoder, same decode-time downscale and same WPF-owned buffer as
@@ -3496,7 +3496,7 @@ namespace ConditioningControlPanel.Services
                     var probe = BitmapFrame.Create(stream, BitmapCreateOptions.DelayCreation, BitmapCacheOption.None);
                     srcW = probe.PixelWidth; srcH = probe.PixelHeight;
                 }
-                catch { }
+                catch (Exception ex) { Diag.Swallowed(ex); }
 
                 stream.Position = 0;
                 var bmp = new BitmapImage();
@@ -4033,7 +4033,7 @@ namespace ConditioningControlPanel.Services
                         // process lifetime. Close it explicitly - a leaked USER object per pool
                         // eviction is exactly the kind of drip that ends a 4h session with
                         // CreateWindowEx failing (#627).
-                        try { pooled.Close(); } catch { }
+                        try { pooled.Close(); } catch (Exception ex) { Diag.Swallowed(ex); }
                         continue;
                     }
                     if (match == null && (int)pooled.Width == width && (int)pooled.Height == height)
@@ -4080,10 +4080,10 @@ namespace ConditioningControlPanel.Services
             {
                 if (s is FlashWindow fw)
                 {
-                    try { fw.LifetimeRegistration?.Dispose(); } catch { }
+                    try { fw.LifetimeRegistration?.Dispose(); } catch (Exception ex) { Diag.Swallowed(ex); }
                     fw.LifetimeRegistration = null;
-                    try { fw.LifetimeCts?.Cancel(); } catch { }
-                    try { fw.LifetimeCts?.Dispose(); } catch { }
+                    try { fw.LifetimeCts?.Cancel(); } catch (Exception ex) { Diag.Swallowed(ex); }
+                    try { fw.LifetimeCts?.Dispose(); } catch (Exception ex) { Diag.Swallowed(ex); }
                     fw.LifetimeCts = null;
                 }
             };
@@ -4121,12 +4121,12 @@ namespace ConditioningControlPanel.Services
             try
             {
                 // Dispose CTS registration first to release the closure capturing this window
-                try { window.LifetimeRegistration?.Dispose(); } catch { }
+                try { window.LifetimeRegistration?.Dispose(); } catch (Exception ex) { Diag.Swallowed(ex); }
                 window.LifetimeRegistration = null;
 
                 // Cancel and dispose per-window lifetime token~ 🧹
-                try { window.LifetimeCts?.Cancel(); } catch { }
-                try { window.LifetimeCts?.Dispose(); } catch { }
+                try { window.LifetimeCts?.Cancel(); } catch (Exception ex) { Diag.Swallowed(ex); }
+                try { window.LifetimeCts?.Dispose(); } catch (Exception ex) { Diag.Swallowed(ex); }
                 window.LifetimeCts = null;
 
                 // Release bitmap references before retiring to prevent memory accumulation
@@ -4152,7 +4152,7 @@ namespace ConditioningControlPanel.Services
                         glow.BeginAnimation(System.Windows.Media.Effects.DropShadowEffect.BlurRadiusProperty, null);
                         glow.BeginAnimation(System.Windows.Media.Effects.DropShadowEffect.OpacityProperty, null);
                     }
-                    catch { }
+                    catch (Exception ex) { Diag.Swallowed(ex); }
                     window.GlowEffect = null;
                 }
 
@@ -4218,7 +4218,7 @@ namespace ConditioningControlPanel.Services
             catch (Exception ex)
             {
                 App.Logger?.Debug("Failed to close flash window: {Error}", ex.Message);
-                try { window.Close(); } catch { }
+                try { window.Close(); } catch (Exception exIgnored) { Diag.Swallowed(exIgnored); }
             }
         }
 
@@ -4239,11 +4239,11 @@ namespace ConditioningControlPanel.Services
                 {
                     window.Dispatcher.BeginInvoke(() =>
                     {
-                        try { window.Close(); } catch { }
+                        try { window.Close(); } catch (Exception ex) { Diag.Swallowed(ex); }
                     });
                 }
             }
-            catch { }
+            catch (Exception ex) { Diag.Swallowed(ex); }
         }
 
         // WndProc hook for flash windows: drop WM_DPICHANGED so WPF never runs its auto DPI-rescale
@@ -4344,19 +4344,19 @@ namespace ConditioningControlPanel.Services
         public void Dispose()
         {
             Stop();
-            try { _flashLayer?.Clear(); } catch { }
+            try { _flashLayer?.Clear(); } catch (Exception ex) { Diag.Swallowed(ex); }
             // Drain the recycled-window pool — the only place pooled hwnds actually close
             // (app shutdown; nothing else is animating, so the close is safe here).
             while (_windowPool.Count > 0)
             {
-                try { _windowPool.Pop().Close(); } catch { }
+                try { _windowPool.Pop().Close(); } catch (Exception ex) { Diag.Swallowed(ex); }
             }
             _cancellationSource?.Dispose();
             // Stop any remote prefetch mid-download. Separate from _cancellationSource, which
             // Stop() already cancelled - the warm pool is meant to survive a stop/start cycle
             // and only dies with the service.
-            try { _remoteCts.Cancel(); } catch { }
-            try { _remoteCts.Dispose(); } catch { }
+            try { _remoteCts.Cancel(); } catch (Exception ex) { Diag.Swallowed(ex); }
+            try { _remoteCts.Dispose(); } catch (Exception ex) { Diag.Swallowed(ex); }
             lock (_remoteLock) _remoteReady.Clear();
             StopCurrentSound();
             CleanupTempPackFiles();
@@ -4526,10 +4526,9 @@ namespace ConditioningControlPanel.Services
                 LifetimeCts.CancelAfter(extraMs);
                 ExpiresAt = DateTime.Now.AddMilliseconds(extraMs);
             }
-            catch
+            catch (Exception ex)
             {
-                // CTS may have been disposed (window fading out) — silent
-                // is fine, the window is already on its way out.
+                Diag.Swallowed(ex, "lifetime CTS disposed, the window is already fading out");
             }
         }
 

--- a/ConditioningControlPanel/Services/Video/VideoService.cs
+++ b/ConditioningControlPanel/Services/Video/VideoService.cs
@@ -712,7 +712,7 @@ namespace ConditioningControlPanel.Services
                 if (_libVLCReady.Task.Wait(timeoutMs))
                     return _libVLC != null;
             }
-            catch { }
+            catch (Exception ex) { Diag.Swallowed(ex); }
 
             App.Logger?.Warning("VideoService: Timed out waiting for LibVLC initialization");
             return _libVLC != null;
@@ -1238,7 +1238,7 @@ namespace ConditioningControlPanel.Services
             // a previous run that never disarmed (its teardown threw). Those handles are dead, and
             // acting on them would make the escape hatch's trace line lie about what it released.
             lock (_managedLock) { _managedWindowHandles.Clear(); }
-            try { _managedWedgeWatchdog?.Dispose(); } catch { }
+            try { _managedWedgeWatchdog?.Dispose(); } catch (Exception ex) { Diag.Swallowed(ex); }
             _managedWedgeWatchdog = new System.Threading.Timer(_ => ManagedWedgeTick(), null, 3000, 3000);
             VideoDiag.Log("WEDGE", $"{label}: managed wedge watchdog armed");
         }
@@ -1250,7 +1250,7 @@ namespace ConditioningControlPanel.Services
             // not a game was running), so stay silent when there was nothing armed rather than write
             // a WEDGE line naming a run that ended long ago.
             bool wasArmed = _managedWedgeWatchdog != null;
-            try { _managedWedgeWatchdog?.Dispose(); } catch { }
+            try { _managedWedgeWatchdog?.Dispose(); } catch (Exception ex) { Diag.Swallowed(ex); }
             _managedWedgeWatchdog = null;
             lock (_managedLock) { _managedWindowHandles.Clear(); }
             if (wasArmed) VideoDiag.Log("WEDGE", $"{_managedLabel}: managed wedge watchdog disarmed");
@@ -1604,9 +1604,9 @@ namespace ConditioningControlPanel.Services
             _feedDeferDeadlineUtc = DateTime.MinValue;
 
             try { Microsoft.Win32.SystemEvents.SessionSwitch -= OnSessionSwitch; }
-            catch { }
+            catch (Exception ex) { Diag.Swallowed(ex); }
             try { Microsoft.Win32.SystemEvents.PowerModeChanged -= OnPowerModeChanged; }
-            catch { }
+            catch (Exception ex) { Diag.Swallowed(ex); }
 
             // Force cleanup of any playing video. Every caller of Stop() is a LIVE stop
             // (engine stop, panic, remote control, feature toggle) — app shutdown never
@@ -1878,7 +1878,7 @@ namespace ConditioningControlPanel.Services
             if (dispatcher == null || dispatcher.HasShutdownStarted)
             {
                 // No dispatcher to poll on, so the action can never run — release the caller's latch.
-                try { onExpired?.Invoke(); } catch { }
+                try { onExpired?.Invoke(); } catch (Exception ex) { Diag.Swallowed(ex); }
                 return;
             }
 
@@ -1908,8 +1908,8 @@ namespace ConditioningControlPanel.Services
                 }
                 catch (Exception ex)
                 {
-                    try { timer.Stop(); } catch { }
-                    try { onExpired?.Invoke(); } catch { }
+                    try { timer.Stop(); } catch (Exception exIgnored) { Diag.Swallowed(exIgnored); }
+                    try { onExpired?.Invoke(); } catch (Exception exIgnored) { Diag.Swallowed(exIgnored); }
                     App.Logger?.Debug("VideoService.RunWhenFeedClear: {E}", ex.Message);
                 }
             };
@@ -2581,7 +2581,7 @@ namespace ConditioningControlPanel.Services
                                 if (!_isCleaningUp)
                                     Application.Current?.Dispatcher?.Invoke(() => ForceCleanup());
                             }
-                            catch { /* Last resort failed */ }
+                            catch (Exception exIgnored) { Diag.Swallowed(exIgnored, "last-resort cleanup failed"); }
                         }
                     });
                 };
@@ -2871,7 +2871,7 @@ namespace ConditioningControlPanel.Services
                 if (App.Achievements?.Progress?.TotalVideoMinutes <= 0)
                     App.EmiDesk?.Fire("firstVideoEver", null);
             }
-            catch { }
+            catch (Exception ex) { Diag.Swallowed(ex); }
 
             // ---- hybrid routing (docs/BROWSER_VIDEO_ENGINE_PLAN.md §4) ----
             // The ONLY change to this path. When the browser engine takes the clip it satisfies the
@@ -3329,7 +3329,7 @@ namespace ConditioningControlPanel.Services
                             {
                                 Application.Current?.Dispatcher?.Invoke(() => ForceCleanup());
                             }
-                            catch { /* Last resort failed */ }
+                            catch (Exception exIgnored) { Diag.Swallowed(exIgnored, "last-resort cleanup failed"); }
                         }
                     });
                 };
@@ -3606,7 +3606,7 @@ namespace ConditioningControlPanel.Services
                     }
                     win?.Close();
                 }
-                catch { /* Ignore cleanup errors */ }
+                catch (Exception exIgnored) { Diag.Swallowed(exIgnored, "cleanup error"); }
 
                 // Create a black placeholder window so we don't crash
                 var fallbackDpi = BubbleCountWindow.GetDpiForScreen(screen);
@@ -3839,7 +3839,7 @@ namespace ConditioningControlPanel.Services
                             // Judging it here would skip to the next video the moment the user paused
                             // inside the grace window. Re-arm for another full grace instead.
                             VideoDiag.Log("BLUR", $"[{surfaceTag}] frame watchdog deferred - video is grace-paused");
-                            try { watch.Timer?.Change(VoutGraceMs, System.Threading.Timeout.Infinite); } catch { }
+                            try { watch.Timer?.Change(VoutGraceMs, System.Threading.Timeout.Infinite); } catch (Exception ex) { Diag.Swallowed(ex); }
                             return;
 
                         case VideoSurfaceHealth.FrameWatchdogAction.Retry:
@@ -3848,7 +3848,7 @@ namespace ConditioningControlPanel.Services
                                 VoutGraceMs, surfaceTag);
                             VideoDiag.Log("BLUR", $"[{surfaceTag}] NO FRAME within {VoutGraceMs}ms - per-surface retry, clip untouched");
                             RetryBlurSurface(watch, gen);
-                            try { watch.Timer?.Change(VoutGraceMs, System.Threading.Timeout.Infinite); } catch { }
+                            try { watch.Timer?.Change(VoutGraceMs, System.Threading.Timeout.Infinite); } catch (Exception ex) { Diag.Swallowed(ex); }
                             return;
 
                         case VideoSurfaceHealth.FrameWatchdogAction.GiveUp:
@@ -4064,7 +4064,7 @@ namespace ConditioningControlPanel.Services
                         if (hwnd != IntPtr.Zero)
                             lock (_videoWindowHandlesLock) { _videoWindowHandles.Remove(hwnd); }
                     }
-                    catch { }
+                    catch (Exception ex) { Diag.Swallowed(ex); }
 
                     win.Hide();
                     App.Logger?.Warning("VideoService: the dead blurred surface {Surface} was hidden - that monitor is free instead of holding a black fullscreen window for the rest of the clip",
@@ -4087,7 +4087,7 @@ namespace ConditioningControlPanel.Services
             }
             foreach (var t in watches.Select(w => w.Timer).Where(t => t != null))
             {
-                try { t!.Dispose(); } catch { }
+                try { t!.Dispose(); } catch (Exception ex) { Diag.Swallowed(ex); }
             }
         }
 
@@ -4319,7 +4319,7 @@ namespace ConditioningControlPanel.Services
                 {
                     if (_frameBuffer != IntPtr.Zero)
                     {
-                        try { Marshal.FreeHGlobal(_frameBuffer); } catch { /* ignore */ }
+                        try { Marshal.FreeHGlobal(_frameBuffer); } catch (Exception ex) { global::ConditioningControlPanel.Diag.Swallowed(ex); }
                     }
                     _frameBuffer = Marshal.AllocHGlobal((int)(bw * bh * 4));
                     _w = bw;
@@ -4578,7 +4578,7 @@ namespace ConditioningControlPanel.Services
             private void Unhook()
             {
                 if (!_hooked) return;
-                try { CompositionTarget.Rendering -= OnRendering; } catch { /* ignore */ }
+                try { CompositionTarget.Rendering -= OnRendering; } catch (Exception ex) { global::ConditioningControlPanel.Diag.Swallowed(ex); }
                 _hooked = false;
             }
 
@@ -4862,7 +4862,7 @@ namespace ConditioningControlPanel.Services
                 }
                 if (buf != IntPtr.Zero)
                 {
-                    try { Marshal.FreeHGlobal(buf); } catch { /* ignore */ }
+                    try { Marshal.FreeHGlobal(buf); } catch (Exception ex) { global::ConditioningControlPanel.Diag.Swallowed(ex); }
                     Diag("frame buffer freed (player Stop() completed)");
                 }
             }
@@ -5104,7 +5104,7 @@ namespace ConditioningControlPanel.Services
                     if (e.Key == Key.Escape)
                     {
                         try { App.Lockdown?.NotifyEscapeAttempt(Services.Possession.EscapeKinds.SystemKey); }
-                        catch { /* never let the haunt break key suppression */ }
+                        catch (Exception ex) { Diag.Swallowed(ex, "the haunt must never break key suppression"); }
                     }
 
                     // In strict mode, block panic key, Alt+F4, and system keys
@@ -5357,7 +5357,7 @@ namespace ConditioningControlPanel.Services
                 lock (_targets) { left = _targets.Count; }
                 if (left == 0) App.EmiDesk?.ReleaseHold("attentionCheckShown");
             }
-            catch { }
+            catch (Exception ex) { Diag.Swallowed(ex); }
         }
 
         private void SpawnTarget()
@@ -5394,7 +5394,7 @@ namespace ConditioningControlPanel.Services
                     var h = toyHandler;
                     if (h == null) return;
                     toyHandler = null;
-                    try { App.Haptics!.ToyInput.ButtonPressed -= h; } catch { }
+                    try { App.Haptics!.ToyInput.ButtonPressed -= h; } catch (Exception ex) { Diag.Swallowed(ex); }
                 }
 
                 App.Logger?.Debug("Spawning attention target: '{Text}' on {ScreenCount} screen(s) ({Spawned}/{Total})",
@@ -5481,7 +5481,7 @@ namespace ConditioningControlPanel.Services
                 // A HOLD, not a line. Released the moment no target is left on the books.
                 if (spawnedTargets.Count > 0)
                 {
-                    try { App.EmiDesk?.Fire("attentionCheckShown", null); } catch { }
+                    try { App.EmiDesk?.Fire("attentionCheckShown", null); } catch (Exception ex) { Diag.Swallowed(ex); }
                 }
 
                 // PHASE F: arm the toy-button alternative for this spawn's lifetime.
@@ -5553,7 +5553,7 @@ namespace ConditioningControlPanel.Services
                         // stops the WPF routed event, not Win32 WM_MOUSEACTIVATE), which raised
                         // it above the chaos run's bubbles/HUD/overlays. Lift the game layer
                         // back first, then the attention targets on top of everything.
-                        try { App.Chaos?.RaiseGameLayerAboveVideo(); } catch { }
+                        try { App.Chaos?.RaiseGameLayerAboveVideo(); } catch (Exception ex) { Diag.Swallowed(ex); }
                         lock (_targets)
                         {
                             foreach (var t in _targets)
@@ -6157,7 +6157,7 @@ namespace ConditioningControlPanel.Services
 
         private void StopGraceCountdown()
         {
-            try { _graceCountdownTimer?.Stop(); } catch { }
+            try { _graceCountdownTimer?.Stop(); } catch (Exception ex) { Diag.Swallowed(ex); }
             _graceCountdownTimer = null;
         }
 
@@ -6240,7 +6240,7 @@ namespace ConditioningControlPanel.Services
             arm.Remaining = TimeSpan.Zero;
             if (timer == null || !timer.IsEnabled) return;
             arm.Remaining = RemainingTimerInterval(arm.ArmedUtc, arm.Interval, nowUtc);
-            try { timer.Stop(); } catch { }
+            try { timer.Stop(); } catch (Exception ex) { Diag.Swallowed(ex); }
         }
 
         private void ResumeGuardTimers(DateTime nowUtc)
@@ -6504,9 +6504,9 @@ namespace ConditioningControlPanel.Services
 
         private void StopVoutWatchdog()
         {
-            try { _voutWatchTimer?.Dispose(); } catch { }
+            try { _voutWatchTimer?.Dispose(); } catch (Exception ex) { Diag.Swallowed(ex); }
             _voutWatchTimer = null;
-            try { _voutMidWatchTimer?.Dispose(); } catch { }
+            try { _voutMidWatchTimer?.Dispose(); } catch (Exception ex) { Diag.Swallowed(ex); }
             _voutMidWatchTimer = null;
         }
 
@@ -6528,12 +6528,12 @@ namespace ConditioningControlPanel.Services
                 if (_gracePaused)
                 {
                     VideoDiag.Log("VOUT", "start watchdog deferred - video is grace-paused");
-                    try { _voutWatchTimer?.Change(VoutGraceMs, System.Threading.Timeout.Infinite); } catch { }
+                    try { _voutWatchTimer?.Change(VoutGraceMs, System.Threading.Timeout.Infinite); } catch (Exception ex) { Diag.Swallowed(ex); }
                     return;
                 }
                 if (_voutSeen) return;
                 // Authoritative live check — covers a vout that appeared before the event was wired.
-                try { if (player.VoutCount > 0) return; } catch { }
+                try { if (player.VoutCount > 0) return; } catch (Exception ex) { Diag.Swallowed(ex); }
 
                 // Reaching here IS the white-screen state the reports describe (#557-#560/#574, and
                 // now #616/#617/#621/#622/#623): the clip is decoding but nothing is on screen.
@@ -6572,7 +6572,7 @@ namespace ConditioningControlPanel.Services
                         return;
                     }
                 }
-                catch { /* track probe is best-effort; fall through to the heal */ }
+                catch (Exception ex) { Diag.Swallowed(ex, "track probe is best effort, the heal follows"); }
 
                 // Retire first, retry only if the retire actually happened — if the circuit breaker
                 // tripped (or another heal already swapped the instance) a replay would just fail the
@@ -6802,9 +6802,9 @@ namespace ConditioningControlPanel.Services
 
         private void StopWedgeWatchdog()
         {
-            try { _wedgeWatchdog?.Dispose(); } catch { }
+            try { _wedgeWatchdog?.Dispose(); } catch (Exception ex) { Diag.Swallowed(ex); }
             _wedgeWatchdog = null;
-            try { _heartbeatTimer?.Stop(); } catch { }
+            try { _heartbeatTimer?.Stop(); } catch (Exception ex) { Diag.Swallowed(ex); }
             _heartbeatTimer = null;
         }
 

--- a/ConditioningControlPanel/Windows/TutorialOverlay.xaml.cs
+++ b/ConditioningControlPanel/Windows/TutorialOverlay.xaml.cs
@@ -58,7 +58,7 @@ namespace ConditioningControlPanel
             {
                 Owner = Application.Current?.MainWindow ?? targetWindow;
             }
-            catch { }
+            catch (Exception ex) { Diag.Swallowed(ex); }
 
             _tutorialService.StepChanged += OnStepChanged;
             _tutorialService.TutorialCompleted += OnTutorialCompleted;
@@ -82,7 +82,7 @@ namespace ConditioningControlPanel
                     }
                 }
             }
-            catch { }
+            catch (Exception ex) { Diag.Swallowed(ex); }
 
             AttachToTarget(_targetWindow);
 
@@ -135,11 +135,11 @@ namespace ConditioningControlPanel
                     }
                     if (activeCcpWindow != null)
                     {
-                        try { Activate(); } catch { }
+                        try { Activate(); } catch (Exception ex) { Diag.Swallowed(ex); }
                     }
                 }), System.Windows.Threading.DispatcherPriority.Background);
             }
-            catch { }
+            catch (Exception ex) { Diag.Swallowed(ex); }
         }
 
         private void OnAppExit(object? sender, ExitEventArgs e) => ForceShutdown();
@@ -155,11 +155,11 @@ namespace ConditioningControlPanel
         {
             DetachAllSubscriptions();
             // Mark service inactive (it may already be).
-            try { if (_tutorialService.IsActive) _tutorialService.Skip(); } catch { }
+            try { if (_tutorialService.IsActive) _tutorialService.Skip(); } catch (Exception ex) { Diag.Swallowed(ex); }
             // Stop any running animations on this window so Close() doesn't
             // leave the dispatcher pumping a fade that's already moot.
-            try { BeginAnimation(OpacityProperty, null); } catch { }
-            try { Close(); } catch { }
+            try { BeginAnimation(OpacityProperty, null); } catch (Exception ex) { Diag.Swallowed(ex); }
+            try { Close(); } catch (Exception ex) { Diag.Swallowed(ex); }
         }
 
         // Idempotent teardown: removes every event subscription this overlay
@@ -171,13 +171,13 @@ namespace ConditioningControlPanel
         private void DetachAllSubscriptions()
         {
             _thisOverlayCompleted = true;
-            try { _spotlightDelayTimer?.Stop(); } catch { }
+            try { _spotlightDelayTimer?.Stop(); } catch (Exception ex) { Diag.Swallowed(ex); }
             _spotlightDelayTimer = null;
             UnsubscribeAdvanceTrigger();
-            try { TutorialEventBus.Event -= OnBusEvent; } catch { }
-            try { _tutorialService.StepChanged -= OnStepChanged; } catch { }
-            try { _tutorialService.TutorialCompleted -= OnTutorialCompleted; } catch { }
-            try { DetachFromTarget(_targetWindow); } catch { }
+            try { TutorialEventBus.Event -= OnBusEvent; } catch (Exception ex) { Diag.Swallowed(ex); }
+            try { _tutorialService.StepChanged -= OnStepChanged; } catch (Exception ex) { Diag.Swallowed(ex); }
+            try { _tutorialService.TutorialCompleted -= OnTutorialCompleted; } catch (Exception ex) { Diag.Swallowed(ex); }
+            try { DetachFromTarget(_targetWindow); } catch (Exception ex) { Diag.Swallowed(ex); }
             try
             {
                 if (Application.Current != null)
@@ -188,12 +188,12 @@ namespace ConditioningControlPanel
                         Application.Current.MainWindow.Closed -= OnMainWindowClosed;
                 }
             }
-            catch { }
+            catch (Exception ex) { Diag.Swallowed(ex); }
         }
 
         protected override void OnClosed(EventArgs e)
         {
-            try { DetachAllSubscriptions(); } catch { }
+            try { DetachAllSubscriptions(); } catch (Exception ex) { Diag.Swallowed(ex); }
             base.OnClosed(e);
         }
 
@@ -227,7 +227,7 @@ namespace ConditioningControlPanel
                 w.SizeChanged += OnTargetResized;
                 w.Closed += OnTargetClosed;
             }
-            catch { }
+            catch (Exception ex) { Diag.Swallowed(ex); }
         }
 
         private void DetachFromTarget(Window w)
@@ -238,7 +238,7 @@ namespace ConditioningControlPanel
                 w.SizeChanged -= OnTargetResized;
                 w.Closed -= OnTargetClosed;
             }
-            catch { }
+            catch (Exception ex) { Diag.Swallowed(ex); }
         }
 
         private void OnTargetClosed(object? sender, EventArgs e)
@@ -282,10 +282,10 @@ namespace ConditioningControlPanel
                         }
                     }
 
-                    try { _tutorialService.Skip(); } catch { }
+                    try { _tutorialService.Skip(); } catch (Exception ex) { Diag.Swallowed(ex); }
                 }), System.Windows.Threading.DispatcherPriority.Background);
             }
-            catch { }
+            catch (Exception ex) { Diag.Swallowed(ex); }
         }
 
         private void OnTargetMoved(object? s, EventArgs e) => UpdateOverlayPosition();
@@ -297,7 +297,7 @@ namespace ConditioningControlPanel
             {
                 Dispatcher.BeginInvoke(new Action(() => HandleBusEventOnUi(eventName)));
             }
-            catch { }
+            catch (Exception ex) { Diag.Swallowed(ex); }
         }
 
         private void HandleBusEventOnUi(string eventName)
@@ -395,7 +395,7 @@ namespace ConditioningControlPanel
                     Height = bounds.Height;
                 }
             }
-            catch { }
+            catch (Exception ex) { Diag.Swallowed(ex); }
 
             if (_tutorialService.CurrentStep != null && IsLoaded)
             {
@@ -525,14 +525,14 @@ namespace ConditioningControlPanel
             // button below never sets IsPressed — so ButtonBase skips Click on
             // MouseUp and the dialog never closes. UpdateSpotlight has its own
             // timer-based retry for the rare "target not laid out yet" case.
-            try { UpdateSpotlight(step); } catch { }
-            try { SubscribeAdvanceTrigger(step); } catch { }
+            try { UpdateSpotlight(step); } catch (Exception ex) { Diag.Swallowed(ex); }
+            try { SubscribeAdvanceTrigger(step); } catch (Exception ex) { Diag.Swallowed(ex); }
 
             // Defer Focus(). UpdateStep can be called synchronously from inside
             // a PreviewMouseLeftButtonUp handler (rails advance). Calling Focus()
             // there steals keyboard focus from the dialog mid-click, which broke
             // the button's Click sequence so DialogResult/Close never ran.
-            Dispatcher.BeginInvoke(new Action(() => { try { Focus(); } catch { } }),
+            Dispatcher.BeginInvoke(new Action(() => { try { Focus(); } catch (Exception ex) { Diag.Swallowed(ex); } }),
                 System.Windows.Threading.DispatcherPriority.Background);
         }
 
@@ -552,7 +552,7 @@ namespace ConditioningControlPanel
             // Cancel any retry from a previous step — otherwise rapid
             // StepChanged events queue up overlapping ticks that paint stale
             // bounds over the new step's layout.
-            try { _spotlightDelayTimer?.Stop(); } catch { }
+            try { _spotlightDelayTimer?.Stop(); } catch (Exception ex) { Diag.Swallowed(ex); }
             _spotlightDelayTimer = null;
 
             SpotlightCanvas.Children.Clear();
@@ -580,8 +580,8 @@ namespace ConditioningControlPanel
             // Give the target window a chance to prepare itself (e.g. expand
             // a collapsed drawer that contains TargetElementName). Wrapped so
             // a buggy callback can't break the tutorial.
-            try { step.PrepareTargetWindowAction?.Invoke(_targetWindow); } catch { }
-            try { _targetWindow.UpdateLayout(); } catch { }
+            try { step.PrepareTargetWindowAction?.Invoke(_targetWindow); } catch (Exception ex) { Diag.Swallowed(ex); }
+            try { _targetWindow.UpdateLayout(); } catch (Exception ex) { Diag.Swallowed(ex); }
 
             var targetElement = FindElementByName(_targetWindow, step.TargetElementName);
             if (targetElement == null)
@@ -596,8 +596,8 @@ namespace ConditioningControlPanel
             // overlay swallows the click and the box never gets focus.
             if (targetElement is TextBox) clickThroughHole = true;
 
-            try { targetElement.BringIntoView(); } catch { }
-            try { _targetWindow.UpdateLayout(); } catch { }
+            try { targetElement.BringIntoView(); } catch (Exception ex) { Diag.Swallowed(ex); }
+            try { _targetWindow.UpdateLayout(); } catch (Exception ex) { Diag.Swallowed(ex); }
 
             var bounds = GetElementBounds(targetElement);
             bool unmeasured = bounds.X == 0 && bounds.Y == 0 && bounds.Width <= 100;
@@ -644,7 +644,7 @@ namespace ConditioningControlPanel
 
             void StopSelf()
             {
-                try { timer.Stop(); } catch { }
+                try { timer.Stop(); } catch (Exception ex) { Diag.Swallowed(ex); }
                 if (ReferenceEquals(_spotlightDelayTimer, timer)) _spotlightDelayTimer = null;
             }
 
@@ -832,7 +832,7 @@ namespace ConditioningControlPanel
                 // SetWindowRgn region would then clip the window to a tiny rect
                 // and the spotlight area outside that rect wouldn't get
                 // hit-tested at all (Down/Up not delivered to anything).
-                try { UpdateLayout(); } catch { }
+                try { UpdateLayout(); } catch (Exception ex) { Diag.Swallowed(ex); }
 
                 var dpi = VisualTreeHelper.GetDpi(this);
                 var sx = dpi.DpiScaleX <= 0 ? 1.0 : dpi.DpiScaleX;
@@ -882,7 +882,7 @@ namespace ConditioningControlPanel
                 // SetWindowRgn(hwnd, IntPtr.Zero, true) clears any custom region.
                 SetWindowRgn(hwnd, IntPtr.Zero, true);
             }
-            catch { }
+            catch (Exception ex) { Diag.Swallowed(ex); }
         }
 
         private void PositionTextPanel(Rect targetBounds, TutorialStepPosition position)
@@ -1003,7 +1003,7 @@ namespace ConditioningControlPanel
                     if (result != null) return result;
                 }
             }
-            catch { }
+            catch (Exception ex) { Diag.Swallowed(ex); }
             return null;
         }
 
@@ -1081,7 +1081,7 @@ namespace ConditioningControlPanel
                                         AdvanceSync();
                                     }
                                 }
-                                catch { }
+                                catch (Exception ex) { Diag.Swallowed(ex); }
                             };
                             parentWindow.Closing += _subParentWindowClosing;
                         }
@@ -1128,11 +1128,11 @@ namespace ConditioningControlPanel
             {
                 if (_subButtonHandler != null)
                 {
-                    try { _subButton.RemoveHandler(ButtonBase.ClickEvent, _subButtonHandler); } catch { }
+                    try { _subButton.RemoveHandler(ButtonBase.ClickEvent, _subButtonHandler); } catch (Exception ex) { Diag.Swallowed(ex); }
                 }
                 if (_subButtonMouseHandler != null)
                 {
-                    try { _subButton.RemoveHandler(UIElement.PreviewMouseLeftButtonUpEvent, _subButtonMouseHandler); } catch { }
+                    try { _subButton.RemoveHandler(UIElement.PreviewMouseLeftButtonUpEvent, _subButtonMouseHandler); } catch (Exception ex) { Diag.Swallowed(ex); }
                 }
                 _subButton = null;
                 _subButtonHandler = null;
@@ -1140,18 +1140,18 @@ namespace ConditioningControlPanel
             }
             if (_subParentWindow != null && _subParentWindowClosing != null)
             {
-                try { _subParentWindow.Closing -= _subParentWindowClosing; } catch { }
+                try { _subParentWindow.Closing -= _subParentWindowClosing; } catch (Exception ex) { Diag.Swallowed(ex); }
                 _subParentWindow = null;
                 _subParentWindowClosing = null;
             }
             if (_subTextBox != null)
             {
-                try { _subTextBox.TextChanged -= OnSubTextChanged; } catch { }
+                try { _subTextBox.TextChanged -= OnSubTextChanged; } catch (Exception ex) { Diag.Swallowed(ex); }
                 _subTextBox = null;
             }
             if (_subSelector != null)
             {
-                try { _subSelector.SelectionChanged -= OnSubSelectionChanged; } catch { }
+                try { _subSelector.SelectionChanged -= OnSubSelectionChanged; } catch (Exception ex) { Diag.Swallowed(ex); }
                 _subSelector = null;
             }
             if (_subSlider != null)
@@ -1161,7 +1161,7 @@ namespace ConditioningControlPanel
                     _subSlider.RemoveHandler(UIElement.PreviewMouseLeftButtonUpEvent,
                         (MouseButtonEventHandler)OnSubSliderMouseUp);
                 }
-                catch { }
+                catch (Exception ex) { Diag.Swallowed(ex); }
                 _subSlider = null;
             }
             _subscribedStep = null;
@@ -1265,7 +1265,7 @@ namespace ConditioningControlPanel
                     if (_tutorialService.IsActive) _tutorialService.Next();
                 }));
             }
-            catch { }
+            catch (Exception ex) { Diag.Swallowed(ex); }
         }
 
         private void Advance()
@@ -1280,7 +1280,7 @@ namespace ConditioningControlPanel
                     if (_tutorialService.IsActive) _tutorialService.Next();
                 }));
             }
-            catch { }
+            catch (Exception ex) { Diag.Swallowed(ex); }
         }
 
         // -- Button click handlers --------------------------------------------
@@ -1313,18 +1313,18 @@ namespace ConditioningControlPanel
                     UseShellExecute = true
                 });
             }
-            catch { }
+            catch (Exception ex) { Diag.Swallowed(ex); }
         }
 
         private void OnTutorialCompleted(object? sender, EventArgs e)
         {
             DetachAllSubscriptions();
-            try { Deactivated -= OnOverlayDeactivated; } catch { }
+            try { Deactivated -= OnOverlayDeactivated; } catch (Exception ex) { Diag.Swallowed(ex); }
 
             var fadeOut = new DoubleAnimation(1, 0, TimeSpan.FromMilliseconds(200));
             fadeOut.Completed += (s, args) =>
             {
-                try { Close(); } catch { }
+                try { Close(); } catch (Exception ex) { Diag.Swallowed(ex); }
             };
             BeginAnimation(OpacityProperty, fadeOut);
         }


### PR DESCRIPTION
**Logging redesign, swallow lane PR 4 of 5.** Base: `feat/log-swallow-catches-2` (#828). Merge #824, #827, #828 first.

## Counts

| file | empty catches before | after (all marked) | to `Diag.Swallowed` | typed `// swallow:` |
|---|---|---|---|---|
| `Services/BubbleService.cs` | 44 | 1 | 43 | 1 |
| `Windows/TutorialOverlay.xaml.cs` | 44 | 0 | 44 | 0 |
| `Services/Flash/FlashService.cs` | 42 | 3 | 39 | 3 |
| `Services/Video/VideoService.cs` | 33 | 0 | 33 | 0 |
| `Services/Chaos/DtrhHostService.cs` | 31 | 0 | 31 | 0 |
| **total** | **194** | **4** | **190** | **4** |

The finder re-run reports **0 unmarked** empty catch bodies across all five files; the 4 that remain empty all carry a `// swallow:` reason.

## Judgement calls

- **The four typed swallows were already typed** - none of them had their type changed:
  - `BubbleService` avatar-egg `await Task.Delay(2500, ct)` - `// swallow: run ended or shutdown mid-egg`
  - `FlashService` remote-prefetch teardown - `// swallow: teardown`
  - `FlashService` x2 around the retired `_cancellationSource` `Cancel()`/`Dispose()` - `// swallow: retired CTS already disposed`
- **Nine notes carried over from comments**, comment dropped: diagnostic-accessor guards in `BubbleService` and `FlashService`, "individual tasks are already guarded", "lifetime CTS disposed, the window is already fading out", the two "last-resort cleanup failed" in `VideoService`, "cleanup error", "the haunt must never break key suppression", and "track probe is best effort, the heal follows".
- **Nothing was narrowed.** Narrowing a blanket catch changes what escapes, and "never change control flow" is the harder rule of the two. `FlashService.ExtendLifetime` was the closest call - its comment names `ObjectDisposedException` outright - but that catch also covers the `DateTime.AddMilliseconds` next to it, and an escape there would surface as a crash in the flash heartbeat. It keeps its blanket catch and gets the note instead.

## Notable mechanics

- Three sites inside the nested `VideoService.BlurVmemSurface` call `global::ConditioningControlPanel.Diag.Swallowed(...)`: that type already has its own `Diag(string)` method, which shadows the class (CS0119).
- Ten sites read `exIgnored` rather than `ex` (CS0136, enclosing scope already binds `ex`).
- **`VideoService.CloseAll` is untouched.** Another agent in this wave edits its `ATTENTION: CloseAll() called` line; `CloseAll` starts at line 7075 and the last empty catch in the file is at 6807, so there is nothing to collide over.

## Hot call sites

Bounded by the helper's ten-per-site cap:

- `TutorialOverlay` spotlight retry timer (`try { timer.Stop(); }` in the retry tick) and the `UpdateSpotlight`/`SubscribeAdvanceTrigger` pair, which run on every step change and every target-window layout pass.
- `FlashService.ExtendLifetime` runs from the flash heartbeat.
- The `BubbleService` and `FlashService` diagnostic accessors are read by the reconciler.

## Verification

```
dotnet build ConditioningControlPanel.sln -c Debug   0 errors
dotnet test Tests/ConditioningControlPanel.Tests     5207 passed, 0 failed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GSSvqeYrpVG9H3EPtqikDC
