### PR TITLE
feat(race): the track chart drives the run

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
@@ -95,9 +95,12 @@ field.update(dt, t, kart)               // kart = { d, x, h, speed }; runs motio
 field.onPop(cb)                         // cb(popEvent)
 field.onMiss(cb)                        // cb({ id, points, d, x, h }) when a treat passes behind the kart unpopped
 field.setDensity(mult)
+field.spawnAt({ kindId, placement, d, x, h, eventId })   // PR c2: an explicit placement from a track cue; the slot id, or -1 when the pool is full
+field.setTracked(on)                    // PR c2: a track is loaded, so setDensity gates the CUE spawns and leaves the seeded lanes alone
 field.dispose()
 ```
-Pop event: `{ id, kind, payload, strength, points, placement, x, d, worldPos }`.
+Pop event: `{ id, kind, payload, strength, points, placement, x, d, eventId, worldPos }`.
+`eventId` is the chart event the bubble came from, or null; `onMiss` events carry it too.
 `kind` is `'treat'` or `'effect'`. `payload` is the `payloadFx` spec name (`flash`, `subliminal`,
 `overlay`, `glitch`, `bambiFreeze`, `gifCascade`, `video`, or `null` for treats) plus `overlayKind`
 where relevant (`spiral | braindrain | pink_filter`). `strength` is 0..1.
@@ -226,8 +229,15 @@ below every `.sf-pfx` layer, and the Brake/End screens at z20 pick their own sta
 ### `race/run.js` + `raceBoot.js` + `race.html` (PR 5, integration)
 ```js
 export function createRace({ root, bridge, media, settings, seed }) ->
-  { start(), setPaused(b), dispose(), setCameraOverride(fn), setStage(s), reseed(seed), renderer, pixel, audio, hud, camera }
+  { start(), setPaused(b), dispose(), setCameraOverride(fn), setStage(s), reseed(seed), renderer, pixel, audio, hud, camera,
+    setTrack(chart | null), replaceTrack(chart), trackClock(t, playing), trackEnded(), track }
 ```
+Track charts (PR c2, CHART.md): `setTrack` before `start()`; `replaceTrack` when the words pass lands
+on a live run; `trackClock` is the host's tick and `race.track` the CHART.md track object or null.
+With a track set, intensity follows the chart's energy curve (smoothed 2 s, floor 0.05), the random
+`spawnAhead` / `rain` timers stand down while `seedChunk` keeps dressing the road, every cue spawn
+goes in at `d = kart.d + kart.speed * max(dueIn + at, 0.25)`, gates and act changes take the act's
+room and name, and the run ends at `durationSec - 0.25`. Without one nothing changes.
 Composes everything: renderer, `createSpine`, `createTunnel(layout)` from `engine/tunnel.js`,
 `createFx` from `engine/fx.js`, `createRoomDresser`, `createBubbleField`, `createKart`,
 `createScore`, `createItems`, `createRaceHud`, `createPayloadFx` from `game/payloadFx.js`,
@@ -324,7 +334,22 @@ resultTier(total, best, personalBest) -> 0..4 (the face index)
 normalizeChart(json) -> chart | demoChart({ seed, durationSec }) -> chart | createScheduler(chart, { leadSec }) -> sched
 export const CHART_VERSION, STRUCTURE_WORDS, DROP_WORDS, EVENT_KINDS, ACT_KINDS, ACT_ROOM;
 ```
-Pure data: no three, no DOM, no clock, so it runs under node (`node race/smoke/chart-check.mjs`). The chart
+```js
+// race/track.js (PR c2): the loaded track's clock, energy and acts. No three, no DOM.
+createTrackState({ leadSec }) -> st
+st.setTrack(chart | null) -> track | null      // track = { chart, sched, t, playing, name, durationSec }
+st.replace(chart)                              // the words pass landing on a partial chart, clock kept
+st.clock(t, playing)                           // the host's 250 ms tick: the only thing that SETS the second
+st.step(dt) -> { t, intensity, act, actChanged, ended } | null   // one frame of real time between ticks
+st.due(kartD, kartSpeed) / st.taken(id) / st.stats() / st.summary() / st.end()
+st.track / st.act / st.intensity / st.triggerKinds / st.ended
+```
+```js
+// race/cues.js (PR c2): one chart event -> the cue run.js spends on the world. Pure, node-checkable.
+cueFor(event, { energy, act, room, intensity, rng, triggerKinds }) -> cue | null
+```
+Pure data: no three, no DOM, no clock, so it runs under node (`node race/smoke/chart-check.mjs`,
+`node race/smoke/track-run-check.mjs`). The chart
 is the analysed hypno file (energy bins, acts, spoken events); the scheduler hands run.js each event `leadSec`
 before its second (2.5 s, floor 1.2) at `d = kartD + speed * dueIn`, so the pop lands on the spoken word
 whatever the throttle did, and anything already spoken is dropped. Full shape and protocol in `CHART.md`.
@@ -334,12 +359,18 @@ whatever the throttle did, and anything already spoken is dropped. Full shape an
 Page -> host (`bridge.send(type, data)`): `ready` (announceReady), `heartbeat`, `pong`, `sfx {name, scale}`,
 `fire-payload {kind:'video'|'audio', strength, durationMult}`, `run-started {seed}`,
 `run-ended {score, banked, durationSec, bestCombo, popped, treats, effects, laps, seed}`,
-`boot-error {message}`, `report-bug {text}`, `fullscreen-set {on}`, `exit`, `exit-done`.
+`boot-error {message}`, `report-bug {text}`, `fullscreen-set {on}`, `exit`, `exit-done`,
+and with a track loaded (PR c2): `track-play {name}` (the run started, start the audio),
+`track-pause {on}` (the Brake, a host pause, a video pop), `track-stop` (run end or exit).
+`track-pick` and `track-cancel` come with the menu in PR c7.
 
 Host -> page: `init {protocol, settings:{masterVolume, reducedMotion}, modId, modContent}`,
 `manifest {images:[{name,url}], videos, skipped, truncated}`, `favorites {names}`,
 `payout-result {baseXp, skillMult, finalXp, sparksEarned, previousBest, dryRun}`, `pause {on}`,
-`ping`, `exit-request`.
+`ping`, `exit-request`, and the track messages (PR c2): `track-progress {stage, pct, name}`,
+`track-chart {chart, partial}`, `track-clock {t, playing, durationSec}`, `track-ended`,
+`track-error {message}`. Standalone, `?chart=demo&dur=N` / `?chart=<url>` load a chart and
+`?audio=<url>` makes an `<audio>` element the clock (wall time without it).
 
 `sfx` names must exist in `Resources/sounds/chaos/*.mp3` (C# `ChaosSfx.Play(name, scale)`), e.g.
 `tunnel_powerup_collect`, `golden_pop`, `chain_pop`, `streak_milestone`, `pb_fanfare`,

--- a/ConditioningControlPanel/Resources/web/dtrh/race/bubbles.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/bubbles.js
@@ -89,7 +89,7 @@ export function createBubbleField({ scene, layout, media, getIntensity, getRoom,
     const sprite = new THREE.Sprite(mat);
     sprite.visible = false; sprite.layers.set(CRISP_LAYER);
     group.add(sprite);
-    pool.push({ sprite, mat, alive: false, kindId: 'treat', placement: 'lane', d: 0, x: 0, h: LANE_H,
+    pool.push({ sprite, mat, slot: i, eventId: null, alive: false, kindId: 'treat', placement: 'lane', d: 0, x: 0, h: LANE_H,
       x0: 0, baseH: LANE_H, phase: 0, age: 0, size: 1, scale: 1, popT: -1, missed: false });
   }
   const shards = [];
@@ -103,6 +103,9 @@ export function createBubbleField({ scene, layout, media, getIntensity, getRoom,
   let liveCount = 0;
   let lastKartD = 0;
   let density = 1;
+  // With a track loaded the density knob changes what it means: the seeded lanes must keep dressing
+  // the road exactly as they do without one, so density gates the CUE spawns instead (CHART.md).
+  let tracked = false;
   let reachX = POP_HIT_X, reachH = POP_HIT_H;   // the pop box, widened by the magnet item (setReach)
   const popCbs = [], missCbs = [];
   const emit = (cbs, ev) => { for (const cb of cbs) { try { cb(ev); } catch (e) { /* listener bug, not ours */ } } };
@@ -141,7 +144,7 @@ export function createBubbleField({ scene, layout, media, getIntensity, getRoom,
     s.kindId = k.id; s.placement = placement;
     s.d = layout.wrap(d); s.x = clamp(x, -ROAD_HALF_W + 0.4, ROAD_HALF_W - 0.4); s.x0 = s.x;
     s.h = h; s.baseH = h; s.phase = Math.random() * Math.PI * 2; s.age = 0;
-    s.size = sizeOf(k.id); s.scale = placement === 'spawn' ? 0 : 1; s.popT = -1; s.missed = false;
+    s.size = sizeOf(k.id); s.scale = placement === 'spawn' ? 0 : 1; s.popT = -1; s.missed = false; s.eventId = null;
     s.mat.map = texOf[k.id]; s.mat.color.set(k.tint); s.mat.opacity = 1; s.mat.needsUpdate = true;
     s.sprite.scale.setScalar(s.size * s.scale);
     layout.toWorld(s.d, s.x, s.h, s.sprite.position);
@@ -175,7 +178,7 @@ export function createBubbleField({ scene, layout, media, getIntensity, getRoom,
     const len = Math.max(0, chunk.d1 - chunk.d0);
     if (chunk.id === 1 && chunk.room === 'teagarden' && chunk.kind === 'straight') seedStartStraight(chunk);
     else if (chunk.kind !== 'gate' && len > 8) {
-      const lines = Math.max(1, Math.round((len / 26) * density));
+      const lines = Math.max(1, Math.round((len / 26) * (tracked ? 1 : density)));
       for (let l = 0; l < lines; l++) {
         const count = 3 + ((Math.random() * 4) | 0);
         const x = pick(LANES) + rand(-0.3, 0.3);
@@ -206,6 +209,24 @@ export function createBubbleField({ scene, layout, media, getIntensity, getRoom,
   }
   function rain(kartD, n = 1) {
     for (let i = 0; i < n; i++) place(roll('rain'), 'rain', kartD + rand(18, 44), rand(-ROAD_HALF_W + 0.6, ROAD_HALF_W - 0.6), CEILING_H);
+  }
+  /** An explicit placement from a track cue (CHART.md): the run has already worked the depth out at
+   *  the kart's speed, so nothing is rolled or gated by intensity here. Returns the slot id, -1 when
+   *  the pool is full (a cue never steals a live bubble) or when density has gated this one out.
+   *  Over 1, density is the chance of a second bubble beside the first. */
+  function spawnAt({ kindId, placement = 'lane', d, x = 0, h, eventId = null } = {}) {
+    if (liveCount >= CAP) return -1;
+    if (tracked) {
+      if (density <= 0) return -1;
+      if (density < 1 && Math.random() >= density) return -1;
+    }
+    const top = h == null ? (placement === 'rain' ? CEILING_H : placement === 'air' ? 2.6 : LANE_H) : h;
+    const s = place(kindId, placement, d, x, top);
+    s.eventId = eventId;
+    if (tracked && density > 1 && liveCount < CAP && Math.random() < density - 1) {
+      place(kindId, placement, d + 2.4, x + (x > 0 ? -1.1 : 1.1), top).eventId = eventId;
+    }
+    return s.slot;
   }
 
   // ---- pop -----------------------------------------------------------------
@@ -244,7 +265,7 @@ export function createBubbleField({ scene, layout, media, getIntensity, getRoom,
     burst(s, golden);
     const strength = k.strength > 0 ? clamp(k.strength + 0.35 * intensity() + Math.random() * 0.1, 0, 1) : 0;
     emit(popCbs, { id: k.id, kind: k.kind, payload: k.payload, overlayKind: k.overlayKind, strength,
-      points: k.points, placement: s.placement, x: s.x, d: s.d, worldPos: s.sprite.position.clone() });
+      points: k.points, placement: s.placement, x: s.x, d: s.d, eventId: s.eventId, worldPos: s.sprite.position.clone() });
     if (k.id === 'prism' && !chained) {
       for (const o of pool) {
         if (!o.alive || o === s || o.popT >= 0 || o.kindId === 'video') continue;
@@ -288,7 +309,7 @@ export function createBubbleField({ scene, layout, media, getIntensity, getRoom,
         if (rel < -MISS_BEHIND && rel > -DROP_BEHIND - 40 && !s.missed) {
           s.missed = true;
           const k = KIND_BY_ID[s.kindId];
-          if (k.kind === 'treat') emit(missCbs, { id: k.id, points: k.points, d: s.d, x: s.x, h: s.h });
+          if (k.kind === 'treat') emit(missCbs, { id: k.id, points: k.points, d: s.d, x: s.x, h: s.h, eventId: s.eventId });
         }
         if (rel < -DROP_BEHIND && rel > -DROP_BEHIND - 40) { freeSlot(s); continue; }
         if (Math.abs(rel) < POP_HIT_D && Math.abs(s.x - kart.x) < reachX && Math.abs(s.h - kart.h) < reachH) pop(s);
@@ -332,10 +353,12 @@ export function createBubbleField({ scene, layout, media, getIntensity, getRoom,
   }
 
   return {
-    seedChunk, spawnAhead, rain, update, dispose,
+    seedChunk, spawnAhead, rain, spawnAt, update, dispose,
     onPop(cb) { if (typeof cb === 'function') popCbs.push(cb); },
     onMiss(cb) { if (typeof cb === 'function') missCbs.push(cb); },
-    setDensity(mult) { density = clamp(Number(mult) || 1, 0.25, 3); },
+    setDensity(mult) { const v = Number(mult); density = clamp(isFinite(v) ? v : 1, tracked ? 0 : 0.25, 3); },
+    /** A track is loaded: setDensity now gates the cue spawns, not the seeded lanes. */
+    setTracked(on) { tracked = !!on; },
     /** Magnet: widen the pop box (X and H) by mult; 1 restores it. */
     setReach(mult) { const m = clamp(Number(mult) || 1, 0.5, 3); reachX = POP_HIT_X * m; reachH = POP_HIT_H * m; },
     get liveCount() { return liveCount; },

--- a/ConditioningControlPanel/Resources/web/dtrh/race/cues.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/cues.js
@@ -1,0 +1,136 @@
+/* ============================================================================
+ * race/cues.js - a chart event turned into the thing the run does about it.
+ * Implements CHART.md section `race/cues.js` (the plain mapping, PR c2).
+ *
+ * One pure function over a flat table: no three, no DOM, no clock, no state, so it
+ * runs under node beside chart.js. `cueFor` decides WHICH of the things the run
+ * already knows how to spend an event is worth (a bubble, a jump, a mood, a boost)
+ * and never HOW: run.js owns every verb, this file only names them.
+ *
+ * `at` on a spawn is seconds relative to the event's own second: 0 puts the bubble
+ * on the spoken word, 0.5 half a second behind it. run.js turns that into a depth
+ * at the kart's current speed, which is why the pop lands on the word whatever the
+ * player did with the throttle.
+ *
+ * This is deliberately the flat reading of the table. PR c3 makes it sing: weight
+ * and confidence, the act's own colour, the room's bubble bias, EMI's poses. The
+ * ctx fields c3 wants (energy, act, room, intensity) are already handed in here so
+ * that pass never has to touch run.js again.
+ * ==========================================================================*/
+
+import { LANE_H, CEILING_H, ROAD_HALF_W } from './consts.js';
+
+/** A trigger phrase nobody has assigned a bubble to still gets one: the strobe. */
+const FALLBACK_TRIGGER = 'flash';
+/** The lanes a spoken word may land in. Narrower than the road: the kart has to steer, not lunge. */
+const LANE_X = [-1.6, -0.8, 0, 0.8, 1.6];
+/** Height of an air bubble over the road, and how much each one of a drop's three climbs. */
+const AIR_H = 2.6, AIR_RISE = 0.6;
+/** A drop is three golden rings through the air, one on the word and two behind it. */
+const DROP_AT = [0.2, 0.5, 0.8], DROP_X = [-1.1, 0, 1.1];
+/** A peak dumps this many treats out of the ceiling, this far apart. */
+const PEAK_N = 6, PEAK_GAP = 0.25;
+/** The chant's two lanes, and the fallback beat when the analyzer sent no period. */
+const CHANT_X = 1.2, CHANT_PERIOD = 1.2, CHANT_MAX = 16;
+/** A build hands over at most this many seconds of boost. */
+const BOOST_CAP = 4;
+
+const clamp = (v, a, b) => Math.max(a, Math.min(b, v));
+const laneX = (rng) => LANE_X[Math.min(LANE_X.length - 1, (rng() * LANE_X.length) | 0)];
+const spread = (rng) => clamp((rng() * 2 - 1) * (ROAD_HALF_W - 0.8), -ROAD_HALF_W + 0.6, ROAD_HALF_W - 0.6);
+
+/** Every field CHART.md promises, so run.js never has to test for one. */
+function blank() {
+  return { spawn: [], jump: 0, mix: null, mood: null, pose: null, toast: null,
+    word: null, fog: null, boost: 0, density: null, holdSec: 0 };
+}
+
+/** The bubble a spoken trigger wears. The map is built per track from the chart's lexicon. */
+function triggerKind(label, kinds) {
+  const id = (kinds && typeof kinds.get === 'function') ? kinds.get(label) : null;
+  return id || FALLBACK_TRIGGER;
+}
+
+/**
+ * @param event a chart event (race/chart.js normalizeChart shape)
+ * @param ctx { energy, act, room, intensity, rng, triggerKinds } - only rng and triggerKinds are
+ *        read in c2; the rest is the colour c3 mixes in.
+ * @returns the cue, or null for an event kind this build has nothing to say about.
+ */
+export function cueFor(event, ctx = {}) {
+  if (!event || typeof event.kind !== 'string') return null;
+  const rng = typeof ctx.rng === 'function' ? ctx.rng : Math.random;
+  const cue = blank();
+
+  switch (event.kind) {
+    // the voice said a trigger phrase: its own effect bubble, in a lane, with the word on the chrome
+    case 'trigger':
+      cue.spawn.push({ kindId: triggerKind(event.label, ctx.triggerKinds), placement: 'lane', x: laneX(rng), h: LANE_H, at: 0 });
+      cue.word = event.label || null;
+      break;
+
+    // a structure word (drop, deeper, breathe): a plain treat to drive through
+    case 'word':
+      cue.spawn.push({ kindId: 'treat', placement: 'lane', x: laneX(rng), h: LANE_H, at: 0 });
+      break;
+
+    // a number inside a countdown: a golden ring in the air, and the last one throws the kart at it
+    case 'count':
+      cue.spawn.push({ kindId: 'golden', placement: 'air', x: laneX(rng) * 0.5, h: AIR_H, at: 0 });
+      if (event.last) cue.jump = 6;
+      break;
+
+    // the drop: a jump, a spiral over the world, and three golden rings climbing away from the word
+    case 'drop':
+      cue.jump = 7;
+      cue.mix = 'spiral';
+      cue.mood = 'streamed';
+      for (let i = 0; i < DROP_AT.length; i++) {
+        cue.spawn.push({ kindId: 'golden', placement: 'air', x: DROP_X[i], h: AIR_H + i * AIR_RISE, at: DROP_AT[i] });
+      }
+      break;
+
+    // the same phrase over and over: a lane of treats in the chant's own rhythm, side to side
+    case 'chant': {
+      const reps = clamp(Math.round(Number(event.reps) || 3), 1, CHANT_MAX);
+      const period = Number(event.period) > 0 ? Number(event.period) : CHANT_PERIOD;
+      for (let k = 0; k < reps; k++) {
+        cue.spawn.push({ kindId: 'treat', placement: 'lane', x: (k % 2 ? CHANT_X : -CHANT_X), h: LANE_H, at: k * period });
+      }
+      cue.word = event.label || null;
+      break;
+    }
+
+    // the RMS climbing: a push in the back and a thicker road while it lasts
+    case 'build':
+      cue.boost = clamp(Number(event.dur) || 0, 0, BOOST_CAP);
+      cue.density = 1.6;
+      break;
+
+    // the top of the climb: treats out of the ceiling
+    case 'peak':
+      for (let i = 0; i < PEAK_N; i++) {
+        cue.spawn.push({ kindId: 'treat', placement: 'rain', x: spread(rng), h: CEILING_H, at: i * PEAK_GAP });
+      }
+      break;
+
+    // the fall away from a peak: she settles, the road thins out
+    case 'release':
+      cue.mood = 'calm';
+      cue.density = 0.6;
+      break;
+
+    // nothing in the file at all: a fogged straight with nothing in it, for as long as the quiet runs
+    case 'silence':
+      cue.fog = 1;
+      cue.density = 0;
+      cue.holdSec = Math.max(0, Number(event.dur) || 0);
+      break;
+
+    default:
+      return null;
+  }
+  return cue;
+}
+
+// self-check: node race/smoke/track-run-check.mjs walks every kind through this table.

--- a/ConditioningControlPanel/Resources/web/dtrh/race/run.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/run.js
@@ -10,7 +10,14 @@
  * Nothing here subtracts: the run ends only from the Brake (Esc) or the host.
  *
  * Host traffic owned here: sends heartbeat, run-started, sfx, fire-payload
- * (video only), run-ended, exit, exit-done; listens to pause, payout-result.
+ * (video only), run-ended, exit, exit-done, and with a track loaded track-play,
+ * track-pause, track-stop; listens to pause, payout-result.
+ *
+ * TRACK CHARTS (CHART.md): setTrack(chart) hands the run a charted hypno file and
+ * from then on the file is the clock. race/track.js holds the second, the energy
+ * curve and the acts; race/cues.js says what each spoken word is worth; everything
+ * below only spends those on the world it already owns. Without a track not one
+ * line of this changes: the seeded run is the else branch throughout.
  * ==========================================================================*/
 
 import * as THREE from 'three';
@@ -26,6 +33,8 @@ import { createWalls } from './walls.js';
 import { KIND_BY_ID } from './bubbleKinds.js';
 import { createCocktail, CATEGORIES } from './cocktail.js';
 import { createBubbleField } from './bubbles.js';
+import { createTrackState } from './track.js';
+import { cueFor } from './cues.js';
 import { createKart } from './kart.js';
 import { createScore } from './score.js';
 import { createRaceHud } from './hud.js';
@@ -43,6 +52,9 @@ const HEARTBEAT_MS = 2000, PAYOUT_WAIT_MS = 2000, NEAR_MISS_M = 1.15, FOV_BASE =
 const WOBBLE_SCALE = 0.82, WOBBLE_SEC = 0.3;
 const ladderMult = (combo) => { let m = 1; for (const [at, mult] of MULT_LADDER) if (combo >= at) m = mult; return m; };
 const SPAWN_T0 = 2.5, RAIN_T0 = 20, EARLY_SLOW = 1.5;   // the opening drips slower (TREATS_ONLY_SEC)
+// track cues: a bubble never lands nearer than this, an act only re-dresses the world when no gate is
+// this many seconds of road away, and the standalone page logs the scheduler this often (track time).
+const CUE_AHEAD_SEC = 0.25, ACT_GATE_SEC = 6, TRACK_STATS_SEC = 10;
 const clamp = (v, a, b) => Math.max(a, Math.min(b, v));
 const hex = (n) => '#' + ((n >>> 0) & 0xffffff).toString(16).padStart(6, '0');
 
@@ -94,8 +106,11 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     elapsed: 0, t: 0, intensity: intensityFloor, timeScale: 1, jackpotBias: 1, parasol: false, magnet: false,
     flip: false, spawnT: SPAWN_T0, rainT: RAIN_T0, tunnelTime: 0, rush: 0, fov: 72, fovBoost: 0, gates: 0, room: null,
     wasAirborne: false, effects: [], moodHeld: null, moodHold: 0, mood: 'calm', bestAtStart: 0, seed, wobble: 0,
+    trackHold: 0, trackFog: 0, trackPaused: false, statsAt: 0, trackGap: 0,
   };
   const mix = createCocktail({ now: () => S.elapsed });   // THE MIX: one live effect per category (cocktail.js); S.effects mirrors its live slots
+  const TR = createTrackState();      // the loaded track chart: its clock, its energy, its acts (race/track.js)
+  const hosted = bridge.isHosted !== false;   // the standalone page logs where the host would be told
   let W = null;                       // the world: everything that is rebuilt on "again"
   let raf = 0, last = 0, lastBeat = 0, payoutResolve = null;
   let camOverride = null;                // fn(camera, dt, w, camOut) -> false when done (intro.js cameras)
@@ -140,6 +155,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     kart.onEvent((e) => onKart(w, e));
     score.onEvent((e) => onScore(w, e));
     items.onEvent((e) => onItem(w, e));
+    field.setTracked(!!TR.track);
     pixel.retexture(scene);
     return w;
   }
@@ -152,18 +168,19 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
   function resetRunState(runSeed) {
     Object.assign(S, { running: false, paused: false, ended: false, elapsed: 0, t: 0, intensity: intensityFloor, timeScale: 1,
       jackpotBias: 1, parasol: false, magnet: false, spawnT: SPAWN_T0, rainT: RAIN_T0, rush: 0, fovBoost: 0, gates: 0, room: null,
-      wasAirborne: false, effects: [], moodHeld: null, moodHold: 0, mood: 'calm', seed: runSeed });
+      wasAirborne: false, effects: [], moodHeld: null, moodHold: 0, mood: 'calm', seed: runSeed,
+      trackHold: 0, trackFog: 0, trackPaused: false, statsAt: 0, trackGap: 0 });
     setFlip(false); trailClear();
     mix.reset(); S.wobble = 0; clearMixChrome();
     hud.setScore(0); hud.setCombo(0, 1); hud.setBank(0); hud.setSpeed(0); hud.setFraught(0); hud.item(null, 'no item yet');
   }
 
   // ---- rooms ----
-  function enterRoom(w, roomId) {
+  function enterRoom(w, roomId, actName) {
     const first = S.gates === 0;
     const spec = w.dresser.applyRoom(w.fx, roomId, first ? 0.2 : 1.2);
     S.room = spec; S.gates++;
-    hud.banner(spec.name, spec.tagline, hex(spec.colors.banner));
+    hud.banner(actName || spec.name, spec.tagline, hex(spec.colors.banner));
     sfx('depth_change', 0.7);
     if (roomId === 'teagarden' && !first && w.score.state.score > 0) {
       const bestBefore = w.score.state.best;
@@ -183,6 +200,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     }
   }
   function onPop(w, p) {
+    if (p.eventId) TR.taken(p.eventId);
     w.kart.pulseTarget(); w.kart.pose('grab', { side: (p.x == null ? w.kart.state.x : p.x) >= w.kart.state.x ? 1 : -1 });
     if (p.kind === 'treat') return treat(w, p);
     if (S.parasol) { S.parasol = false; hud.toast('parasol', 'item'); return treat(w, p); }
@@ -199,7 +217,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
 
   // ---- THE MIX: actions -> payloadFx + chrome, recipes -> the ledger ----
   const fire = (p, strength, durationMult) => {
-    if (p.payload === 'video') send({ type: 'fire-payload', kind: 'video', strength, durationMult });
+    if (p.payload === 'video') { trackPause(true); send({ type: 'fire-payload', kind: 'video', strength, durationMult }); }
     else payloadFx.applyPayload({ payload: { kind: p.payload, overlay: p.overlayKind }, strength }, { durationMult });
   };
   function clearMixChrome() { root.removeAttribute('data-ov'); root.removeAttribute('data-tint'); if (hud.setTint) hud.setTint(0); }
@@ -306,6 +324,85 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     }
   }
 
+  // ---- the track chart: the file is the clock (CHART.md) ----
+  /** Page -> host, and only when there is a host and a track: the audio has to follow the run. */
+  function trackSend(type, data) { if (hosted && TR.track) send({ type, ...(data || {}) }); }
+  /** The Brake, a host pause and a video pop all stop the voice; anything that resumes starts it. */
+  function trackPause(on) {
+    if (!TR.track || S.trackPaused === !!on) return;
+    S.trackPaused = !!on;
+    trackSend('track-pause', { on: !!on });
+  }
+  /** Load a chart (null goes back to the seeded run). Call before start(), or live for an upgrade. */
+  function setTrack(chart) {
+    const t = TR.setTrack(chart);
+    S.trackHold = 0; S.statsAt = 0;
+    if (W) { W.field.setTracked(!!t); W.field.setDensity(1); if (!t) applyFog(W, 0); }
+    if (bridge.log) bridge.log(t ? `race track: ${t.name}, ${Math.round(t.durationSec)}s, ${TR.stats().countable} to take` : 'race track: cleared');
+    return t;
+  }
+  /** The chart's fog knob rides the tunnel weather: fx.update writes scene.fog every frame, so the
+   *  zone is the only fog dial the run may hold. 0 hands the organic roll back. */
+  function applyFog(w, v) {
+    S.trackFog = clamp(Number(v) || 0, 0, 1);
+    if (w.fx.forceZone) w.fx.forceZone(S.trackFog > 0.4 ? 'pinkfog' : null);
+  }
+  /** A cue's `mix`: pour an effect through THE MIX exactly as a popped bubble of that kind would. */
+  function cueMix(w, kindId) {
+    const k = KIND_BY_ID[kindId];
+    if (!k || k.kind !== 'effect') return;
+    const durationMult = 0.5 + 0.5 * S.intensity;
+    const r = mix.add(k.id, { durationMult });
+    if (r.action === 'held' || r.action === 'ignore') return;
+    pour(w, { id: k.id, payload: k.payload, overlayKind: k.overlayKind }, r, Math.round(clamp(k.strength, 0, 1) * 100), durationMult);
+    if (r.recipe) serve(w, r.recipe);
+  }
+  /** One event off the scheduler, spent on the world. Every spawn goes in at the depth the kart will
+   *  have reached when the voice says it, so the pop lands on the word whatever the throttle did. */
+  function applyCue(w, due) {
+    const ks = w.kart.state;
+    const cue = cueFor(due.event, { energy: TR.intensity, act: TR.act, room: S.room, intensity: S.intensity, rng: w.rng, triggerKinds: TR.triggerKinds });
+    if (!cue) return;
+    for (const sp of cue.spawn) {
+      const d = ks.d + ks.speed * Math.max(due.dueIn + (sp.at || 0), CUE_AHEAD_SEC);
+      w.field.spawnAt({ kindId: sp.kindId, placement: sp.placement, d, x: sp.x, h: sp.h, eventId: due.event.id });
+    }
+    if (cue.jump) { ks.vh = Math.max(ks.vh, cue.jump); ks.h = Math.max(ks.h, 0.06); ks.airborne = true; w.kart.pose('air'); }
+    if (cue.mix) cueMix(w, cue.mix);
+    if (cue.mood) poke(cue.mood, Math.max(1.2, cue.holdSec));
+    if (cue.pose) w.kart.pose(cue.pose);
+    if (cue.toast) hud.toast(cue.toast.text, cue.toast.kind || 'effect');
+    if (cue.word) hud.toast(cue.word, 'effect');
+    if (cue.fog != null) applyFog(w, cue.fog);
+    if (cue.boost) w.kart.applyBoost(cue.boost);
+    if (cue.density != null) w.field.setDensity(cue.density);
+    if (cue.holdSec > 0) S.trackHold = cue.holdSec;
+  }
+  /** The act moved with no gate in reach: dress the new room where we stand and marquee its name. */
+  function actMoved(w, act, ks) {
+    if (!act) return;
+    for (const f of w.layout.featuresBetween(ks.d, ks.d + Math.max(20, ks.speed * ACT_GATE_SEC))) if (f.type === 'gate') return;
+    S.room = w.dresser.applyRoom(w.fx, act.room, 2.5);
+    S.gates++;
+    hud.banner(act.name, S.room.tagline, hex(S.room.colors.banner));
+    sfx('depth_change', 0.6);
+  }
+  /** One frame of the track. Returns true when the file is over and the run has been ended. */
+  function trackFrame(w, ts) {
+    const ks = w.kart.state;
+    if (S.trackHold > 0) { S.trackHold -= ts.dt; if (S.trackHold <= 0) { applyFog(w, 0); w.field.setDensity(1); } }
+    for (const due of TR.due(ks.d, ks.speed)) applyCue(w, due);
+    if (ts.actChanged) actMoved(w, ts.act, ks);
+    if (ts.dt > S.trackGap) S.trackGap = ts.dt;   // the worst frame the scheduler had to reach over
+    if (!hosted && ts.t - S.statsAt >= TRACK_STATS_SEC) {   // standalone dev aid: the scheduler on the console
+      S.statsAt = ts.t;
+      if (bridge.log) bridge.log(`track ${ts.t.toFixed(0)}s gap ${S.trackGap.toFixed(2)}s ${JSON.stringify(TR.stats())}`);
+      S.trackGap = 0;
+    }
+    if (ts.ended) { endRun(); return true; }
+    return false;
+  }
+
   // ---- kart events (drift turbo, tricks, the wheel, laps) ----
   const TURBO = ['', 'mini turbo', 'super turbo', 'ultra turbo'];
   function onKart(w, e) {
@@ -324,7 +421,10 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
   function step(w, dt) {
     const k = w.kart, ks = k.state, lay = w.layout;
     S.elapsed += dt;
-    S.intensity = clamp(Math.max(intensityFloor, S.elapsed / INTENSITY_RAMP_SEC), 0, 1);
+    // with a track the intensity is the file's energy curve (smoothed, floored), not the clock ramp.
+    // step() takes no delta: the voice runs on the wall, never on the run's clamped frame (track.js).
+    const ts = TR.step();
+    S.intensity = clamp(Math.max(intensityFloor, ts ? ts.intensity : S.elapsed / INTENSITY_RAMP_SEC), 0, 1);
     const wdt = dt * S.timeScale;                     // the world clock (tea_time); the kart keeps real time
     S.t += wdt;
     const prevD = ks.d;
@@ -341,18 +441,23 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
 
     // bubbles: seed the chunks ahead, drip spawns, rain bursts
     for (const c of lay.chunks) { const rel = lay.wrap(c.d0 - ks.d + lay.totalDepth / 2) - lay.totalDepth / 2; if (rel > -20 && rel < 250) w.field.seedChunk(c); }
-    const early = S.elapsed < TREATS_ONLY_SEC ? EARLY_SLOW : 1;
-    S.spawnT -= wdt;
-    if (S.spawnT <= 0) { w.field.spawnAhead(ks.d, 1 + Math.round(S.intensity * 2)); S.spawnT = (3.4 - 1.8 * S.intensity) * early; }
-    S.rainT -= wdt;
-    if (S.rainT <= 0) { w.field.rain(ks.d, 3 + Math.round(S.intensity * 4)); S.rainT = (S.room && S.room.loud ? 9 : 14) * (1 - 0.5 * S.intensity) * early; }
+    // a track owns the spawns outright: the random drip and the rain bursts stand down, seedChunk
+    // still dresses the chunks ahead so the road never looks empty between the spoken words
+    if (ts) { if (trackFrame(w, ts)) return; }
+    else {
+      const early = S.elapsed < TREATS_ONLY_SEC ? EARLY_SLOW : 1;
+      S.spawnT -= wdt;
+      if (S.spawnT <= 0) { w.field.spawnAhead(ks.d, 1 + Math.round(S.intensity * 2)); S.spawnT = (3.4 - 1.8 * S.intensity) * early; }
+      S.rainT -= wdt;
+      if (S.rainT <= 0) { w.field.rain(ks.d, 3 + Math.round(S.intensity * 4)); S.rainT = (S.room && S.room.loud ? 9 : 14) * (1 - 0.5 * S.intensity) * early; }
+    }
     w.field.update(wdt, S.t, ks);
 
     // track features crossed this frame
     for (const f of lay.featuresBetween(prevD, ks.d)) {
       if (f.type === 'boost' && !ks.airborne && Math.abs(f.x - ks.x) <= 1.2) { k.applyBoost(1.6); sfx('tunnel_powerup_collect', 0.8); shake.shake(0.25, 200); poke('streamed', 1.2); k.pose('boost'); }
       else if (f.type === 'itembox' && Math.abs(f.x - ks.x) <= 1.2 && w.dresser.breakItemBox(f)) { shake.shake(0.2, 120); if (w.items.roll(w.score.state.mult)) sfx('ui_click', 0.5); }
-      else if (f.type === 'gate') enterRoom(w, f.room);
+      else if (f.type === 'gate') enterRoom(w, ts && ts.act ? ts.act.room : f.room, ts && ts.act ? ts.act.name : null);
     }
     if (S.wasAirborne && !ks.airborne) { shake.shake(0.8, 300); poke('smug', 0.7); }
     S.wasAirborne = ks.airborne;
@@ -409,12 +514,12 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
   async function brake() {
     if (!W || !S.running || S.ended || S.paused) return;
     S.paused = true; sfx('ui_click', 0.5);
-    audio.duck(true, 'brake');
+    audio.duck(true, 'brake'); trackPause(true);
     const pick = await hud.setPaused(true);
     if (S.disposed || !S.paused) return;
     if (pick === 'end') return endRun();
     S.paused = false;
-    audio.duck(false, 'brake');
+    audio.duck(false, 'brake'); trackPause(false);
   }
   function waitPayout(ms) {
     return new Promise((res) => { const t = setTimeout(() => { payoutResolve = null; res(null); }, ms); payoutResolve = (m) => { clearTimeout(t); payoutResolve = null; res(m); }; });
@@ -428,7 +533,10 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     const summary = { score: st.score, banked: st.banked, bestCombo: st.bestCombo, popped: st.popped, treats: st.treats, effects: st.effects,
       nearMisses: st.nearMisses, laps: w.kart.state.lap, durationSec: Math.round(S.elapsed), seed: S.seed,
       personalBest: st.banked + st.score > S.bestAtStart && st.banked + st.score > 0 };
-    send({ type: 'run-ended', ...summary });
+    const track = TR.summary();   // "you took N of M" on a charted run (the results screen is PR c7)
+    if (track) Object.assign(summary, { taken: track.taken, countable: track.countable, trackName: track.name });
+    send({ type: 'run-ended', ...summary, ...(track ? { track } : {}) });
+    trackSend('track-stop');
     sfx('surface', 0.8);
     audio.duck(true, 'end');
     setCameraOverride(resultsCamera({ tier: resultTier(st.banked + st.score, S.bestAtStart, summary.personalBest), reducedMotion }));   // she turns to face the card
@@ -448,6 +556,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     hud.countdown().then(start);
   }
   function exit() {
+    trackSend('track-stop');
     send({ type: 'exit' });
     dispose();
     send({ type: 'exit-done' });
@@ -470,10 +579,11 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     S.room = W.dresser.applyRoom(W.fx, W.layout.roomAtDepth(0), 0.2);   // the gate 9 m in shows the banner
     W.kart.setMood('calm');
     send({ type: 'run-started', seed: S.seed });
+    if (TR.track) { S.trackPaused = false; trackSend('track-play', { name: TR.track.name }); }
     last = 0;
   }
   /** Host pause (native video playing etc): freezes the frame, no Brake screen. */
-  function setPaused(on) { S.hostPaused = !!on; if (!on) last = 0; audio.duck(!!on, 'host'); }
+  function setPaused(on) { S.hostPaused = !!on; if (!on) last = 0; audio.duck(!!on, 'host'); trackPause(!!on); }
   function dispose() {
     if (S.disposed) return;
     S.disposed = true;
@@ -494,7 +604,12 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
   raf = requestAnimationFrame(frame);
   function setCameraOverride(fn) { camOverride = typeof fn === 'function' ? fn : null; }
   function setStage(s) { stage = s && typeof s.update === 'function' ? s : null; if (!stage) pixel.retexture(scene); }   // the menu may have changed the block
-  return { start, setPaused, dispose, setCameraOverride, setStage, reseed, renderer, pixel, audio, hud, camera };
+  return { start, setPaused, dispose, setCameraOverride, setStage, reseed, renderer, pixel, audio, hud, camera,
+    // track charts (CHART.md): setTrack before start(), replaceTrack for the words pass landing live,
+    // trackClock for the host's 250 ms tick, trackEnded when the file runs out at the host's end
+    setTrack, replaceTrack: (chart) => TR.replace(chart), trackClock: (t, playing) => TR.clock(t, playing),
+    trackEnded: () => { TR.end(); if (TR.track && S.running) endRun(); },
+    get track() { return TR.track; } };
 }
 
 // self-check: node --check is the bar; everything touches the DOM inside createRace.

--- a/ConditioningControlPanel/Resources/web/dtrh/race/smoke/track-run-check.mjs
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/smoke/track-run-check.mjs
@@ -1,0 +1,196 @@
+/* ============================================================================
+ * race/smoke/track-run-check.mjs - node self-check for race/track.js + race/cues.js.
+ *
+ *   node race/smoke/track-run-check.mjs      (exits 0 on pass, 1 with a count of failures)
+ *
+ * run.js itself cannot be driven here: it builds a WebGLRenderer and reads the DOM
+ * on the first line of createRace. So the two halves that CAN be pure are, and this
+ * walks them the way run.js does: the demo track at 60 Hz behind a kart holding
+ * KART_BASE_SPEED, the scheduler's events run through cueFor, every spawn placed at
+ * the same depth run.js computes, into a stub field with bubbles.js's pool rules.
+ *
+ * In order: setTrack fills the CHART.md track object; the clock only moves while the
+ * host says playing and a tick snaps it; intensity follows the energy curve smoothed
+ * with a floor; the acts arrive in order, once each, never the opening one twice;
+ * every event kind has a cue and every cue field is legal; a whole run spawns
+ * everything ahead of the kart; the run ends inside END_PAD of the duration and the
+ * summary counts what the player took; replace() keeps the clock and the taken ids.
+ * ==========================================================================*/
+
+import { KART_BASE_SPEED, LANE_H, CEILING_H, ROAD_HALF_W, makeRng } from '../consts.js';
+import { demoChart, EVENT_KINDS } from '../chart.js';
+import { KIND_BY_ID } from '../bubbleKinds.js';
+import { createTrackState } from '../track.js';
+import { cueFor } from '../cues.js';
+
+let fails = 0;
+const ok = (cond, what) => { if (!cond) { console.error('FAIL ' + what); fails++; } else console.log('  ok  ' + what); };
+
+const DUR = 240, SPEED = KART_BASE_SPEED, STEP = 1 / 60, CUE_AHEAD_SEC = 0.25, CAP = 160;
+const MOODS = ['calm', 'streamed', 'fraught', 'smug', 'shock', 'jackpot'];
+const PLACEMENTS = ['lane', 'air', 'spawn', 'rain'];
+const chart = demoChart(DUR);
+
+/** The bubble field run.js spawns into, with bubbles.js's pool cap and density gate. */
+function stubField() {
+  const live = [];
+  let density = 1;
+  return {
+    spawnAt({ kindId, placement, d, x, h, eventId }) {
+      if (live.length >= CAP) return -1;
+      if (density <= 0) return -1;
+      live.push({ kindId, placement, d, x, h, eventId });
+      return live.length - 1;
+    },
+    setDensity(m) { density = m; },
+    get live() { return live; },
+    get density() { return density; },
+  };
+}
+
+/* ---- 1. setTrack, the clock and the intensity --------------------------- */
+{
+  const st = createTrackState();
+  ok(st.track === null && st.step(1) === null, 'no track: step() is null and the seeded run is untouched');
+  const tr = st.setTrack(chart);
+  ok(!!tr && tr.chart === chart && tr.name === 'the demo track' && tr.durationSec === DUR, 'setTrack fills { chart, sched, t, playing, name, durationSec }');
+  ok(tr.t === 0 && tr.playing === false, 'and the clock starts at 0, stopped');
+  ok(st.step(0.5).t === 0, 'a stopped clock does not move on step()');
+  st.clock(0, true);
+  let n = 0;
+  for (let i = 0; i < 60; i++) { st.step(STEP); n++; }
+  ok(Math.abs(tr.t - n * STEP) < 1e-6, 'a playing clock integrates the frame time: ' + tr.t.toFixed(3) + ' s');
+  st.clock(90, true);
+  ok(tr.t === 90, 'a host tick snaps the second');
+  st.clock(90, false);
+  st.step(1);
+  ok(tr.t === 90, 'and playing:false freezes it again (the Brake, a host pause, a video pop)');
+
+  st.clock(0, true);
+  let floored = true, tracked = 0;
+  for (let t = 0; t < DUR; t += 0.25) {
+    const s = st.step(0.25);
+    if (s.intensity < 0.05 - 1e-9 || s.intensity > 1) floored = false;
+    if (Math.abs(s.intensity - chartEnergy(s.t)) < 0.12) tracked++;
+  }
+  ok(floored, 'intensity stays inside [0.05, 1] for the whole file');
+  ok(tracked > 700, 'and follows the energy curve within 0.12 for ' + tracked + ' of 960 samples');
+}
+function chartEnergy(t) {
+  const i = Math.max(0, Math.min(chart.energy.length - 1, Math.floor(t / chart.binSec)));
+  return chart.energy[i];
+}
+
+/* ---- 2. the acts -------------------------------------------------------- */
+{
+  const st = createTrackState();
+  st.setTrack(chart);
+  st.clock(0, true);
+  const changes = [];
+  for (let t = 0; t < DUR; t += STEP) { const s = st.step(STEP); if (s.actChanged) changes.push(s.act.id); }
+  ok(changes.length === chart.acts.length - 1, 'every act after the opening one announces itself once: ' + changes.length);
+  ok(changes.every((id, i) => id === i + 1), 'and they arrive in order: ' + changes.join(', '));
+  ok(chart.acts.every((a) => !!a.name && !!a.room), 'every act carries the name and room the MARQUEE needs');
+}
+
+/* ---- 3. the cue table --------------------------------------------------- */
+{
+  const rng = makeRng(7);
+  const triggerKinds = createTrackState();
+  triggerKinds.setTrack(chart);
+  const ctx = { energy: 0.5, act: chart.acts[0], room: null, intensity: 0.5, rng, triggerKinds: triggerKinds.triggerKinds };
+  const seen = new Set();
+  let bad = '';
+  for (const e of chart.events) {
+    const cue = cueFor(e, ctx);
+    if (!cue) { bad = bad || ('no cue for ' + e.kind); continue; }
+    seen.add(e.kind);
+    for (const sp of cue.spawn) {
+      if (!KIND_BY_ID[sp.kindId]) bad = bad || ('unknown bubble kind ' + sp.kindId + ' from ' + e.kind);
+      if (!PLACEMENTS.includes(sp.placement)) bad = bad || ('bad placement ' + sp.placement);
+      if (!(Math.abs(sp.x) <= ROAD_HALF_W)) bad = bad || ('x off the road: ' + sp.x);
+      if (!(sp.h >= 0 && sp.h <= CEILING_H)) bad = bad || ('h out of the tube: ' + sp.h);
+      if (!(sp.at >= 0)) bad = bad || ('at before the word: ' + sp.at);
+    }
+    if (cue.mood && !MOODS.includes(cue.mood)) bad = bad || ('unknown mood ' + cue.mood);
+    if (cue.mix && !KIND_BY_ID[cue.mix]) bad = bad || ('unknown mix kind ' + cue.mix);
+    if (cue.boost < 0 || cue.boost > 4) bad = bad || ('boost out of range ' + cue.boost);
+  }
+  ok(!bad, bad || 'every cue names a real bubble kind, placement, mood and mix');
+  ok(EVENT_KINDS.every((k) => seen.has(k)), 'the demo track exercised all nine event kinds');
+  ok(cueFor(null, ctx) === null && cueFor({ kind: 'nonsense' }, ctx) === null, 'a junk event is null, never a throw');
+
+  const t = cueFor({ kind: 'trigger', label: 'good girl' }, ctx);
+  ok(t.spawn.length === 1 && KIND_BY_ID[t.spawn[0].kindId].kind === 'effect' && t.word === 'good girl', 'a trigger is one effect bubble and the word: ' + t.spawn[0].kindId);
+  ok(cueFor({ kind: 'trigger', label: 'never analysed' }, ctx).spawn[0].kindId === 'flash', 'an unmapped phrase falls back to flash');
+  const w = cueFor({ kind: 'word', label: 'deeper' }, ctx);
+  ok(w.spawn.length === 1 && w.spawn[0].kindId === 'treat' && w.spawn[0].h === LANE_H, 'a structure word is one lane treat');
+  const c = cueFor({ kind: 'count', label: '1', n: 1, of: 10, last: true }, ctx);
+  ok(c.spawn[0].kindId === 'golden' && c.spawn[0].placement === 'air' && c.jump === 6, 'the last of a countdown is a golden air bubble and a jump');
+  const dr = cueFor({ kind: 'drop', strength: 1 }, ctx);
+  ok(dr.jump === 7 && dr.mix === 'spiral' && dr.mood === 'streamed' && dr.spawn.length === 3, 'a drop is jump 7, a spiral and three rings');
+  ok(dr.spawn.map((s) => s.at).join() === '0.2,0.5,0.8', 'the three land at 0.2, 0.5, 0.8');
+  const ch = cueFor({ kind: 'chant', label: 'good girl', reps: 5, period: 2.4 }, ctx);
+  ok(ch.spawn.length === 5 && ch.spawn.every((s, i) => Math.abs(s.at - i * 2.4) < 1e-9), 'a chant is one treat per rep on the chant beat');
+  ok(new Set(ch.spawn.map((s) => s.x)).size === 2, 'alternating between two lanes');
+  const b = cueFor({ kind: 'build', dur: 9 }, ctx);
+  ok(b.boost === 4 && b.density === 1.6, 'a build caps the boost at 4 s and thickens the road');
+  ok(cueFor({ kind: 'peak' }, ctx).spawn.filter((s) => s.placement === 'rain').length === 6, 'a peak is six rain treats');
+  const rl = cueFor({ kind: 'release' }, ctx);
+  ok(rl.mood === 'calm' && rl.density === 0.6, 'a release calms her and thins the road');
+  const si = cueFor({ kind: 'silence', dur: 12 }, ctx);
+  ok(si.fog === 1 && si.density === 0 && si.holdSec === 12, 'silence is fog, nothing on the road, for as long as the quiet runs');
+}
+
+/* ---- 4. a whole run ----------------------------------------------------- */
+{
+  const st = createTrackState();
+  st.setTrack(chart);
+  st.clock(0, true);
+  const field = stubField(), rng = makeRng(3);
+  let d = 0, ended = 0, endedAt = 0, behind = 0, hold = 0, spawns = 0;
+  for (let t = 0; t <= DUR + 1 && !ended; t += STEP) {
+    const s = st.step(STEP);
+    d += SPEED * STEP;
+    if (hold > 0) { hold -= STEP; if (hold <= 0) field.setDensity(1); }
+    for (const due of st.due(d, SPEED)) {
+      const cue = cueFor(due.event, { energy: s.intensity, act: s.act, room: null, intensity: s.intensity, rng, triggerKinds: st.triggerKinds });
+      if (!cue) continue;
+      for (const sp of cue.spawn) {
+        const at = d + SPEED * Math.max(due.dueIn + (sp.at || 0), CUE_AHEAD_SEC);
+        if (at <= d) behind++;
+        if (field.spawnAt({ kindId: sp.kindId, placement: sp.placement, d: at, x: sp.x, h: sp.h, eventId: due.event.id }) >= 0) spawns++;
+      }
+      if (cue.density != null) field.setDensity(cue.density);
+      if (cue.holdSec > 0) hold = cue.holdSec;
+      if (due.event.kind === 'trigger' || due.event.kind === 'word') st.taken(due.event.id);
+    }
+    if (s.ended) { ended = 1; endedAt = s.t; }
+  }
+  ok(ended === 1, 'the run ended on its own');
+  ok(endedAt >= DUR - 0.25 - STEP && endedAt <= DUR, 'and inside the end pad: ' + endedAt.toFixed(2) + ' of ' + DUR + ' s');
+  ok(behind === 0, 'no cue bubble was ever placed behind the kart');
+  ok(spawns >= 40 && spawns === field.live.length, spawns + ' cue bubbles went in, none of them gated out by a full pool');
+  ok(field.live.every((b) => !!b.eventId), 'every one of them carries its event id back for the pop');
+  const sum = st.summary();
+  const took = chart.events.filter((e) => e.kind === 'trigger' || e.kind === 'word').length;
+  ok(sum.taken === took && sum.countable >= took, 'the summary counts ' + sum.taken + ' taken of ' + sum.countable + ' countable');
+  ok(sum.name === 'the demo track' && sum.hash === 'demo' && sum.durationSec === DUR, 'and names the file for run-ended');
+}
+
+/* ---- 5. the words pass landing live ------------------------------------- */
+{
+  const st = createTrackState();
+  st.setTrack(demoChart({ durationSec: DUR, seed: 1 }));
+  st.clock(120, true);
+  st.step(STEP);
+  st.taken('d0');
+  const before = st.stats().taken;
+  st.replace(demoChart({ durationSec: DUR, seed: 1 }));
+  ok(Math.abs(st.track.t - 120) < 0.1, 'replace() keeps the clock where it was: ' + st.track.t.toFixed(2) + ' s');
+  ok(st.stats().taken === before, 'and keeps what the player had already taken');
+  ok(st.setTrack(null) === null && st.track === null, 'setTrack(null) hands the seeded run back');
+}
+
+console.log(fails ? '\ntrack-run-check: ' + fails + ' failure(s)' : '\ntrack-run-check: all good');
+process.exit(fails ? 1 : 0);

--- a/ConditioningControlPanel/Resources/web/dtrh/race/track.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/track.js
@@ -1,0 +1,144 @@
+/* ============================================================================
+ * race/track.js - the loaded track: its clock, its intensity and its acts.
+ * Implements the state half of CHART.md section `race/run.js + raceBoot.js`.
+ *
+ * Split out of run.js so the run brain stays about the world and this stays about
+ * the file. Nothing here imports three or touches the DOM, so the whole clock runs
+ * under node (`node race/smoke/track-run-check.mjs`).
+ *
+ * The clock is the file. `clock(t, playing)` is the host's 250 ms tick and is the
+ * only thing that ever SETS the second; `step()` walks it forward between ticks off
+ * performance.now(), and only while the host says it is playing. It reads the wall
+ * itself rather than taking the run's frame delta on purpose: run.js clamps a frame
+ * to 0.1 s so one long stall cannot teleport the kart, and a clock that inherited
+ * that clamp would fall behind the voice on a slow machine and then be yanked
+ * forward by the next host tick, dropping every word in between. `step(dt)` with an
+ * explicit delta is the node harness's door in. A pause stops step advancing at all,
+ * which is why the Brake, a host pause and a video pop all freeze the voice.
+ *
+ * One frame may still only carry MAX_STEP_SEC of the file. Integrating between 250 ms
+ * ticks is all this is for, so a page that was backgrounded, hitched or fast-forwarded
+ * must not leap the clock over whole words on the frame it comes back: it walks, and
+ * the host's next tick puts it where the audio actually is.
+ * ==========================================================================*/
+
+import { createScheduler } from './chart.js';
+import { BUBBLE_KINDS } from './bubbleKinds.js';
+
+/** Intensity never quite reaches zero: even a silent stretch keeps the tube alive. */
+const FLOOR = 0.05;
+/** Seconds the intensity takes to follow the energy curve (CHART.md: smoothed over 2 s). */
+const SMOOTH_SEC = 2;
+/** The run ends this far before the last sample rather than on a clock that may never arrive. */
+const END_PAD = 0.25;
+/** The most of the file one frame may carry on its own: see the header. */
+const MAX_STEP_SEC = 1;
+/** The effect bubbles a trigger phrase may wear, dealt round robin over the chart's lexicon. */
+const TRIGGER_KINDS = ['flash', 'subliminal', 'pink', 'spiral', 'glitch', 'freeze']
+  .filter((id) => BUBBLE_KINDS.some((k) => k.id === id));
+
+const clamp01 = (v) => (v < 0 ? 0 : v > 1 ? 1 : v);
+
+/**
+ * Every distinct trigger phrase in the chart gets its own bubble, the same one every time the file
+ * is loaded: the lexicon and the spoken labels sorted, then dealt round robin. The player learns
+ * "good girl is the pink one" over a track and that reading holds for the whole file.
+ */
+function mapTriggers(chart) {
+  const m = new Map();
+  const words = new Set();
+  for (const w of chart.analysis.lexicon || []) if (w) words.add(String(w).toLowerCase());
+  for (const e of chart.events) if (e.kind === 'trigger' && e.label) words.add(e.label);
+  [...words].sort().forEach((w, i) => m.set(w, TRIGGER_KINDS[i % TRIGGER_KINDS.length]));
+  return m;
+}
+
+/**
+ * createTrackState() -> the run's one handle on the loaded file. `track` is the CHART.md object
+ * ({ chart, sched, t, playing, name, durationSec }) or null for the seeded run.
+ */
+export function createTrackState(opts = {}) {
+  const leadSec = opts.leadSec;
+  const now = typeof opts.now === 'function' ? opts.now
+    : (typeof performance === 'object' && performance && performance.now) ? () => performance.now() : () => Date.now();
+  let track = null, sched = null, triggerKinds = new Map();
+  let intensity = FLOOR, act = null, ended = false, mark = 0;
+
+  /** Load a chart (or null to go back to the seeded run). Returns the new `track`. */
+  function setTrack(chart) {
+    if (!chart) { track = null; sched = null; triggerKinds = new Map(); intensity = FLOOR; act = null; ended = false; return null; }
+    sched = createScheduler(chart, leadSec != null ? { leadSec } : {});
+    const ch = sched.chart;
+    triggerKinds = mapTriggers(ch);
+    intensity = Math.max(FLOOR, sched.energyAt(0));
+    act = sched.actAt(0);            // the opening act is where we already are, never a change
+    ended = false; mark = 0;
+    track = { chart: ch, sched, t: 0, playing: false, name: ch.source.name, durationSec: ch.source.durationSec };
+    return track;
+  }
+
+  /** The words pass landing on a partial chart: keep the clock, adopt only what is still ahead. */
+  function replace(chart) {
+    if (!track) return setTrack(chart);
+    const ch = sched.replace(chart);
+    track.chart = ch;
+    track.name = ch.source.name;
+    track.durationSec = ch.source.durationSec;
+    triggerKinds = mapTriggers(ch);
+    return track;
+  }
+
+  /** The host's clock tick. The only thing that sets the second; `playing` gates step(). */
+  function clock(t, playing) {
+    if (!track) return;
+    const v = Number(t);
+    if (isFinite(v)) track.t = Math.max(0, Math.min(track.durationSec, v));
+    track.playing = playing !== false;
+    mark = now();
+  }
+
+  /**
+   * One frame. Walks the clock on between host ticks off the wall, eases the intensity toward the
+   * energy curve and reports the act. `dt` overrides the wall (the node harness). Null without a track.
+   */
+  function step(dt) {
+    if (!track) return null;
+    const at = now();
+    const given = Number(dt);
+    const d = isFinite(given) && given >= 0 ? given
+      : Math.min(MAX_STEP_SEC, Math.max(0, mark ? (at - mark) / 1000 : 0));
+    mark = at;
+    if (track.playing && !ended) track.t = Math.min(track.durationSec, track.t + d);
+    const target = Math.max(FLOOR, sched.energyAt(track.t));
+    intensity += (target - intensity) * Math.min(1, d / SMOOTH_SEC);
+    const a = sched.actAt(track.t);
+    const actChanged = !!a && (!act || a.id !== act.id);
+    if (a) act = a;
+    if (!ended && track.t >= track.durationSec - END_PAD) ended = true;
+    return { t: track.t, dt: d, intensity: Math.max(FLOOR, clamp01(intensity)), act, actChanged, ended };
+  }
+
+  return {
+    setTrack, replace, clock, step,
+    /** Everything the scheduler wants spawned this frame, each with the depth it belongs at. */
+    due(kartD, kartSpeed) { return track ? sched.update(track.t, kartD, kartSpeed) : []; },
+    /** The player met this event: popped its bubble, took its drop. */
+    taken(id) { if (sched) sched.taken(id); },
+    stats() { return sched ? sched.stats() : { total: 0, fired: 0, countable: 0, taken: 0, missed: 0 }; },
+    /** The end-of-run fields CHART.md adds to the summary and to `run-ended`. */
+    summary() {
+      if (!track) return null;
+      const s = sched.stats();
+      return { name: track.name, hash: track.chart.source.hash, durationSec: track.durationSec, taken: s.taken, countable: s.countable };
+    },
+    /** The host said the file is over, wherever our clock had got to. */
+    end() { ended = true; },
+    get track() { return track; },
+    get act() { return act; },
+    get intensity() { return Math.max(FLOOR, clamp01(intensity)); },
+    get triggerKinds() { return triggerKinds; },
+    get ended() { return ended; },
+  };
+}
+
+// self-check: node race/smoke/track-run-check.mjs drives a whole demo track through this.

--- a/ConditioningControlPanel/Resources/web/dtrh/raceBoot.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/raceBoot.js
@@ -24,6 +24,13 @@
  * into the intro and `?hold=ms` freezes it at that intro time (screenshots);
  * `?pixel=N` (0 = off) beats `race.options` which beats `settings.pixel` from
  * the host init.
+ *
+ * TRACK CHARTS (CHART.md): the host posts track-progress / track-chart /
+ * track-clock / track-ended / track-error and this file hands them to the run.
+ * Standalone there is no host, so `?chart=demo&dur=240` builds the demo chart and
+ * `?chart=<url>` fetches one; `?audio=<url>` plays an <audio> element and its
+ * currentTime is the clock, and without it the clock is wall time. Either way the
+ * page ticks race.trackClock on the host's own 250 ms cadence.
  * ==========================================================================*/
 
 import * as bridge from './bridge.js';
@@ -31,11 +38,12 @@ import { detectMode } from './shared/capability.js';
 import { setQuality } from './shared/quality.js';
 import { createHostMediaSource } from './hostMedia.js';
 
-const INIT_TIMEOUT_MS = 4000, SPLASH_MS = 1000;
+const INIT_TIMEOUT_MS = 4000, SPLASH_MS = 1000, TRACK_TICK_MS = 250;
 const params = new URLSearchParams(location.search);
 const hosted = bridge.isHosted;
 const host = hosted ? bridge : {
   on: bridge.on,
+  isHosted: false,
   send: (m) => { try { console.log('[race->host]', JSON.stringify(m)); } catch (e) { console.log('[race->host]', m); } },
   log: (m) => console.log('[race->host] log', String(m)),
   announceReady: () => console.log('[race->host] ready (standalone)'),
@@ -49,6 +57,7 @@ const media = createHostMediaSource();
 const rollSeed = () => (Date.now() ^ Math.floor(Math.random() * 0x7fffffff)) >>> 0;
 let initMsg = null, haveManifest = false, race = null, menu = null, booted = false, started = false, exiting = false;
 let settings = {}, seed = 0;
+let trackProgress = null, startTrackClock = null, trackTimer = 0, trackAudio = null;
 
 const note = (t) => { if (waitEl) waitEl.textContent = t || ''; };
 function fail(err) {
@@ -83,10 +92,28 @@ bridge.on('favorites', (m) => { try { media.setFavorites(m && m.names || []); } 
 bridge.on('ping', (m) => host.send({ type: 'pong', t: m && m.t }));
 bridge.on('fullscreen', (m) => host.send({ type: 'fullscreen-set', on: !!(m && m.on) }));
 bridge.on('exit-request', surface);
+// ---- track charts (CHART.md host protocol). The run owns the clock; this only relays. ----
+bridge.on('track-chart', (m) => {
+  if (!race || !m || !m.chart) return;
+  try { (race.track && started) ? race.replaceTrack(m.chart) : race.setTrack(m.chart); }
+  catch (err) { host.log('track-chart: ' + ((err && err.message) || err)); trackError(String((err && err.message) || err)); }
+});
+bridge.on('track-clock', (m) => { if (race && m) race.trackClock(Number(m.t) || 0, m.playing !== false); });
+bridge.on('track-ended', () => { if (race) race.trackEnded(); });
+bridge.on('track-error', (m) => trackError((m && m.message) || 'the track would not load'));
+bridge.on('track-progress', (m) => {   // the menu's progress plate is PR c7; hold it for that
+  trackProgress = m || null;
+  host.log(`track-progress: ${(m && m.stage) || '?'} ${Math.round(((m && m.pct) || 0) * 100)}% ${(m && m.name) || ''}`);
+});
+function trackError(message) {
+  host.log('track-error: ' + message);
+  try { if (race && race.hud) race.hud.toast(String(message).slice(0, 60).toLowerCase(), 'effect'); } catch (e) { /* no hud yet */ }
+}
 /** The one exit: the menu's `surface` and the host's exit-request (the End screen's own goes through run.js). */
 function surface() {
   if (exiting) return;
   exiting = true;
+  stopTrackClock();
   try { if (menu) menu.dispose(); } catch (e) { host.log('menu dispose: ' + e); }
   try { if (race) race.dispose(); } catch (e) { host.log('exit dispose: ' + e); }
   host.send({ type: 'exit' });
@@ -123,6 +150,7 @@ async function boot() {
     race = createRace({ root, bridge: host, media, settings, seed });
     note('');
     host.log(`race booted: seed ${seed} (${opts.seed}), tier ${mode.tier}, hosted ${hosted}, manifest ${haveManifest}`);
+    await standaloneTrack();
     if (params.get('autostart') === '1') { startRun(false); return; }
     if (hudRoot) hudRoot.classList.add('is-lobby');   // the run's chrome stays out of the menu and the intro
     menu = createMenu({ root, renderer: race.renderer, pixel: race.pixel, audio: race.audio, settings, log: host.log });
@@ -140,6 +168,48 @@ async function boot() {
   } catch (err) {
     fail(err);
   }
+}
+
+/**
+ * No host, but a track was asked for on the query string: `?chart=demo&dur=240` builds the demo
+ * chart, `?chart=<url>` fetches one. `?audio=<url>` plays the file and its currentTime becomes the
+ * clock; without it the clock is wall time from the moment the run starts. Nothing here runs hosted.
+ */
+async function standaloneTrack() {
+  const want = params.get('chart');
+  if (hosted || !want || !race) return;
+  let chart = null;
+  try {
+    const mod = await import('./race/chart.js');
+    if (want === 'demo') chart = mod.demoChart({ durationSec: Number(params.get('dur')) || 240 });
+    else chart = mod.normalizeChart(await (await fetch(want)).json());
+    race.setTrack(chart);
+  } catch (err) {
+    trackError('chart: ' + ((err && err.message) || err));
+    return;
+  }
+  const src = params.get('audio');
+  if (src) {
+    try { trackAudio = new Audio(src); trackAudio.preload = 'auto'; } catch (e) { trackAudio = null; }
+  }
+  const dur = chart.source.durationSec;
+  startTrackClock = () => {
+    if (trackTimer) return;
+    if (trackAudio) { const p = trackAudio.play(); if (p && p.catch) p.catch((e) => host.log('track audio: ' + e)); }
+    race.trackClock(0, true);
+    trackTimer = setInterval(() => {
+      // with audio the file is the authority and its currentTime snaps the clock. Without it the run
+      // integrates the wall itself (race/track.js), and a second clock here would only race it, so
+      // the tick just watches for the end. Same 250 ms cadence either way, same as the host's.
+      if (trackAudio) race.trackClock(trackAudio.currentTime, !trackAudio.paused);
+      if ((race.track ? race.track.t : dur) >= dur) { stopTrackClock(); race.trackEnded(); }
+    }, TRACK_TICK_MS);
+  };
+  host.log(`track: ${chart.source.name}, ${Math.round(dur)}s, clock ${trackAudio ? 'audio' : 'wall'}`);
+}
+function stopTrackClock() {
+  if (trackTimer) { clearInterval(trackTimer); trackTimer = 0; }
+  if (trackAudio) { try { trackAudio.pause(); } catch (e) { /* already gone */ } }
 }
 
 function hideSplash() {
@@ -165,11 +235,13 @@ async function startRun(withIntro) {
       intro.dispose();
       if (hudRoot) hudRoot.classList.remove('is-lobby');
       race.start();
+      if (startTrackClock) startTrackClock();
       race.setCameraOverride(cameraWhip(0.8));
     } else {
       race.setStage(null);
       if (hudRoot) hudRoot.classList.remove('is-lobby');
       race.start();
+      if (startTrackClock) startTrackClock();
     }
   } catch (err) {
     host.log('start: ' + ((err && err.stack) || err));


### PR DESCRIPTION
## Racing Thoughts (ex Caucus Race) web stack

Stacked on `feat/race-c1-chart`. Merge bottom-up.

### Commits
- feat(race): the track chart drives the run

**Size:** Over the 600-line cap by ~150 lines (747). It is the scheduler wiring into run.js plus its smoke; say the word and it splits.

`7 files changed, 747 insertions(+), 30 deletions(-)`

### From the commit message
The scheduler from c1 is now wired into the kart game. race/cues.js reads a chart
event as the plain table in CHART.md: a trigger is its own effect bubble with the
word on the chrome, a countdown is golden rings and the last one throws the kart,
a drop is a jump and a spiral, a build is a boost, silence is fog and an empty road.
race/track.js holds the file's clock, its energy curve and its acts, so run.js can
stay about the world and the whole clock runs under node. With a track loaded the
random drip and the rain stand down and every bubble is a spoken word; without one
not a line of the seeded run changes.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0166ij3Q8xyseVkhWajzkWG3
