### PR TITLE
feat(race): boot goes splash, menu, intro, run

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/race.html
+++ b/ConditioningControlPanel/Resources/web/dtrh/race.html
@@ -8,6 +8,7 @@
          Same import map as index.html: three.js from the fork's own vendored ESM, no bundler. -->
     <link rel="stylesheet" href="./styles.css">
     <link rel="stylesheet" href="./race/race.css">
+    <link rel="stylesheet" href="./race/menu.css">
     <script type="importmap">
     {
       "imports": {
@@ -21,22 +22,19 @@
          takes the mirror flip, so the two never share one style.transform */
       #race-root { position: fixed; inset: 0; overflow: hidden; background: #12261f; }
       #race-root > canvas { display: block; width: 100%; height: 100%; }
-      /* boot splash, z30: above the HUD chrome (z3) and every payload layer (z4 / z9), below the loader */
+      /* boot splash, z30: a 1 s title flash above the HUD chrome (z3), the payload layers (z4 / z9) and the menu (z25); the menu is the resting state */
       .race-splash {
         position: fixed; inset: 0; z-index: 30; display: flex; flex-direction: column;
         align-items: center; justify-content: center; gap: .6rem; text-align: center;
         font-family: var(--rh-font); color: #fff; background: radial-gradient(ellipse at 50% 60%, rgba(18,38,31,.55), rgba(10,8,18,.92));
-        transition: opacity .5s ease-out; cursor: pointer;
+        transition: opacity .5s ease-out;
       }
       .race-splash.is-off { opacity: 0; pointer-events: none; }
       .race-splash .rs-cup { font-size: 3.2rem; line-height: 1; letter-spacing: .04em; color: #ffb6d9; }
       .race-splash .rs-title { font-size: clamp(2rem, 6vw, 3.6rem); font-weight: 700; letter-spacing: .06em; color: #ff69b4; text-shadow: 0 0 24px rgba(255,105,180,.55); }
       .race-splash .rs-sub { font-size: clamp(1rem, 2.4vw, 1.4rem); letter-spacing: .18em; color: #f6e7c8; }
-      .race-splash .rs-press { margin-top: 1.6rem; font-size: .95rem; letter-spacing: .22em; color: #fff; animation: rs-blink 1.6s ease-in-out infinite; }
-      .race-splash .rs-keys { font-size: .78rem; letter-spacing: .12em; color: rgba(255,255,255,.55); }
       .race-splash .rs-wait { font-size: .78rem; letter-spacing: .12em; color: rgba(255,255,255,.4); min-height: 1.2em; }
       @keyframes rs-blink { 0%, 100% { opacity: .35; } 50% { opacity: 1; } }
-      @media (prefers-reduced-motion: reduce) { .race-splash .rs-press { animation: none; } }
     </style>
 </head>
 <body>
@@ -44,14 +42,12 @@
         <canvas id="sf-canvas" aria-hidden="true"></canvas>
         <!-- payloadFx draws its .sf-pfx / .sf-pfx-front layers inside this one (styles.css: fixed, z10) -->
         <div id="sf-hud" class="sf-hud"></div>
-        <!-- the race HUD chrome, Brake and End screens are built in here by race/hud.js -->
+        <!-- the race HUD chrome, Brake, End and countdown are built in here by race/hud.js; race/menu.js appends its .rm-root to #race-root -->
         <div class="race-hud"></div>
         <div id="race-splash" class="race-splash">
             <div class="rs-cup" aria-hidden="true">(^_^)</div>
             <div class="rs-title">the caucus race</div>
             <div class="rs-sub">steer. pop. never stop.</div>
-            <div class="rs-press" id="race-press">press any key</div>
-            <div class="rs-keys">arrows or wasd steer · shift drift · e item · p pixels · esc brake</div>
             <div class="rs-wait" id="race-wait"></div>
         </div>
     </div>

--- a/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
@@ -225,7 +225,8 @@ below every `.sf-pfx` layer, and the Brake/End screens at z20 pick their own sta
 
 ### `race/run.js` + `raceBoot.js` + `race.html` (PR 5, integration)
 ```js
-export function createRace({ root, bridge, media, settings, seed }) -> { start(), setPaused(b), dispose() }
+export function createRace({ root, bridge, media, settings, seed }) ->
+  { start(), setPaused(b), dispose(), setCameraOverride(fn), setStage(s), reseed(seed), renderer, pixel, audio, hud, camera }
 ```
 Composes everything: renderer, `createSpine`, `createTunnel(layout)` from `engine/tunnel.js`,
 `createFx` from `engine/fx.js`, `createRoomDresser`, `createBubbleField`, `createKart`,
@@ -291,6 +292,32 @@ null from either function always means the same thing: keep the voxel fallback.
 fixture that mounts around the quad (`frame` + `frameY`, the authored opening centre). Wall props
 are centred on their mounting plate and keep it by merging it in; shoulder props and extras move to
 `PROP_X` and are mirrored on x because `shoulderMatrix` is left handed like `roadMatrix`.
+
+### `race/menu.js` + `race/intro.js` (pass five, the front door)
+```js
+createMenu({ root, renderer, pixel, audio, settings, log }) -> { show(), hide(), onPick(cb), options, stage: { update(dt), render(), dispose(), live }, dispose() }
+createIntro({ stage, hud, audio, reducedMotion, log }) -> { play(): Promise, skip(), update(dt), render(), dispose() }
+cameraWhip(sec) / resultsCamera({ tier, reducedMotion }) / preRollCamera() -> fn(camera, dt, w, camOut), `false` when done
+resultTier(total, best, personalBest) -> 0..4 (the face index)
+```
+- Boot order: splash (a 1 s title flash) -> menu (the resting state) -> `race` -> intro on the menu stage -> run under the
+  camera whip. `?autostart=1` skips menu and intro (the headless checks depend on it), `?intro=0` skips the intro only,
+  `?scene=intro` boots straight into the intro. `surface` from the menu sends the same `exit` + `exit-done` the End screen does.
+- The stage is a second `THREE.Scene` drawn by the race's renderer + pixelizer through `race.setStage(s)`: while set,
+  `frame()` calls `s.update(dt)` + `s.render()` and the world is not drawn. `setStage(null)` retextures the world for any
+  pixel block the menu changed. No second canvas.
+- Camera overrides run in `frame()` after `step()`, so they work while the run is stopped (results) and while it drives
+  (the whip). `start()` clears the override; the boot installs the whip after `start()`.
+- `w.kart.emiModel()`, `w.kart.emiReady(cb)`, `w.kart.setFace(i)` are the kart's contract for the run's EMI; every call
+  is guarded for null (the stage carries its own clone with its own glass material, so the two faces never fight).
+- Options persist under the single localStorage key `race.options` (`pixel, music, sfx, motion, seed, seedValue`), not in
+  `engine/settings.js`. Precedence for the block: `?pixel` > `race.options.pixel` > host `settings.pixel` > `PIXEL_DEFAULT`.
+  The seed rule (daily / random / custom) sets `settings.seedLock`, which `again` honours; a change in the menu calls `reseed`.
+- Music / sfx sliders store their values and call `audio.setLevels({ music, sfx })` when audio.js grows one; until then
+  the rows are dimmed with a note. Reduced motion from the menu drives the stage and the intro at once, the run on the next launch.
+- props.glb (`podium`, `kart_cup`, `kart_saucer`, `floor_tile`, `gantry`) dresses the stage when it resolves; lathe
+  placeholders otherwise. `emi.glb`'s `EMI_glass` carries the atlas as `emissiveTexture` only, so the stage sets the face
+  on `emissiveMap` (and `map` when present); gltf.js `setFace` shifts whichever of the two the material carries.
 
 ## Host protocol (bridge.js, Protocol v1)
 

--- a/ConditioningControlPanel/Resources/web/dtrh/race/run.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/run.js
@@ -99,6 +99,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
   let W = null;                       // the world: everything that is rebuilt on "again"
   let raf = 0, last = 0, lastBeat = 0, payoutResolve = null;
   let camOverride = null;                // fn(camera, dt, w, camOut) -> false when done (intro.js cameras)
+  let stage = null;                      // { update(dt), render() } drawn INSTEAD of the world while set (menu, intro)
   // last ~1 s of kart {d,x,h} for the ALMOST on a miss: a fixed ring, no per-frame objects
   const TRAIL_N = 70, trail = [];
   for (let i = 0; i < TRAIL_N; i++) trail.push({ d: 0, x: 0, h: 0, ok: false });
@@ -395,6 +396,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     if (now - lastBeat > HEARTBEAT_MS) { lastBeat = now; send({ type: 'heartbeat', t: now }); }
     const dt = last ? clamp((now - last) / 1000, 0, 0.1) : 0;
     last = now;
+    if (stage) { try { stage.update(dt); stage.render(); } catch (e) { bridge.log && bridge.log('race stage: ' + (e && e.stack || e)); } return; }
     if (!W) return;
     if (S.running && !S.paused && !S.hostPaused) {
       try { step(W, dt); } catch (e) { bridge.log && bridge.log('race step: ' + (e && e.stack || e)); }
@@ -438,12 +440,10 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     if (S.disposed) return;
     if (pick === 'again') again(); else exit();
   }
+  /** Rebuild the world on a new seed (again, or the menu changing the seed rule). settings.seedLock pins again to one track. */
+  function reseed(runSeed) { teardown(); resetRunState(runSeed); W = build(runSeed); S.started = false; }
   function again() {
-    teardown();
-    const runSeed = (Date.now() ^ Math.floor(Math.random() * 0x7fffffff)) >>> 0;
-    resetRunState(runSeed);
-    W = build(runSeed);
-    S.started = false;
+    reseed(settings.seedLock != null ? settings.seedLock >>> 0 : (Date.now() ^ Math.floor(Math.random() * 0x7fffffff)) >>> 0);
     setCameraOverride(preRollCamera());   // again skips the intro: the chase seat, then 3 2 1
     hud.countdown().then(start);
   }
@@ -493,7 +493,8 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
   resetRunState(seed);
   raf = requestAnimationFrame(frame);
   function setCameraOverride(fn) { camOverride = typeof fn === 'function' ? fn : null; }
-  return { start, setPaused, dispose, setCameraOverride };
+  function setStage(s) { stage = s && typeof s.update === 'function' ? s : null; if (!stage) pixel.retexture(scene); }   // the menu may have changed the block
+  return { start, setPaused, dispose, setCameraOverride, setStage, reseed, renderer, pixel, audio, hud, camera };
 }
 
 // self-check: node --check is the bar; everything touches the DOM inside createRace.

--- a/ConditioningControlPanel/Resources/web/dtrh/raceBoot.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/raceBoot.js
@@ -1,20 +1,29 @@
 /* ============================================================================
  * raceBoot.js - boots The Caucus Race page. Implements CONTRACT.md
- * "race/run.js + raceBoot.js + race.html (PR 5, integration)".
+ * "race/run.js + raceBoot.js + race.html (PR 5, integration)" and the
+ * "race/menu.js + race/intro.js" section (the front door).
  *
  * Order: capability detect -> quality tier -> bridge handlers -> announceReady
  * -> wait for `init` (+ `manifest`, `favorites`) with a 4 s timeout -> hostMedia
- * -> createRace -> start on the first key / pointer / gamepad press.
+ * -> createRace + createMenu -> the splash is a 1 s title flash (it covers the
+ * module import, the world build and the glb fetch, and hosts the wait note
+ * and boot errors) -> the MENU is the resting state -> `race` plays the intro
+ * on the menu stage -> the run starts under the camera whip. `surface` from
+ * the menu is the same exit the End screen takes.
  *
  * Host messages owned here: init, manifest, favorites, ping, exit-request,
  * fullscreen (run.js owns pause + payout-result). Sent here: pong, boot-error,
- * fullscreen-set, exit + exit-done on a host exit-request.
+ * fullscreen-set, exit + exit-done on a host exit-request or a menu surface.
  *
  * STANDALONE DEV MODE (no WebView2): `bridge.isHosted` is false, so `init` is
  * synthesised (masterVolume 60, reducedMotion from matchMedia, empty manifest)
  * and every would-be host message is logged to the console with a
- * `[race->host]` prefix. `?autostart=1` skips the splash; `?pixel=N` (0 = off)
- * overrides the pixel look, as does `settings.pixel` from the host init.
+ * `[race->host]` prefix. Query switches: `?autostart=1` skips the menu AND the
+ * intro and boots straight into the run (headless checks depend on it);
+ * `?intro=0` keeps the menu and skips the intro; `?scene=intro` boots straight
+ * into the intro and `?hold=ms` freezes it at that intro time (screenshots);
+ * `?pixel=N` (0 = off) beats `race.options` which beats `settings.pixel` from
+ * the host init.
  * ==========================================================================*/
 
 import * as bridge from './bridge.js';
@@ -22,7 +31,7 @@ import { detectMode } from './shared/capability.js';
 import { setQuality } from './shared/quality.js';
 import { createHostMediaSource } from './hostMedia.js';
 
-const INIT_TIMEOUT_MS = 4000;
+const INIT_TIMEOUT_MS = 4000, SPLASH_MS = 1000;
 const params = new URLSearchParams(location.search);
 const hosted = bridge.isHosted;
 const host = hosted ? bridge : {
@@ -33,10 +42,13 @@ const host = hosted ? bridge : {
 };
 
 const root = document.getElementById('race-root');
+const hudRoot = document.querySelector('#race-root .race-hud');
 const splash = document.getElementById('race-splash');
 const waitEl = document.getElementById('race-wait');
 const media = createHostMediaSource();
-let initMsg = null, haveManifest = false, race = null, booted = false, started = false, exiting = false;
+const rollSeed = () => (Date.now() ^ Math.floor(Math.random() * 0x7fffffff)) >>> 0;
+let initMsg = null, haveManifest = false, race = null, menu = null, booted = false, started = false, exiting = false;
+let settings = {}, seed = 0;
 
 const note = (t) => { if (waitEl) waitEl.textContent = t || ''; };
 function fail(err) {
@@ -70,13 +82,16 @@ bridge.on('manifest', (m) => { try { media.setManifest(m); } catch (e) { host.lo
 bridge.on('favorites', (m) => { try { media.setFavorites(m && m.names || []); } catch (e) { host.log('favorites: ' + e); } });
 bridge.on('ping', (m) => host.send({ type: 'pong', t: m && m.t }));
 bridge.on('fullscreen', (m) => host.send({ type: 'fullscreen-set', on: !!(m && m.on) }));
-bridge.on('exit-request', () => {
+bridge.on('exit-request', surface);
+/** The one exit: the menu's `surface` and the host's exit-request (the End screen's own goes through run.js). */
+function surface() {
   if (exiting) return;
   exiting = true;
+  try { if (menu) menu.dispose(); } catch (e) { host.log('menu dispose: ' + e); }
   try { if (race) race.dispose(); } catch (e) { host.log('exit dispose: ' + e); }
   host.send({ type: 'exit' });
   host.send({ type: 'exit-done' });
-});
+}
 
 function synthInit() {
   return {
@@ -93,37 +108,74 @@ function maybeBoot() {
 async function boot() {
   if (booted) return;
   booted = true;
+  const t0 = performance.now();
   try {
-    const settings = { ...((initMsg && initMsg.settings) || {}) };
+    const [{ createRace }, { createMenu, loadOptions, seedFromOptions, wantsReducedMotion }] = await Promise.all([import('./race/run.js'), import('./race/menu.js')]);
+    const opts = loadOptions();
+    settings = { ...((initMsg && initMsg.settings) || {}) };
+    if (opts.pixel !== undefined) settings.pixel = opts.pixel;
     if (params.has('pixel') && params.get('pixel') !== '') settings.pixel = Number(params.get('pixel'));
-    const seed = (Date.now() ^ Math.floor(Math.random() * 0x7fffffff)) >>> 0;
+    settings.reducedMotion = wantsReducedMotion(opts, settings.reducedMotion != null ? settings.reducedMotion : !!(matchMedia && matchMedia('(prefers-reduced-motion: reduce)').matches));
+    settings.musicVolume = opts.music; settings.sfxVolume = opts.sfx;   // for the audio pass; audio.js reads masterVolume today
+    settings.seedLock = seedFromOptions(opts);
+    seed = settings.seedLock != null ? settings.seedLock : rollSeed();
     note('the road is drawing');
-    const { createRace } = await import('./race/run.js');
     race = createRace({ root, bridge: host, media, settings, seed });
     note('');
-    host.log(`race booted: seed ${seed}, tier ${mode.tier}, hosted ${hosted}, manifest ${haveManifest}`);
-    if (params.get('autostart') === '1') startRace();
+    host.log(`race booted: seed ${seed} (${opts.seed}), tier ${mode.tier}, hosted ${hosted}, manifest ${haveManifest}`);
+    if (params.get('autostart') === '1') { startRun(false); return; }
+    if (hudRoot) hudRoot.classList.add('is-lobby');   // the run's chrome stays out of the menu and the intro
+    menu = createMenu({ root, renderer: race.renderer, pixel: race.pixel, audio: race.audio, settings, log: host.log });
+    menu.onPick((id) => { if (id === 'race') startRun(true); else if (id === 'surface') surface(); });
+    menu.seedCheck = () => {   // the menu may have changed the seed rule: rebuild the world once, before the intro
+      const lock = seedFromOptions(menu.options);
+      if (lock === settings.seedLock) return;
+      settings.seedLock = lock; seed = lock != null ? lock : rollSeed();
+      race.reseed(seed);
+      host.log(`race reseeded: ${seed} (${menu.options.seed})`);
+    };
+    race.setStage(menu.stage);
+    if (params.get('scene') === 'intro') { startRun(true); return; }
+    setTimeout(() => { hideSplash(); menu.show(); }, Math.max(0, SPLASH_MS - (performance.now() - t0)));
   } catch (err) {
     fail(err);
   }
 }
 
-function startRace() {
-  if (started || !race) return;
-  started = true;
+function hideSplash() {
   splash.classList.add('is-off');
   setTimeout(() => { splash.hidden = true; }, 600);
-  race.start();
 }
-// "press any key": keyboard, pointer, or a gamepad button (polled while the splash is up)
-window.addEventListener('keydown', (e) => { if (!e.repeat && race && !started) startRace(); });
-splash.addEventListener('pointerdown', () => { if (race && !started) startRace(); });
-(function pollPad() {
-  if (started) return;
-  const pads = navigator.getGamepads ? navigator.getGamepads() : null;
-  if (pads && race) for (const g of pads) if (g && g.buttons.some((b) => b && b.pressed)) { startRace(); return; }
-  requestAnimationFrame(pollPad);
-})();
+/** race: the intro on the menu stage, then the run under the camera whip. autostart / intro=0 go straight to the run. */
+async function startRun(withIntro) {
+  if (started || !race) return;
+  started = true;
+  hideSplash();
+  try {
+    if (menu) { menu.hide(); menu.seedCheck(); }
+    if (menu && withIntro && params.get('intro') !== '0') {
+      const { createIntro, cameraWhip } = await import('./race/intro.js');
+      const reducedMotion = menu.options.motion === 'on' || (menu.options.motion === 'system' && settings.reducedMotion);
+      const intro = createIntro({ stage: menu.stage.live, hud: race.hud, audio: race.audio, reducedMotion, log: host.log });
+      const hold = Number(params.get('hold')) / 1000;   // screenshot aid: freeze the intro at that intro time
+      race.setStage(hold > 0 ? { update(dt) { if (intro.time < hold) intro.update(dt); }, render: intro.render } : intro);
+      await intro.play();
+      if (exiting) return;
+      race.setStage(null);
+      intro.dispose();
+      if (hudRoot) hudRoot.classList.remove('is-lobby');
+      race.start();
+      race.setCameraOverride(cameraWhip(0.8));
+    } else {
+      race.setStage(null);
+      if (hudRoot) hudRoot.classList.remove('is-lobby');
+      race.start();
+    }
+  } catch (err) {
+    host.log('start: ' + ((err && err.stack) || err));
+    try { race.setStage(null); race.start(); } catch (e) { fail(e); }
+  }
+}
 
 // ---- go ----
 bridge.announceReady();


### PR DESCRIPTION
## Racing Thoughts (ex Caucus Race) web stack

Stacked on `feat/race-b10-intro`. Merge bottom-up.

### Commits
- feat(race): boot goes splash, menu, intro, run

`4 files changed, 118 insertions(+), 42 deletions(-)`

### From the commit message
raceBoot.js: the splash stays as a 1 s title flash (it covers the module
import, the world build and the glb fetch, and still hosts the wait note
and boot errors), then the menu is the resting state. `race` plays the
intro on the menu stage and starts the run under the camera whip.
`?autostart=1` still boots straight into the run with no menu or intro
(the headless checks depend on it); `?intro=0` skips the intro only;
`?scene=intro` boots straight into the intro for screenshots. `surface`
from the menu sends the same exit + exit-done the End screen does.
race.options feed the boot: the pixel block (?pixel beats it, it beats
the host setting), reduced motion, the seed rule (daily / random /
custom) as settings.seedLock, which `again` honours and a change in the
menu applies through the new race.reseed. run.js exposes setStage (the
menu and intro draw through the race's renderer and pixelizer), reseed,
and its renderer / pixel / audio / hud / camera. race.html links
menu.css and trims the splash. CONTRACT.md gets the menu / intro section.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0166ij3Q8xyseVkhWajzkWG3
