### PR TITLE
fix(quests): never roll a camera or mic quest on a machine that has neither

### DIFF
--- a/ConditioningControlPanel/Services/Progression/QuestHardwareGate.cs
+++ b/ConditioningControlPanel/Services/Progression/QuestHardwareGate.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using ConditioningControlPanel.Models;
+
+namespace ConditioningControlPanel.Services;
+
+/// <summary>
+/// THE HARDWARE GATE ON THE QUEST ROLL (ccp-bugs#1151). A machine with no webcam was still dealt
+/// the blink-trainer quests (blink_drill_d, obedient_eyes_d, blink_century_w, eyes_trained_w):
+/// impossible to move, and the only way out was to burn a reroll on a board that could deal
+/// another one straight back. The roll now asks whether this machine HAS a camera first.
+///
+/// CAMERA ONLY, deliberately. No quest category needs the microphone: the one voice-adjacent
+/// category is Mantra, and mantras are completed by TYPING them (MantraService.TryCompleteMantra)
+/// - the mic-verified spoken path (CreditExternalMantra) is an extra way in, never the only one.
+/// A future voice-only category needs a second predicate here and nothing else.
+///
+/// Three rules the callers depend on. ONE probe per roll: the answer is cached, so dealing three
+/// daily seats enumerates devices once and a camera plugged in later is still noticed. NEVER
+/// BLOCK: the roll can run on the UI thread (QuestService's constructor), so the probe runs on the
+/// thread pool and the caller waits at most ProbeBudget for it. FAIL OPEN: a probe that throws,
+/// times out or has never run reads as PRESENT, because narrowing the pool on an error would
+/// silently take quests away from people who own the camera.
+/// </summary>
+internal sealed class QuestHardwareGate
+{
+    /// <summary>The instance the roll uses. Tests construct their own with a fake probe.</summary>
+    public static readonly QuestHardwareGate Shared = new();
+
+    private static readonly TimeSpan CacheTtl = TimeSpan.FromMinutes(5);
+    private static readonly TimeSpan ProbeBudget = TimeSpan.FromMilliseconds(400);
+
+    private readonly Func<bool> _cameraProbe;
+    private readonly object _lock = new();
+    private Task? _inFlight;
+    private bool _hasCamera = true;
+    private DateTime _probedAtUtc = DateTime.MinValue;
+
+    internal QuestHardwareGate(Func<bool>? cameraProbe = null) => _cameraProbe = cameraProbe ?? DetectCamera;
+
+    /// <summary>Whether this machine has a camera, cached. Safe to call from the UI thread.</summary>
+    public bool HasCamera()
+    {
+        Task probe;
+        lock (_lock)
+        {
+            if (DateTime.UtcNow - _probedAtUtc < CacheTtl) return _hasCamera;
+            probe = _inFlight ??= Task.Run(RunProbe);
+        }
+        try
+        {
+            // On timeout: answer "present" and let the probe land for the next roll.
+            if (!probe.Wait(ProbeBudget)) return true;
+        }
+        catch (Exception ex)
+        {
+            App.Logger?.Warning(ex, "Quest camera probe failed; assuming a camera is present");
+            return true;
+        }
+        lock (_lock) { return _hasCamera; }
+    }
+
+    private void RunProbe()
+    {
+        bool found;
+        try { found = _cameraProbe(); }
+        catch (Exception ex)
+        {
+            App.Logger?.Warning(ex, "Quest camera probe threw; assuming a camera is present");
+            found = true;
+        }
+        lock (_lock) { _hasCamera = found; _probedAtUtc = DateTime.UtcNow; _inFlight = null; }
+        App.Logger?.Information("Quest hardware probe: camera={HasCamera}", found);
+    }
+
+    /// <summary>The enumeration the Lab tab shows "(no cameras detected)" from; the service's
+    /// DirectShow + WinRT/MF pair is repeated for a roll that happens before it is up.</summary>
+    private static bool DetectCamera()
+    {
+        var svc = App.Webcam;
+        if (svc != null) return svc.EnumerateDevices().Count > 0;
+        return WebcamDeviceEnumerator.Enumerate().Count > 0 || WebcamWinRtEnumerator.Enumerate().Count > 0;
+    }
+
+    /// <summary>Categories that cannot move without a webcam.</summary>
+    internal static bool NeedsCamera(QuestCategory category) => category == QuestCategory.BlinkTrainer;
+
+    /// <summary>Drops what this machine cannot serve - and hands the ungated pool back untouched if
+    /// that would leave nothing to roll. A missing camera costs the player blink quests, never the
+    /// day itself, so the gate is the first predicate dropped when the pool runs dry.</summary>
+    internal static List<QuestDefinition> GateOrFallBack(List<QuestDefinition> pool, bool hasCamera)
+    {
+        if (hasCamera) return pool;
+        var gated = pool.Where(q => !NeedsCamera(q.Category)).ToList();
+        return gated.Count > 0 ? gated : pool;
+    }
+}

--- a/ConditioningControlPanel/Services/Progression/QuestService.cs
+++ b/ConditioningControlPanel/Services/Progression/QuestService.cs
@@ -566,7 +566,9 @@ public class QuestService : IDisposable
         // Use remote quests from QuestDefinitionService if available, fall back to embedded
         var questPool = App.QuestDefinitions?.GetDailyQuests() ?? QuestDefinition.DailyQuests.ToList();
         var hasPremium = App.Patreon?.HasPremiumAccess == true;
-        var availableQuests = FilterDailyRollPool(questPool, excludeIds, hasPremium, DateTime.Today, applyDateWindow: true);
+        // Cached, so dealing all three seats enumerates devices once (ccp-bugs#1151).
+        var hasCamera = QuestHardwareGate.Shared.HasCamera();
+        var availableQuests = FilterDailyRollPool(questPool, excludeIds, hasPremium, DateTime.Today, applyDateWindow: true, hasCamera);
 
         // THE WINDOW MUST NEVER STARVE THE PLAYER. If a date window emptied the pool,
         // fall back to the undated pool rather than leaving the day questless: an event
@@ -574,7 +576,7 @@ public class QuestService : IDisposable
         // with it. See IsQuestInDateWindow.
         if (availableQuests.Count == 0)
         {
-            availableQuests = FilterDailyRollPool(questPool, excludeIds, hasPremium, DateTime.Today, applyDateWindow: false);
+            availableQuests = FilterDailyRollPool(questPool, excludeIds, hasPremium, DateTime.Today, applyDateWindow: false, hasCamera);
         }
 
         // LAST RESORT: three slots can drain a pool that one slot never could (a low-level
@@ -586,7 +588,7 @@ public class QuestService : IDisposable
             // Through the same helper, with the exclusions dropped rather than the predicates.
             // Hand-rolling this filter is how a Remote quest gets onto the board: it is the one
             // path that never sees IsRollableAsDaily unless it goes through here.
-            availableQuests = FilterDailyRollPool(questPool, (ICollection<string>?)null, hasPremium, DateTime.Today, applyDateWindow: false);
+            availableQuests = FilterDailyRollPool(questPool, (ICollection<string>?)null, hasPremium, DateTime.Today, applyDateWindow: false, hasCamera);
         }
 
         if (availableQuests.Count == 0) return null;
@@ -622,21 +624,23 @@ public class QuestService : IDisposable
 
         // Use remote quests from QuestDefinitionService if available, fall back to embedded
         var questPool = App.QuestDefinitions?.GetWeeklyQuests() ?? QuestDefinition.WeeklyQuests.ToList();
-        var availableQuests = questPool
+        // Same hardware gate as the daily roll (ccp-bugs#1151): no webcam, no blink weekly.
+        var hasCamera = QuestHardwareGate.Shared.HasCamera();
+        var availableQuests = QuestHardwareGate.GateOrFallBack(questPool
             .Where(q => q.Id != excludeId)
             .Where(q => IsQuestAvailableForLevel(q.Category))
             .Where(IsQuestAvailableForTier)
             .Where(IsQuestInDateWindow)
-            .ToList();
+            .ToList(), hasCamera);
 
         // Same starvation guard as the daily generator — see the note there.
         if (availableQuests.Count == 0)
         {
-            availableQuests = questPool
+            availableQuests = QuestHardwareGate.GateOrFallBack(questPool
                 .Where(q => q.Id != excludeId)
                 .Where(q => IsQuestAvailableForLevel(q.Category))
                 .Where(IsQuestAvailableForTier)
-                .ToList();
+                .ToList(), hasCamera);
         }
 
         if (availableQuests.Count == 0) return;
@@ -773,11 +777,11 @@ public class QuestService : IDisposable
     /// </summary>
     internal static List<QuestDefinition> FilterDailyRollPool(
         IEnumerable<QuestDefinition> pool, string? excludeId, bool hasPremium,
-        DateTime today, bool applyDateWindow)
+        DateTime today, bool applyDateWindow, bool hasCamera = true)
         => FilterDailyRollPool(
             pool,
             string.IsNullOrEmpty(excludeId) ? null : new[] { excludeId },
-            hasPremium, today, applyDateWindow);
+            hasPremium, today, applyDateWindow, hasCamera);
 
     /// <summary>
     /// Set-excluding form, for the three-up daily board. Each seat has to roll against every id
@@ -789,15 +793,18 @@ public class QuestService : IDisposable
     /// </summary>
     internal static List<QuestDefinition> FilterDailyRollPool(
         IEnumerable<QuestDefinition> pool, ICollection<string>? excludeIds, bool hasPremium,
-        DateTime today, bool applyDateWindow)
+        DateTime today, bool applyDateWindow, bool hasCamera = true)
     {
-        return pool
+        var filtered = pool
             .Where(q => excludeIds == null || !excludeIds.Contains(q.Id))
             .Where(q => IsQuestAvailableForLevel(q.Category))
             .Where(q => IsQuestAvailableForTier(q, hasPremium))
             .Where(IsRollableAsDaily)
             .Where(q => !applyDateWindow || IsQuestInDateWindow(q.ActiveFrom, q.ActiveUntil, today))
             .ToList();
+        // LAST predicate, and the first one dropped when the pool runs dry: a machine with no
+        // webcam must not be dealt a blink quest (ccp-bugs#1151) but must still be dealt a quest.
+        return QuestHardwareGate.GateOrFallBack(filtered, hasCamera);
     }
 
     /// <summary>

--- a/Tests/ConditioningControlPanel.Tests/QuestHardwareRollTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/QuestHardwareRollTests.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using ConditioningControlPanel.Models;
+using ConditioningControlPanel.Services;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// ccp-bugs#1151: a machine with no webcam was still dealt the blink-trainer quests, which it can
+/// never complete - and rerolling could deal another one straight back. These exercise the same
+/// pure predicates the daily and weekly rolls call, with the camera probe injected, so nothing
+/// here touches a real device.
+/// </summary>
+public class QuestHardwareRollTests
+{
+    private static readonly DateTime AnyDay = new(2026, 9, 5);
+
+    private static List<QuestDefinition> DailyPool(bool hasCamera) =>
+        QuestService.FilterDailyRollPool(
+            QuestDefinition.DailyQuests, excludeId: null, hasPremium: true,
+            today: AnyDay, applyDateWindow: true, hasCamera: hasCamera);
+
+    [Fact]
+    public void DailyRoll_WithNoCamera_NeverYieldsABlinkTrainerQuest()
+    {
+        var pool = DailyPool(hasCamera: false);
+        Assert.NotEmpty(pool);   // the day is never lost, only the blink quests
+        Assert.DoesNotContain(pool, q => q.Category == QuestCategory.BlinkTrainer);
+        Assert.DoesNotContain(pool, q => q.Id == "blink_drill_d" || q.Id == "obedient_eyes_d");
+    }
+
+    [Fact]
+    public void DailyRoll_WithACamera_CanStillYieldABlinkTrainerQuest()
+    {
+        var pool = DailyPool(hasCamera: true);
+        Assert.Contains(pool, q => q.Id == "blink_drill_d");
+        Assert.Contains(pool, q => q.Id == "obedient_eyes_d");
+    }
+
+    [Fact]
+    public void WeeklyRoll_WithNoCamera_NeverYieldsABlinkTrainerQuest()
+    {
+        var full = QuestDefinition.WeeklyQuests.ToList();
+        var gated = QuestHardwareGate.GateOrFallBack(full, hasCamera: false);
+        Assert.NotEmpty(gated);
+        Assert.DoesNotContain(gated, q => q.Category == QuestCategory.BlinkTrainer);
+        Assert.Contains(QuestHardwareGate.GateOrFallBack(full, hasCamera: true), q => q.Id == "blink_century_w");
+    }
+
+    [Fact]
+    public void GateNeverEmptiesThePool_ARollMustNeverFail()
+    {
+        // The pathological pool: everything left needs the camera this machine does not have. An
+        // empty slot is worse than an impossible one, and the player still has their rerolls.
+        var blinkOnly = QuestDefinition.DailyQuests.Where(q => q.Category == QuestCategory.BlinkTrainer).ToList();
+        Assert.NotEmpty(blinkOnly);
+        Assert.Equal(blinkOnly.Count, QuestHardwareGate.GateOrFallBack(blinkOnly, hasCamera: false).Count);
+    }
+
+    [Fact]
+    public void ProbeThatThrows_IsReadAsCameraPresent_NeverAsAbsent()
+    {
+        // Fail OPEN: narrowing the pool because an enumeration blew up would take quests away
+        // from people who own the camera.
+        var gate = new QuestHardwareGate(() => throw new InvalidOperationException("enumeration exploded"));
+        Assert.True(gate.HasCamera());
+    }
+
+    [Fact]
+    public void ProbeIsRunOnceAndCached_SoAThreeSeatRollEnumeratesOnce()
+    {
+        int probes = 0;
+        var gate = new QuestHardwareGate(() => { probes++; return false; });
+        Assert.False(gate.HasCamera());
+        gate.HasCamera();
+        gate.HasCamera();
+        Assert.Equal(1, probes);
+    }
+}


### PR DESCRIPTION
## What

The daily board and the weekly slot kept dealing the blink-trainer quests to machines with no webcam: `blink_drill_d`, `obedient_eyes_d` (daily), `blink_century_w`, `eyes_trained_w` (weekly), all `QuestCategory.BlinkTrainer`. They cannot move a single point without a camera, so the only way out was to spend a reroll - on a board that could deal another one straight back.

The roll now asks what the machine actually has before it picks.

- New `Services/Progression/QuestHardwareGate.cs`: probes for a camera using the same DirectShow + WinRT/MF enumeration the Lab tab shows "(no cameras detected)" from (`App.Webcam.EnumerateDevices()`, with `WebcamDeviceEnumerator` / `WebcamWinRtEnumerator` as the pre-service fallback), caches the answer, and exposes the category predicate.
- `QuestService.FilterDailyRollPool` (every daily roll and reroll funnels through it, including the last-resort pass) and `GenerateNewWeeklyQuest` now apply the gate.

## Why it is safe

- **One probe per roll.** The answer is cached for 5 minutes, so dealing all three daily seats enumerates devices once, and a camera plugged in later is noticed without a restart.
- **Never blocks.** Rolls can run on the UI thread (`QuestService`'s constructor), so the probe runs on the thread pool and the caller waits at most 400ms for it; past that it answers "present" and the probe still lands for the next roll.
- **Fails open.** A probe that throws, times out or has never run reads as PRESENT. Narrowing the pool on an error would silently take quests away from people who own the camera.
- **Never starves a roll.** If the gate would empty the pool, the ungated pool is handed back untouched - a missing camera costs the player blink quests, never the day itself.
- Filtering is by CATEGORY, not by id, so a blink quest published later through the server-side definitions channel is covered too.

## Microphone

**No quest category needs the microphone, so only the camera is gated.** The one voice-adjacent category is `Mantra`, and mantras are completed by TYPING them (`MantraService.TryCompleteMantra`); the mic-verified spoken path (`CreditExternalMantra`) is an extra way in, never the only one. `KeywordTrigger` is OCR (screen reading), not audio. The gate's doc comment records this so a future voice-only category is one predicate away.

## Deliberately out of scope

A blink quest ALREADY on the board is left alone: an unfinished slot is only replaced by the existing tier/level legality pass, and the board self-corrects at the next daily/weekly rollover. Taking a live quest away mid-day is the one thing the surrounding code (see #889) goes out of its way not to do.

## How tested

- `dotnet build ConditioningControlPanel/ConditioningControlPanel.csproj` - 0 errors.
- `dotnet test Tests/ConditioningControlPanel.Tests` - **5287 passed, 0 failed**.
- New `Tests/ConditioningControlPanel.Tests/QuestHardwareRollTests.cs` (6 tests, probe injected as a delegate so nothing touches a real device):
  - a camera-absent daily roll never yields a `BlinkTrainer` quest, and the pool is still non-empty;
  - a camera-present daily roll still can;
  - the weekly pool behaves the same both ways;
  - a blink-only pool with no camera falls back rather than returning empty;
  - a probe that throws reads as "camera present";
  - three consecutive reads enumerate once.
- App NOT launched (single-instance takeover would seize the running app).

Diff: 198 insertions, 11 deletions across 3 files.

Closes CC-Labs-llc/ccp-bugs#1151 (different repo, so it will not auto-close). Reported by techslut Angie.
