### PR TITLE
feat(race): the cue feel pass, a guess never costs a miss, the track owns the room (PR c3)

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/race/CHART.md
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/CHART.md
@@ -92,7 +92,8 @@ export function createScheduler(chart, { leadSec = 2.2 } = {}) -> sched
   sched.energyAt(t) -> 0..1       // linear interpolation between bins, 0 outside the file
   sched.replace(chart)            // swap in an upgraded chart: keeps fired ids and taken ids, adopts events with t > lastT only
   sched.taken(id)                 // the player met this event (popped its bubble, hit the drop)
-  sched.stats() -> { total, fired, countable, taken }   // countable = events of kind trigger|word|count|drop
+  sched.skip(id)                  // cues.js put nothing on the road for it (a guess): it leaves the count, never a miss
+  sched.stats() -> { total, fired, countable, taken }   // countable = events of kind trigger|word|count|drop, minus skipped ids
   sched.lastT                     // the last trackT seen
   sched.reset()
 ```
@@ -117,6 +118,24 @@ placement, `word: label`; `word` -> a treat bubble; `count` -> a golden air bubb
 `at = 0.2, 0.5, 0.8`; `chant` -> `reps` treats in lane placement alternating `x = +-1.2` at
 `at = k * period`; `build` -> `boost: min(dur, 4)`, `density: 1.6`; `peak` -> 6 rain treats; `release`
 -> `mood: 'calm'`, `density: 0.6`; `silence` -> `fog: 1`, `density: 0`, `holdSec: dur`.
+
+The feel (c3), on top of the mapping. Confidence: a `trigger` under conf 0.55 is a plain treat with no
+`word` and no pose; a `word` under conf 0.5, a lone number word (the spotter hears "one" in "someone"),
+or a wake word (`wake awake waking up open`) outside a `wake`/`free` act returns null, and run.js
+calls `sched.skip(id)` so it never counts against the player. Room: an unmapped trigger wears the
+room's effect (`teagarden flash, undertow spiral, toybox pink, chapel spiral, mirrors glitch, greyward
+freeze, coronation prism, casino lucky`); a `peak` rains the room's bubble (`casino lucky, coronation
+golden, chapel/mirrors prism`, else treats), 4..8 of them by `intensity`. Amount: a `chant` lane is
+`reps * max(0.5, weight)` treats, every fourth gold; a `build` boost is `dur * max(0.5, weight)` capped
+at 4; a `drop` under strength 0.6 is `jump: 5`, two rings and no spiral. A `count` ring sinks toward
+the road as the spoken number falls (`n` is the number, `of` the run length) and toasts the number;
+a lifting `word` (`float up open light rise lift`) hangs in the air. Poses and toasts: trigger `grab`,
+last count `clamp` + `item` toast, drop `jackpot` toast of its label, chant `cheer`, build `boost`,
+peak `cheer` (`smug` over intensity 0.7), release `drift`, silence a `. . .` toast.
+`resultTag(taken, countable)` is the end card's second line: `every word`, `good girl` (>= 0.8),
+`half of her` (>= 0.5), `she noticed` (>= 0.2), `you were not listening`; null with nothing to take.
+A loaded track ducks the room OST to `TRACK_DUCK` (0.12) and the bed to silence via
+`audio.duck(on, 'track')`, the standing level `update()` eases back to, until the track is cleared.
 
 ### `race/bubbles.js` additions (PR c2)
 ```js

--- a/ConditioningControlPanel/Resources/web/dtrh/race/audio.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/audio.js
@@ -4,7 +4,9 @@
  *   createRaceAudio({ bridge, hud, settings, input }) -> audio
  *   audio.sfx(name, scale)       the run's sfx() helper lands here: host legs + in-page beats
  *   audio.update(dt, live)       live = { world, run, kart }; once per step, after everything moved
- *   audio.duck(on, why)          'host' (native video) | 'brake' | 'end'
+ *   audio.duck(on, why)          'host' (native video) | 'brake' | 'end' | 'track'
+ *                                'track' is the standing one: a loaded file (CHART.md) is the
+ *                                soundtrack, so the OST and the bed sit under it until it is cleared
  *   audio.toggleMute() -> bool   M key; shared with the dive's master mute (shared/audioMute.js)
  *   audio.dispose()
  *
@@ -82,6 +84,7 @@ export function pickVoiceToDrop(voices) {
 export const OST_BASE = '/arcademy/assets/sfx/';
 export const CROSSFADE_SEC = 1.5;
 export const MUSIC_LEVEL = 0.3;          // the OSTs sit at about -15.5 LUFS; this keeps them under the pops
+export const TRACK_DUCK = 0.12;          // where the OST sits under a loaded track: felt, never heard over her
 export const TRACKS = Object.freeze([
   { name: 'ost_campus',          title: 'Star Byte Loop',     mood: 'soft', energy: 0.45, sec: 75,  start: 0 },
   { name: 'ost_deep_end',        title: 'Pixel Rush',         mood: 'loud', energy: 0.8,  sec: 77,  start: 0 },
@@ -139,6 +142,7 @@ export function createRaceAudio({ bridge, hud, settings = {}, input } = {}) {
   let lastScorePop = null;       // the score 'pop' event that ran just before the field pop reaches us
   // music: the chain is duck -> lowpass (fraught / Undertow / tea time) -> highpass (Grey Ward) -> level -> master
   let musicDuck = null, musicLp = null, musicHp = null, musicLevelNode = null, elementMode = false;
+  let standing = 1;   // the level update() eases the music back to: 1, or TRACK_DUCK while a track is loaded
   const tracks = new Map();      // name -> { name, el, gain, bound, failed, vol, fadeTimer, pauseTimer }
   const music = { cur: null, playlist: {}, dead: new Set(), duckTo: 1, duckWhy: null, lp: 20000, hp: 20, gesture: false, roomId: null };
 
@@ -448,7 +452,7 @@ export function createRaceAudio({ bridge, hud, settings = {}, input } = {}) {
     const roomId = run.room ? run.room.id : null;
     if (roomId !== edge.room) { if (edge.room) gateSting(); edge.room = roomId; }
     if (roomId && roomId !== music.roomId) { music.roomId = roomId; enterTrack(roomId); }
-    if (music.duckTo < 1) setDuck(1, null);     // update() only runs while the run is live: nothing ducks it
+    if (music.duckTo !== standing) setDuck(standing, standing < 1 ? 'track' : null);   // update() only runs while the run is live: only a loaded track ducks it
     colour(roomId, clamp((run.effects ? run.effects.length : 0) / 3, 0, 1), run.timeScale == null ? 1 : run.timeScale);
     if (k.airborne && !edge.airborne) rampRise(); else if (!k.airborne && edge.airborne) rampLand();
     edge.airborne = !!k.airborne;
@@ -462,6 +466,7 @@ export function createRaceAudio({ bridge, hud, settings = {}, input } = {}) {
 
   // ---- duck / mute / dispose ----
   function duck(on, why) {
+    if (why === 'track') { standing = on ? TRACK_DUCK : 1; setDuck(standing, on ? 'track' : null); return; }
     if (why === 'brake') { if (on) play('pop', { level: 0.3, semis: -7 }); else play('pop2', { level: 0.24, semis: 3 }); }
     if (on) setDuck(why === 'end' ? 0.45 : 0.1, why || 'host'); else setDuck(1, null);
   }

--- a/ConditioningControlPanel/Resources/web/dtrh/race/chart.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/chart.js
@@ -214,7 +214,7 @@ export function demoChart(opts = {}) {
 export function createScheduler(chart, opts = {}) {
   let ch = (chart && chart.version === CHART_VERSION && Object.isFrozen(chart)) ? chart : normalizeChart(chart);
   const leadSec = Math.max(MIN_LEAD_SEC, num(opts.leadSec, LEAD_SEC));
-  const fired = new Set(), takenIds = new Set();
+  const fired = new Set(), takenIds = new Set(), skipped = new Set();
   let cursor = 0, lastT = 0, missed = 0;
 
   // The cursor is the first event nobody has looked at yet: after a seek or a swap it walks past
@@ -272,12 +272,14 @@ export function createScheduler(chart, opts = {}) {
     },
     /** The player met this event: popped its bubble, took the drop. */
     taken(id) { if (id) takenIds.add(id); },
+    /** cues.js had nothing to put on the road for this one (a word the spotter only guessed at): it leaves the count. */
+    skip(id) { if (id) skipped.add(id); },
     stats() {
       let countable = 0;
-      for (const e of ch.events) if (COUNTABLE.has(e.kind)) countable++;
+      for (const e of ch.events) if (COUNTABLE.has(e.kind) && !skipped.has(e.id)) countable++;
       return { total: ch.events.length, fired: fired.size, countable, taken: takenIds.size, missed };
     },
-    reset() { fired.clear(); takenIds.clear(); cursor = 0; lastT = 0; missed = 0; },
+    reset() { fired.clear(); takenIds.clear(); skipped.clear(); cursor = 0; lastT = 0; missed = 0; },
     get chart() { return ch; },
     get lastT() { return lastT; },
     get leadSec() { return leadSec; },

--- a/ConditioningControlPanel/Resources/web/dtrh/race/cues.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/cues.js
@@ -1,10 +1,10 @@
 /* ============================================================================
  * race/cues.js - a chart event turned into the thing the run does about it.
- * Implements CHART.md section `race/cues.js` (the plain mapping, PR c2).
+ * Implements CHART.md section `race/cues.js`: the mapping (PR c2) and its feel (PR c3).
  *
- * One pure function over a flat table: no three, no DOM, no clock, no state, so it
- * runs under node beside chart.js. `cueFor` decides WHICH of the things the run
- * already knows how to spend an event is worth (a bubble, a jump, a mood, a boost)
+ * One pure function over a table: no three, no DOM, no clock, no state, so it runs
+ * under node beside chart.js. `cueFor` decides WHICH of the things the run already
+ * knows how to spend an event is worth (a bubble, a jump, a mood, a pose, a boost)
  * and never HOW: run.js owns every verb, this file only names them.
  *
  * `at` on a spawn is seconds relative to the event's own second: 0 puts the bubble
@@ -12,32 +12,67 @@
  * at the kart's current speed, which is why the pop lands on the word whatever the
  * player did with the throttle.
  *
- * This is deliberately the flat reading of the table. PR c3 makes it sing: weight
- * and confidence, the act's own colour, the room's bubble bias, EMI's poses. The
- * ctx fields c3 wants (energy, act, room, intensity) are already handed in here so
- * that pass never has to touch run.js again.
+ * The feel pass (c3) reads the colour c2 handed in and left alone:
+ *   conf     - the word spotter runs a closed grammar and will hear "wake" in the
+ *              middle of a trance at full confidence, so a guess is worth less than
+ *              a certainty: an unsure trigger is a plain treat, an unsure word is
+ *              nothing at all (a guess must never cost the player a miss), a lone
+ *              number outside a countdown is nothing, and a wake word before the
+ *              track is on its way up is nothing.
+ *   room     - an unmapped trigger wears the room's own effect and a peak rains
+ *              the room's own bubble, so the file's acts read on the road.
+ *   weight / strength / intensity - how much of a cue there is: rings on a drop,
+ *              treats in a chant, the size of the rain.
+ *   pose / toast - she reaches for a trigger, braces for the last count, cheers a
+ *              peak; the count and the drop word go on the chrome.
  * ==========================================================================*/
 
 import { LANE_H, CEILING_H, ROAD_HALF_W } from './consts.js';
 
-/** A trigger phrase nobody has assigned a bubble to still gets one: the strobe. */
+/** A trigger phrase nobody has assigned a bubble to wears the room's own effect, else this. */
 const FALLBACK_TRIGGER = 'flash';
+/** Which effect an unmapped trigger wears per room (rooms.js ids; chart.js ACT_ROOM picks them). */
+const ROOM_TRIGGER = {
+  teagarden: 'flash', undertow: 'spiral', toybox: 'pink', chapel: 'spiral',
+  mirrors: 'glitch', greyward: 'freeze', coronation: 'prism', casino: 'lucky',
+};
+/** What a peak rains per room; anywhere else it is plain treats. */
+const ROOM_RAIN = { casino: 'lucky', coronation: 'golden', chapel: 'prism', mirrors: 'prism' };
+/** Below this the spotter was guessing: the trigger is a treat, not its effect, and no word on the chrome. */
+const TRIGGER_SURE = 0.55;
+/** Below this a structure word is nothing; a guess must never cost the player a miss. */
+const WORD_SURE = 0.5;
+/** A number on its own (the spotter hears "one" in "someone"): only a countdown may count. */
+const NUMBER_WORD = /^(\d+|zero|one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve|fifteen|twenty)$/;
+/** Words that only mean anything on the way up; the spotter hears "wake" mid-trance at conf 1. */
+const WAKE_WORDS = new Set(['wake', 'awake', 'waking', 'up', 'open']);
+/** Acts a wake word is welcome in (chart.js ACT_KINDS). */
+const WAKE_ACTS = new Set(['wake', 'free']);
+/** Words that lift: their treat hangs in the air; every other structure word sits in a lane. */
+const FLOAT_WORDS = new Set(['float', 'floating', 'up', 'open', 'light', 'rise', 'lift']);
 /** The lanes a spoken word may land in. Narrower than the road: the kart has to steer, not lunge. */
 const LANE_X = [-1.6, -0.8, 0, 0.8, 1.6];
-/** Height of an air bubble over the road, and how much each one of a drop's three climbs. */
-const AIR_H = 2.6, AIR_RISE = 0.6;
-/** A drop is three golden rings through the air, one on the word and two behind it. */
+/** Height of an air bubble over the road, how much each of a drop's rings climbs, a floating word's hang. */
+const AIR_H = 2.6, AIR_RISE = 0.6, FLOAT_H = 1.9;
+/** A drop is golden rings through the air, one on the word and the rest behind it. */
 const DROP_AT = [0.2, 0.5, 0.8], DROP_X = [-1.1, 0, 1.1];
-/** A peak dumps this many treats out of the ceiling, this far apart. */
-const PEAK_N = 6, PEAK_GAP = 0.25;
+/** A drop this weak is a dip, not a fall: no spiral over the world, fewer rings, a lower jump. */
+const DROP_SOFT = 0.6;
+/** A peak rains between these many, by intensity, this far apart. */
+const PEAK_MIN = 4, PEAK_MAX = 8, PEAK_GAP = 0.25;
 /** The chant's two lanes, and the fallback beat when the analyzer sent no period. */
 const CHANT_X = 1.2, CHANT_PERIOD = 1.2, CHANT_MAX = 16;
+/** Every this-many chant treats, one is gold. */
+const CHANT_GOLD_EVERY = 4;
 /** A build hands over at most this many seconds of boost. */
 const BOOST_CAP = 4;
 
 const clamp = (v, a, b) => Math.max(a, Math.min(b, v));
+const conf01 = (e) => (Number.isFinite(Number(e.conf)) ? clamp(Number(e.conf), 0, 1) : 1);
+const weight01 = (e) => (Number.isFinite(Number(e.weight)) ? clamp(Number(e.weight), 0, 1) : 1);
 const laneX = (rng) => LANE_X[Math.min(LANE_X.length - 1, (rng() * LANE_X.length) | 0)];
 const spread = (rng) => clamp((rng() * 2 - 1) * (ROAD_HALF_W - 0.8), -ROAD_HALF_W + 0.6, ROAD_HALF_W - 0.6);
+const roomId = (ctx) => (ctx.room && typeof ctx.room.id === 'string' ? ctx.room.id : (ctx.act && ctx.act.room) || null);
 
 /** Every field CHART.md promises, so run.js never has to test for one. */
 function blank() {
@@ -45,92 +80,145 @@ function blank() {
     word: null, fog: null, boost: 0, density: null, holdSec: 0 };
 }
 
-/** The bubble a spoken trigger wears. The map is built per track from the chart's lexicon. */
-function triggerKind(label, kinds) {
+/** The bubble a spoken trigger wears: the chart's own map, else the room's effect, else the strobe. */
+function triggerKind(label, ctx) {
+  const kinds = ctx.triggerKinds;
   const id = (kinds && typeof kinds.get === 'function') ? kinds.get(label) : null;
-  return id || FALLBACK_TRIGGER;
+  return id || ROOM_TRIGGER[roomId(ctx)] || FALLBACK_TRIGGER;
 }
 
 /**
  * @param event a chart event (race/chart.js normalizeChart shape)
- * @param ctx { energy, act, room, intensity, rng, triggerKinds } - only rng and triggerKinds are
- *        read in c2; the rest is the colour c3 mixes in.
- * @returns the cue, or null for an event kind this build has nothing to say about.
+ * @param ctx { energy, act, room, intensity, rng, triggerKinds }
+ * @returns the cue, or null for an event this build has nothing to say about (an unknown
+ *          kind, or a word the feel pass decided the spotter only guessed at).
  */
 export function cueFor(event, ctx = {}) {
   if (!event || typeof event.kind !== 'string') return null;
   const rng = typeof ctx.rng === 'function' ? ctx.rng : Math.random;
+  const intensity = Number.isFinite(Number(ctx.intensity)) ? clamp(Number(ctx.intensity), 0, 1) : 0.5;
+  const label = typeof event.label === 'string' ? event.label : '';
   const cue = blank();
 
   switch (event.kind) {
-    // the voice said a trigger phrase: its own effect bubble, in a lane, with the word on the chrome
-    case 'trigger':
-      cue.spawn.push({ kindId: triggerKind(event.label, ctx.triggerKinds), placement: 'lane', x: laneX(rng), h: LANE_H, at: 0 });
-      cue.word = event.label || null;
+    // the voice said a trigger phrase: its own effect bubble in a lane, the word on the chrome, and
+    // she reaches for it. A phrase the spotter only half heard is a plain treat and stays off the chrome.
+    case 'trigger': {
+      const sure = conf01(event) >= TRIGGER_SURE;
+      cue.spawn.push({ kindId: sure ? triggerKind(label, ctx) : 'treat', placement: 'lane', x: laneX(rng), h: LANE_H, at: 0 });
+      if (sure) { cue.word = label || null; cue.pose = 'grab'; }
       break;
+    }
 
-    // a structure word (drop, deeper, breathe): a plain treat to drive through
-    case 'word':
-      cue.spawn.push({ kindId: 'treat', placement: 'lane', x: laneX(rng), h: LANE_H, at: 0 });
+    // a structure word (drop, deeper, breathe): a treat to drive through; a lifting word hangs in the air.
+    // A lone number, a wake word before the way up, or a guess is nothing at all.
+    case 'word': {
+      if (conf01(event) < WORD_SURE) return null;
+      if (NUMBER_WORD.test(label)) return null;
+      if (WAKE_WORDS.has(label) && !(ctx.act && WAKE_ACTS.has(ctx.act.kind))) return null;
+      const floats = FLOAT_WORDS.has(label);
+      cue.spawn.push({ kindId: 'treat', placement: floats ? 'air' : 'lane', x: laneX(rng), h: floats ? FLOAT_H : LANE_H, at: 0 });
       break;
+    }
 
-    // a number inside a countdown: a golden ring in the air, and the last one throws the kart at it
-    case 'count':
-      cue.spawn.push({ kindId: 'golden', placement: 'air', x: laneX(rng) * 0.5, h: AIR_H, at: 0 });
-      if (event.last) cue.jump = 6;
+    // a number inside a countdown: a golden ring in the air that sinks toward the road as the count
+    // runs down (n is the spoken number, of the run length: ten hangs high, one skims the road; a
+    // count going up climbs instead), the number on the chrome, and the last one braces her and
+    // throws the kart at it
+    case 'count': {
+      const of = Math.max(1, Number(event.of) || 1), n = clamp(Number(event.n) || 1, 1, of);
+      const sink = of > 1 ? 1 - (n - 1) / (of - 1) : 1;
+      cue.spawn.push({ kindId: 'golden', placement: 'air', x: laneX(rng) * 0.5, h: AIR_H - (AIR_H - LANE_H - 0.6) * sink, at: 0 });
+      if (label) cue.toast = { text: label, kind: event.last ? 'item' : 'pop' };
+      if (event.last) { cue.jump = 6; cue.pose = 'clamp'; }
       break;
+    }
 
-    // the drop: a jump, a spiral over the world, and three golden rings climbing away from the word
-    case 'drop':
-      cue.jump = 7;
-      cue.mix = 'spiral';
+    // the drop: a jump, a spiral over the world, and golden rings climbing away from the word. A
+    // soft drop (a dip in the voice, not the fall) is a lower jump, two rings and no spiral.
+    case 'drop': {
+      const strength = Number.isFinite(Number(event.strength)) ? clamp(Number(event.strength), 0, 1) : 1;
+      const hard = strength >= DROP_SOFT;
+      cue.jump = hard ? 7 : 5;
+      cue.mix = hard ? 'spiral' : null;
       cue.mood = 'streamed';
-      for (let i = 0; i < DROP_AT.length; i++) {
+      cue.toast = { text: label || 'drop', kind: hard ? 'jackpot' : 'effect' };
+      const rings = hard ? DROP_AT.length : 2;
+      for (let i = 0; i < rings; i++) {
         cue.spawn.push({ kindId: 'golden', placement: 'air', x: DROP_X[i], h: AIR_H + i * AIR_RISE, at: DROP_AT[i] });
       }
       break;
+    }
 
-    // the same phrase over and over: a lane of treats in the chant's own rhythm, side to side
+    // the same phrase over and over: a lane of treats in the chant's own rhythm, side to side, every
+    // fourth one gold, the phrase on the chrome and a cheer. A light chant is a shorter lane.
     case 'chant': {
-      const reps = clamp(Math.round(Number(event.reps) || 3), 1, CHANT_MAX);
+      const reps = clamp(Math.round((Number(event.reps) || 3) * Math.max(0.5, weight01(event))), 1, CHANT_MAX);
       const period = Number(event.period) > 0 ? Number(event.period) : CHANT_PERIOD;
       for (let k = 0; k < reps; k++) {
-        cue.spawn.push({ kindId: 'treat', placement: 'lane', x: (k % 2 ? CHANT_X : -CHANT_X), h: LANE_H, at: k * period });
+        const gold = (k + 1) % CHANT_GOLD_EVERY === 0;
+        cue.spawn.push({ kindId: gold ? 'golden' : 'treat', placement: 'lane', x: (k % 2 ? CHANT_X : -CHANT_X), h: LANE_H, at: k * period });
       }
-      cue.word = event.label || null;
+      cue.word = label || null;
+      cue.pose = 'cheer';
       break;
     }
 
     // the RMS climbing: a push in the back and a thicker road while it lasts
     case 'build':
-      cue.boost = clamp(Number(event.dur) || 0, 0, BOOST_CAP);
+      cue.boost = clamp((Number(event.dur) || 0) * Math.max(0.5, weight01(event)), 0, BOOST_CAP);
       cue.density = 1.6;
+      cue.mood = 'streamed';
+      cue.pose = 'boost';
       break;
 
-    // the top of the climb: treats out of the ceiling
-    case 'peak':
-      for (let i = 0; i < PEAK_N; i++) {
-        cue.spawn.push({ kindId: 'treat', placement: 'rain', x: spread(rng), h: CEILING_H, at: i * PEAK_GAP });
+    // the top of the climb: the room's own bubbles out of the ceiling, more the louder the file is, and a cheer
+    case 'peak': {
+      const n = Math.round(PEAK_MIN + (PEAK_MAX - PEAK_MIN) * intensity);
+      const kindId = ROOM_RAIN[roomId(ctx)] || 'treat';
+      for (let i = 0; i < n; i++) {
+        cue.spawn.push({ kindId, placement: 'rain', x: spread(rng), h: CEILING_H, at: i * PEAK_GAP });
       }
+      cue.pose = 'cheer';
+      cue.mood = intensity > 0.7 ? 'smug' : 'streamed';
       break;
+    }
 
     // the fall away from a peak: she settles, the road thins out
     case 'release':
       cue.mood = 'calm';
       cue.density = 0.6;
+      cue.pose = 'drift';
       break;
 
     // nothing in the file at all: a fogged straight with nothing in it, for as long as the quiet runs
     case 'silence':
       cue.fog = 1;
       cue.density = 0;
+      cue.mood = 'calm';
       cue.holdSec = Math.max(0, Number(event.dur) || 0);
+      cue.toast = { text: '. . .', kind: 'item' };
       break;
 
     default:
       return null;
   }
   return cue;
+}
+
+/**
+ * The line under "you took N of M" on the end card. Pure so the smoke can read it; null when the
+ * track had nothing to take (an energy-only chart with no words in it).
+ */
+export function resultTag(taken, countable) {
+  const of = Math.max(0, Number(countable) || 0), got = clamp(Number(taken) || 0, 0, of);
+  if (of <= 0) return null;
+  const r = got / of;
+  if (got === of) return 'every word';
+  if (r >= 0.8) return 'good girl';
+  if (r >= 0.5) return 'half of her';
+  if (r >= 0.2) return 'she noticed';
+  return 'you were not listening';
 }
 
 // self-check: node race/smoke/track-run-check.mjs walks every kind through this table.

--- a/ConditioningControlPanel/Resources/web/dtrh/race/run.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/run.js
@@ -34,7 +34,7 @@ import { KIND_BY_ID } from './bubbleKinds.js';
 import { createCocktail, CATEGORIES } from './cocktail.js';
 import { createBubbleField } from './bubbles.js';
 import { createTrackState } from './track.js';
-import { cueFor } from './cues.js';
+import { cueFor, resultTag } from './cues.js';
 import { createKart } from './kart.js';
 import { createScore } from './score.js';
 import { createRaceHud } from './hud.js';
@@ -338,6 +338,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     const t = TR.setTrack(chart);
     S.trackHold = 0; S.statsAt = 0;
     if (W) { W.field.setTracked(!!t); W.field.setDensity(1); if (!t) applyFog(W, 0); }
+    audio.duck(!!t, 'track');   // the file is the soundtrack: the room OST sits under it until it is cleared
     if (bridge.log) bridge.log(t ? `race track: ${t.name}, ${Math.round(t.durationSec)}s, ${TR.stats().countable} to take` : 'race track: cleared');
     return t;
   }
@@ -362,7 +363,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
   function applyCue(w, due) {
     const ks = w.kart.state;
     const cue = cueFor(due.event, { energy: TR.intensity, act: TR.act, room: S.room, intensity: S.intensity, rng: w.rng, triggerKinds: TR.triggerKinds });
-    if (!cue) return;
+    if (!cue) { TR.skip(due.event.id); return; }   // a guess the feel pass threw out never counts against the player
     for (const sp of cue.spawn) {
       const d = ks.d + ks.speed * Math.max(due.dueIn + (sp.at || 0), CUE_AHEAD_SEC);
       w.field.spawnAt({ kindId: sp.kindId, placement: sp.placement, d, x: sp.x, h: sp.h, eventId: due.event.id });
@@ -543,7 +544,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     const payout = await waitPayout(PAYOUT_WAIT_MS);
     if (S.disposed) return;
     const shown = { ...summary };
-    if (track && track.countable > 0) shown.title = `you took ${track.taken} of ${track.countable}`;   // a charted run is scored by the words it met
+    if (track && track.countable > 0) shown.title = `you took ${track.taken} of ${track.countable} · ${resultTag(track.taken, track.countable)}`;   // a charted run is scored by the words it met
     if (payout && payout.finalXp != null) shown.title = (shown.title || 'the tea party') + ` · +${Math.round(payout.finalXp)} xp` + (payout.sparksEarned ? ` · ${payout.sparksEarned} sparks` : '');
     const pick = await hud.showEnd(shown, { beside: true });
     if (S.disposed) return;

--- a/ConditioningControlPanel/Resources/web/dtrh/race/smoke/track-run-check.mjs
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/smoke/track-run-check.mjs
@@ -21,7 +21,7 @@ import { KART_BASE_SPEED, LANE_H, CEILING_H, ROAD_HALF_W, makeRng } from '../con
 import { demoChart, EVENT_KINDS } from '../chart.js';
 import { KIND_BY_ID } from '../bubbleKinds.js';
 import { createTrackState } from '../track.js';
-import { cueFor } from '../cues.js';
+import { cueFor, resultTag } from '../cues.js';
 
 let fails = 0;
 const ok = (cond, what) => { if (!cond) { console.error('FAIL ' + what); fails++; } else console.log('  ok  ' + what); };
@@ -102,7 +102,7 @@ function chartEnergy(t) {
   const seen = new Set();
   let bad = '';
   for (const e of chart.events) {
-    const cue = cueFor(e, ctx);
+    const cue = cueFor(e, { ...ctx, act: chart.acts.find((a) => e.t >= a.t0 && e.t < a.t1) || ctx.act });   // a wake word only counts in its own act
     if (!cue) { bad = bad || ('no cue for ' + e.kind); continue; }
     seen.add(e.kind);
     for (const sp of cue.spawn) {
@@ -140,6 +140,30 @@ function chartEnergy(t) {
   ok(rl.mood === 'calm' && rl.density === 0.6, 'a release calms her and thins the road');
   const si = cueFor({ kind: 'silence', dur: 12 }, ctx);
   ok(si.fog === 1 && si.density === 0 && si.holdSec === 12, 'silence is fog, nothing on the road, for as long as the quiet runs');
+
+  // the feel pass (c3): a guess is worth less than a certainty, the room colours the road
+  const shy = cueFor({ kind: 'trigger', label: 'good girl', conf: 0.4 }, ctx);
+  ok(shy.spawn[0].kindId === 'treat' && shy.word === null && shy.pose === null, 'an unsure trigger is a plain treat and stays off the chrome');
+  ok(t.pose === 'grab', 'a sure one she reaches for');
+  ok(cueFor({ kind: 'word', label: 'deeper', conf: 0.3 }, ctx) === null, 'an unsure structure word is nothing (never a miss)');
+  ok(cueFor({ kind: 'word', label: 'one' }, ctx) === null && cueFor({ kind: 'word', label: '3' }, ctx) === null, 'a lone number outside a countdown is nothing');
+  const wakeAct = chart.acts.find((a) => a.kind === 'wake');
+  ok(cueFor({ kind: 'word', label: 'wake' }, ctx) === null, 'a wake word in the induction is the spotter guessing');
+  ok(!!wakeAct && cueFor({ kind: 'word', label: 'wake' }, { ...ctx, act: wakeAct }).spawn.length === 1, 'and on the way up it is a treat');
+  const fl = cueFor({ kind: 'word', label: 'float' }, ctx);
+  ok(fl.spawn[0].placement === 'air' && fl.spawn[0].h > LANE_H, 'a lifting word hangs in the air');
+  ok(cueFor({ kind: 'trigger', label: 'never analysed' }, { ...ctx, room: { id: 'chapel' } }).spawn[0].kindId === 'spiral', 'an unmapped phrase in the chapel wears the spiral');
+  ok(cueFor({ kind: 'peak' }, { ...ctx, room: { id: 'casino' } }).spawn.every((s) => s.kindId === 'lucky'), 'a peak in the casino rains lucky bubbles');
+  ok(cueFor({ kind: 'peak' }, { ...ctx, intensity: 1 }).spawn.length === 8 && cueFor({ kind: 'peak' }, { ...ctx, intensity: 0 }).spawn.length === 4, 'and rains more the louder the file is');
+  const soft = cueFor({ kind: 'drop', strength: 0.4, label: 'sink' }, ctx);
+  ok(soft.jump === 5 && soft.mix === null && soft.spawn.length === 2 && soft.toast.text === 'sink', 'a soft drop is a lower jump, two rings, no spiral, its word on the chrome');
+  ok(dr.toast && dr.toast.kind === 'jackpot', 'a hard drop puts its word up in gold');
+  const c5 = cueFor({ kind: 'count', label: 'five', n: 5, of: 10 }, ctx), c10 = cueFor({ kind: 'count', label: 'ten', n: 10, of: 10 }, ctx);
+  ok(c5.toast.text === 'five' && c5.spawn[0].h < c10.spawn[0].h && c.spawn[0].h < c5.spawn[0].h, 'a countdown sinks its rings toward the road as it runs down');
+  ok(c.pose === 'clamp' && c.toast.kind === 'item', 'and she braces on the last one');
+  ok(ch.spawn.filter((s) => s.kindId === 'golden').length === 1 && ch.pose === 'cheer', 'every fourth chant treat is gold, and she cheers the chant');
+  ok(cueFor({ kind: 'chant', label: 'x', reps: 8, weight: 0.5 }, ctx).spawn.length === 4, 'a light chant is a shorter lane');
+  ok(resultTag(0, 0) === null && resultTag(9, 9) === 'every word' && resultTag(8, 10) === 'good girl' && resultTag(5, 10) === 'half of her' && resultTag(2, 10) === 'she noticed' && resultTag(0, 10) === 'you were not listening', 'the end card tag reads the ratio');
 }
 
 /* ---- 4. a whole run ----------------------------------------------------- */
@@ -148,14 +172,14 @@ function chartEnergy(t) {
   st.setTrack(chart);
   st.clock(0, true);
   const field = stubField(), rng = makeRng(3);
-  let d = 0, ended = 0, endedAt = 0, behind = 0, hold = 0, spawns = 0;
+  let d = 0, ended = 0, endedAt = 0, behind = 0, hold = 0, spawns = 0, skips = 0;
   for (let t = 0; t <= DUR + 1 && !ended; t += STEP) {
     const s = st.step(STEP);
     d += SPEED * STEP;
     if (hold > 0) { hold -= STEP; if (hold <= 0) field.setDensity(1); }
     for (const due of st.due(d, SPEED)) {
       const cue = cueFor(due.event, { energy: s.intensity, act: s.act, room: null, intensity: s.intensity, rng, triggerKinds: st.triggerKinds });
-      if (!cue) continue;
+      if (!cue) { st.skip(due.event.id); skips++; continue; }
       for (const sp of cue.spawn) {
         const at = d + SPEED * Math.max(due.dueIn + (sp.at || 0), CUE_AHEAD_SEC);
         if (at <= d) behind++;
@@ -175,6 +199,10 @@ function chartEnergy(t) {
   const sum = st.summary();
   const took = chart.events.filter((e) => e.kind === 'trigger' || e.kind === 'word').length;
   ok(sum.taken === took && sum.countable >= took, 'the summary counts ' + sum.taken + ' taken of ' + sum.countable + ' countable');
+  ok(sum.countable === chart.events.filter((e) => ['trigger', 'word', 'count', 'drop'].includes(e.kind)).length - skips, 'the ' + skips + ' words the feel pass threw out left the count');
+  const guess = chart.events.find((e) => e.kind === 'word');
+  st.skip(guess.id);
+  ok(st.stats().countable === sum.countable - 1, 'and a word skipped later leaves it too: never a miss for a guess');
   ok(sum.name === 'the demo track' && sum.hash === 'demo' && sum.durationSec === DUR, 'and names the file for run-ended');
 }
 

--- a/ConditioningControlPanel/Resources/web/dtrh/race/track.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/track.js
@@ -124,6 +124,8 @@ export function createTrackState(opts = {}) {
     due(kartD, kartSpeed) { return track ? sched.update(track.t, kartD, kartSpeed) : []; },
     /** The player met this event: popped its bubble, took its drop. */
     taken(id) { if (sched) sched.taken(id); },
+    /** cues.js left this event off the road: it is not one the player can take, so it leaves the count. */
+    skip(id) { if (sched) sched.skip(id); },
     stats() { return sched ? sched.stats() : { total: 0, fired: 0, countable: 0, taken: 0, missed: 0 }; },
     /** The end-of-run fields CHART.md adds to the summary and to `run-ended`. */
     summary() {


### PR DESCRIPTION
## Racing Thoughts (ex Caucus Race) web stack

Stacked on `feat/race-c7-menu`. Merge bottom-up.

### Commits
- feat(race): the cue feel pass, a guess never costs a miss, the track owns the room (PR c3)

`7 files changed, 203 insertions(+), 58 deletions(-)`

### From the commit message
cues.js reads the colour c2 left alone: an unsure trigger is a plain treat off the chrome, an
unsure word / a lone number / a wake word before the way up is nothing (sched.skip keeps it out
of the count), an unmapped trigger wears the room effect, a peak rains the room bubble by
intensity, chants and builds scale by weight, soft drops dip, count rings sink with the number,
poses and toasts per kind, resultTag under "you took N of M". audio.duck(on, "track") parks the
OST at 0.12 and the bed at 0 while a file is loaded. CHART.md records it; smoke 54 checks.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0166ij3Q8xyseVkhWajzkWG3
