### PR TITLE
feat(logging): one log file per run, with a header and a footer

### DIFF
--- a/ConditioningControlPanel/App.xaml.cs
+++ b/ConditioningControlPanel/App.xaml.cs
@@ -1534,6 +1534,22 @@ namespace ConditioningControlPanel
             Logger.Information("Application starting v{Version} | workingSet {WS}MB",
                 Services.UpdateService.AppVersion, Environment.WorkingSet / (1024 * 1024));
 
+            // "App ready in N ms", measured to the first IDLE dispatcher frame - the moment the
+            // window is actually usable, not the moment OnStartup returns. Startup regressions have
+            // shipped unnoticed because nothing in the log ever said how long startup took. The
+            // line also carries lang/mod, which the session header cannot: the logger is built
+            // here, and Settings does not exist until two hundred lines further down.
+            try
+            {
+                Dispatcher.BeginInvoke(
+                    System.Windows.Threading.DispatcherPriority.ApplicationIdle,
+                    new Action(() => Services.Logging.LogPipeline.LogAppReady()));
+            }
+            catch (Exception exReady)
+            {
+                Logger.Debug("[Startup] ready-timer hook failed: {Msg}", exReady.Message);
+            }
+
             // Rotate crash.log so a bug report only carries crashes from THIS build. The log is
             // append-only, so without this it accumulates months of old crashes and the reporter
             // ships them all (the last 120KB), burying the real failure and polluting triage.

--- a/ConditioningControlPanel/Services/BugReportService.cs
+++ b/ConditioningControlPanel/Services/BugReportService.cs
@@ -50,11 +50,26 @@ namespace ConditioningControlPanel.Services
         internal const int MaxDiagScanLines = 2000;
         internal const int MaxDiagMatches = 40;      // most-recent matches kept
         internal const int MaxDiagSectionChars = 16_000; // GitHub issue-body budget guard
-        // Grep-friendly markers written to the rolling app log. [RES]/[WATCHDOG] come from
+        // Grep-friendly markers written to the session log. [RES]/[WATCHDOG] come from
         // UiHangWatchdog and are the ones that actually appear today; the video markers are
         // kept defensively (VideoDiag writes its own file, already appended in full above).
+        //
+        // TWO spellings each, because the session-file format lifts "[RES]" out of the message text
+        // and renders it as the padded category column ("[Res          ] user=..."). An exact
+        // "[RES]" match would quietly stop finding anything the day that format shipped, and a
+        // returning user still has old app-*.log files in the old spelling, so both are listed.
+        // The trailing space on the column forms is load-bearing: "[Res" alone would also match
+        // "[Reset", which 20 unrelated call sites write.
+        // Video stays old-spelling-only on purpose: as a CATEGORY, "Video" is every VideoService
+        // line, which would crowd the 40 retained matches out with routine playback chatter - and
+        // the video trace is appended in full from its own file anyway.
         internal static readonly string[] DiagMarkers =
-            { "[RES]", "[WATCHDOG]", "[BLUR]", "[VIDEO]", "[VideoDiag]" };
+        {
+            "[RES]", "[Res ",
+            "[WATCHDOG]", "[Watchdog ",
+            "[BLUR]", "[Blur ",
+            "[VIDEO]", "[VideoDiag]"
+        };
 
         // #769: how many report numbers we remember in AppSettings.RecentBugReports.
         // Newest last; the oldest are trimmed on insert.
@@ -721,22 +736,50 @@ namespace ConditioningControlPanel.Services
         }
 
         /// <summary>
-        /// Read the last N lines of today's rolling Serilog file.
-        /// Serilog rolls daily with name `app-YYYYMMDD.log` (RollingInterval.Day).
+        /// The log file this report should carry: THIS session's file if the pipeline has one,
+        /// otherwise the newest on disk (a returning user's old daily <c>app-*.log</c> included).
+        /// Returns null when there is nothing to read.
+        ///
+        /// <para>Preferring the live session file matters for exactly the reports that need it
+        /// most: a user who had to relaunch after a freeze is now filing from a NEW session, and
+        /// "newest file" would hand them the startup chatter of the relaunch. The frozen session's
+        /// file is still on disk under its own name, and the flight-recorder dump above carries the
+        /// failure itself.</para>
+        /// </summary>
+        internal static string? PickLogFile(string logDir)
+        {
+            try
+            {
+                if (!Directory.Exists(logDir)) return null;
+
+                var current = Services.Logging.LogPipeline.SessionFilePath;
+                if (!string.IsNullOrEmpty(current) && File.Exists(current)) return current;
+
+                var files = Directory.GetFiles(logDir, "session-*.log");
+                if (files.Length == 0) files = Directory.GetFiles(logDir, "app-*.log");
+                if (files.Length == 0) return null;
+                Array.Sort(files, StringComparer.OrdinalIgnoreCase);
+                return files[^1];
+            }
+            catch
+            {
+                return null; // swallow: no log is survivable, a throw from the reporter is not
+            }
+        }
+
+        /// <summary>
+        /// Read the last N lines of this session's log file (see <see cref="PickLogFile"/>).
         /// </summary>
         private static string TryReadRecentAppLog(int maxLines)
         {
             try
             {
                 var logDir = Path.Combine(App.UserDataPath, "logs");
-                if (!Directory.Exists(logDir)) return string.Empty;
-                var files = Directory.GetFiles(logDir, "app-*.log");
-                if (files.Length == 0) return string.Empty;
-                Array.Sort(files, StringComparer.OrdinalIgnoreCase);
-                var latest = files[^1];
+                var latest = PickLogFile(logDir);
+                if (latest == null) return string.Empty;
 
-                // Tail-read: read the whole file then take the last maxLines lines.
-                // Serilog logs are bounded to 7 days × ~1 log/event, typically small.
+                // Tail-read: read the whole file then take the last maxLines lines. A session
+                // file is one run and capped at 8 MB, so this stays small.
                 using var fs = new FileStream(latest, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
                 using var sr = new StreamReader(fs, Encoding.UTF8);
                 var allLines = new List<string>();

--- a/ConditioningControlPanel/Services/Logging/CountingSink.cs
+++ b/ConditioningControlPanel/Services/Logging/CountingSink.cs
@@ -1,0 +1,30 @@
+using System.Threading;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace ConditioningControlPanel.Services.Logging
+{
+    /// <summary>
+    /// Counts warnings and errors as they go past, so the session footer can state what the run
+    /// cost without anyone having to read the file to find out.
+    ///
+    /// <para>"warn=0 err=0" on the last line is the cheapest triage signal we have: a support
+    /// thread can be answered from the footer alone, and a user who says "it was fine" against a
+    /// footer reading err=37 is telling us where to look.</para>
+    /// </summary>
+    public sealed class CountingSink : ILogEventSink
+    {
+        private int _warnings;
+        private int _errors;
+
+        public int Warnings => Volatile.Read(ref _warnings);
+        public int Errors => Volatile.Read(ref _errors);
+
+        public void Emit(LogEvent logEvent)
+        {
+            if (logEvent == null) return;
+            if (logEvent.Level == LogEventLevel.Warning) Interlocked.Increment(ref _warnings);
+            else if (logEvent.Level >= LogEventLevel.Error) Interlocked.Increment(ref _errors);
+        }
+    }
+}

--- a/ConditioningControlPanel/Services/Logging/LogPipeline.cs
+++ b/ConditioningControlPanel/Services/Logging/LogPipeline.cs
@@ -20,14 +20,42 @@ namespace ConditioningControlPanel.Services.Logging
         /// </summary>
         public static readonly LoggingLevelSwitch LevelSwitch = new(LogEventLevel.Debug);
 
-        /// <summary>Identifies this run in diag dumps (and, from the session-files PR, the header).</summary>
+        /// <summary>Identifies this run: names its log file, its diag dumps and its header.</summary>
         public static string SessionId { get; } = DateTime.Now.ToString("yyyyMMdd-HHmmss");
 
-        /// <summary>8 MB. The daily roll alone let one bad loop write an unbounded file.</summary>
+        /// <summary>8 MB. Without a size cap one bad loop writes an unbounded file.</summary>
         public const long FileSizeLimitBytes = 8L * 1024 * 1024;
+
+        /// <summary>This run's log file, or null before the pipeline is built.</summary>
+        public static string? SessionFilePath { get; private set; }
 
         private static Logger? _logger;
         private static ThrottlingSink? _throttle;
+        private static CountingSink? _counters;
+        private static string? _logsDir;
+        private static bool _footerHooked;
+        private static bool _footerWritten;
+        private static readonly object FooterGate = new();
+
+        /// <summary>
+        /// Where the header's <c>lang=</c> and <c>mod=</c> come from. A seam because the logger is
+        /// built long before settings are loaded (see <see cref="LogAppReady"/>), and because tests
+        /// must not need an App.
+        /// </summary>
+        internal static Func<(string Language, string ModId)> EnvironmentProvider { get; set; } = DefaultEnvironment;
+
+        private static (string, string) DefaultEnvironment()
+        {
+            try
+            {
+                var s = App.Settings?.Current;
+                return (s?.Language ?? "?", s?.ActiveModId ?? "?");
+            }
+            catch
+            {
+                return ("?", "?"); // swallow: never let a settings read cost us the log
+            }
+        }
 
         /// <summary>
         /// True when this run was asked for Debug on disk: <c>--verbose</c> on the command line or
@@ -71,6 +99,13 @@ namespace ConditioningControlPanel.Services.Logging
             var recorder = new FlightRecorderSink(logsDir, SessionId);
             FlightRecorderSink.Instance = recorder;
 
+            _logsDir = logsDir;
+            var (lang, mod) = SafeEnvironment();
+            // Retention and the header run BEFORE the sink opens the file: the sweep must not
+            // consider the file we are about to write, and the header must be its first line.
+            var sessionPath = SessionLog.Prepare(logsDir, SessionId, SafeVersion(), lang, mod);
+            SessionFilePath = sessionPath;
+
             // The file sink is built as its own logger so it can be WRAPPED. Serilog's Logger is an
             // ILogEventSink, which is the only way to put the throttle between the pipeline and the
             // file without reimplementing the rolling file sink. Its own floor is Verbose because
@@ -80,12 +115,13 @@ namespace ConditioningControlPanel.Services.Logging
                 .MinimumLevel.Verbose()
                 .WriteTo.File(
                     new CcpLineFormatter(),
-                    Path.Combine(logsDir, "app-.log"),
-                    rollingInterval: RollingInterval.Day,
-                    retainedFileCountLimit: 7,
-                    // A size cap as well as the daily roll: a render-loop exception writes the same
-                    // line thousands of times a minute, and "one file per day" is no cap at all
-                    // when the day has a storm in it.
+                    sessionPath,
+                    // One file per RUN, not per day. The daily file mixed the session that broke
+                    // with the relaunch the user needed in order to report it; a session file is
+                    // the same object as "the thing that went wrong", so it can be attached whole.
+                    rollingInterval: RollingInterval.Infinite,
+                    // The size cap stays: a render-loop exception writes the same line thousands of
+                    // times a minute, and one run is no cap at all when the run has a storm in it.
                     fileSizeLimitBytes: FileSizeLimitBytes,
                     rollOnFileSizeLimit: true,
                     // Force a disk flush each second so the LAST lines survive a hard process death
@@ -97,6 +133,9 @@ namespace ConditioningControlPanel.Services.Logging
             var previousThrottle = _throttle;
             _throttle = throttled;
 
+            var counters = new CountingSink();
+            _counters = counters;
+
             var config = new LoggerConfiguration()
                 .MinimumLevel.ControlledBy(LevelSwitch)
                 // Order matters: the category is derived from the template, which redaction never
@@ -106,6 +145,7 @@ namespace ConditioningControlPanel.Services.Logging
                 // Debug reaches the ring and nothing else. The file keeps its Information floor
                 // unless this run asked for verbose, so enabling Debug costs disk nothing.
                 .WriteTo.Sink(recorder)
+                .WriteTo.Sink(counters, restrictedToMinimumLevel: LogEventLevel.Warning)
                 .WriteTo.Sink(throttled,
                     restrictedToMinimumLevel: verbose ? LogEventLevel.Debug : LogEventLevel.Information);
 
@@ -115,7 +155,89 @@ namespace ConditioningControlPanel.Services.Logging
             var previous = _logger;
             _logger = built;
             try { previous?.Dispose(); } catch { /* swallow: replacing a logger must not throw */ }
+
+            HookFooter();
             return built;
+        }
+
+        /// <summary>
+        /// The footer is written from ProcessExit rather than App.OnExit: OnExit does not run when
+        /// the app is closed by a taskbar kill or a restart-for-update, and those sessions are
+        /// precisely the ones whose end we want recorded.
+        /// </summary>
+        private static void HookFooter()
+        {
+            if (_footerHooked) return;
+            _footerHooked = true;
+            try { AppDomain.CurrentDomain.ProcessExit += (_, _) => WriteSessionFooter(); }
+            catch { /* swallow: no footer is survivable, a throw here is not */ }
+        }
+
+        /// <summary>
+        /// Close the sinks and write the last line. Idempotent - whichever of ProcessExit and
+        /// App.OnExit gets there first wins, and the second is a no-op.
+        /// </summary>
+        public static void WriteSessionFooter()
+        {
+            lock (FooterGate)
+            {
+                if (_footerWritten) return;
+                _footerWritten = true;
+            }
+
+            int warn = _counters?.Warnings ?? 0;
+            int err = _counters?.Errors ?? 0;
+            int suppressed = _throttle?.TotalSuppressed ?? 0;
+            var dir = _logsDir;
+
+            // Sinks first: the file sink holds the handle, and the throttle's flush can still add
+            // suppression summaries that belong above the footer.
+            Shutdown();
+
+            if (!string.IsNullOrEmpty(dir))
+                SessionLog.WriteFooter(dir!, SessionId, Uptime(), warn, err, suppressed);
+        }
+
+        /// <summary>
+        /// "App ready in N ms", from process start to the first idle dispatcher frame - the moment
+        /// the window is actually usable. Startup regressions have shipped unnoticed because
+        /// nothing in the log ever said how long startup took.
+        /// </summary>
+        public static void LogAppReady()
+        {
+            try
+            {
+                var (lang, mod) = SafeEnvironment();
+                Log.Information("App ready in {Ms} ms | lang={Lang} mod={Mod}",
+                    (long)Uptime().TotalMilliseconds, lang, mod);
+            }
+            catch { /* swallow: a timing line is not worth a startup crash */ }
+        }
+
+        private static TimeSpan Uptime()
+        {
+            try
+            {
+                using var p = System.Diagnostics.Process.GetCurrentProcess();
+                var up = DateTime.Now - p.StartTime;
+                return up > TimeSpan.Zero ? up : TimeSpan.Zero;
+            }
+            catch
+            {
+                return TimeSpan.Zero; // swallow: a missing uptime prints 0:00:00
+            }
+        }
+
+        private static (string, string) SafeEnvironment()
+        {
+            try { return EnvironmentProvider(); }
+            catch { return ("?", "?"); /* swallow */ }
+        }
+
+        private static string SafeVersion()
+        {
+            try { return UpdateService.AppVersion ?? "?"; }
+            catch { return "?"; /* swallow */ }
         }
 
         /// <summary>Flush and release the file handle. Idempotent.</summary>

--- a/ConditioningControlPanel/Services/Logging/SessionLog.cs
+++ b/ConditioningControlPanel/Services/Logging/SessionLog.cs
@@ -1,0 +1,134 @@
+using System;
+using System.Globalization;
+using System.IO;
+using System.Text;
+
+namespace ConditioningControlPanel.Services.Logging
+{
+    /// <summary>
+    /// One file per run: <c>logs/session-yyyyMMdd-HHmmss.log</c>.
+    ///
+    /// <para>The daily <c>app-YYYYMMDD.log</c> was the wrong unit. Nobody debugs a Tuesday; they
+    /// debug a run - and a user who has to relaunch after a freeze in order to file a report was
+    /// appending the relaunch to the very file that held the evidence, behind a hundred lines of
+    /// startup chatter. A file per session means "the log" and "the thing that went wrong" are the
+    /// same object, and the bug reporter can attach it whole.</para>
+    ///
+    /// <para>The header carries what used to be repeated on all 34,000 lines a week: the date, and
+    /// the environment. Paths appear as the redactor's own tokens because the real ones are exactly
+    /// what we do not want in a file people paste into Discord.</para>
+    /// </summary>
+    public static class SessionLog
+    {
+        public const int MaxSessionFiles = 20;
+        public const long MaxSessionBytes = 20L * 1024 * 1024;
+
+        /// <summary>Old daily logs age out on their own; this is the sweep that finally removes them.</summary>
+        public const int LegacyAppLogDays = 14;
+
+        public static string FileName(string sessionId) => "session-" + sessionId + ".log";
+
+        /// <summary>
+        /// Enforce retention over the EXISTING files, then write the header for this run. Returns
+        /// the full path of this session's file.
+        /// </summary>
+        public static string Prepare(string logsDir, string sessionId, string version, string language, string modId)
+        {
+            try { Directory.CreateDirectory(logsDir); } catch { /* swallow: the sink reports this better */ }
+
+            Prune(logsDir);
+            SweepLegacyAppLogs(logsDir);
+
+            var path = Path.Combine(logsDir, FileName(sessionId));
+            try
+            {
+                var sb = new StringBuilder(256);
+                sb.Append("== CCP v").Append(version)
+                  .Append(" session ").Append(DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss zzz", CultureInfo.InvariantCulture))
+                  .Append(" pid ").Append(Environment.ProcessId.ToString(CultureInfo.InvariantCulture))
+                  .AppendLine(" ==");
+                sb.Append("os=").Append(Safe(() => Environment.OSVersion.ToString()))
+                  .Append(" dotnet=").Append(Safe(() => Environment.Version.ToString()))
+                  .Append(" install=%APP% data=%DATA%")
+                  .Append(" lang=").Append(string.IsNullOrWhiteSpace(language) ? "?" : language)
+                  .Append(" mod=").Append(string.IsNullOrWhiteSpace(modId) ? "none" : modId)
+                  .AppendLine();
+                File.AppendAllText(path, sb.ToString(), Encoding.UTF8);
+            }
+            catch { /* swallow: a missing header must not cost us the log */ }
+            return path;
+        }
+
+        /// <summary>
+        /// The closing line. Written after the sinks are closed, because the file sink holds the
+        /// handle while it is alive.
+        /// </summary>
+        public static void WriteFooter(string logsDir, string sessionId, TimeSpan uptime, int warnings, int errors, int suppressed)
+        {
+            try
+            {
+                var line = string.Format(CultureInfo.InvariantCulture,
+                    "== end: uptime {0:h\\:mm\\:ss} warn={1} err={2} suppressed={3} ==",
+                    uptime, warnings, errors, suppressed);
+                File.AppendAllText(Path.Combine(logsDir, FileName(sessionId)), line + Environment.NewLine, Encoding.UTF8);
+            }
+            catch { /* swallow: shutdown is best effort */ }
+        }
+
+        /// <summary>
+        /// Oldest first, delete until the folder holds at most <see cref="MaxSessionFiles"/> files
+        /// AND <see cref="MaxSessionBytes"/>. Both limits, because 20 crash-loop sessions can be
+        /// far larger than 20 ordinary ones.
+        /// </summary>
+        public static void Prune(string logsDir)
+        {
+            try
+            {
+                var dir = new DirectoryInfo(logsDir);
+                if (!dir.Exists) return;
+                var files = dir.GetFiles("session-*.log");
+                if (files.Length == 0) return;
+                Array.Sort(files, (a, b) => string.CompareOrdinal(a.Name, b.Name)); // name IS the timestamp
+
+                long total = 0;
+                foreach (var f in files) total += Length(f);
+
+                int count = files.Length;
+                for (int i = 0; i < files.Length && (count > MaxSessionFiles || total > MaxSessionBytes); i++)
+                {
+                    long len = Length(files[i]);
+                    try { files[i].Delete(); total -= len; count--; }
+                    catch { /* swallow: locked file, try again next launch */ }
+                }
+            }
+            catch { /* swallow */ }
+        }
+
+        /// <summary>Remove the pre-session daily logs once they are older than two weeks.</summary>
+        public static void SweepLegacyAppLogs(string logsDir)
+        {
+            try
+            {
+                var dir = new DirectoryInfo(logsDir);
+                if (!dir.Exists) return;
+                var cutoff = DateTime.Now.AddDays(-LegacyAppLogDays);
+                foreach (var f in dir.GetFiles("app-*.log"))
+                {
+                    try { if (f.LastWriteTime < cutoff) f.Delete(); }
+                    catch { /* swallow */ }
+                }
+            }
+            catch { /* swallow */ }
+        }
+
+        private static long Length(FileInfo f)
+        {
+            try { return f.Length; } catch { return 0; }
+        }
+
+        private static string Safe(Func<string> get)
+        {
+            try { return get() ?? "?"; } catch { return "?"; }
+        }
+    }
+}

--- a/ConditioningControlPanel/Services/Logging/ThrottlingSink.cs
+++ b/ConditioningControlPanel/Services/Logging/ThrottlingSink.cs
@@ -54,6 +54,17 @@ namespace ConditioningControlPanel.Services.Logging
         private readonly Dictionary<string, Entry> _keys = new(StringComparer.Ordinal);
         private readonly object _gate = new();
         private bool _disposed;
+        private int _totalSuppressed;
+
+        /// <summary>
+        /// Lines this session dropped as repeats. The session footer reports it, because a run that
+        /// suppressed 40,000 lines is a very different run from one that suppressed none - and the
+        /// per-template summaries scattered through the file do not add themselves up.
+        /// </summary>
+        public int TotalSuppressed
+        {
+            get { lock (_gate) { return _totalSuppressed; } }
+        }
 
         public ThrottlingSink(ILogEventSink inner) => _inner = inner;
 
@@ -96,7 +107,7 @@ namespace ConditioningControlPanel.Services.Logging
                     entry.Level = logEvent.Level;
                     entry.Count++;
                     pass = entry.Count <= BurstLimit;
-                    if (!pass) entry.Suppressed++;
+                    if (!pass) { entry.Suppressed++; _totalSuppressed++; }
                 }
             }
             catch

--- a/Tests/ConditioningControlPanel.Tests/BugReportDiagnosticsTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/BugReportDiagnosticsTests.cs
@@ -299,4 +299,36 @@ public class BugReportDiagnosticsTests
         Assert.Equal(filled, BugReportService.TidyEmptyTokenPlaceholder(filled));
         Assert.Equal(string.Empty, BugReportService.TidyEmptyTokenPlaceholder(null));
     }
+
+    // ------------------------------------------------------------------
+    // Session-file format: the tag moved into the category column.
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void MarkerLines_AreFoundInBothLogFormats()
+    {
+        // The session format lifts "[RES]" out of the message and renders it as a padded category
+        // column, so the old exact-tag markers would have quietly matched NOTHING from the day it
+        // shipped - and a returning user still has old app-*.log files in the old spelling.
+        var lines = new List<string>
+        {
+            "12:00:01.100 INF [Res          ] user=100 gdi=200",
+            "12:00:02.100 ERR [Watchdog     ] UI thread unresponsive for 5s",
+            "12:00:03.100 INF [Blur         ] vmem surface rebuilt",
+            "2026-07-24 12:00:04 INF [RES] user=101 gdi=201",
+            "12:00:05.100 INF [Reset        ] session counters cleared",
+            "12:00:06.100 INF [Session      ] resumed",
+        };
+
+        var result = BugReportService.BuildSampledDiagnostics(lines);
+
+        Assert.Contains("user=100 gdi=200", result);
+        Assert.Contains("UI thread unresponsive", result);
+        Assert.Contains("vmem surface rebuilt", result);
+        Assert.Contains("user=101 gdi=201", result);
+        // "[Res" without the trailing space would swallow [Reset], which 20 unrelated call sites
+        // write - and those would crowd the retained matches out with noise.
+        Assert.DoesNotContain("session counters cleared", result);
+        Assert.DoesNotContain("[Session", result);
+    }
 }

--- a/Tests/ConditioningControlPanel.Tests/SessionLogTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/SessionLogTests.cs
@@ -1,0 +1,141 @@
+using System;
+using System.IO;
+using System.Linq;
+using ConditioningControlPanel.Services.Logging;
+using Serilog.Events;
+using Serilog.Parsing;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// One log file per RUN, and what bounds it.
+///
+/// <para>The daily <c>app-YYYYMMDD.log</c> was the wrong unit: a user who has to relaunch after a
+/// freeze in order to file a report was appending the relaunch to the very file that held the
+/// evidence. A session file makes "the log" and "the thing that went wrong" the same object - but
+/// only if the folder cannot grow without bound and the file says, at the top and the bottom, which
+/// run it was and what that run cost.</para>
+/// </summary>
+public class SessionLogTests : IDisposable
+{
+    private readonly string _dir = Path.Combine(Path.GetTempPath(), "ccp-sess-" + Guid.NewGuid().ToString("N"));
+    private static readonly MessageTemplateParser Parser = new();
+
+    public SessionLogTests() => Directory.CreateDirectory(_dir);
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); } catch { /* swallow: temp dir */ }
+    }
+
+    private void Session(string stamp, int bytes = 16)
+        => File.WriteAllText(Path.Combine(_dir, "session-" + stamp + ".log"), new string('x', bytes));
+
+    private string[] Sessions() => Directory.GetFiles(_dir, "session-*.log");
+
+    [Fact]
+    public void Prune_KeepsTheNewestTwenty()
+    {
+        for (int i = 0; i < 25; i++) Session($"202609{i:D2}-000000");
+
+        SessionLog.Prune(_dir);
+
+        var left = Sessions().Select(Path.GetFileName).OrderBy(n => n, StringComparer.Ordinal).ToArray();
+        Assert.Equal(SessionLog.MaxSessionFiles, left.Length);
+        // Oldest went, newest stayed. A retention that kept the oldest 20 would be worse than none.
+        Assert.DoesNotContain("session-20260900-000000.log", left);
+        Assert.Contains("session-20260924-000000.log", left);
+    }
+
+    [Fact]
+    public void Prune_AlsoCapsTotalSize()
+    {
+        // Twenty files is a fine cap until a crash loop makes each one enormous: 5 x 8 MB is
+        // already the whole allowance, so the count limit alone would let the folder reach 160 MB.
+        for (int i = 0; i < 5; i++) Session($"202609{i:D2}-000000", bytes: 6 * 1024 * 1024);
+
+        SessionLog.Prune(_dir);
+
+        long total = Sessions().Sum(f => new FileInfo(f).Length);
+        Assert.True(total <= SessionLog.MaxSessionBytes, $"folder still holds {total} bytes");
+        Assert.True(Sessions().Length < 5);
+        // The newest survives the size sweep, because it is the one anyone would read.
+        Assert.Contains(Sessions(), f => f.EndsWith("session-20260904-000000.log", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void SweepLegacyAppLogs_RemovesTheOldDailyFilesOnly()
+    {
+        var stale = Path.Combine(_dir, "app-20260101.log");
+        var fresh = Path.Combine(_dir, "app-20260903.log");
+        File.WriteAllText(stale, "old");
+        File.WriteAllText(fresh, "recent");
+        File.SetLastWriteTime(stale, DateTime.Now.AddDays(-SessionLog.LegacyAppLogDays - 1));
+        Session("20260904-000000");
+
+        SessionLog.SweepLegacyAppLogs(_dir);
+
+        Assert.False(File.Exists(stale));
+        Assert.True(File.Exists(fresh));   // inside the window: an upgrading user keeps recent history
+        Assert.Single(Sessions());          // and the sweep never touches session files
+    }
+
+    [Fact]
+    public void Prepare_WritesTheHeaderAndReturnsThisSessionsPath()
+    {
+        var path = SessionLog.Prepare(_dir, "20260904-101112", "6.9.2", "en", "bambisleep");
+
+        Assert.EndsWith("session-20260904-101112.log", path);
+        var header = File.ReadAllLines(path);
+        Assert.StartsWith("== CCP v6.9.2 session ", header[0]);
+        Assert.Contains(" pid ", header[0]);
+        Assert.Contains("lang=en", header[1]);
+        Assert.Contains("mod=bambisleep", header[1]);
+        // Paths appear as the redactor's own tokens. The header is the first thing a user pastes
+        // into Discord, so it is the last place to print C:\Users\<their real name>.
+        Assert.Contains("install=%APP%", header[1]);
+        Assert.Contains("data=%DATA%", header[1]);
+        Assert.DoesNotContain(":\\Users\\", header[1]);
+    }
+
+    [Fact]
+    public void Footer_StatesWhatTheRunCost()
+    {
+        var path = SessionLog.Prepare(_dir, "20260904-101112", "6.9.2", "en", "none");
+        SessionLog.WriteFooter(_dir, "20260904-101112", TimeSpan.FromSeconds(3725), warnings: 4, errors: 2, suppressed: 380);
+
+        var last = File.ReadAllLines(path)[^1];
+        // "warn=0 err=0" on the last line answers a support thread without opening the file.
+        Assert.Equal("== end: uptime 1:02:05 warn=4 err=2 suppressed=380 ==", last);
+    }
+
+    [Fact]
+    public void CountingSink_CountsWarningsAndErrorsSeparately()
+    {
+        var sink = new CountingSink();
+        sink.Emit(Event(LogEventLevel.Information));
+        sink.Emit(Event(LogEventLevel.Warning));
+        sink.Emit(Event(LogEventLevel.Warning));
+        sink.Emit(Event(LogEventLevel.Error));
+        sink.Emit(Event(LogEventLevel.Fatal));   // a Fatal is an error, not a category of its own
+
+        Assert.Equal(2, sink.Warnings);
+        Assert.Equal(2, sink.Errors);
+    }
+
+    [Fact]
+    public void ThrottleReportsWhatTheWholeSessionDropped()
+    {
+        // The per-template summaries are scattered through the file and do not add themselves up;
+        // the footer needs one number.
+        var sink = new ThrottlingSink(new CountingSink());
+        for (int i = 0; i < ThrottlingSink.BurstLimit + 7; i++)
+            sink.Emit(Event(LogEventLevel.Information, "[EMOTE] xfade -> {Emote}"));
+
+        Assert.Equal(7, sink.TotalSuppressed);
+    }
+
+    private static LogEvent Event(LogEventLevel level, string template = "[TEST] line") =>
+        new(DateTimeOffset.Now, level, null, Parser.Parse(template), Array.Empty<LogEventProperty>());
+}


### PR DESCRIPTION
Last of the logging-redesign stack (agent A). **Base: `feat/log-flight-recorder` (#835)** ->
`feat/log-throttle` (#831) -> `feat/log-format` (#829) -> `feat/log-pipeline` (#825). Merge in that
order.

## What this does

The daily `app-YYYYMMDD.log` was the wrong unit. Nobody debugs a Tuesday; they debug a run - and a
user whose PC froze has to **relaunch the app in order to file the report**, which appends the
relaunch to the very file that held the evidence, behind a hundred lines of startup chatter. Every
freeze report since v6.5.0 has that shape.

Logging now writes **`logs/session-yyyyMMdd-HHmmss.log`, one file per launch**. "The log" and "the
thing that went wrong" become the same object: the reporter can attach it whole, and support can
ask for one file by name.

**Header** - what used to be repeated on all 34,500 lines a week:

```
== CCP v6.9.2 session 2026-09-04 14:02:11 +02:00 pid 18244 ==
os=Microsoft Windows NT 10.0.26200.0 dotnet=8.0.20 install=%APP% data=%DATA% lang=en mod=bambisleep
```

**Footer** - what the run cost:

```
== end: uptime 1:02:05 warn=4 err=2 suppressed=380 ==
```

`warn=0 err=0` answers a support thread without anyone opening the file. A new `CountingSink`
supplies the numbers; `ThrottlingSink` now totals what it dropped. Paths are the redactor's own
tokens, because the header is the first thing a user pastes into Discord.

**`App ready in {ms} ms`** - process start to the first idle dispatcher frame, i.e. the moment the
window is usable. Startup regressions have shipped unnoticed because nothing in the log ever said
how long startup took.

**Retention**, at startup, before the new file opens: at most **20 session files AND 20 MB**,
whichever bites first (five 8 MB crash-loop files are already half the allowance, so a count limit
alone would let the folder reach 160 MB). `app-*.log` older than **14 days** is deleted, so an
upgrading user keeps recent history and then stops carrying it forever. The daily sink is gone.

**Bug reports** now read *this* session's file rather than "the newest file" - the same distinction
again: someone filing after a relaunch would otherwise ship the relaunch. The diagnostic markers
learned the new spelling too: the session format lifts `[RES]` out of the message and renders it as
the **category column**, so the old exact `"[RES]"` markers would have quietly matched nothing from
the day this shipped, and a returning user still has old `app-*.log` files in the old spelling.
Both are listed, with a trailing space on the column forms so `"[Res "` cannot swallow the 20
unrelated `[RESET]` call sites (there is a test for exactly that).

## Placement notes (worth a reviewer's eye)

- The **footer is written from `ProcessExit`**, not `App.OnExit`: OnExit does not run on a taskbar
  kill or a restart-for-update, and those sessions are the ones whose end we most want recorded. It
  closes the sinks first (the file sink holds the handle) and is idempotent.
- **`lang`/`mod` also appear on the ready line**, not only the header: the logger is built at
  `App.xaml.cs:1515` and `Settings` does not exist until ~1724, so at header time they are `?` on a
  first run. The ready line fires at idle, when both are known.

## Verification

`dotnet build ConditioningControlPanel.sln -c Debug` 0 errors. `dotnet test` **5242 passed, 0
failed** (8 new). **569 changed lines.**

Not runtime-tested: no real launch has yet produced a session file - the header, footer, retention
sweep and ready timing have unit coverage only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GSSvqeYrpVG9H3EPtqikDC
