### PR TITLE
feat(race): the tape bubble goes dark

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
@@ -126,7 +126,12 @@ Bubble kinds (mirror `game/variants.js` and `engine/bubbles.js`; sprites from
 | glitch | effect | glitch | 20 | |
 | freeze | effect | bambiFreeze | 25 | minIntensity 0.15 |
 | gifrain | effect | gifCascade | 25 | minIntensity 0.45 |
-| video | effect | video | 40 | rare, minIntensity 0.45, host plays it |
+| video | effect | video | 40 | DARK since 2026-09-06, never spawns (see below) |
+
+A row may carry `spawn: false`. Video bubbles are dark since 2026-09-06: `rollKind` leaves the row out
+of every pool and `field.spawnAt` returns -1 for it, so no roll, lane line, rain or track cue can put
+one on the road, and `CaucusHostService` refuses a `fire-payload {kind:'video'}` as well. The row, its
+sprite and its THE MIX `video` slot stay put for a later use.
 
 Placements: `lane` (rests on the road, h ~0.9, bobbing), `air` (along a ramp air line, h rises
 2..5), `spawn` (materialises ahead, wobbles laterally), `rain` (falls from `h = 9` to the road in
@@ -259,7 +264,8 @@ As built (PR 5 reality notes):
 - `run.js` registers the `pause` and `payout-result` bridge handlers itself; `raceBoot.js` owns `init`,
   `manifest`, `favorites`, `ping`, `exit-request`, `fullscreen`.
 - Only `video` pops go to the host (`fire-payload {kind:'video', strength 0..100, durationMult}`);
-  `payloadFx` never sends it. There is no `audio` bubble kind.
+  `payloadFx` never sends it. There is no `audio` bubble kind. Since 2026-09-06 no video bubble spawns
+  and the host refuses the message, so this path is dark at both ends.
 - The first Tea Garden gate sits at d = 9 (mid gate chunk), so it crosses ~0.4 s after start: that crossing
   shows the opening MARQUEE and never banks. Later Tea Garden gates bank only when the road score is > 0.
 - Magnet (the wand) is a known gap: the field's hit box is fixed at `POP_HIT_*` and exposes no widen API,

--- a/ConditioningControlPanel/Resources/web/dtrh/race/bubbleKinds.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/bubbleKinds.js
@@ -19,6 +19,11 @@ const PLAIN_SPRITE = '/dtrh/assets/bubbles/bubble.png';   // the classic soap bu
 // strength: the base 0..1 power of the effect (intensity nudges it up at pop).
 // weight: spawn odds; minIntensity gates the kind until the run is that deep.
 // category: THE MIX slot (race/cocktail.js CATEGORIES) an effect pop lands in; treats have none.
+// spawn: false darkens a row. The row keeps its data, sprite, tint, points and THE MIX slot so the
+//   rest of the game still knows the kind, but rollKind never returns it and bubbles.js refuses to
+//   place one, so no roll, lane line, rain or track cue can put it on the road. 'video' is dark
+//   since 2026-09-06: the tape bubble fired a real mandatory video mid-run and the owner has
+//   another use in mind for the slot. The host refuses a video fire-payload too.
 export const BUBBLE_KINDS = [
   { id: 'treat',      label: '',  kind: 'treat',  payload: null,         overlayKind: null,  category: null,
     strength: 0,    points: 10, weight: 22,  minIntensity: 0,    tint: 'rgb(184,222,255)', sprite: PLAIN_SPRITE },
@@ -45,17 +50,19 @@ export const BUBBLE_KINDS = [
   { id: 'gifrain',    label: '▼', kind: 'effect', payload: 'gifCascade', overlayKind: null,  category: 'cards',
     strength: 0.6,  points: 25, weight: 1.2, minIntensity: 0.45, tint: 'rgb(255,200,61)',  sprite: ART_BASE + 'htlink.png' },
   { id: 'video',      label: '▶', kind: 'effect', payload: 'video',      overlayKind: null,  category: 'video',
+    spawn: false,   // dark since 2026-09-06, see the header; the row stays for a later use
     strength: 0.7,  points: 40, weight: 0.35, minIntensity: 0.45, tint: 'rgb(224,64,77)',  sprite: ART_BASE + 'video.png' },
 ];
 
 export const KIND_BY_ID = Object.fromEntries(BUBBLE_KINDS.map((k) => [k.id, k]));
 export const TREAT_IDS = BUBBLE_KINDS.filter((k) => k.kind === 'treat').map((k) => k.id);
 
-/** Weighted roll over the kinds allowed at this intensity, in this room.
+/** Weighted roll over the kinds allowed at this intensity, in this room. Dark rows (spawn:false)
+ *  are out of the pool entirely, at every intensity and whatever the bias says.
  *  `bias` is the room's bubbleBias map; `extra(kind)` is an optional per-call
  *  multiplier (air lines favour gold, etc). rng defaults to Math.random. */
 export function rollKind(intensity, bias = null, extra = null, rng = Math.random) {
-  let pool = BUBBLE_KINDS.filter((k) => k.minIntensity <= intensity);
+  let pool = BUBBLE_KINDS.filter((k) => k.spawn !== false && k.minIntensity <= intensity);
   if (!pool.length) pool = [BUBBLE_KINDS[0]];
   const w = pool.map((k) => k.weight * ((bias && bias[k.id]) || 1) * (extra ? extra(k) : 1));
   let r = rng() * w.reduce((s, v) => s + v, 0);

--- a/ConditioningControlPanel/Resources/web/dtrh/race/bubbles.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/bubbles.js
@@ -212,10 +212,12 @@ export function createBubbleField({ scene, layout, media, getIntensity, getRoom,
   }
   /** An explicit placement from a track cue (CHART.md): the run has already worked the depth out at
    *  the kart's speed, so nothing is rolled or gated by intensity here. Returns the slot id, -1 when
-   *  the pool is full (a cue never steals a live bubble) or when density has gated this one out.
+   *  the pool is full (a cue never steals a live bubble), when the kind is dark (bubbleKinds.js
+   *  spawn:false), or when density has gated this one out.
    *  Over 1, density is the chance of a second bubble beside the first. */
   function spawnAt({ kindId, placement = 'lane', d, x = 0, h, eventId = null } = {}) {
     if (liveCount >= CAP) return -1;
+    if (KIND_BY_ID[kindId] && KIND_BY_ID[kindId].spawn === false) return -1;   // a dark kind: no chart may place one
     if (tracked) {
       if (density <= 0) return -1;
       if (density < 1 && Math.random() >= density) return -1;


### PR DESCRIPTION
## Racing Thoughts (ex Caucus Race) web stack

Stacked on `feat/race-d3-saucer`. Merge bottom-up.

### Commits
- feat(race): the tape bubble goes dark

`3 files changed, 20 insertions(+), 5 deletions(-)`

### From the commit message
The video bubble fired a real mandatory video mid-run, which is not what a
kart race is for. The kind is now dark rather than deleted: the owner has
another use in mind for the tape slot, so the row, its sprite, its points
and its THE MIX 'video' category all stay exactly where they are.
A bubbleKinds.js row may now carry `spawn: false`, documented in the file
header. rollKind drops dark rows from the pool before any weighting, so no
random spawn, lane line, ramp air line, itembox pair or rain can pick one
whatever the room bias says. field.spawnAt refuses a dark kind with -1, so
no track cue and no chart can place one either.
CONTRACT.md carries the note in both places that promised a video pop.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0166ij3Q8xyseVkhWajzkWG3
