### PR TITLE
perf(race): flatten the EMI rig to one draw per pivot and material

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/race/emi.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/emi.js
@@ -19,7 +19,7 @@
 // the pack lands. Needs feat/race-b4-props-glb underneath for the file itself.
 
 import * as THREE from 'three';
-import { loadPack, setFace as packSetFace, preparePixel, FACES } from './gltf.js';
+import { loadPack, setFace as packSetFace, preparePixel, flattenRig, FACES } from './gltf.js';
 import { createPoseLayer } from './emiPoses.js';
 
 const PINK = 0xff69b4, GOLD = 0xF2C14E, PALE = 0xB3C7FF, PORCELAIN = 0xF6E7C8;
@@ -242,6 +242,7 @@ export function createEmiRig({ scene, reducedMotion = false, pixel = null }) {
     const root = pack.clone('EMI_root');
     const ant0 = root && root.getObjectByName('ant0'), ballpiv = root && root.getObjectByName('ballpiv');
     if (!root || !ant0 || !ballpiv) return;         // a pack without the contract pivots: the primitive stays
+    flattenRig(root, pack.animations);                // 69 draws a frame down to ~30: one per pivot and material
     blackOutline(root);
     const ballMats = [], glassMats = [];
     ownMaterials(root.getObjectByName('ball') || ballpiv, ballMats);

--- a/ConditioningControlPanel/Resources/web/dtrh/race/gltf.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/gltf.js
@@ -22,6 +22,7 @@
  *   toInstanceGeometry(node) -> BufferGeometry    roomProps-shaped, ready for
  *                                                 InstancedMesh + Lambert
  *   setFace(model, index) / FACES
+ *   flattenRig(root, animations, { keep })   one draw per pivot + material
  *   preparePixel(model, pixel)
  *   disposePack(url)
  *
@@ -215,6 +216,83 @@ function normalizeColor(g) {
   const arr = new Float32Array(n * 3);
   for (let i = 0; i < n; i++) { arr[i * 3] = src.getX(i); arr[i * 3 + 1] = src.getY(i); arr[i * 3 + 2] = src.getZ(i); }
   g.setAttribute('color', new THREE.BufferAttribute(arr, 3));
+}
+
+// ---- rig flatten: one draw per animated node and material -------------------------------
+
+/**
+ * Bake a rig down to one mesh per (animated pivot, material). A Blender export arrives as one
+ * mesh per part (emi.glb: 69 primitives, so 69 draw calls per EMI on screen); only the nodes a
+ * clip drives ever move, so every static part under a pivot can share one buffer with its
+ * siblings of the same material and still animate right. Rules:
+ *   - the pivot set = every node any clip in `animations` targets, plus `root` and `keep`
+ *   - a mesh whose material carries a texture stays as it is (the face glass and its atlas)
+ *   - a mesh named in `keep`, or that is itself a pivot, stays as it is
+ *   - the merged mesh hangs off the first contributor's parent (static under the pivot by
+ *     construction), so names like EMI_case / ball keep resolving to a node that holds geometry
+ *   - outline hulls keep their winding; mirrored bakes of everything else are re-wound
+ * Returns { before, after }: mesh counts. Safe to call twice (the second pass finds nothing).
+ */
+export function flattenRig(root, animations = [], { keep = [] } = {}) {
+  const out = { before: 0, after: 0 };
+  if (!root || !root.traverse) return out;
+  const pivots = new Set(keep);
+  for (const clip of animations || []) for (const t of clip.tracks || []) {
+    const name = THREE.PropertyBinding.parseTrackName(t.name).nodeName;
+    if (name) pivots.add(name);
+  }
+  const isPivot = (o) => o === root || pivots.has(o.name);
+  const pivotOf = (o) => { let p = o.parent; while (p && p !== root && !isPivot(p)) p = p.parent; return p || root; };
+  root.updateWorldMatrix(true, true);
+  const groups = new Map();                   // pivot -> Map(material -> { host, name, parts, nonIndexed })
+  const dead = [];
+  root.traverse((o) => {
+    if (!o.isMesh || !o.geometry || !o.geometry.attributes || !o.geometry.attributes.position) return;
+    if (o.visible === false || isPivot(o) || Array.isArray(o.material) || !o.material) return;
+    if (MAP_KEYS.some((k) => o.material[k])) return;
+    const pivot = pivotOf(o);
+    const host = o.parent || pivot;
+    let byMat = groups.get(pivot);
+    if (!byMat) groups.set(pivot, (byMat = new Map()));
+    let part = byMat.get(o.material);
+    if (!part) byMat.set(o.material, (part = { host, name: o.name, parts: [], nonIndexed: false, shadow: o.castShadow }));
+    const g = o.geometry.clone();
+    for (const key of Object.keys(g.attributes)) if (key !== 'position' && key !== 'normal') g.deleteAttribute(key);
+    if (!g.attributes.normal) g.computeVertexNormals();
+    _inv.copy(part.host.matrixWorld).invert();
+    _mat.multiplyMatrices(_inv, o.matrixWorld);
+    g.applyMatrix4(_mat);
+    if (_mat.determinant() < 0 && !isOutline(o.material)) flipWinding(g);
+    g.morphAttributes = {};
+    g.clearGroups();
+    if (!g.index) part.nonIndexed = true;
+    part.parts.push(g);
+    dead.push(o);
+  });
+  out.before = dead.length;
+  for (const byMat of groups.values()) for (const [material, part] of byMat) {
+    const ready = part.nonIndexed ? part.parts.map((g) => (g.index ? g.toNonIndexed() : g)) : part.parts;
+    const merged = ready.length === 1 ? ready[0] : mergeGeometries(ready, false);
+    for (const g of ready) if (g !== merged && !part.parts.includes(g)) g.dispose();
+    for (const g of part.parts) if (g !== merged) g.dispose();
+    if (!merged) continue;
+    merged.computeBoundingSphere();
+    const m = new THREE.Mesh(merged, material);
+    m.name = part.name;
+    m.castShadow = part.shadow;
+    part.host.add(m);
+    out.after++;
+  }
+  for (const o of dead) {
+    if (o.children.length) {                  // a mesh with children becomes a plain node, kids kept
+      const g = new THREE.Group();
+      g.name = o.name; g.position.copy(o.position); g.quaternion.copy(o.quaternion); g.scale.copy(o.scale);
+      while (o.children.length) g.add(o.children[0]);
+      o.parent.add(g);
+    }
+    o.removeFromParent();
+  }
+  return out;
 }
 
 // ---- the face atlas ---------------------------------------------------------------------

--- a/ConditioningControlPanel/Resources/web/dtrh/race/menu.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/menu.js
@@ -34,7 +34,7 @@
  * ==========================================================================*/
 
 import * as THREE from 'three';
-import { loadPack, preparePixel, toInstanceGeometry } from './gltf.js';
+import { loadPack, preparePixel, toInstanceGeometry, flattenRig } from './gltf.js';
 import { PIXEL_STEPS, PIXEL_DEFAULT, normalizeBlock } from './pixel.js';
 
 export const OPTIONS_KEY = 'race.options';
@@ -165,6 +165,7 @@ export function createStage({ renderer, pixel, reducedMotion = false, log = null
   loadPack(character.glb, { log }).then((pack) => {
     if (disposed) return;
     const model = pack.scene.clone(true);
+    flattenRig(model, pack.animations);       // one draw per pivot and material, the face glass kept apart
     model.traverse((o) => {
       if (!o.isMesh) return;
       const fix = (m) => {

--- a/ConditioningControlPanel/Resources/web/dtrh/race/smoke/gltf-smoke.mjs
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/smoke/gltf-smoke.mjs
@@ -36,7 +36,7 @@ registerHooks({
 });
 
 const THREE = await import('three');
-const { makePack, toInstanceGeometry, setFace, preparePixel, disposePack, FACES } = await import('../gltf.js');
+const { makePack, toInstanceGeometry, setFace, preparePixel, flattenRig, disposePack, FACES } = await import('../gltf.js');
 const { GLTFLoader } = await import('three/addons/loaders/GLTFLoader.js');
 
 // ---- the tiny assert kit ----------------------------------------------------------------
@@ -187,6 +187,38 @@ const plain = Array.from(toInstanceGeometry(mirroredHull('body')).index.array);
 const hull = Array.from(toInstanceGeometry(mirroredHull('outline')).index.array);
 ok(hull.join() === src.join(), 'an `outline` material keeps its winding, mirror or not');
 ok(plain[0] === src[2] && plain[2] === src[0], 'a mirrored ordinary mesh is re-wound');
+
+// ---- flattenRig --------------------------------------------------------------------------
+// scene: kart_cup (the clip target) holds cup_body (`body`) + cup_handle (`outline`), item_cube
+// stands alone. A second `body` box is added 1 m along x so the pivot has something to merge:
+// 4 meshes -> 3 (cup_body + twin fold into one, handle and cube stay).
+{
+  const rig = pack.scene.clone(true);
+  const cupBefore = rig.getObjectByName('kart_cup');
+  const twin = cupBefore.getObjectByName('cup_body').clone(); twin.name = 'cup_twin'; twin.position.x += 1; cupBefore.add(twin);
+  const meshesBefore = []; rig.traverse((o) => { if (o.isMesh) meshesBefore.push(o); });
+  const pos0 = cupBefore.getObjectByName('cup_body').position.clone(); pos0.x += 0.5;   // merged centre sits between the two
+  const r = flattenRig(rig, pack.animations);
+  ok(r.before === meshesBefore.length, 'flattenRig visits every mesh (' + r.before + ')');
+  const meshesAfter = []; rig.traverse((o) => { if (o.isMesh) meshesAfter.push(o); });
+  ok(meshesAfter.length === r.after && r.after < r.before, 'flattenRig leaves fewer meshes (' + r.before + ' -> ' + r.after + ')');
+  const cup = rig.getObjectByName('kart_cup');
+  ok(cup === cupBefore, 'the clip target node survives untouched');
+  const byMat = new Map(); cup.traverse((o) => { if (o.isMesh) byMat.set(o.material.name, o); });
+  ok(byMat.size === cup.children.filter((c) => c.isMesh).length, 'one mesh per material under the pivot (' + [...byMat.keys()].join(',') + ')');
+  const body = byMat.get('body');
+  ok(body && body.geometry.attributes.position && !body.geometry.attributes.color, 'merged geometry keeps position/normal only');
+  body.geometry.computeBoundingBox();
+  const c = body.geometry.boundingBox.getCenter(new THREE.Vector3());
+  ok(near(c.x, pos0.x, 1e-3) && near(c.y, pos0.y, 1e-3) && near(c.z, pos0.z, 1e-3), 'the child offsets are baked into the pivot frame');
+  ok(rig.getObjectByName('cup_body') === body, 'the merged mesh keeps the first contributor name');
+  const again = flattenRig(rig, pack.animations);
+  ok(again.before === meshesAfter.length && again.after === meshesAfter.length, 'a second pass is a no-op in mesh count');
+  const glass = new THREE.Mesh(new THREE.PlaneGeometry(1, 1), new THREE.MeshBasicMaterial({ map: new THREE.DataTexture(new Uint8Array(4), 1, 1) }));
+  glass.name = 'EMI_glass'; rig.add(glass);
+  flattenRig(rig, pack.animations);
+  ok(glass.parent === rig, 'a textured mesh is left alone');
+}
 
 // ---- setFace -------------------------------------------------------------------------------
 const tex = new THREE.DataTexture(new Uint8Array(FACES.length * 4 * 4), FACES.length * 4, 4);


### PR DESCRIPTION
## Racing Thoughts (ex Caucus Race) web stack

Stacked on `feat/race-b11-boot`. Merge bottom-up.

### Commits
- perf(race): flatten the EMI rig to one draw per pivot and material

`4 files changed, 115 insertions(+), 3 deletions(-)`

### From the commit message
emi.glb arrives as 69 primitives, so every EMI on screen cost 69 draw calls
(the run went 67 -> 164 calls with the rig and the props crockery, the menu
stage 82). flattenRig bakes every static part into its nearest clip-driven
pivot, one mesh per material, keeps textured meshes (the face glass) and the
pivots themselves untouched, and hangs each merged mesh off the first
contributor's parent so EMI_case / ball still resolve to nodes with geometry.
Outline hulls keep their winding. Called from the kart mount and the menu
stage. Headless at the same daily seed: run 164 -> 96 calls, menu 82 -> 43,
tris unchanged, zero console errors. Smoke: 9 new assertions (49 total).


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0166ij3Q8xyseVkhWajzkWG3
