### PR TITLE
feat(race): EMI pose layer on race events (+1)

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
@@ -159,6 +159,20 @@ from behind, gloves on the rim, bead antenna with the six mood states, sweat par
 fraught, her face only as a mirrored emoticon in the tea (`:3`, `>_<`, `o_o`, `^_^`, `$_$`). Text
 emoticons only, never a drawn face, never a speech line.
 
+### `race/emiPoses.js` (pass four, EMI's body)
+```js
+export const POSES, PIVOTS;   // the pure preset table, and the four glb pivots a preset may name
+export function resolvePose(name, opts) -> flattened target
+export function createPoseLayer(model) -> { set(name, opts), update(dt, ctx), dispose, fraught, name }
+```
+Poses: `cruise` (the rest), `drift`, `boost` -> `boostOut`, `air`, `landing` / `landingKerb`,
+`grab`, `clamp`, `tuck`, `throw`, `cheer`. `opts` = `{ side:-1|1, tier:1..3, hold:sec }`; sided
+presets are authored for +1 and mirrored for -1. Every value is an offset on the pack's authored
+rest rotation, blended on damped springs (Law XI, never a linear tween), and a pose with a `hold`
+falls back to `next` on its own. `clamp` and `landingKerb` report `fraught` and emi.js takes the
+max of that and the run brain's. run.js only ever calls `kart.pose(...)`; the layer exists only
+while the glb is mounted (the primitive EMI has no limbs to pose).
+
 ### `race/items.js` (PR 4)
 ```js
 export const ITEMS;   // 10 items: { id, name, glyph, desc, durationSec }

--- a/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
@@ -151,6 +151,9 @@ kart.dispose()
 `retexture(scene)` pass, so the rig walks them through `preparePixel` when the model mounts. EMI is
 the Blender glb from the moment `emi.glb` resolves; the primitive CRT is the fallback and rides on
 if it never does.
+The cup and the saucer come from `props.glb` (`kart_cup`, `kart_saucer`) on the same terms: the
+lathe cup, its rim torus, the handle tube, the saucer cylinder and its rim are the fallback, and
+the tea disc, the pink saucer mark, `cupLight`, the seat and `TEA_Y` are shared by both paths.
 Speed: cruise `KART_BASE_SPEED`, cap `KART_MAX_SPEED`, floor `KART_MIN_SPEED`. Ramps: when
 `layout.rampAt(d)` matches the lip, give `vh` an upward impulse scaled by speed; `GRAVITY` pulls
 back; `airborne` while `h > 0.05`. Steering moves `x` with inertia, clamped to `ROAD_HALF_W`

--- a/ConditioningControlPanel/Resources/web/dtrh/race/emi.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/emi.js
@@ -10,8 +10,13 @@
 // THE MODEL. The primitive CRT below is now only the fallback. On creation the rig asks gltf.js for
 // race/assets/emi.glb (the Blender hard-surface EMI); the moment it lands the primitive group comes
 // off the graph and is freed, and the glb clone takes the same seat in the cup. Until then, and for
-// good if the load fails, the primitive rides. Everything else (saucer, cup, handle, tea, cupLight,
-// sweat, sparks) is untouched and the MOODS table drives the glb's own pivots instead.
+// good if the load fails, the primitive rides. Everything else (tea, cupLight, sweat, sparks) is
+// untouched and the MOODS table drives the glb's own pivots instead.
+//
+// THE CROCKERY. The same deal for the cup and the saucer: race/assets/props.glb ships kart_cup
+// (lathe, glaze rim and handle in one node) and kart_saucer, and they take over from the
+// LatheGeometry cup, its rim torus, the handle tube, the saucer cylinder and its rim the moment
+// the pack lands. Needs feat/race-b4-props-glb underneath for the file itself.
 
 import * as THREE from 'three';
 import { loadPack, setFace as packSetFace, preparePixel, FACES } from './gltf.js';
@@ -21,6 +26,11 @@ const PINK = 0xff69b4, GOLD = 0xF2C14E, PALE = 0xB3C7FF, PORCELAIN = 0xF6E7C8;
 const BREATH_SEC = 3.9;      // the one breath on screen (Law III)
 const SWEAT_N = 28, SPARK_N = 32;
 const EMI_GLB = '/dtrh/race/assets/emi.glb';
+const PROPS_GLB = '/dtrh/race/assets/props.glb';
+// props.glb, measured off the node bboxes (assets/PROPS.md): the saucer stands 0.125 tall to the
+// top of its glaze band, the cup is 0.695 to its rim with the band at 0.645..0.690, handle on +x.
+// The cup sits CUP_Y above the saucer base, the way the JS rig always sat it.
+const CUP_Y = 0.09, SAUCER_TOP = 0.125, CUP_RIM_TOP = 0.695;
 const OUTLINE = 'outline';   // the inverted hull's material name (gltf.js header, assets/README.md)
 // The glb is metres, sole centre at the origin, +Z forward, case top at 1.00 m. 0.64 puts the case
 // at the old 1.25-scaled CRT's 0.525 m; with the sole on the tea (y 0.66) the case bottom lands at
@@ -140,7 +150,9 @@ export function createEmiRig({ scene, reducedMotion = false, pixel = null }) {
   // ---- the tea: a plain tinted liquid disc, nothing drawn in it. It takes the room's colour
   // (the scene fog hue, which fx grades per room) and ripples a little. EMI faces forward, away
   // from the camera, so there is no face to reflect and none is ever painted here.
-  const TEA_R = 0.46, TEA_Y = 0.66;
+  // the tea sits the same 0.11 under the rim it always did, now measured off the glb cup's node
+  // bbox: CUP_Y + CUP_RIM_TOP is the rim at 0.785, so the surface lands at 0.675.
+  const TEA_R = 0.46, TEA_Y = CUP_Y + CUP_RIM_TOP - 0.11;
   const teaMat = new THREE.MeshStandardMaterial({ color: 0xC94A9A, emissive: 0x3c1630, roughness: 0.12, metalness: 0.25, transparent: true, opacity: 0.9 });
   const tea = new THREE.Mesh(new THREE.CircleGeometry(TEA_R + 0.01, 32), teaMat);
   tea.rotation.set(-Math.PI / 2, 0, Math.PI); tea.position.y = TEA_Y; body.add(tea);
@@ -191,6 +203,7 @@ export function createEmiRig({ scene, reducedMotion = false, pixel = null }) {
 
   // ---- the glb: loaded once, mounted in the same seat, primitive freed ----
   let G = null;                     // { root, ant0, ant1, ant2, ballpiv, caseNode, ballMats, glassMats, rest }
+  let P = null;                     // { cup, dish }: the props.glb crockery once it lands
   let poses = null;                 // race/emiPoses.js, built with the model
   let dead = false;
   const readyCbs = [], owned = [];  // owned = the materials this rig cloned or made, freed with it
@@ -215,15 +228,21 @@ export function createEmiRig({ scene, reducedMotion = false, pixel = null }) {
     });
   }
 
+  // the inverted hulls: a lit standard material reads grey, so every pack's outline meshes take
+  // this one flat near-black, front faces only (the hull is already wound inside out)
+  const black = new THREE.MeshBasicMaterial({ name: OUTLINE, color: 0x07060f, side: THREE.FrontSide });
+  owned.push(black);
+  const blackOutline = (node) => node.traverse((o) => { if (o.isMesh && isOutline(o)) o.material = black; });
+  /** Take a primitive off the graph and free its geometry. Its material may be shared, so that is
+   *  left to dispose() (the ones that go unshared are pushed onto `owned` at the call site). */
+  const retire = (m) => { if (m.parent) m.parent.remove(m); if (m.geometry) m.geometry.dispose(); };
+
   function mountGlb(pack) {
     if (dead || G) return;
     const root = pack.clone('EMI_root');
     const ant0 = root && root.getObjectByName('ant0'), ballpiv = root && root.getObjectByName('ballpiv');
     if (!root || !ant0 || !ballpiv) return;         // a pack without the contract pivots: the primitive stays
-    // the inverted hulls: a lit standard material reads grey, so they all take one flat near-black
-    const black = new THREE.MeshBasicMaterial({ name: OUTLINE, color: 0x07060f, side: THREE.FrontSide });
-    owned.push(black);
-    root.traverse((o) => { if (o.isMesh && isOutline(o)) o.material = black; });
+    blackOutline(root);
     const ballMats = [], glassMats = [];
     ownMaterials(root.getObjectByName('ball') || ballpiv, ballMats);
     ownMaterials(root.getObjectByName('EMI_glass'), glassMats);
@@ -264,6 +283,26 @@ export function createEmiRig({ scene, reducedMotion = false, pixel = null }) {
     }
     return hit;
   }
+  /** The crockery. kart_cup carries the lathe, the glaze rim and the handle in one node, kart_saucer
+   *  the dish and its rim band, so five primitives come off for two clones. The tea disc, the pink
+   *  saucer mark, cupLight, the seat and every y this rig quotes are untouched: the glb heights are
+   *  the ones those numbers were measured against. */
+  function mountProps(pack) {
+    if (dead || P) return;
+    const cup = pack.clone('kart_cup'), dish = pack.clone('kart_saucer');
+    if (!cup || !dish) return;                      // a pack without the crockery: the primitives stay
+    blackOutline(cup); blackOutline(dish);
+    P = { cup, dish };
+    retire(sc); retire(saucerRim);                  // pinkGlow still dresses the mark, so it lives on
+    saucer.add(dish);
+    saucerMark.position.y = SAUCER_TOP + 0.01;      // back on top of the new glaze band
+    retire(cupMesh); retire(rim); retire(handle);
+    owned.push(cupMat, porcelain);                  // nothing on the graph wears these two now
+    cup.position.y = CUP_Y;
+    body.add(cup);
+    if (pixel) { preparePixel(cup, pixel); preparePixel(dish, pixel); }
+  }
+
   function onReady(cb) { if (typeof cb !== 'function') return; if (G) cb(G.root); else readyCbs.push(cb); }
   function model() { return G ? G.root : null; }
   /** Race events pose her body (race/emiPoses.js). No model yet, nothing to pose. */
@@ -363,6 +402,7 @@ export function createEmiRig({ scene, reducedMotion = false, pixel = null }) {
     // the glb clone shares the cached pack's geometry and textures, so it comes off the graph before
     // the blanket teardown and only the materials this rig made are freed. The pack stays cached.
     if (G) { seat.remove(G.root); body.remove(seat); G = null; }
+    if (P) { body.remove(P.cup); saucer.remove(P.dish); P = null; }
     for (const m of owned.splice(0)) m.dispose();
     readyCbs.length = 0;
     scene.remove(sweat.mesh); scene.remove(sparks.mesh);
@@ -370,6 +410,7 @@ export function createEmiRig({ scene, reducedMotion = false, pixel = null }) {
   }
 
   loadPack(EMI_GLB).then(mountGlb).catch(() => { /* no pack, no swap: the primitive EMI rides on */ });
+  loadPack(PROPS_GLB).then(mountProps).catch(() => { /* no pack, no swap: the JS crockery rides on */ });
 
   return { group, update, setMood, setFraught, squash, dispose, onReady, model, setFace: setFaceFrame, pose };
 }

--- a/ConditioningControlPanel/Resources/web/dtrh/race/emi.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/emi.js
@@ -15,6 +15,7 @@
 
 import * as THREE from 'three';
 import { loadPack, setFace as packSetFace, preparePixel, FACES } from './gltf.js';
+import { createPoseLayer } from './emiPoses.js';
 
 const PINK = 0xff69b4, GOLD = 0xF2C14E, PALE = 0xB3C7FF, PORCELAIN = 0xF6E7C8;
 const BREATH_SEC = 3.9;      // the one breath on screen (Law III)
@@ -190,6 +191,7 @@ export function createEmiRig({ scene, reducedMotion = false, pixel = null }) {
 
   // ---- the glb: loaded once, mounted in the same seat, primitive freed ----
   let G = null;                     // { root, ant0, ant1, ant2, ballpiv, caseNode, ballMats, glassMats, rest }
+  let poses = null;                 // race/emiPoses.js, built with the model
   let dead = false;
   const readyCbs = [], owned = [];  // owned = the materials this rig cloned or made, freed with it
   const seat = new THREE.Group();   // the mount point: the seat, the scale, the breath and the steer lean
@@ -237,6 +239,7 @@ export function createEmiRig({ scene, reducedMotion = false, pixel = null }) {
     body.remove(emi); disposeTree(emi);
     ballpiv.add(beadLight);
     seat.add(screenLight); screenLight.position.set(0, GLOW_Y, GLOW_Z);
+    poses = createPoseLayer(root);
     if (pixel) preparePixel(root, pixel);
     setFaceFrame(0);
     for (const cb of readyCbs.splice(0)) { try { cb(root); } catch (e) { /* a listener never breaks the rig */ } }
@@ -263,8 +266,8 @@ export function createEmiRig({ scene, reducedMotion = false, pixel = null }) {
   }
   function onReady(cb) { if (typeof cb !== 'function') return; if (G) cb(G.root); else readyCbs.push(cb); }
   function model() { return G ? G.root : null; }
-  /** The pose layer lands in the next commit; kart.js and the menus can already call this. */
-  function pose() { return false; }
+  /** Race events pose her body (race/emiPoses.js). No model yet, nothing to pose. */
+  function pose(name, opts) { return poses ? poses.set(name, opts || {}) : false; }
 
   function emitFrom(obj, lx, ly, lz, ctx, pool, ttl, size, spread, upSpeed, backSpeed) {
     _p.set(lx, ly, lz); obj.localToWorld(_p);
@@ -275,10 +278,13 @@ export function createEmiRig({ scene, reducedMotion = false, pixel = null }) {
   function update(dt, ctx) {
     dt = Math.min(dt, 0.05);
     const t = ctx.t || 0, m = mood;
+    // the clamp and the kerbed landing carry their own fraught; the run brain's own value still wins
+    // whenever it is higher, so a stack of effects is never talked down by a pose
+    const fr = poses ? Math.max(fraught, poses.fraught) : fraught;
     const wind = Math.max(0, Math.min(1, (ctx.speedNorm - 0.55) / 0.45)) * 0.8 + (ctx.airborne ? 0.5 : 0);
-    const antTarget = m.antX - Math.min(1, wind) * m.wind + (fraught > 0.4 ? 0.25 * fraught : 0);
-    const kinkXT = m.kinkX + 1.7 * fraught * (m === MOODS.fraught ? 0.3 : 1);
-    const hush = ctx.airborne || m.sway === 0 ? 0 : m.sway * (1 - 0.6 * fraught);
+    const antTarget = m.antX - Math.min(1, wind) * m.wind + (fr > 0.4 ? 0.25 * fr : 0);
+    const kinkXT = m.kinkX + 1.7 * fr * (m === MOODS.fraught ? 0.3 : 1);
+    const hush = ctx.airborne || m.sway === 0 ? 0 : m.sway * (1 - 0.6 * fr);
     const sway = hush * 0.14 * Math.sin(t * (Math.PI * 2) / BREATH_SEC);
     // one set of springs, two bodies to hang them on: the glb's authored pivots or the primitive's
     const antX = sAnt.step(antTarget, dt, m.w, m.zeta);
@@ -298,7 +304,8 @@ export function createEmiRig({ scene, reducedMotion = false, pixel = null }) {
       kink.rotation.set(kinkX, 0, kinkZ);
       bead.scale.setScalar(beadScale);
     }
-    beadTarget.setHex(m.bead); if (m !== MOODS.jackpot) beadTarget.lerp(_c.setHex(PALE), fraught);
+    if (poses) poses.update(dt, ctx);        // the body, on top of the mood the antenna just took
+    beadTarget.setHex(m.bead); if (m !== MOODS.jackpot) beadTarget.lerp(_c.setHex(PALE), fr);
     const glow = m === MOODS.jackpot ? 1.4 : 0.9;
     for (const bm of G ? G.ballMats : [beadMat]) {
       bm.color.lerp(beadTarget, Math.min(1, dt * 6));
@@ -327,7 +334,7 @@ export function createEmiRig({ scene, reducedMotion = false, pixel = null }) {
 
     // sweat off the bead and the CRT's top corners; a Bambi-scale anime sweat, not a rain
     if (!reducedMotion) {
-      const rate = fraught > 0.3 || m === MOODS.fraught ? 4 + 6 * Math.max(fraught, m === MOODS.fraught ? 0.5 : 0) : 0;
+      const rate = fr > 0.3 || m === MOODS.fraught ? 4 + 6 * Math.max(fr, m === MOODS.fraught ? 0.5 : 0) : 0;
       sweatAcc += dt * rate;
       while (sweatAcc >= 1) {
         sweatAcc -= 1;

--- a/ConditioningControlPanel/Resources/web/dtrh/race/emiPoses.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/emiPoses.js
@@ -1,0 +1,193 @@
+/* ============================================================================
+ * race/emiPoses.js - The Caucus Race: EMI's pose layer over the Blender glb.
+ *
+ * race/emi.js owns the moods (the antenna, the bead, the sweat). This owns her
+ * BODY on the race's events: the arms, the feet and a root lean / tilt / lift /
+ * squash, blended on damped springs (House Book Law XI: overshoot, never a
+ * linear tween) and always falling back to `cruise` when a pose's hold runs out.
+ *
+ *   createPoseLayer(model, { }) -> { set(name, opts), update(dt, ctx), dispose, fraught, name }
+ *   POSES                        the pure preset table (a node smoke reads it)
+ *   PIVOTS                       the four glb pivots a preset is allowed to name
+ *
+ * `model` is the glb root (EMI_root clone). Every preset value is an OFFSET on
+ * the pivot's authored rest rotation, so the model's own stance is never lost.
+ * `opts`: { side: -1 | 1, tier: 1..3, hold: seconds }. A sided preset is authored
+ * for side +1 (the kart's right, +x) and mirrored for -1: L and R swap and the y
+ * and z of every rotation flip, along with the root lean.
+ *
+ * The one thing this layer reads back out is `fraught` (clamp and a kerbed
+ * landing raise it); emi.js takes the max of that and the run brain's own value.
+ * ==========================================================================*/
+
+/** The pivots a preset may name. Anything else is a typo and the smoke fails on it. */
+export const PIVOTS = ['shoulderL', 'shoulderR', 'footL', 'footR'];
+
+const BREATH_SEC = 3.9;      // the same one breath emi.js runs on (Law III)
+const BREATH_LIFT = 0.02;    // model metres, so 0.013 m once the seat's 0.64 is on it
+const ANT_MAX = 1.2;         // how far the tuck is allowed to drag the antenna base
+
+/**
+ * The presets. `root` is { lean (z), tilt (x), lift (y), squash (y scale) }, the four pivots are
+ * [x, y, z] offsets in radians, `w` / `zeta` are the spring, `hold` is seconds before `next`
+ * (0 = hold until something else is set), `breath` keeps the idle bob, `fraught` feeds emi.js and
+ * `antDown` lets the antenna base fall toward the real floor while the world is upside down.
+ */
+export const POSES = {
+  // hands on the far rim, shoulders soft, the breath running
+  cruise: { w: 7, zeta: 0.7, hold: 0, breath: 1, root: { lean: 0, tilt: 0, lift: 0, squash: 1 },
+    shoulderL: [-0.95, 0, -0.10], shoulderR: [-0.95, 0, 0.10], footL: [0, 0, 0], footR: [0, 0, 0] },
+
+  // lean into the turn; the outside hand (shoulderL at side +1) lifts off the rim and points
+  drift: { sided: 1, w: 9, zeta: 0.55, hold: 1.1, next: 'cruise', root: { lean: -0.20, tilt: 0.04, lift: 0, squash: 1 },
+    shoulderL: [0.45, 0, -0.75], shoulderR: [-1.15, 0, 0.06], footL: [-0.12, 0, -0.10], footR: [0.10, 0, 0.06] },
+
+  // the mini turbo: squash on the kick...
+  boost: { w: 18, zeta: 0.6, hold: 0.11, next: 'boostOut', root: { lean: 0, tilt: 0.14, lift: -0.06, squash: 0.86 },
+    shoulderL: [0.55, 0, 0.18], shoulderR: [0.55, 0, -0.18], footL: [-0.20, 0, 0], footR: [-0.20, 0, 0] },
+  // ...then stretch, arms pinned back down the road
+  boostOut: { w: 10, zeta: 0.38, hold: 0.55, next: 'cruise', root: { lean: 0, tilt: -0.07, lift: 0.05, squash: 1.10 },
+    shoulderL: [0.95, 0, 0.26], shoulderR: [0.95, 0, -0.26], footL: [0.16, 0, 0], footR: [0.16, 0, 0] },
+
+  // off the ramp: arms out, one leg kicks, a little nose up
+  air: { w: 8, zeta: 0.5, hold: 3, next: 'cruise', root: { lean: 0, tilt: -0.16, lift: 0.04, squash: 1.03 },
+    shoulderL: [-0.20, 0, -1.05], shoulderR: [-0.20, 0, 1.05], footL: [-0.70, 0, -0.15], footR: [0.28, 0, 0.10] },
+
+  // touchdown: squash hard with the overshoot, hands slap the rim
+  landing: { w: 16, zeta: 0.35, hold: 0.28, next: 'cruise', root: { lean: 0, tilt: 0.06, lift: -0.05, squash: 0.82 },
+    shoulderL: [-1.35, 0, 0.06], shoulderR: [-1.35, 0, -0.06], footL: [0.22, 0, 0], footR: [0.22, 0, 0] },
+  // the same, kerbed: a wobble on the way down and a beat of fraught
+  landingKerb: { w: 14, zeta: 0.30, hold: 0.5, next: 'cruise', fraught: 0.7, root: { lean: 0.16, tilt: 0.12, lift: -0.07, squash: 0.78 },
+    shoulderL: [-1.45, 0, 0.22], shoulderR: [-1.10, 0, -0.30], footL: [0.34, 0, 0.12], footR: [0.16, 0, -0.10] },
+
+  // a treat went by: the near hand reaches for it (side +1 = the pop is to her +x)
+  grab: { sided: 1, w: 12, zeta: 0.5, hold: 0.5, next: 'cruise', root: { lean: -0.10, tilt: -0.05, lift: 0.02, squash: 1 },
+    shoulderL: [-0.85, 0, -0.10], shoulderR: [-1.75, 0, 0.55], footL: [0, 0, 0], footR: [-0.10, 0, 0] },
+
+  // an effect is pouring: hands clamp the rim and she gets small
+  clamp: { w: 11, zeta: 0.7, hold: 1.2, next: 'cruise', fraught: 1, root: { lean: 0, tilt: 0.10, lift: -0.06, squash: 0.90 },
+    shoulderL: [-1.30, 0, 0.14], shoulderR: [-1.30, 0, -0.14], footL: [0.35, 0, 0.08], footR: [0.35, 0, -0.08] },
+
+  // upside down in the Wheel: knees up, white knuckles, the antenna hangs toward the real floor
+  tuck: { w: 10, zeta: 0.6, hold: 0, antDown: 1, root: { lean: 0, tilt: 0.18, lift: -0.08, squash: 0.94 },
+    shoulderL: [-1.50, 0, 0.20], shoulderR: [-1.50, 0, -0.20], footL: [-0.85, 0, 0.10], footR: [-0.85, 0, -0.10] },
+
+  // the item goes over the side: the free hand throws an arc (the low zeta IS the arc)
+  throw: { sided: 1, w: 14, zeta: 0.35, hold: 0.45, next: 'cruise', root: { lean: -0.07, tilt: 0.05, lift: 0.02, squash: 1 },
+    shoulderL: [-0.95, 0, -0.10], shoulderR: [1.00, 0, 0.35], footL: [0, 0, 0], footR: [0.12, 0, 0] },
+
+  // a personal best or a jackpot: both arms up
+  cheer: { w: 9, zeta: 0.45, hold: 1.3, next: 'cruise', root: { lean: 0, tilt: -0.08, lift: 0.06, squash: 1.04 },
+    shoulderL: [-2.60, 0, -0.35], shoulderR: [-2.60, 0, 0.35], footL: [-0.18, 0, 0], footR: [-0.18, 0, 0] },
+};
+
+const ZERO3 = [0, 0, 0];
+const DEF_ROOT = { lean: 0, tilt: 0, lift: 0, squash: 1 };
+const clamp = (v, a, b) => Math.max(a, Math.min(b, v));
+const flip = (k) => (k.endsWith('L') ? k.slice(0, -1) + 'R' : k.slice(0, -1) + 'L');
+
+/** Damped spring toward a target; zeta < 1 overshoots a little, which is the point (Law XI). */
+class Spring {
+  constructor(x = 0) { this.x = x; this.v = 0; }
+  step(target, dt, w, zeta) {
+    this.v += (w * w * (target - this.x) - 2 * zeta * w * this.v) * dt;
+    this.x += this.v * dt;
+    return this.x;
+  }
+}
+
+/** One preset plus its options, flattened into the numbers update() blends toward. */
+export function resolvePose(name, opts = {}) {
+  const p = POSES[name] || POSES.cruise;
+  const side = p.sided && +opts.side < 0 ? -1 : 1;
+  const t = {
+    w: p.w, zeta: p.zeta, breath: !!p.breath, fraught: p.fraught || 0, antDown: p.antDown || 0,
+    root: { ...DEF_ROOT, ...(p.root || {}) },
+  };
+  for (const k of PIVOTS) {
+    const src = p[side > 0 ? k : flip(k)] || ZERO3;
+    t[k] = side > 0 ? [src[0], src[1], src[2]] : [src[0], -src[1], -src[2]];
+  }
+  if (side < 0) t.root.lean = -t.root.lean;
+  if (opts.tier) t.root.lean *= 1 + 0.12 * clamp(+opts.tier || 0, 0, 3);   // a fatter drift leans harder
+  return t;
+}
+
+/**
+ * The layer. `model` is the glb root; a model without the contract pivots simply drives the ones
+ * it has and skips the rest, so a half-finished pack degrades a limb at a time.
+ */
+export function createPoseLayer(model) {
+  const find = (n) => (model && model.getObjectByName ? model.getObjectByName(n) || null : null);
+  const piv = {}, rest = {}, sp = {};
+  for (const k of PIVOTS) {
+    const o = find(k);
+    piv[k] = o;
+    rest[k] = o ? [o.rotation.x, o.rotation.y, o.rotation.z] : ZERO3;
+    sp[k] = [new Spring(), new Spring(), new Spring()];
+  }
+  const ant0 = find('ant0');
+  const rootRest = model ? [model.rotation.x, model.rotation.z, model.position.y] : [0, 0, 0];
+  const sLean = new Spring(), sTilt = new Spring(), sLift = new Spring(), sSquash = new Spring(1);
+  const sAntX = new Spring(), sAntZ = new Spring();
+  let name = 'cruise', target = resolvePose('cruise'), hold = 0;
+  const api = { fraught: 0, get name() { return name; } };
+
+  /** Set a pose. Unknown names are ignored (false) rather than blanking her stance. */
+  function set(n, opts = {}) {
+    if (!POSES[n]) return false;
+    name = n;
+    target = resolvePose(n, opts);
+    hold = opts.hold != null ? Math.max(0, +opts.hold || 0) : (POSES[n].hold || 0);
+    api.fraught = target.fraught;
+    return true;
+  }
+
+  function update(dt, ctx) {
+    if (!model) return;
+    dt = Math.min(Math.max(+dt || 0, 0), 0.05);
+    if (hold > 0) {
+      hold -= dt;
+      if (hold <= 0) set(POSES[name].next || 'cruise');
+    }
+    const w = target.w, z = target.zeta;
+    for (const k of PIVOTS) {
+      const o = piv[k];
+      if (!o) continue;
+      const tt = target[k], r = rest[k], s = sp[k];
+      o.rotation.set(r[0] + s[0].step(tt[0], dt, w, z), r[1] + s[1].step(tt[1], dt, w, z), r[2] + s[2].step(tt[2], dt, w, z));
+    }
+    const t = (ctx && ctx.t) || 0;
+    const breath = target.breath ? BREATH_LIFT * Math.sin(t * (Math.PI * 2) / BREATH_SEC) : 0;
+    model.rotation.x = rootRest[0] + sTilt.step(target.root.tilt, dt, w, z);
+    model.rotation.z = rootRest[1] + sLean.step(target.root.lean, dt, w, z);
+    model.position.y = rootRest[2] + sLift.step(target.root.lift, dt, w, z) + breath;
+    const sq = Math.max(0.4, sSquash.step(target.root.squash, dt, w, z));
+    const wide = 1 + (1 - sq) * 0.6;
+    model.scale.set(wide, sq, wide);
+    // the tuck: while the road's up has rolled under the world's, the antenna base falls toward the
+    // real floor. World down in kart space is just the frame vectors' y, negated, and how inverted
+    // she is scales the whole thing, so upright it is exactly zero.
+    let ax = 0, az = 0;
+    if (target.antDown && ctx && ctx.up) {
+      const inv = Math.max(0, -ctx.up.y);
+      const dx = -(ctx.right ? ctx.right.y : 0), dy = -ctx.up.y, dz = -(ctx.tangent ? ctx.tangent.y : 0);
+      ax = clamp(Math.atan2(dz, dy) * inv, -ANT_MAX, ANT_MAX);
+      az = clamp(-Math.atan2(dx, dy) * inv, -ANT_MAX, ANT_MAX);
+    }
+    const antX = sAntX.step(ax, dt, w, z), antZ = sAntZ.step(az, dt, w, z);
+    if (ant0) { ant0.rotation.x += antX; ant0.rotation.z += antZ; }   // emi.js wrote the mood first
+    api.fraught = target.fraught;
+  }
+
+  /** Put the stance back the way the pack authored it (the rig frees the model right after). */
+  function dispose() {
+    for (const k of PIVOTS) { const o = piv[k]; if (o) o.rotation.set(rest[k][0], rest[k][1], rest[k][2]); }
+    if (model) { model.rotation.x = rootRest[0]; model.rotation.z = rootRest[1]; model.position.y = rootRest[2]; model.scale.set(1, 1, 1); }
+  }
+
+  api.set = set; api.update = update; api.dispose = dispose;
+  return api;
+}
+
+// self-check: node --check is the bar; race/smoke/poses-smoke.mjs runs the table and the springs.

--- a/ConditioningControlPanel/Resources/web/dtrh/race/run.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/run.js
@@ -176,11 +176,11 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     if (p.id === 'lucky') w.items.roll(w.score.state.mult);
     if (p.id === 'golden') {
       w.score.jackpot(S.jackpotBias > 1 ? 'major' : 'minor');
-      sfx('golden_pop', 0.9); shake.shake(0.35, 240); poke('jackpot', 1.4);
+      sfx('golden_pop', 0.9); shake.shake(0.35, 240); poke('jackpot', 1.4); w.kart.pose('cheer');
     }
   }
   function onPop(w, p) {
-    w.kart.pulseTarget();
+    w.kart.pulseTarget(); w.kart.pose('grab', { side: (p.x == null ? w.kart.state.x : p.x) >= w.kart.state.x ? 1 : -1 });
     if (p.kind === 'treat') return treat(w, p);
     if (S.parasol) { S.parasol = false; hud.toast('parasol', 'item'); return treat(w, p); }
     // THE MIX: one live effect per category, each with its own re-pop rule (cocktail.js); 'held' scores as a treat
@@ -206,6 +206,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     const label = (KIND_BY_ID[p.id] || {}).label || p.id;
     const slot = mix.live(r.category);
     const holdMult = slot && CATEGORIES[r.category].scaled ? clamp(slot.sec / CATEGORIES[r.category].sec, 0.1, 10) : durationMult;
+    w.kart.pose('clamp', { hold: clamp(slot ? slot.sec : 1.2, 0.6, 4) });   // she rides the pour out
     switch (r.category) {
       case 'strobe':
         fire(p, strength, durationMult); w.kart.applySlow(0.92, 2.0);
@@ -284,7 +285,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
   function onItem(w, e) {
     switch (e.type) {
       case 'itemArm': sfx('ui_click', 0.4); break;
-      case 'itemUse': sfx('tunnel_powerup_collect', 0.7); poke('smug', 0.8); break;
+      case 'itemUse': sfx('tunnel_powerup_collect', 0.7); poke('smug', 0.8); w.kart.pose('throw'); break;
       case 'timeScale': S.timeScale = e.value; sfx('time_slow_in', 0.8); break;
       case 'magnet': S.magnet = true; w.field.setReach(2.2); w.kart.setReach(2.2); break;
       case 'multBoost': w.score.boostMult(e.mult, e.sec); break;
@@ -306,12 +307,12 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
   const TURBO = ['', 'mini turbo', 'super turbo', 'ultra turbo'];
   function onKart(w, e) {
     switch (e.type) {
-      case 'driftTier': sfx('ui_click', 0.3 + 0.15 * e.tier); break;
-      case 'driftBoost': hud.toast(TURBO[e.tier] || 'turbo', 'pop'); sfx('tunnel_powerup_collect', 0.5 + 0.15 * e.tier); if (e.tier >= 2) shake.shake(0.12 * e.tier, 160); poke(e.tier >= 3 ? 'smug' : 'streamed', 1.0); break;
-      case 'trick': { const g = w.score.trick(e.points, e.name); hud.toast(`${e.name} +${g}`, 'pop'); sfx('chain_pop', 0.8); poke('smug', 0.6); break; }
-      case 'landing': if (e.trick) { hud.toast(e.clean ? (e.streak >= 3 ? 'hat trick, clean' : 'clean') : 'kerbed it', e.clean ? 'pop' : 'almost'); if (e.clean) sfx('surface', 0.5); } break;
-      case 'inverted': w.score.setInverted(e.on); if (e.on) { hud.toast('upside down', 'effect'); poke('shock', 0.8); } break;
-      case 'lap': { const r = w.score.lap(e.sec); hud.toast(`lap ${r.text}`, 'item'); if (r.pb && r.prevBest > 0) { hud.toast('pb!', 'jackpot'); sfx('pb_fanfare', 0.9); poke('jackpot', 1.5); } break; }
+      case 'driftTier': sfx('ui_click', 0.3 + 0.15 * e.tier); w.kart.pose('drift', { side: w.kart.state.steer > 0 ? 1 : -1, tier: e.tier }); break;
+      case 'driftBoost': hud.toast(TURBO[e.tier] || 'turbo', 'pop'); sfx('tunnel_powerup_collect', 0.5 + 0.15 * e.tier); if (e.tier >= 2) shake.shake(0.12 * e.tier, 160); poke(e.tier >= 3 ? 'smug' : 'streamed', 1.0); w.kart.pose('boost'); break;
+      case 'trick': { const g = w.score.trick(e.points, e.name); hud.toast(`${e.name} +${g}`, 'pop'); sfx('chain_pop', 0.8); poke('smug', 0.6); w.kart.pose('air'); break; }
+      case 'landing': w.kart.pose(e.clean ? 'landing' : 'landingKerb'); if (e.trick) { hud.toast(e.clean ? (e.streak >= 3 ? 'hat trick, clean' : 'clean') : 'kerbed it', e.clean ? 'pop' : 'almost'); if (e.clean) sfx('surface', 0.5); } break;
+      case 'inverted': w.score.setInverted(e.on); w.kart.pose(e.on ? 'tuck' : 'cruise'); if (e.on) { hud.toast('upside down', 'effect'); poke('shock', 0.8); } break;
+      case 'lap': { const r = w.score.lap(e.sec); hud.toast(`lap ${r.text}`, 'item'); if (r.pb && r.prevBest > 0) { hud.toast('pb!', 'jackpot'); sfx('pb_fanfare', 0.9); poke('jackpot', 1.5); w.kart.pose('cheer'); } break; }
       case 'split': w.score.pace(e.frac, e.sec); break;
     }
   }
@@ -346,7 +347,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
 
     // track features crossed this frame
     for (const f of lay.featuresBetween(prevD, ks.d)) {
-      if (f.type === 'boost' && !ks.airborne && Math.abs(f.x - ks.x) <= 1.2) { k.applyBoost(1.6); sfx('tunnel_powerup_collect', 0.8); shake.shake(0.25, 200); poke('streamed', 1.2); }
+      if (f.type === 'boost' && !ks.airborne && Math.abs(f.x - ks.x) <= 1.2) { k.applyBoost(1.6); sfx('tunnel_powerup_collect', 0.8); shake.shake(0.25, 200); poke('streamed', 1.2); k.pose('boost'); }
       else if (f.type === 'itembox' && Math.abs(f.x - ks.x) <= 1.2 && w.dresser.breakItemBox(f)) { shake.shake(0.2, 120); if (w.items.roll(w.score.state.mult)) sfx('ui_click', 0.5); }
       else if (f.type === 'gate') enterRoom(w, f.room);
     }

--- a/ConditioningControlPanel/Resources/web/dtrh/race/smoke/poses-smoke.mjs
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/smoke/poses-smoke.mjs
@@ -1,0 +1,129 @@
+/* ============================================================================
+ * race/smoke/poses-smoke.mjs - node smoke for race/emiPoses.js.
+ *
+ *   node race/smoke/poses-smoke.mjs      (exits 0 on pass, 1 on the first failure)
+ *
+ * emiPoses.js imports nothing, so this needs no three and no DOM: it stands up a
+ * fake glb root (getObjectByName over the contract nodes, each with a rotation /
+ * position / scale of plain numbers) and drives the layer on a fixed 1/60 step.
+ *
+ * It checks:
+ *   1. every POSES entry names only the four contract pivots, with 3 numbers each,
+ *      and a `next` that exists in the table;
+ *   2. the springs settle: 4 seconds of `cheer` lands on the preset's numbers;
+ *   3. the hold timer returns to `cruise` on its own;
+ *   4. sided presets mirror (L and R swap, y and z and the root lean negate);
+ *   5. the tuck's antDown is exactly zero upright and non-zero inverted, and the
+ *      layer never touches a pivot the model does not have.
+ * ==========================================================================*/
+
+import { POSES, PIVOTS, resolvePose, createPoseLayer } from '../emiPoses.js';
+
+let fails = 0;
+const ok = (cond, what) => { if (!cond) { console.error('FAIL ' + what); fails++; } else console.log('  ok  ' + what); };
+const near = (a, b, eps = 1e-3) => Math.abs(a - b) <= eps;
+
+/* ---- a fake glb root ---------------------------------------------------- */
+const NODES = ['shoulderL', 'shoulderR', 'footL', 'footR', 'ant0'];
+function makeNode(name) {
+  return { name, rotation: { x: 0, y: 0, z: 0, set(a, b, c) { this.x = a; this.y = b; this.z = c; } } };
+}
+function makeModel(names = NODES) {
+  const kids = new Map(names.map((n) => [n, makeNode(n)]));
+  return {
+    kids,
+    rotation: { x: 0, y: 0, z: 0 }, position: { x: 0, y: 0, z: 0 },
+    scale: { x: 1, y: 1, z: 1, set(a, b, c) { this.x = a; this.y = b; this.z = c; } },
+    getObjectByName: (n) => kids.get(n) || null,
+  };
+}
+const CTX = { t: 0, up: { x: 0, y: 1, z: 0 }, right: { x: 1, y: 0, z: 0 }, tangent: { x: 0, y: 0, z: 1 } };
+// emi.js writes the antenna's mood rotation fresh every frame and THEN calls the layer, so the
+// harness does the same: anything else lets the layer's `+=` on ant0 pile up frame over frame.
+const run = (layer, sec, ctx = CTX, pre = null) => {
+  for (let i = 0; i < Math.round(sec * 60); i++) { if (pre) pre(); layer.update(1 / 60, ctx); }
+};
+
+/* ---- 1. the table ------------------------------------------------------- */
+const KEYS = new Set(['sided', 'w', 'zeta', 'hold', 'next', 'breath', 'fraught', 'antDown', 'root', ...PIVOTS]);
+for (const [name, p] of Object.entries(POSES)) {
+  const bad = Object.keys(p).filter((k) => !KEYS.has(k));
+  ok(bad.length === 0, `${name}: names only contract keys${bad.length ? ' (stray: ' + bad.join(', ') + ')' : ''}`);
+  for (const k of PIVOTS) {
+    if (p[k] === undefined) continue;
+    ok(Array.isArray(p[k]) && p[k].length === 3 && p[k].every((v) => typeof v === 'number' && isFinite(v)), `${name}.${k}: three finite radians`);
+  }
+  ok(p.w > 0 && p.zeta > 0 && p.zeta < 1, `${name}: spring overshoots (0 < zeta < 1)`);
+  ok(!p.next || !!POSES[p.next], `${name}: next '${p.next || ''}' exists`);
+  ok(!(p.hold === 0 && p.next), `${name}: a held-forever pose has no next`);
+}
+ok(!!POSES.cruise && !POSES.cruise.hold, 'cruise is the resting pose and never times out');
+
+/* ---- 2. the springs settle ---------------------------------------------- */
+{
+  const m = makeModel(), L = createPoseLayer(m);
+  L.set('cheer', { hold: 99 });
+  run(L, 4);
+  const c = POSES.cheer;
+  ok(near(m.kids.get('shoulderL').rotation.x, c.shoulderL[0]), 'cheer settles shoulderL.x on the preset');
+  ok(near(m.kids.get('shoulderR').rotation.z, c.shoulderR[2]), 'cheer settles shoulderR.z on the preset');
+  ok(near(m.rotation.x, c.root.tilt), 'cheer settles the root tilt');
+  ok(near(m.scale.y, c.root.squash, 5e-3), 'cheer settles the root squash');
+  const finite = [m.rotation.x, m.rotation.z, m.position.y, m.scale.x, m.scale.y].every(Number.isFinite);
+  ok(finite, 'no NaN anywhere in the root after 4 s');
+}
+
+/* ---- 3. the hold returns to cruise -------------------------------------- */
+{
+  const m = makeModel(), L = createPoseLayer(m);
+  ok(L.set('landing'), 'set("landing") takes');
+  ok(L.name === 'landing', 'the layer reports the pose it is holding');
+  run(L, 0.1);
+  ok(L.name === 'landing', 'still landing inside the hold');
+  run(L, POSES.landing.hold + 3);
+  ok(L.name === 'cruise', 'landing falls back to cruise once the hold runs out');
+  ok(near(m.kids.get('shoulderL').rotation.x, POSES.cruise.shoulderL[0]), 'and the arms settle back on cruise');
+  ok(near(m.scale.y, 1, 5e-3), 'and the squash comes back to 1');
+  ok(L.set('nope') === false, 'an unknown pose name is ignored, not blanked');
+  ok(L.name === 'cruise', 'and leaves the current pose alone');
+  // boost chains through boostOut on its own
+  L.set('boost');
+  run(L, POSES.boost.hold + 0.05);
+  ok(L.name === 'boostOut', 'boost chains into boostOut');
+  run(L, POSES.boostOut.hold + 0.1);
+  ok(L.name === 'cruise', 'and boostOut lands back on cruise');
+}
+
+/* ---- 4. sided presets mirror -------------------------------------------- */
+{
+  const R = resolvePose('drift', { side: 1 }), Lft = resolvePose('drift', { side: -1 });
+  ok(near(Lft.shoulderL[0], R.shoulderR[0]), 'drift mirrors: L takes R.x');
+  ok(near(Lft.shoulderL[2], -R.shoulderR[2]), 'drift mirrors: and negates z');
+  ok(near(Lft.root.lean, -R.root.lean), 'drift mirrors the root lean');
+  const t3 = resolvePose('drift', { side: 1, tier: 3 });
+  ok(Math.abs(t3.root.lean) > Math.abs(R.root.lean), 'a fatter drift tier leans harder');
+  ok(near(resolvePose('cheer', { side: -1 }).root.lean, resolvePose('cheer').root.lean), 'an unsided preset ignores side');
+  ok(resolvePose('clamp').fraught === 1, 'clamp reports fraught to emi.js');
+  ok(resolvePose('landingKerb').fraught > 0, 'a kerbed landing is fraught too');
+}
+
+/* ---- 5. antDown, and a half-finished pack ------------------------------- */
+{
+  const m = makeModel(), L = createPoseLayer(m), ant = m.kids.get('ant0');
+  L.set('tuck'); run(L, 2, CTX, () => { ant.rotation.x = 0; ant.rotation.z = 0; });
+  ok(near(ant.rotation.x, 0) && near(ant.rotation.z, 0), 'upright, the tuck leaves the antenna base alone');
+  const inv = { t: 0, up: { x: 0, y: -1, z: 0 }, right: { x: 0.6, y: -0.4, z: 0 }, tangent: { x: 0, y: 0.3, z: 0.9 } };
+  const zero = () => { ant.rotation.x = 0; ant.rotation.z = 0; };
+  run(L, 2, inv, zero);
+  ok(Math.abs(ant.rotation.z) > 0.05, 'inverted, the antenna base falls toward the real floor');
+  ok(Math.abs(ant.rotation.x) <= 1.2 && Math.abs(ant.rotation.z) <= 1.2, 'and never past the ANT_MAX clamp');
+  ok(POSES.tuck.hold === 0, 'the tuck holds until the wheel lets go');
+
+  const bare = makeModel(['shoulderL']), B = createPoseLayer(bare);
+  B.set('cheer'); run(B, 1);
+  ok(Number.isFinite(bare.kids.get('shoulderL').rotation.x), 'a pack missing three pivots still drives the one it has');
+  ok(createPoseLayer(null).update(1 / 60, CTX) === undefined, 'no model at all is a no-op, not a throw');
+}
+
+console.log(fails ? `\n${fails} failure(s)` : '\nposes-smoke: all good');
+process.exit(fails ? 1 : 0);


### PR DESCRIPTION
## Racing Thoughts (ex Caucus Race) web stack

Stacked on `feat/race-b5-emi-rig`. Merge bottom-up.

### Commits
- feat(race): the cup and the saucer come from props.glb
- feat(race): EMI pose layer on race events

`5 files changed, 412 insertions(+), 24 deletions(-)`

### From the commit message
NEEDS feat/race-b4-props-glb UNDER IT. The pack file is on that branch;
this commit references it by URL only and never adds it.
Same deal the mascot got: race/assets/props.glb ships kart_cup (the lathe,
the pink glaze rim and the handle in one node, handle on +x) and
kart_saucer (dish plus glaze band and mark), so five JS primitives come off
for two clones the moment the pack lands. The LatheGeometry cup, its rim
torus, the handle tube, the saucer cylinder and its rim are the fallback
and ride on forever if the load fails.
Heights are measured off the node bboxes, not guessed: the saucer stands
0.125 to the top of its glaze band, the cup 0.695 to its rim with the band
at 0.645 to 0.690. The cup sits the same 0.09 above the saucer the JS rig
always sat it, which puts the rim at 0.785, so TEA_Y is now CUP_Y plus
CUP_RIM_TOP minus the 0.11 the tea always sat under the rim: 0.675 against
the old 0.660. The seat, the breath and the sweat quote TEA_Y, so EMI came
up the same 15 mm and stayed exactly where she sat.
Kept: the tea disc and its swirl, the pink saucer mark (raised onto the new
glaze band, it is the only emissive thing on the saucer), cupLight, the
saucer spin, the squash on the root and the drift sparks off the saucer.
The outline hulls take the same flat near-black the mascot's do, now a
shared helper. The clones share the cached pack's geometry and materials,
so they come off the graph before the teardown and are never disposed.
Headless: zero page console errors, race-perf at t+22s reads 212,613 tris,
under the 250k line and 10k below the primitives it replaced.
She rode the glb but she rode it stiff. race/emiPoses.js gives her a body
over the moods: shoulders, feet and a root lean / tilt / lift / squash,
every value an offset on the pack's authored rest rotation so a preset can
never lose her stance, all of it on damped springs with zeta under one
(Law XI: she overshoots, she never tweens).
POSES is a pure table so a node smoke can read it: cruise, drift (sided,
tier scales the lean), boost squashing into boostOut's stretch, air,
landing and its kerbed variant, grab (sided), clamp, tuck, throw, cheer.
A pose with a hold falls back to next on its own, which is always cruise
in the end. clamp and a kerbed landing report fraught and emi.js takes the
max of that and the run brain's, so a pour makes her sweat without run.js
saying so twice. The tuck's antDown drags the antenna base toward the real
floor while the Wheel has her upside down, scaled by how inverted she
actually is, so it is exactly zero upright.
run.js only learns one verb: kart.pose(name, opts), eleven call sites
inside paths that already fire (drift tier, drift boost, boost pad, trick,
landing, inverted on and off, treat pop, effect pour, item use, lap pb and


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0166ij3Q8xyseVkhWajzkWG3
