### PR TITLE
fix(race): the saucer stays on the road, the cup does the leaning

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/race/emi.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/emi.js
@@ -31,6 +31,22 @@ const PROPS_GLB = '/dtrh/race/assets/props.glb';
 // top of its glaze band, the cup is 0.695 to its rim with the band at 0.645..0.690, handle on +x.
 // The cup sits CUP_Y above the saucer base, the way the JS rig always sat it.
 const CUP_Y = 0.09, SAUCER_TOP = 0.125, CUP_RIM_TOP = 0.695;
+/** The saucer's outer radius in rig units (kart_saucer is 1.90 across, the JS dish 0.95 too).
+ *  kart.js needs it to know how much air a pitch costs. */
+export const SAUCER_R = 0.95;
+// THE CUP TIPS, THE SAUCER DOES NOT. kart.js hands its steer lean over as `ctx.lean` now instead
+// of rolling the whole kart about the forward axis: the group rides ON the road, so a banked
+// saucer put its outer edge sin(lean) * 0.95 * KART_SCALE under the surface, 0.84 m under it at a
+// drift lean. A saucer slides, it does not bank. So `body` alone turns, about the cup's foot on
+// the dish (CUP_PIVOT_Y), lifted by sin(tip) * CUP_FOOT_R so the low half of the foot kisses the
+// dish instead of cutting into it, and slid CUP_SLIDE * sin(tip) toward the outside of the turn so
+// the lean still reads as g-force. CUP_TIP_MAX saturates the angle (tanh, so small leans are one
+// for one and only the big ones are held back): the lift keeps the foot honest at any angle, but
+// the handle bows out to x 0.86 and reaches the road on its own at about 45 degrees, and a cup
+// tipped that far on a flat saucer reads as falling off it. At the 21 degree cap the foot clears
+// the road by 0.13 m, the handle by 0.24 m, and the cup rises 0.15 m off the dish at full lock.
+// This is geometry, not a transition, so reduced motion keeps every bit of it.
+const CUP_FOOT_R = 0.3, CUP_PIVOT_Y = CUP_Y, CUP_TIP_MAX = 0.38, CUP_SLIDE = 0.07;
 const OUTLINE = 'outline';   // the inverted hull's material name (gltf.js header, assets/README.md)
 // The glb is metres, sole centre at the origin, +Z forward, case top at 1.00 m. 0.64 puts the case
 // at the old 1.25-scaled CRT's 0.525 m; with the sole on the tea (y 0.66) the case bottom lands at
@@ -114,7 +130,7 @@ function ventTexture() {
 /**
  * createEmiRig({ scene, reducedMotion, pixel }) ->
  *   { group, update(dt, ctx), setMood, setFraught, squash, dispose, onReady(cb), model(), setFace(i), pose(name, opts) }
- * ctx = { t, up, right, tangent, speedNorm, airborne, steerVel, drift, driftSide }  (world-space frame)
+ * ctx = { t, up, right, tangent, speedNorm, airborne, steerVel, drift, driftSide, lean }  (world-space frame)
  * `group` is the whole rig; the caller positions and orients it. Particles are added to `scene`.
  * `pixel` is race/pixel.js: the glb's textures arrive after the run's one retexture(scene) pass, so
  * they go through preparePixel on mount. `model()` is the glb root once it lands, else null.
@@ -375,6 +391,15 @@ export function createEmiRig({ scene, reducedMotion = false, pixel = null }) {
     const sq = sSquash.step(0, dt, 9, 0.45);
     root.scale.set(1 + sq * 0.18, 1 - sq * 0.28, 1 + sq * 0.18);
     saucer.rotation.y += (0.7 + ctx.speedNorm * 2.5) * dt;
+
+    // the steer lean: the cup tips on the dish, the saucer stays flat on the road (see CUP_TIP_MAX
+    // above). Turning about the foot and lifting by sin(tip) * CUP_FOOT_R puts the low half of the
+    // foot on the dish at every angle, so nothing here can reach the road however hard the turn.
+    const tip = CUP_TIP_MAX * Math.tanh((ctx.lean || 0) / CUP_TIP_MAX);
+    const ts = Math.sin(tip), tc = Math.cos(tip);
+    body.rotation.z = tip;
+    body.position.x = (CUP_PIVOT_Y + CUP_SLIDE) * ts;      // hold the foot, then slide it outward
+    body.position.y = CUP_PIVOT_Y * (1 - tc) + Math.abs(ts) * CUP_FOOT_R;
 
     // sweat off the bead and the CRT's top corners; a Bambi-scale anime sweat, not a rain
     if (!reducedMotion) {

--- a/ConditioningControlPanel/Resources/web/dtrh/race/kart.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/kart.js
@@ -13,6 +13,16 @@
 //   { type:'inverted', on }           roll past 120 degrees (inside THE BIG WHEEL) began / ended; state.inverted mirrors it
 //   { type:'lap', lap, sec }          the Tea Garden gate crossed again: a timed lap (the first crossing only starts the clock)
 //   { type:'split', frac, sec }       a quarter mark of the lap (0.25 / 0.5 / 0.75) passed at `sec` into the lap
+//
+// THE SAUCER NEVER BANKS. The steer lean used to roll the whole group about the forward axis, and
+// the group sits ON the road (h = 0), so the saucer's outer edge swung sin(lean) * 1.28 m straight
+// down through the road surface: 0.84 m under it at a drift lean. The lean now rides on `ctx.lean`
+// into race/emi.js, which tips the cup alone on a saucer that stays flat (a saucer slides, it does
+// not bank). Pitch is still the group's, capped here at what the height above the road allows.
+//
+// SCREENSHOT AID: `?lean=1` (steer right) / `?lean=-1` pins the lean at LEAN_MAX for as long as the
+// page is open, so a headless shot can be taken at full lock without holding a key. It only writes
+// `lean`; speed, steering and the pop box are untouched. Anything but -1..1 is ignored.
 
 import * as THREE from 'three';
 import {
@@ -20,7 +30,7 @@ import {
   CAM_BACK, CAM_UP, CAM_LOOK_AHEAD, CAM_LOOK_SPEED, KART_SCALE,
   POP_HIT_D, POP_HIT_X, POP_HIT_H, LANE_H, DRIFT_TIER_SEC, DRIFT_BOOST_SEC, WALL_SCRUB_SEC,
 } from './consts.js';
-import { createEmiRig } from './emi.js';
+import { createEmiRig, SAUCER_R } from './emi.js';
 
 const STEER_VMAX = 6.5;       // lateral m/s at full lock, cruise speed, no drift
 const DRIFT_STEER = 1.45;     // drift tightens the steer
@@ -39,10 +49,20 @@ const TARGET_AHEAD = POP_HIT_D * 0.5;   // the pop ring floats this far in front
 const TARGET_H = LANE_H - 0.15;         // ring centre: between the road box centre and a lane bubble
 const RING_ALPHA = 0.14;                // resting alpha; a pop pulses it up
 const CAM_BOOST_BACK = 0.7;             // the seat slides back a touch under boost
+// The saucer's outer radius in road metres (1.28), widened by the landing squash's fattest frame
+// (emi.js scales the rig 1.18 in x and z at squash 1) so the pitch cap below holds through a THUD.
+const SAUCER_R_W = SAUCER_R * KART_SCALE * 1.18;
+// The steepest lean the physics below can reach: full lock at the speed floor, drifting, plus the
+// drift term. Only the screenshot aid uses it, and it is derived so it cannot go stale.
+const LEAN_MAX = STEER_VMAX * 1.15 * DRIFT_STEER * 0.07 + 0.1;
+const FORCE_LEAN = (() => {                 // `?lean=-1..1`, see the header. No DOM, no aid.
+  try { const v = +new URLSearchParams(location.search).get('lean') || 0; return Math.max(-1, Math.min(1, v)); }
+  catch (e) { return 0; }                   // node, or a page with no location: the aid is simply off
+})();
 const WORLD_UP = new THREE.Vector3(0, 1, 0), ZERO = new THREE.Vector3();
 const _m = new THREE.Matrix4(), _q = new THREE.Quaternion(), _v = new THREE.Vector3();
 const _fwd = new THREE.Vector3(), _up = new THREE.Vector3(), _right = new THREE.Vector3(), _lvl = new THREE.Vector3();
-const AX_X = new THREE.Vector3(1, 0, 0), AX_Y = new THREE.Vector3(0, 1, 0), AX_Z = new THREE.Vector3(0, 0, 1);
+const AX_X = new THREE.Vector3(1, 0, 0), AX_Y = new THREE.Vector3(0, 1, 0);   // z (the roll) is emi.js's
 
 const clamp = (v, a, b) => Math.max(a, Math.min(b, v));
 const ease = (k, dt) => 1 - Math.exp(-k * dt);
@@ -114,7 +134,7 @@ export function createKart({ scene, layout, reducedMotion = false, pixel = null 
   let airWas = false, steerWas = 0, trickArmed = false, trickKind = null, trickDir = 1, trickT = 1;
   let gateLay = null, gateD = 0, lapTimed = false, lapMark = 0;
   const cam = { pos: new THREE.Vector3(), look: new THREE.Vector3(), up: new THREE.Vector3(0, 1, 0), roll: 0 };
-  const ctx = { t: 0, up: _up, right: _right, tangent: _fwd, speedNorm: 0, airborne: false, steerVel: 0, drift: false, driftSide: 1, driftTier: 0 };
+  const ctx = { t: 0, up: _up, right: _right, tangent: _fwd, speedNorm: 0, airborne: false, steerVel: 0, drift: false, driftSide: 1, driftTier: 0, lean: 0 };
   const listeners = [];
   const emit = (ev) => { for (const cb of listeners) { try { cb(ev); } catch (e) { /* a listener never breaks the kart */ } } };
 
@@ -200,6 +220,7 @@ export function createKart({ scene, layout, reducedMotion = false, pixel = null 
     state.scrub = scrub;
     const leanT = -vx * 0.07 - (state.drift ? state.steer * 0.1 : 0);
     lean += (leanT - lean) * ease(8, dt);
+    if (FORCE_LEAN) lean = -FORCE_LEAN * LEAN_MAX;      // screenshot aid, see the header
   }
 
   function stepRamps(dt, lay, prevD) {
@@ -301,7 +322,12 @@ export function createKart({ scene, layout, reducedMotion = false, pixel = null 
     _m.lookAt(_fwd, ZERO, _up);                                        // +z faces down the road
     group.quaternion.setFromRotationMatrix(_m);
     ring.quaternion.copy(group.quaternion);                            // the ring never leans
-    group.quaternion.multiply(_q.setFromAxisAngle(AX_Z, lean)).multiply(_q.setFromAxisAngle(AX_X, pitch));
+    // The lean is emi.js's now (the cup tips, the saucer stays flat). Pitch is still the whole
+    // kart's, but only as far as the air under the saucer allows: on the road the nose-up left
+    // over from a landing would otherwise drive the saucer's back edge sin(pitch) * 1.28 m under
+    // the surface, so it is capped at asin(clearance / SAUCER_R_W) and touches down level.
+    const clear = Math.asin(clamp((state.h + Math.max(0, hopH)) / SAUCER_R_W, 0, 1));
+    group.quaternion.multiply(_q.setFromAxisAngle(AX_X, clamp(pitch, -clear, clear)));
     if (trickT < 1) {                                                  // the trick: one full turn, eased
       const ang = Math.PI * 2 * smooth(trickT);
       group.quaternion.multiply(trickKind === 'flip' ? _q.setFromAxisAngle(AX_X, -ang) : _q.setFromAxisAngle(AX_Y, ang * trickDir));
@@ -372,7 +398,7 @@ export function createKart({ scene, layout, reducedMotion = false, pixel = null 
     stepCamera(dt, lay);
     stepTierSparks(dt);
     ctx.t = elapsed; ctx.speedNorm = state.speed / KART_MAX_SPEED; ctx.airborne = state.airborne;
-    ctx.steerVel = vx; ctx.drift = state.drift; ctx.driftSide = driftSide;
+    ctx.steerVel = vx; ctx.drift = state.drift; ctx.driftSide = driftSide; ctx.lean = lean;
     rig.update(dt, ctx);
   }
 


### PR DESCRIPTION
## Racing Thoughts (ex Caucus Race) web stack

Stacked on `feat/race-d2-intro-hop`. Merge bottom-up.

### Commits
- fix(race): the saucer stays on the road, the cup does the leaning

`2 files changed, 57 insertions(+), 6 deletions(-)`

### From the commit message
The steer lean rolled the whole kart about the forward axis, and the kart group
sits ON the road (h = 0), so the saucer's outer edge swung straight down through
the road surface: 0.52 m under it at a cruise lean, 0.84 m at a drift lean, up
to 0.97 m at full lock off the speed floor. That is the pink disc disappearing
into the green road in the owner's shot.
A saucer slides, it does not bank. The lean now travels to race/emi.js on
ctx.lean and turns the cup alone:
  * the saucer never rolls, so the road can never cut into it;
  * the cup turns about its foot on the dish and is lifted sin(tip) * foot
    radius, so the low half of the foot kisses the dish instead of sinking
    through it and through the road under it;
  * the cup slides a few cm toward the outside of the turn, so the lean still
    reads as g-force;
  * the angle saturates (tanh) at 21 degrees. The lift keeps the foot honest at
    any angle, but the handle bows out to x 0.86 and reaches the road on its own
    near 45 degrees, and a cup tipped that far on a flat saucer reads as falling
    off it. At the cap the foot clears the road by 0.13 m and the handle by
    0.24 m.
Pitch stays on the whole kart but is now capped at asin(clearance / saucer
radius), the saucer widened by the landing squash's fattest frame. The nose-up
left over from a jump used to drive the saucer's back edge 0.44 m under the road
for the fifth of a second after touchdown; it now lands level. A swept check of
lean past full lock, pitch, height, hop and squash puts the lowest point of the
rig at exactly 0 below the road.
None of this is a transition, so reduced motion keeps every bit of it.
Adds a screenshot aid: ?lean=1 / ?lean=-1 pins the lean at its maximum so a
headless shot can be taken at full lock. Documented in the kart.js header.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0166ij3Q8xyseVkhWajzkWG3
