### PR TITLE
fix(logging): smoke-test fixes (footer on exit, literal message rendering, video-diag redaction)

### DIFF
--- a/ConditioningControlPanel/App.xaml.cs
+++ b/ConditioningControlPanel/App.xaml.cs
@@ -1699,6 +1699,18 @@ namespace ConditioningControlPanel
             {
                 var ex = args.ExceptionObject as Exception;
                 LogCrashDetails("DOMAIN", ex);
+
+                // Last chance to close the session file: the runtime is about to tear the process
+                // down and ProcessExit does not run for an unhandled exception, so without this
+                // the log of the run that CRASHED is the one with no end line. Guarded on
+                // IsTerminating, and deliberately NOT done in the dispatcher or task handlers -
+                // both of those mark the exception handled and the app keeps running, where
+                // writing the footer would close the sinks under a live session.
+                if (args.IsTerminating)
+                {
+                    try { Services.Logging.LogPipeline.WriteSessionFooter(); }
+                    catch { /* swallow: nothing useful is left to report it to */ }
+                }
             };
             TaskScheduler.UnobservedTaskException += (s, args) =>
             {
@@ -4953,7 +4965,16 @@ Application State:
             SecureAuthTokenStore.ClearMemoryCache();
             SecureApiKeyStore.ClearMemoryCache();
 
-            // Close and flush the logger
+            // Close the session file and write its "== end:" line. This has to happen HERE rather
+            // than only from the pipeline's ProcessExit hook, because OnExit finishes with
+            // TerminateProcess (see the comment at the bottom of this method), which skips
+            // ProcessExit handlers entirely - so every ordinary close was ending with no footer at
+            // all. Idempotent: the ProcessExit hook and the unhandled-exception path can still call
+            // it, and whichever arrives first is the one that writes.
+            Services.Logging.LogPipeline.WriteSessionFooter();
+
+            // Close and flush the logger (WriteSessionFooter has already done this; harmless and
+            // kept so the shutdown reads the same whether or not the pipeline was ever built).
             Log.CloseAndFlush();
 
             // Dispose show-window signal

--- a/ConditioningControlPanel/Services/Logging/CategoryEnricher.cs
+++ b/ConditioningControlPanel/Services/Logging/CategoryEnricher.cs
@@ -18,6 +18,11 @@ namespace ConditioningControlPanel.Services.Logging
     /// literal from the call site, so the same string instance comes back every time. The cache is
     /// bounded and cleared wholesale when it fills, which cannot happen with a fixed set of call
     /// sites but can if someone builds templates by concatenation.</para>
+    ///
+    /// <para>The one template shape the text alone cannot answer is a tag passed as a PARAMETER
+    /// (<c>"{Tag} blocked"</c>). Those are rendered through <see cref="LiteralMessage"/> - the same
+    /// renderer the formatter uses, so the column and the line can never disagree - and are not
+    /// cached, because the answer belongs to the event rather than the template.</para>
     /// </summary>
     public sealed class CategoryEnricher : ILogEventEnricher
     {
@@ -35,11 +40,20 @@ namespace ConditioningControlPanel.Services.Logging
             var text = logEvent.MessageTemplate?.Text;
             if (string.IsNullOrEmpty(text)) return;
 
-            if (!_cache.TryGetValue(text!, out var cat))
+            string cat;
+            if (text![0] == '{')
             {
-                cat = Derive(text!);
+                // The tag is a PARAMETER, not literal text: Log.Warning("{Tag} blocked", "[BARK]").
+                // The template alone reads as "{Tag} blocked" and derives App, so render the line
+                // the way the formatter will - strings literal, no quotes - and read the tag off
+                // that. Not cached: unlike a template, the answer varies per event.
+                cat = Derive(LiteralMessage.Render(logEvent));
+            }
+            else if (!_cache.TryGetValue(text, out cat!))
+            {
+                cat = Derive(text);
                 if (_cache.Count >= CacheCap) _cache.Clear();
-                _cache[text!] = cat;
+                _cache[text] = cat;
             }
 
             logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty(PropertyName, cat));

--- a/ConditioningControlPanel/Services/Logging/CcpLineFormatter.cs
+++ b/ConditioningControlPanel/Services/Logging/CcpLineFormatter.cs
@@ -77,12 +77,12 @@ namespace ConditioningControlPanel.Services.Logging
             return "App";
         }
 
-        private static string Render(LogEvent e)
-        {
-            using var sw = new StringWriter(CultureInfo.InvariantCulture);
-            e.RenderMessage(sw);
-            return sw.ToString();
-        }
+        /// <summary>
+        /// The message, with string parameters written literally. NOT
+        /// <see cref="LogEvent.RenderMessage(TextWriter, System.IFormatProvider)"/>: that quotes
+        /// every string scalar. See <see cref="LiteralMessage"/>.
+        /// </summary>
+        private static string Render(LogEvent e) => LiteralMessage.Render(e);
 
         /// <summary>
         /// How many characters of the message repeat the category column. Only an EXACT repeat is

--- a/ConditioningControlPanel/Services/Logging/LiteralMessage.cs
+++ b/ConditioningControlPanel/Services/Logging/LiteralMessage.cs
@@ -1,0 +1,119 @@
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using Serilog.Events;
+using Serilog.Parsing;
+
+namespace ConditioningControlPanel.Services.Logging
+{
+    /// <summary>
+    /// Renders a log event's message template the way the old output template did, with
+    /// <c>{Message:lj}</c>: string values appear as themselves, not wrapped in quotes.
+    ///
+    /// <para>Serilog's own <see cref="LogEvent.RenderMessage(TextWriter, System.IFormatProvider)"/>
+    /// renders a string scalar through <see cref="ScalarValue.Render"/>, which QUOTES it, because
+    /// the default rendering is meant to round-trip as structured data. The app's file sink used to
+    /// be an output template carrying <c>:lj</c>, so nobody ever saw those quotes; moving to an
+    /// <see cref="Serilog.Formatting.ITextFormatter"/> lost the flag and every string parameter
+    /// arrived on disk in quotes - <c>Application starting v"6.9.1"</c>, <c>lang='"en"'</c>, and a
+    /// bare <c>""</c> wherever a parameter was the empty string.</para>
+    ///
+    /// <para>It also broke the category column: <see cref="CategoryEnricher"/> reads the tag off the
+    /// front of the message, and <c>"[BARK]"</c> passed as a PARAMETER rendered as <c>"[BARK]"</c>
+    /// (quotes included), which is not a tag. One shared renderer means the formatter and the
+    /// enricher can never disagree about what a line says.</para>
+    /// </summary>
+    public static class LiteralMessage
+    {
+        /// <summary>The message as it will appear on disk, before redaction and prefix stripping.</summary>
+        public static string Render(LogEvent logEvent)
+        {
+            if (logEvent?.MessageTemplate == null) return string.Empty;
+            using var sw = new StringWriter(CultureInfo.InvariantCulture);
+            Render(logEvent, sw);
+            return sw.ToString();
+        }
+
+        /// <summary>Writes the rendered message straight to <paramref name="output"/>.</summary>
+        public static void Render(LogEvent logEvent, TextWriter output)
+        {
+            if (logEvent?.MessageTemplate == null || output == null) return;
+
+            foreach (var token in logEvent.MessageTemplate.Tokens)
+            {
+                if (token is TextToken text)
+                {
+                    output.Write(text.Text);
+                    continue;
+                }
+
+                if (token is PropertyToken property)
+                {
+                    RenderProperty(property, logEvent.Properties, output);
+                    continue;
+                }
+
+                // Not a shape Serilog produces today, but a token type we do not know how to
+                // treat literally is still better rendered than dropped.
+                token.Render(logEvent.Properties, output, CultureInfo.InvariantCulture);
+            }
+        }
+
+        private static void RenderProperty(
+            PropertyToken token,
+            IReadOnlyDictionary<string, LogEventPropertyValue> properties,
+            TextWriter output)
+        {
+            if (!properties.TryGetValue(token.PropertyName, out var value))
+            {
+                // Serilog writes the placeholder back out when the parameter is missing, and so do
+                // we: "{Count}" on the line is a clearer bug report than a silent gap.
+                output.Write(token.ToString());
+                return;
+            }
+
+            if (!token.Alignment.HasValue)
+            {
+                WriteValue(value, token.Format, output);
+                return;
+            }
+
+            // Alignment has to measure the rendered text, so this one path buffers.
+            using var buffer = new StringWriter(CultureInfo.InvariantCulture);
+            WriteValue(value, token.Format, buffer);
+            Pad(output, buffer.ToString(), token.Alignment.Value);
+        }
+
+        private static void WriteValue(LogEventPropertyValue value, string? format, TextWriter output)
+        {
+            // The whole point: a string is written as itself. Everything else - numbers, enums,
+            // sequences, structures - keeps Serilog's own rendering, including the format string.
+            if (value is ScalarValue scalar && scalar.Value is string s)
+            {
+                output.Write(s);
+                return;
+            }
+            value.Render(output, format, CultureInfo.InvariantCulture);
+        }
+
+        private static void Pad(TextWriter output, string value, Alignment alignment)
+        {
+            int pad = alignment.Width - value.Length;
+            if (pad <= 0)
+            {
+                output.Write(value);
+                return;
+            }
+            if (alignment.Direction == AlignmentDirection.Left)
+            {
+                output.Write(value);
+                output.Write(new string(' ', pad));
+            }
+            else
+            {
+                output.Write(new string(' ', pad));
+                output.Write(value);
+            }
+        }
+    }
+}

--- a/ConditioningControlPanel/Services/Logging/LogPipeline.cs
+++ b/ConditioningControlPanel/Services/Logging/LogPipeline.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.IO;
 using Serilog;
 using Serilog.Core;
@@ -34,8 +35,7 @@ namespace ConditioningControlPanel.Services.Logging
         private static CountingSink? _counters;
         private static string? _logsDir;
         private static bool _footerHooked;
-        private static bool _footerWritten;
-        private static readonly object FooterGate = new();
+        private static int _footerWritten;
 
         /// <summary>
         /// Where the header's <c>lang=</c> and <c>mod=</c> come from. A seam because the logger is
@@ -161,9 +161,12 @@ namespace ConditioningControlPanel.Services.Logging
         }
 
         /// <summary>
-        /// The footer is written from ProcessExit rather than App.OnExit: OnExit does not run when
-        /// the app is closed by a taskbar kill or a restart-for-update, and those sessions are
-        /// precisely the ones whose end we want recorded.
+        /// ProcessExit is the BACKUP hook, not the only one. It covers the exits App.OnExit never
+        /// sees - a taskbar kill, a restart-for-update - but it does NOT cover the ordinary one:
+        /// App.OnExit ends in TerminateProcess, which skips ProcessExit handlers and finalizers by
+        /// design (see the comment there; it is what stopped WPF's DirectWriteForwarder crashing on
+        /// close). So every clean exit used to end with no footer at all. App.OnExit now calls
+        /// <see cref="WriteSessionFooter"/> itself, and this stays for the other paths.
         /// </summary>
         private static void HookFooter()
         {
@@ -174,28 +177,44 @@ namespace ConditioningControlPanel.Services.Logging
         }
 
         /// <summary>
-        /// Close the sinks and write the last line. Idempotent - whichever of ProcessExit and
-        /// App.OnExit gets there first wins, and the second is a no-op.
+        /// Where the footer's <c>swallowed=</c> comes from. A seam so the pipeline does not reach
+        /// into app-wide state, and so a test can supply its own numbers without touching the
+        /// process-wide counter in <see cref="Diag"/>.
+        /// </summary>
+        internal static Func<(int Count, string Summary)> SwallowProvider { get; set; } = DefaultSwallow;
+
+        private static (int, string) DefaultSwallow()
+        {
+            try { return (Diag.SwallowCount, Diag.SwallowSummary(SessionLog.MaxSwallowSites)); }
+            catch { return (0, string.Empty); /* swallow: a footer number is not worth an exit crash */ }
+        }
+
+        /// <summary>
+        /// Close the sinks and write the last line. Idempotent, and cheaply so: App.OnExit,
+        /// ProcessExit and the crash path can all reach it, and only the first one writes.
         /// </summary>
         public static void WriteSessionFooter()
         {
-            lock (FooterGate)
-            {
-                if (_footerWritten) return;
-                _footerWritten = true;
-            }
+            if (Interlocked.Exchange(ref _footerWritten, 1) != 0) return;
 
             int warn = _counters?.Warnings ?? 0;
             int err = _counters?.Errors ?? 0;
             int suppressed = _throttle?.TotalSuppressed ?? 0;
             var dir = _logsDir;
+            var (swallowed, swallowSites) = SafeSwallow();
 
             // Sinks first: the file sink holds the handle, and the throttle's flush can still add
             // suppression summaries that belong above the footer.
             Shutdown();
 
             if (!string.IsNullOrEmpty(dir))
-                SessionLog.WriteFooter(dir!, SessionId, Uptime(), warn, err, suppressed);
+                SessionLog.WriteFooter(dir!, SessionId, Uptime(), warn, err, suppressed, swallowed, swallowSites);
+        }
+
+        private static (int, string) SafeSwallow()
+        {
+            try { return SwallowProvider(); }
+            catch { return (0, string.Empty); /* swallow */ }
         }
 
         /// <summary>

--- a/ConditioningControlPanel/Services/Logging/SessionLog.cs
+++ b/ConditioningControlPanel/Services/Logging/SessionLog.cs
@@ -59,20 +59,47 @@ namespace ConditioningControlPanel.Services.Logging
             return path;
         }
 
+        /// <summary>At most this many swallow-site lines under the footer, and none at all beyond
+        /// that: a truncated top-five tells a reader less than the count already did.</summary>
+        public const int MaxSwallowSites = 5;
+
         /// <summary>
         /// The closing line. Written after the sinks are closed, because the file sink holds the
         /// handle while it is alive.
+        ///
+        /// <para><c>swallowed=</c> is the session's <see cref="Diag.SwallowCount"/>: exceptions the
+        /// app deliberately ignored. It belongs here precisely because those stop being logged once
+        /// a site passes its per-site budget, so the footer is the only place a run ever says
+        /// "there were four hundred of these" - a number that is often the first sign of a real
+        /// fault behind an empty-looking log.</para>
+        ///
+        /// <para><paramref name="swallowSummary"/> is the busiest sites, newline separated, written
+        /// one line each and only while the list stays short.</para>
         /// </summary>
-        public static void WriteFooter(string logsDir, string sessionId, TimeSpan uptime, int warnings, int errors, int suppressed)
+        public static void WriteFooter(string logsDir, string sessionId, TimeSpan uptime, int warnings, int errors, int suppressed,
+            int swallowed = 0, string? swallowSummary = null)
         {
             try
             {
-                var line = string.Format(CultureInfo.InvariantCulture,
-                    "== end: uptime {0:h\\:mm\\:ss} warn={1} err={2} suppressed={3} ==",
-                    uptime, warnings, errors, suppressed);
-                File.AppendAllText(Path.Combine(logsDir, FileName(sessionId)), line + Environment.NewLine, Encoding.UTF8);
+                var sb = new StringBuilder(256);
+                sb.AppendFormat(CultureInfo.InvariantCulture,
+                    "== end: uptime {0:h\\:mm\\:ss} warn={1} err={2} suppressed={3} swallowed={4} ==",
+                    uptime, warnings, errors, suppressed, swallowed);
+                sb.Append(Environment.NewLine);
+
+                foreach (var site in SummaryLines(swallowSummary))
+                    sb.Append("   swallowed at ").Append(site).Append(Environment.NewLine);
+
+                File.AppendAllText(Path.Combine(logsDir, FileName(sessionId)), sb.ToString(), Encoding.UTF8);
             }
             catch { /* swallow: shutdown is best effort */ }
+        }
+
+        private static string[] SummaryLines(string? summary)
+        {
+            if (string.IsNullOrWhiteSpace(summary)) return Array.Empty<string>();
+            var lines = summary!.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            return lines.Length > 0 && lines.Length <= MaxSwallowSites ? lines : Array.Empty<string>();
         }
 
         /// <summary>

--- a/ConditioningControlPanel/Services/Video/VideoDiag.cs
+++ b/ConditioningControlPanel/Services/Video/VideoDiag.cs
@@ -276,8 +276,21 @@ namespace ConditioningControlPanel.Services
                         _headerDate = today;
                         sw.WriteLine($"==== {today} (local, UTC{DateTime.Now:zzz}) ====");
                     }
+                    // Redact on the way to disk. This file bypasses Serilog entirely, so none of
+                    // the pipeline's redaction reaches it, and its callers hand it raw paths -
+                    // UiHangWatchdog writes the dump path and the log folder verbatim. video-diag
+                    // is attached to bug reports like any other log, so "C:\Users\<name>\..." in it
+                    // is the same leak the session file was fixed for.
+                    //
+                    // Here rather than in Log(): Log() is called from the UI thread and from
+                    // LibVLC's native callback threads while the UI may already be wedged, and the
+                    // redactor's assets-root rule does a Directory.Exists that can block on an
+                    // unplugged drive. On this thread - the writer's own, which is what keeps the
+                    // trace alive during a freeze - that cost is paid where it is safe to pay it.
+                    // The redactor itself is regex-only: no locks, no Serilog, no shared state
+                    // beyond the cached roots.
                     while (_queue.TryDequeue(out var line))
-                        sw.WriteLine(line);
+                        sw.WriteLine(Services.Logging.LogRedactor.Redact(line));
                     int dropped = Interlocked.Exchange(ref _dropped, 0);
                     if (dropped > 0) sw.WriteLine($"(diag queue overflow — {dropped} line(s) dropped)");
                     sw.Flush();

--- a/Tests/ConditioningControlPanel.Tests/LogFormatTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/LogFormatTests.cs
@@ -128,6 +128,67 @@ public class LogFormatTests
     }
 
     [Fact]
+    public void StringParameters_AreWrittenLiterally_NotQuoted()
+    {
+        // Serilog's own RenderMessage quotes string scalars, because its default rendering is meant
+        // to round-trip as structured data. The file sink used to be an output template carrying
+        // ":lj", so nobody ever saw those quotes; moving to an ITextFormatter lost the flag and put
+        // Application starting v"6.9.1" on the first line of every log the app writes.
+        var e = Event("Application starting v{Version}", null,
+            new LogEventProperty("Version", new ScalarValue("6.9.1")));
+        Assert.Equal("12:34:56.789 INF [App          ] Application starting v6.9.1" + Environment.NewLine, Format(e));
+    }
+
+    [Fact]
+    public void AnEmptyStringParameter_LeavesNothingBehind()
+    {
+        // The visible symptom was a bare pair of quotes at the end of a line - unresponsive for
+        // 15s"" - which reads as a mangled log rather than as an empty parameter.
+        var line = Format(Event("unresponsive for 15s{Detail}", null,
+            new LogEventProperty("Detail", new ScalarValue(string.Empty))));
+        Assert.Equal("12:34:56.789 INF [App          ] unresponsive for 15s" + Environment.NewLine, line);
+    }
+
+    [Fact]
+    public void ATagPassedAsAParameter_StillNamesTheCategory()
+    {
+        // A template beginning with a placeholder derives App from its text alone, because the tag
+        // is in the ARGUMENT, not the template. The enricher renders the message literally for
+        // exactly this shape, so the line lands in Bark instead of App-with-a-quoted-tag.
+        var line = Format(Event("Hello {Name} {Tag}", null,
+            new LogEventProperty("Name", new ScalarValue("x")),
+            new LogEventProperty("Tag", new ScalarValue("[BARK]"))));
+        Assert.Contains("Hello x [BARK]", line);
+
+        var tagged = Event("{Tag} blocked by the flash guard", null,
+            new LogEventProperty("Tag", new ScalarValue("[BARK]")));
+        new CategoryEnricher().Enrich(tagged, new Factory());
+        Assert.Equal("Bark", ((ScalarValue)tagged.Properties[CategoryEnricher.PropertyName]).Value);
+    }
+
+    [Fact]
+    public void NonStringParameters_KeepSerilogsOwnRendering()
+    {
+        // Only STRINGS go literal. Numbers, and any format or alignment on them, are unchanged.
+        var line = Format(Event("ready in {Ms} ms | {Pct,5:F1} pct", null,
+            new LogEventProperty("Ms", new ScalarValue(1234)),
+            new LogEventProperty("Pct", new ScalarValue(9.26))));
+        Assert.Contains("ready in 1234 ms |   9.3 pct", line);
+    }
+
+    [Fact]
+    public void LiteralRendering_StillShowsRedactedPropertyValues()
+    {
+        // The literal path must not step around RedactingEnricher: it writes the property value it
+        // is handed, and by then that value is already %DATA%.
+        var line = Format(Event("[SETTINGS] saved to {Path}", null,
+            new LogEventProperty("Path", new ScalarValue(@"C:\Users\alice\AppData\Local\ConditioningControlPanel\settings.json"))));
+        Assert.Contains(@"%DATA%\settings.json", line);
+        Assert.DoesNotContain("alice", line);
+        Assert.DoesNotContain("\"", line);
+    }
+
+    [Fact]
     public void VerboseIsOptIn()
     {
         Assert.False(LogPipeline.VerboseRequested(new[] { "--hidden" }));

--- a/Tests/ConditioningControlPanel.Tests/LogRedactorTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/LogRedactorTests.cs
@@ -86,6 +86,22 @@ public class LogRedactorTests
     }
 
     [Fact]
+    public void VideoDiagLines_AreRedactedLikeAnyOther()
+    {
+        // video-diag.log bypasses Serilog entirely - it is written by VideoDiag's own thread so it
+        // survives a UI freeze - and UiHangWatchdog hands it raw paths: the hang dump it just wrote
+        // and the folder it wrote it to. The file is attached to bug reports like any other log, so
+        // it gets the same rules; VideoDiag now runs each line through here on the way to disk.
+        Assert.Equal(@"14:02:11.402 [t9] HANG: wrote %DATA%\logs\hang.txt",
+            LogRedactor.Redact(@"14:02:11.402 [t9] HANG: wrote " + Data + @"\logs\hang.txt"));
+
+        // A path under some OTHER app's LocalAppData is not a known root, so it falls through to
+        // the home-directory rule and still loses the user name.
+        Assert.Equal(@"HANG: wrote ~\AppData\Local\X\logs\hang.txt",
+            LogRedactor.Redact(@"HANG: wrote C:\Users\PC\AppData\Local\X\logs\hang.txt"));
+    }
+
+    [Fact]
     public void OrdinaryLines_ArePassedThroughUnchanged()
     {
         // The cheap pre-filter is the whole reason this is affordable per line: a line with no

--- a/Tests/ConditioningControlPanel.Tests/SessionLogTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/SessionLogTests.cs
@@ -103,11 +103,43 @@ public class SessionLogTests : IDisposable
     public void Footer_StatesWhatTheRunCost()
     {
         var path = SessionLog.Prepare(_dir, "20260904-101112", "6.9.2", "en", "none");
-        SessionLog.WriteFooter(_dir, "20260904-101112", TimeSpan.FromSeconds(3725), warnings: 4, errors: 2, suppressed: 380);
+        SessionLog.WriteFooter(_dir, "20260904-101112", TimeSpan.FromSeconds(3725),
+            warnings: 4, errors: 2, suppressed: 380, swallowed: 91);
 
         var last = File.ReadAllLines(path)[^1];
-        // "warn=0 err=0" on the last line answers a support thread without opening the file.
-        Assert.Equal("== end: uptime 1:02:05 warn=4 err=2 suppressed=380 ==", last);
+        // "warn=0 err=0" on the last line answers a support thread without opening the file, and
+        // "swallowed=" is the only place the deliberately-ignored exceptions are ever counted: past
+        // their per-site budget they stop being logged at all.
+        Assert.Equal("== end: uptime 1:02:05 warn=4 err=2 suppressed=380 swallowed=91 ==", last);
+    }
+
+    [Fact]
+    public void Footer_ListsTheBusiestSwallowSites_WhileTheListIsShort()
+    {
+        var path = SessionLog.Prepare(_dir, "20260904-101113", "6.9.2", "en", "none");
+        SessionLog.WriteFooter(_dir, "20260904-101113", TimeSpan.FromSeconds(60),
+            warnings: 0, errors: 0, suppressed: 0, swallowed: 12,
+            swallowSummary: "VideoService.cs:412 9\nApp.xaml.cs:1204 3");
+
+        var lines = File.ReadAllLines(path);
+        Assert.Contains("swallowed=12", lines[^3]);
+        Assert.Equal("   swallowed at VideoService.cs:412 9", lines[^2]);
+        Assert.Equal("   swallowed at App.xaml.cs:1204 3", lines[^1]);
+    }
+
+    [Fact]
+    public void Footer_DropsTheSiteListRatherThanTruncateIt()
+    {
+        var path = SessionLog.Prepare(_dir, "20260904-101114", "6.9.2", "en", "none");
+        var many = string.Join("\n", Enumerable.Range(0, SessionLog.MaxSwallowSites + 1).Select(i => $"F{i}.cs:1 {i}"));
+        SessionLog.WriteFooter(_dir, "20260904-101114", TimeSpan.FromSeconds(60),
+            warnings: 0, errors: 0, suppressed: 0, swallowed: 99, swallowSummary: many);
+
+        // A truncated top-five tells a reader less than the count already did, so the footer stays
+        // one line.
+        var lines = File.ReadAllLines(path);
+        Assert.Contains("swallowed=99", lines[^1]);
+        Assert.DoesNotContain(lines, l => l.Contains("swallowed at"));
     }
 
     [Fact]


### PR DESCRIPTION
Four defects found by a runtime smoke test of the logging redesign, plus the tests that pin them.

Branched from `feat/log-session-files` (the tip of the pipeline stack #825 -> #829 -> #831 -> #835 -> #836), with `main` merged in as the first commit. `main` carries the already-merged call-site PRs of this same programme, including `Services/Diag.cs`, which the footer needs; the merge is clean and there is nothing hand-resolved in it. My own diff is the three commits after it.

## D1 - the footer was never written

`LogPipeline.HookFooter` registered `WriteSessionFooter` on `AppDomain.ProcessExit` only, and `App.OnExit` ends in `TerminateProcess`, which skips ProcessExit handlers and finalizers by design (that is what stopped WPF's DirectWriteForwarder crashing on close, so it stays). `WriteSessionFooter` had no other caller. Three clean exits in the smoke test produced zero `== end:` lines.

`App.OnExit` now calls it directly, just before `Log.CloseAndFlush`. The `AppDomain.UnhandledException` handler calls it too when `args.IsTerminating` - ProcessExit does not run for those either, so the log of the run that crashed was the one with no end line. The ProcessExit hook stays for the exits `OnExit` never sees (taskbar kill, restart-for-update). The guard is now an `Interlocked.Exchange`, so whichever path arrives first is the one that writes.

Deliberately NOT wired into the dispatcher and unobserved-task handlers: both mark the exception handled and the app keeps running, where writing the footer would close the sinks under a live session.

## D2 - every string parameter was quoted

`CcpLineFormatter` used `LogEvent.RenderMessage`, which renders string scalars with quotes. The old sink was an output template carrying `{Message:lj}`, so nobody had ever seen them. On disk:

```
Application starting v"6.9.1"
lang='"en"' mod="none"
UI unresponsive for 15s""
```

and, worse than cosmetic, `"[BARK]" blocked ...` landed in category `App`, because `CategoryEnricher` reads the tag off the front of the message and a quoted tag is not a tag.

New `Services/Logging/LiteralMessage.cs` renders the template with strings written raw and everything else (numbers, enums, sequences, structures, formats, alignment) left to Serilog. Both the formatter and the enricher use it, so the column and the line can never disagree. Redaction is unaffected: `RedactingEnricher` rewrites property values before either caller renders, and the formatter still runs the redactor over the finished line.

## D3 - the footer omitted the swallowed count

`== end:` now carries `swallowed={n}` from `Diag.SwallowCount`, plus the busiest sites as one line each while that list stays at five or fewer. Those exceptions stop being logged once a site passes its per-site budget, so the footer is the only place a run ever says there were four hundred of them.

The count reaches the pipeline through a `SwallowProvider` seam rather than a direct reach into app-wide state, so the footer tests can supply their own numbers.

## D4 - video-diag.log wrote absolute user paths

`VideoDiag` bypasses Serilog entirely - it owns its thread and its file so the trace survives a wedged UI - so no pipeline redaction reached it, and `UiHangWatchdog` hands it raw paths at two call sites. Fixed at the sink so the next caller cannot reintroduce it.

Redaction runs on the writer thread, not in `Log()`: `Log()` is called from the UI thread and from LibVLC's native callback threads while the UI may already be wedged, and the redactor's assets-root rule does a `Directory.Exists` that can block on an unplugged drive. The redactor is otherwise regex-only, with no locks, no Serilog and no shared state beyond its cached roots.

## Not in scope

D5 (`CCP_USERDATA_DIR` not honoured by the Roaming `achievements.json` or by WebView2's `browser_data_video`) is left alone.

## Verification

`dotnet test` on the whole suite: 5280 passed, 0 failed. Logging classes alone: 280 passed.

Runtime, on `main` + this branch with `CCP_USERDATA_DIR` pointed at a sandbox: see the verification notes on the task. Footer present with `swallowed=`, `Application starting v6.9.1` unquoted, no stray `""`, `%DATA%`/`%APP%`/`~` intact, and no `C:\Users` in either the session file or video-diag.log.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
