### PR TITLE
fix(logging): sweep the rest of the content-bearing log lines

### DIFF
--- a/ConditioningControlPanel/AvatarTube/AvatarTubeWindow.Reactions.cs
+++ b/ConditioningControlPanel/AvatarTube/AvatarTubeWindow.Reactions.cs
@@ -152,8 +152,8 @@ namespace ConditioningControlPanel
                     Giggle(reaction);
                 }
 
-                App.Logger?.Debug("Awareness reaction for {DisplayName} ({Category}): {Reaction}",
-                    displayName, e.Category, reaction);
+                App.Logger?.Debug("Awareness reaction fired ({Category}, app {AppChars} chars, line {Chars} chars)",
+                    e.Category, (displayName ?? "").Length, (reaction ?? "").Length);
             }
             catch (Exception ex)
             {
@@ -263,8 +263,8 @@ namespace ConditioningControlPanel
                 else
                     Giggle(reaction);
 
-                App.Logger?.Debug("Still-on reaction for {DisplayName} ({Duration}, useServiceOnly={UseService}): {Reaction}",
-                    displayName, duration, useServiceNameOnly, reaction);
+                App.Logger?.Debug("Still-on reaction fired ({Duration}, useServiceOnly={UseService}, app {AppChars} chars, line {Chars} chars)",
+                    duration, useServiceNameOnly, (displayName ?? "").Length, (reaction ?? "").Length);
             }
             catch (Exception ex)
             {

--- a/ConditioningControlPanel/AvatarTube/AvatarTubeWindow.Speech.cs
+++ b/ConditioningControlPanel/AvatarTube/AvatarTubeWindow.Speech.cs
@@ -1159,7 +1159,8 @@ namespace ConditioningControlPanel
                 if (fuzzy != null)
                 {
                     linkPositions.Add((spanStart, spanLength, fuzzy.Value.Title, fuzzy.Value.Url));
-                    App.Logger?.Information("Fuzzy-linked video: '{Span}' -> '{Title}'", span, fuzzy.Value.Title);
+                    App.Logger?.Information("Fuzzy-linked video on {Host} ({Chars} chars of link text)",
+                        UrlLog.Host(fuzzy.Value.Url), span.Length);
                 }
             }
 

--- a/ConditioningControlPanel/Chaos/ChaosWebViewHost.cs
+++ b/ConditioningControlPanel/Chaos/ChaosWebViewHost.cs
@@ -262,8 +262,8 @@ internal sealed class ChaosWebViewHost : IDisposable
         if (_opts.InputEnabled) { try { _window.Activate(); } catch { } }
 
         _ = InitWebAsync();
-        App.Logger?.Information("{Tag}: window up (input={Input}, fullscreen={FS}) → {Url}",
-            _opts.LogTag, _opts.InputEnabled, _isFullscreen, _opts.StartUrl);
+        App.Logger?.Information("{Tag}: window up (input={Input}, fullscreen={FS}) → {Host}",
+            _opts.LogTag, _opts.InputEnabled, _isFullscreen, Services.Logging.UrlLog.Host(_opts.StartUrl));
     }
 
     /// <summary>Lay the window out as borderless-fullscreen or a normal titled window.</summary>
@@ -1290,7 +1290,7 @@ internal sealed class ChaosWebViewHost : IDisposable
         if (IsAllowedNavigationHost(e.Uri, _opts.PrimaryHost)) return;
         foreach (var host in _opts.AdditionalNavigationHosts)
             if (IsAllowedNavigationHost(e.Uri, host)) return;
-        App.Logger?.Debug("{Tag}: blocked navigation to {Uri}", _opts.LogTag, e.Uri);
+        App.Logger?.Debug("{Tag}: blocked navigation to {Host}", _opts.LogTag, Services.Logging.UrlLog.Host(e.Uri));
         e.Cancel = true;
     }
 

--- a/ConditioningControlPanel/Controls/SeasonRecapWindow.xaml.cs
+++ b/ConditioningControlPanel/Controls/SeasonRecapWindow.xaml.cs
@@ -6,6 +6,8 @@ using ConditioningControlPanel.Localization;
 using ConditioningControlPanel.Services;
 using ConditioningControlPanel.ViewModels;
 
+using ConditioningControlPanel.Services.Logging;
+
 namespace ConditioningControlPanel.Controls
 {
     /// <summary>
@@ -88,7 +90,7 @@ namespace ConditioningControlPanel.Controls
             }
             catch (Exception ex)
             {
-                App.Logger?.Warning(ex, "SeasonRecap: failed to open URL {Url}", url);
+                App.Logger?.Warning(ex, "SeasonRecap: failed to open URL on {Host}", UrlLog.Host(url));
                 return false;
             }
         }

--- a/ConditioningControlPanel/Helpers/BrowserLauncher.cs
+++ b/ConditioningControlPanel/Helpers/BrowserLauncher.cs
@@ -2,6 +2,8 @@ using System;
 using System.Diagnostics;
 using System.Windows;
 
+using ConditioningControlPanel.Services.Logging;
+
 namespace ConditioningControlPanel.Helpers
 {
     /// <summary>
@@ -33,7 +35,7 @@ namespace ConditioningControlPanel.Helpers
             }
             catch (Exception ex)
             {
-                App.Logger?.Warning(ex, "ShellExecute failed to open {Url}; trying fallbacks", url);
+                App.Logger?.Warning(ex, "ShellExecute failed to open {Host}; trying fallbacks", UrlLog.Host(url));
             }
 
             // 2. explorer.exe <url> — explorer resolves the default browser itself.
@@ -45,7 +47,7 @@ namespace ConditioningControlPanel.Helpers
             // 4. rundll32 url.dll,FileProtocolHandler <url>
             if (TryStart("rundll32.exe", $"url.dll,FileProtocolHandler {url}")) return true;
 
-            App.Logger?.Error("All browser-launch strategies failed for {Url}", url);
+            App.Logger?.Error("All browser-launch strategies failed for {Host}", UrlLog.Host(url));
             return false;
         }
 

--- a/ConditioningControlPanel/MainWindow/MainWindow.Assets.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.Assets.cs
@@ -268,7 +268,7 @@ namespace ConditioningControlPanel
                 }
                 catch (Exception ex)
                 {
-                    App.Logger?.Debug("Failed to load preview image from {Url}: {Error}", url, ex.Message);
+                    App.Logger?.Debug("Failed to load preview image from {Host}: {Error}", Services.Logging.UrlLog.Host(url), ex.Message);
                 }
             }
 

--- a/ConditioningControlPanel/MainWindow/MainWindow.Leaderboard.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.Leaderboard.cs
@@ -932,7 +932,7 @@ namespace ConditioningControlPanel
             // Get the double-clicked item
             if (LeaderboardTab?.LstLeaderboard?.SelectedItem is Services.LeaderboardEntry entry && !string.IsNullOrEmpty(entry.DisplayName))
             {
-                App.Logger?.Information("Leaderboard double-click: Opening profile for {DisplayName}", entry.DisplayName);
+                App.Logger?.Information("Leaderboard double-click: Opening profile for rank {Rank}", entry.Rank);
 
                 // Switch to Discord tab (which contains the Profile Viewer)
                 ShowTab("discord");

--- a/ConditioningControlPanel/MainWindow/MainWindow.Presets.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.Presets.cs
@@ -2130,7 +2130,7 @@ namespace ConditioningControlPanel
             }
             catch (Exception ex)
             {
-                App.Logger?.Error("Failed to open hyperlink: {Uri} - {Error}", e.Uri.AbsoluteUri, ex.Message);
+                App.Logger?.Error("Failed to open hyperlink on {Host} - {Error}", Services.Logging.UrlLog.Host(e.Uri), ex.Message);
             }
         }
 

--- a/ConditioningControlPanel/MainWindow/MainWindow.xaml.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.xaml.cs
@@ -3117,7 +3117,7 @@ namespace ConditioningControlPanel
                 if (Uri.TryCreate(u, UriKind.Absolute, out var uri) && uri.Scheme == Uri.UriSchemeHttps)
                 {
                     try { Process.Start(new ProcessStartInfo(u) { UseShellExecute = true }); }
-                    catch (Exception ex) { App.Logger?.Warning(ex, "Failed to open video link preview: {Url}", u); }
+                    catch (Exception ex) { App.Logger?.Warning(ex, "Failed to open video link preview on {Host}", Services.Logging.UrlLog.Host(u)); }
                 }
             };
             Grid.SetColumn(openBtn, 3);

--- a/ConditioningControlPanel/Models/AiCommandData.cs
+++ b/ConditioningControlPanel/Models/AiCommandData.cs
@@ -42,13 +42,13 @@ namespace ConditioningControlPanel.Models
                 }
                 catch (Exception inner)
                 {
-                    App.Logger?.Warning(inner, "AiCommandData: brace-recovery parse failed for: {Json}", json);
+                    App.Logger?.Warning(inner, "AiCommandData: brace-recovery parse failed ({Bytes} bytes)", json?.Length ?? 0);
                     return null;
                 }
             }
             catch (Exception e)
             {
-                App.Logger?.Warning(e, "AiCommandData: parse failed for: {Json}", json);
+                App.Logger?.Warning(e, "AiCommandData: parse failed ({Bytes} bytes)", json?.Length ?? 0);
                 return null;
             }
         }

--- a/ConditioningControlPanel/Services/AIService/LocalAiService.cs
+++ b/ConditioningControlPanel/Services/AIService/LocalAiService.cs
@@ -515,7 +515,7 @@ namespace ConditioningControlPanel.Services.AIService
 
                 if (status != 200)
                 {
-                    App.Logger?.Warning("LocalAiService.SendAsync: Ollama returned HTTP {Status}: {Body}", status, body);
+                    App.Logger?.Warning("LocalAiService.SendAsync: Ollama returned HTTP {Status} (body {Bytes} bytes)", status, body?.Length ?? 0);
                     Meter(AiMeter.OutcomeError);
                     // Diagnostics are not model output and must never wear the AI badge, but they are
                     // the single most useful thing we can show ("Ollama isn't running — start it").
@@ -525,7 +525,7 @@ namespace ConditioningControlPanel.Services.AIService
                 var content = ExtractContent(body);
                 if (string.IsNullOrEmpty(content))
                 {
-                    App.Logger?.Warning("LocalAiService.SendAsync: empty content in 200 response: {Body}", Truncate(body, 300));
+                    App.Logger?.Warning("LocalAiService.SendAsync: empty content in 200 response (body {Bytes} bytes)", body?.Length ?? 0);
                     Meter(AiMeter.OutcomeEmpty);
                     return new AiReplyResult(GetFallbackResponse(), IsAiGenerated: false, Refusal: null);
                 }
@@ -816,7 +816,7 @@ namespace ConditioningControlPanel.Services.AIService
 
                 if (status != 200)
                 {
-                    App.Logger?.Warning("LocalAiService: Ollama returned HTTP {Status}: {Body}", status, body);
+                    App.Logger?.Warning("LocalAiService: Ollama returned HTTP {Status} (body {Bytes} bytes)", status, body?.Length ?? 0);
                     // Roll back the user turn so we don't poison history with an unanswered turn.
                     // (Automated reactions never appended to _messages, so there's nothing to undo.)
                     if (isUser && _messages.Count > 0 && _messages[^1].Role == "user") _messages.RemoveAt(_messages.Count - 1);
@@ -827,7 +827,7 @@ namespace ConditioningControlPanel.Services.AIService
                 var content = ExtractContent(body);
                 if (string.IsNullOrEmpty(content))
                 {
-                    App.Logger?.Warning("LocalAiService: empty content in 200 response: {Body}", Truncate(body, 300));
+                    App.Logger?.Warning("LocalAiService: empty content in 200 response (body {Bytes} bytes)", body?.Length ?? 0);
                     if (isUser && _messages.Count > 0 && _messages[^1].Role == "user") _messages.RemoveAt(_messages.Count - 1);
                     Meter(AiMeter.OutcomeEmpty);
                     return GetFallbackResponse();

--- a/ConditioningControlPanel/Services/AIService/OpenAiCompatibleService.cs
+++ b/ConditioningControlPanel/Services/AIService/OpenAiCompatibleService.cs
@@ -129,7 +129,7 @@ namespace ConditioningControlPanel.Services.AIService
 
             if (!Uri.TryCreate(raw, UriKind.Absolute, out var parsed))
             {
-                App.Logger?.Warning("OpenAiCompatibleService: invalid endpoint '{Endpoint}', falling back to OpenAI base", raw);
+                App.Logger?.Warning("OpenAiCompatibleService: invalid endpoint ({Chars} chars), falling back to OpenAI base", (raw ?? "").Length);
                 return new Uri("https://api.openai.com/v1/");
             }
 
@@ -474,7 +474,7 @@ namespace ConditioningControlPanel.Services.AIService
                     };
                     request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
 
-                    App.Logger?.Debug("OpenAiCompatibleService: request to {Url} (attempt {Attempt})", request.RequestUri, attempt + 1);
+                    App.Logger?.Debug("OpenAiCompatibleService: request to {Host} (attempt {Attempt})", Logging.UrlLog.Host(request.RequestUri), attempt + 1);
 
                     using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
                     var json = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
@@ -490,10 +490,12 @@ namespace ConditioningControlPanel.Services.AIService
                             continue;
                         }
 
-                        App.Logger?.Warning("OpenAiCompatibleService: HTTP {Status} from {Endpoint}: {Body}",
+                        // Host + size. A bring-your-own endpoint can carry the key in the URL,
+                        // and the error body of a chat completion often quotes the prompt back.
+                        App.Logger?.Warning("OpenAiCompatibleService: HTTP {Status} from {Host} (body {Bytes} bytes)",
                             status,
-                            endpointUri,
-                            json);
+                            Logging.UrlLog.Host(endpointUri),
+                            json?.Length ?? 0);
                         Meter(AiMeter.OutcomeError);
                         return null;
                     }

--- a/ConditioningControlPanel/Services/Account/V2AuthService.cs
+++ b/ConditioningControlPanel/Services/Account/V2AuthService.cs
@@ -246,7 +246,7 @@ namespace ConditioningControlPanel.Services
                 var response = await _http.PostAsync($"{SERVER_URL}/v2/auth/discord", content);
                 var json = await response.Content.ReadAsStringAsync();
 
-                Log.Debug("[V2Auth] Discord auth response: {Json}", RedactSensitiveFields(json));
+                Log.Debug("[V2Auth] Discord auth response ({Bytes} bytes)", json?.Length ?? 0);
 
                 if (!response.IsSuccessStatusCode)
                 {
@@ -289,7 +289,7 @@ namespace ConditioningControlPanel.Services
                 var response = await _http.PostAsync($"{SERVER_URL}/v2/auth/patreon", content);
                 var json = await response.Content.ReadAsStringAsync();
 
-                Log.Debug("[V2Auth] Patreon auth response: {Json}", RedactSensitiveFields(json));
+                Log.Debug("[V2Auth] Patreon auth response ({Bytes} bytes)", json?.Length ?? 0);
 
                 if (!response.IsSuccessStatusCode)
                 {
@@ -334,7 +334,7 @@ namespace ConditioningControlPanel.Services
                 var response = await _http.PostAsync($"{SERVER_URL}/v2/auth/substar", content);
                 var json = await response.Content.ReadAsStringAsync();
 
-                Log.Debug("[V2Auth] SubscribeStar auth response: {Json}", RedactSensitiveFields(json));
+                Log.Debug("[V2Auth] SubscribeStar auth response ({Bytes} bytes)", json?.Length ?? 0);
 
                 if (!response.IsSuccessStatusCode)
                 {
@@ -372,7 +372,7 @@ namespace ConditioningControlPanel.Services
                 var response = await _http.PostAsync($"{SERVER_URL}/v2/auth/register", content);
                 var json = await response.Content.ReadAsStringAsync();
 
-                Log.Debug("[V2Auth] Register response: {Json}", RedactSensitiveFields(json));
+                Log.Debug("[V2Auth] Register response ({Bytes} bytes)", json?.Length ?? 0);
 
                 if (!response.IsSuccessStatusCode)
                 {
@@ -409,7 +409,7 @@ namespace ConditioningControlPanel.Services
                 var response = await _http.PostAsync($"{SERVER_URL}/v2/auth/login", content);
                 var json = await response.Content.ReadAsStringAsync();
 
-                Log.Debug("[V2Auth] Login response: {Json}", RedactSensitiveFields(json));
+                Log.Debug("[V2Auth] Login response ({Bytes} bytes)", json?.Length ?? 0);
 
                 if (!response.IsSuccessStatusCode)
                 {
@@ -454,7 +454,7 @@ namespace ConditioningControlPanel.Services
                 var response = await _http.SendAsync(request);
                 var json = await response.Content.ReadAsStringAsync();
 
-                Log.Debug("[V2Auth] Link response: {Json}", RedactSensitiveFields(json));
+                Log.Debug("[V2Auth] Link response ({Bytes} bytes)", json?.Length ?? 0);
 
                 if (!response.IsSuccessStatusCode)
                 {
@@ -510,8 +510,8 @@ namespace ConditioningControlPanel.Services
                     // erroring out with a fat body would write that whole body into
                     // the log once a minute for as long as the Trainer Card is open.
                     // The status plus the first 200 chars is all triage ever needs.
-                    Log.Warning("[V2Auth] Get profile failed: {Status} {Body}",
-                        (int)response.StatusCode, TruncateForLog(json));
+                    Log.Warning("[V2Auth] Get profile failed: {Status} (body {Bytes} bytes)",
+                        (int)response.StatusCode, json?.Length ?? 0);
                     return null;
                 }
 

--- a/ConditioningControlPanel/Services/Arcademy/ArcademyHostService.cs
+++ b/ConditioningControlPanel/Services/Arcademy/ArcademyHostService.cs
@@ -1400,7 +1400,7 @@ internal static class ArcademyHostService
                 catch (Exception ex)
                 {
                     // A phrase whose clip cannot be resolved is a TEXT row, never a missing row.
-                    App.Logger?.Debug("ArcademyHost.BuildTriggers({Text}): {E}", text, ex.Message);
+                    App.Logger?.Debug("ArcademyHost.BuildTriggers: clip resolve failed for a {Chars}-char phrase: {E}", (text ?? "").Length, ex.Message);
                     url = null;
                 }
             }

--- a/ConditioningControlPanel/Services/AutonomyService.Voice.cs
+++ b/ConditioningControlPanel/Services/AutonomyService.Voice.cs
@@ -315,7 +315,7 @@ namespace ConditioningControlPanel.Services
                     }
                     else if (!string.IsNullOrWhiteSpace(heard))
                     {
-                        App.Logger?.Information("AutonomyService: wake word heard ('{Heard}')", heard);
+                        App.Logger?.Information("AutonomyService: wake word heard ({Chars} chars of transcript)", heard.Length);
                         OnWakeWordHeard(heard);
                         // Let the prompt claim the mic before we loop back and re-grab it.
                         await Task.Delay(400, loopCt).ConfigureAwait(false);

--- a/ConditioningControlPanel/Services/AutonomyService.VoiceCommands.cs
+++ b/ConditioningControlPanel/Services/AutonomyService.VoiceCommands.cs
@@ -924,12 +924,12 @@ namespace ConditioningControlPanel.Services
                 if (best == null)
                 {
                     App.Logger?.Information(
-                        "AutonomyService: voice command no-match (heard '{Heard}', best {Score:0.00})", heard, bestScore);
+                        "AutonomyService: voice command no-match ({Chars} chars heard, best {Score:0.00})", (heard ?? "").Length, bestScore);
                     return VoiceCmdOutcome.NoMatch;
                 }
 
-                App.Logger?.Information("AutonomyService: voice command '{Name}' (heard '{Heard}', score {Score:0.00})",
-                    best.Name, heard, bestScore);
+                App.Logger?.Information("AutonomyService: voice command '{Name}' ({Chars} chars heard, score {Score:0.00})",
+                    best.Name, (heard ?? "").Length, bestScore);
 
                 // Explicit "give me a mantra" -> let the funnel run the Spoken-Mantra flow.
                 if (best.IsMantra) return VoiceCmdOutcome.Mantra;

--- a/ConditioningControlPanel/Services/AutonomyService.cs
+++ b/ConditioningControlPanel/Services/AutonomyService.cs
@@ -1510,7 +1510,8 @@ namespace ConditioningControlPanel.Services
             _shownWebVideos.Add(videoName);
             App.Logger?.Debug("AutonomyService: Shown {Shown}/{Total} web videos", _shownWebVideos.Count, videoList.Count);
 
-            App.Logger?.Information("AutonomyService: Playing web video '{Name}' at {Url}", videoName, videoUrl);
+            App.Logger?.Information("AutonomyService: Playing web video {Index}/{Total} on {Host}",
+                _shownWebVideos.Count, videoList.Count, Logging.UrlLog.Host(videoUrl));
 
             // Find MainWindow - try multiple approaches
             var mainWindow = Application.Current?.MainWindow as MainWindow
@@ -1974,19 +1975,21 @@ namespace ConditioningControlPanel.Services
                     // (no XP, no quest, no program day).
                     if (App.Mantra?.TryCompleteMantra() != true)
                         App.Mantra?.CreditExternalMantra();
-                    App.Logger?.Information("AutonomyService: SpokenMantra matched '{Phrase}' (score={Score:0.00}, conf={Conf:0.00})",
-                        phrase, result.Score, result.Confidence);
+                    App.Logger?.Information("AutonomyService: SpokenMantra matched ({Chars} chars, score={Score:0.00}, conf={Conf:0.00})",
+                        (phrase ?? "").Length, result.Score, result.Confidence);
                 }
                 else if (result.TimedOut && string.IsNullOrWhiteSpace(result.Transcript))
                 {
                     SpeakLine(App.MantraVoice?.GetTimeout(), "Too shy? I'll ask again later~");
-                    App.Logger?.Information("AutonomyService: SpokenMantra timed out (no speech) for '{Phrase}'", phrase);
+                    App.Logger?.Information("AutonomyService: SpokenMantra timed out, no speech ({Chars} chars)", (phrase ?? "").Length);
                 }
                 else
                 {
                     SpeakLine(App.MantraVoice?.GetRetry(), "Mmm, not quite. Next time say it just for me~");
-                    App.Logger?.Information("AutonomyService: SpokenMantra miss for '{Phrase}' — heard '{Heard}' (score={Score:0.00})",
-                        phrase, result.Transcript, result.Score);
+                    // Never the transcript: that is a recording of the user's own voice in text
+                    // form, and it is the one thing in this method they did not choose to write down.
+                    App.Logger?.Information("AutonomyService: SpokenMantra miss ({Chars} chars, heard {HeardChars} chars, score={Score:0.00})",
+                        (phrase ?? "").Length, (result.Transcript ?? "").Length, result.Score);
                 }
             }
             catch (Exception ex)

--- a/ConditioningControlPanel/Services/Content/ReleaseContentService.cs
+++ b/ConditioningControlPanel/Services/Content/ReleaseContentService.cs
@@ -835,7 +835,7 @@ namespace ConditioningControlPanel.Services
                     }
                     if (response.StatusCode == HttpStatusCode.NotFound)
                     {
-                        App.Logger?.Warning("ReleaseContentService: pack asset 404 for {Pack} at {Url}", info.Id, url);
+                        App.Logger?.Warning("ReleaseContentService: pack asset 404 for {Pack} at {Host}", info.Id, Logging.UrlLog.Host(url));
                         return false;
                     }
                     if (response.StatusCode != HttpStatusCode.OK && response.StatusCode != HttpStatusCode.PartialContent)

--- a/ConditioningControlPanel/Services/Deeper/BrowserAutoDiscovery.cs
+++ b/ConditioningControlPanel/Services/Deeper/BrowserAutoDiscovery.cs
@@ -106,7 +106,7 @@ namespace ConditioningControlPanel.Services.Deeper
                 if (!match.Success) return;
 
                 var refUrl = match.Groups["url"].Value.TrimEnd(',', '.', ')', ']');
-                App.Logger?.Information("Deeper auto-discovery: found ccp ref {Url} on {Page}", UrlSafety.RedactUrl(refUrl), UrlSafety.RedactUrl(url));
+                App.Logger?.Information("Deeper auto-discovery: found ccp ref on {RefHost} from page on {Host}", Logging.UrlLog.Host(refUrl), Logging.UrlLog.Host(url));
 
                 var enh = await _fetcher.FetchAsync(refUrl, ct).ConfigureAwait(true);
                 if (enh == null || ct.IsCancellationRequested) return;

--- a/ConditioningControlPanel/Services/Deeper/BrowserEnhancementBridge.cs
+++ b/ConditioningControlPanel/Services/Deeper/BrowserEnhancementBridge.cs
@@ -153,15 +153,18 @@ namespace ConditioningControlPanel.Services.Deeper
 
                 var entries = App.EnhancementLibrary?.ScanLibrary();
                 var count = entries?.Count ?? 0;
+                // Hosts, not media sources. A media_source is a full URL into the site the user
+                // was on (or a path on their disk), and three of them were going into every
+                // no-match line.
                 var sample = "";
                 if (entries != null && count > 0)
                 {
-                    var top = entries.Take(3).Select(e => e.MediaSource ?? "(none)");
-                    sample = " | sample media_source: " + string.Join("  ;  ", top);
+                    var top = entries.Take(3).Select(e => Logging.UrlLog.Host(e.MediaSource));
+                    sample = " | sample media_source hosts: " + string.Join("  ;  ", top);
                 }
                 App.Logger?.Information(
-                    "BrowserEnhancementBridge: no match for {Url} ({Count} library entries){Sample}",
-                    UrlSafety.RedactUrl(url), count, sample);
+                    "BrowserEnhancementBridge: no match for {Host} ({Count} library entries){Sample}",
+                    Logging.UrlLog.Host(url), count, sample);
             }
             catch (Exception ex)
             {

--- a/ConditioningControlPanel/Services/Deeper/EnhancementFetcher.cs
+++ b/ConditioningControlPanel/Services/Deeper/EnhancementFetcher.cs
@@ -74,7 +74,7 @@ namespace ConditioningControlPanel.Services.Deeper
             {
                 if (!Uri.TryCreate(url, UriKind.Absolute, out var uri))
                 {
-                    App.Logger?.Debug("EnhancementFetcher: malformed url ({Url})", UrlSafety.RedactUrl(url));
+                    App.Logger?.Debug("EnhancementFetcher: malformed url ({Host})", Logging.UrlLog.Host(url));
                     return null;
                 }
 
@@ -83,7 +83,7 @@ namespace ConditioningControlPanel.Services.Deeper
                 // host their ccpenh.json on https hosts (gist, github pages, etc.).
                 if (uri.Scheme != Uri.UriSchemeHttps)
                 {
-                    App.Logger?.Debug("EnhancementFetcher: rejecting non-https url ({Url})", UrlSafety.RedactUrl(url));
+                    App.Logger?.Debug("EnhancementFetcher: rejecting non-https url ({Host})", Logging.UrlLog.Host(url));
                     return null;
                 }
 
@@ -121,14 +121,14 @@ namespace ConditioningControlPanel.Services.Deeper
                 using var _resp = finalResp;
                 if (!_resp.IsSuccessStatusCode)
                 {
-                    App.Logger?.Debug("EnhancementFetcher: HTTP {Status} for {Url}", (int)_resp.StatusCode, UrlSafety.RedactUrl(url));
+                    App.Logger?.Debug("EnhancementFetcher: HTTP {Status} for {Host}", (int)_resp.StatusCode, Logging.UrlLog.Host(url));
                     return null;
                 }
 
                 var contentLength = _resp.Content.Headers.ContentLength;
                 if (contentLength.HasValue && contentLength.Value > MaxResponseBytes)
                 {
-                    App.Logger?.Debug("EnhancementFetcher: response too large ({Size} bytes) for {Url}", contentLength.Value, UrlSafety.RedactUrl(url));
+                    App.Logger?.Debug("EnhancementFetcher: response too large ({Size} bytes) for {Host}", contentLength.Value, Logging.UrlLog.Host(url));
                     return null;
                 }
 
@@ -145,7 +145,7 @@ namespace ConditioningControlPanel.Services.Deeper
                     }
                     if (read > MaxResponseBytes)
                     {
-                        App.Logger?.Debug("EnhancementFetcher: response exceeded {Cap} bytes (truncated read) for {Url}", MaxResponseBytes, UrlSafety.RedactUrl(url));
+                        App.Logger?.Debug("EnhancementFetcher: response exceeded {Cap} bytes (truncated read) for {Host}", MaxResponseBytes, Logging.UrlLog.Host(url));
                         return null;
                     }
                     json = System.Text.Encoding.UTF8.GetString(buffer, 0, read);
@@ -155,7 +155,7 @@ namespace ConditioningControlPanel.Services.Deeper
                 // (some HT users embed arbitrary URLs in descriptions).
                 if (!json.Contains(Enhancement.SchemaTag, StringComparison.OrdinalIgnoreCase))
                 {
-                    App.Logger?.Debug("EnhancementFetcher: schema sniff failed for {Url}", UrlSafety.RedactUrl(url));
+                    App.Logger?.Debug("EnhancementFetcher: schema sniff failed for {Host}", Logging.UrlLog.Host(url));
                     return null;
                 }
 
@@ -163,18 +163,18 @@ namespace ConditioningControlPanel.Services.Deeper
                 var issues = EnhancementValidator.Validate(enh);
                 if (issues.Exists(i => i.Severity == ValidationSeverity.Error))
                 {
-                    App.Logger?.Debug("EnhancementFetcher: validation failed for {Url}", UrlSafety.RedactUrl(url));
+                    App.Logger?.Debug("EnhancementFetcher: validation failed for {Host}", Logging.UrlLog.Host(url));
                     return null;
                 }
 
                 lock (_gate) _cache[url] = enh;
-                App.Logger?.Information("EnhancementFetcher: cached '{Name}' from {Url}", enh.Metadata?.Name, UrlSafety.RedactUrl(url));
+                App.Logger?.Information("EnhancementFetcher: cached '{Name}' from {Host}", enh.Metadata?.Name, Logging.UrlLog.Host(url));
                 return enh;
             }
             catch (TaskCanceledException) { return null; }
             catch (Exception ex)
             {
-                App.Logger?.Debug("EnhancementFetcher: fetch failed for {Url} - {Error}", UrlSafety.RedactUrl(url), ex.Message);
+                App.Logger?.Debug("EnhancementFetcher: fetch failed for {Host} - {Error}", Logging.UrlLog.Host(url), ex.Message);
                 return null;
             }
         }

--- a/ConditioningControlPanel/Services/Deeper/SpeakPromptSession.cs
+++ b/ConditioningControlPanel/Services/Deeper/SpeakPromptSession.cs
@@ -303,8 +303,8 @@ namespace ConditioningControlPanel.Services.Deeper
 
                     if (ct.IsCancellationRequested) break;
 
-                    App.Logger?.Debug("SpeakPromptSession: heard '{Heard}' matched={M} score={S:0.00} loud={L} timedOut={T} unavail={U}",
-                        res.Transcript, res.Matched, res.Score, res.LoudEnough, res.TimedOut, res.Unavailable);
+                    App.Logger?.Debug("SpeakPromptSession: heard {Chars} chars matched={M} score={S:0.00} loud={L} timedOut={T} unavail={U}",
+                        (res.Transcript ?? "").Length, res.Matched, res.Score, res.LoudEnough, res.TimedOut, res.Unavailable);
 
                     if (res.Unavailable)
                     {
@@ -319,7 +319,7 @@ namespace ConditioningControlPanel.Services.Deeper
                         _reps++;
                         FlashFeedback(_correctMsg);
                         Giggle(_correctMsg);
-                        App.Logger?.Information("SpeakPromptSession: correct ({Reps}/{Need}) heard '{Heard}'", _reps, _requiredReps, res.Transcript);
+                        App.Logger?.Information("SpeakPromptSession: correct ({Reps}/{Need}, {Chars} chars heard)", _reps, _requiredReps, (res.Transcript ?? "").Length);
                         if (_reps >= _requiredReps) break;
                         await Task.Delay(600, ct).ConfigureAwait(false);
                     }

--- a/ConditioningControlPanel/Services/Flash/FlashService.cs
+++ b/ConditioningControlPanel/Services/Flash/FlashService.cs
@@ -3409,7 +3409,7 @@ namespace ConditioningControlPanel.Services
             catch (OperationCanceledException) { return null; }
             catch (Exception ex)
             {
-                App.Logger?.Debug("FlashService: remote still {Url} failed to load: {Error}", url, ex.Message);
+                App.Logger?.Debug("FlashService: remote still from {Host} failed to load: {Error}", Logging.UrlLog.Host(url), ex.Message);
                 return null;
             }
         }
@@ -3480,7 +3480,7 @@ namespace ConditioningControlPanel.Services
                 }
                 catch (Exception ex)
                 {
-                    App.Logger?.Debug("FlashService: remote GIF {Url} frame decode failed, falling back to still: {Error}", url, ex.Message);
+                    App.Logger?.Debug("FlashService: remote GIF from {Host} frame decode failed, falling back to still: {Error}", Logging.UrlLog.Host(url), ex.Message);
                 }
                 finally { try { if (stream.CanSeek) stream.Position = 0; } catch { } }
             }
@@ -3523,7 +3523,7 @@ namespace ConditioningControlPanel.Services
             }
             catch (Exception ex)
             {
-                App.Logger?.Debug("FlashService: WIC could not decode remote still {Url}: {Error}", url, ex.Message);
+                App.Logger?.Debug("FlashService: WIC could not decode remote still from {Host}: {Error}", Logging.UrlLog.Host(url), ex.Message);
             }
 
             // WEBP IS WHY THIS FALLBACK EXISTS. Scrolller's stills are mostly webp (the largest
@@ -3566,7 +3566,7 @@ namespace ConditioningControlPanel.Services
             }
             catch (Exception ex)
             {
-                App.Logger?.Warning("FlashService: Skia could not decode remote still {Url}: {Error}", url, ex.Message);
+                App.Logger?.Warning("FlashService: Skia could not decode remote still from {Host}: {Error}", Logging.UrlLog.Host(url), ex.Message);
                 return null;
             }
         }
@@ -3654,7 +3654,7 @@ namespace ConditioningControlPanel.Services
             catch (OperationCanceledException) { return null; }
             catch (Exception ex)
             {
-                App.Logger?.Debug("FlashService: chaos overlay could not load remote still {Url}: {Error}", url, ex.Message);
+                App.Logger?.Debug("FlashService: chaos overlay could not load remote still from {Host}: {Error}", Logging.UrlLog.Host(url), ex.Message);
                 return null;
             }
         }

--- a/ConditioningControlPanel/Services/Fyp/Online/RemoteMediaCache.cs
+++ b/ConditioningControlPanel/Services/Fyp/Online/RemoteMediaCache.cs
@@ -121,7 +121,7 @@ internal static class RemoteMediaCache
         }
         catch (Exception ex)
         {
-            App.Logger?.Debug("[remote media] stream open failed for {Url}: {E}", url, ex.Message);
+            App.Logger?.Debug("[remote media] stream open failed for {Host}: {E}", Logging.UrlLog.Host(url), ex.Message);
             return null;
         }
     }
@@ -157,7 +157,7 @@ internal static class RemoteMediaCache
         {
             // A half-written file is worse than none: a video player would open it and stall.
             TryDelete(path);
-            App.Logger?.Warning("[remote media] temp materialize failed for {Url}: {E}", url, ex.Message);
+            App.Logger?.Warning("[remote media] temp materialize failed for {Host}: {E}", Logging.UrlLog.Host(url), ex.Message);
             return null;
         }
 
@@ -246,7 +246,7 @@ internal static class RemoteMediaCache
     {
         if (!IsUsable(url))
         {
-            App.Logger?.Debug("[remote media] refused non-media url {Url}", url);
+            App.Logger?.Debug("[remote media] refused non-media url from {Host}", Logging.UrlLog.Host(url));
             return null;
         }
 
@@ -265,7 +265,7 @@ internal static class RemoteMediaCache
         }
         catch (Exception ex)
         {
-            App.Logger?.Debug("[remote media] fetch of {Url} failed: {E}", url, ex.Message);
+            App.Logger?.Debug("[remote media] fetch from {Host} failed: {E}", Logging.UrlLog.Host(url), ex.Message);
             return null;
         }
     }
@@ -300,15 +300,15 @@ internal static class RemoteMediaCache
 
             if (!resp.IsSuccessStatusCode)
             {
-                App.Logger?.Debug("[remote media] HTTP {Code} for {Url}", (int)resp.StatusCode, url);
+                App.Logger?.Debug("[remote media] HTTP {Code} for {Host}", (int)resp.StatusCode, Logging.UrlLog.Host(url));
                 return null;
             }
 
             long declared = resp.Content.Headers.ContentLength ?? -1;
             if (declared > MaxSingleEntryBytes)
             {
-                App.Logger?.Debug("[remote media] {Url} is {Size} bytes — over the per-item cap, skipped",
-                    url, declared);
+                App.Logger?.Debug("[remote media] item from {Host} is {Size} bytes — over the per-item cap, skipped",
+                    Logging.UrlLog.Host(url), declared);
                 return null;
             }
 
@@ -322,7 +322,7 @@ internal static class RemoteMediaCache
         {
             // Includes the HttpClient timeout (surfaces as TaskCanceledException) and every
             // transport failure. One log line at Debug: a flaky CDN must not spam the log.
-            App.Logger?.Debug("[remote media] download of {Url} failed: {E}", url, ex.Message);
+            App.Logger?.Debug("[remote media] download from {Host} failed: {E}", Logging.UrlLog.Host(url), ex.Message);
             return null;
         }
         finally
@@ -349,7 +349,7 @@ internal static class RemoteMediaCache
             if (read <= 0) break;
             if (buffer.Length + read > MaxSingleEntryBytes)
             {
-                App.Logger?.Debug("[remote media] {Url} exceeded the per-item cap mid-stream, dropped", url);
+                App.Logger?.Debug("[remote media] item from {Host} exceeded the per-item cap mid-stream, dropped", Logging.UrlLog.Host(url));
                 return null;
             }
             buffer.Write(chunk, 0, read);

--- a/ConditioningControlPanel/Services/Fyp/Online/ScrolllerSource.cs
+++ b/ConditioningControlPanel/Services/Fyp/Online/ScrolllerSource.cs
@@ -337,8 +337,8 @@ query SubredditQuery($url: String!, $iterator: String, $sortBy: GallerySortBy, $
             var text = await resp.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
             if (!resp.IsSuccessStatusCode)
             {
-                App.Logger?.Warning("[FYP online] scrolller API HTTP {Code}: {Body}",
-                    (int)resp.StatusCode, text.Length > 200 ? text[..200] : text);
+                App.Logger?.Warning("[FYP online] scrolller API HTTP {Code} (body {Bytes} bytes)",
+                    (int)resp.StatusCode, text?.Length ?? 0);
                 return null;
             }
             var parsed = JObject.Parse(text);

--- a/ConditioningControlPanel/Services/Haptics/ButtplugProvider.cs
+++ b/ConditioningControlPanel/Services/Haptics/ButtplugProvider.cs
@@ -49,7 +49,7 @@ namespace ConditioningControlPanel.Services.Haptics
         public void SetUrl(string url)
         {
             _serverUrl = url;
-            Log.Debug("ButtplugProvider: URL set to {Url}", url);
+            Log.Debug("ButtplugProvider: URL set to {Host}", Logging.UrlLog.Host(url));
         }
 
         /// <summary>Snapshot of the devices we currently drive (never enumerate the field directly).</summary>
@@ -69,7 +69,7 @@ namespace ConditioningControlPanel.Services.Haptics
         {
             try
             {
-                Log.Information("ButtplugProvider: Connecting to {Url}", _serverUrl);
+                Log.Information("ButtplugProvider: Connecting to {Host}", Logging.UrlLog.Host(_serverUrl));
 
                 // Create client
                 _client = new ButtplugClient("Conditioning Control Panel");

--- a/ConditioningControlPanel/Services/Haptics/ButtplugProviderV2.cs
+++ b/ConditioningControlPanel/Services/Haptics/ButtplugProviderV2.cs
@@ -151,7 +151,7 @@ namespace ConditioningControlPanel.Services.Haptics
                 if (!Uri.TryCreate(url, UriKind.Absolute, out var uri))
                     throw new UriFormatException($"'{url}' is not a valid WebSocket URL.");
 
-                Log.Information("ButtplugProviderV2: connecting to {Url}", url);
+                Log.Information("ButtplugProviderV2: connecting to {Host}", Logging.UrlLog.Host(url));
 
                 client = new ButtplugClient("Conditioning Control Panel");
                 client.DeviceAdded += OnDeviceAdded;
@@ -179,7 +179,7 @@ namespace ConditioningControlPanel.Services.Haptics
             }
             catch (Exception ex)
             {
-                Log.Warning(ex, "ButtplugProviderV2: connect failed ({Url})", url);
+                Log.Warning(ex, "ButtplugProviderV2: connect failed ({Host})", Logging.UrlLog.Host(url));
                 RaiseError($"Intiface connection failed: {ex.Message}");
                 if (!ReferenceEquals(client, _client))
                 {

--- a/ConditioningControlPanel/Services/Haptics/LovenseProviderV2.cs
+++ b/ConditioningControlPanel/Services/Haptics/LovenseProviderV2.cs
@@ -202,8 +202,8 @@ namespace ConditioningControlPanel.Services.Haptics
             {
                 // Reachable, but GetToys answered with something we cannot read (error envelope /
                 // foreign firmware). Never treat that as "no toys" - the 20 s poll retries.
-                App.Logger?.Debug("Lovense: GetToys answered unintelligibly at connect: {Body}",
-                                  Truncate(body));
+                App.Logger?.Debug("Lovense: GetToys answered unintelligibly at connect ({Bytes} bytes)",
+                                  body?.Length ?? 0);
             }
             _lastPollUtc = DateTime.UtcNow;
             RaiseDevicesChanged();
@@ -874,7 +874,7 @@ namespace ConditioningControlPanel.Services.Haptics
                     return;
                 }
 
-                App.Logger?.Debug("Lovense: reconnect probe answered unintelligibly: {Body}", Truncate(body));
+                App.Logger?.Debug("Lovense: reconnect probe answered unintelligibly ({Bytes} bytes)", body?.Length ?? 0);
             }
             catch (OperationCanceledException) when (ct.IsCancellationRequested) { return; }
             catch (Exception ex)

--- a/ConditioningControlPanel/Services/KeywordTriggerService.cs
+++ b/ConditioningControlPanel/Services/KeywordTriggerService.cs
@@ -1729,7 +1729,7 @@ namespace ConditioningControlPanel.Services
                     {
                         if (attempt >= 16)   // 16 x 750ms = give up after ~12s of nonstop talking
                         {
-                            App.Logger?.Debug("Awareness comment dropped - companion busy: {Line}", line);
+                            App.Logger?.Debug("Awareness comment dropped - companion busy ({Chars} chars)", (line ?? "").Length);
                             return;
                         }
                         var retry = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(750) };

--- a/ConditioningControlPanel/Services/LockCard/LockCardService.cs
+++ b/ConditioningControlPanel/Services/LockCard/LockCardService.cs
@@ -244,7 +244,7 @@ namespace ConditioningControlPanel.Services
                             // as the active LockCard, so re-enqueuing would hold the slot with nothing on
                             // screen until the 5-min stuck backstop, and could bounce indefinitely. Give up
                             // after this single re-defer and release the slot so the queue keeps moving.
-                            App.Logger?.Warning("LockCardService: Deferred lock card still blocked on replay ({Blocker} is open). Dropping after one re-defer. Phrase: {Phrase}", blocker, phraseSnippet);
+                            App.Logger?.Warning("LockCardService: Deferred lock card still blocked on replay ({Blocker} is open). Dropping after one re-defer. Phrase chars: {Chars}", blocker, (phraseSnippet ?? "").Length);
                             // CompleteIfCurrent, not Complete: if the card blocking us is the one
                             // holding the slot, a type-blind Complete would release SOMEONE ELSE's
                             // live claim and dequeue the next interaction over their open window.
@@ -252,7 +252,7 @@ namespace ConditioningControlPanel.Services
                             break;
 
                         case BlockedCardAction.Defer:
-                            App.Logger?.Warning("LockCardService: {Blocker} is already open. Deferring this lock card to the interaction queue. Phrase: {Phrase}", blocker, phraseSnippet);
+                            App.Logger?.Warning("LockCardService: {Blocker} is already open. Deferring this lock card to the interaction queue. Phrase chars: {Chars}", blocker, (phraseSnippet ?? "").Length);
                             App.InteractionQueue?.TryStart(
                                 InteractionQueueService.InteractionType.LockCard,
                                 () => ShowLockCard(customPhrase, customRepeats, customStrict, isTest, isDeferredReplay: true),
@@ -260,7 +260,7 @@ namespace ConditioningControlPanel.Services
                             break;
 
                         case BlockedCardAction.DropNoQueue:
-                            App.Logger?.Warning("LockCardService: {Blocker} is already open and no interaction queue is available to defer to. Dropping. Phrase: {Phrase}", blocker, phraseSnippet);
+                            App.Logger?.Warning("LockCardService: {Blocker} is already open and no interaction queue is available to defer to. Dropping. Phrase chars: {Chars}", blocker, (phraseSnippet ?? "").Length);
                             break;
                     }
                     return;
@@ -317,7 +317,7 @@ namespace ConditioningControlPanel.Services
 
                     _lastShown = DateTime.Now;
 
-                    App.Logger?.Information("Lock Card shown on all monitors - Phrase: {Phrase}", phrase);
+                    App.Logger?.Information("Lock Card shown on all monitors - Phrase chars: {Chars}", (phrase ?? "").Length);
                 }
                 catch (Exception ex)
                 {

--- a/ConditioningControlPanel/Services/Progression/QuestDefinitionService.cs
+++ b/ConditioningControlPanel/Services/Progression/QuestDefinitionService.cs
@@ -341,7 +341,7 @@ public class QuestDefinitionService : IDisposable
             }
             catch (Exception ex)
             {
-                App.Logger?.Warning(ex, "Failed to cache quest image for {QuestId}: {Url}", quest.Id, quest.ImageUrl);
+                App.Logger?.Warning(ex, "Failed to cache quest image for {QuestId} from {Host}", quest.Id, Logging.UrlLog.Host(quest.ImageUrl));
             }
         }
     }

--- a/ConditioningControlPanel/Services/Quiz/IntakeHostService.Speech.cs
+++ b/ConditioningControlPanel/Services/Quiz/IntakeHostService.Speech.cs
@@ -110,7 +110,7 @@ namespace ConditioningControlPanel.Services.Quiz
                 _speechCts = cts;
                 _speechId = id;
             }
-            App.Logger?.Information("IntakeHostService: speech-start #{Id} target='{Phrase}'", id, phrase);
+            App.Logger?.Information("IntakeHostService: speech-start #{Id} ({Chars}-char target)", id, (phrase ?? "").Length);
             _ = Task.Run(() => RunSpeechLoopAsync(id, phrase, cts.Token));
         }
 
@@ -206,8 +206,8 @@ namespace ConditioningControlPanel.Services.Quiz
 
                     if (res.Matched)
                     {
-                        App.Logger?.Information("IntakeHostService: speech #{Id} matched '{Phrase}' (score={S:0.00}, conf={C:0.00})",
-                            id, phrase, res.Score, res.Confidence);
+                        App.Logger?.Information("IntakeHostService: speech #{Id} matched ({Chars} chars, score={S:0.00}, conf={C:0.00})",
+                            id, (phrase ?? "").Length, res.Score, res.Confidence);
                         PostSpeechEvent(id, "final", new { matched = true, transcript = res.Transcript, score = res.Score, loudEnough = res.LoudEnough });
                         return;
                     }
@@ -222,8 +222,8 @@ namespace ConditioningControlPanel.Services.Quiz
                     {
                         misses++;
                         silent = 0;
-                        App.Logger?.Information("IntakeHostService: speech #{Id} miss — heard '{Heard}' (score={S:0.00}, loud={L})",
-                            id, res.Transcript, res.Score, res.LoudEnough);
+                        App.Logger?.Information("IntakeHostService: speech #{Id} miss — {Chars} chars heard (score={S:0.00}, loud={L})",
+                            id, (res.Transcript ?? "").Length, res.Score, res.LoudEnough);
                         PostSpeechEvent(id, "final", new { matched = false, transcript = res.Transcript, score = res.Score, loudEnough = res.LoudEnough });
                         // A beat between windows so the page's "almost" can land before the mic reopens.
                         try { await Task.Delay(350, ct).ConfigureAwait(false); } catch (OperationCanceledException) { return; }

--- a/ConditioningControlPanel/Services/Subliminal/BouncingTextService.cs
+++ b/ConditioningControlPanel/Services/Subliminal/BouncingTextService.cs
@@ -312,7 +312,7 @@ public class BouncingTextService : IDisposable
             logo.TextWidth = formattedText.Width;
             logo.TextHeight = formattedText.Height;
 
-            App.Logger?.Debug("Measured text '{Text}': {W}x{H}", logo.Text, logo.TextWidth, logo.TextHeight);
+            App.Logger?.Debug("Measured text ({Chars} chars): {W}x{H}", (logo.Text ?? "").Length, logo.TextWidth, logo.TextHeight);
         }
         catch (Exception ex)
         {

--- a/ConditioningControlPanel/Services/UI/WindowAwarenessService.cs
+++ b/ConditioningControlPanel/Services/UI/WindowAwarenessService.cs
@@ -593,7 +593,9 @@ namespace ConditioningControlPanel.Services
                 // Debug: Log what we're seeing
                 if (!string.IsNullOrEmpty(windowTitle) && windowTitle != _lastWindowTitle)
                 {
-                    App.Logger?.Debug("WindowAwareness: Active window = '{Title}'", windowTitle);
+                    // Never the title itself. This is whatever the user has on screen right
+                    // now - browser tab titles, document names - and it changes on every switch.
+                    App.Logger?.Debug("WindowAwareness: Active window changed ({Chars} chars of title)", windowTitle.Length);
                 }
 
                 // Check for idle (same window for too long)

--- a/ConditioningControlPanel/Services/Video/DualMonitorVideoService.cs
+++ b/ConditioningControlPanel/Services/Video/DualMonitorVideoService.cs
@@ -130,8 +130,8 @@ namespace ConditioningControlPanel.Services
                 _mediaPlayer.Play(media);
                 _isPlaying = true;
 
-                App.Logger?.Information("DualMonitorVideo: Started playback of {Url} on {Count} monitors",
-                    videoUrl, _windowData.Count);
+                App.Logger?.Information("DualMonitorVideo: Started playback from {Host} on {Count} monitors",
+                    Logging.UrlLog.Host(videoUrl), _windowData.Count);
             }
             catch (Exception ex)
             {

--- a/ConditioningControlPanel/Services/Video/VideoService.cs
+++ b/ConditioningControlPanel/Services/Video/VideoService.cs
@@ -2481,7 +2481,7 @@ namespace ConditioningControlPanel.Services
                         secondaries.Count, allScreens.Count);
                 }
 
-                App.Logger?.Information("Playing URL via LibVLC on {Count} screen(s): {Url}", _windows.Count, url);
+                App.Logger?.Information("Playing URL via LibVLC on {Count} screen(s), host {Host}", _windows.Count, Logging.UrlLog.Host(url));
             });
         }
 
@@ -5397,8 +5397,8 @@ namespace ConditioningControlPanel.Services
                     try { App.Haptics!.ToyInput.ButtonPressed -= h; } catch { }
                 }
 
-                App.Logger?.Debug("Spawning attention target: '{Text}' on {ScreenCount} screen(s) ({Spawned}/{Total})",
-                    text, screens.Length, _spawned, _total);
+                App.Logger?.Debug("Spawning attention target ({Chars} chars) on {ScreenCount} screen(s) ({Spawned}/{Total})",
+                    (text ?? "").Length, screens.Length, _spawned, _total);
 
                 foreach (var screen in screens)
                 {
@@ -8455,7 +8455,7 @@ namespace ConditioningControlPanel.Services
                 };
 
                 _win.Show();
-                App.Logger?.Debug("Attention target window created: '{Text}' size {W}x{H}", text, w, h);
+                App.Logger?.Debug("Attention target window created ({Chars} chars) size {W}x{H}", (text ?? "").Length, w, h);
             }
             catch (Exception ex)
             {

--- a/ConditioningControlPanel/Views/Deeper/DeeperEditorWindow.xaml.cs
+++ b/ConditioningControlPanel/Views/Deeper/DeeperEditorWindow.xaml.cs
@@ -651,7 +651,7 @@ namespace ConditioningControlPanel.Views.Deeper
                     || !IsAllowedPreviewHost(uri))
                 {
                     e.Cancel = true;
-                    App.Logger?.Debug("DeeperEditor: blocked preview navigation to {Url}", e.Uri);
+                    App.Logger?.Debug("DeeperEditor: blocked preview navigation to {Host}", Services.Logging.UrlLog.Host(e.Uri));
                 }
             }
             catch

--- a/ConditioningControlPanel/Views/Deeper/EnhancementPlayerWindow.xaml.cs
+++ b/ConditioningControlPanel/Views/Deeper/EnhancementPlayerWindow.xaml.cs
@@ -1441,7 +1441,7 @@ namespace ConditioningControlPanel.Views.Deeper
                     || !IsAllowedPlayerHost(uri))
                 {
                     e.Cancel = true;
-                    App.Logger?.Debug("EnhancementPlayer: blocked nav to {Url}", e.Uri);
+                    App.Logger?.Debug("EnhancementPlayer: blocked nav to {Host}", Services.Logging.UrlLog.Host(e.Uri));
                 }
             }
             catch

--- a/ConditioningControlPanel/Windows/LockCardWindow.xaml.cs
+++ b/ConditioningControlPanel/Windows/LockCardWindow.xaml.cs
@@ -614,8 +614,8 @@ namespace ConditioningControlPanel
             Activate();
             FocusInput();
 
-            App.Logger?.Information("Lock Card shown - Phrase: {Phrase}, Repeats: {Repeats}, Strict: {Strict}, Voice: {Voice}, Monitors: {Count}",
-                _phrase, _requiredRepeats, _strictMode, _voiceMode, _allWindows.Count);
+            App.Logger?.Information("Lock Card shown - PhraseChars: {Chars}, Repeats: {Repeats}, Strict: {Strict}, Voice: {Voice}, Monitors: {Count}",
+                (_phrase ?? "").Length, _requiredRepeats, _strictMode, _voiceMode, _allWindows.Count);
 
             // Begin the spoken-solve listen loop on the primary monitor.
             if (_voiceMode) StartVoiceSolve();


### PR DESCRIPTION
Stacked on #826 (`feat/log-pii-sites`) - merge that first. Review only the second commit.

#826 fixed the leaks we already had a list for. This is the grep pass over everything else: every Info/Warning/Error/Debug call whose placeholder was a URL, a page or window title, spoken or model-generated text, a mantra phrase, a speech transcript, or a raw HTTP body. Same rule - **ids, counts, enums, status codes only.**

## URLs -> `UrlLog.Host` (~45 sites)

`BrowserLauncher`, `SeasonRecapWindow`, the browser and video-preview paths in `MainWindow`, `ChaosWebViewHost`, `FlashService`'s five remote-still paths, `RemoteMediaCache`'s eight, `EnhancementFetcher` and `BrowserAutoDiscovery`, the two Deeper preview windows, `ButtplugProvider` v1/v2, `DualMonitorVideoService`, `VideoService`'s LibVLC URL play, `ReleaseContentService`, `QuestDefinitionService`, `AutonomyService`'s web video, and `OpenAiCompatibleService` - where a bring-your-own endpoint can carry the API key in the URL itself.

The Deeper files were already going through `UrlSafety.RedactUrl`, which strips the query but keeps host **and path**. On a media host the path *is* the title of what the user was watching, so those move to host-only too. `BrowserEnhancementBridge`'s no-match line was additionally printing three `media_source` URLs out of the user's own library on every miss; it now prints their hosts.

## Titles

`WindowAwarenessService` logged the title of whatever window the user had focused, on every switch, at Debug - browser tab titles, document names, all of it. Length only now. The companion's fuzzy video-linker logged the matched video's title; host + span length now.

## Spoken text and transcripts

`{Heard}` was a transcript of the user's own voice, in `AutonomyService.Voice`, `AutonomyService.VoiceCommands`, `SpeakPromptSession` and `IntakeHostService.Speech`. Lengths now. Same treatment for the mantra phrase in `AutonomyService` / `LockCardService` / `LockCardWindow`, the attention-target text in `VideoService`, the measured mantra in `BouncingTextService`, the awareness comment in `KeywordTriggerService`, and the companion's awareness / still-on reaction lines in `AvatarTubeWindow.Reactions`.

## Bodies that are not ours to log

`LocalAiService` and `OpenAiCompatibleService` were writing model output - the companion's own generated text - into Warning lines. `AiCommandData` wrote the raw AI command JSON on a parse failure. `ScrolllerSource` wrote 200 chars of a third-party media API. `LovenseProviderV2` wrote GetToys replies carrying toy nicknames. The six `V2AuthService` auth-response dumps carried the display name and provider profile even after `RedactSensitiveFields`. All become status + byte count.

## Left alone, deliberately

- **Our own server's error bodies** - Arcademy sync/wallet/presence, `CatalogueService`, `RemoteControlService`, `BugReportService`, the Deeper tab. Short server-authored error envelopes, several already truncated, and the main thing support actually reads.
- **`KeywordTriggerService`'s trigger keywords** and **`CompanionTab`'s personality name** - the user's own settings, not screen or chat content.
- **Marquee / announcement text and update-banner messages** - authored by us, and the noise-diet PR owns those lines.
- **`{Message}` placeholders that are `ex.Message`**, and `{Line}` placeholders that are already an id (EmiDesk) or a built summary (`AwarenessPromptBuilder.LogLine`, which is documented as ids-only).
- **Local resource URIs** in `AnimatedWebp` / `CornerGifMedia` - `pack://` and file paths, which the PR1 write-time redactor maps to `%ASSETS%` / `~`.
- **Our own API paths** (`UpdateService`'s GitHub URLs, `CatalogueService`, the OAuth localhost callback listeners) - constants, no user content, no secrets in the query.

## Coordination

`Services/Video/VideoService.cs`, `Services/AutonomyService.cs` and `Chaos/ChaosWebViewHost.cs` are also touched by the noise-diet and swallow-sweep PRs, but at different lines (the LibVLC play line and two attention-target Debug lines; the web-video play line; the window-up and blocked-navigation lines). `Services/Arcademy/ArcademyHostService.cs` and `Services/Flash/FlashService.cs` are on the swallow sweep's list, but every catch touched here already logged, so it should not be converting them.

## Verification

- `dotnet build ConditioningControlPanel.sln -c Debug` - 0 errors.
- `dotnet test Tests/ConditioningControlPanel.Tests` - 5220 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GSSvqeYrpVG9H3EPtqikDC
