### PR TITLE
feat(race): race/gltf.js pack loader, instance merge, face atlas (+1)

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
@@ -241,6 +241,10 @@ pop scores as a treat. Live category sets match `RECIPES` (first row whose `need
 run.js maps a served recipe to `score.boostMult` (never below x1), a toast, a mood poke and, for
 `marquee` rows, the banner. Durations for effects live in `CATEGORIES`, not run.js.
 
+### `race/gltf.js` (pass four, the Blender packs)
+
+`loadPack`, `toInstanceGeometry`, `setFace`/`FACES`, `preparePixel`, `disposePack` for `race/assets/emi.glb` + `props.glb`; the node names, clip names and the linear colour rule live in that file header, `byName` returns null for anything missing and the voxel kit stays the fallback.
+
 ## Host protocol (bridge.js, Protocol v1)
 
 Page -> host (`bridge.send(type, data)`): `ready` (announceReady), `heartbeat`, `pong`, `sfx {name, scale}`,

--- a/ConditioningControlPanel/Resources/web/dtrh/race/gltf.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/gltf.js
@@ -232,8 +232,10 @@ export function setFace(model, index) {
   const mats = Array.isArray(mesh.material) ? mesh.material : mesh.material ? [mesh.material] : [];
   const i = Math.min(FACE_N - 1, Math.max(0, index | 0));
   let hit = false;
-  for (const m of mats) {
-    const tex = m && m.map;
+  // the atlas may ride the base map or the emissive map (emi.glb puts it on the emissive
+  // slot so the screen stays self-lit); shift whichever the material carries
+  for (const m of mats) for (const key of ['map', 'emissiveMap']) {
+    const tex = m && m[key];
     if (!tex) continue;
     tex.wrapS = THREE.RepeatWrapping;
     tex.magFilter = THREE.NearestFilter;

--- a/ConditioningControlPanel/Resources/web/dtrh/race/gltf.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/gltf.js
@@ -1,0 +1,264 @@
+/* ============================================================================
+ * race/gltf.js - The Caucus Race glTF pack loader.
+ *
+ * Two packs, both authored in Blender and dropped in race/assets/:
+ *
+ *   emi.glb    the mascot rig. Nodes: EMI_root, EMI_case, EMI_glass, ant0,
+ *              ant1, ant2, ballpiv, shoulderL, shoulderR, footL, footR,
+ *              button. Clips: idle, wave, hop, peek, drum. EMI_glass carries
+ *              the face atlas (see setFace / FACES).
+ *   props.glb  every prop as a NAMED TOP-LEVEL node: kart_cup, kart_saucer,
+ *              item_cube, item_shard_00 .. item_shard_11, boost_pad, ramp_lip,
+ *              air_marker, gantry, podium, floor_tile, plus one <room>_<slot>
+ *              per roomProps ROOM_PROPS entry (teagarden_wall, casino_shoulder,
+ *              toybox_extra, ...).
+ *
+ * NOTHING here depends on any of those names existing. byName() returns null
+ * for a miss and every caller falls back to the hand-built voxel kit, so a
+ * half-finished pack degrades one prop at a time instead of blanking the race.
+ *
+ *   loadPack(url, { log }) -> Promise<Pack>       cached per url
+ *   Pack = { scene, animations, byName, clone, names, stats }
+ *   toInstanceGeometry(node) -> BufferGeometry    roomProps-shaped, ready for
+ *                                                 InstancedMesh + Lambert
+ *   setFace(model, index) / FACES
+ *   preparePixel(model, pixel)
+ *   disposePack(url)
+ *
+ * COLOUR SPACE. roomProps voxel() writes Color.setHex(hex).r/g/b into its
+ * `color` attribute, and setHex decodes sRGB into the linear working space, so
+ * that attribute is LINEAR. glTF agrees: baseColorFactor and COLOR_0 are both
+ * linear by spec and GLTFLoader keeps them that way. So the merge below copies
+ * material.color / COLOR_0 straight through with no conversion, and a merged
+ * prop shades identically to a voxel() one beside it.
+ * ==========================================================================*/
+
+import * as THREE from 'three';
+import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+import { mergeGeometries } from 'three/addons/utils/BufferGeometryUtils.js';
+
+/** Face atlas order, left to right across EMI_glass's map. */
+export const FACES = ['^_^', ':3', '>_<', 'o_o', '$_$'];
+const FACE_N = FACES.length;
+const GLASS = 'EMI_glass';
+const OUTLINE = 'outline';                 // material name: inverted hull, never re-wound
+const MAP_KEYS = ['map', 'emissiveMap', 'alphaMap', 'normalMap', 'roughnessMap', 'metalnessMap', 'aoMap'];
+
+const _cache = new Map();                  // url -> { promise, pack }
+const _mat = new THREE.Matrix4();
+const _inv = new THREE.Matrix4();
+
+// ---- loading ---------------------------------------------------------------------------
+
+/**
+ * Load (or hand back) a pack. One in-flight request per url; a failed load drops out of the
+ * cache so a later call can retry. `log` is the race's one-argument logger (bridge.log style).
+ */
+export function loadPack(url, { log } = {}) {
+  const hit = _cache.get(url);
+  if (hit) return hit.promise;
+  const entry = { promise: null, pack: null };
+  entry.promise = new Promise((resolve, reject) => {
+    new GLTFLoader().load(url, resolve, undefined, reject);
+  }).then((gltf) => {
+    const pack = makePack(gltf, url);
+    entry.pack = pack;
+    if (log) log(`gltf ${url}: ${pack.stats.nodes} nodes, ${pack.stats.tris} tris, ${(pack.stats.bytes / 1024).toFixed(0)} KB`);
+    return pack;
+  }).catch((e) => {
+    _cache.delete(url);
+    if (log) log(`gltf ${url} failed: ${(e && e.message) || e}`);
+    throw e;
+  });
+  _cache.set(url, entry);
+  return entry.promise;
+}
+
+/**
+ * Wrap a parsed gltf. Exported so the node smoke can go through GLTFLoader.parse() without a
+ * network fetch; the race itself only ever calls loadPack.
+ */
+export function makePack(gltf, url = '') {
+  const scene = gltf.scene || (gltf.scenes && gltf.scenes[0]) || new THREE.Group();
+  const animations = gltf.animations || [];
+  const index = new Map();
+  let nodes = 0, tris = 0;
+  scene.traverse((o) => {
+    nodes++;
+    if (o.name && !index.has(o.name)) index.set(o.name, o);
+    const g = o.geometry;
+    if (!g || !g.attributes || !g.attributes.position) return;
+    tris += (g.index ? g.index.count : g.attributes.position.count) / 3;
+  });
+  return {
+    scene,
+    animations,
+    url,
+    byName: (name) => index.get(name) || null,
+    names: () => Array.from(index.keys()),
+    clone: (name) => {
+      const src = index.get(name);
+      return src ? src.clone(true) : null;      // Object3D.clone shares geometry AND material
+    },
+    stats: { nodes, tris: Math.round(tris), bytes: byteSize(gltf) },
+  };
+}
+
+/** Best effort source size: the GLB body hangs off the parser on the binary path, so fall back
+ *  to the json length rather than guessing when a pack arrives as plain .gltf. */
+function byteSize(gltf) {
+  const p = gltf.parser;
+  const bin = p && p.extensions && p.extensions.KHR_binary_glTF;
+  if (bin && bin.body && bin.body.byteLength) return bin.body.byteLength;
+  if (p && p.json) { try { return JSON.stringify(p.json).length; } catch (e) { /* cyclic, give up */ } }
+  return 0;
+}
+
+/** Dispose everything a pack owns and forget it. Safe on an unknown or still-loading url. */
+export function disposePack(url) {
+  const entry = _cache.get(url);
+  if (!entry) return;
+  _cache.delete(url);
+  const kill = (pack) => {
+    if (!pack || !pack.scene) return;
+    const seen = new Set();
+    pack.scene.traverse((o) => {
+      if (o.geometry && !seen.has(o.geometry)) { seen.add(o.geometry); o.geometry.dispose(); }
+      const mats = Array.isArray(o.material) ? o.material : o.material ? [o.material] : [];
+      for (const m of mats) {
+        if (seen.has(m)) continue;
+        seen.add(m);
+        for (const k of MAP_KEYS) if (m[k] && !seen.has(m[k])) { seen.add(m[k]); m[k].dispose(); }
+        m.dispose();
+      }
+    });
+  };
+  if (entry.pack) kill(entry.pack);
+  else entry.promise.then(kill, () => {});
+}
+
+// ---- merge to a roomProps-shaped instance geometry --------------------------------------
+
+/**
+ * Flatten every mesh under `node` into ONE geometry in `node`'s local frame, with a flat
+ * per-vertex colour, exactly the shape voxel() produces: attributes position + normal + color,
+ * ready for `new THREE.InstancedMesh(geo, new THREE.MeshLambertMaterial({ vertexColors: true }), n)`.
+ *
+ * Colour source per mesh: COLOR_0 if the mesh has one, else the material's base color, both
+ * already linear (see the header). Meshes whose material is named `outline` are inverted hulls:
+ * they come through untouched, winding included. Everything else gets its index re-wound when
+ * its baked matrix mirrors, so it still lights right.
+ *
+ * Nothing shared is disposed: the per-mesh copies are throwaway clones and only those go.
+ */
+export function toInstanceGeometry(node) {
+  if (!node) return null;
+  node.updateWorldMatrix(true, true);
+  _inv.copy(node.matrixWorld).invert();
+  const parts = [];
+  let anyNonIndexed = false;
+  node.traverse((o) => {
+    if (!o.isMesh || !o.geometry || !o.geometry.attributes || !o.geometry.attributes.position) return;
+    if (o.visible === false) return;
+    const g = o.geometry.clone();
+    for (const key of Object.keys(g.attributes)) {
+      if (key !== 'position' && key !== 'normal' && key !== 'color') g.deleteAttribute(key);
+    }
+    if (!g.attributes.normal) g.computeVertexNormals();
+    _mat.multiplyMatrices(_inv, o.matrixWorld);
+    g.applyMatrix4(_mat);
+    if (_mat.determinant() < 0 && !isOutline(o.material)) flipWinding(g);
+    if (!g.attributes.color) g.setAttribute('color', flatColor(o.material, g.attributes.position.count));
+    else normalizeColor(g);
+    g.morphAttributes = {};
+    g.clearGroups();
+    if (!g.index) anyNonIndexed = true;
+    parts.push(g);
+  });
+  if (!parts.length) return null;
+  const ready = anyNonIndexed ? parts.map((g) => (g.index ? g.toNonIndexed() : g)) : parts;
+  const merged = ready.length === 1 ? ready[0].clone() : mergeGeometries(ready, false);
+  for (const g of ready) if (!parts.includes(g)) g.dispose();
+  for (const g of parts) g.dispose();
+  if (merged) merged.computeBoundingSphere();
+  return merged;
+}
+
+function isOutline(material) {
+  const mats = Array.isArray(material) ? material : material ? [material] : [];
+  return mats.some((m) => m && m.name === OUTLINE);
+}
+
+/** Reverse each triangle's winding in place (index only: positions and normals are already baked). */
+function flipWinding(g) {
+  if (!g.index) g.setIndex(Array.from({ length: g.attributes.position.count }, (_, i) => i));
+  const a = g.index.array;
+  for (let i = 0; i + 2 < a.length; i += 3) { const t = a[i]; a[i] = a[i + 2]; a[i + 2] = t; }
+  g.index.needsUpdate = true;
+}
+
+/** One flat colour repeated per vertex, taken from the material (linear, see the header). */
+function flatColor(material, count) {
+  const m = Array.isArray(material) ? material[0] : material;
+  const c = m && m.color ? m.color : null;
+  const r = c ? c.r : 1, gg = c ? c.g : 1, b = c ? c.b : 1;
+  const arr = new Float32Array(count * 3);
+  for (let i = 0; i < count; i++) { arr[i * 3] = r; arr[i * 3 + 1] = gg; arr[i * 3 + 2] = b; }
+  return new THREE.BufferAttribute(arr, 3);
+}
+
+/** COLOR_0 may arrive as RGBA or as normalized bytes; the merge wants a plain float RGB. */
+function normalizeColor(g) {
+  const src = g.attributes.color;
+  if (src.itemSize === 3 && src.array instanceof Float32Array && !src.normalized) return;
+  const n = src.count;
+  const arr = new Float32Array(n * 3);
+  for (let i = 0; i < n; i++) { arr[i * 3] = src.getX(i); arr[i * 3 + 1] = src.getY(i); arr[i * 3 + 2] = src.getZ(i); }
+  g.setAttribute('color', new THREE.BufferAttribute(arr, 3));
+}
+
+// ---- the face atlas ---------------------------------------------------------------------
+
+/**
+ * Point EMI_glass's map at one of the five frames. The atlas is a horizontal strip of FACE_N
+ * frames and the authored UVs span frame 0 only, so a repeat of 1/FACE_N is already baked into
+ * the mesh and all we move is the offset. Returns true if a glass mesh with a map was found.
+ */
+export function setFace(model, index) {
+  if (!model || !model.traverse) return false;
+  let mesh = null;
+  model.traverse((o) => { if (!mesh && o.isMesh && o.name === GLASS) mesh = o; });
+  if (!mesh) return false;
+  const mats = Array.isArray(mesh.material) ? mesh.material : mesh.material ? [mesh.material] : [];
+  const i = Math.min(FACE_N - 1, Math.max(0, index | 0));
+  let hit = false;
+  for (const m of mats) {
+    const tex = m && m.map;
+    if (!tex) continue;
+    tex.wrapS = THREE.RepeatWrapping;
+    tex.magFilter = THREE.NearestFilter;
+    tex.minFilter = THREE.NearestFilter;
+    tex.generateMipmaps = false;
+    tex.offset.x = i / FACE_N;
+    tex.needsUpdate = true;
+    hit = true;
+  }
+  return hit;
+}
+
+// ---- the pixel pass ---------------------------------------------------------------------
+
+/** Run every texture on `model` through the pixelizer so it snaps to NearestFilter with the
+ *  rest of the world while a block size is on. No pixelizer, nothing to do. */
+export function preparePixel(model, pixel) {
+  if (!model || !model.traverse || !pixel || !pixel.filterTexture) return;
+  model.traverse((o) => {
+    const mats = Array.isArray(o.material) ? o.material : o.material ? [o.material] : [];
+    for (const m of mats) {
+      for (const k of MAP_KEYS) if (m[k]) pixel.filterTexture(m[k]);
+      if (m.uniforms) for (const u of Object.values(m.uniforms)) if (u && u.value && u.value.isTexture) pixel.filterTexture(u.value);
+    }
+  });
+}
+
+// self-check: node --check is the bar; race/smoke/gltf-smoke.mjs exercises the rest.

--- a/ConditioningControlPanel/Resources/web/dtrh/race/smoke/gltf-smoke.mjs
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/smoke/gltf-smoke.mjs
@@ -1,0 +1,222 @@
+/* ============================================================================
+ * race/smoke/gltf-smoke.mjs - node smoke for race/gltf.js.
+ *
+ *   node race/smoke/gltf-smoke.mjs        (exits 0 on pass, 1 on the first failure)
+ *
+ * Node has no DOM and no WebGL, so this file:
+ *   1. resolves the bare specifiers `three` and `three/addons/` with a local
+ *      module hook (node has no import map; the browser gets the same two
+ *      mappings from race.html), then dynamically imports everything;
+ *   2. writes a small TEXTURELESS GLB itself with a ~60 line writer, rather
+ *      than vendoring GLTFExporter: two top-level nodes (kart_cup with two
+ *      coloured box children, item_cube with a COLOR_0 attribute) and one
+ *      1-second `idle` clip;
+ *   3. parses it with GLTFLoader.parse(arrayBuffer, '', onLoad, onError);
+ *   4. asserts names(), stats, toInstanceGeometry (vertex count, colours, the
+ *      node-relative bake, outline winding), setFace on a hand-built
+ *      EMI_glass + DataTexture, preparePixel, and the clip names.
+ *
+ * SHIMS: none. three r169 and GLTFLoader both import clean under node 22+,
+ * and the textureless GLB path never reaches createImageBitmap, ImageBitmap-
+ * Loader or document. TextDecoder / TextEncoder / URL are node globals
+ * already. If a future pack gains textures this smoke must stay textureless.
+ * ==========================================================================*/
+
+import { registerHooks } from 'node:module';
+import { pathToFileURL } from 'node:url';
+import path from 'node:path';
+
+const VENDOR = pathToFileURL(path.resolve(import.meta.dirname, '../../vendor/three/') + path.sep).href;
+registerHooks({
+  resolve(spec, ctx, next) {
+    if (spec === 'three') return { url: VENDOR + 'three.module.min.js', shortCircuit: true };
+    if (spec.startsWith('three/addons/')) return { url: VENDOR + 'addons/' + spec.slice('three/addons/'.length), shortCircuit: true };
+    return next(spec, ctx);
+  },
+});
+
+const THREE = await import('three');
+const { makePack, toInstanceGeometry, setFace, preparePixel, disposePack, FACES } = await import('../gltf.js');
+const { GLTFLoader } = await import('three/addons/loaders/GLTFLoader.js');
+
+// ---- the tiny assert kit ----------------------------------------------------------------
+let passed = 0;
+const ok = (cond, what) => { if (!cond) { console.error('FAIL ' + what); process.exit(1); } passed++; console.log('  ok  ' + what); };
+const near = (a, b, eps = 1e-4) => Math.abs(a - b) <= eps;
+
+// ---- the GLB writer ---------------------------------------------------------------------
+const COMP = { SCALAR: 1, VEC3: 3, VEC4: 4 };
+const FLOAT = 5126, USHORT = 5123;
+
+function makeGlb() {
+  const chunks = [];
+  let len = 0;
+  const bufferViews = [], accessors = [];
+  const put = (arr, componentType, type, extra) => {
+    const bytes = new Uint8Array(arr.buffer, arr.byteOffset, arr.byteLength);
+    bufferViews.push({ buffer: 0, byteOffset: len, byteLength: bytes.length });
+    chunks.push(bytes); len += bytes.length;
+    const pad = (4 - (len % 4)) % 4;
+    if (pad) { chunks.push(new Uint8Array(pad)); len += pad; }
+    accessors.push({ bufferView: bufferViews.length - 1, componentType, count: arr.length / COMP[type], type, ...extra });
+    return accessors.length - 1;
+  };
+
+  const box = new THREE.BoxGeometry(1, 1, 1);
+  const aPos = put(new Float32Array(box.attributes.position.array), FLOAT, 'VEC3', { min: [-0.5, -0.5, -0.5], max: [0.5, 0.5, 0.5] });
+  const aNor = put(new Float32Array(box.attributes.normal.array), FLOAT, 'VEC3', {});
+  const aIdx = put(new Uint16Array(box.index.array), USHORT, 'SCALAR', {});
+  const rgb = new Float32Array(box.attributes.position.count * 3);
+  for (let i = 0; i < box.attributes.position.count; i++) { rgb[i * 3] = 0.25; rgb[i * 3 + 1] = 0.5; rgb[i * 3 + 2] = 0.75; }
+  const aCol = put(rgb, FLOAT, 'VEC3', {});
+  const aTime = put(new Float32Array([0, 1]), FLOAT, 'SCALAR', { min: [0], max: [1] });
+  const aMove = put(new Float32Array([2, 0, 0, 2, 0.4, 0]), FLOAT, 'VEC3', {});
+  box.dispose();
+
+  const prim = (mat, withColor) => ({
+    attributes: withColor ? { POSITION: aPos, NORMAL: aNor, COLOR_0: aCol } : { POSITION: aPos, NORMAL: aNor },
+    indices: aIdx, material: mat,
+  });
+  const json = {
+    asset: { version: '2.0', generator: 'race/smoke/gltf-smoke.mjs' },
+    scene: 0,
+    scenes: [{ nodes: [0, 3] }],
+    nodes: [
+      { name: 'kart_cup', translation: [2, 0, 0], children: [1, 2] },
+      { name: 'cup_body', mesh: 0, translation: [0, 0.5, 0] },
+      { name: 'cup_handle', mesh: 1 },
+      { name: 'item_cube', mesh: 2, translation: [-3, 0, 0] },
+    ],
+    meshes: [
+      { name: 'cup_body_mesh', primitives: [prim(0, false)] },
+      { name: 'cup_handle_mesh', primitives: [prim(1, false)] },
+      { name: 'item_cube_mesh', primitives: [prim(2, true)] },
+    ],
+    materials: [
+      { name: 'body', pbrMetallicRoughness: { baseColorFactor: [0.2, 0.4, 0.6, 1] } },
+      { name: 'outline', pbrMetallicRoughness: { baseColorFactor: [0, 0, 0, 1] } },
+      { name: 'cube', pbrMetallicRoughness: { baseColorFactor: [1, 1, 1, 1] } },
+    ],
+    animations: [{
+      name: 'idle',
+      samplers: [{ input: aTime, output: aMove, interpolation: 'LINEAR' }],
+      channels: [{ sampler: 0, target: { node: 0, path: 'translation' } }],
+    }],
+    bufferViews,
+    accessors,
+    buffers: [{ byteLength: len }],
+  };
+
+  const jsonBytes = new TextEncoder().encode(JSON.stringify(json));
+  const jsonPad = (4 - (jsonBytes.length % 4)) % 4;
+  const jsonLen = jsonBytes.length + jsonPad;
+  const total = 12 + 8 + jsonLen + 8 + len;
+  const out = new Uint8Array(total);
+  const dv = new DataView(out.buffer);
+  dv.setUint32(0, 0x46546c67, true); dv.setUint32(4, 2, true); dv.setUint32(8, total, true);
+  dv.setUint32(12, jsonLen, true); dv.setUint32(16, 0x4e4f534a, true);
+  out.set(jsonBytes, 20);
+  for (let i = 0; i < jsonPad; i++) out[20 + jsonBytes.length + i] = 0x20;   // JSON chunk pads with spaces
+  let at = 20 + jsonLen;
+  dv.setUint32(at, len, true); dv.setUint32(at + 4, 0x004e4942, true);
+  at += 8;
+  for (const c of chunks) { out.set(c, at); at += c.length; }
+  return out.buffer;
+}
+
+// ---- parse ------------------------------------------------------------------------------
+const glb = makeGlb();
+const gltf = await new Promise((resolve, reject) => new GLTFLoader().parse(glb, '', resolve, reject));
+const pack = makePack(gltf, 'race/assets/smoke.glb');
+
+console.log('pack: ' + JSON.stringify(pack.stats) + ' names ' + JSON.stringify(pack.names()));
+
+// ---- pack --------------------------------------------------------------------------------
+const names = pack.names();
+ok(names.includes('kart_cup') && names.includes('item_cube'), 'names() lists the top-level nodes');
+ok(names.includes('cup_body') && names.includes('cup_handle'), 'names() lists the children too');
+ok(pack.byName('kart_cup') !== null, 'byName finds a node');
+ok(pack.byName('nope_not_here') === null, 'byName returns null for a miss (callers fall back)');
+ok(pack.stats.tris === 36, 'stats.tris counts 3 boxes = 36 (got ' + pack.stats.tris + ')');
+ok(pack.stats.nodes === 5, 'stats.nodes counts scene + 4 nodes (got ' + pack.stats.nodes + ')');
+ok(pack.stats.bytes > 0, 'stats.bytes sees the GLB body (' + pack.stats.bytes + ')');
+
+const clone = pack.clone('kart_cup');
+ok(clone && clone !== pack.byName('kart_cup'), 'clone() returns a fresh object');
+ok(clone.children.length === 2, 'clone() is deep');
+ok(clone.children[0].material === pack.byName('cup_body').material, 'clone() shares materials');
+ok(pack.clone('nope_not_here') === null, 'clone() returns null for a miss');
+
+// ---- animations --------------------------------------------------------------------------
+ok(pack.animations.length === 1 && pack.animations[0].name === 'idle', 'animations carry the clip names');
+ok(near(pack.animations[0].duration, 1), 'the clip is 1 second');
+
+// ---- toInstanceGeometry ------------------------------------------------------------------
+const geo = toInstanceGeometry(pack.byName('kart_cup'));
+ok(geo && geo.attributes.position.count === 48, 'kart_cup merges 2 boxes into 48 verts (got ' + (geo && geo.attributes.position.count) + ')');
+ok(geo.index && geo.index.count === 72, 'and 72 indices (got ' + (geo.index && geo.index.count) + ')');
+ok(!!geo.attributes.normal && !!geo.attributes.color, 'attributes are position + normal + color');
+ok(Object.keys(geo.attributes).sort().join(',') === 'color,normal,position', 'and nothing else (no uv, so it drops into MeshLambertMaterial({vertexColors:true}))');
+const c = geo.attributes.color;
+ok(near(c.getX(0), 0.2) && near(c.getY(0), 0.4) && near(c.getZ(0), 0.6), 'flat colour comes from the material baseColorFactor, linear, uncorrected');
+ok(near(c.getX(47), 0) && near(c.getY(47), 0), 'the second box carries its own flat colour');
+geo.computeBoundingBox();
+const bb = geo.boundingBox;
+ok(near(bb.min.x, -0.5) && near(bb.max.x, 0.5), 'the bake is RELATIVE to the node: the +2 x offset is gone');
+ok(near(bb.min.y, -0.5) && near(bb.max.y, 1), 'the child translation IS baked in (y spans -0.5..1)');
+
+const cubeGeo = toInstanceGeometry(pack.byName('item_cube'));
+const cc = cubeGeo.attributes.color;
+ok(near(cc.getX(0), 0.25) && near(cc.getY(0), 0.5) && near(cc.getZ(0), 0.75), 'COLOR_0 wins over the material colour when a mesh has one');
+ok(cubeGeo.attributes.color.itemSize === 3, 'COLOR_0 is normalised to a float RGB attribute');
+ok(toInstanceGeometry(null) === null, 'toInstanceGeometry(null) is null, not a throw');
+ok(toInstanceGeometry(new THREE.Group()) === null, 'an empty node merges to null (caller falls back)');
+
+// ---- outline winding ----------------------------------------------------------------------
+// Both hulls are mirrored on x. The plain one gets re-wound so it lights right; the one whose
+// material is named `outline` is an inverted hull and must come through exactly as authored.
+function mirroredHull(matName) {
+  const g = new THREE.Group();
+  const mesh = new THREE.Mesh(new THREE.BoxGeometry(1, 1, 1), new THREE.MeshBasicMaterial({ name: matName }));
+  mesh.scale.set(-1, 1, 1);
+  g.add(mesh);
+  return g;
+}
+const src = Array.from(new THREE.BoxGeometry(1, 1, 1).index.array);
+const plain = Array.from(toInstanceGeometry(mirroredHull('body')).index.array);
+const hull = Array.from(toInstanceGeometry(mirroredHull('outline')).index.array);
+ok(hull.join() === src.join(), 'an `outline` material keeps its winding, mirror or not');
+ok(plain[0] === src[2] && plain[2] === src[0], 'a mirrored ordinary mesh is re-wound');
+
+// ---- setFace -------------------------------------------------------------------------------
+const tex = new THREE.DataTexture(new Uint8Array(FACES.length * 4 * 4), FACES.length * 4, 4);
+const glass = new THREE.Mesh(new THREE.PlaneGeometry(1, 1), new THREE.MeshBasicMaterial({ map: tex }));
+glass.name = 'EMI_glass';
+const emi = new THREE.Group();
+emi.name = 'EMI_root';
+emi.add(glass);
+
+ok(FACES.join(' ') === '^_^ :3 >_< o_o $_$', 'FACES is the authored atlas order');
+ok(setFace(emi, 2) === true, 'setFace finds EMI_glass');
+ok(near(tex.offset.x, 2 / 5), 'frame 2 sits at offset 0.4 (got ' + tex.offset.x + ')');
+ok(tex.wrapS === THREE.RepeatWrapping, 'wrapS is RepeatWrapping');
+ok(tex.magFilter === THREE.NearestFilter && tex.minFilter === THREE.NearestFilter, 'filters are Nearest both ways');
+ok(tex.generateMipmaps === false, 'mipmaps are off');
+setFace(emi, 99); ok(near(tex.offset.x, 4 / 5), 'an out of range index clamps to the last frame');
+setFace(emi, -7); ok(near(tex.offset.x, 0), 'a negative index clamps to the first frame');
+ok(setFace(new THREE.Group(), 1) === false, 'no EMI_glass, no throw, just false');
+ok(setFace(null, 1) === false, 'setFace(null) is false');
+
+// ---- preparePixel ----------------------------------------------------------------------------
+const seen = [];
+preparePixel(emi, { filterTexture: (t) => seen.push(t) });
+ok(seen.length === 1 && seen[0] === tex, 'preparePixel walks every texture through pixel.filterTexture');
+preparePixel(emi, null);
+ok(true, 'preparePixel with no pixelizer is a no-op');
+
+// ---- disposePack ------------------------------------------------------------------------------
+disposePack('race/assets/never-loaded.glb');
+ok(true, 'disposePack on an unknown url is a no-op');
+
+console.log('\ngltf smoke PASS: ' + passed + ' assertions');
+process.exit(0);


### PR DESCRIPTION
## Racing Thoughts (ex Caucus Race) web stack

Stacked on `feat/race-b1-vendor`. Merge bottom-up.

### Commits
- fix(race): setFace shifts the emissive atlas too
- feat(race): race/gltf.js pack loader, instance merge, face atlas

`3 files changed, 492 insertions(+)`

### From the commit message
race/gltf.js (264 lines) loads the two Blender packs the race is about to
gain, race/assets/emi.glb and props.glb, and hands them to the existing
voxel-look renderer:
  loadPack(url, { log })  cached per url, one in-flight request, logs
                          nodes / tris / KB through the race's one-argument
                          logger; a failure drops out of the cache so a
                          later call retries
  Pack.byName/clone/names/stats/scene/animations
  toInstanceGeometry(node)  bakes every mesh under a node into ONE geometry
                          in that node's frame with attributes position +
                          normal + color, exactly the shape roomProps
                          voxel() makes, so it drops straight into
                          InstancedMesh + MeshLambertMaterial({vertexColors})
  setFace(model, index) / FACES   moves EMI_glass's atlas offset
  preparePixel(model, pixel)      every texture through pixel.filterTexture
  disposePack(url)
Colour space: voxel() writes Color.setHex().r/g/b, which is LINEAR working
space, and glTF baseColorFactor and COLOR_0 are linear by spec, so the merge
copies both straight through with no conversion and a merged prop shades
identically to a hand-built one beside it.
Meshes whose material is named `outline` are inverted hulls and keep their
winding untouched; an ordinary mesh whose baked matrix mirrors gets its
index re-wound so it still lights right.
Nothing here requires any contract name to exist. byName returns null on a
miss and every call site keeps the voxel kit as its fallback, so a
half-finished pack degrades one prop at a time.
race/smoke/gltf-smoke.mjs writes a small textureless GLB itself (a ~60 line
GLB writer rather than vendoring GLTFExporter), parses it through
GLTFLoader.parse, and runs 40 assertions over names, stats, the merge, the
node-relative bake, COLOR_0 vs material colour, outline winding, setFace
clamping and filters, and preparePixel. It needs no DOM or WebGL shims at
all; the only node-specific piece is a local module.registerHooks resolver
standing in for race.html's import map. `node race/smoke/gltf-smoke.mjs`
exits 0.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0166ij3Q8xyseVkhWajzkWG3
