### PR TITLE
feat(race): load a track from the menu, the plate, you took N of M (PR c7)

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/race/hud.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/hud.js
@@ -431,6 +431,10 @@ export function createRaceHud(root) {
       line('popped', fmt(s.popped || 0));
       line('laps', fmt(s.laps || 0));
       line('time', fmtDur(s.durationSec || 0));
+      if (s.trackName) {   // a charted run: the file, and how many of its words the player met
+        line('track', String(s.trackName).replace(/\.[a-z0-9]{2,4}$/i, '').slice(0, 28));
+        if (s.countable > 0) line('taken', `${fmt(s.taken || 0)} of ${fmt(s.countable)}`);
+      }
       if (endResolve) settleEnd('exit');
       end.classList.add('is-on');
       return new Promise((res) => { endResolve = res; });

--- a/ConditioningControlPanel/Resources/web/dtrh/race/menu.css
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/menu.css
@@ -73,6 +73,24 @@
 }
 #race-root .rm-key span { color: #ffd6ea; }
 #race-root .rm-hint { font-size: 12px; color: rgba(255, 214, 234, 0.6); margin-top: 6px; }
+#race-root .rm-btn[hidden] { display: none; }
+
+/* ---- the track plate: a file in hand, or the host still reading it ---- */
+#race-root .rm-track {
+  margin-top: 14px; padding: 10px 14px; background: rgba(18, 11, 36, 0.82);
+  box-shadow: 0 0 0 2px #2b1b3f, 0 0 0 3px rgba(255, 105, 180, 0.35);
+  animation: rmIn 0.32s cubic-bezier(0.2, 1.4, 0.4, 1);
+}
+#race-root .rm-track-name { font-size: 14px; font-weight: 800; letter-spacing: 0.06em; color: #fff; text-transform: none; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+#race-root .rm-track-bar { height: 6px; margin: 8px 0 6px; background: rgba(255, 255, 255, 0.08); box-shadow: 0 0 0 2px #2b1b3f; }
+#race-root .rm-track-bar i { display: block; height: 100%; width: 0; background: var(--pink, #ff69b4); transition: width 0.25s linear; }
+#race-root .rm-track.is-ready .rm-track-bar i { background: #5be7d8; }
+#race-root .rm-track.is-ready { box-shadow: 0 0 0 2px #2b1b3f, 0 0 0 3px rgba(91, 231, 216, 0.7), 0 0 18px rgba(91, 231, 216, 0.35); }
+#race-root .rm-track.is-error { box-shadow: 0 0 0 2px #2b1b3f, 0 0 0 3px rgba(255, 90, 120, 0.8); }
+#race-root .rm-track.is-error .rm-track-bar { display: none; }
+#race-root .rm-track-cap { font-size: 12px; color: rgba(255, 214, 234, 0.75); }
+#race-root .rm-track.is-busy .rm-track-cap::after { content: '…'; animation: rmDots 1.2s steps(3, end) infinite; }
+@keyframes rmDots { from { opacity: 0.2; } to { opacity: 1; } }
 
 /* ---- the stage hole + nameplate ---- */
 #race-root .rm-stage { position: relative; min-width: 0; }

--- a/ConditioningControlPanel/Resources/web/dtrh/race/menu.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/menu.js
@@ -3,7 +3,8 @@
  *
  *   createMenu({ root, renderer, pixel, audio, settings, log }) ->
  *     { show(), hide(), onPick(cb), options, stage: { update(dt), render(), dispose() }, dispose() }
- *   onPick yields 'race' | 'surface'.
+ *   onPick yields 'race' | 'track' | 'clear' | 'surface'; setTrack(state | null) drives the track plate
+ *   (CHART.md: the host's track-progress and the chart that lands).
  *
  * Two halves. LEFT is a DOM column (menu.css, .rm-*): the title, the tagline,
  * four verbs (race / options / how to drive / surface), options opening in
@@ -267,6 +268,11 @@ export function createMenu({ root, renderer, pixel, audio, settings = {}, log = 
   const list = el('div', 'rm-list', col); list.setAttribute('role', 'menu');
   const optPanel = el('div', 'rm-panel rm-options', col); optPanel.hidden = true;
   const howPanel = el('div', 'rm-panel rm-how', col); howPanel.hidden = true;
+  // ---- the track plate: what the host is doing with the file, then what it found ----
+  const trackEl = el('div', 'rm-track', col); trackEl.hidden = true; trackEl.setAttribute('aria-live', 'polite');
+  const trackName = el('div', 'rm-track-name', trackEl, '');
+  const trackBar = el('div', 'rm-track-bar', trackEl); const trackFill = el('i', '', trackBar);
+  const trackCap = el('div', 'rm-track-cap', trackEl, '');
   el('div', 'rm-foot', col, 'arrows move · enter picks · esc back · p pixels · m mute');
   const stageEl = el('div', 'rm-stage', layer);
   const plate = el('div', 'rm-plate', stageEl);
@@ -307,14 +313,51 @@ export function createMenu({ root, renderer, pixel, audio, settings = {}, log = 
   seedIn.addEventListener('input', () => { const v = Number(seedIn.value); if (isFinite(v) && v > 0) { options.seedValue = v >>> 0; refresh(); } });
   seedIn.addEventListener('keydown', (e) => { if (e.key === 'Enter' || e.key === 'Escape') { e.preventDefault(); seedIn.blur(); } e.stopPropagation(); });
 
-  // ---- the four verbs ----
-  const VERBS = [['race', 'race'], ['options', 'options'], ['how', 'how to drive'], ['surface', 'surface']];
+  // ---- the verbs. `track` only under a host (the file dialog is its), `clear` only once a file is in ----
+  const canTrack = !!settings.trackPick;
+  const VERBS = [['race', 'race'], ['track', 'load a track'], ['clear', 'just the road'], ['options', 'options'], ['how', 'how to drive'], ['surface', 'surface']];
   const verbEls = VERBS.map(([id, label], i) => {
     const b = el('button', 'rm-btn', list, label); b.type = 'button'; b.dataset.id = id; b.setAttribute('role', 'menuitem');
     b.addEventListener('click', () => { idx.main = i; act('press'); });
     b.addEventListener('pointerenter', () => { idx.main = i; refresh(); });
     return b;
   });
+  const verbEl = (id) => verbEls[VERBS.findIndex(([v]) => v === id)];
+  verbEl('track').hidden = !canTrack; verbEl('clear').hidden = true;
+  const stepVerb = (from, dir) => {   // the next visible verb in that direction, wrapping
+    let i = from;
+    for (let k = 0; k < VERBS.length; k++) { i = (i + dir + VERBS.length) % VERBS.length; if (!verbEls[i].hidden) return i; }
+    return from;
+  };
+  const STAGE_CAP = { picking: 'pick a file', decode: 'reading the file', energy: 'feeling the pulse', words: 'listening for the words', cancelled: '', error: '' };
+  let trackState = null;
+  /**
+   * setTrack(state | null): the plate and the verbs follow the host. state = { stage, pct, name,
+   * durationSec, countable, partial, message }; stage 'ready' is a chart in hand (partial while the
+   * words are still landing). Null clears the plate and the verbs read as the seeded run again.
+   */
+  function setTrack(state) {
+    trackState = state && state.stage ? state : null;
+    const st = trackState, ready = !!st && st.stage === 'ready';
+    trackEl.hidden = !st || st.stage === 'cancelled';
+    trackEl.classList.toggle('is-ready', ready); trackEl.classList.toggle('is-error', !!st && st.stage === 'error');
+    trackEl.classList.toggle('is-busy', !!st && !ready && st.stage !== 'error');
+    if (st) {
+      trackName.textContent = st.name || (st.stage === 'picking' ? 'a track' : '');
+      const pct = ready ? 1 : clamp(Number(st.pct) || 0, 0, 1);
+      trackFill.style.width = `${Math.round(pct * 100)}%`;
+      if (ready) {
+        const mins = Math.max(1, Math.round((Number(st.durationSec) || 0) / 60));
+        const n = Number(st.countable) || 0;
+        trackCap.textContent = st.partial ? `${mins} min · still listening for the words` : `${mins} min · ${n ? `${n} to take` : 'nothing spoken, the pulse drives'}`;
+      } else trackCap.textContent = st.stage === 'error' ? (st.message || 'the track would not load') : (STAGE_CAP[st.stage] || st.stage);
+    }
+    verbEl('race').textContent = ready ? 'race the track' : 'race';
+    verbEl('track').textContent = ready ? 'another track' : 'load a track';
+    verbEl('clear').hidden = !ready;
+    if (verbEls[idx.main].hidden) idx.main = stepVerb(idx.main, 1);
+    refresh();
+  }
 
   // ---- navigation: one focus index per panel, every input path lands on act() ----
   let panel = 'main', shown = false, disposed = false;
@@ -329,9 +372,10 @@ export function createMenu({ root, renderer, pixel, audio, settings = {}, log = 
   function act(what) {
     if (!shown || disposed) return;
     if (panel === 'main') {
-      if (what === 'up' || what === 'down') { idx.main = (idx.main + (what === 'up' ? -1 : 1) + VERBS.length) % VERBS.length; refresh(); return; }
+      if (what === 'up' || what === 'down') { idx.main = stepVerb(idx.main, what === 'up' ? -1 : 1); refresh(); return; }
       if (what !== 'press') return;
       const id = VERBS[idx.main][0];
+      if (verbEls[idx.main].hidden) return;
       hit(verbEls[idx.main], 'is-hit');
       if (id === 'options' || id === 'how') open(id); else pick(id);
       return;
@@ -373,6 +417,7 @@ export function createMenu({ root, renderer, pixel, audio, settings = {}, log = 
   const menu = {
     options, stage: { update(dt) { if (shown) pollPad(dt); stage.update(dt); }, render: stage.render, dispose: stage.dispose, live: stage },
     onPick(cb) { if (typeof cb === 'function') picks.push(cb); },
+    setTrack, get track() { return trackState; },
     show() { shown = true; layer.hidden = false; stage.setMode('menu'); open('main'); onResize(); hit(layer, 'is-in'); },
     hide() { shown = false; layer.hidden = true; stage.setViewFraction(0.5); },
     refresh,

--- a/ConditioningControlPanel/Resources/web/dtrh/race/run.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/run.js
@@ -543,7 +543,8 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     const payout = await waitPayout(PAYOUT_WAIT_MS);
     if (S.disposed) return;
     const shown = { ...summary };
-    if (payout && payout.finalXp != null) shown.title = `the tea party · +${Math.round(payout.finalXp)} xp` + (payout.sparksEarned ? ` · ${payout.sparksEarned} sparks` : '');
+    if (track && track.countable > 0) shown.title = `you took ${track.taken} of ${track.countable}`;   // a charted run is scored by the words it met
+    if (payout && payout.finalXp != null) shown.title = (shown.title || 'the tea party') + ` · +${Math.round(payout.finalXp)} xp` + (payout.sparksEarned ? ` · ${payout.sparksEarned} sparks` : '');
     const pick = await hud.showEnd(shown, { beside: true });
     if (S.disposed) return;
     if (pick === 'again') again(); else exit();
@@ -608,7 +609,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     // track charts (CHART.md): setTrack before start(), replaceTrack for the words pass landing live,
     // trackClock for the host's 250 ms tick, trackEnded when the file runs out at the host's end
     setTrack, replaceTrack: (chart) => TR.replace(chart), trackClock: (t, playing) => TR.clock(t, playing),
-    trackEnded: () => { TR.end(); if (TR.track && S.running) endRun(); },
+    trackEnded: () => { TR.end(); if (TR.track && S.running) endRun(); }, trackStats: () => TR.stats(),
     get track() { return TR.track; } };
 }
 

--- a/ConditioningControlPanel/Resources/web/dtrh/raceBoot.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/raceBoot.js
@@ -57,7 +57,7 @@ const media = createHostMediaSource();
 const rollSeed = () => (Date.now() ^ Math.floor(Math.random() * 0x7fffffff)) >>> 0;
 let initMsg = null, haveManifest = false, race = null, menu = null, booted = false, started = false, exiting = false;
 let settings = {}, seed = 0;
-let trackProgress = null, startTrackClock = null, trackTimer = 0, trackAudio = null;
+let trackProgress = null, trackReady = null, errorTimer = 0, startTrackClock = null, trackTimer = 0, trackAudio = null;
 
 const note = (t) => { if (waitEl) waitEl.textContent = t || ''; };
 function fail(err) {
@@ -96,24 +96,35 @@ bridge.on('exit-request', surface);
 bridge.on('track-chart', (m) => {
   if (!race || !m || !m.chart) return;
   try { (race.track && started) ? race.replaceTrack(m.chart) : race.setTrack(m.chart); }
-  catch (err) { host.log('track-chart: ' + ((err && err.message) || err)); trackError(String((err && err.message) || err)); }
+  catch (err) { host.log('track-chart: ' + ((err && err.message) || err)); trackError(String((err && err.message) || err)); return; }
+  const t = race.track, st = race.trackStats ? race.trackStats() : null;
+  trackReady = t ? { stage: 'ready', name: t.name, durationSec: t.durationSec, countable: st ? st.countable : 0, partial: !!m.partial } : null;
+  plate(trackReady);
 });
 bridge.on('track-clock', (m) => { if (race && m) race.trackClock(Number(m.t) || 0, m.playing !== false); });
 bridge.on('track-ended', () => { if (race) race.trackEnded(); });
 bridge.on('track-error', (m) => trackError((m && m.message) || 'the track would not load'));
-bridge.on('track-progress', (m) => {   // the menu's progress plate is PR c7; hold it for that
+bridge.on('track-progress', (m) => {
   trackProgress = m || null;
   host.log(`track-progress: ${(m && m.stage) || '?'} ${Math.round(((m && m.pct) || 0) * 100)}% ${(m && m.name) || ''}`);
+  if (!m) return;
+  // a cancelled dialog leaves whatever was loaded before in place; any other stage is the host at work
+  plate(m.stage === 'cancelled' ? trackReady : { stage: m.stage, pct: m.pct, name: m.name });
 });
+/** The menu's plate, when there is a menu to show it on (the run has the toast instead). */
+function plate(state) { try { if (menu && !started) menu.setTrack(state); } catch (e) { host.log('plate: ' + e); } }
 function trackError(message) {
   host.log('track-error: ' + message);
   try { if (race && race.hud) race.hud.toast(String(message).slice(0, 60).toLowerCase(), 'effect'); } catch (e) { /* no hud yet */ }
+  plate({ stage: 'error', message: String(message).slice(0, 80).toLowerCase() });
+  errorTimer = setTimeout(() => plate(trackReady), 4000);
 }
 /** The one exit: the menu's `surface` and the host's exit-request (the End screen's own goes through run.js). */
 function surface() {
   if (exiting) return;
   exiting = true;
   stopTrackClock();
+  if (errorTimer) clearTimeout(errorTimer);
   try { if (menu) menu.dispose(); } catch (e) { host.log('menu dispose: ' + e); }
   try { if (race) race.dispose(); } catch (e) { host.log('exit dispose: ' + e); }
   host.send({ type: 'exit' });
@@ -145,6 +156,7 @@ async function boot() {
     settings.reducedMotion = wantsReducedMotion(opts, settings.reducedMotion != null ? settings.reducedMotion : !!(matchMedia && matchMedia('(prefers-reduced-motion: reduce)').matches));
     settings.musicVolume = opts.music; settings.sfxVolume = opts.sfx;   // for the audio pass; audio.js reads masterVolume today
     settings.seedLock = seedFromOptions(opts);
+    settings.trackPick = hosted;   // the file dialog is the host's; standalone loads a track off the query string
     seed = settings.seedLock != null ? settings.seedLock : rollSeed();
     note('the road is drawing');
     race = createRace({ root, bridge: host, media, settings, seed });
@@ -154,7 +166,13 @@ async function boot() {
     if (params.get('autostart') === '1') { startRun(false); return; }
     if (hudRoot) hudRoot.classList.add('is-lobby');   // the run's chrome stays out of the menu and the intro
     menu = createMenu({ root, renderer: race.renderer, pixel: race.pixel, audio: race.audio, settings, log: host.log });
-    menu.onPick((id) => { if (id === 'race') startRun(true); else if (id === 'surface') surface(); });
+    menu.onPick((id) => {
+      if (id === 'race') startRun(true);
+      else if (id === 'surface') surface();
+      else if (id === 'track') { plate({ stage: 'picking' }); host.send({ type: 'track-pick' }); }
+      else if (id === 'clear') { host.send({ type: 'track-cancel' }); race.setTrack(null); trackReady = null; plate(null); }
+    });
+    if (trackReady) plate(trackReady); else if (trackProgress && trackProgress.stage !== 'cancelled') plate(trackProgress);
     menu.seedCheck = () => {   // the menu may have changed the seed rule: rebuild the world once, before the intro
       const lock = seedFromOptions(menu.options);
       if (lock === settings.seedLock) return;
@@ -184,6 +202,8 @@ async function standaloneTrack() {
     if (want === 'demo') chart = mod.demoChart({ durationSec: Number(params.get('dur')) || 240 });
     else chart = mod.normalizeChart(await (await fetch(want)).json());
     race.setTrack(chart);
+    const st = race.trackStats ? race.trackStats() : null;
+    trackReady = { stage: 'ready', name: chart.source.name, durationSec: chart.source.durationSec, countable: st ? st.countable : 0, partial: false };
   } catch (err) {
     trackError('chart: ' + ((err && err.message) || err));
     return;


### PR DESCRIPTION
## Racing Thoughts (ex Caucus Race) web stack

Stacked on `feat/race-c2-run`. Merge bottom-up.

### Commits
- feat(race): load a track from the menu, the plate, you took N of M (PR c7)

`5 files changed, 98 insertions(+), 10 deletions(-)`

### From the commit message
The menu grows the two verbs CHART.md asks for: load a track (hosted only, the
dialog is the host) and just the road once a file is in, with a plate under the
list that follows track-progress through decode, pulse and words and then reads
the file name, its minutes and how many words there are to take. The end card
titles a charted run "you took N of M" and lists the track. Hidden verbs are
skipped by the keyboard and the pad.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0166ij3Q8xyseVkhWajzkWG3
