### PR TITLE
feat(logging): flight recorder - keep Debug in memory, write it when something breaks

### DIFF
--- a/ConditioningControlPanel/App.xaml.cs
+++ b/ConditioningControlPanel/App.xaml.cs
@@ -4389,6 +4389,11 @@ Application State:
                 // happened to quote. LogScrubber only cleaned that up at bug-report upload time,
                 // which is far too late for a file that is already sitting in the logs folder.
                 File.AppendAllText(crashLogPath, Services.Logging.LogRedactor.Redact(crashInfo));
+
+                // The stack says where it died; the flight recorder says what led there. Dump the
+                // ring next to the crash so the report carries the minutes BEFORE it, which is the
+                // half every freeze/black-video report has been missing.
+                Services.Logging.FlightRecorderSink.DumpIfActive("crash");
             }
             catch
             {

--- a/ConditioningControlPanel/Services/BugReportService.cs
+++ b/ConditioningControlPanel/Services/BugReportService.cs
@@ -37,6 +37,12 @@ namespace ConditioningControlPanel.Services
         // terse (one short line per transition), so 200 lines covers several videos plus a whole
         // freeze window at a few KB — well inside the crash-log-sized fields the server accepts.
         private const int MaxVideoDiagLines = 200;
+        // Flight-recorder attachment. The ring holds Debug detail that has never reached a disk
+        // before, so it is the most valuable thing in the field and also the largest; these caps
+        // keep the whole app-log field inside the server's 200,000-char limit with room to spare.
+        private const int MaxAppLogChars = 120_000;
+        private const int MaxDiagDumpChars = 60_000;
+        internal const int MaxAppLogFieldChars = 190_000;
         // Diagnostic-line rescue (#634 + freeze reports). The last-N tail scrolls the [RES]/
         // [WATCHDOG] history out of every report because a relaunch writes far more startup
         // chatter than MaxAppLogLines. Scan a much wider tail and keep only the marker lines so
@@ -150,7 +156,11 @@ namespace ConditioningControlPanel.Services
             var appCounts = ScrubberCounts.Empty;
             if (includeAppLog && !isSuggestion)
             {
-                var appLogRaw = TryReadRecentAppLog(MaxAppLogLines);
+                // Freeze the ring FIRST: whatever the user was doing when they hit "report" is
+                // still in memory at this instant and nowhere else.
+                Services.Logging.FlightRecorderSink.DumpIfActive("bugreport");
+
+                var appLogRaw = Tail(TryReadRecentAppLog(MaxAppLogLines), MaxAppLogChars);
 
                 // #616/#617/#621/#622/#623: the app-log tail alone was useless for the v6.5.0 freeze
                 // reports. A user whose PC had to be hard-reset must relaunch the app to file the
@@ -166,6 +176,14 @@ namespace ConditioningControlPanel.Services
                       "===== video/panic diagnostic trace (video-diag.log) =====" + Environment.NewLine +
                       diagRaw;
 
+                // The flight-recorder dump: the last 4,096 events including Debug, which the file
+                // sink never carried. For a freeze or a black video this is the only part of the
+                // report that says what happened BEFORE the symptom.
+                var ring = Tail(TryReadNewestDiagDump(), MaxDiagDumpChars);
+                if (!string.IsNullOrWhiteSpace(ring))
+                    combined = combined + Environment.NewLine + Environment.NewLine +
+                        "===== flight recorder (diag dump) =====" + Environment.NewLine + ring;
+
                 // #634 + freeze reports: rescue the [RES]/[WATCHDOG] resource+hang timeline from a
                 // much wider window of the rolling app log so it survives even when the 100-line
                 // tail above is all startup chatter. Appended to the same field before scrubbing,
@@ -176,6 +194,10 @@ namespace ConditioningControlPanel.Services
                         "## Diagnostics (sampled)" + Environment.NewLine + diagSampled;
 
                 (scrubbedApp, appCounts) = LogScrubber.Scrub(combined);
+
+                // Hard cap below the server's 200,000, applied AFTER scrubbing so the cap can never
+                // decide which text got redacted. Newest wins - the tail is the failure.
+                scrubbedApp = Tail(scrubbedApp, MaxAppLogFieldChars);
             }
 
             var totalCounts = crashCounts.Add(appCounts);
@@ -666,6 +688,36 @@ namespace ConditioningControlPanel.Services
             if (section.Length > MaxDiagSectionChars)
                 section = section.Substring(section.Length - MaxDiagSectionChars);
             return section;
+        }
+
+        /// <summary>Keep the last <paramref name="maxChars"/> characters. Empty in, empty out.</summary>
+        internal static string Tail(string? text, int maxChars)
+        {
+            if (string.IsNullOrEmpty(text)) return string.Empty;
+            return text!.Length <= maxChars ? text! : text!.Substring(text!.Length - maxChars);
+        }
+
+        /// <summary>
+        /// Read the newest flight-recorder dump. Written moments ago by CreateDraft, or by the
+        /// crash/hang triggers if the app died before the user could file anything.
+        /// </summary>
+        private static string TryReadNewestDiagDump()
+        {
+            try
+            {
+                var logDir = Path.Combine(App.UserDataPath, "logs");
+                var newest = Services.Logging.FlightRecorderSink.NewestDump(logDir);
+                if (newest == null) return string.Empty;
+                using var fs = new FileStream(newest, FileMode.Open, FileAccess.Read,
+                    FileShare.ReadWrite | FileShare.Delete);
+                using var sr = new StreamReader(fs, Encoding.UTF8);
+                return sr.ReadToEnd();
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Debug("[BugReport] diag dump read failed: {Msg}", ex.Message);
+                return string.Empty;
+            }
         }
 
         /// <summary>

--- a/ConditioningControlPanel/Services/Logging/FlightRecorderSink.cs
+++ b/ConditioningControlPanel/Services/Logging/FlightRecorderSink.cs
@@ -1,0 +1,217 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace ConditioningControlPanel.Services.Logging
+{
+    /// <summary>
+    /// Keeps the last 4,096 log events in memory and writes them out when something goes wrong.
+    ///
+    /// <para>The app makes 2,927 Debug calls that have never once reached a disk, because the floor
+    /// has been Information since someone (rightly, at the time) worried about what Debug would put
+    /// in a file. So every report of a freeze or a black video arrives with the one level of detail
+    /// that would have explained it already discarded - and turning Debug on for everyone would
+    /// trade that for a log nobody can read and a privacy problem.</para>
+    ///
+    /// <para>This is the third option: Debug is enabled, but only into a ring buffer in memory. It
+    /// costs a slot in an array per event and touches no disk. When an Error fires, the UI hangs,
+    /// the app crashes, or the user files a bug report, the ring is written to
+    /// <c>logs/diag-*.log</c> - so the minutes BEFORE the failure are in the report, which is the
+    /// half that was always missing. Values are already redacted by the enricher upstream.</para>
+    /// </summary>
+    public sealed class FlightRecorderSink : ILogEventSink
+    {
+        public const int Capacity = 4096;
+        public const int KeepDumps = 5;
+
+        /// <summary>At most one automatic dump a minute: a crash loop must not become a disk loop.</summary>
+        private const int AutoDumpCooldownMs = 60_000;
+
+        private readonly LogEvent?[] _ring = new LogEvent?[Capacity];
+        private readonly object _gate = new();
+        private readonly string _logsDir;
+        private readonly string _sessionId;
+        private int _next;
+        private long _lastAutoDump = -AutoDumpCooldownMs;
+
+        /// <summary>The live recorder, or null before the pipeline is built (very early startup).</summary>
+        public static FlightRecorderSink? Instance { get; internal set; }
+
+        public FlightRecorderSink(string logsDir, string sessionId)
+        {
+            _logsDir = logsDir;
+            _sessionId = sessionId;
+        }
+
+        public void Emit(LogEvent logEvent)
+        {
+            if (logEvent == null) return;
+            bool autoDump = false;
+            try
+            {
+                lock (_gate)
+                {
+                    _ring[_next] = logEvent;
+                    _next = (_next + 1) % Capacity;
+
+                    if (logEvent.Level >= LogEventLevel.Error && !IsShutdownCancellation(logEvent))
+                    {
+                        long now = Environment.TickCount64;
+                        if (now - _lastAutoDump >= AutoDumpCooldownMs)
+                        {
+                            _lastAutoDump = now;
+                            autoDump = true;
+                        }
+                    }
+                }
+            }
+            catch { /* swallow: never throw out of a sink */ }
+
+            // Outside the lock: writing 4,096 lines must not block the thread that is logging.
+            if (autoDump) Dump("error");
+        }
+
+        /// <summary>
+        /// A cancellation thrown while the app is closing is the normal shape of shutdown in this
+        /// codebase (HTTP calls in flight, timers being torn down). Dumping the ring for those
+        /// would mean a diag file on every clean exit, which buries the ones that mean something.
+        /// </summary>
+        private static bool IsShutdownCancellation(LogEvent e) =>
+            e.Exception is OperationCanceledException && ShuttingDown();
+
+        /// <summary>
+        /// "Is the app closing?" A seam, because the honest answer lives in a WPF dispatcher that a
+        /// test host either does not have or shares with another suite's harness window.
+        /// </summary>
+        internal static Func<bool> ShuttingDown { get; set; } = DefaultShuttingDown;
+
+        private static bool DefaultShuttingDown()
+        {
+            try
+            {
+                var app = System.Windows.Application.Current;
+                return app == null || app.Dispatcher == null || app.Dispatcher.HasShutdownStarted;
+            }
+            catch
+            {
+                return true; // swallow: if we cannot tell, assume shutdown and stay quiet
+            }
+        }
+
+        /// <summary>Dump the live recorder if there is one. Safe to call from anywhere.</summary>
+        public static string? DumpIfActive(string reason)
+        {
+            try { return Instance?.Dump(reason); }
+            catch { return null; /* swallow: a diagnostic must never break the thing it diagnoses */ }
+        }
+
+        /// <summary>
+        /// Write the ring, oldest first, to <c>logs/diag-yyyyMMdd-HHmmss-reason.log</c>. Returns the
+        /// path, or null if nothing could be written.
+        /// </summary>
+        public string? Dump(string reason)
+        {
+            try
+            {
+                var events = Snapshot();
+                if (events.Count == 0) return null;
+
+                Directory.CreateDirectory(_logsDir);
+                var safeReason = Sanitise(reason);
+                var path = Path.Combine(_logsDir,
+                    $"diag-{DateTime.Now:yyyyMMdd-HHmmss}-{safeReason}.log");
+
+                var formatter = new CcpLineFormatter();
+                var sb = new StringBuilder(64 * 1024);
+                sb.Append("== CCP diag dump reason=").Append(safeReason)
+                  .Append(" v").Append(SafeVersion())
+                  .Append(" session ").Append(_sessionId)
+                  .Append(' ').Append(DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss zzz"))
+                  .Append(" events=").Append(events.Count).AppendLine(" ==");
+
+                using (var sw = new StringWriter(sb))
+                {
+                    foreach (var e in events)
+                    {
+                        try { formatter.Format(e, sw); }
+                        catch { /* swallow: one bad event must not cost the whole dump */ }
+                    }
+                }
+
+                File.WriteAllText(path, sb.ToString(), Encoding.UTF8);
+                Prune();
+                return path;
+            }
+            catch
+            {
+                return null; // swallow: best effort by design
+            }
+        }
+
+        /// <summary>Newest diag file, or null. Used by the bug reporter.</summary>
+        public static string? NewestDump(string logsDir)
+        {
+            try
+            {
+                var files = Directory.GetFiles(logsDir, "diag-*.log");
+                if (files.Length == 0) return null;
+                Array.Sort(files, StringComparer.OrdinalIgnoreCase);
+                return files[^1];
+            }
+            catch { return null; /* swallow */ }
+        }
+
+        private List<LogEvent> Snapshot()
+        {
+            var list = new List<LogEvent>(Capacity);
+            lock (_gate)
+            {
+                // Oldest first: start at the write cursor and wrap.
+                for (int i = 0; i < Capacity; i++)
+                {
+                    var e = _ring[(_next + i) % Capacity];
+                    if (e != null) list.Add(e);
+                }
+            }
+            return list;
+        }
+
+        /// <summary>Keep the newest <see cref="KeepDumps"/>. A hang that repeats would otherwise
+        /// fill the logs folder with dumps of the same minute.</summary>
+        private void Prune()
+        {
+            try
+            {
+                var files = Directory.GetFiles(_logsDir, "diag-*.log");
+                if (files.Length <= KeepDumps) return;
+                Array.Sort(files, StringComparer.OrdinalIgnoreCase);
+                for (int i = 0; i < files.Length - KeepDumps; i++)
+                {
+                    try { File.Delete(files[i]); } catch { /* swallow: locked file, try next time */ }
+                }
+            }
+            catch { /* swallow */ }
+        }
+
+        private static string SafeVersion()
+        {
+            try { return UpdateService.AppVersion ?? "?"; }
+            catch { return "?"; }
+        }
+
+        private static string Sanitise(string reason)
+        {
+            if (string.IsNullOrWhiteSpace(reason)) return "manual";
+            var sb = new StringBuilder(reason.Length);
+            foreach (var c in reason)
+            {
+                if ((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '-')
+                    sb.Append(c);
+            }
+            return sb.Length == 0 ? "manual" : sb.ToString();
+        }
+    }
+}

--- a/ConditioningControlPanel/Services/Logging/LogPipeline.cs
+++ b/ConditioningControlPanel/Services/Logging/LogPipeline.cs
@@ -14,10 +14,14 @@ namespace ConditioningControlPanel.Services.Logging
     public static class LogPipeline
     {
         /// <summary>
-        /// The global floor, held as a switch rather than a constant so the flight recorder can
-        /// drop it to Debug later without the file sink following it down.
+        /// The global floor. Debug, so the 2,927 Debug calls in this codebase finally go SOMEWHERE:
+        /// the flight recorder's ring, in memory. The file sink below is restricted separately, so
+        /// what lands on disk is unchanged unless --verbose asks otherwise.
         /// </summary>
-        public static readonly LoggingLevelSwitch LevelSwitch = new(LogEventLevel.Information);
+        public static readonly LoggingLevelSwitch LevelSwitch = new(LogEventLevel.Debug);
+
+        /// <summary>Identifies this run in diag dumps (and, from the session-files PR, the header).</summary>
+        public static string SessionId { get; } = DateTime.Now.ToString("yyyyMMdd-HHmmss");
 
         /// <summary>8 MB. The daily roll alone let one bad loop write an unbounded file.</summary>
         public const long FileSizeLimitBytes = 8L * 1024 * 1024;
@@ -62,7 +66,10 @@ namespace ConditioningControlPanel.Services.Logging
             LogRedactor.ConfigureRoots(App.UserDataPath, AppContext.BaseDirectory);
             LogRedactor.AssetsRootProvider = () => App.EffectiveAssetsPath;
 
-            LevelSwitch.MinimumLevel = verbose ? LogEventLevel.Debug : LogEventLevel.Information;
+            LevelSwitch.MinimumLevel = LogEventLevel.Debug;
+
+            var recorder = new FlightRecorderSink(logsDir, SessionId);
+            FlightRecorderSink.Instance = recorder;
 
             // The file sink is built as its own logger so it can be WRAPPED. Serilog's Logger is an
             // ILogEventSink, which is the only way to put the throttle between the pipeline and the
@@ -96,6 +103,9 @@ namespace ConditioningControlPanel.Services.Logging
                 // touches, but the formatter needs BOTH properties present when it renders.
                 .Enrich.With(new CategoryEnricher())
                 .Enrich.With(new RedactingEnricher())
+                // Debug reaches the ring and nothing else. The file keeps its Information floor
+                // unless this run asked for verbose, so enabling Debug costs disk nothing.
+                .WriteTo.Sink(recorder)
                 .WriteTo.Sink(throttled,
                     restrictedToMinimumLevel: verbose ? LogEventLevel.Debug : LogEventLevel.Information);
 

--- a/ConditioningControlPanel/Services/UI/UiHangWatchdog.cs
+++ b/ConditioningControlPanel/Services/UI/UiHangWatchdog.cs
@@ -336,6 +336,11 @@ public static class UiHangWatchdog
 
             App.Logger?.Error("[WATCHDOG] hang report written: {Path}", path);
             VideoDiag.Log("WATCHDOG", "hang report written: " + path);
+
+            // The hang report is a snapshot of the moment; the flight recorder is the run-up to it.
+            // A frozen UI is exactly the case where the last few hundred Debug lines - which have
+            // never reached a disk before - say which subsystem stopped answering.
+            Services.Logging.FlightRecorderSink.DumpIfActive("hang");
         }
         catch (Exception ex)
         {

--- a/Tests/ConditioningControlPanel.Tests/FlightRecorderTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/FlightRecorderTests.cs
@@ -1,0 +1,127 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using ConditioningControlPanel.Services;
+using ConditioningControlPanel.Services.Logging;
+using Serilog.Events;
+using Serilog.Parsing;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// The flight recorder: Debug detail kept in memory and written out only when something goes wrong.
+///
+/// <para>The app makes 2,927 Debug calls that have never reached a disk, because the floor has been
+/// Information for years. Every freeze and black-video report therefore arrives with the run-up to
+/// the failure already discarded. These pin the three properties that make the ring worth having:
+/// it keeps the NEWEST events (a ring that dropped the recent ones would be worse than nothing), it
+/// writes on an error but not on the cancellations that are ordinary shutdown, and it does not fill
+/// the logs folder with dumps.</para>
+/// </summary>
+public class FlightRecorderTests : IDisposable
+{
+    private readonly string _dir = Path.Combine(Path.GetTempPath(), "ccp-fr-" + Guid.NewGuid().ToString("N"));
+    private static readonly MessageTemplateParser Parser = new();
+
+    public FlightRecorderTests() => Directory.CreateDirectory(_dir);
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); } catch { /* swallow: temp dir */ }
+    }
+
+    private static LogEvent Event(string template, LogEventLevel level = LogEventLevel.Debug, Exception? ex = null) =>
+        new(DateTimeOffset.Now, level, ex, Parser.Parse(template), Array.Empty<LogEventProperty>());
+
+    private string[] Dumps() => Directory.GetFiles(_dir, "diag-*.log");
+
+    [Fact]
+    public void TheRingKeepsTheNewestEvents()
+    {
+        var sink = new FlightRecorderSink(_dir, "test");
+        for (int i = 0; i < FlightRecorderSink.Capacity + 50; i++)
+            sink.Emit(Event("[TEST] line " + i));
+
+        var path = sink.Dump("manual");
+        Assert.NotNull(path);
+        var text = File.ReadAllText(path!);
+
+        Assert.Contains("line " + (FlightRecorderSink.Capacity + 49), text);
+        // The first 50 were overwritten, which is the whole point of a bounded ring.
+        Assert.DoesNotContain("] line 0" + Environment.NewLine, text);
+        Assert.Contains("reason=manual", text);
+    }
+
+    [Fact]
+    public void AnErrorDumpsTheRing_OnceAMinute()
+    {
+        var sink = new FlightRecorderSink(_dir, "test");
+        sink.Emit(Event("[TEST] context"));
+        sink.Emit(Event("[TEST] boom", LogEventLevel.Error, new InvalidOperationException("boom")));
+        Assert.Single(Dumps());
+
+        // A crash loop must not become a disk loop: the second error inside the window is silent.
+        sink.Emit(Event("[TEST] boom", LogEventLevel.Error, new InvalidOperationException("boom")));
+        Assert.Single(Dumps());
+    }
+
+    [Fact]
+    public void CancellationAtShutdownDoesNotDump()
+    {
+        // Timers and in-flight HTTP calls throw these on every clean exit. Dumping for them would
+        // mean a diag file after every session, burying the ones that mean something. There is no
+        // WPF Application in a test host, which is the same "we are shutting down" answer.
+        var sink = new FlightRecorderSink(_dir, "test");
+        var restore = FlightRecorderSink.ShuttingDown;
+        FlightRecorderSink.ShuttingDown = () => true;
+        try
+        {
+            sink.Emit(Event("[TEST] cancelled", LogEventLevel.Error, new TaskCanceledException()));
+            Assert.Empty(Dumps());
+
+            // The same exception while the app is actually running is a real failure and dumps.
+            FlightRecorderSink.ShuttingDown = () => false;
+            sink.Emit(Event("[TEST] cancelled", LogEventLevel.Error, new TaskCanceledException()));
+            Assert.Single(Dumps());
+        }
+        finally
+        {
+            FlightRecorderSink.ShuttingDown = restore;
+        }
+    }
+
+    [Fact]
+    public void OnlyTheNewestFiveDumpsAreKept()
+    {
+        for (int i = 0; i < 7; i++)
+            File.WriteAllText(Path.Combine(_dir, $"diag-2026090{i}-000000-old.log"), "old");
+
+        var sink = new FlightRecorderSink(_dir, "test");
+        sink.Emit(Event("[TEST] something"));
+        sink.Dump("manual");
+
+        Assert.Equal(FlightRecorderSink.KeepDumps, Dumps().Length);
+        // Newest survive: the two oldest stamps are the ones that went.
+        Assert.DoesNotContain(Dumps(), f => f.Contains("20260900") || f.Contains("20260901"));
+    }
+
+    [Fact]
+    public void NewestDump_IsTheOneTheBugReporterAttaches()
+    {
+        File.WriteAllText(Path.Combine(_dir, "diag-20260901-000000-crash.log"), "old");
+        File.WriteAllText(Path.Combine(_dir, "diag-20260903-000000-hang.log"), "new");
+        Assert.EndsWith("diag-20260903-000000-hang.log", FlightRecorderSink.NewestDump(_dir));
+    }
+
+    [Fact]
+    public void TheAppLogFieldIsCappedBelowTheServerLimit()
+    {
+        // The server rejects an appLog over 200,000 chars, and the ring dump is large enough to
+        // reach that on its own now. The cap keeps the TAIL, because the tail is the failure.
+        var text = new string('x', 250_000) + "END";
+        var capped = BugReportService.Tail(text, BugReportService.MaxAppLogFieldChars);
+        Assert.Equal(BugReportService.MaxAppLogFieldChars, capped.Length);
+        Assert.EndsWith("END", capped);
+    }
+}


### PR DESCRIPTION
Fourth of the logging-redesign stack (agent A). **Base: `feat/log-throttle` (#831)** ->
`feat/log-format` (#829) -> `feat/log-pipeline` (#825). Merge in that order.

## What this does

The app makes **2,927 Debug calls that have never once reached a disk.** The floor has been
Information for years, for a good reason at the time (Debug in a file was a privacy problem), so
every freeze and black-video report arrives with the run-up to the failure already discarded - and
the 100-line app-log tail it does carry is usually nothing but the startup chatter of the relaunch
the user had to perform in order to file the report.

`FlightRecorderSink` is the third option:

- The global floor goes to **Debug**; every event lands in a 4,096-slot ring **in memory**. The file
  sink keeps its Information floor, so **nothing new is written to disk** in normal running.
- On trouble the ring is written to `logs/diag-yyyyMMdd-HHmmss-<reason>.log`, newest 5 kept.
- Triggers: any Error/Fatal (at most one dump per 60 s, and never for an
  `OperationCanceledException` while the app is closing - that is what ordinary shutdown looks like
  in this codebase, and dumping for it would put a diag file after every clean exit), a
  `UiHangWatchdog` hang report, `App.LogCrashDetails`, and `BugReportService.CreateDraft`.
- Ring values were already redacted by `RedactingEnricher` upstream, so the privacy objection to
  Debug-on-disk does not apply to what gets dumped.

Bug reports now carry it: app-log tail (<= 120,000) + newest diag dump (<= 60,000) + the existing
video-diag tail, scrubbed as before, then capped at 190,000 against the server's 200,000 limit. The
cap keeps the **tail** and runs **after** scrubbing, so it can never decide which text got redacted.

## Per-frame Debug audit (asked for, since Debug is now enabled)

14 Debug call sites sit inside per-frame handlers - `CompositionTarget.Rendering` blits in
ChaosGifCascade, ChaosSkiaFx, InlineLoopVideo (x2), TakeoverAnnouncer, GazeDebugCursor,
AttentionTargets, DualMonitorVideo (x2), VideoService/BlurVmemSurface (x3), plus the webcam capture
loop and the EmiDesk wobble tick.

**All 14 are error paths**: 13 are inside `catch` blocks, and the webcam one is an explicitly
aggregated ~10 s summary that its own comment already documents as not-per-frame. **Zero fire per
frame in the normal case**, so no modulo guard was needed and none was added. A persistent
per-frame error (a frame copy failing every frame) would fire at 60 fps, but the throttling sink
from #831 caps that at 20 a minute and reports the count - which is the behaviour we want anyway.

## Verification

`dotnet build ConditioningControlPanel.sln -c Debug` 0 errors. `dotnet test` 5234 passed, 0 failed
(6 new here). 426 changed lines.

Not runtime-tested: the dump path has unit coverage but nobody has yet crashed a real build and
read the diag file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GSSvqeYrpVG9H3EPtqikDC
