### PR TITLE
fix(sessions): the session creator offers Brain Drain again

### DIFF
--- a/ConditioningControlPanel/Services/Session/SessionEngine.cs
+++ b/ConditioningControlPanel/Services/Session/SessionEngine.cs
@@ -564,8 +564,9 @@ namespace ConditioningControlPanel.Services
             if (settings.BouncingTextEnabled && !IsFeaturePending("bouncing text")) App.BouncingText?.Start();
             if (settings.MindWipeEnabled && !IsFeaturePending("mind wipe"))
                 App.MindWipe?.Start(settings.MindWipeBaseMultiplier, settings.MindWipeVolume / 100.0);
-            // DISABLED: Brain Drain is up for rework due to performance issues
-            // if (_brainDrainActive && App.Settings.Current.IsLevelUnlocked(70)) App.BrainDrain?.Start();
+            // Brain Drain (#1147). The pause stopped both halves; the visual one comes back with
+            // App.Overlay?.Start() below. No level gate - that one went with the other dead gates.
+            if (settings.BrainDrainEnabled && _brainDrainActive) App.BrainDrain?.Start();
             if (settings.MandatoryVideosEnabled && !IsFeaturePending("mandatory videos")) App.Video?.Start();
             // Re-enable overlays via the overlay service
             App.Overlay?.Start();
@@ -776,15 +777,21 @@ namespace ConditioningControlPanel.Services
                 }
             }
 
-            // DISABLED: Brain Drain is up for rework due to performance issues
-            // if (settings.BrainDrainEnabled && _brainDrainActive && elapsedMinutes >= settings.BrainDrainStartMinute)
-            // {
-            //     var brainDrainDuration = totalMinutes - settings.BrainDrainStartMinute;
-            //     var brainDrainProgress = (elapsedMinutes - settings.BrainDrainStartMinute) / brainDrainDuration;
-            //     brainDrainProgress = Math.Clamp(brainDrainProgress, 0, 1);
-            //     _currentBrainDrainIntensity = Lerp(settings.BrainDrainStartIntensity, settings.BrainDrainEndIntensity, brainDrainProgress);
-            //     if (IsMainWindowValid) _mainWindow.UpdateBrainDrainIntensity((int)_currentBrainDrainIntensity);
-            // }
+            // Brain Drain intensity ramp (#1147). Drives the SERVICE directly instead of writing
+            // App.Settings.Current.BrainDrainIntensity every second: that is the USER's persisted
+            // value and it auto-saves, so a kill mid-session would freeze the ramp maximum into
+            // settings.json for good - the pink filter's #471/#476 bug, which is why pink ramps
+            // this way too. Ramp-only, like the flash and spiral ramps above.
+            if (settings.BrainDrainEnabled && _brainDrainActive
+                && settings.BrainDrainStartIntensity != settings.BrainDrainEndIntensity
+                && elapsedMinutes >= settings.BrainDrainStartMinute)
+            {
+                var brainDrainDuration = Math.Max(0.01, totalMinutes - settings.BrainDrainStartMinute);
+                var brainDrainProgress = Math.Clamp((elapsedMinutes - settings.BrainDrainStartMinute) / brainDrainDuration, 0, 1);
+                brainDrainProgress = RampCurves.ApplyCurve(brainDrainProgress, curve);
+                if (App.BrainDrain != null)
+                    App.BrainDrain.Intensity = Lerp(settings.BrainDrainStartIntensity, settings.BrainDrainEndIntensity, brainDrainProgress);
+            }
         }
         
         private void CheckDelayedFeatures(double elapsedMinutes)
@@ -910,16 +917,31 @@ namespace ConditioningControlPanel.Services
                 }
             }
 
-            // DISABLED: Brain Drain is up for rework due to performance issues
-            // if (settings.BrainDrainEnabled && !_brainDrainActive && settings.BrainDrainStartMinute > 0)
-            // {
-            //     if (elapsedMinutes >= settings.BrainDrainStartMinute)
-            //     {
-            //         _brainDrainActive = true;
-            //         if (IsMainWindowValid) _mainWindow.EnableBrainDrain(true, settings.BrainDrainStartIntensity);
-            //         App.Logger?.Information("Brain Drain activated at {Minutes:F1} minutes", elapsedMinutes);
-            //     }
-            // }
+            // Brain Drain delayed start (#1147). The settings write is what raises the VISUAL
+            // half: OverlayService reconciles BrainDrainEnabled every 500ms. Start() is the AUDIO
+            // half, and it reads the same flag, so the write has to come first.
+            if (settings.BrainDrainEnabled && !_brainDrainActive && settings.BrainDrainStartMinute > 0
+                && elapsedMinutes >= settings.BrainDrainStartMinute)
+            {
+                _brainDrainActive = true;
+                App.Settings.Current.BrainDrainEnabled = true;
+                App.Settings.Current.BrainDrainIntensity = settings.BrainDrainStartIntensity;
+                App.BrainDrain?.Start();
+                App.Logger?.Information("Brain Drain activated at {Minutes:F1} minutes (target was {Target})",
+                    elapsedMinutes, settings.BrainDrainStartMinute);
+            }
+
+            // Brain Drain delayed end - the timeline editor writes a stop event as an end minute,
+            // same shape as the corner GIF above.
+            if (_brainDrainActive && settings.BrainDrainEndMinute > 0
+                && elapsedMinutes >= settings.BrainDrainEndMinute)
+            {
+                _brainDrainActive = false;
+                App.Settings.Current.BrainDrainEnabled = false;
+                App.BrainDrain?.Stop();
+                App.Logger?.Information("Brain Drain deactivated at {Minutes:F1} minutes (target was {Target})",
+                    elapsedMinutes, settings.BrainDrainEndMinute);
+            }
         }
         
         /// <summary>
@@ -1046,6 +1068,9 @@ namespace ConditioningControlPanel.Services
             
             _savedSettings.SpiralEnabled = current.SpiralEnabled;
             _savedSettings.SpiralOpacity = current.SpiralOpacity;
+
+            _savedSettings.BrainDrainEnabled = current.BrainDrainEnabled;
+            _savedSettings.BrainDrainIntensity = current.BrainDrainIntensity;
             
             _savedSettings.BubblesEnabled = current.BubblesEnabled;
             _savedSettings.BubblesFrequency = current.BubblesFrequency;
@@ -1456,6 +1481,28 @@ namespace ConditioningControlPanel.Services
             {
                 current.SpiralEnabled = false;
             }
+
+            // Brain Drain (delayed start - don't enable yet if delayed).
+            // #1147: this whole path used to be commented out ("up for rework due to performance
+            // issues"), which made a brain-drain block on the timeline a no-op and got the icon
+            // pulled from the creator palette (#430). The rework shipped - the blur renders on the
+            // compositor off its own capture pump and OverlayService.BrainDrainWithheld is false -
+            // so the session half is wired back up. Writing the flag is the whole of the VISUAL
+            // half (OverlayService.Start reads it, and its 500ms reconciler keeps it honest); the
+            // service call below is the AUDIO half, whose Start() reads the same flag.
+            _brainDrainActive = false;
+            if (settings.BrainDrainEnabled && settings.BrainDrainStartMinute == 0)
+            {
+                current.BrainDrainEnabled = true;
+                current.BrainDrainIntensity = settings.BrainDrainStartIntensity;
+                _brainDrainActive = true;
+                App.BrainDrain?.Start();
+            }
+            else
+            {
+                current.BrainDrainEnabled = false;
+                App.BrainDrain?.Stop();
+            }
             
             // Bubbles
             if (settings.BubblesEnabled)
@@ -1655,6 +1702,12 @@ namespace ConditioningControlPanel.Services
             
             current.SpiralEnabled = _savedSettings.SpiralEnabled;
             current.SpiralOpacity = _savedSettings.SpiralOpacity;
+
+            // The session owned Brain Drain for its run and may have ramped the service past the
+            // user's own intensity; hand both halves back.
+            current.BrainDrainEnabled = _savedSettings.BrainDrainEnabled;
+            current.BrainDrainIntensity = _savedSettings.BrainDrainIntensity;
+            App.BrainDrain?.UpdateSettings();
             
             current.BubblesEnabled = _savedSettings.BubblesEnabled;
             current.BubblesFrequency = _savedSettings.BubblesFrequency;

--- a/ConditioningControlPanel/Windows/SessionEditorWindow.xaml.cs
+++ b/ConditioningControlPanel/Windows/SessionEditorWindow.xaml.cs
@@ -155,13 +155,11 @@ namespace ConditioningControlPanel
 
             foreach (var feature in features)
             {
-                // Brain Drain is a dead feature in sessions — its runtime apply path in
-                // SessionEngine is fully commented out (it never did anything when a session
-                // ran), so hide it from the creator palette to stop users adding a no-op block
-                // (bug #430). The definition itself stays so any legacy session that already
-                // has a brain_drain item still resolves/loads without a null lookup.
-                if (feature.Id == "brain_drain") continue;
-
+                // Brain Drain used to be skipped here: its SessionEngine apply path was fully
+                // commented out, so a block dropped on the timeline did nothing at all (#430).
+                // The engine now honours BrainDrainEnabled / start minute / intensity ramp again
+                // and the visual half's rework has shipped, so the palette offers it once more
+                // (#1147).
                 var panel = GetCategoryPanel(feature.Category);
                 if (panel == null) continue;
 

--- a/Tests/ConditioningControlPanel.Tests/SessionBrainDrainRoundTripTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/SessionBrainDrainRoundTripTests.cs
@@ -1,0 +1,74 @@
+using System.Linq;
+using ConditioningControlPanel.Models;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// #1147: "Brain drain not offered as option when creating a new session". The runtime model has
+/// carried BrainDrainEnabled / StartMinute / Start+End intensity all along, and TimelineSession
+/// converts them in both directions - what was missing was the palette icon (skipped outright in
+/// SessionEditorWindow, #430) and the SessionEngine apply path (fully commented out, so a block on
+/// the timeline was a no-op). These tests pin the data half: the feature is still in the palette
+/// catalogue, and a brain-drain block survives create -> save -> reload with its numbers intact.
+/// Pure data classes, so no WPF Application is required.
+/// </summary>
+public class SessionBrainDrainRoundTripTests
+{
+    [Fact]
+    public void BrainDrain_IsInTheCreatorFeatureCatalogue()
+    {
+        var feature = FeatureDefinition.GetAllFeatures().SingleOrDefault(f => f.Id == "brain_drain");
+
+        Assert.NotNull(feature);
+        Assert.Equal(FeatureCategory.Overlays, feature!.Category);
+        Assert.True(feature.SupportsRamping);
+        Assert.Contains(feature.Settings, s => s.Key == "intensity" && s.SupportsRamp);
+    }
+
+    [Fact]
+    public void ABrainDrainBlock_SurvivesSaveAndReload()
+    {
+        // Create: drop a ramping brain-drain block on the timeline from minute 10 to minute 40.
+        var authored = new TimelineSession { Name = "Drain Test", DurationMinutes = 60 };
+        var start = authored.AddStartEvent("brain_drain", 10);
+        start.SetSetting("intensity", 4);
+        start.StartValue = 4;
+        start.EndValue = 18;
+        authored.AddStopEvent(start, 40);
+
+        // Save: this is what the engine actually runs.
+        var settings = authored.ToSessionSettings();
+
+        Assert.True(settings.BrainDrainEnabled);
+        Assert.Equal(10, settings.BrainDrainStartMinute);
+        Assert.Equal(40, settings.BrainDrainEndMinute);
+        Assert.Equal(4, settings.BrainDrainStartIntensity);
+        Assert.Equal(18, settings.BrainDrainEndIntensity);
+
+        // Reload: reopening the saved session in the editor has to show the same block.
+        var reopened = TimelineSession.FromSession(new Session
+        {
+            Name = authored.Name,
+            DurationMinutes = authored.DurationMinutes,
+            Settings = settings
+        });
+
+        var reloaded = Assert.Single(reopened.GetStartEvents("brain_drain"));
+        Assert.Equal(10, reloaded.Minute);
+        Assert.Equal(4, reloaded.StartValue);
+        Assert.Equal(18, reloaded.EndValue);
+        Assert.Equal(40, reopened.GetPairedStopEvent(reloaded)?.Minute);
+    }
+
+    [Fact]
+    public void ATimelineWithoutBrainDrain_LeavesTheFeatureOff()
+    {
+        var authored = new TimelineSession { Name = "No Drain", DurationMinutes = 30 };
+        authored.AddStartEvent("flash", 0);
+
+        var settings = authored.ToSessionSettings();
+
+        Assert.False(settings.BrainDrainEnabled);
+    }
+}


### PR DESCRIPTION
## What

Brain Drain is back in the session creator, and a Brain Drain block on a session timeline actually does something again.

## Why

Report #1147: "Brain drain not offered as option when creating a new session."

The row was **not renamed and not tier-gated** - it was deliberately removed. Two halves of one old decision:

1. `SessionEngine`'s entire Brain Drain apply path was commented out under `// DISABLED: Brain Drain is up for rework due to performance issues` - the delayed start, the intensity ramp, and the resume-after-pause line. A brain-drain block on a session timeline was a no-op.
2. Because of that, #430 then hid the icon from the creator palette (`if (feature.Id == "brain_drain") continue;`) so nobody could add a block that did nothing. That is the symptom the reporter hit.

The rework has since shipped. The blur renders through the shared compositor (`BrainDrainLayer` plus its off-UI-thread `BrainDrainCapturePump`, the fix for the #777 freeze), the base feature has its own blur-strength and melt settings, and `OverlayService.BrainDrainWithheld` is already `false` - the standalone feature has been live for several releases. Only the session path stayed switched off, so the settings the model, the built-in presets and the session summary text all still carry had no runtime behind them.

## How

`Services/Session/SessionEngine.cs`

- `ApplySessionSettings` honours `BrainDrainEnabled` again: a minute-0 block turns the feature on and starts the audio service; a session that does not ask for it turns it off. Same shape as the pink-filter and spiral blocks either side of it. Writing the flag is the whole of the visual half - `OverlayService.Start` reads it and its 500ms reconciler keeps it honest.
- `CheckDelayedFeatures` gets the delayed start back, plus the delayed **end** the old code never had. The timeline editor has always written a stop event as `BrainDrainEndMinute`.
- The intensity ramp is back, curved through `RampCurves` like the flash/pink/spiral ramps. It drives `BrainDrainService.Intensity` **directly** rather than writing the user's persisted `BrainDrainIntensity` every second - a kill mid-session would otherwise freeze the ramp maximum into `settings.json`, which is exactly the pink filter's #471/#476 bug.
- `SaveCurrentSettings` / `RestoreSettings` now snapshot and hand back `BrainDrainEnabled` and `BrainDrainIntensity`, so a session cannot leave the user's own values changed.
- `ResumeSession` restarts the audio half after a pause; the visual half comes back with the `App.Overlay.Start()` on the next line.

`Windows/SessionEditorWindow.xaml.cs`

- Stop skipping the feature, so the icon is in the Overlays column of the creator palette again.

`Tests/.../SessionBrainDrainRoundTripTests.cs` (new)

- The feature is still in the palette catalogue with a rampable intensity setting.
- A ramping block authored from minute 10 to minute 40 survives create -> `ToSessionSettings` -> `FromSession` with start minute, stop minute and start/end intensity intact.
- A timeline with no brain-drain block leaves `BrainDrainEnabled` false.

No localization changes needed: the creator palette is not localized (every feature name there is a plain `FeatureDefinition.Name`), and every Brain Drain string the session paths use - `session_feature_brain_drain`, `label_brain_drain`, `section_brain_drain` - already exists in all 9 language files.

## How tested

- `dotnet build ConditioningControlPanel.sln` - 0 errors (only the pre-existing xUnit-analyzer and CA1416 warnings).
- `dotnet test` - 5284 passed, 0 failed, including the 3 new round-trip tests.
- Round-trip verified by test rather than by hand: the app was not launched, because a second instance would take over the owner's running app.
- Not runtime play-tested. A real session run with a delayed brain-drain block (start, ramp, end minute, pause/resume, and that the user's own intensity comes back after the session) still wants an owner play-test.

Closes CC-Labs-llc/ccp-bugs#1147
