### PR TITLE
feat(race): the stage gets a backdrop, not a blue screen (+1)

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/race/intro.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/intro.js
@@ -10,11 +10,14 @@
  *
  * Six to eight seconds on the menu stage, drawn through the same renderer and
  * pixelizer (the boot hands this object to race.setStage while it plays):
- *   A  0.0..2.6  she waddles from the podium to the cup: two hops while a
+ *   A  0.0..2.42 she waddles from the podium to the cup: two hops while a
  *                spring carries her, face ^_^
- *   B  2.6..3.4  she hops in: up over the rim, down into the tea, the cup body
- *                squashes and stretches, the tea rings out, face >_< then ^_^
- *   C  3.4..5.4  the cup rolls to the start gantry; the camera settles into a
+ *   B  2.42..3.5 THE LEAP. 0.18 s of squat with >_<, then a 0.55 s parabola
+ *                to the rim (the apex a metre over it) with a forward tumble
+ *                and o_o, then the landing: the cup body squashes deep and
+ *                stretches back, the tea rings out and throws eight beads
+ *                over the rim, the camera dips 8 cm, >_< then ^_^ 0.35 s on
+ *   C  3.5..5.4  the cup rolls to the start gantry; the camera settles into a
  *                front seat (props.glb `gantry`, else two pink posts + a cream bar)
  *   D  5.4..     3 2 1 on the HUD with o_o, :3 on GO; play() resolves on GO
  * Then the boot starts the run and installs cameraWhip: 0.8 s from the run's
@@ -37,15 +40,28 @@ const GANTRY_Z = -3.6, RIM_H = 0.75 * CUP_SCALE, PINK = 0xff69b4, CREAM = 0xf6e7
 // there; walking any further would put her over the rim with nothing under her feet.
 const STAND_R = 0.7;
 const FACE = { happy: 0, cat: 1, squint: 2, wide: 3, money: 4 };
-const T_HOP_IN = 2.6, T_SINK = 3.0, T_ROLL = 3.4, T_COUNT = 5.4;
+const T_CROUCH = 2.42, T_HOP_IN = 2.6, T_ARC = 0.55, T_SINK = T_HOP_IN + T_ARC, T_ROLL = 3.5, T_COUNT = 5.4;
+// the leap: how far over the rim the apex goes, how far she tips into it, where she comes down.
+const APEX_UP = 0.72, TUMBLE = -25 * Math.PI / 180, RIM_CLEAR = 0.16;
+// the tea that jumps the rim on the landing: eight cream beads, ballistic, gone in half a second.
+const DROPS = 8, DROP_SEC = 0.5, DROP_G = 9.5, CAM_DIP = 0.08;
 const clamp = (v, a, b) => Math.max(a, Math.min(b, v));
+
+/** The longest step a spring integrates in one go. run.js clamps a frame at 0.1 s, and explicit Euler
+ *  on a stiff spring (w 22, w 26) diverges long before that, so a slow frame is walked in pieces. */
+const SUB_H = 0.02, SUB_MAX = 8;
+const subSteps = (dt) => (dt > SUB_H ? Math.min(SUB_MAX, Math.ceil(dt / SUB_H)) : 1);
 
 /** Damped spring on a scalar: `w` rad/s, `zeta` < 1 overshoots (the stretch), 1 settles clean. */
 export class Spring {
   constructor(x = 0, w = 10, zeta = 0.9) { this.x = x; this.v = 0; this.target = x; this.w = w; this.zeta = zeta; }
   to(t) { this.target = t; return this; }
   set(x) { this.x = x; this.target = x; this.v = 0; return this; }
-  step(dt) { this.v += (this.w * this.w * (this.target - this.x) - 2 * this.zeta * this.w * this.v) * dt; this.x += this.v * dt; return this.x; }
+  step(dt) {
+    const n = subSteps(dt), h = dt / n;
+    for (let i = 0; i < n; i++) { this.v += (this.w * this.w * (this.target - this.x) - 2 * this.zeta * this.w * this.v) * h; this.x += this.v * h; }
+    return this.x;
+  }
   get done() { return Math.abs(this.target - this.x) < 0.002 && Math.abs(this.v) < 0.02; }
 }
 /** The same spring on a Vector3, written in place on `x`. */
@@ -54,8 +70,12 @@ export class Spring3 {
   to(t) { this.target.copy(t); return this; }
   set(p) { this.x.copy(p); this.target.copy(p); this.v.set(0, 0, 0); return this; }
   step(dt) {
-    this._a.subVectors(this.target, this.x).multiplyScalar(this.w * this.w).addScaledVector(this.v, -2 * this.zeta * this.w);
-    this.v.addScaledVector(this._a, dt); this.x.addScaledVector(this.v, dt); return this.x;
+    const n = subSteps(dt), h = dt / n;
+    for (let i = 0; i < n; i++) {
+      this._a.subVectors(this.target, this.x).multiplyScalar(this.w * this.w).addScaledVector(this.v, -2 * this.zeta * this.w);
+      this.v.addScaledVector(this._a, h); this.x.addScaledVector(this.v, h);
+    }
+    return this.x;
   }
 }
 
@@ -72,32 +92,68 @@ export function createIntro({ stage, hud, audio = null, reducedMotion = false, l
   const cupHome = cup.position.clone(), lineAt = new THREE.Vector3(0, 0, GANTRY_Z + 1.0);
   const walk = new Spring3(emi.root.position, 6, 0.95), ride = new Spring3(cup.position, 5, 0.9);
   const camPos = new Spring3(camera.position, 3, 1), camLook = new Spring3(new THREE.Vector3(0, 0.6, 0), 3, 1);   // gentle for the waddle, 5.5 for the roll
-  const squash = new Spring(1, 22, 0.32);
+  const squash = new Spring(1, 22, 0.28);            // the cup body: deeper now, and it rings back harder
+  const crouch = new Spring(1, 26, 0.42);            // her root: the squat, then the stretch off the floor
+  const dip = new Spring(0, 24, 0.9);                // the camera nods 8 cm on the landing and comes back
   let t = 0, phase = -1, inCup = false, hops = 0, disposed = false, resolveGo = null, counting = false, atLine = false;
-  const _v = new THREE.Vector3(), _m = new THREE.Vector3();
+  let faceWant = -1, dipOn = 0, dropT = -1, arcMid = 0, liftWant = 0;
+  const _v = new THREE.Vector3(), _m = new THREE.Vector3(), _w = new THREE.Vector3();
+  const arcFrom = new THREE.Vector3(), arcTo = new THREE.Vector3(), base = new THREE.Vector3(1, 1, 1);
+
+  // ---- the splash: eight beads on one instanced mesh, thrown off the rim and integrated under gravity ----
+  const dropGeo = keep(new THREE.SphereGeometry(0.038, 6, 4));
+  const drops = new THREE.InstancedMesh(dropGeo, keep(new THREE.MeshStandardMaterial({ color: CREAM, roughness: 0.25, emissive: 0x3a1428 })), DROPS);
+  drops.frustumCulled = false; drops.visible = false; scene.add(drops);
+  const dropP = [], dropV = [], _mx = new THREE.Matrix4(), _sc = new THREE.Vector3();
+  for (let i = 0; i < DROPS; i++) { dropP.push(new THREE.Vector3()); dropV.push(new THREE.Vector3()); }
+  function splash() {
+    cup.getWorldPosition(_w);
+    dropT = 0; drops.visible = true;
+    for (let i = 0; i < DROPS; i++) {
+      const a = (i / DROPS) * Math.PI * 2 + 0.4, out = 1.05 + (i % 3) * 0.3;
+      dropP[i].set(_w.x + Math.cos(a) * 0.44 * CUP_SCALE, _w.y + 0.68 * CUP_SCALE, _w.z + Math.sin(a) * 0.44 * CUP_SCALE);
+      dropV[i].set(Math.cos(a) * out, 2.4 + (i % 4) * 0.4, Math.sin(a) * out);
+    }
+  }
+  function stepDrops(dt) {
+    if (dropT < 0) return;
+    dropT += dt;
+    if (dropT >= DROP_SEC) { dropT = -1; drops.visible = false; return; }
+    const k = 1 - dropT / DROP_SEC;
+    for (let i = 0; i < DROPS; i++) {
+      dropV[i].y -= DROP_G * dt; dropP[i].addScaledVector(dropV[i], dt);
+      _mx.makeTranslation(dropP[i].x, dropP[i].y, dropP[i].z);
+      drops.setMatrixAt(i, _mx.scale(_sc.setScalar(0.45 + k * 0.55)));
+    }
+    drops.instanceMatrix.needsUpdate = true;
+  }
 
   function sinkIn() {
     if (inCup) return;
     inCup = true;
     cup.attach(emi.root);   // she rides with the cup from here on
     walk.set(emi.root.position).to(_v.set(0, 0.42, 0));   // cup-local: she sinks in past the rim (tea at 0.66), her face still clears it
-    squash.set(0.8).to(1);  // the stretch is the overshoot
+    squash.set(0.72).to(1); // deeper in, and the stretch is the overshoot
     stage.cup.ripple();
-    emi.face(FACE.squint);
+    faceWant = FACE.squint; emi.face(FACE.squint);
   }
   /** The front seat on the cup (the roll and the line). */
   function seat(p) { camPos.to(_v.set(p.x, p.y + 1.35, p.z + 3.7)); camLook.to(_v.set(p.x, p.y + 0.95, p.z)); }
-  /** The wide seat for the waddle and the hop in: the menu camera, drifting with the midpoint of her and the cup. */
-  function wide(p) { camPos.to(_v.set(p.x * 0.5, 1.05, 4.4)); camLook.to(_v.set(p.x * 0.5, 0.6, 0)); }
+  /** The wide seat for the waddle and the leap: the menu camera, drifting with the midpoint of her and the
+   *  cup. `lift` is how far off the floor she is, so the seat tips up with the jump and she stays in frame. */
+  function wide(p, lift = 0) { camPos.to(_v.set(p.x * 0.5, 1.05 + lift * 0.6, 4.4)); camLook.to(_v.set(p.x * 0.5, 0.6 + lift * 1.15, 0)); }
   function toLine() {
     if (atLine) return;
     atLine = true;
+    emi.root.rotation.x = 0; emi.root.scale.set(1, 1, 1);
     sinkIn();
+    base.copy(emi.root.scale); crouch.set(1);
+    dip.set(0); dipOn = 0; dropT = -1; drops.visible = false; liftWant = 0;
     walk.set(_v.set(0, 0.55, 0));
     ride.set(lineAt); squash.set(1); body.rotation.z = 0; body.scale.setScalar(1);
     seat(lineAt); camPos.set(camPos.target); camLook.set(camLook.target);
     camera.lookAt(camLook.x);
-    emi.face(FACE.happy);
+    faceWant = -1; emi.face(FACE.happy);
     count();
   }
   function count() {
@@ -128,7 +184,8 @@ export function createIntro({ stage, hud, audio = null, reducedMotion = false, l
     phase = 0; t = 0;
     _m.set(cupHome.x, 0, cupHome.z).setLength(STAND_R);
     walk.to(_v.set(_m.x, PODIUM_H, _m.z));
-    emi.face(FACE.happy);
+    faceWant = FACE.happy; emi.face(FACE.happy);
+    base.copy(emi.root.scale);
     if (emi.play('hop', { timeScale: 1.25 })) hops = 1;
     return p;
   }
@@ -139,21 +196,50 @@ export function createIntro({ stage, hud, audio = null, reducedMotion = false, l
     if (atLine) { camPos.step(dt); camLook.step(dt); camera.lookAt(camLook.x); return; }
     t += dt;
     if (phase === 0 && t >= 1.28 && hops === 1) { hops = 2; emi.play('hop', { timeScale: 1.25 }); }
-    if (phase === 0 && t >= T_HOP_IN) { phase = 1; walk.w = 14; walk.to(_v.set(cupHome.x, cupHome.y + RIM_H + 0.45, cupHome.z)); }
-    if (phase === 1 && t >= T_SINK) { phase = 2; sinkIn(); }
-    if (phase === 2 && t >= T_ROLL) { phase = 3; ride.to(lineAt); emi.face(FACE.happy); camPos.w = camLook.w = 5.5; }
-    if (phase === 3 && t >= T_COUNT) { phase = 4; count(); }
-    walk.step(dt); ride.step(dt);
+    if (phase === 0 && t >= T_CROUCH) { phase = 1; crouch.to(0.85); faceWant = FACE.squint; }   // load the legs
+    if (phase === 1 && t >= T_HOP_IN) {                                  // the leap. Ballistics, never a spring to a point
+      phase = 2; walk.w = 14;
+      arcFrom.copy(emi.root.position);
+      arcTo.set(cupHome.x, cupHome.y + RIM_H + RIM_CLEAR, cupHome.z);
+      arcMid = cupHome.y + RIM_H + APEX_UP - (arcFrom.y + arcTo.y) * 0.5;
+      liftWant = cupHome.y + RIM_H + APEX_UP - PODIUM_H;   // the seat starts tipping up now, so the apex lands in frame
+      crouch.set(0.82).to(1); faceWant = FACE.wide; camPos.w = camLook.w = 4.5;
+    }
+    if (phase === 2) {
+      const a = clamp((t - T_HOP_IN) / T_ARC, 0, 1);
+      emi.root.position.set(arcFrom.x + (arcTo.x - arcFrom.x) * a,
+        arcFrom.y + (arcTo.y - arcFrom.y) * a + 4 * arcMid * a * (1 - a),
+        arcFrom.z + (arcTo.z - arcFrom.z) * a);
+      emi.root.rotation.x = TUMBLE * Math.sin(Math.PI * a);             // tips into the jump, level again at the rim
+      walk.set(emi.root.position);                                      // the spring rides along, so the landing has no jump
+    }
+    if (phase === 2 && t >= T_SINK) {
+      phase = 3;
+      emi.root.rotation.x = 0; emi.root.scale.set(1, 1, 1);
+      sinkIn(); splash();
+      base.copy(emi.root.scale); crouch.set(0.88).to(1); dip.set(-CAM_DIP).to(0);
+      liftWant = 0; camPos.w = camLook.w = 5;   // the seat drops back onto the cup as she does
+    }
+    if (phase === 3 && t >= T_ROLL) { phase = 4; ride.to(lineAt); faceWant = -1; emi.face(FACE.happy); camPos.w = camLook.w = 5.5; }
+    if (phase === 4 && t >= T_COUNT) { phase = 5; count(); }
+    if (faceWant >= 0 && phase < 4) emi.face(faceWant);
+    walk.step(dt); ride.step(dt); stepDrops(dt);
+    const c = crouch.step(dt);
+    emi.root.scale.set(base.x / Math.sqrt(c), base.y * c, base.z / Math.sqrt(c));
     body.scale.set(1 / Math.sqrt(squash.step(dt)), squash.x, 1 / Math.sqrt(squash.x));
-    if (phase >= 3) { const rolling = clamp(ride.v.length() * 0.6, 0, 1); body.rotation.z = Math.sin(t * 11) * 0.08 * rolling; }
-    if (phase >= 3) seat(cup.position); else wide(_m.copy(cupHome).lerp(emi.root.getWorldPosition(_v), 0.5));
-    camPos.step(dt); camLook.step(dt); camera.lookAt(camLook.x);
+    if (phase >= 4) { const rolling = clamp(ride.v.length() * 0.6, 0, 1); body.rotation.z = Math.sin(t * 11) * 0.08 * rolling; }
+    if (phase >= 4) seat(cup.position);
+    else wide(_m.copy(cupHome).lerp(emi.root.getWorldPosition(_v), 0.5), liftWant);
+    camera.position.y -= dipOn;                                         // the dip lives outside the spring's own state
+    camPos.step(dt); camLook.step(dt);
+    dipOn = dip.step(dt); camera.position.y += dipOn;
+    camera.lookAt(camLook.x);
   }
   function dispose() {
     if (disposed) return;
     disposed = true;
     window.removeEventListener('keydown', onKey); window.removeEventListener('pointerdown', onPointer);
-    scene.remove(gantry);
+    scene.remove(gantry); scene.remove(drops); drops.dispose();
     for (const x of own) x.dispose();
   }
   return { play, skip, update, render: stage.render, dispose, get atLine() { return atLine; }, get time() { return t; } };

--- a/ConditioningControlPanel/Resources/web/dtrh/race/menu.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/menu.js
@@ -27,6 +27,13 @@
  * of the cached pack with its own glass material so the stage face and the
  * run's face never fight.
  *
+ * The BACKDROP is geometry, never an asset: a 32 m sky dome painted with a
+ * canvas gradient (plum overhead, a pink haze band on the eye line, the mist
+ * below), three oversized lathe cups sat far back as flat-shaded silhouettes
+ * and a dozen additive bubbles drifting up behind the stage. The scene fog is
+ * that same mist, so the checker dies in the haze instead of ending on a line.
+ * Reduced motion holds the bubbles still.
+ *
  * Options persist under ONE localStorage key, `race.options`, not through
  * engine/settings.js: that store is the dive's typed `sf-settings` row with a
  * fixed DEFAULTS table and a purchase ladder, and the race must not widen it.
@@ -66,6 +73,10 @@ export const CUP_AT = Object.freeze({ x: -2.05, y: 0, z: -1.15 });
 const CUP_PROFILE = [[0.001, 0], [0.28, 0], [0.34, 0.06], [0.44, 0.3], [0.52, 0.58], [0.55, 0.66], [0.5, 0.68], [0.47, 0.6], [0.4, 0.3], [0.3, 0.1], [0.001, 0.08]];
 const PODIUM_PROFILE = [[0.001, 0], [0.75, 0], [1.05, PODIUM_H - 0.05], [1.1, PODIUM_H], [1.1, PODIUM_H + 0.04], [0.98, PODIUM_H + 0.04], [0.98, PODIUM_H], [0.001, PODIUM_H]];
 const PINK = 0xff69b4, PORCELAIN = 0xf6e7c8, HAZE = 0x1b1232;
+// the backdrop. MIST is both the fog and the bottom of the sky, so the floor's edge has nowhere to show.
+const MIST = 0x3a1c4e, FOG_NEAR = 9, FOG_FAR = 21, SKY_R = 44, FAR_PLUM = 0x4a2464, FLOOR_W = 46, FLOOR_N = 21, BUBBLE_N = 12;
+// far shapes: [x, z, scale, yaw]. The same cup profile, blown up and sat on the floor behind the gantry.
+const FAR_CUPS = [[-15, -28, 6, 0.5], [14, -33, 7, -0.8], [-6.5, -37, 6.4, 2.1]];
 const PAD = { a: 0, b: 1, up: 12, down: 13, left: 14, right: 15 };
 const clamp = (v, a, b) => Math.max(a, Math.min(b, v));
 
@@ -95,19 +106,28 @@ export function seedFromOptions(o, now = new Date()) {
 export function wantsReducedMotion(o, system) { return o.motion === 'on' ? true : o.motion === 'off' ? false : !!system; }
 
 // ---- textures the placeholders need ------------------------------------------------------------
-function checkerTexture(a, b) {
+function checkerTexture(a, b, repeat = 15) {
   const c = document.createElement('canvas'); c.width = c.height = 2;
   const g = c.getContext('2d'); g.fillStyle = a; g.fillRect(0, 0, 2, 2); g.fillStyle = b; g.fillRect(0, 0, 1, 1); g.fillRect(1, 1, 1, 1);
-  const t = new THREE.CanvasTexture(c); t.wrapS = t.wrapT = THREE.RepeatWrapping; t.repeat.set(15, 15);
+  const t = new THREE.CanvasTexture(c); t.wrapS = t.wrapT = THREE.RepeatWrapping; t.repeat.set(repeat, repeat);
   t.magFilter = t.minFilter = THREE.NearestFilter; t.generateMipmaps = false; t.colorSpace = THREE.SRGBColorSpace;
   return t;
 }
-function hazeTexture() {
-  const c = document.createElement('canvas'); c.width = 64; c.height = 128;
-  const g = c.getContext('2d'), grad = g.createLinearGradient(0, 0, 0, 128);
-  // the plane spans y -5..13 behind the stage: the pink band sits just above the floor's horizon (canvas y 0.55 = plane y ~ 3)
-  grad.addColorStop(0, '#120b24'); grad.addColorStop(0.42, '#2a1540'); grad.addColorStop(0.55, '#7a2f66'); grad.addColorStop(0.64, '#3a1c4e'); grad.addColorStop(1, '#1b1232');
-  g.fillStyle = grad; g.fillRect(0, 0, 64, 128);
+function skyTexture() {
+  const c = document.createElement('canvas'); c.width = 128; c.height = 256;
+  const g = c.getContext('2d'), grad = g.createLinearGradient(0, 0, 0, 256);
+  // the dome is a sphere: the top of the canvas is the zenith, the middle is the eye line, the bottom is the mist
+  grad.addColorStop(0, '#120b24'); grad.addColorStop(0.38, '#2c1544'); grad.addColorStop(0.452, '#5a2660');
+  grad.addColorStop(0.477, '#a04a86'); grad.addColorStop(0.495, '#6b2c63'); grad.addColorStop(0.5, '#3a1c4e'); grad.addColorStop(1, '#3a1c4e');
+  g.fillStyle = grad; g.fillRect(0, 0, 128, 256);
+  g.globalCompositeOperation = 'lighter';
+  for (const [x, r, a] of [[18, 20, 0.40], [64, 13, 0.24], [106, 24, 0.34]]) {   // pink glows on the band, so the drift reads
+    const b = g.createRadialGradient(x, 122, 0, x, 122, r);
+    b.addColorStop(0, `rgba(255,105,180,${a})`); b.addColorStop(1, 'rgba(255,105,180,0)');
+    g.fillStyle = b; g.fillRect(x - r, 122 - r, r * 2, r * 2);
+  }
+  // below the eye line the dome is flat mist and nothing else: that is the colour the fog leaves the floor
+  g.globalCompositeOperation = 'source-over'; g.fillStyle = '#3a1c4e'; g.fillRect(0, 128, 128, 128);
   const t = new THREE.CanvasTexture(c); t.wrapS = THREE.RepeatWrapping; t.colorSpace = THREE.SRGBColorSpace;
   return t;
 }
@@ -116,7 +136,7 @@ function hazeTexture() {
 export function createStage({ renderer, pixel, reducedMotion = false, log = null, character = ROSTER[0] } = {}) {
   const scene = new THREE.Scene();
   scene.background = new THREE.Color(HAZE);
-  scene.fog = new THREE.FogExp2(HAZE, 0.07);
+  scene.fog = new THREE.Fog(MIST, FOG_NEAR, FOG_FAR);
   const camera = new THREE.PerspectiveCamera(42, 1, 0.1, 80);
   camera.position.set(0, 1.0, 4.4); camera.lookAt(0, 0.6, 0);   // pulled back from the brief's (0, 0.9, 3.2): at block 3 she filled the frame
   const view = { w: 1, h: 1, frac: 0.5 };
@@ -131,11 +151,36 @@ export function createStage({ renderer, pixel, reducedMotion = false, log = null
   const porcelain = keep(new THREE.MeshStandardMaterial({ color: PORCELAIN, roughness: 0.4, metalness: 0.05 }));
   const glow = keep(new THREE.MeshStandardMaterial({ color: PINK, emissive: PINK, emissiveIntensity: 1.1, roughness: 0.4 }));
 
-  // backdrop haze + checker floor (props.glb floor_tile replaces the floor)
-  const haze = keep(hazeTexture());
-  const back = new THREE.Mesh(keep(new THREE.PlaneGeometry(40, 18)), keep(new THREE.MeshBasicMaterial({ map: haze, fog: false, depthWrite: false })));
-  back.position.set(0, 4, -9); scene.add(back);
-  let floor = new THREE.Mesh(keep(new THREE.PlaneGeometry(30, 30)), keep(new THREE.MeshLambertMaterial({ map: keep(checkerTexture('#2b1f47', '#3a2a5e')) })));
+  // ---- the backdrop: one dome, three far shapes, one instanced field of bubbles ----
+  const sky = keep(skyTexture());
+  const dome = new THREE.Mesh(keep(new THREE.SphereGeometry(SKY_R, 20, 14)), keep(new THREE.MeshBasicMaterial({ map: sky, side: THREE.BackSide, fog: false })));
+  scene.add(dome);
+  const farMat = keep(new THREE.MeshLambertMaterial({ color: FAR_PLUM, flatShading: true, fog: false }));
+  const farGeo = keep(new THREE.LatheGeometry(CUP_PROFILE.map(([x, y]) => new THREE.Vector2(x, y)), 12));
+  for (const [fx, fz, fs, fr] of FAR_CUPS) {   // one geometry, one material: they read as shapes, never as detail
+    const m = new THREE.Mesh(farGeo, farMat);
+    m.position.set(fx, 0, fz); m.scale.setScalar(fs); m.rotation.y = fr; scene.add(m);
+  }
+  const bubMat = keep(new THREE.MeshBasicMaterial({ color: PINK, transparent: true, opacity: 0.22, blending: THREE.AdditiveBlending, depthWrite: false, fog: false }));
+  const bubbles = keep(new THREE.InstancedMesh(keep(new THREE.SphereGeometry(0.34, 6, 4)), bubMat, BUBBLE_N));
+  bubbles.frustumCulled = false; scene.add(bubbles);
+  const bub = [], _bm = new THREE.Matrix4(), _bs = new THREE.Vector3();
+  for (let i = 0; i < BUBBLE_N; i++) bub.push({ x: -13 + ((i * 5.3) % 26), y: 0.5 + ((i * 1.9) % 4.6), z: -8 - ((i * 3.7) % 15), s: 0.55 + ((i * 7) % 5) * 0.3, ph: i * 1.9, rise: 0.14 + ((i * 3) % 4) * 0.05 });
+  let bubDirty = true;
+  /** The bubbles rise and sway behind the stage. Reduced motion holds them where they are (Law III). */
+  function driftBubbles(dt) {
+    if (reduced && !bubDirty) return;
+    for (let i = 0; i < BUBBLE_N; i++) {
+      const b = bub[i];
+      if (!reduced) { b.y += dt * b.rise; if (b.y > 6.4) b.y = 0.4; }
+      _bm.makeTranslation(b.x + (reduced ? 0 : Math.sin(t * 0.45 + b.ph) * 0.55), b.y, b.z);
+      bubbles.setMatrixAt(i, _bm.scale(_bs.setScalar(b.s)));
+    }
+    bubbles.instanceMatrix.needsUpdate = true; bubDirty = false;
+  }
+  driftBubbles(0);
+  // the checker floor (props.glb floor_tile replaces it): wide enough that the fog eats it before its edge
+  let floor = new THREE.Mesh(keep(new THREE.PlaneGeometry(FLOOR_W, FLOOR_W)), keep(new THREE.MeshLambertMaterial({ map: keep(checkerTexture('#2b1f47', '#3a2a5e', FLOOR_W / 2)) })));
   floor.rotation.x = -Math.PI / 2; scene.add(floor);
   // the saucer podium she stands on
   const podium = new THREE.Group(); scene.add(podium);
@@ -161,9 +206,9 @@ export function createStage({ renderer, pixel, reducedMotion = false, log = null
     const tileGeo = pack.byName('floor_tile') ? toInstanceGeometry(pack.byName('floor_tile')) : null;
     if (tileGeo) {
       scene.remove(floor);
-      const n = 11, im = new THREE.InstancedMesh(keep(tileGeo), keep(new THREE.MeshLambertMaterial({ vertexColors: true })), n * n), m = new THREE.Matrix4();
+      const n = FLOOR_N, half = (n - 1) / 2, im = new THREE.InstancedMesh(keep(tileGeo), keep(new THREE.MeshLambertMaterial({ vertexColors: true })), n * n), m = new THREE.Matrix4();
       let i = 0;
-      for (let x = 0; x < n; x++) for (let z = 0; z < n; z++) im.setMatrixAt(i++, m.makeTranslation((x - 5) * 2, 0, (z - 5) * 2));
+      for (let x = 0; x < n; x++) for (let z = 0; z < n; z++) im.setMatrixAt(i++, m.makeTranslation((x - half) * 2, 0, (z - half) * 2));
       floor = im; scene.add(im);
     }
     pixel.retexture(scene);
@@ -235,7 +280,8 @@ export function createStage({ renderer, pixel, reducedMotion = false, log = null
     t += dt;
     if (emi.mixer) emi.mixer.update(dt);
     if (mode === 'menu' && !reduced && !emi.busy && t >= emi.nextAt) play(ONE_SHOTS[Math.floor(Math.random() * ONE_SHOTS.length)]);
-    haze.offset.x += dt * 0.004;   // scenery drifts; EMI is the one breath (Law III)
+    sky.offset.x += dt * 0.004;    // scenery drifts; EMI is the one breath (Law III)
+    driftBubbles(dt);
     if (ripple.material.opacity > 0) { ripple.scale.addScalar(dt * 4); ripple.material.opacity = Math.max(0, ripple.material.opacity - dt * 1.6); }
   }
   function render() { pixel.render(scene, camera); }
@@ -257,7 +303,7 @@ export function createStage({ renderer, pixel, reducedMotion = false, log = null
   return {
     scene, camera, podium, cup: { group: cup, body: cupBody, ripple: rippleTea },
     emi: { root: emi.root, play, face, peek, model: () => emi.model, busy: () => emi.busy, ready(cb) { if (emi.model) cb(emi.model); else emi.ready.push(cb); } },
-    update, render, resize, setViewFraction, setMode(m) { mode = m; }, setReduced(v) { reduced = !!v; }, dispose,
+    update, render, resize, setViewFraction, setMode(m) { mode = m; }, setReduced(v) { reduced = !!v; bubDirty = true; }, dispose,
   };
 }
 


### PR DESCRIPTION
## Racing Thoughts (ex Caucus Race) web stack

Stacked on `feat/race-d1-stage-clip`. Merge bottom-up.

### Commits
- feat(race): she jumps into the cup instead of appearing in it
- feat(race): the stage gets a backdrop, not a blue screen

`2 files changed, 175 insertions(+), 43 deletions(-)`

### From the commit message
Phase B of the intro used to spring her to a point over the rim and then
attach her, which read as a pop. It is a jump now.
  2.42  the squat. Her root springs down to 0.85 with >_< on the screen.
  2.60  the leap: a real parabola over 0.55 s from wherever she is standing
        to 0.16 over the rim, apex 0.72 above it, with a forward tumble of
        25 degrees that peaks at the top and is level again on the way in.
        Face flips to o_o. The wide seat tips up with her (it is told the
        apex at takeoff, so it leads the jump instead of chasing it) and
        stiffens to 4.5 so she stays in frame.
  3.15  the landing. The cup body squashes from 0.72 (was 0.8) and rings
        back, the tea ripples, eight cream beads fly the rim on ballistic
        arcs and are gone in half a second, the camera dips 8 cm and comes
        back, and her root takes a small second squash. >_< on impact.
  3.50  ^_^ and the roll to the gantry, as before.
T_SINK moved 3.0 -> 3.15 and T_ROLL 3.4 -> 3.5 to fit the 0.55 s arc.
T_COUNT is untouched, so the intro still runs the same length.
Springs are sub-stepped at 20 ms now. run.js clamps a frame at 100 ms and
explicit Euler on the stiff ones (w 22, w 26) diverges long before that,
which showed up as a giant stretched EMI on a slow first frame. The cup
squash spring had the same latent hole.
Any press still skips to the line and reduced motion still cuts to it:
toLine() resets the tumble, the crouch, the dip and the beads first.
The menu stage (the intro rides it too) ended at a flat navy clear colour: the
checker floor stopped on a hard line and everything above it was void. Now the
stage is a place.
  - a 44 m sky dome, one inverted sphere painted from a canvas gradient: deep
    plum overhead, a pink haze band sitting just above the eye line, and flat
    mist below it. Below the eye line the dome is nothing but the fog colour,
    so the floor has nowhere to show an edge.
  - the fog is linear now (9 m to 21 m) instead of exponential. The cup, the
    podium and EMI all sit inside the near plane and stay clean; the checker is
    pure mist by the time it reaches its own edge, which is the whole point.
  - three oversized lathe cups from the stage's own CUP_PROFILE, 6x to 7x and
    sat 28 to 37 m back, flat shaded in plum with the fog off, so they read as
    a skyline and never as detail. One geometry, one material.
  - twelve additive pink bubbles on one InstancedMesh, rising and swaying
    behind the stage. Reduced motion holds them where they are.
  - the tile floor widened from 11 to 21 a side so its edge lands out past the
    fog, and the placeholder plane grew with it.
No new assets, no textures off disk: it is all geometry and one 128x256 canvas,


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0166ij3Q8xyseVkhWajzkWG3
