### PR TITLE
rename(race): the game is Racing Thoughts (+1)

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/race.html
+++ b/ConditioningControlPanel/Resources/web/dtrh/race.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-    <title>the caucus race</title>
-    <!-- race.html - The Caucus Race page. Implements CONTRACT.md "race/run.js + raceBoot.js + race.html".
+    <title>racing thoughts</title>
+    <!-- race.html - Racing Thoughts page. Implements CONTRACT.md "race/run.js + raceBoot.js + race.html".
          Same import map as index.html: three.js from the fork's own vendored ESM, no bundler. -->
     <link rel="stylesheet" href="./styles.css">
     <link rel="stylesheet" href="./race/race.css">
@@ -46,7 +46,7 @@
         <div class="race-hud"></div>
         <div id="race-splash" class="race-splash">
             <div class="rs-cup" aria-hidden="true">(^_^)</div>
-            <div class="rs-title">the caucus race</div>
+            <div class="rs-title">racing thoughts</div>
             <div class="rs-sub">steer. pop. never stop.</div>
             <div class="rs-wait" id="race-wait"></div>
         </div>

--- a/ConditioningControlPanel/Resources/web/dtrh/race/AUDIO.md
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/AUDIO.md
@@ -1,4 +1,4 @@
-# The Caucus Race - audio
+# Racing Thoughts - audio
 
 One module, `race/audio.js`, owns every sound. Two doors: the hot beats are WebAudio in the page
 on the dive's shared context (`engine/audioBus.js`, so the DtRH master colour applies); the

--- a/ConditioningControlPanel/Resources/web/dtrh/race/CHART.md
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/CHART.md
@@ -1,4 +1,4 @@
-# The Caucus Race - track charts (the file is the track)
+# Racing Thoughts - track charts (the file is the track)
 
 Owner call 2026-09-06: the race gets its identity from a hypno file. The player loads an audio
 file, the host charts it (energy curve + spoken trigger words with timestamps), and the run is

--- a/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
@@ -1,4 +1,8 @@
-# The Caucus Race - module contract
+# Racing Thoughts - module contract
+
+> Named **The Caucus Race** until 2026-09-06, so older notes, memory files and PR titles
+> that say "caucus" mean this game. The folder, the module names and the host message types
+> never changed.
 
 Single-player, no-lose kart run through the DtRH tube. Sibling entry to `index.html` / `loom.html`:
 `race.html` + `raceBoot.js` + this `race/` folder. Nothing in `game/chaosRun.js` or `engine/scene.js`

--- a/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
@@ -333,6 +333,25 @@ resultTier(total, best, personalBest) -> 0..4 (the face index)
   placeholders otherwise. `emi.glb`'s `EMI_glass` carries the atlas as `emissiveTexture` only, so the stage sets the face
   on `emissiveMap` (and `map` when present); gltf.js `setFace` shifts whichever of the two the material carries.
 
+### `race/cards.js` (the introduction cards, PR c8)
+```js
+createCards({ root, audio, reducedMotion, log, start }) -> { show(): Promise<void>, dispose(), index }
+cardsSeen() -> bool | markCardsSeen() -> void
+export const CARDS_KEY = 'race.cards', CARDS;
+```
+- Four cards read one at a time on a `.rc-root` DOM layer at z26: above the menu (z25), below the boot
+  splash (z30). Same two-column layout as `.rm-root`, so EMI keeps the right half of the frame while
+  they read. The boot hides the menu around them and calls `menu.refreshView()`, which parks the stage
+  at the column framing that `hide()` would otherwise reset to 0.5.
+- Enter / space / right / d / a pointer press / pad A advances, left / a / pad B goes back (nothing on
+  card 1), esc ends it. The last card's advance ends it too. `show()` resolves either way.
+- Gate: its OWN localStorage key `race.cards` = `'1'`, written by `show()` the moment they go up, so
+  read through, escaped and abandoned all count. `race.options` keeps the shape menu.js documents; the
+  cards never widen it. Every read and write is wrapped, a storage that refuses shows them again.
+- The boot shows them once after the splash and again from the menu's `the story` verb. `?cards=1`
+  forces them, `?cards=0` skips them, `?card=N` opens on card N (screenshot aid). `?autostart=1` and
+  `?scene=intro` never reach them.
+
 ### `race/chart.js` (track charts, PR c1)
 ```js
 normalizeChart(json) -> chart | demoChart({ seed, durationSec }) -> chart | createScheduler(chart, { leadSec }) -> sched

--- a/ConditioningControlPanel/Resources/web/dtrh/race/assets/PROPS.md
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/assets/PROPS.md
@@ -1,4 +1,4 @@
-# props.glb - The Caucus Race prop pack
+# props.glb - Racing Thoughts prop pack
 
 Every prop, the kart cup and saucer, the item box and the road furniture, built in Blender in the
 same hard-surface look as the EMI mascot: flat Principled colours (no image textures), one-segment

--- a/ConditioningControlPanel/Resources/web/dtrh/race/audio.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/audio.js
@@ -1,5 +1,5 @@
 /* ============================================================================
- * race/audio.js - every sound The Caucus Race makes. See race/AUDIO.md.
+ * race/audio.js - every sound Racing Thoughts makes. See race/AUDIO.md.
  *
  *   createRaceAudio({ bridge, hud, settings, input }) -> audio
  *   audio.sfx(name, scale)       the run's sfx() helper lands here: host legs + in-page beats

--- a/ConditioningControlPanel/Resources/web/dtrh/race/bubbleKinds.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/bubbleKinds.js
@@ -1,5 +1,5 @@
 /* ============================================================================
- * race/bubbleKinds.js - The Caucus Race bubble table, data only (no three.js)
+ * race/bubbleKinds.js - Racing Thoughts bubble table, data only (no three.js)
  * so score.js and the HUD can read it without pulling the renderer in.
  * Implements the "Bubble kinds" table of CONTRACT.md section `race/bubbles.js`;
  * bubbles.js re-exports BUBBLE_KINDS from here.

--- a/ConditioningControlPanel/Resources/web/dtrh/race/bubbles.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/bubbles.js
@@ -1,5 +1,5 @@
 /* ============================================================================
- * race/bubbles.js - The Caucus Race pickup layer: the bubbles on the road.
+ * race/bubbles.js - Racing Thoughts pickup layer: the bubbles on the road.
  * Implements CONTRACT.md section `race/bubbles.js` (createBubbleField + the
  * BUBBLE_KINDS table, which lives in bubbleKinds.js and is re-exported here).
  *

--- a/ConditioningControlPanel/Resources/web/dtrh/race/cards.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/cards.js
@@ -1,0 +1,203 @@
+/* ============================================================================
+ * race/cards.js - the four introduction cards of Racing Thoughts, the first
+ * thing a new player reads. Not the RUN intro (race/intro.js): that one is the
+ * podium, the cup and the gantry countdown, and it plays every race.
+ *
+ *   createCards({ root, audio, reducedMotion, log, start }) ->
+ *     { show(): Promise<void>, dispose() }
+ *   cardsSeen()      -> true once the cards have been through (finished OR escaped)
+ *   markCardsSeen()  -> writes the gate
+ *
+ * A DOM layer (.rc-*, menu.css) at z26: above the menu's .rm-root (z25) and
+ * below the boot splash (z30). It is laid out like the menu, a left column over
+ * the same gradient and a hole on the right, so EMI keeps standing on her podium
+ * while the cards read. The boot hides the menu around them and calls
+ * menu.refreshView() so she does not slide back to the middle of the frame.
+ *
+ * The four cards, one at a time:
+ *   1  the wordmark, racing thoughts, and the one line under it
+ *   2  the road      what the road is made of and how you drive it
+ *   3  the track     what a loaded file does to the road
+ *   4  (^_^)         who is in the cup, and who is not steering
+ *
+ * Enter / space / right / d / a pointer press / pad A goes forward, left / a /
+ * pad B goes back (nothing on card 1), esc ends it there. show() resolves when
+ * the cards end, either way. THE BOUNCE on every advance and a spring on each
+ * card as it lands (Law VIII, Law XI); reduced motion gets neither, through the
+ * same [data-motion] hook the menu uses.
+ *
+ * GATE: localStorage `race.cards` = '1', written the moment they go up, so the
+ * front door never repeats itself: read through, escaped or walked away from all
+ * count the same. Its own key, so the options store `race.options` keeps the
+ * shape menu.js documents. Every read and write is wrapped: the WebView can
+ * refuse storage and the cards must still run.
+ * The boot's `?cards=1` forces them, `?cards=0` skips them, `?card=N` opens on
+ * card N (a screenshot aid, the way `?hold=` is one for the intro).
+ * ==========================================================================*/
+
+export const CARDS_KEY = 'race.cards';
+
+/** The four cards, in order. `title` is the wordmark card, `face` puts the heading in the pink. */
+export const CARDS = [
+  {
+    title: true,
+    head: 'racing thoughts',
+    line: 'a teacup, a road, and a girl who never stops smiling.',
+  },
+  {
+    head: 'the road',
+    line: 'the road is built from your own pictures. steer with the arrows, drift with shift, pop what you can reach. nothing here can be lost. it can only be missed.',
+  },
+  {
+    head: 'the track',
+    line: 'load a track and the road learns to listen. every drop, every count, every trigger on the file lands on the asphalt as a bubble, on the word. be under it when it does.',
+  },
+  {
+    face: true,
+    head: '(^_^)',
+    line: 'she rides in the cup. she does not steer. that part is yours.',
+  },
+];
+
+const PAD = { a: 0, b: 1, left: 14, right: 15 };
+const KEYMAP = { Enter: 'next', Space: 'next', ArrowRight: 'next', KeyD: 'next', ArrowLeft: 'back', KeyA: 'back', Escape: 'end' };
+const clamp = (v, a, b) => Math.max(a, Math.min(b, v));
+
+/** Have the cards already been through once? A storage that refuses to answer reads as "not yet". */
+export function cardsSeen() {
+  try { return localStorage.getItem(CARDS_KEY) === '1'; } catch (e) { return false; }
+}
+/** Mark them seen. Read through, escaped or abandoned all count: nobody meets the front door twice. */
+export function markCardsSeen() {
+  try { localStorage.setItem(CARDS_KEY, '1'); } catch (e) { /* private mode, they get them again */ }
+}
+
+export function createCards({ root, audio = null, reducedMotion = false, log = null, start = 0 } = {}) {
+  const say = (m) => { try { if (log) log('cards: ' + m); } catch (e) { /* no log */ } };
+  const el = (tag, cls, parent, text) => { const d = document.createElement(tag); d.className = cls; if (text != null) d.textContent = text; parent.appendChild(d); return d; };
+  const hit = (node, cls) => { node.classList.remove(cls); void node.offsetWidth; node.classList.add(cls); };
+
+  const layer = el('div', 'rc-root', root);
+  layer.hidden = true;
+  layer.setAttribute('role', 'dialog');
+  layer.setAttribute('aria-label', 'the story');
+  layer.dataset.motion = reducedMotion ? 'on' : 'off';   // same hook menu.css reads: 'on' means hold nobody
+  const col = el('div', 'rc-col', layer);
+  const deck = el('div', 'rc-deck', col);
+  deck.setAttribute('aria-live', 'polite');
+
+  const cardEls = CARDS.map((c) => {
+    const card = el('div', 'rc-card', deck);
+    card.hidden = true;
+    if (c.title) el('div', 'rc-word', card, c.head);
+    else el('h2', `rc-h${c.face ? ' rc-face' : ''}`, card, c.head);
+    el('p', 'rc-line', card, c.line);
+    return card;
+  });
+
+  const rail = el('div', 'rc-dots', col);
+  rail.setAttribute('aria-hidden', 'true');
+  const dotEls = CARDS.map((c, n) => {
+    if (n) el('span', 'rc-sep', rail, '·');
+    return el('span', 'rc-dot', rail, String(n + 1));
+  });
+
+  const foot = el('div', 'rc-foot', col);
+  const footNext = el('span', 'rc-foot-k', foot, 'enter · next');
+  const footSkip = el('span', 'rc-foot-k', foot, 'esc · skip');
+
+  // ---- state ----
+  let i = clamp(Math.round(Number(start) || 0), 0, CARDS.length - 1);
+  let live = false, disposed = false, raf = 0, resolve = null;
+  const padWas = {};
+
+  function click() {
+    if (!audio) return;
+    try { audio.sfx('ui_click', 0.5); } catch (e) { /* muted or gone */ }
+  }
+
+  function draw(animate) {
+    cardEls.forEach((c, n) => { c.hidden = n !== i; });
+    dotEls.forEach((d, n) => d.classList.toggle('is-on', n === i));
+    const last = i === CARDS.length - 1;
+    footNext.textContent = last ? 'enter · begin' : 'enter · next';
+    footSkip.hidden = last;
+    if (animate) hit(cardEls[i], 'is-in');
+  }
+
+  function go(dir) {
+    if (!live) return;
+    const n = i + dir;
+    if (n < 0) return;                       // card 1 has nothing behind it
+    hit(cardEls[i], 'is-hit');
+    click();
+    if (n >= CARDS.length) { end('read'); return; }
+    i = n;
+    draw(true);
+  }
+
+  function end(why) {
+    if (!live) return;
+    live = false;
+    if (raf) { cancelAnimationFrame(raf); raf = 0; }
+    window.removeEventListener('keydown', onKey);
+    layer.removeEventListener('pointerdown', onPointer);
+    layer.hidden = true;
+    say('done (' + why + ')');
+    const r = resolve; resolve = null;
+    if (r) r();
+  }
+
+  function onKey(e) {
+    if (!live || e.repeat || e.altKey || e.ctrlKey || e.metaKey) return;
+    const what = KEYMAP[e.code];
+    if (!what) return;
+    e.preventDefault();
+    if (what === 'end') { click(); end('skipped'); }
+    else go(what === 'next' ? 1 : -1);
+  }
+  function onPointer(e) { if (live && e.button === 0) go(1); }
+  function pollPad() {
+    raf = 0;
+    if (!live) return;
+    const pads = navigator.getGamepads ? navigator.getGamepads() : null;
+    let g = null;
+    if (pads) for (const p of pads) if (p && p.connected) { g = p; break; }
+    if (g) {
+      const btn = (n) => !!(g.buttons[n] && g.buttons[n].pressed);
+      const ax = g.axes || [];
+      const now = { next: btn(PAD.a) || btn(PAD.right) || ax[0] > 0.6, back: btn(PAD.b) || btn(PAD.left) || ax[0] < -0.6 };
+      for (const k of Object.keys(now)) {
+        if (now[k] && !padWas[k]) go(k === 'next' ? 1 : -1);
+        padWas[k] = now[k];
+      }
+    }
+    if (live) raf = requestAnimationFrame(pollPad);
+  }
+
+  return {
+    /** Put the cards up and hand back a promise that settles when they end, read through or escaped. */
+    show() {
+      if (disposed) return Promise.resolve();
+      if (live) return Promise.resolve();
+      live = true;
+      markCardsSeen();   // the moment they go up: a window closed on card 2 is not a first open any more
+      layer.hidden = false;
+      draw(true);
+      window.addEventListener('keydown', onKey);
+      layer.addEventListener('pointerdown', onPointer);
+      raf = requestAnimationFrame(pollPad);
+      say('open on card ' + (i + 1));
+      return new Promise((res) => { resolve = res; });
+    },
+    get index() { return i; },
+    dispose() {
+      if (disposed) return;
+      disposed = true;
+      end('disposed');
+      layer.remove();
+    },
+  };
+}
+
+// self-check: node --check is the bar; cardsSeen / markCardsSeen are pure given a localStorage stub.

--- a/ConditioningControlPanel/Resources/web/dtrh/race/chart.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/chart.js
@@ -1,5 +1,5 @@
 /* ============================================================================
- * race/chart.js - The Caucus Race track charts: the file is the track.
+ * race/chart.js - Racing Thoughts track charts: the file is the track.
  * Implements CHART.md section `race/chart.js`.
  *
  * A chart is timestamps and labels, never audio: an energy curve in fixed bins, a list

--- a/ConditioningControlPanel/Resources/web/dtrh/race/cocktail.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/cocktail.js
@@ -1,5 +1,5 @@
 /* ============================================================================
- * race/cocktail.js - THE MIX. How effect bubbles chain in The Caucus Race.
+ * race/cocktail.js - THE MIX. How effect bubbles chain in Racing Thoughts.
  *
  * Pass two ran one screen-level effect at a time and scored the rest as
  * treats. Pass three replaces that with CATEGORIES: one live effect per

--- a/ConditioningControlPanel/Resources/web/dtrh/race/consts.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/consts.js
@@ -1,4 +1,4 @@
-// The Caucus Race - shared constants. Import these; never redeclare them in a module.
+// Racing Thoughts - shared constants. Import these; never redeclare them in a module.
 // Track space is (d, x, h): depth along the spine, lateral offset, height above the road.
 // See race/CONTRACT.md.
 

--- a/ConditioningControlPanel/Resources/web/dtrh/race/emi.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/emi.js
@@ -1,4 +1,4 @@
-// race/emi.js - The Caucus Race: the teacup rig with EMI riding in it, seen from behind.
+// race/emi.js - Racing Thoughts: the teacup rig with EMI riding in it, seen from behind.
 // Visual half of CONTRACT.md "race/kart.js (PR 3)": saucer + cup + handle + tea surface, EMI as a
 // CRT body with vents, two glove arms on the rim, a bead antenna with the six mood poses, pooled
 // sweat drops, drift sparks, and a plain disc of tea. Canon lock: EMI faces forward, away from the

--- a/ConditioningControlPanel/Resources/web/dtrh/race/emiPoses.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/emiPoses.js
@@ -1,5 +1,5 @@
 /* ============================================================================
- * race/emiPoses.js - The Caucus Race: EMI's pose layer over the Blender glb.
+ * race/emiPoses.js - Racing Thoughts: EMI's pose layer over the Blender glb.
  *
  * race/emi.js owns the moods (the antenna, the bead, the sweat). This owns her
  * BODY on the race's events: the arms, the feet and a root lean / tilt / lift /

--- a/ConditioningControlPanel/Resources/web/dtrh/race/gltf.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/gltf.js
@@ -1,5 +1,5 @@
 /* ============================================================================
- * race/gltf.js - The Caucus Race glTF pack loader.
+ * race/gltf.js - Racing Thoughts glTF pack loader.
  *
  * Two packs, both authored in Blender and dropped in race/assets/:
  *

--- a/ConditioningControlPanel/Resources/web/dtrh/race/hud.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/hud.js
@@ -1,5 +1,5 @@
 /* ============================================================================
- * hud.js - The Caucus Race HUD. Implements CONTRACT.md "race/hud.js + race/race.css".
+ * hud.js - Racing Thoughts HUD. Implements CONTRACT.md "race/hud.js + race/race.css".
  *
  * DOM only, built inside the `.race-hud` div race.html provides. Score rolls
  * up on a short tween (tabular numerals), the multiplier pill pulses on every

--- a/ConditioningControlPanel/Resources/web/dtrh/race/intro.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/intro.js
@@ -1,5 +1,5 @@
 /* ============================================================================
- * race/intro.js - the intro sequence and the results camera of The Caucus Race.
+ * race/intro.js - the intro sequence and the results camera of Racing Thoughts.
  *
  *   createIntro({ stage, hud, audio, reducedMotion, log }) ->
  *     { play(): Promise<void>, skip(), update(dt), render(), dispose() }

--- a/ConditioningControlPanel/Resources/web/dtrh/race/kart.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/kart.js
@@ -1,4 +1,4 @@
-// race/kart.js - The Caucus Race: the kart (the teacup) in track space, its placement on the road,
+// race/kart.js - Racing Thoughts: the kart (the teacup) in track space, its placement on the road,
 // and the chase camera. Implements CONTRACT.md "race/kart.js (PR 3)". The cup + EMI meshes,
 // antenna moods, sweat and sparks live in race/emi.js; this file owns speed, steering, drift,
 // the drift mini-turbo, ramps, the lap counter and the camera seat. There is no fail state: speed

--- a/ConditioningControlPanel/Resources/web/dtrh/race/mediaLane.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/mediaLane.js
@@ -1,5 +1,5 @@
 /* ============================================================================
- * mediaLane.js - the media lane governor for The Caucus Race.
+ * mediaLane.js - the media lane governor for Racing Thoughts.
  *
  * game/payloadFx.js scatters its cards at random over the whole viewport:
  * `.sf-pfx-flash` lands at (14..86vw, 16..80vh), `.sf-pfx-cascade` rains from

--- a/ConditioningControlPanel/Resources/web/dtrh/race/menu.css
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/menu.css
@@ -124,3 +124,63 @@
 }
 #race-root .rm-root[data-motion="on"] .rm-col, #race-root .rm-root[data-motion="on"] .is-hit, #race-root .rm-root[data-motion="on"] .rm-btn:active { animation: none; }
 #race-root .rm-root[data-motion="on"] .rm-btn, #race-root .rm-root[data-motion="on"] .rm-row { transition: none; }
+
+/* ---- the cards ---- */
+/* race/cards.js, z26: above the menu (z25), below the boot splash (z30). Same column as .rm-root
+   so EMI keeps the right half of the frame while the four cards read. */
+#race-root .rc-root {
+  position: fixed; inset: 0; z-index: 26;
+  display: grid; grid-template-columns: minmax(300px, 38%) 1fr;
+  font-family: var(--rh-font, 'Poppins', 'Segoe UI', system-ui, sans-serif);
+  color: #fff1f8; text-transform: lowercase; user-select: none;
+  pointer-events: auto; cursor: pointer;
+}
+#race-root .rc-root[hidden] { display: none; }
+#race-root .rc-col {
+  display: flex; flex-direction: column; gap: 14px; justify-content: center;
+  padding: 6vh 28px 6vh 5vw; min-width: 0;
+  background: linear-gradient(90deg, rgba(18, 11, 36, 0.92) 0%, rgba(18, 11, 36, 0.86) 88%, rgba(18, 11, 36, 0) 100%);
+}
+#race-root .rc-deck { display: flex; flex-direction: column; min-height: 46vh; justify-content: center; }
+/* the copy stops before the plate thins: this column is prose, not a verb list with its own box */
+#race-root .rc-card { display: flex; flex-direction: column; gap: 14px; padding-right: 9%; }
+#race-root .rc-card[hidden] { display: none; }
+#race-root .rc-card.is-in { animation: rcIn 0.42s cubic-bezier(0.2, 1.4, 0.4, 1) both; }
+#race-root .rc-card.is-hit { animation: rcBounce 0.28s cubic-bezier(0.2, 1.6, 0.4, 1); }
+
+/* card 1 wears the menu wordmark: 800 weight, the pink stepped shadow */
+#race-root .rc-word {
+  font-size: clamp(30px, 4.6vw, 62px); font-weight: 800; line-height: 0.95; letter-spacing: -0.02em;
+  color: #fff; text-shadow: 0 3px 0 #b5177c, 0 6px 0 #4a0a35, 0 0 22px rgba(255, 105, 180, 0.55);
+}
+#race-root .rc-h { margin: 0; font-size: clamp(22px, 2.6vw, 32px); font-weight: 800; letter-spacing: 0.02em; color: var(--pink, #ff69b4); }
+#race-root .rc-h.rc-face { font-size: clamp(30px, 4vw, 48px); letter-spacing: 0.06em; text-shadow: 0 0 22px rgba(255, 105, 180, 0.5); }
+#race-root .rc-line { margin: 0; max-width: 30em; font-size: clamp(15px, 1.5vw, 19px); font-weight: 500; line-height: 1.55; color: #ffe4f2; }
+
+/* the rail: 1 · 2 · 3 · 4, the one you are on lit */
+#race-root .rc-dots { display: flex; align-items: center; gap: 8px; font-size: 13px; font-weight: 800; font-variant-numeric: tabular-nums; }
+#race-root .rc-dot {
+  min-width: 22px; padding: 3px 0; text-align: center; color: rgba(255, 214, 234, 0.45);
+  background: rgba(255, 255, 255, 0.04); box-shadow: 0 0 0 2px #2b1b3f;
+  transition: color 0.12s, background 0.12s, box-shadow 0.12s;
+}
+#race-root .rc-dot.is-on { color: #fff; background: rgba(255, 105, 180, 0.2); box-shadow: 0 0 0 2px #2b1b3f, 0 0 0 3px var(--pink, #ff69b4); }
+#race-root .rc-sep { color: rgba(255, 214, 234, 0.3); }
+#race-root .rc-foot { display: flex; flex-wrap: wrap; gap: 18px; font-size: 12px; color: rgba(255, 214, 234, 0.55); }
+#race-root .rc-foot-k[hidden] { display: none; }
+
+@keyframes rcIn { from { opacity: 0; transform: translateX(-22px); } to { opacity: 1; transform: none; } }
+@keyframes rcBounce { 0% { transform: scale(1); } 35% { transform: scale(0.97); } 100% { transform: scale(1); } }
+
+@media (max-width: 720px) {
+  #race-root .rc-root { grid-template-columns: 1fr; }
+  #race-root .rc-col { padding: 4vh 22px; background: linear-gradient(180deg, rgba(18, 11, 36, 0.94) 0%, rgba(18, 11, 36, 0.86) 70%, rgba(18, 11, 36, 0) 100%); }
+}
+
+/* Law VI again: no card holds anyone. The system preference or the menu's own switch. */
+@media (prefers-reduced-motion: reduce) {
+  #race-root .rc-card.is-in, #race-root .rc-card.is-hit { animation: none; }
+  #race-root .rc-dot { transition: none; }
+}
+#race-root .rc-root[data-motion="on"] .rc-card.is-in, #race-root .rc-root[data-motion="on"] .rc-card.is-hit { animation: none; }
+#race-root .rc-root[data-motion="on"] .rc-dot { transition: none; }

--- a/ConditioningControlPanel/Resources/web/dtrh/race/menu.css
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/menu.css
@@ -1,4 +1,4 @@
-/* race/menu.css - the main menu of The Caucus Race (.rm-*). Scoped under #race-root.
+/* race/menu.css - the main menu of Racing Thoughts (.rm-*). Scoped under #race-root.
  * Same pixel look as the HUD: hard plates, stepped shadows, Poppins, lowercase.
  * The left column is DOM; the right side is a hole the stage shows through.
  * THE BOUNCE on press (Law VIII, inside 100 ms), THE GLOW on focus, springs never linear tweens (Law XI). */

--- a/ConditioningControlPanel/Resources/web/dtrh/race/menu.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/menu.js
@@ -3,12 +3,14 @@
  *
  *   createMenu({ root, renderer, pixel, audio, settings, log }) ->
  *     { show(), hide(), onPick(cb), options, stage: { update(dt), render(), dispose() }, dispose() }
- *   onPick yields 'race' | 'track' | 'clear' | 'surface'; setTrack(state | null) drives the track plate
- *   (CHART.md: the host's track-progress and the chart that lands).
+ *   onPick yields 'race' | 'track' | 'clear' | 'story' | 'surface'; setTrack(state | null) drives the
+ *   track plate (CHART.md: the host's track-progress and the chart that lands). refreshView() parks
+ *   the stage where the column would park it even while the menu is hidden (race/cards.js borrows it).
  *
  * Two halves. LEFT is a DOM column (menu.css, .rm-*): the title, the tagline,
- * four verbs (race / options / how to drive / surface), options opening in
- * place, a key card. RIGHT is the stage: a second THREE.Scene drawn through
+ * the verbs (race / load a track / just the road / options / how to drive /
+ * the story / surface), options and the key card opening in place. `the story`
+ * replays the four introduction cards of race/cards.js. RIGHT is the stage: a second THREE.Scene drawn through
  * the race's own renderer + pixelizer (no second canvas) by a menu camera
  * whose view offset parks EMI in the right part of the frame (the boot puts
  * `is-lobby` on .race-hud so the run's chrome stays out of it). She STANDS on a
@@ -315,7 +317,7 @@ export function createMenu({ root, renderer, pixel, audio, settings = {}, log = 
 
   // ---- the verbs. `track` only under a host (the file dialog is its), `clear` only once a file is in ----
   const canTrack = !!settings.trackPick;
-  const VERBS = [['race', 'race'], ['track', 'load a track'], ['clear', 'just the road'], ['options', 'options'], ['how', 'how to drive'], ['surface', 'surface']];
+  const VERBS = [['race', 'race'], ['track', 'load a track'], ['clear', 'just the road'], ['options', 'options'], ['how', 'how to drive'], ['story', 'the story'], ['surface', 'surface']];
   const verbEls = VERBS.map(([id, label], i) => {
     const b = el('button', 'rm-btn', list, label); b.type = 'button'; b.dataset.id = id; b.setAttribute('role', 'menuitem');
     b.addEventListener('click', () => { idx.main = i; act('press'); });
@@ -360,7 +362,7 @@ export function createMenu({ root, renderer, pixel, audio, settings = {}, log = 
   }
 
   // ---- navigation: one focus index per panel, every input path lands on act() ----
-  let panel = 'main', shown = false, disposed = false;
+  let panel = 'main', shown = false, disposed = false, viewHeld = false;
   const idx = { main: 0, options: 0 };
   function open(p) { panel = p; list.hidden = p !== 'main'; optPanel.hidden = p !== 'options'; howPanel.hidden = p !== 'how'; if (p === 'options') idx.options = 0; refresh(); if (p !== 'options') seedIn.blur(); }
   function focusRow(i) { idx.options = clamp(i, 0, ROWS.length - 1); refresh(); }
@@ -406,7 +408,10 @@ export function createMenu({ root, renderer, pixel, audio, settings = {}, log = 
   function onResize() {
     const w = root.clientWidth || window.innerWidth, h = root.clientHeight || window.innerHeight;
     stage.resize(w, h);
-    stage.setViewFraction(shown ? ((col.offsetWidth || w * 0.38) / w + 1) / 2 + 0.03 : 0.5);   // a hair right of the visible centre: room for the cup
+    // a hair right of the visible centre: room for the cup. `viewHeld` keeps that framing while the
+    // menu is hidden but something else owns the same column (race/cards.js), so a late resize does
+    // not walk her back to the middle of the frame.
+    stage.setViewFraction((shown || viewHeld) ? ((col.offsetWidth || w * 0.38) / w + 1) / 2 + 0.03 : 0.5);
   }
   const onPointer = (e) => { if (shown && e.clientX > window.innerWidth * 0.5) stage.emi.peek(); };
   window.addEventListener('keydown', onKey);
@@ -418,8 +423,12 @@ export function createMenu({ root, renderer, pixel, audio, settings = {}, log = 
     options, stage: { update(dt) { if (shown) pollPad(dt); stage.update(dt); }, render: stage.render, dispose: stage.dispose, live: stage },
     onPick(cb) { if (typeof cb === 'function') picks.push(cb); },
     setTrack, get track() { return trackState; },
-    show() { shown = true; layer.hidden = false; stage.setMode('menu'); open('main'); onResize(); hit(layer, 'is-in'); },
+    show() { shown = true; viewHeld = false; layer.hidden = false; stage.setMode('menu'); open('main'); onResize(); hit(layer, 'is-in'); },
     hide() { shown = false; layer.hidden = true; stage.setViewFraction(0.5); },
+    /** Park the stage the way the column parks it, with the menu hidden: race/cards.js uses the same
+     *  layout, so hide() sending her back to the middle of the frame would only be a jump and a jump
+     *  back. The hold survives a resize; show() takes it off again. */
+    refreshView() { viewHeld = true; onResize(); },
     refresh,
     dispose() {
       if (disposed) return;

--- a/ConditioningControlPanel/Resources/web/dtrh/race/menu.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/menu.js
@@ -1,5 +1,5 @@
 /* ============================================================================
- * race/menu.js - the main menu and the character stage of The Caucus Race.
+ * race/menu.js - the main menu and the character stage of Racing Thoughts.
  *
  *   createMenu({ root, renderer, pixel, audio, settings, log }) ->
  *     { show(), hide(), onPick(cb), options, stage: { update(dt), render(), dispose() }, dispose() }
@@ -261,9 +261,9 @@ export function createMenu({ root, renderer, pixel, audio, settings = {}, log = 
   const hit = (node, cls) => { node.classList.remove(cls); void node.offsetWidth; node.classList.add(cls); };
   const canLevels = !!(audio && typeof audio.setLevels === 'function');
 
-  const layer = el('div', 'rm-root', root); layer.hidden = true; layer.setAttribute('role', 'dialog'); layer.setAttribute('aria-label', 'the caucus race');
+  const layer = el('div', 'rm-root', root); layer.hidden = true; layer.setAttribute('role', 'dialog'); layer.setAttribute('aria-label', 'racing thoughts');
   const col = el('div', 'rm-col', layer);
-  el('div', 'rm-title', col, 'the caucus race');
+  el('div', 'rm-title', col, 'racing thoughts');
   el('div', 'rm-tag', col, 'steer. pop. never stop.');
   const list = el('div', 'rm-list', col); list.setAttribute('role', 'menu');
   const optPanel = el('div', 'rm-panel rm-options', col); optPanel.hidden = true;

--- a/ConditioningControlPanel/Resources/web/dtrh/race/pixel.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/pixel.js
@@ -1,5 +1,5 @@
 /* ============================================================================
- * race/pixel.js - the big-pixel look for The Caucus Race, with a crisp layer.
+ * race/pixel.js - the big-pixel look for Racing Thoughts, with a crisp layer.
  *
  * Two-pass render while a block size is on:
  *   (a) the WORLD (THREE layer 0) renders into a low-resolution render target

--- a/ConditioningControlPanel/Resources/web/dtrh/race/race.css
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/race.css
@@ -1,5 +1,5 @@
 /* ============================================================================
- * race.css - The Caucus Race HUD skin. Implements CONTRACT.md "race/hud.js + race/race.css".
+ * race.css - Racing Thoughts HUD skin. Implements CONTRACT.md "race/hud.js + race/race.css".
  *
  * Everything is scoped under .race-hud. Fonts and palette ride styles.css
  * (--rh-font, --pink); nothing new is loaded. Layers: the chrome sits at z3,

--- a/ConditioningControlPanel/Resources/web/dtrh/race/roomProps.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/roomProps.js
@@ -1,5 +1,5 @@
 /* ============================================================================
- * race/roomProps.js - The Caucus Race diegetic props. Everything is grounded:
+ * race/roomProps.js - Racing Thoughts diegetic props. Everything is grounded:
  * shoulder props stand on a chunky step block beside the kerb, wall props sit
  * flush on the tube wall at shoulder height and above. Nothing floats mid-tube.
  *

--- a/ConditioningControlPanel/Resources/web/dtrh/race/rooms.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/rooms.js
@@ -1,5 +1,5 @@
 /* ============================================================================
- * race/rooms.js - The Caucus Race rooms and road furniture.
+ * race/rooms.js - Racing Thoughts rooms and road furniture.
  *
  * Implements CONTRACT.md section "race/rooms.js": ROOMS (the eight room specs),
  * rollRoomOrder(seed) (Tea Garden first, then the rest dealt loud/soft/loud so the

--- a/ConditioningControlPanel/Resources/web/dtrh/race/run.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/run.js
@@ -1,5 +1,5 @@
 /* ============================================================================
- * race/run.js - the run brain of The Caucus Race. Implements CONTRACT.md
+ * race/run.js - the run brain of Racing Thoughts. Implements CONTRACT.md
  * "race/run.js + raceBoot.js + race.html (PR 5, integration)".
  *
  *   createRace({ root, bridge, media, settings, seed }) -> { start(), setPaused(b), dispose() }

--- a/ConditioningControlPanel/Resources/web/dtrh/race/score.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/score.js
@@ -1,5 +1,5 @@
 /* ============================================================================
- * race/score.js - The Caucus Race ledger: score, combo, the multiplier ladder,
+ * race/score.js - Racing Thoughts ledger: score, combo, the multiplier ladder,
  * THE BANK at the Tea Garden, near-miss ALMOSTs and the jackpot ladder.
  * Implements CONTRACT.md section `race/score.js`.
  *

--- a/ConditioningControlPanel/Resources/web/dtrh/race/speed.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/speed.js
@@ -1,5 +1,5 @@
 /* ============================================================================
- * race/speed.js - the sense of speed for The Caucus Race.
+ * race/speed.js - the sense of speed for Racing Thoughts.
  *
  * Three cheap layers, all additive, none of them paint over the road:
  *  - streaks: short lines around the camera edge (a child of the camera) that

--- a/ConditioningControlPanel/Resources/web/dtrh/race/spine.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/spine.js
@@ -1,5 +1,5 @@
 /* ============================================================================
- * race/spine.js - The Caucus Race track spine.
+ * race/spine.js - Racing Thoughts track spine.
  *
  * Implements CONTRACT.md section "race/spine.js": createSpine({ seed, roomOrder })
  * returns a closed CatmullRom layout built from the chunk grammar (straight, bendL,

--- a/ConditioningControlPanel/Resources/web/dtrh/race/walls.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/walls.js
@@ -1,5 +1,5 @@
 /* ============================================================================
- * race/walls.js - The Caucus Race wall media: the player's own images plastered on
+ * race/walls.js - Racing Thoughts wall media: the player's own images plastered on
  * the upper tube wall, exactly like the descent's wall posters (engine/wallPosters.js
  * is reused as-is), plus painted room signage so the wall is never bare when the
  * library is empty.

--- a/ConditioningControlPanel/Resources/web/dtrh/raceBoot.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/raceBoot.js
@@ -1,5 +1,5 @@
 /* ============================================================================
- * raceBoot.js - boots The Caucus Race page. Implements CONTRACT.md
+ * raceBoot.js - boots Racing Thoughts page. Implements CONTRACT.md
  * "race/run.js + raceBoot.js + race.html (PR 5, integration)" and the
  * "race/menu.js + race/intro.js" section (the front door).
  *

--- a/ConditioningControlPanel/Resources/web/dtrh/raceBoot.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/raceBoot.js
@@ -7,7 +7,8 @@
  * -> wait for `init` (+ `manifest`, `favorites`) with a 4 s timeout -> hostMedia
  * -> createRace + createMenu -> the splash is a 1 s title flash (it covers the
  * module import, the world build and the glb fetch, and hosts the wait note
- * and boot errors) -> the MENU is the resting state -> `race` plays the intro
+ * and boot errors) -> on a first open the four introduction cards
+ * (race/cards.js) -> the MENU is the resting state -> `race` plays the intro
  * on the menu stage -> the run starts under the camera whip. `surface` from
  * the menu is the same exit the End screen takes.
  *
@@ -22,6 +23,9 @@
  * intro and boots straight into the run (headless checks depend on it);
  * `?intro=0` keeps the menu and skips the intro; `?scene=intro` boots straight
  * into the intro and `?hold=ms` freezes it at that intro time (screenshots);
+ * `?cards=1` forces the introduction cards and `?cards=0` skips them (without
+ * either they show once, gated on localStorage `race.cards`), and `?card=N`
+ * opens them on card N (1..4, a screenshot aid the way `?hold=` is one);
  * `?pixel=N` (0 = off) beats `race.options` which beats `settings.pixel` from
  * the host init.
  *
@@ -171,6 +175,7 @@ async function boot() {
       else if (id === 'surface') surface();
       else if (id === 'track') { plate({ stage: 'picking' }); host.send({ type: 'track-pick' }); }
       else if (id === 'clear') { host.send({ type: 'track-cancel' }); race.setTrack(null); trackReady = null; plate(null); }
+      else if (id === 'story') { menu.hide(); menu.refreshView(); showCards().then(() => { if (!exiting && !started) menu.show(); }); }
     });
     if (trackReady) plate(trackReady); else if (trackProgress && trackProgress.stage !== 'cancelled') plate(trackProgress);
     menu.seedCheck = () => {   // the menu may have changed the seed rule: rebuild the world once, before the intro
@@ -182,7 +187,7 @@ async function boot() {
     };
     race.setStage(menu.stage);
     if (params.get('scene') === 'intro') { startRun(true); return; }
-    setTimeout(() => { hideSplash(); menu.show(); }, Math.max(0, SPLASH_MS - (performance.now() - t0)));
+    setTimeout(() => { hideSplash(); firstCards(); }, Math.max(0, SPLASH_MS - (performance.now() - t0)));
   } catch (err) {
     fail(err);
   }
@@ -235,6 +240,33 @@ function stopTrackClock() {
 function hideSplash() {
   splash.classList.add('is-off');
   setTimeout(() => { splash.hidden = true; }, 600);
+}
+/**
+ * The four introduction cards (race/cards.js) on the menu's own stage framing. Resolves when they
+ * end, read through or escaped; either way they count as seen. A card layer that will not build is
+ * never worth the front door, so it is logged and swallowed.
+ */
+async function showCards() {
+  try {
+    const { createCards } = await import('./race/cards.js');
+    const reducedMotion = menu ? (menu.options.motion === 'on' || (menu.options.motion === 'system' && settings.reducedMotion)) : !!settings.reducedMotion;
+    const cards = createCards({ root, audio: race && race.audio, reducedMotion, log: host.log, start: (Number(params.get('card')) || 1) - 1 });
+    await cards.show();   // show() writes the gate itself, so a window closed mid-read still counts
+    cards.dispose();
+  } catch (err) {
+    host.log('cards: ' + ((err && err.message) || err));
+  }
+}
+/** First open: the cards, then the menu. `?cards=1` forces them, `?cards=0` says never. */
+async function firstCards() {
+  const want = params.get('cards');
+  if (want !== '0' && !started) {
+    try {
+      const { cardsSeen } = await import('./race/cards.js');
+      if (want === '1' || !cardsSeen()) { menu.refreshView(); await showCards(); }
+    } catch (err) { host.log('cards gate: ' + ((err && err.message) || err)); }
+  }
+  if (!exiting && !started) menu.show();
 }
 /** race: the intro on the menu stage, then the run under the camera whip. autostart / intro=0 go straight to the run. */
 async function startRun(withIntro) {


### PR DESCRIPTION
## Racing Thoughts (ex Caucus Race) web stack

Stacked on `feat/race-c3-cues`. Merge bottom-up.

### Commits
- feat(race): four introduction cards on the first open, and a verb to replay them
- rename(race): the game is Racing Thoughts

`31 files changed, 371 insertions(+), 44 deletions(-)`

### From the commit message
New race/cards.js: a .rc-root DOM layer at z26, between the menu and the boot
splash, laid out on the menu's own column so EMI keeps standing on her podium
in the right of the frame while the cards read. Four cards one at a time: the
wordmark, the road, the track, and (^_^) in the pink. Enter, space, right, d,
a pointer press or pad A goes forward, left, a or pad B goes back, esc ends it.
The last card's advance ends it too, and show() resolves either way.
The bounce on every advance and a spring on each card as it lands, neither
under reduced motion, through the same [data-motion] hook menu.css already
reads for the menu.
The gate is its own localStorage key, race.cards, written by show() the moment
the cards go up, so read through, escaped and walked away from all count as
seen and the front door never repeats itself. race.options keeps the shape
menu.js documents. Every read and write is wrapped: the WebView can refuse
storage and the cards still run.
Boot: the splash timeout now hands off to the cards on a first open and to the
menu after. ?cards=1 forces them, ?cards=0 skips them, ?card=N opens on card N
for screenshots. ?autostart=1 and ?scene=intro return before any of it, so the
headless checks are untouched. The menu grows a sixth verb, "the story", which
replays them.
menu.js also grows refreshView(), a view hold that keeps the stage framed on
the column while the menu is hidden. Without it a resize landing during the
cards walked EMI back to the middle of the frame, which the headless shot
caught.
The Caucus Race is now Racing Thoughts. The splash title, the page title,
the menu wordmark and its aria-label all read "racing thoughts" in the
house lowercase; every module header comment and the race/ markdown say
"Racing Thoughts" in prose.
Nothing moved and nothing was renamed in code: the folder is still race/,
the entry is still raceBoot.js, createRace and every host message type are
untouched, and CaucusHostService in CHART.md stays as written because it
names a C# class. CONTRACT.md carries a line saying the game was called
The Caucus Race until 2026-09-06, so old notes and PR titles still resolve.
34 replacements across 30 files.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0166ij3Q8xyseVkhWajzkWG3
