### PR TITLE
fix(race): the stage stops eating her feet and the saucer stops eating the podium

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/race/intro.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/intro.js
@@ -32,6 +32,10 @@ import { PODIUM_H, CUP_SCALE, PROPS_URL } from './menu.js';
 import { CAM_BACK, CAM_UP, CAM_LOOK_AHEAD, LANE_H } from './consts.js';
 
 const GANTRY_Z = -3.6, RIM_H = 0.75 * CUP_SCALE, PINK = 0xff69b4, CREAM = 0xf6e7c8;
+// The waddle ends at the podium's near edge, on the plate and facing the cup: the plate runs to
+// r 0.98 and her shoes are 0.22 wide, so 0.7 keeps both soles on porcelain. She hops the gap from
+// there; walking any further would put her over the rim with nothing under her feet.
+const STAND_R = 0.7;
 const FACE = { happy: 0, cat: 1, squint: 2, wide: 3, money: 4 };
 const T_HOP_IN = 2.6, T_SINK = 3.0, T_ROLL = 3.4, T_COUNT = 5.4;
 const clamp = (v, a, b) => Math.max(a, Math.min(b, v));
@@ -122,7 +126,8 @@ export function createIntro({ stage, hud, audio = null, reducedMotion = false, l
     const p = new Promise((res) => { resolveGo = res; });
     if (reducedMotion) { toLine(); return p; }
     phase = 0; t = 0;
-    walk.to(_v.set(cupHome.x + 0.95, PODIUM_H, cupHome.z + 0.35));
+    _m.set(cupHome.x, 0, cupHome.z).setLength(STAND_R);
+    walk.to(_v.set(_m.x, PODIUM_H, _m.z));
     emi.face(FACE.happy);
     if (emi.play('hop', { timeScale: 1.25 })) hops = 1;
     return p;

--- a/ConditioningControlPanel/Resources/web/dtrh/race/menu.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/menu.js
@@ -52,10 +52,19 @@ const DEFAULTS = { pixel: PIXEL_DEFAULT, music: 0.8, sfx: 0.8, motion: 'system',
 const MOTIONS = ['system', 'on', 'off'], SEEDS = ['daily', 'random', 'custom'];
 const FACE_N = 5, GLASS = 'EMI_glass', FADE = 0.3, ONE_SHOTS = ['wave', 'hop', 'drum'];
 const BEAT_MIN = 3, BEAT_MAX = 6, PEEK_GAP = 6;
-export const PODIUM_H = 0.22, CUP_SCALE = 1.3;
-export const CUP_AT = Object.freeze({ x: -1.2, y: 0, z: 0.45 });
+// Stage metres, all of them read off props.glb so the placeholders and the real props agree.
+// `podium` is a saucer: a foot of radius 0.75 on the floor flaring to a rim of radius 1.10, whose
+// TOP PLATE is y 0.31 (the raised lip around it tops out at 0.35). PODIUM_H is that plate, the
+// height her soles stand at; the lathe fallback below is cut to the same silhouette, so she never
+// sinks into one podium and floats on the other.
+export const PODIUM_H = 0.31, CUP_SCALE = 1.3;
+// `kart_saucer` is 0.98 wide before CUP_SCALE, so the dish alone is wider than the podium plate: the
+// cup can only stand clear on the FLOOR, never half over the rim. Widest dish (r 1.27 at y 0.13)
+// against the podium's flare at that height (r 0.93) wants 2.20 between the two centres; CUP_AT is
+// 2.35 out, back and to her left so the menu column never swallows it.
+export const CUP_AT = Object.freeze({ x: -2.05, y: 0, z: -1.15 });
 const CUP_PROFILE = [[0.001, 0], [0.28, 0], [0.34, 0.06], [0.44, 0.3], [0.52, 0.58], [0.55, 0.66], [0.5, 0.68], [0.47, 0.6], [0.4, 0.3], [0.3, 0.1], [0.001, 0.08]];
-const PODIUM_PROFILE = [[0.001, 0], [1.25, 0], [1.32, 0.05], [1.2, 0.12], [1.02, 0.18], [0.98, PODIUM_H], [0.001, PODIUM_H]];
+const PODIUM_PROFILE = [[0.001, 0], [0.75, 0], [1.05, PODIUM_H - 0.05], [1.1, PODIUM_H], [1.1, PODIUM_H + 0.04], [0.98, PODIUM_H + 0.04], [0.98, PODIUM_H], [0.001, PODIUM_H]];
 const PINK = 0xff69b4, PORCELAIN = 0xf6e7c8, HAZE = 0x1b1232;
 const PAD = { a: 0, b: 1, up: 12, down: 13, left: 14, right: 15 };
 const clamp = (v, a, b) => Math.max(a, Math.min(b, v));
@@ -131,7 +140,7 @@ export function createStage({ renderer, pixel, reducedMotion = false, log = null
   // the saucer podium she stands on
   const podium = new THREE.Group(); scene.add(podium);
   podium.add(lathe(PODIUM_PROFILE, porcelain, 48));
-  const pring = new THREE.Mesh(keep(new THREE.TorusGeometry(1.1, 0.03, 8, 64)), glow); pring.rotation.x = Math.PI / 2; pring.position.y = PODIUM_H + 0.005; podium.add(pring);
+  const pring = new THREE.Mesh(keep(new THREE.TorusGeometry(1.04, 0.03, 8, 64)), glow); pring.rotation.x = Math.PI / 2; pring.position.y = PODIUM_H + 0.045; podium.add(pring);
   // the cup BESIDE her: group keeps the place, body takes the squash and stretch
   const cup = new THREE.Group(); cup.position.set(CUP_AT.x, CUP_AT.y, CUP_AT.z); cup.scale.setScalar(CUP_SCALE); cup.rotation.y = -0.6; scene.add(cup);
   const cupBody = new THREE.Group(); cup.add(cupBody);


### PR DESCRIPTION
## Racing Thoughts (ex Caucus Race) web stack

Stacked on `feat/race-c8-intro`. Merge bottom-up.

### Commits
- fix(race): the stage stops eating her feet and the saucer stops eating the podium

`2 files changed, 19 insertions(+), 5 deletions(-)`

### From the commit message
Two stage numbers were guesses, and props.glb disagreed with both.
PODIUM_H was 0.22. It is the y her soles stand at, but the podium she actually
stands on is props.glb `podium`, whose top plate is 0.31 (its raised lip tops
out at 0.35). She was set 0.09 under the porcelain, so both shoes and most of
both legs were inside it and only two black stubs came out the top. PODIUM_H is
now 0.31, and the lathe podium that stands in when the pack is missing is cut to
the same silhouette (a foot of radius 0.75 flaring to a rim of 1.10, the plate at
PODIUM_H, the lip 0.04 over it) so the fallback and the prop put her feet in the
same place. The glow ring moves onto that lip.
CUP_AT was 1.28 from the podium centre. `kart_saucer` is 0.98 across before
CUP_SCALE 1.3, which makes the dish alone WIDER than the podium: at 1.28 the
saucer ran straight through the podium's rim and out over its plate. The dish is
widest (1.27) at y 0.13, where the podium's flare is 0.93, so the two centres
want 2.20 between them. The cup now sits 2.35 out, back and to her left, fully on
the tiles, clear of the rim and clear of the menu column.
The intro's waddle target was written off the cup (cupHome + 0.95), which with
the cup that far out would have walked her off the plate into the air. It is now
a point on the podium in the cup's direction: she waddles to the near edge, both
soles on porcelain, and hops the gap from there. Checked headless at 2.5 s (the
edge), 2.7 s (the hop) and 3.3 s (the sink).


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0166ij3Q8xyseVkhWajzkWG3
