### PR TITLE
refactor(logging): route the possession, audio, arcademy, chaos-host and webcam empty catches through Diag.Swallowed

### DIFF
--- a/ConditioningControlPanel/Chaos/ChaosWebViewHost.cs
+++ b/ConditioningControlPanel/Chaos/ChaosWebViewHost.cs
@@ -259,7 +259,7 @@ internal sealed class ChaosWebViewHost : IDisposable
         _countedActive = true;
         System.Threading.Interlocked.Increment(ref _activeHostCount);
         if (_opts.OwnedByMainWindow) AttachMainWindowGlue();
-        if (_opts.InputEnabled) { try { _window.Activate(); } catch { } }
+        if (_opts.InputEnabled) { try { _window.Activate(); } catch (Exception ex) { Diag.Swallowed(ex); } }
 
         _ = InitWebAsync();
         App.Logger?.Information("{Tag}: window up (input={Input}, fullscreen={FS}) → {Url}",
@@ -373,7 +373,7 @@ internal sealed class ChaosWebViewHost : IDisposable
             if (_window.ActualHeight > 0) _windowedH = _window.ActualHeight;
         }
         ApplyWindowMode(on);
-        if (_opts.InputEnabled) { try { _window.Activate(); } catch { } }
+        if (_opts.InputEnabled) { try { _window.Activate(); } catch (Exception ex) { Diag.Swallowed(ex); } }
     }
 
     // ======================= host-owned fullscreen (Options.HostOwnedFullscreen) =======================
@@ -462,8 +462,8 @@ internal sealed class ChaosWebViewHost : IDisposable
         // the claim after another window took focus is how a modal ends up alive and invisible
         // BEHIND the page, holding the input queue with no way to reach the button that dismisses
         // it. Dropped on deactivation, taken back on activation.
-        _window.Deactivated += (_, _) => { try { if (_isFullscreen && _window != null) _window.Topmost = false; } catch { } };
-        _window.Activated += (_, _) => { try { if (_isFullscreen && _window != null) _window.Topmost = true; } catch { } };
+        _window.Deactivated += (_, _) => { try { if (_isFullscreen && _window != null) _window.Topmost = false; } catch (Exception ex) { Diag.Swallowed(ex); } };
+        _window.Activated += (_, _) => { try { if (_isFullscreen && _window != null) _window.Topmost = true; } catch (Exception ex) { Diag.Swallowed(ex); } };
     }
 
     /// <summary>
@@ -490,7 +490,7 @@ internal sealed class ChaosWebViewHost : IDisposable
             // Pump the render queue between the frame change and the maximize; skipping it is what
             // produces the mis-sized first frame on per-monitor-DPI displays.
             try { _window.Dispatcher.Invoke(() => { }, System.Windows.Threading.DispatcherPriority.Render); }
-            catch { }
+            catch (Exception ex) { Diag.Swallowed(ex); }
         }
         _window.WindowState = WindowState.Maximized;
         _window.Topmost = true;
@@ -562,7 +562,7 @@ internal sealed class ChaosWebViewHost : IDisposable
             _window?.Activate();
             _web?.Focus();
         }
-        catch { }
+        catch (Exception ex) { Diag.Swallowed(ex); }
     }
 
     // ============================ main-window glue ============================
@@ -624,7 +624,7 @@ internal sealed class ChaosWebViewHost : IDisposable
                         System.Windows.Threading.DispatcherPriority.Background,
                         new Action(EnsureNativeVisible));
                 }
-                catch { }
+                catch (Exception ex) { Diag.Swallowed(ex); }
             };
             main.StateChanged += _glueOwnerStateChanged;
             App.Logger?.Information("{Tag}: glued above MainWindow (native owner)", _opts.LogTag);
@@ -694,7 +694,7 @@ internal sealed class ChaosWebViewHost : IDisposable
                 // at the top of the NON-topmost band — still under the tube, which is how the tube ended
                 // up floating over the Graded Intake window. SinkToMainZOrder self-marshals to the avatar
                 // thread (never block main on it), so it lands right after our own insert below and wins.
-                try { App.AvatarWindow?.SinkToMainZOrder(); } catch { }
+                try { App.AvatarWindow?.SinkToMainZOrder(); } catch (Exception ex) { Diag.Swallowed(ex); }
                 var insertAfter = _glueOwnerHandle;
                 var tube = App.AvatarWindow?.AttachedHandleOrZero ?? IntPtr.Zero;
                 if (tube != IntPtr.Zero && IsWindowVisible(tube)) insertAfter = tube;
@@ -759,7 +759,7 @@ internal sealed class ChaosWebViewHost : IDisposable
                     System.Windows.Threading.DispatcherPriority.Background,
                     new Action(() => KickRenderVisibility("owner-minimize cascade vetoed")));
             }
-            catch { }
+            catch (Exception ex) { Diag.Swallowed(ex); }
         }
         return IntPtr.Zero;
     }
@@ -785,7 +785,7 @@ internal sealed class ChaosWebViewHost : IDisposable
                     System.Windows.Threading.DispatcherPriority.Background,
                     new Action(() => KickRenderVisibility("cascade hide healed")));
             }
-            catch { }
+            catch (Exception ex) { Diag.Swallowed(ex); }
         }
         catch (Exception ex) { App.Logger?.Debug("{Tag}.EnsureNativeVisible: {E}", _opts.LogTag, ex.Message); }
     }
@@ -819,7 +819,7 @@ internal sealed class ChaosWebViewHost : IDisposable
             if (_disposed || _window == null || _web == null) return;
             if (!_window.Dispatcher.CheckAccess())
             {
-                try { _window.Dispatcher.BeginInvoke(new Action(() => KickRenderVisibility(reason))); } catch { }
+                try { _window.Dispatcher.BeginInvoke(new Action(() => KickRenderVisibility(reason))); } catch (Exception ex) { Diag.Swallowed(ex); }
                 return;
             }
             if (_window.Visibility != Visibility.Visible) return;   // hidden on purpose (tray)
@@ -841,7 +841,7 @@ internal sealed class ChaosWebViewHost : IDisposable
                     c.IsVisible = true;
                 }
             }
-            catch { /* SDK internals moved — the element bounce below still re-drives the wrapper */ }
+            catch (Exception ex) { Diag.Swallowed(ex, "SDK internals moved, the element bounce below still re-drives the wrapper"); }
 
             bool elementWas = _web.IsVisible;
             _web.Visibility = Visibility.Hidden;
@@ -867,13 +867,13 @@ internal sealed class ChaosWebViewHost : IDisposable
             if (_glueOwner != null && _glueOwnerStateChanged != null)
                 _glueOwner.StateChanged -= _glueOwnerStateChanged;
         }
-        catch { }
+        catch (Exception ex) { Diag.Swallowed(ex); }
         try
         {
             if (_glueHwndSource != null && _glueWndHook != null)
                 _glueHwndSource.RemoveHook(_glueWndHook);
         }
-        catch { }
+        catch (Exception ex) { Diag.Swallowed(ex); }
         ApplyNativeOwner(false);
         _glueAttached = false;
         _glueOwner = null;
@@ -1082,7 +1082,7 @@ internal sealed class ChaosWebViewHost : IDisposable
     {
         var setting = Models.MotionLevel.Full;
         try { setting = App.Settings?.Current?.MotionLevel ?? Models.MotionLevel.Full; }
-        catch { /* no settings yet = the default, Full */ }
+        catch (Exception ex) { Diag.Swallowed(ex, "no settings yet, so the default stands"); }
         var arg = PrefersReducedMotionArgument(setting);
 
         // THE BREADCRUMB THAT SETTLES THE NEXT REPORT, at Information because Serilog's floor is
@@ -1098,7 +1098,7 @@ internal sealed class ChaosWebViewHost : IDisposable
                     "{Tag}: Windows animation effects are OFF; hosted page is kept in motion anyway ({Arg}) - #980",
                     _opts.LogTag, arg);
         }
-        catch { /* the flag is unreadable on some sessions; the argument still stands */ }
+        catch (Exception ex) { Diag.Swallowed(ex, "the flag is unreadable on some sessions, the argument still stands"); }
 
         return arg;
     }
@@ -1331,7 +1331,7 @@ internal sealed class ChaosWebViewHost : IDisposable
     private void OnProcessFailed(object? sender, CoreWebView2ProcessFailedEventArgs e)
     {
         App.Logger?.Warning("{Tag}: WebView2 process failed ({Kind})", _opts.LogTag, e.ProcessFailedKind);
-        try { _opts.OnProcessFailed?.Invoke(e.ProcessFailedKind); } catch { }
+        try { _opts.OnProcessFailed?.Invoke(e.ProcessFailedKind); } catch (Exception ex) { Diag.Swallowed(ex); }
     }
 
     /// <summary>
@@ -1407,7 +1407,7 @@ internal sealed class ChaosWebViewHost : IDisposable
         if (_web?.CoreWebView2 == null) return;
         foreach (var json in _pending)
         {
-            try { _web.CoreWebView2.PostWebMessageAsJson(json); } catch { }
+            try { _web.CoreWebView2.PostWebMessageAsJson(json); } catch (Exception ex) { Diag.Swallowed(ex); }
         }
         _pending.Clear();
     }
@@ -1427,10 +1427,10 @@ internal sealed class ChaosWebViewHost : IDisposable
                 _web.CoreWebView2.PermissionRequested -= OnPermissionRequested;
             }
         }
-        catch { }
-        try { DetachMainWindowGlue(); } catch { }
-        try { _web?.Dispose(); } catch { }
-        try { _window?.Close(); } catch { }
+        catch (Exception ex) { Diag.Swallowed(ex); }
+        try { DetachMainWindowGlue(); } catch (Exception ex) { Diag.Swallowed(ex); }
+        try { _web?.Dispose(); } catch (Exception ex) { Diag.Swallowed(ex); }
+        try { _window?.Close(); } catch (Exception ex) { Diag.Swallowed(ex); }
         if (_countedActive) { _countedActive = false; System.Threading.Interlocked.Decrement(ref _activeHostCount); }
         _web = null; _window = null; IsReady = false; _pending.Clear();
     }
@@ -1452,7 +1452,7 @@ internal sealed class ChaosWebViewHost : IDisposable
             int ex = GetWindowLong(hwnd, GWL_EXSTYLE);
             SetWindowLong(hwnd, GWL_EXSTYLE, ex | WS_EX_NOACTIVATE | WS_EX_TOOLWINDOW);
         }
-        catch { }
+        catch (Exception ex) { Diag.Swallowed(ex); }
     }
 
     private const int GWL_EXSTYLE = -20;

--- a/ConditioningControlPanel/Services/Arcademy/ArcademyHostService.cs
+++ b/ConditioningControlPanel/Services/Arcademy/ArcademyHostService.cs
@@ -184,13 +184,13 @@ internal static class ArcademyHostService
         }
 
         // EMI Desk: the ring learns from every open, not just its own cards.
-        try { App.EmiDesk?.NoteOpen("arcademy"); } catch { }
+        try { App.EmiDesk?.NoteOpen("arcademy"); } catch (Exception ex) { Diag.Swallowed(ex); }
         // She does not follow you to school. If she is out, she says goodbye here and winks
         // herself off screen a couple of seconds later, BEFORE `arcademyOpened` and before the
         // ring's own `arcademyFromRing` can land: the farewell claims her voice for that window,
         // so whichever of the three paths opened the Arcademy, the last thing you get is the bye.
-        try { App.EmiDesk?.FarewellForArcademy(); } catch { }
-        try { App.EmiDesk?.Fire("arcademyOpened", null); } catch { }
+        try { App.EmiDesk?.FarewellForArcademy(); } catch (Exception ex) { Diag.Swallowed(ex); }
+        try { App.EmiDesk?.Fire("arcademyOpened", null); } catch (Exception ex) { Diag.Swallowed(ex); }
         _emiOpenedUtc = DateTime.UtcNow;
 
         _devDoor = devDoor;
@@ -584,7 +584,7 @@ internal static class ArcademyHostService
                     (string?)o["gameKey"], (int?)o["gradeTier"] ?? 0);
                 // CAMPUS PRESENCE: a door opened. Best-effort and gated on the share rung inside;
                 // at `off`, or with no identity, this line does nothing at all.
-                try { ArcademyPresenceService.NoteRoomEnter((string?)o["gameKey"]); } catch { }
+                try { ArcademyPresenceService.NoteRoomEnter((string?)o["gameKey"]); } catch (Exception ex) { Diag.Swallowed(ex); }
                 break;
             case "class-ended":
                 OnClassEnded(o);
@@ -1451,7 +1451,7 @@ internal static class ArcademyHostService
                     if (name == norm) return ToAudioUrl(host, Path.GetFileName(f));
                 }
             }
-            catch { /* the scan is best-effort; the exact-match pass already ran */ }
+            catch (Exception ex) { Diag.Swallowed(ex, "the scan is best effort, the exact-match pass already ran"); }
         }
         return null;
     }
@@ -3862,7 +3862,7 @@ internal static class ArcademyHostService
             // junk field from the page cannot mint a grade for a stranger's map. A zen `pass` is
             // not one of S/A/B/C and rides as null, which the renderer draws as a finish with no
             // letter. Own try/catch: nothing about company may cost the payout frame below.
-            try { ArcademyPresenceService.NoteClassEnd(gameKey, grade); } catch { }
+            try { ArcademyPresenceService.NoteClassEnd(gameKey, grade); } catch (Exception ex) { Diag.Swallowed(ex); }
 
             // Everything the debrief needs that is NOT money, gathered once so both endings below
             // send the same frame and there is only one place to change the wording of a payout.
@@ -4434,7 +4434,7 @@ internal static class ArcademyHostService
                 App.Logger?.Information("ArcademyHost: Discord link timed out after {S}s - cancelled",
                     LinkDeadline.TotalSeconds);
                 _linkCancelled = true;
-                try { d.CancelOAuthFlow(); } catch { }
+                try { d.CancelOAuthFlow(); } catch (Exception ex) { Diag.Swallowed(ex); }
                 PushProfile("cancelled");
                 return;
             }
@@ -4499,7 +4499,7 @@ internal static class ArcademyHostService
         if (Volatile.Read(ref _linkInFlight) == 0) return;
         App.Logger?.Information("ArcademyHost: cancelling the open Discord link-up ({Why})", why);
         _linkCancelled = true;
-        try { App.Discord?.CancelOAuthFlow(); } catch { }
+        try { App.Discord?.CancelOAuthFlow(); } catch (Exception ex) { Diag.Swallowed(ex); }
         if (tellPage) PushProfile("cancelled");
     }
 
@@ -4733,7 +4733,7 @@ internal static class ArcademyHostService
             App.Logger?.Warning("ArcademyHost: remote batch failed: {E}", ex.Message);
             if (Volatile.Read(ref _generation) == epoch)
             {
-                try { _host?.Post(new { type = "assets", reqId, urls = Array.Empty<object>(), done = true }); } catch { }
+                try { _host?.Post(new { type = "assets", reqId, urls = Array.Empty<object>(), done = true }); } catch (Exception exIgnored) { Diag.Swallowed(exIgnored); }
             }
         }
         finally { Interlocked.Exchange(ref _remoteFetchInFlight, 0); }
@@ -4802,7 +4802,7 @@ internal static class ArcademyHostService
         foreach (var w in list)
         {
             if (w.Epoch != epoch) continue;
-            try { PostTaggedAssets(w.ReqId, w.Tag, TakeBuffered(key, w.Want), true); } catch { }
+            try { PostTaggedAssets(w.ReqId, w.Tag, TakeBuffered(key, w.Want), true); } catch (Exception ex) { Diag.Swallowed(ex); }
         }
     }
 
@@ -5018,7 +5018,7 @@ internal static class ArcademyHostService
             App.Logger?.Warning("ArcademyHost: tagged batch failed: {E}", ex.Message);
             if (Volatile.Read(ref _generation) == epoch)
             {
-                try { PostTaggedAssets(reqId, tag, Array.Empty<AssetUrl>(), true); } catch { }
+                try { PostTaggedAssets(reqId, tag, Array.Empty<AssetUrl>(), true); } catch (Exception exIgnored) { Diag.Swallowed(exIgnored); }
             }
             DrainTaggedWaiters(key);
         }
@@ -5348,7 +5348,7 @@ internal static class ArcademyHostService
             App.Logger?.Warning("ArcademyHost: sub probe failed: {E}", ex.Message);
             if (Volatile.Read(ref _generation) == epoch)
             {
-                try { PostSubProbe(reqId, clean, false, null, "offline"); } catch { }
+                try { PostSubProbe(reqId, clean, false, null, "offline"); } catch (Exception exIgnored) { Diag.Swallowed(exIgnored); }
             }
         }
         finally { lock (ProbesInFlight) ProbesInFlight.Remove(clean); }
@@ -5629,7 +5629,7 @@ internal static class ArcademyHostService
                 App.Video.VideoEnded -= OnVideoEnded;
             }
         }
-        catch { }
+        catch (Exception ex) { Diag.Swallowed(ex); }
     }
 
     /// <summary>
@@ -5657,7 +5657,7 @@ internal static class ArcademyHostService
                 App.BrowserMedia.PlayingChanged -= OnBrowserVideoPlayingChanged;
             }
         }
-        catch { }
+        catch (Exception ex) { Diag.Swallowed(ex); }
     }
 
     private static void OnBrowserVideoPlayingChanged(object? sender, bool playing)
@@ -5733,7 +5733,7 @@ internal static class ArcademyHostService
                 _settingsReplaceHooked = true;
             }
         }
-        catch { }
+        catch (Exception ex) { Diag.Swallowed(ex); }
     }
 
     private static void OnSettingsCurrentReplaced()
@@ -5907,7 +5907,7 @@ internal static class ArcademyHostService
 
     private static void CancelBootDeadline()
     {
-        try { _bootWatch?.Stop(); } catch { }
+        try { _bootWatch?.Stop(); } catch (Exception ex) { Diag.Swallowed(ex); }
         _bootWatch = null;
     }
 
@@ -5936,7 +5936,7 @@ internal static class ArcademyHostService
 
     private static void StopHeartbeatWatch()
     {
-        try { _heartbeatWatch?.Stop(); } catch { }
+        try { _heartbeatWatch?.Stop(); } catch (Exception ex) { Diag.Swallowed(ex); }
         _heartbeatWatch = null;
     }
 
@@ -5979,7 +5979,7 @@ internal static class ArcademyHostService
                     Loc.GetF("arcademy_boot_error_body", ProductName, msg ?? string.Empty),
                     ProductName, MessageBoxButton.OK, MessageBoxImage.Warning);
             }
-            catch { }
+            catch (Exception ex) { Diag.Swallowed(ex); }
         });
     }
 
@@ -5995,7 +5995,7 @@ internal static class ArcademyHostService
 
     private static void CancelExitWatchdog()
     {
-        try { _exitWatchdog?.Stop(); } catch { }
+        try { _exitWatchdog?.Stop(); } catch (Exception ex) { Diag.Swallowed(ex); }
         _exitWatchdog = null;
     }
 
@@ -6013,7 +6013,7 @@ internal static class ArcademyHostService
         {
             int emiMinutes = Math.Max(0, (int)(DateTime.UtcNow - _emiOpenedUtc).TotalMinutes);
             _emiOpenedUtc = DateTime.MinValue;
-            try { App.EmiDesk?.Fire("arcademyClosed", new { minutes = emiMinutes }); } catch { }
+            try { App.EmiDesk?.Fire("arcademyClosed", new { minutes = emiMinutes }); } catch (Exception ex) { Diag.Swallowed(ex); }
 
             // ...and she comes home in whatever the Locker put her in. The live hook on
             // `meta-command` has normally already done this; this is the backstop for the session
@@ -6036,17 +6036,17 @@ internal static class ArcademyHostService
             // Unbind the mirror BEFORE the store goes: a push still sitting in the debounce is
             // sent now (payload taken first, so the request outlives this window without touching
             // anything being disposed) and every reply still in the air is dropped by generation.
-            try { ArcademySyncService.Detach(); } catch { }
+            try { ArcademySyncService.Detach(); } catch (Exception ex) { Diag.Swallowed(ex); }
             // And the wallet with it. Nothing to flush here: a frame the server never took is
             // already on disk in `pendingMints`, and the next launch is what carries it up.
-            try { ArcademyWalletSyncService.Detach(); } catch { }
+            try { ArcademyWalletSyncService.Detach(); } catch (Exception ex) { Diag.Swallowed(ex); }
             // Stop the presence poll BEFORE the host goes: the timer must never outlive the window
             // that armed it, and Detach also sends this session's one best-effort `campus_leave`.
-            try { ArcademyPresenceService.Detach(); } catch { }
+            try { ArcademyPresenceService.Detach(); } catch (Exception ex) { Diag.Swallowed(ex); }
             // A link-up the player started from the student ID belongs to THIS window. No frame:
             // there is nothing left to paint it.
-            try { CancelPendingLink("teardown", tellPage: false); } catch { }
-            try { _meta?.FlushSave(); } catch { }
+            try { CancelPendingLink("teardown", tellPage: false); } catch (Exception ex) { Diag.Swallowed(ex); }
+            try { _meta?.FlushSave(); } catch (Exception ex) { Diag.Swallowed(ex); }
             _meta = null;
             _classActive = false;
             _panicSuspended = false;
@@ -6056,7 +6056,7 @@ internal static class ArcademyHostService
             // The piles belong to the class that picked them; the next launch names its own.
             lock (TaggedChannels) TaggedChannels.Clear();
             _taggedSubsEmptyLogged = false;
-            try { _host?.Dispose(); } catch { }
+            try { _host?.Dispose(); } catch (Exception ex) { Diag.Swallowed(ex); }
             _host = null;
             _exiting = false;
             // Bring the control panel back from the tray if we tucked it away at launch. Every
@@ -6065,7 +6065,7 @@ internal static class ArcademyHostService
             if (_minimizedMainWindow)
             {
                 _minimizedMainWindow = false;
-                try { (Application.Current?.MainWindow as MainWindow)?.ShowFromTray(); } catch { }
+                try { (Application.Current?.MainWindow as MainWindow)?.ShowFromTray(); } catch (Exception ex) { Diag.Swallowed(ex); }
             }
             App.Logger?.Information("ArcademyHostService: closed");
         }

--- a/ConditioningControlPanel/Services/Audio/AudioService.Playback.cs
+++ b/ConditioningControlPanel/Services/Audio/AudioService.Playback.cs
@@ -33,8 +33,8 @@ namespace ConditioningControlPanel.Services
             lock (_sync) { _output = output; stop = _stopRequested; pause = _pauseRequested; }
             // A Stop() that arrived while the clip was still queued must not be lost, or the
             // caller's "cut off the previous line" contract silently breaks.
-            if (stop) { try { output.Stop(); } catch { } }
-            else if (pause) { try { output.Pause(); } catch { } }
+            if (stop) { try { output.Stop(); } catch (Exception ex) { Diag.Swallowed(ex); } }
+            else if (pause) { try { output.Pause(); } catch (Exception ex) { Diag.Swallowed(ex); } }
         }
 
         internal void Detach() { lock (_sync) { _output = null; } }
@@ -43,21 +43,21 @@ namespace ConditioningControlPanel.Services
         {
             WaveOutEvent? o;
             lock (_sync) { _stopRequested = true; o = _output; }
-            if (o != null) { try { o.Stop(); } catch { } }
+            if (o != null) { try { o.Stop(); } catch (Exception ex) { Diag.Swallowed(ex); } }
         }
 
         public void Pause()
         {
             WaveOutEvent? o;
             lock (_sync) { _pauseRequested = true; o = _output; }
-            if (o != null) { try { if (o.PlaybackState == PlaybackState.Playing) o.Pause(); } catch { } }
+            if (o != null) { try { if (o.PlaybackState == PlaybackState.Playing) o.Pause(); } catch (Exception ex) { Diag.Swallowed(ex); } }
         }
 
         public void Resume()
         {
             WaveOutEvent? o;
             lock (_sync) { _pauseRequested = false; o = _output; }
-            if (o != null) { try { if (o.PlaybackState == PlaybackState.Paused) o.Play(); } catch { } }
+            if (o != null) { try { if (o.PlaybackState == PlaybackState.Paused) o.Play(); } catch (Exception ex) { Diag.Swallowed(ex); } }
         }
     }
 
@@ -249,7 +249,7 @@ namespace ConditioningControlPanel.Services
             {
                 if (!handle.TryFinish()) return;   // PlaybackStopped and the safety timer race — one wins
                 handle.Detach();
-                try { safety?.Dispose(); } catch { }
+                try { safety?.Dispose(); } catch (Exception ex) { Diag.Swallowed(ex); }
                 ScheduleTeardown(output, reader);
                 Interlocked.Decrement(ref _oneShotsInFlight);
                 if (ok) NoteOutputSuccess();
@@ -282,7 +282,7 @@ namespace ConditioningControlPanel.Services
                             return;
                         }
                     }
-                    catch { }
+                    catch (Exception ex) { Diag.Swallowed(ex); }
                     Complete(false, "playback never reported stopped");
                 }, null, Timeout.Infinite, Timeout.Infinite);
 
@@ -294,7 +294,7 @@ namespace ConditioningControlPanel.Services
 
                 // Safety net: if PlaybackStopped never arrives (endpoint yanked mid-clip, driver
                 // stops pumping) this is what still frees the device, the reader and the slot.
-                try { safety.Change(safetyMs, Timeout.Infinite); } catch { }
+                try { safety.Change(safetyMs, Timeout.Infinite); } catch (Exception ex) { Diag.Swallowed(ex); }
 
                 NoteOutputSuccess();
                 if (onStarted != null)
@@ -305,9 +305,9 @@ namespace ConditioningControlPanel.Services
             }
             catch (Exception ex)
             {
-                try { safety?.Dispose(); } catch { }
-                try { output?.Dispose(); } catch { }
-                try { reader?.Dispose(); } catch { }
+                try { safety?.Dispose(); } catch (Exception exIgnored) { Diag.Swallowed(exIgnored); }
+                try { output?.Dispose(); } catch (Exception exIgnored) { Diag.Swallowed(exIgnored); }
+                try { reader?.Dispose(); } catch (Exception exIgnored) { Diag.Swallowed(exIgnored); }
                 if (handle.TryFinish())
                 {
                     handle.Detach();
@@ -333,9 +333,9 @@ namespace ConditioningControlPanel.Services
                 // teardown: true — never dropped by the queue cap, or the cap itself would leak.
                 EnqueuePlaybackWork(() =>
                 {
-                    try { output?.Stop(); } catch { }
-                    try { output?.Dispose(); } catch { }
-                    try { reader?.Dispose(); } catch { }
+                    try { output?.Stop(); } catch (Exception ex) { Diag.Swallowed(ex); }
+                    try { output?.Dispose(); } catch (Exception ex) { Diag.Swallowed(ex); }
+                    try { reader?.Dispose(); } catch (Exception ex) { Diag.Swallowed(ex); }
                 }, teardown: true);
             }
 
@@ -344,7 +344,7 @@ namespace ConditioningControlPanel.Services
                 System.Threading.Timer? t = null;
                 t = new System.Threading.Timer(_ =>
                 {
-                    try { t?.Dispose(); } catch { }
+                    try { t?.Dispose(); } catch (Exception ex) { Diag.Swallowed(ex); }
                     Teardown();
                 }, null, 50, Timeout.Infinite);
             }
@@ -365,7 +365,7 @@ namespace ConditioningControlPanel.Services
                     catch (Exception ex) { App.Logger?.Debug("[Audio] one-shot completion callback threw: {E}", ex.Message); }
                 }, null);
             }
-            catch { }
+            catch (Exception ex) { Diag.Swallowed(ex); }
         }
 
         #endregion
@@ -479,10 +479,10 @@ namespace ConditioningControlPanel.Services
             {
                 foreach (var item in _playbackWork.GetConsumingEnumerable())
                 {
-                    try { item(); } catch { }
+                    try { item(); } catch (Exception ex) { Diag.Swallowed(ex); }
                 }
             }
-            catch { /* collection completed / disposed */ }
+            catch (Exception ex) { Diag.Swallowed(ex, "collection completed or disposed"); }
 
             TryUnregisterEndpointWatcher();
         }
@@ -518,9 +518,9 @@ namespace ConditioningControlPanel.Services
                 if (_notifyEnumerator != null && _endpointWatcher != null)
                     _notifyEnumerator.UnregisterEndpointNotificationCallback(_endpointWatcher);
             }
-            catch { }
+            catch (Exception ex) { Diag.Swallowed(ex); }
             _endpointWatcher = null;
-            try { _notifyEnumerator?.Dispose(); } catch { }
+            try { _notifyEnumerator?.Dispose(); } catch (Exception ex) { Diag.Swallowed(ex); }
             _notifyEnumerator = null;
         }
 
@@ -547,7 +547,7 @@ namespace ConditioningControlPanel.Services
                     App.Logger?.Information("[Audio] audio endpoint change ({Reason}) — device cache dropped, playback re-enabled", reason);
                 }
             }
-            catch { }
+            catch (Exception ex) { Diag.Swallowed(ex); }
         }
 
         private sealed class EndpointWatcher : IMMNotificationClient
@@ -570,7 +570,7 @@ namespace ConditioningControlPanel.Services
         /// <summary>Stop accepting new playback work and drop the endpoint watcher. Called from Dispose.</summary>
         private void ShutdownPlayback()
         {
-            try { _playbackWork.CompleteAdding(); } catch { }
+            try { _playbackWork.CompleteAdding(); } catch (Exception ex) { Diag.Swallowed(ex); }
             if (Volatile.Read(ref _playbackWorkerStarted) == 0) TryUnregisterEndpointWatcher();
         }
 

--- a/ConditioningControlPanel/Services/AudioService.cs
+++ b/ConditioningControlPanel/Services/AudioService.cs
@@ -153,9 +153,9 @@ namespace ConditioningControlPanel.Services
                     App.Logger?.Information("AudioService: using WaveOut device #{Num} as fallback", i);
                     return w;
                 }
-                catch
+                catch (Exception ex)
                 {
-                    // try next
+                    Diag.Swallowed(ex, "try the next WaveOut device");
                 }
             }
 
@@ -223,7 +223,7 @@ namespace ConditioningControlPanel.Services
                 {
                     if (string.Equals(player.OutputDevice, deviceId, StringComparison.Ordinal)) return true;
                 }
-                catch { /* OutputDevice is advisory — fall through and apply as usual */ }
+                catch (Exception ex) { Diag.Swallowed(ex, "OutputDevice is advisory, apply as usual"); }
 
                 bool deviceFound = false;
                 int enumerated = 0;
@@ -286,12 +286,12 @@ namespace ConditioningControlPanel.Services
 
             string wanted = "(system default)", resolved = "(unavailable)";
             string outputs = "?", track = "?", vol = "?", mute = "?";
-            try { var id = App.Settings?.Current?.AudioOutputDeviceId; if (!string.IsNullOrEmpty(id)) wanted = id; } catch { }
-            try { resolved = player.OutputDevice ?? "(none)"; } catch { }
-            try { outputs = (player.AudioOutputDeviceEnum?.Count() ?? 0).ToString(); } catch { }
-            try { track = player.AudioTrack + "/" + player.AudioTrackCount; } catch { }
-            try { vol = player.Volume.ToString(); } catch { }
-            try { mute = player.Mute.ToString(); } catch { }
+            try { var id = App.Settings?.Current?.AudioOutputDeviceId; if (!string.IsNullOrEmpty(id)) wanted = id; } catch (Exception ex) { Diag.Swallowed(ex); }
+            try { resolved = player.OutputDevice ?? "(none)"; } catch (Exception ex) { Diag.Swallowed(ex); }
+            try { outputs = (player.AudioOutputDeviceEnum?.Count() ?? 0).ToString(); } catch (Exception ex) { Diag.Swallowed(ex); }
+            try { track = player.AudioTrack + "/" + player.AudioTrackCount; } catch (Exception ex) { Diag.Swallowed(ex); }
+            try { vol = player.Volume.ToString(); } catch (Exception ex) { Diag.Swallowed(ex); }
+            try { mute = player.Mute.ToString(); } catch (Exception ex) { Diag.Swallowed(ex); }
 
             return $"wanted={wanted} resolved={resolved} outputs={outputs} track={track} vol={vol} mute={mute}";
         }
@@ -373,7 +373,7 @@ namespace ConditioningControlPanel.Services
                         return i;
                     }
                 }
-                catch { /* skip unreadable device */ }
+                catch (Exception ex) { Diag.Swallowed(ex, "skip unreadable device"); }
             }
 
             App.Logger?.Warning("AudioService: chosen output device '{Friendly}' has no matching WaveOut driver — using default", friendly);
@@ -425,7 +425,7 @@ namespace ConditioningControlPanel.Services
                     var def = _deviceEnumerator.GetDefaultAudioEndpoint(DataFlow.Render, Role.Multimedia);
                     defaultId = def?.ID ?? "";
                 }
-                catch { /* default may be unset */ }
+                catch (Exception ex) { Diag.Swallowed(ex, "the default endpoint may be unset"); }
 
                 var endpoints = _deviceEnumerator.EnumerateAudioEndPoints(DataFlow.Render, DeviceState.Active);
                 for (int i = 0; i < endpoints.Count; i++)
@@ -440,7 +440,7 @@ namespace ConditioningControlPanel.Services
                             IsDefault = !string.IsNullOrEmpty(defaultId) && dev.ID == defaultId
                         });
                     }
-                    catch { /* skip */ }
+                    catch (Exception ex) { Diag.Swallowed(ex, "skip unreadable endpoint"); }
                 }
             }
             catch (Exception ex)
@@ -725,7 +725,7 @@ namespace ConditioningControlPanel.Services
                                 restoredCount++;
                             }
                         }
-                        catch { /* Session may have ended */ }
+                        catch (Exception ex) { Diag.Swallowed(ex, "the session may have ended"); }
                     }
 
                     App.Logger?.Information("Restored {Count} audio sessions from crash recovery", restoredCount);
@@ -738,7 +738,7 @@ namespace ConditioningControlPanel.Services
             {
                 App.Logger?.Warning("Failed to recover ducking state: {Error}", ex.Message);
                 // Try to delete the file anyway to avoid repeated failures
-                try { File.Delete(DuckingRecoveryFile); } catch { }
+                try { File.Delete(DuckingRecoveryFile); } catch (Exception exIgnored) { Diag.Swallowed(exIgnored); }
             }
         }
 
@@ -943,7 +943,7 @@ namespace ConditioningControlPanel.Services
             // Our layered-audio mixer is in-process, so the session-based ducker (which skips our
             // own PID) can't touch it — duck it cooperatively instead. (#659) In-process gain
             // change, no COM, so it stays inline and our own layers dip on the same frame.
-            try { App.LayeredAudio?.ApplyDuck(amount); } catch { }
+            try { App.LayeredAudio?.ApplyDuck(amount); } catch (Exception ex) { Diag.Swallowed(ex); }
 
             EnqueueDuckWork("duck", () => ApplyDuckSweep(amount, strength), trace: true);
         }
@@ -1064,7 +1064,7 @@ namespace ConditioningControlPanel.Services
                         if (name.Contains("msedgewebview2") || name.Contains("webview2"))
                             newPids.Add(proc.Id);
                     }
-                    catch { }
+                    catch (Exception ex) { Diag.Swallowed(ex); }
                     finally { proc.Dispose(); }
                 }
                 lock (_lockObj)
@@ -1120,7 +1120,7 @@ namespace ConditioningControlPanel.Services
                 restore = true;
             }
 
-            try { App.LayeredAudio?.ReleaseDuck(); } catch { } // restore layered-audio gain (#659)
+            try { App.LayeredAudio?.ReleaseDuck(); } catch (Exception ex) { Diag.Swallowed(ex); } // restore layered-audio gain (#659)
 
             if (restore) EnqueueDuckWork("unduck", RestoreDuckedVolumes, trace: true);
         }
@@ -1198,7 +1198,7 @@ namespace ConditioningControlPanel.Services
                             }
                         }
                     }
-                    catch { /* session may have ended between checks */ }
+                    catch (Exception ex) { Diag.Swallowed(ex, "the session may have ended between checks"); }
                 }
             }
             catch (Exception ex)
@@ -1292,7 +1292,7 @@ namespace ConditioningControlPanel.Services
                 restore = true;
             }
 
-            try { App.LayeredAudio?.ReleaseDuck(); } catch { }
+            try { App.LayeredAudio?.ReleaseDuck(); } catch (Exception ex) { Diag.Swallowed(ex); }
             if (restore) EnqueueDuckWork("watchdog-restore", RestoreDuckedVolumes, trace: true);
         }
 
@@ -1359,7 +1359,7 @@ namespace ConditioningControlPanel.Services
                         scope.Own(sessions);
                         for (int i = 0; i < sessions.Count; i++)
                         {
-                            try { scope.Sessions.Add(sessions[i]); } catch { /* session ended mid-enumeration */ }
+                            try { scope.Sessions.Add(sessions[i]); } catch (Exception ex) { Diag.Swallowed(ex, "the session ended mid-enumeration"); }
                         }
                     }
                     catch (Exception ex)
@@ -1413,7 +1413,7 @@ namespace ConditioningControlPanel.Services
             {
                 if (o is IDisposable d)
                 {
-                    try { d.Dispose(); } catch { /* already released / endpoint vanished */ }
+                    try { d.Dispose(); } catch (Exception ex) { Diag.Swallowed(ex, "already released or the endpoint vanished"); }
                 }
             }
         }
@@ -1491,7 +1491,7 @@ namespace ConditioningControlPanel.Services
                         newlyDucked++;
                         duckedNames.Add($"{name}:{processId}");
                     }
-                    catch { /* session may have ended */ }
+                    catch (Exception ex) { Diag.Swallowed(ex, "the session may have ended"); }
                 }
             }
 
@@ -1575,7 +1575,7 @@ namespace ConditioningControlPanel.Services
                         if (!string.IsNullOrEmpty(name) && !nameToPid.ContainsKey(name))
                             nameToPid[name] = pid;
                     }
-                    catch { }
+                    catch (Exception ex) { Diag.Swallowed(ex); }
                 }
 
                 foreach (var kv in pending)
@@ -1591,7 +1591,7 @@ namespace ConditioningControlPanel.Services
                         {
                             if ((int)sessions[i].GetProcessID == storedPid) { targetPid = storedPid; break; }
                         }
-                        catch { }
+                        catch (Exception ex) { Diag.Swallowed(ex); }
                     }
 
                     // Fallback: process-name match (handles app-restart with new PID)
@@ -1615,7 +1615,7 @@ namespace ConditioningControlPanel.Services
                                 break;
                             }
                         }
-                        catch { }
+                        catch (Exception ex) { Diag.Swallowed(ex); }
                     }
                 }
             }
@@ -1712,12 +1712,12 @@ namespace ConditioningControlPanel.Services
             {
                 foreach (var item in _duckWork.GetConsumingEnumerable())
                 {
-                    try { item(); } catch { }
+                    try { item(); } catch (Exception ex) { Diag.Swallowed(ex); }
                 }
             }
-            catch { /* collection completed / disposed */ }
+            catch (Exception ex) { Diag.Swallowed(ex, "collection completed or disposed"); }
 
-            try { _sweepEnumerator?.Dispose(); } catch { }
+            try { _sweepEnumerator?.Dispose(); } catch (Exception ex) { Diag.Swallowed(ex); }
             _sweepEnumerator = null;
         }
 
@@ -1763,7 +1763,7 @@ namespace ConditioningControlPanel.Services
             _duckWatchdog?.Dispose();
             _duckRescanTimer?.Dispose();
             _restoreRetryTimer?.Dispose();
-            try { _duckWork.CompleteAdding(); } catch { }
+            try { _duckWork.CompleteAdding(); } catch (Exception ex) { Diag.Swallowed(ex); }
 
             // Only release the enumerators once we know no sweep is mid-COM-call on one. Yanking
             // them out from under a wedged worker turns a clean exit into a native crash; process

--- a/ConditioningControlPanel/Services/Possession/PossessionDirector.cs
+++ b/ConditioningControlPanel/Services/Possession/PossessionDirector.cs
@@ -132,8 +132,8 @@ public sealed class PossessionDirector : IDisposable
             // down now rather than leaking a ghost that outlives its room.
             foreach (var g in _live.Where(g => ReferenceEquals(g.Host.Host, host)).ToArray())
                 UndoGhostSync(g);
-            try { _events.Detach(host); } catch { }
-            try { entry.Attribution.ReleaseAll(); } catch { }
+            try { _events.Detach(host); } catch (Exception ex) { Diag.Swallowed(ex); }
+            try { entry.Attribution.ReleaseAll(); } catch (Exception ex) { Diag.Swallowed(ex); }
             _hosts.Remove(entry);
         });
     }
@@ -150,7 +150,7 @@ public sealed class PossessionDirector : IDisposable
             foreach (var g in _live.ToArray()) UndoGhostSync(g);
             _live.Clear();
             _liveKeys.Clear();
-            foreach (var h in _hosts) { try { h.Attribution.ReleaseAll(); } catch { } }
+            foreach (var h in _hosts) { try { h.Attribution.ReleaseAll(); } catch (Exception ex) { Diag.Swallowed(ex); } }
         }
         catch (Exception ex) { App.Logger?.Warning("Possession UndoAll failed: {Error}", ex.Message); }
     }
@@ -230,7 +230,7 @@ public sealed class PossessionDirector : IDisposable
                 var previous = CurrentRung;
                 CurrentRung = rung;
                 App.Logger?.Information("Possession rung {From} -> {To} at {Pct:P0}", previous, rung, frac);
-                try { RungChanged?.Invoke(rung); } catch { }
+                try { RungChanged?.Invoke(rung); } catch (Exception ex) { Diag.Swallowed(ex); }
 
                 // Belt for the timer restart: a restart sets the rung, pulses the edge at 0.6 and
                 // spends that rung's bark itself, so a tick landing on the same moment would flare
@@ -241,7 +241,7 @@ public sealed class PossessionDirector : IDisposable
                 // The rung change itself is an event: the whole window flares once so the escalation is
                 // never something the user only notices in hindsight.
                 if (!justRestarted) PulseAll(0.35 + 0.15 * (int)rung);
-                if (_barkedRungs.Add(rung) && !justRestarted) { try { App.Bark?.NotifyPossessionRung((int)rung); } catch { } }
+                if (_barkedRungs.Add(rung) && !justRestarted) { try { App.Bark?.NotifyPossessionRung((int)rung); } catch (Exception ex) { Diag.Swallowed(ex); } }
 
                 if (rung == PossessionRung.ItKnows && _wardenEnabled && Warden?.IsAvailable == true)
                     FireAndForget(RunWardenAsync(ct => Warden!.LeaveAsync(ct), "leave"), "warden leave");
@@ -373,7 +373,7 @@ public sealed class PossessionDirector : IDisposable
 
             App.Logger?.Information("Possession: {Effect} on {Target} at rung {Rung} (live {Live})",
                 effect.Id, target?.Key ?? "(window)", rung, _live.Count);
-            try { EffectStarted?.Invoke(effect.Id, target?.Key, effect.IsBig); } catch { }
+            try { EffectStarted?.Invoke(effect.Id, target?.Key, effect.IsBig); } catch (Exception ex) { Diag.Swallowed(ex); }
 
             if (knock && Warden != null)
                 await RunWardenAsync(ct => Warden.KnockAsync(target!, ct), "knock").ConfigureAwait(true);
@@ -382,7 +382,7 @@ public sealed class PossessionDirector : IDisposable
             {
                 await effect.ApplyAsync(ctx, target, cts.Token).ConfigureAwait(true);
             }
-            catch (OperationCanceledException) { /* exit or UndoAll pulled it */ }
+            catch (OperationCanceledException) { } // swallow: exit or UndoAll pulled it
             catch (Exception ex)
             {
                 App.Logger?.Warning("Possession effect {Effect} failed: {Error}", effect.Id, ex.Message);
@@ -398,7 +398,7 @@ public sealed class PossessionDirector : IDisposable
         catch (Exception ex)
         {
             App.Logger?.Warning("Possession pick failed: {Error}", ex.Message);
-            if (ghost != null) { try { await UndoGhostAsync(ghost, TimeSpan.Zero).ConfigureAwait(true); } catch { } }
+            if (ghost != null) { try { await UndoGhostAsync(ghost, TimeSpan.Zero).ConfigureAwait(true); } catch (Exception exIgnored) { Diag.Swallowed(exIgnored); } }
         }
         finally
         {
@@ -544,7 +544,7 @@ public sealed class PossessionDirector : IDisposable
                         _cooldowns[t.Key] = until;
                         _liveKeys.Remove(t.Key);
                     }
-                    catch { }
+                    catch (Exception ex) { Diag.Swallowed(ex); }
                 }
                 claimed.Clear();
             };
@@ -552,11 +552,11 @@ public sealed class PossessionDirector : IDisposable
 
             App.Logger?.Information("Possession scene: {Scene} at rung {Rung} (live slots {Slots})",
                 scene.Id, rung, LiveSlots);
-            try { EffectStarted?.Invoke(scene.Id, null, true); } catch { }
+            try { EffectStarted?.Invoke(scene.Id, null, true); } catch (Exception ex) { Diag.Swallowed(ex); }
 
             var ctx = BuildContext(host, rung, remaining, frac, () => adapter);
             try { await adapter.ApplyAsync(ctx, null, cts.Token).ConfigureAwait(true); }
-            catch (OperationCanceledException) { }
+            catch (OperationCanceledException) { } // swallow: the scene was cancelled
 
             if (adapter.HoldFor > TimeSpan.Zero) FireAndForget(HoldThenUndoAsync(ghost, adapter.HoldFor), "scene hold");
             else await UndoGhostAsync(ghost, TimeSpan.FromMilliseconds(600)).ConfigureAwait(true);
@@ -565,7 +565,7 @@ public sealed class PossessionDirector : IDisposable
         catch (Exception ex)
         {
             App.Logger?.Warning("Possession scene start failed: {Error}", ex.Message);
-            if (ghost != null) { try { await UndoGhostAsync(ghost, TimeSpan.Zero).ConfigureAwait(true); } catch { } }
+            if (ghost != null) { try { await UndoGhostAsync(ghost, TimeSpan.Zero).ConfigureAwait(true); } catch (Exception exIgnored) { Diag.Swallowed(exIgnored); } }
             return true;   // the beat was spent either way; do not immediately try a second thing
         }
     }
@@ -637,7 +637,7 @@ public sealed class PossessionDirector : IDisposable
 
             App.Logger?.Information("Possession reactive: {Effect} on {Target} at rung {Rung}",
                 effect.Id, target?.Key ?? "(window)", rung);
-            try { EffectStarted?.Invoke(effect.Id, target?.Key, effect.IsBig); } catch { }
+            try { EffectStarted?.Invoke(effect.Id, target?.Key, effect.IsBig); } catch (Exception ex) { Diag.Swallowed(ex); }
 
             FireAndForget(RunReactiveAsync(ghost, ctx, effect, target, cts), "reactive");
         }
@@ -651,7 +651,7 @@ public sealed class PossessionDirector : IDisposable
         {
             await effect.ApplyAsync(ctx, target, cts.Token).ConfigureAwait(true);
         }
-        catch (OperationCanceledException) { }
+        catch (OperationCanceledException) { } // swallow: the effect was cancelled
         catch (Exception ex)
         {
             App.Logger?.Warning("Possession reactive {Effect} failed: {Error}", effect.Id, ex.Message);
@@ -718,7 +718,7 @@ public sealed class PossessionDirector : IDisposable
                     var d = dx * dx + dy * dy;
                     if (d < bestDist) { bestDist = d; best = t; }
                 }
-                catch { }
+                catch (Exception ex) { Diag.Swallowed(ex); }
             }
             return best;
         }
@@ -754,7 +754,7 @@ public sealed class PossessionDirector : IDisposable
                 BarkTimerRestarted(reason, SafeRestartCount());
 
                 _nextDue = DateTime.Now + PossessionDeck.FirstDelay(CurrentRung, _intensity, _rng);
-                try { RungChanged?.Invoke(CurrentRung); } catch { }
+                try { RungChanged?.Invoke(CurrentRung); } catch (Exception ex) { Diag.Swallowed(ex); }
 
                 App.Logger?.Information("Possession: timer restarted ({Reason}), rung reset to {Rung}, next haunt in {Sec:F0}s",
                     reason, CurrentRung, (_nextDue - DateTime.Now).TotalSeconds);
@@ -805,7 +805,7 @@ public sealed class PossessionDirector : IDisposable
             {
                 // A victim that is still possessed keeps its booking; Release() gives it a fresh
                 // cooldown when its ghost finally comes down.
-                try { if (t != null && !t.IsLive) t.CooldownUntil = DateTime.MinValue; } catch { }
+                try { if (t != null && !t.IsLive) t.CooldownUntil = DateTime.MinValue; } catch (Exception ex) { Diag.Swallowed(ex); }
             }
         }
     }
@@ -876,7 +876,7 @@ public sealed class PossessionDirector : IDisposable
                 {
                     if (effect().IsBig) App.Bark?.NotifyPossessionEffect(id, targetName);
                 }
-                catch { }
+                catch (Exception ex) { Diag.Swallowed(ex); }
             },
         };
     }
@@ -940,8 +940,8 @@ public sealed class PossessionDirector : IDisposable
         if (ghost == null || ghost.Released) return false;
         ghost.Released = true;
         _live.Remove(ghost);
-        try { ghost.Cts.Cancel(); } catch { }
-        try { ghost.OnRelease?.Invoke(); } catch { }
+        try { ghost.Cts.Cancel(); } catch (Exception ex) { Diag.Swallowed(ex); }
+        try { ghost.OnRelease?.Invoke(); } catch (Exception ex) { Diag.Swallowed(ex); }
 
         var target = ghost.Target;
         if (target != null)
@@ -985,7 +985,7 @@ public sealed class PossessionDirector : IDisposable
                 return;
             }
 
-            foreach (var h in _hosts) { try { h.Attribution.ReleaseAll(); } catch { } }
+            foreach (var h in _hosts) { try { h.Attribution.ReleaseAll(); } catch (Exception ex) { Diag.Swallowed(ex); } }
 
             if (_wardenEnabled && Warden != null)
                 await RunWardenAsync(ct => Warden.ReturnAsync(ct), "return").ConfigureAwait(true);
@@ -995,7 +995,7 @@ public sealed class PossessionDirector : IDisposable
             if (!ShouldFinishReassembly(generation, _generation, IsHaunting)) return;
 
             CurrentRung = PossessionRung.Settle;
-            try { RungChanged?.Invoke(CurrentRung); } catch { }
+            try { RungChanged?.Invoke(CurrentRung); } catch (Exception ex) { Diag.Swallowed(ex); }
             App.Logger?.Information("Possession: reassembled, room is quiet");
         }
         catch (Exception ex) { App.Logger?.Warning("Possession reassembly failed: {Error}", ex.Message); }
@@ -1028,8 +1028,8 @@ public sealed class PossessionDirector : IDisposable
             var repeat = attempt.Repeat;
             var strength = repeat <= 1 ? 0.5 : 0.8;
             PulseAll(strength);
-            try { TripwireReacted?.Invoke(attempt); } catch { }
-            try { App.Bark?.NotifyPossessionTripwire(attempt.Kind, attempt.Repeat, attempt.Total); } catch { }
+            try { TripwireReacted?.Invoke(attempt); } catch (Exception ex) { Diag.Swallowed(ex); }
+            try { App.Bark?.NotifyPossessionTripwire(attempt.Kind, attempt.Repeat, attempt.Total); } catch (Exception ex) { Diag.Swallowed(ex); }
 
             if (repeat >= 2)
             {
@@ -1037,7 +1037,7 @@ public sealed class PossessionDirector : IDisposable
                 {
                     // A blink, not a strobe: one extra flare 120 ms later plus a short shake.
                     FireAndForget(BlinkAsync(), "tripwire blink");
-                    try { App.ScreenShake?.Shake(0.4, 250); } catch { }
+                    try { App.ScreenShake?.Shake(0.4, 250); } catch (Exception ex) { Diag.Swallowed(ex); }
                 }
             }
 
@@ -1062,14 +1062,14 @@ public sealed class PossessionDirector : IDisposable
     public void PulseEdges(double strength)
     {
         if (_disposed || !IsHaunting) return;
-        try { PulseAll(Math.Clamp(strength, 0.0, 1.0)); } catch { }
+        try { PulseAll(Math.Clamp(strength, 0.0, 1.0)); } catch (Exception ex) { Diag.Swallowed(ex); }
     }
 
     private void PulseAll(double strength)
     {
         foreach (var h in _hosts)
         {
-            try { h.Attribution.EdgePulse(strength); } catch { }
+            try { h.Attribution.EdgePulse(strength); } catch (Exception ex) { Diag.Swallowed(ex); }
         }
     }
 
@@ -1115,8 +1115,8 @@ public sealed class PossessionDirector : IDisposable
             _lockdown.EscapeAttempted -= OnEscapeAttempted;
             _lockdown.TimerRestarted -= OnTimerRestarted;
         }
-        catch { }
-        try { _events.DetachAll(); } catch { }
+        catch (Exception ex) { Diag.Swallowed(ex); }
+        try { _events.DetachAll(); } catch (Exception ex) { Diag.Swallowed(ex); }
         IsHaunting = false;
         UndoAll();
     }
@@ -1151,6 +1151,6 @@ public sealed class PossessionDirector : IDisposable
         /// <summary>Extra bookkeeping to unwind when this ghost is released (a scene's claimed victims).</summary>
         public Action? OnRelease { get; set; }
 
-        public void Dispose() { try { Cts.Dispose(); } catch { } }
+        public void Dispose() { try { Cts.Dispose(); } catch (Exception ex) { Diag.Swallowed(ex); } }
     }
 }

--- a/ConditioningControlPanel/Services/Webcam/WebcamTrackingService.cs
+++ b/ConditioningControlPanel/Services/Webcam/WebcamTrackingService.cs
@@ -1336,7 +1336,7 @@ namespace ConditioningControlPanel.Services
                     if (Volatile.Read(ref _openGeneration) != generation)
                     {
                         // The caller has moved on — don't hand over something nobody will dispose.
-                        try { cap.Dispose(); } catch { }
+                        try { cap.Dispose(); } catch (Exception ex) { Diag.Swallowed(ex); }
                         return false;
                     }
                     opened = cap;
@@ -1355,7 +1355,7 @@ namespace ConditioningControlPanel.Services
                     stray = opened;
                     opened = null;
                 }
-                if (stray != null) { try { stray.Dispose(); } catch { } }
+                if (stray != null) { try { stray.Dispose(); } catch (Exception ex) { Diag.Swallowed(ex); } }
 
                 App.Logger?.Warning(
                     "WebcamTrackingService: camera open timed out after {Seconds}s — driver may be hung or the device is held exclusively by another app",
@@ -1636,7 +1636,7 @@ namespace ConditioningControlPanel.Services
                     _nativeRuntimeMissing = true;
                 }
                 App.Logger?.Warning(ex, "WebcamTrackingService: TryOpenWithBackend({Api}) threw for index {Index}", label, deviceIndex);
-                try { cap?.Dispose(); } catch { }
+                try { cap?.Dispose(); } catch (Exception exIgnored) { Diag.Swallowed(exIgnored); }
                 return null;
             }
         }
@@ -1685,25 +1685,25 @@ namespace ConditioningControlPanel.Services
                 {
                     App.Logger?.Warning(ex, "WebcamTrackingService: failed to load detection models");
                 }
-                try { face?.Dispose(); } catch { }
-                try { mesh?.Dispose(); } catch { }
-                try { iris?.Dispose(); } catch { }
+                try { face?.Dispose(); } catch (Exception exIgnored) { Diag.Swallowed(exIgnored); }
+                try { mesh?.Dispose(); } catch (Exception exIgnored) { Diag.Swallowed(exIgnored); }
+                try { iris?.Dispose(); } catch (Exception exIgnored) { Diag.Swallowed(exIgnored); }
                 return false;
             }
         }
 
         private void ReleaseCapture()
         {
-            try { _capture?.Release(); } catch { }
-            try { _capture?.Dispose(); } catch { }
+            try { _capture?.Release(); } catch (Exception ex) { Diag.Swallowed(ex); }
+            try { _capture?.Dispose(); } catch (Exception ex) { Diag.Swallowed(ex); }
             _capture = null;
         }
 
         private void ReleaseModels()
         {
-            try { _faceDetector?.Dispose(); } catch { }
-            try { _faceMesh?.Dispose(); } catch { }
-            try { _irisDetector?.Dispose(); } catch { }
+            try { _faceDetector?.Dispose(); } catch (Exception ex) { Diag.Swallowed(ex); }
+            try { _faceMesh?.Dispose(); } catch (Exception ex) { Diag.Swallowed(ex); }
+            try { _irisDetector?.Dispose(); } catch (Exception ex) { Diag.Swallowed(ex); }
             _faceDetector = null;
             _faceMesh = null;
             _irisDetector = null;
@@ -3591,9 +3591,9 @@ namespace ConditioningControlPanel.Services
 
             public void Dispose()
             {
-                try { _session.Dispose(); } catch { }
-                try { _resizeBuffer?.Dispose(); } catch { }
-                try { _paddedBuffer?.Dispose(); } catch { }
+                try { _session.Dispose(); } catch (Exception ex) { Diag.Swallowed(ex); }
+                try { _resizeBuffer?.Dispose(); } catch (Exception ex) { Diag.Swallowed(ex); }
+                try { _paddedBuffer?.Dispose(); } catch (Exception ex) { Diag.Swallowed(ex); }
                 _resizeBuffer = null;
                 _paddedBuffer = null;
             }
@@ -3741,9 +3741,9 @@ namespace ConditioningControlPanel.Services
 
             public void Dispose()
             {
-                try { _session.Dispose(); } catch { }
-                try { _croppedBuffer?.Dispose(); } catch { }
-                try { _resizedBuffer?.Dispose(); } catch { }
+                try { _session.Dispose(); } catch (Exception ex) { Diag.Swallowed(ex); }
+                try { _croppedBuffer?.Dispose(); } catch (Exception ex) { Diag.Swallowed(ex); }
+                try { _resizedBuffer?.Dispose(); } catch (Exception ex) { Diag.Swallowed(ex); }
                 _croppedBuffer = null;
                 _resizedBuffer = null;
             }
@@ -4107,10 +4107,10 @@ namespace ConditioningControlPanel.Services
 
             public void Dispose()
             {
-                try { _session.Dispose(); } catch { }
-                try { _croppedBuffer?.Dispose(); } catch { }
-                try { _resizedBuffer?.Dispose(); } catch { }
-                try { _flippedBuffer?.Dispose(); } catch { }
+                try { _session.Dispose(); } catch (Exception ex) { Diag.Swallowed(ex); }
+                try { _croppedBuffer?.Dispose(); } catch (Exception ex) { Diag.Swallowed(ex); }
+                try { _resizedBuffer?.Dispose(); } catch (Exception ex) { Diag.Swallowed(ex); }
+                try { _flippedBuffer?.Dispose(); } catch (Exception ex) { Diag.Swallowed(ex); }
                 _croppedBuffer = null;
                 _resizedBuffer = null;
                 _flippedBuffer = null;


### PR DESCRIPTION
**Logging redesign, swallow lane PR 5 of 5.** Base: `feat/log-swallow-catches-3` (#832). Merge #824, #827, #828, #832 first.

Last six files of the top-15 sweep.

## Counts

| file | empty catches before | after | to `Diag.Swallowed` | typed `// swallow:` | left for another agent |
|---|---|---|---|---|---|
| `Services/Possession/PossessionDirector.cs` | 30 | 3 | 27 | 3 | 0 |
| `Services/AudioService.cs` | 28 | 0 | 28 | 0 | 0 |
| `Services/Arcademy/ArcademyHostService.cs` | 27 | 0 | 27 | 0 | 0 |
| `Chaos/ChaosWebViewHost.cs` | 24 | 1 | 23 | 0 | 1 (line 1378, inside the 1340-1400 `PageLogLevel` block another agent owns) |
| `Services/Audio/AudioService.Playback.cs` | 22 | 0 | 22 | 0 | 0 |
| `Services/Webcam/WebcamTrackingService.cs` | 21 | 0 | 21 | 0 | 0 |
| **total** | **152** | **4** | **148** | **3** | **1** |

The finder re-run reports exactly one unmarked site left, and it is the one reserved for the `PageLogLevel` work.

## Judgement calls

- **The three typed swallows were already typed** - none had its type changed. All are `OperationCanceledException` on an awaited possession `ApplyAsync`: `// swallow: exit or UndoAll pulled it`, `// swallow: the scene was cancelled`, `// swallow: the effect was cancelled`.
- **Sixteen notes carried over from comments**, comment dropped. The audio ones are the useful half: "try the next WaveOut device", "OutputDevice is advisory, apply as usual", "skip unreadable device", "the default endpoint may be unset", "the session may have ended" (x3 variants), "already released or the endpoint vanished", "collection completed or disposed" (x2). Plus the Arcademy scan fallback and three ChaosWebViewHost default-value guards.
- **Nothing was narrowed.** Same reasoning as the earlier PRs in this stack: narrowing a blanket catch changes what escapes, and these are device-enumeration and dispose paths where the blanket catch is what keeps teardown going.

## Notable mechanics

Thirteen sites read `exIgnored` rather than `ex` (CS0136, enclosing scope already binds `ex`): three in `ArcademyHostService`, three in `AudioService.Playback`, one in `AudioService`, two in `PossessionDirector`, four in `WebcamTrackingService`.

## Hot call sites

Bounded by the helper's ten-per-site cap:

- `WebcamTrackingService` capture-open retries and the ONNX `Dispose` chains run on every tracking start/stop, which the gaze work restarts often.
- `AudioService.Playback` `Stop`/`Pause`/`Resume` fire per voice line.
- `AudioService` session enumeration runs on every ducking pass.

## Verification

```
dotnet build ConditioningControlPanel.sln -c Debug   0 errors
dotnet test Tests/ConditioningControlPanel.Tests     5207 passed, 0 failed
```

## Sweep total across the stack

633 empty catch bodies over the 15 worst files: **605 now log through `Diag.Swallowed`**, **8 stay typed and empty with a `// swallow:` reason**, and **20 are left untouched** inside line ranges other agents own in this wave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GSSvqeYrpVG9H3EPtqikDC
