### PR TITLE
fix(race): the score you keep says kept, never banked

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
@@ -232,6 +232,8 @@ hud.dispose()
 ```
 All HUD text is in the DtRH voice: lowercase, short, no em-dashes. `root` is the `.race-hud` div
 that `race.html` provides; `payloadFx` gets its own `.sf-hud` sibling so overlays never clip the HUD.
+Player-facing copy never says bank/banked: THE BANK reads as `kept` in the score block, the toast
+and the end card. Identifiers, event types and css classes keep `bank`.
 `.race-hud` must stay unpositioned (no `position`/`z-index` of its own): the chrome rides at z3,
 below every `.sf-pfx` layer, and the Brake/End screens at z20 pick their own stacking.
 

--- a/ConditioningControlPanel/Resources/web/dtrh/race/hud.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/hud.js
@@ -74,7 +74,7 @@ export function createRaceHud(root) {
   comboFill.style.setProperty('--rh-hold', `${COMBO_HOLD_SEC}s`);
   const comboN = el('rh-num', comboRow, 'combo 0');
   const nextEl = el('rh-next rh-num', scoreWrap, '');
-  const bankEl = el('rh-bank rh-num', scoreWrap, 'banked 0');
+  const bankEl = el('rh-bank rh-num', scoreWrap, 'kept 0');
 
   // ---- the rung ladder: consts by default, swappable via setLadder ----
   let ladder = okLadder(MULT_LADDER) ? MULT_LADDER : NEW_LADDER;
@@ -168,7 +168,7 @@ export function createRaceHud(root) {
     if (Math.abs(bankTarget - bankShown) > 0.5) {
       bankShown += (bankTarget - bankShown) * (reduced ? 1 : 0.2);
       if (Math.abs(bankTarget - bankShown) < 0.5) bankShown = bankTarget; else busy = true;
-      bankEl.textContent = `banked ${fmt(bankShown)}`;
+      bankEl.textContent = `kept ${fmt(bankShown)}`;
     }
     if (busy && !disposed) raf = requestAnimationFrame(tick);
   }
@@ -426,7 +426,7 @@ export function createRaceHud(root) {
         rows.appendChild(Object.assign(document.createElement('dd'), { textContent: v, className: 'rh-num' }));
       };
       line('score', fmt(s.score || 0));
-      line('banked', fmt(s.banked || 0));
+      line('kept', fmt(s.banked || 0));
       line('best combo', fmt(s.bestCombo || 0));
       line('popped', fmt(s.popped || 0));
       line('laps', fmt(s.laps || 0));

--- a/ConditioningControlPanel/Resources/web/dtrh/race/run.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/run.js
@@ -299,7 +299,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
       case 'mult': hud.setCombo(w.score.state.combo, e.to); if (e.to > e.from) { hud.toast(`x${e.to}`, 'pop'); sfx('streak_milestone', 0.6); poke('smug', 1.0); } break;
       case 'miss': hud.setCombo(0, e.mult); break;
       case 'almost': hud.setScore(e.score); hud.toast(`almost +${e.gain}`, 'almost'); break;
-      case 'bank': hud.setBank(e.banked); hud.setScore(0); hud.toast(`bank +${e.amount}`, 'bank'); break;
+      case 'bank': hud.setBank(e.banked); hud.setScore(0); hud.toast(`kept +${e.amount}`, 'bank'); break;
       case 'jackpot': hud.setScore(e.score); hud.toast(`jackpot +${e.gain}`, 'jackpot'); break;
     }
   }


### PR DESCRIPTION
## Racing Thoughts (ex Caucus Race) web stack

Stacked on `feat/race-d4-no-video`. Merge bottom-up.

### Commits
- fix(race): the score you keep says kept, never banked

`3 files changed, 6 insertions(+), 4 deletions(-)`

### From the commit message
Owner rule: the words bank/banked/banking never appear in player-facing
web copy. The Tea Garden gate mechanic keeps its identifiers, event
types and css class names; only the strings the player reads change.
- hud.js score block and its ticker read "kept N"
- hud.js end card row label reads "kept"
- run.js gate toast reads "kept +N"
- CONTRACT.md notes the rule next to the hud copy law


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0166ij3Q8xyseVkhWajzkWG3
