### PR TITLE
feat(race): track charts, the chart module and its node self-check (PR c1)

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/race/CHART.md
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/CHART.md
@@ -1,0 +1,188 @@
+# The Caucus Race - track charts (the file is the track)
+
+Owner call 2026-09-06: the race gets its identity from a hypno file. The player loads an audio
+file, the host charts it (energy curve + spoken trigger words with timestamps), and the run is
+driven by that chart: every trigger the voice says is a bubble the kart drives into at that second,
+a drop is a jump and a spiral, a countdown is a run of air rings, a chant is a bubble lane in the
+chant's rhythm, silence is a fogged straight with nothing in it. The run ends when the file ends.
+
+Hard rules:
+- **The clock is the file.** Kart speed, boost and brake change spectacle and score, never when an
+  event is met. Events are scheduled by track time and spawned ahead at the kart's current speed
+  so the pop lands on the spoken word whatever the player did with the throttle.
+- **Pause pauses the voice.** The Brake, a host pause and a video pop all stop the track clock.
+- **Audio never leaves the machine.** Charts hold timestamps and labels only. The cache key is a
+  hash of the file, never its path or name in anything that is uploaded.
+- Without a track the race runs exactly as today (seeded rooms, random spawns). Nothing in this
+  document changes the no-track path.
+- Everything else in `CONTRACT.md` still holds (600 lines per PR, track space via `layout.toWorld`,
+  EMI canon, no em-dashes anywhere).
+
+## Chart JSON (version 1)
+
+```json
+{
+  "version": 1,
+  "source": { "name": "bambi sleep 01.mp3", "hash": "3f2a...", "durationSec": 1834.2, "sampleRate": 16000 },
+  "analysis": { "energy": "rms-flux-v1", "words": "vosk-v1", "lexicon": ["drop", "sleep", "good girl"], "generatedAt": "2026-09-06T10:00:00Z", "partial": false },
+  "binSec": 0.5,
+  "energy": [0.12, 0.13, 0.11],
+  "acts": [ { "id": 0, "t0": 0, "t1": 212.5, "kind": "induction", "room": "teagarden", "name": "the settle" } ],
+  "events": [ { "id": "e12", "t": 312.4, "kind": "trigger", "label": "good girl", "conf": 0.82, "dur": 0, "weight": 1 } ]
+}
+```
+
+- `source.hash`: SHA1 hex of the file length (8 bytes little endian) + the first 1 MiB of the file.
+- `analysis.words`: `"vosk-v1"` or `"none"`. `analysis.partial` is `true` on the chart posted after
+  the energy pass and before the word pass has landed.
+- `energy`: one value per `binSec`, `0..1`, normalised so the file's 98th percentile RMS is 1.
+  Length is `ceil(durationSec / binSec)`.
+- `acts`: contiguous, sorted, `t0` of the first is 0, `t1` of the last is `durationSec`. `kind` in
+  `induction | deepening | triggers | mantra | build | silence | wake | free`. `room` is a room id
+  from `consts.js ROOM_IDS`; the default mapping is `ACT_ROOM` below and the analyzer may override it
+  to avoid repeating a room back to back.
+- `events`: sorted by `t`. `id` unique in the chart. `conf` 0..1 (1 for energy events). `dur` seconds,
+  0 for point events. `weight` 0..1 scales how loud the cue is (default 1).
+
+Event kinds:
+
+| kind | source | fields | meaning |
+|------|--------|--------|---------|
+| `trigger` | words | `label` (the phrase) | a mod trigger phrase or a user keyword trigger was spoken |
+| `word` | words | `label` | a structure word from `STRUCTURE_WORDS` (drop, sleep, deeper, ...) |
+| `count` | words | `label` ("3"), `n` (3), `of` (run length), `last` (bool) | a number inside a countdown run (numbers within 2.5 s of each other, descending or ascending) |
+| `drop` | words | `strength` 0..1 | a drop moment: the end of a countdown, or a `word` in `DROP_WORDS` not inside a countdown |
+| `chant` | words | `label`, `dur`, `reps`, `period` | the same phrase 3+ times within 25 s: `t` is the first, `period` the mean gap |
+| `build` | energy | `dur` | RMS rising for 8 s or more (slope over the window > 0.25 of full scale) |
+| `peak` | energy | | a local maximum above 0.8 |
+| `release` | energy | | RMS falls by more than 0.4 within 3 s after a peak |
+| `silence` | energy | `dur` | RMS under 0.06 for 3 s or more; `t` is the start |
+
+`STRUCTURE_WORDS` (English v1, lowercase, the words pass grammar is this list + the trigger
+lexicon + `[unk]`):
+`drop, dropping, sleep, sleepy, asleep, deeper, deep, down, sink, sinking, relax, relaxing, breathe,
+breath, blank, empty, obey, listen, focus, surrender, melt, float, floating, heavy, wake, awake,
+waking, up, open, count, zero, one, two, three, four, five, six, seven, eight, nine, ten, now, good,
+girl, bimbo, doll, mind, mindless, pink, spiral, trance, trigger`
+
+`DROP_WORDS`: `drop, dropping, sleep, asleep, deeper, sink, sinking, now` (only `now` when it follows
+a count within 1.5 s).
+
+`ACT_ROOM` default: `induction: teagarden, deepening: undertow, triggers: toybox, mantra: chapel,
+build: mirrors, silence: greyward, wake: coronation, free: casino`.
+
+Act detection (energy pass, no words): split at every `silence` of 6 s or more and at every
+`release` after a `peak`, merge segments under 45 s into their neighbour, then label by position
+and energy: first segment `induction`; a segment whose mean energy is under 0.25 and that follows a
+release is `deepening`; a segment with a `build` inside is `build`; the last 12 percent of the file
+is `wake` if its mean energy is above the file mean; a segment that is mostly silence is `silence`;
+everything else `free`. The words pass upgrades: a segment holding 3+ `trigger` events becomes
+`triggers`; one holding a `chant` becomes `mantra`.
+
+## Page side
+
+### `race/chart.js` (PR c1, pure, node self-check, no THREE)
+```js
+export const STRUCTURE_WORDS, DROP_WORDS, EVENT_KINDS, ACT_KINDS, ACT_ROOM, CHART_VERSION;
+export function normalizeChart(obj) -> chart        // validates + sorts + fills ids/defaults; throws Error('chart: ...') on a bad shape
+export function demoChart({ seed = 1, durationSec = 240 } = {}) -> chart   // deterministic synthetic chart with every event kind, uses makeRng from consts.js
+export function createScheduler(chart, { leadSec = 2.2 } = {}) -> sched
+  sched.update(trackT, fire)      // fire(event, dueIn) once per event when event.t - leadSec <= trackT; dueIn = event.t - trackT (can be < 0 after a seek or a stall)
+  sched.actAt(t) -> act | null
+  sched.energyAt(t) -> 0..1       // linear interpolation between bins, 0 outside the file
+  sched.replace(chart)            // swap in an upgraded chart: keeps fired ids and taken ids, adopts events with t > lastT only
+  sched.taken(id)                 // the player met this event (popped its bubble, hit the drop)
+  sched.stats() -> { total, fired, countable, taken }   // countable = events of kind trigger|word|count|drop
+  sched.lastT                     // the last trackT seen
+  sched.reset()
+```
+Scheduler rules: `update` never fires the same id twice; a trackT that jumps backwards by more than
+1 s resets fired ids with `t > trackT` (a seek); events with `t < trackT - 0.5` at first sight fire
+with a negative `dueIn` and the run may drop them.
+
+### `race/cues.js` (PR c2 builds the plain mapping, PR c3 makes it sing)
+```js
+export function cueFor(event, ctx) -> cue | null
+// ctx = { energy: 0..1, act, room, intensity, rng, triggerKinds: Map(label -> bubbleKindId) }
+// cue = {
+//   spawn: [ { kindId, placement: 'spawn' | 'air' | 'rain', x, h, at } ],   // at = seconds relative to event.t (0 = on the word)
+//   jump: vh | 0, mix: bubbleKindId | null, mood: 'calm'|'streamed'|'fraught'|'smug'|'shock'|'jackpot' | null,
+//   pose: name | null, toast: { text, kind } | null, word: label | null, fog: 0..1 | null, boost: sec | 0, density: mult | null,
+//   holdSec: 0
+// }
+```
+The plain mapping (c2): `trigger` -> one effect bubble of `triggerKinds.get(label)` or `flash`, lane
+placement, `word: label`; `word` -> a treat bubble; `count` -> a golden air bubble, `last` adds
+`jump: 6`; `drop` -> `jump: 7`, `mix: 'spiral'`, `mood: 'streamed'`, three golden air bubbles at
+`at = 0.2, 0.5, 0.8`; `chant` -> `reps` treats in lane placement alternating `x = +-1.2` at
+`at = k * period`; `build` -> `boost: min(dur, 4)`, `density: 1.6`; `peak` -> 6 rain treats; `release`
+-> `mood: 'calm'`, `density: 0.6`; `silence` -> `fog: 1`, `density: 0`, `holdSec: dur`.
+
+### `race/bubbles.js` additions (PR c2)
+```js
+field.spawnAt({ kindId, placement, d, x, h, eventId })   // an explicit placement; returns the slot id or -1 when the pool is full
+field.setDensity(mult)                                  // already in CONTRACT.md; with a track this scales only the cue spawns
+```
+Pop events carry `eventId` when the bubble came from a cue; `onMiss` events do too.
+
+### `race/run.js` + `raceBoot.js` (PR c2)
+```js
+race.setTrack(chart | null)        // before start(); null returns to the seeded run
+race.trackClock(t, playing)        // the host's clock; the run integrates between ticks with performance.now()
+race.track                          // { chart, sched, t, playing, name, durationSec } or null
+```
+- With a track: `S.intensity` follows `sched.energyAt(t)` smoothed over 2 s (floor 0.05); the random
+  `spawnAhead` / `rain` timers are off; `seedChunk` still dresses chunks with plain treats at
+  `density` so the road never looks empty; every cue spawn goes through `field.spawnAt` at
+  `d = kart.d + kart.speed * max(dueIn + at, 0.25)`.
+- Acts: at a gate crossing use the current act's room instead of the feature's room; if the act
+  changed and no gate is within 6 s of road, call `dresser.applyRoom` with a 2.5 s fade right away
+  and show the MARQUEE with the act's `name`.
+- The run ends when `t >= durationSec - 0.25` or on `track-ended`: the end summary gains
+  `taken`, `countable`, `trackName`; `run-ended` gains `track: { name, hash, durationSec, taken, countable }`.
+- Pause: the Brake, `pause {on:true}` from the host and a video pop send `track-pause {on:true}`;
+  resume sends `{on:false}`. The clock only moves on `track-clock` ticks that say `playing`.
+- Standalone (not hosted): `?chart=demo&dur=240` uses `demoChart`; `?chart=<url>` fetches a chart;
+  `?audio=<url>` plays an `<audio>` element as the clock (its `currentTime` drives `trackClock`);
+  without `?audio` the clock is wall time. The headless checks use `?autostart=1&chart=demo`.
+- A `track-chart` message with `partial: true` calls `setTrack` (or `sched.replace` when the run is
+  live); the later full chart calls `sched.replace`.
+
+### The menu (PR c7, Fable)
+"load a track" on the menu sends `track-pick`; a progress plate shows `track-progress`; when the
+chart lands the plate shows the name, the duration and "N triggers found", and `race` starts the
+run with the track. The results screen reads "you took N of M" for a tracked run.
+
+## Host protocol additions (PR c6)
+
+Page -> host: `track-pick` (open the file dialog), `track-play` (the run started; start the audio),
+`track-pause {on}`, `track-stop` (end of run or exit: stop the audio), `track-cancel` (abandon an
+analysis in flight).
+
+Host -> page: `track-progress { stage: 'decode' | 'energy' | 'words', pct: 0..1, name }`,
+`track-chart { chart, partial }`, `track-clock { t, playing, durationSec }` every 250 ms while a
+track is loaded, `track-ended`, `track-error { message }` (dialog cancelled is not an error: the
+host posts `track-progress { stage: 'cancelled' }`).
+
+## C# side
+
+- `Models/Race/TrackChart.cs` (c4): POCOs mirroring the JSON with Newtonsoft attributes:
+  `TrackChart`, `TrackSource`, `TrackAnalysis`, `TrackAct`, `TrackEvent`.
+- `Services/Race/TrackPcm.cs` + `Services/Race/TrackAnalyzer.cs` (c4):
+  `TrackDecoder.Decode(path, IProgress<double>, ct) -> TrackPcm { float[] Mono16k, double DurationSec, string Hash, string Name }`
+  via `MediaFoundationReader` (falls back to `AudioFileReader`), `StereoToMonoSampleProvider`,
+  `WdlResamplingSampleProvider(16000)`.
+  `TrackAnalyzer.Energy(TrackPcm, IProgress<double>, ct) -> TrackChart` (energy, energy events, acts).
+  `TrackChartCache.TryLoad(hash) / Save(chart)` under `Path.Combine(App.UserDataPath, "race", "charts")`.
+- `Services/Race/TrackWordSpotter.cs` + `Services/Race/TrackLexicon.cs` (c5):
+  `TrackLexicon.Build() -> IReadOnlyList<string>` = STRUCTURE_WORDS + the active mod's trigger
+  phrases + `AppSettings.CustomTriggers` + `KeywordTriggers` phrases, lowercased, letters and spaces
+  only, distinct. `TrackWordSpotter.Spot(TrackPcm, lexicon, IProgress<double>, ct) -> List<TrackEvent>`
+  on a Vosk grammar recognizer (`SetWords(true)`, 8000-sample chunks, `result[]` word timings),
+  then `TrackChartWords.Apply(chart, events, lexicon)` adds trigger/word/count/drop/chant events,
+  upgrades acts, sets `analysis.words = "vosk-v1"`. No model on disk = `analysis.words = "none"`,
+  never an exception to the caller.
+- `Services/Race/TrackPlayer.cs` + `CaucusHostService` track messages (c6): `AudioFileReader` +
+  `WaveOutEvent`, master volume, `PositionSec`, `Play/Pause/Resume/Stop`, `Ended` event; the file
+  dialog on the UI thread; the analysis on a worker with progress posts; the 250 ms clock timer;
+  `track-stop` on `run-ended` and `exit`.

--- a/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
@@ -319,6 +319,16 @@ resultTier(total, best, personalBest) -> 0..4 (the face index)
   placeholders otherwise. `emi.glb`'s `EMI_glass` carries the atlas as `emissiveTexture` only, so the stage sets the face
   on `emissiveMap` (and `map` when present); gltf.js `setFace` shifts whichever of the two the material carries.
 
+### `race/chart.js` (track charts, PR c1)
+```js
+normalizeChart(json) -> chart | demoChart({ seed, durationSec }) -> chart | createScheduler(chart, { leadSec }) -> sched
+export const CHART_VERSION, STRUCTURE_WORDS, DROP_WORDS, EVENT_KINDS, ACT_KINDS, ACT_ROOM;
+```
+Pure data: no three, no DOM, no clock, so it runs under node (`node race/smoke/chart-check.mjs`). The chart
+is the analysed hypno file (energy bins, acts, spoken events); the scheduler hands run.js each event `leadSec`
+before its second (2.5 s, floor 1.2) at `d = kartD + speed * dueIn`, so the pop lands on the spoken word
+whatever the throttle did, and anything already spoken is dropped. Full shape and protocol in `CHART.md`.
+
 ## Host protocol (bridge.js, Protocol v1)
 
 Page -> host (`bridge.send(type, data)`): `ready` (announceReady), `heartbeat`, `pong`, `sfx {name, scale}`,

--- a/ConditioningControlPanel/Resources/web/dtrh/race/chart.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/chart.js
@@ -1,0 +1,285 @@
+/* ============================================================================
+ * race/chart.js - The Caucus Race track charts: the file is the track.
+ * Implements CHART.md section `race/chart.js`.
+ *
+ * A chart is timestamps and labels, never audio: an energy curve in fixed bins, a list
+ * of acts (induction, deepening, triggers, mantra, build, silence, wake, free) and a
+ * sorted list of events, the words the voice says. The host analyses the file and posts
+ * one of these; the page schedules the whole run off it. Nothing here imports three,
+ * touches the DOM or reads a clock, so it runs under `node race/smoke/chart-check.mjs`.
+ *
+ * The scheduler is the piece that matters. The clock is the file, so an event at
+ * track time `te` cannot wait for the kart: it is handed out `leadSec` before its
+ * second at the depth the kart will have reached by then, which is why the pop lands
+ * on the spoken word whatever the player did with the throttle. An event first seen
+ * after its second is dropped and counted as missed, never spawned behind the kart.
+ * ==========================================================================*/
+
+import { ROOM_IDS, KART_BASE_SPEED, makeRng } from './consts.js';
+
+export const CHART_VERSION = 1;
+
+/** English v1 structure words. The words pass grammar is this list + the trigger lexicon + [unk]. */
+export const STRUCTURE_WORDS = [
+  'drop', 'dropping', 'sleep', 'sleepy', 'asleep', 'deeper', 'deep', 'down', 'sink', 'sinking',
+  'relax', 'relaxing', 'breathe', 'breath', 'blank', 'empty', 'obey', 'listen', 'focus',
+  'surrender', 'melt', 'float', 'floating', 'heavy', 'wake', 'awake', 'waking', 'up', 'open',
+  'count', 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine', 'ten',
+  'now', 'good', 'girl', 'bimbo', 'doll', 'mind', 'mindless', 'pink', 'spiral', 'trance', 'trigger',
+];
+
+/** A structure word outside a countdown that reads as a drop ('now' only right after a count). */
+export const DROP_WORDS = ['drop', 'dropping', 'sleep', 'asleep', 'deeper', 'sink', 'sinking', 'now'];
+
+export const EVENT_KINDS = ['trigger', 'word', 'count', 'drop', 'chant', 'build', 'peak', 'release', 'silence'];
+export const ACT_KINDS = ['induction', 'deepening', 'triggers', 'mantra', 'build', 'silence', 'wake', 'free'];
+
+/** Default act -> room. The analyzer may override a room to avoid repeating one back to back. */
+export const ACT_ROOM = {
+  induction: 'teagarden', deepening: 'undertow', triggers: 'toybox', mantra: 'chapel',
+  build: 'mirrors', silence: 'greyward', wake: 'coronation', free: 'casino',
+};
+
+const LEAD_SEC = 2.5;         // seconds of warning an event gets by default
+const MIN_LEAD_SEC = 1.2;     // and the floor, so a caller cannot spawn a bubble on the bumper
+const MIN_AHEAD_SEC = 0.25;   // an event never materialises behind the kart
+const MISS_SEC = 0.5;         // first seen this late and it is gone, not spawned late
+const SEEK_SEC = 1.0;         // a clock that jumps back further than this is a seek
+const COUNTABLE = new Set(['trigger', 'word', 'count', 'drop']);
+
+const num = (v, d) => (typeof v === 'number' && isFinite(v) ? v : d);
+const clamp = (v, lo, hi) => (v < lo ? lo : v > hi ? hi : v);
+const clamp01 = (v) => clamp(v, 0, 1);
+const str = (v, d = '') => (typeof v === 'string' ? v : d);
+
+/* ---- normalize ---------------------------------------------------------- */
+
+/**
+ * Validate a chart off the wire and fill in what the page assumes: contiguous sorted acts, sorted
+ * events with unique ids, clamped ranges. Throws a plain Error the caller can put on screen, and
+ * freezes the result so a run can never scribble on the host's chart.
+ */
+export function normalizeChart(json) {
+  if (!json || typeof json !== 'object') throw new Error('chart: expected an object');
+  const version = num(json.version, CHART_VERSION);
+  if (version !== CHART_VERSION) throw new Error('chart: version ' + version + ' is not supported, this build reads version ' + CHART_VERSION);
+  const src = (json.source && typeof json.source === 'object') ? json.source : {};
+  const durationSec = num(src.durationSec, num(json.durationSec, 0));
+  if (!(durationSec > 0)) throw new Error('chart: source.durationSec is missing or not a positive number');
+
+  const binSec = clamp(num(json.binSec, 0.5), 0.05, 5);
+  const energy = (Array.isArray(json.energy) ? json.energy : []).map((v) => clamp01(num(v, 0)));
+  const an = (json.analysis && typeof json.analysis === 'object') ? json.analysis : {};
+
+  return Object.freeze({
+    version: CHART_VERSION, binSec, energy: Object.freeze(energy),
+    acts: normalizeActs(Array.isArray(json.acts) ? json.acts : [], durationSec),
+    events: normalizeEvents(Array.isArray(json.events) ? json.events : [], durationSec),
+    source: Object.freeze({ name: str(src.name, 'track'), hash: str(src.hash, ''), durationSec, sampleRate: num(src.sampleRate, 16000) }),
+    analysis: Object.freeze({
+      energy: str(an.energy, ''), words: str(an.words, 'none'), generatedAt: str(an.generatedAt, ''), partial: an.partial === true,
+      lexicon: Object.freeze((Array.isArray(an.lexicon) ? an.lexicon : []).filter((w) => typeof w === 'string')),
+    }),
+  });
+}
+
+function normalizeActs(raw, durationSec) {
+  const out = raw
+    .filter((a) => a && typeof a === 'object' && isFinite(num(a.t0, NaN)))
+    .map((a) => ({ t0: clamp(num(a.t0, 0), 0, durationSec), t1: clamp(num(a.t1, durationSec), 0, durationSec), src: a }))
+    .sort((a, b) => a.t0 - b.t0)
+    .map((a, i) => {
+      const kind = ACT_KINDS.includes(a.src.kind) ? a.src.kind : 'free';
+      const room = ROOM_IDS.includes(a.src.room) ? a.src.room : ACT_ROOM[kind];
+      return { id: i, t0: a.t0, t1: a.t1, kind, room, name: str(a.src.name, kind) };
+    });
+  if (!out.length) out.push({ id: 0, t0: 0, t1: durationSec, kind: 'free', room: ACT_ROOM.free, name: 'free' });
+  // Contiguous by construction: the first starts at 0, each one ends where the next begins.
+  out[0].t0 = 0;
+  for (let i = 0; i < out.length - 1; i++) out[i].t1 = out[i + 1].t0;
+  out[out.length - 1].t1 = durationSec;
+  return Object.freeze(out.filter((a) => a.t1 > a.t0).map((a, i) => Object.freeze(Object.assign(a, { id: i }))));
+}
+
+function normalizeEvents(raw, durationSec) {
+  const seen = new Set();
+  const out = raw
+    .filter((e) => e && typeof e === 'object' && EVENT_KINDS.includes(e.kind) && isFinite(num(e.t, NaN)))
+    .map((e, i) => ({ e, i, t: clamp(num(e.t, 0), 0, durationSec) }))
+    .sort((a, b) => (a.t - b.t) || (a.i - b.i))
+    .map(({ e, t }, i) => {
+      let id = str(e.id, '');
+      if (!id || seen.has(id)) id = 'e' + i;
+      seen.add(id);
+      const ev = { id, t, kind: e.kind, label: str(e.label, '').toLowerCase(), conf: clamp01(num(e.conf, 1)),
+        dur: clamp(num(e.dur, 0), 0, durationSec - t), weight: clamp01(num(e.weight, 1)) };
+      if (e.kind === 'count') { ev.n = num(e.n, 0); ev.of = num(e.of, 0); ev.last = e.last === true; }
+      if (e.kind === 'drop') ev.strength = clamp01(num(e.strength, 1));
+      if (e.kind === 'chant') { ev.reps = Math.max(1, Math.round(num(e.reps, 3))); ev.period = Math.max(0, num(e.period, 0)); }
+      return Object.freeze(ev);
+    });
+  return Object.freeze(out);
+}
+
+/* ---- the demo track ----------------------------------------------------- */
+
+// One act of every kind, so `?chart=demo` walks every room and every cue with no audio at all.
+const DEMO_ACTS = [
+  { kind: 'induction', frac: 0.18, name: 'the settle', base: 0.34 },
+  { kind: 'deepening', frac: 0.16, name: 'the undertow', base: 0.26 },
+  { kind: 'triggers', frac: 0.16, name: 'the toybox', base: 0.55 },
+  { kind: 'mantra', frac: 0.14, name: 'the chant', base: 0.48 },
+  { kind: 'build', frac: 0.14, name: 'the climb', base: 0.4 },
+  { kind: 'silence', frac: 0.08, name: 'the quiet', base: 0.03 },
+  { kind: 'wake', frac: 0.14, name: 'the way up', base: 0.72 },
+];
+const DEMO_TRIGGERS = ['good girl', 'bimbo', 'doll', 'spiral', 'blank'];
+const SETTLE_WORDS = ['relax', 'breathe', 'listen', 'focus', 'down'];
+const SINK_WORDS = ['deeper', 'heavy', 'float', 'sink'];
+
+/**
+ * A deterministic synthetic chart carrying every event kind: a settle, a countdown into a drop, a
+ * room of triggers, a chant, a climb that peaks and releases, a fogged quiet and a wake. Same seed,
+ * same track, forever, so the headless checks and the standalone page agree on what they see. Takes
+ * the CHART.md options object or a bare duration in seconds.
+ */
+export function demoChart(opts = {}) {
+  const o = (typeof opts === 'number') ? { durationSec: opts } : (opts || {});
+  const durationSec = clamp(num(o.durationSec, 240), 40, 7200);
+  const rng = makeRng(num(o.seed, 1) | 0);
+  const binSec = 0.5, events = [], acts = [];
+  let n = 0, cut = 0;
+  const ev = (kind, t, extra) => { events.push(Object.assign({ id: 'd' + (n++), kind, t }, extra)); };
+
+  DEMO_ACTS.forEach((a, i) => {
+    const t1 = (i === DEMO_ACTS.length - 1) ? durationSec : Math.min(durationSec, cut + durationSec * a.frac);
+    acts.push({ id: i, t0: cut, t1, kind: a.kind, room: ACT_ROOM[a.kind], name: a.name });
+    cut = t1;
+  });
+
+  for (const a of acts) {
+    const len = a.t1 - a.t0;
+    if (a.kind === 'induction') {
+      for (let k = 0, t = a.t0 + 6; t < a.t1 - 2; t += 8.5, k++) ev('word', t, { label: SETTLE_WORDS[k % SETTLE_WORDS.length], weight: 0.8 });
+    } else if (a.kind === 'deepening') {
+      for (let k = 0, t = a.t0 + 5; t < a.t1 - 20; t += 7, k++) ev('word', t, { label: SINK_WORDS[k % SINK_WORDS.length], weight: 0.9 });
+      const from = Math.max(a.t0 + 2, a.t1 - 17);              // ten, nine, eight, and away
+      for (let i = 10; i >= 1; i--) ev('count', from + (10 - i) * 1.4, { label: String(i), n: i, of: 10, last: i === 1 });
+      ev('drop', from + 9 * 1.4 + 1.1, { strength: 1, label: 'drop' });
+    } else if (a.kind === 'triggers') {
+      for (let k = 0, t = a.t0 + 4; t < a.t1 - 2; t += 6.5, k++) ev('trigger', t, { label: DEMO_TRIGGERS[k % DEMO_TRIGGERS.length], conf: 0.7 + rng() * 0.3 });
+    } else if (a.kind === 'mantra') {
+      const period = 2.4, reps = Math.max(3, Math.min(8, Math.floor((len - 6) / period)));
+      ev('chant', a.t0 + 3, { label: 'good girl', reps, period, dur: reps * period });
+      ev('trigger', a.t0 + 4 + reps * period, { label: 'doll', conf: 0.9 });
+    } else if (a.kind === 'build') {
+      const dur = Math.max(6, Math.min(12, len - 8));
+      ev('build', a.t0 + 3, { dur });
+      ev('peak', a.t0 + 3 + dur, {});
+      ev('drop', a.t0 + 3.2 + dur, { strength: 0.85, label: 'sink' });
+      ev('release', a.t0 + 5.4 + dur, {});
+    } else if (a.kind === 'silence') {
+      ev('silence', a.t0 + 0.5, { dur: Math.max(3, len - 1.5) });
+    } else if (a.kind === 'wake') {
+      ['wake', 'awake', 'up'].forEach((w, k) => ev('word', a.t0 + 3 + k * 4.5, { label: w }));
+      ev('trigger', Math.min(a.t1 - 2, a.t0 + 17), { label: 'good girl', conf: 0.95 });
+    }
+  }
+
+  const bins = Math.ceil(durationSec / binSec);
+  const energy = new Array(bins);
+  for (let i = 0; i < bins; i++) {
+    const t = (i + 0.5) * binSec;
+    const a = acts.find((x) => t >= x.t0 && t < x.t1) || acts[acts.length - 1];
+    const frac = (t - a.t0) / Math.max(1, a.t1 - a.t0);
+    let v = DEMO_ACTS.find((x) => x.kind === a.kind).base;
+    if (a.kind === 'build') v = 0.32 + 0.62 * frac;            // the climb is the curve, not a level
+    if (a.kind === 'wake') v = 0.55 + 0.35 * frac;
+    energy[i] = clamp01(v + (rng() - 0.5) * (a.kind === 'silence' ? 0.02 : 0.08));
+  }
+
+  return normalizeChart({
+    version: CHART_VERSION, binSec, energy, acts, events,
+    source: { name: 'the demo track', hash: 'demo', durationSec, sampleRate: 16000 },
+    analysis: { energy: 'demo-v1', words: 'demo-v1', lexicon: DEMO_TRIGGERS, generatedAt: '', partial: false },
+  });
+}
+
+/* ---- the scheduler ------------------------------------------------------ */
+
+/**
+ * Walk a chart against the track clock. `update` hands back everything that has to be spawned on
+ * this frame, each with the depth its bubble belongs at, so the run only has to place it.
+ */
+export function createScheduler(chart, opts = {}) {
+  let ch = (chart && chart.version === CHART_VERSION && Object.isFrozen(chart)) ? chart : normalizeChart(chart);
+  const leadSec = Math.max(MIN_LEAD_SEC, num(opts.leadSec, LEAD_SEC));
+  const fired = new Set(), takenIds = new Set();
+  let cursor = 0, lastT = 0, missed = 0;
+
+  // The cursor is the first event nobody has looked at yet: after a seek or a swap it walks past
+  // anything already fired, so update() stays a straight run down the list.
+  const seekCursor = () => { cursor = 0; while (cursor < ch.events.length && fired.has(ch.events[cursor].id)) cursor++; };
+
+  return {
+    /**
+     * @param t track seconds, @param kartD the kart's depth, @param kartSpeed metres a second. A
+     * function in place of kartD is the CHART.md callback form, fire(event, dueIn). Returns
+     * [{ event, dueIn, d }] for everything due this frame, in chart order.
+     */
+    update(t, kartD, kartSpeed) {
+      let fire = null;
+      if (typeof kartD === 'function') { fire = kartD; kartD = 0; kartSpeed = KART_BASE_SPEED; }
+      const d0 = num(kartD, 0);
+      const speed = Math.max(0, num(kartSpeed, KART_BASE_SPEED));
+      if (t < lastT - SEEK_SEC) {                              // the host seeked: let the future back in
+        for (const e of ch.events) if (e.t > t) fired.delete(e.id);
+        seekCursor();
+      }
+      lastT = t;
+      const due = [];
+      while (cursor < ch.events.length) {
+        const e = ch.events[cursor];
+        if (e.t - leadSec > t) break;
+        cursor++;
+        if (fired.has(e.id)) continue;
+        fired.add(e.id);
+        const dueIn = e.t - t;
+        if (dueIn < -MISS_SEC) { missed++; continue; }         // the voice already said it, let it go
+        due.push({ event: e, dueIn, d: d0 + speed * Math.max(dueIn, MIN_AHEAD_SEC) });
+        if (fire) fire(e, dueIn);
+      }
+      return due;
+    },
+    actAt(t) {
+      for (const a of ch.acts) if (t >= a.t0 && t < a.t1) return a;
+      return (ch.acts.length && t >= ch.source.durationSec) ? ch.acts[ch.acts.length - 1] : null;
+    },
+    energyAt(t) {
+      const bins = ch.energy.length;
+      if (!bins || t < 0 || t > ch.source.durationSec) return 0;
+      const p = clamp(t / ch.binSec - 0.5, 0, bins - 1);
+      const i = Math.floor(p);
+      const a = ch.energy[i], b = ch.energy[Math.min(bins - 1, i + 1)];
+      return clamp01(a + (b - a) * (p - i));
+    },
+    /** Swap in an upgraded chart (the words pass landing on a partial one) without re-firing. */
+    replace(next) {
+      ch = (next && next.version === CHART_VERSION && Object.isFrozen(next)) ? next : normalizeChart(next);
+      for (const e of ch.events) if (e.t <= lastT) fired.add(e.id);   // only the future is adopted
+      seekCursor();
+      return ch;
+    },
+    /** The player met this event: popped its bubble, took the drop. */
+    taken(id) { if (id) takenIds.add(id); },
+    stats() {
+      let countable = 0;
+      for (const e of ch.events) if (COUNTABLE.has(e.kind)) countable++;
+      return { total: ch.events.length, fired: fired.size, countable, taken: takenIds.size, missed };
+    },
+    reset() { fired.clear(); takenIds.clear(); cursor = 0; lastT = 0; missed = 0; },
+    get chart() { return ch; },
+    get lastT() { return lastT; },
+    get leadSec() { return leadSec; },
+  };
+}

--- a/ConditioningControlPanel/Resources/web/dtrh/race/smoke/chart-check.mjs
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/smoke/chart-check.mjs
@@ -1,0 +1,116 @@
+/* ============================================================================
+ * race/smoke/chart-check.mjs - node self-check for race/chart.js.
+ *
+ *   node race/smoke/chart-check.mjs      (exits 0 on pass, 1 with a count of failures)
+ *
+ * chart.js imports only consts.js, so this needs no three and no DOM: it builds the
+ * demo track, walks a scheduler at 60 Hz behind a kart holding KART_BASE_SPEED and
+ * checks the promises CHART.md makes. In order: the demo chart normalizes with
+ * contiguous acts and every event kind in it; one walk spawns every event exactly
+ * once, nothing behind the kart and each spawn a lead of road ahead; actAt never
+ * walks backwards and energyAt stays in 0..1; replace() halfway does not re-spawn
+ * what already fired and keeps taken ids; a scheduler joined late counts what it
+ * skipped as missed; a version 2 chart and a chart with no duration both throw.
+ * ==========================================================================*/
+
+import { KART_BASE_SPEED } from '../consts.js';
+import { demoChart, normalizeChart, createScheduler, ACT_ROOM, EVENT_KINDS, STRUCTURE_WORDS, DROP_WORDS } from '../chart.js';
+
+let fails = 0;
+const ok = (cond, what) => { if (!cond) { console.error('FAIL ' + what); fails++; } else console.log('  ok  ' + what); };
+
+const DUR = 240, SPEED = KART_BASE_SPEED, STEP = 1 / 60;
+const chart = demoChart(DUR);
+
+/* ---- 1. the demo chart -------------------------------------------------- */
+{
+  ok(chart.version === 1 && chart.source.durationSec === DUR, 'demoChart(240) is a version 1 chart of 240 s');
+  ok(!!normalizeChart(chart) && Object.isFrozen(chart.events), 'a normalized chart re-normalizes and its events are frozen');
+  ok(chart.acts[0].t0 === 0 && chart.acts[chart.acts.length - 1].t1 === DUR, 'the acts span the file end to end');
+  let gap = false, back = false, sorted = true;
+  for (let i = 1; i < chart.acts.length; i++) {
+    if (chart.acts[i].t0 !== chart.acts[i - 1].t1) gap = true;
+    if (chart.acts[i].t0 < chart.acts[i - 1].t0) back = true;
+  }
+  for (let i = 1; i < chart.events.length; i++) if (chart.events[i].t < chart.events[i - 1].t) sorted = false;
+  ok(!gap && !back, 'the acts are contiguous and sorted');
+  ok(chart.acts.every((a) => a.room === ACT_ROOM[a.kind]), 'every act sits in its ACT_ROOM');
+  ok(EVENT_KINDS.every((k) => chart.events.some((e) => e.kind === k)), 'every event kind is in the demo: ' + EVENT_KINDS.join(', '));
+  ok(sorted && new Set(chart.events.map((e) => e.id)).size === chart.events.length, 'events are sorted by t with unique ids');
+  const count = chart.events.filter((e) => e.kind === 'count');
+  ok(count.length === 10 && count[9].last === true, 'the countdown is ten numbers and the last is flagged');
+  ok(DROP_WORDS.every((w) => STRUCTURE_WORDS.includes(w)), 'DROP_WORDS is a subset of STRUCTURE_WORDS');
+}
+
+/* ---- 2. one walk at 60 Hz ----------------------------------------------- */
+{
+  const sched = createScheduler(chart), lead = sched.leadSec, seen = new Map();
+  let behind = 0, tooFar = 0, tooNear = 0, d = 0;
+  for (let t = 0; t <= DUR + lead; t += STEP, d += SPEED * STEP) {
+    for (const hit of sched.update(t, d, SPEED)) {
+      seen.set(hit.event.id, (seen.get(hit.event.id) || 0) + 1);
+      const ahead = hit.d - d;
+      if (ahead <= 0) behind++;
+      if (ahead > SPEED * lead + 1e-6) tooFar++;
+      if (ahead < SPEED * (lead - STEP) - 1e-6) tooNear++;
+    }
+  }
+  const st = sched.stats();
+  ok(seen.size === chart.events.length, 'every event spawned: ' + seen.size + ' of ' + chart.events.length);
+  ok([...seen.values()].every((n) => n === 1), 'and none of them twice');
+  ok(behind === 0, 'no event ever spawned behind the kart');
+  ok(tooFar === 0 && tooNear === 0, 'every spawn sat a lead of road ahead (' + (SPEED * lead).toFixed(1) + ' m, one frame of slack)');
+  ok(st.missed === 0, 'a clean walk misses nothing');
+  ok(st.fired === st.total && st.countable > 0 && st.countable < st.total, 'stats: fired ' + st.fired + '/' + st.total + ', countable ' + st.countable);
+}
+
+/* ---- 3. acts and energy ------------------------------------------------- */
+{
+  const sched = createScheduler(chart);
+  let lastAct = -1, actBack = 0, hole = 0, outOfRange = 0;
+  for (let t = 0; t < DUR; t += 0.25) {
+    const a = sched.actAt(t);
+    if (!a) { hole++; continue; }
+    if (a.id < lastAct) actBack++;
+    lastAct = a.id;
+    const e = sched.energyAt(t);
+    if (!(e >= 0 && e <= 1)) outOfRange++;
+  }
+  const quiet = chart.acts.find((a) => a.kind === 'silence'), wake = chart.acts.find((a) => a.kind === 'wake');
+  ok(hole === 0 && actBack === 0, 'actAt covers the file and never walks backwards');
+  ok(outOfRange === 0, 'energyAt stays inside 0..1 for the whole file');
+  ok(sched.energyAt(-5) === 0 && sched.energyAt(DUR + 5) === 0, 'energyAt is 0 off both ends');
+  ok(sched.energyAt(quiet.t0 + 2) < sched.energyAt(wake.t0 + 5), 'the quiet reads lower than the wake');
+}
+
+/* ---- 4. replace mid-run, then reset ------------------------------------- */
+{
+  const sched = createScheduler(chart), first = new Set();
+  let d = 0, t = 0, dupes = 0, second = 0;
+  for (; t < DUR / 2; t += STEP, d += SPEED * STEP) for (const h of sched.update(t, d, SPEED)) { first.add(h.event.id); sched.taken(h.event.id); }
+  sched.replace(demoChart(DUR));                                 // the words pass landing on a partial
+  for (; t <= DUR + 3; t += STEP, d += SPEED * STEP) for (const h of sched.update(t, d, SPEED)) { second++; if (first.has(h.event.id)) dupes++; }
+  ok(first.size > 0, 'the first half spawned ' + first.size + ' events');
+  ok(dupes === 0, 'replace() re-spawned nothing that had already fired');
+  ok(second > 0 && first.size + second === chart.events.length, 'and the rest of the track still came through');
+  ok(sched.stats().taken === first.size, 'taken ids survive the swap');
+  sched.reset();
+  ok(sched.stats().fired === 0 && sched.stats().taken === 0 && sched.lastT === 0, 'reset() empties the scheduler');
+}
+
+/* ---- 5. joining late, and bad charts ------------------------------------ */
+{
+  const sched = createScheduler(chart);
+  const due = sched.update(120, 0, SPEED);
+  ok(due.every((h) => h.dueIn > -0.5), 'joining at 120 s hands out only what is still ahead');
+  ok(sched.stats().missed > 0, 'and counts the ' + sched.stats().missed + ' events it skipped as missed');
+
+  const threw = (fn) => { try { fn(); return ''; } catch (e) { return e instanceof Error ? e.message : ''; } };
+  const v2 = threw(() => normalizeChart({ version: 2, source: { durationSec: 60 } }));
+  ok(v2.startsWith('chart:') && v2.includes('version 2'), 'a version 2 chart throws: ' + v2);
+  ok(threw(() => normalizeChart({ version: 1, source: {} })).includes('durationSec'), 'a chart with no duration throws too');
+  ok(threw(() => normalizeChart(null)).startsWith('chart:'), 'and null throws a readable Error');
+}
+
+console.log(fails ? '\nchart-check: ' + fails + ' failure(s)' : '\nchart-check: all good');
+process.exit(fails ? 1 : 0);


### PR DESCRIPTION
## Racing Thoughts (ex Caucus Race) web stack

Stacked on `feat/race-c0-seat`. Merge bottom-up.

### Commits
- feat(race): track charts, the chart module and its node self-check (PR c1)

**Size:** Sized to 599 lines on purpose.

`4 files changed, 599 insertions(+)`

### From the commit message
race/chart.js turns an analysed hypno file into the track: normalizeChart validates
and fills a chart off the wire, demoChart builds a deterministic synthetic one so the
race is playable with no audio at all, and createScheduler hands the run each event a
lead of road before its second, at the depth the kart will have reached by then, so a
pop lands on the spoken word whatever the player did with the throttle. Pure data, no
three and no DOM, so race/smoke/chart-check.mjs walks a whole track under node.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0166ij3Q8xyseVkhWajzkWG3
