### PR TITLE
feat(race): chart skeleton, the C# shapes the track chart stack fills in

### DIFF
--- a/ConditioningControlPanel/Models/Race/TrackChart.cs
+++ b/ConditioningControlPanel/Models/Race/TrackChart.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace ConditioningControlPanel.Models.Race;
+
+/// <summary>
+/// A hypno track's chart: the energy curve, the acts and the timed events the Caucus Race lays on
+/// the road. Mirrors Resources/web/dtrh/race/CHART.md (chart JSON version 1) field for field; the
+/// page reads this JSON as-is, so the names here are the wire names.
+/// </summary>
+public sealed class TrackChart
+{
+    public const int CurrentVersion = 1;
+
+    [JsonProperty("version")] public int Version { get; set; } = CurrentVersion;
+    [JsonProperty("source")] public TrackSource Source { get; set; } = new();
+    [JsonProperty("analysis")] public TrackAnalysis Analysis { get; set; } = new();
+    /// <summary>Seconds per energy bin.</summary>
+    [JsonProperty("binSec")] public double BinSec { get; set; } = 0.5;
+    /// <summary>One value per bin, 0..1, the file's 98th percentile RMS normalised to 1.</summary>
+    [JsonProperty("energy")] public List<double> Energy { get; set; } = new();
+    /// <summary>Contiguous, sorted; the first starts at 0 and the last ends at the duration.</summary>
+    [JsonProperty("acts")] public List<TrackAct> Acts { get; set; } = new();
+    /// <summary>Sorted by <see cref="TrackEvent.T"/>; ids unique within the chart.</summary>
+    [JsonProperty("events")] public List<TrackEvent> Events { get; set; } = new();
+}
+
+public sealed class TrackSource
+{
+    [JsonProperty("name")] public string Name { get; set; } = "";
+    /// <summary>SHA1 hex of the file length (8 bytes little endian) + the first 1 MiB of the file.</summary>
+    [JsonProperty("hash")] public string Hash { get; set; } = "";
+    [JsonProperty("durationSec")] public double DurationSec { get; set; }
+    [JsonProperty("sampleRate")] public int SampleRate { get; set; } = 16000;
+}
+
+public sealed class TrackAnalysis
+{
+    /// <summary>"rms-flux-v1".</summary>
+    [JsonProperty("energy")] public string Energy { get; set; } = "rms-flux-v1";
+    /// <summary>"vosk-v1" or "none".</summary>
+    [JsonProperty("words")] public string Words { get; set; } = "none";
+    [JsonProperty("lexicon")] public List<string> Lexicon { get; set; } = new();
+    [JsonProperty("generatedAt")] public DateTime GeneratedAt { get; set; } = DateTime.UtcNow;
+    /// <summary>True on the chart posted after the energy pass and before the word pass lands.</summary>
+    [JsonProperty("partial")] public bool Partial { get; set; }
+}
+
+/// <summary>kind: induction | deepening | triggers | mantra | build | silence | wake | free.</summary>
+public sealed class TrackAct
+{
+    [JsonProperty("id")] public int Id { get; set; }
+    [JsonProperty("t0")] public double T0 { get; set; }
+    [JsonProperty("t1")] public double T1 { get; set; }
+    [JsonProperty("kind")] public string Kind { get; set; } = "free";
+    /// <summary>A room id from the page's consts.js ROOM_IDS.</summary>
+    [JsonProperty("room")] public string Room { get; set; } = "";
+    [JsonProperty("name")] public string Name { get; set; } = "";
+}
+
+/// <summary>
+/// kind: trigger | word | count | drop | chant (words) or build | peak | release | silence (energy).
+/// Optional fields serialise only when set so the wire JSON stays the shape CHART.md shows.
+/// </summary>
+public sealed class TrackEvent
+{
+    [JsonProperty("id")] public string Id { get; set; } = "";
+    [JsonProperty("t")] public double T { get; set; }
+    [JsonProperty("kind")] public string Kind { get; set; } = "";
+    [JsonProperty("label", NullValueHandling = NullValueHandling.Ignore)] public string? Label { get; set; }
+    /// <summary>0..1; 1 for energy events.</summary>
+    [JsonProperty("conf")] public double Conf { get; set; } = 1;
+    /// <summary>Seconds; 0 for point events.</summary>
+    [JsonProperty("dur")] public double Dur { get; set; }
+    /// <summary>0..1, scales how loud the cue is.</summary>
+    [JsonProperty("weight")] public double Weight { get; set; } = 1;
+    // count
+    [JsonProperty("n", NullValueHandling = NullValueHandling.Ignore)] public int? N { get; set; }
+    [JsonProperty("of", NullValueHandling = NullValueHandling.Ignore)] public int? Of { get; set; }
+    [JsonProperty("last", NullValueHandling = NullValueHandling.Ignore)] public bool? Last { get; set; }
+    // drop
+    [JsonProperty("strength", NullValueHandling = NullValueHandling.Ignore)] public double? Strength { get; set; }
+    // chant
+    [JsonProperty("reps", NullValueHandling = NullValueHandling.Ignore)] public int? Reps { get; set; }
+    [JsonProperty("period", NullValueHandling = NullValueHandling.Ignore)] public double? Period { get; set; }
+}

--- a/ConditioningControlPanel/Services/Race/TrackAnalyzer.cs
+++ b/ConditioningControlPanel/Services/Race/TrackAnalyzer.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Threading;
+using ConditioningControlPanel.Models.Race;
+
+namespace ConditioningControlPanel.Services.Race;
+
+/// <summary>
+/// The energy pass: RMS per bin normalised to the 98th percentile, then build / peak / release /
+/// silence events and a first cut of the acts from the energy shape alone (CHART.md thresholds).
+/// Filled in by PR c4.
+/// </summary>
+public static class TrackAnalyzer
+{
+    public const double BinSec = 0.5;
+
+    public static TrackChart Energy(TrackPcm pcm, IProgress<double>? progress, CancellationToken ct)
+        => throw new NotImplementedException("PR c4: TrackAnalyzer.Energy");
+}

--- a/ConditioningControlPanel/Services/Race/TrackChartCache.cs
+++ b/ConditioningControlPanel/Services/Race/TrackChartCache.cs
@@ -1,0 +1,17 @@
+using System;
+using System.IO;
+using ConditioningControlPanel.Models.Race;
+
+namespace ConditioningControlPanel.Services.Race;
+
+/// <summary>Charts keyed by source hash under %LOCALAPPDATA%/ConditioningControlPanel/race/charts. PR c4.</summary>
+public static class TrackChartCache
+{
+    public static string Root => Path.Combine(App.UserDataPath, "race", "charts");
+
+    public static TrackChart? TryLoad(string hash)
+        => throw new NotImplementedException("PR c4: TrackChartCache.TryLoad");
+
+    public static void Save(TrackChart chart)
+        => throw new NotImplementedException("PR c4: TrackChartCache.Save");
+}

--- a/ConditioningControlPanel/Services/Race/TrackLexicon.cs
+++ b/ConditioningControlPanel/Services/Race/TrackLexicon.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Collections.Generic;
+
+namespace ConditioningControlPanel.Services.Race;
+
+/// <summary>
+/// The phrases the word spotter listens for: CHART.md STRUCTURE_WORDS + the active mod's trigger
+/// phrases + the user's custom triggers + keyword-trigger phrases; lowercased, letters and spaces
+/// only, distinct. Filled in by PR c5.
+/// </summary>
+public static class TrackLexicon
+{
+    public static IReadOnlyList<string> Build()
+        => throw new NotImplementedException("PR c5: TrackLexicon.Build");
+}

--- a/ConditioningControlPanel/Services/Race/TrackPcm.cs
+++ b/ConditioningControlPanel/Services/Race/TrackPcm.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Threading;
+
+namespace ConditioningControlPanel.Services.Race;
+
+/// <summary>A decoded track: mono 16 kHz float PCM plus what the chart needs to name and key it.</summary>
+public sealed class TrackPcm
+{
+    public const int SampleRate = 16000;
+
+    public float[] Mono16k { get; init; } = Array.Empty<float>();
+    public double DurationSec { get; init; }
+    /// <summary>SHA1 hex of the file length (8 bytes LE) + the first 1 MiB. See CHART.md.</summary>
+    public string Hash { get; init; } = "";
+    /// <summary>The file name without its directory.</summary>
+    public string Name { get; init; } = "";
+    public string Path { get; init; } = "";
+}
+
+/// <summary>
+/// Decodes an audio file to <see cref="TrackPcm"/> with NAudio: MediaFoundationReader first,
+/// AudioFileReader as the fallback, then stereo to mono and a WDL resample to 16 kHz.
+/// Filled in by PR c4.
+/// </summary>
+public static class TrackDecoder
+{
+    public static TrackPcm Decode(string path, IProgress<double>? progress, CancellationToken ct)
+        => throw new NotImplementedException("PR c4: TrackDecoder.Decode");
+
+    /// <summary>The cache key: SHA1 of the length prefix + the first 1 MiB, so a rename keeps its chart.</summary>
+    public static string HashFile(string path)
+        => throw new NotImplementedException("PR c4: TrackDecoder.HashFile");
+}

--- a/ConditioningControlPanel/Services/Race/TrackPlayer.cs
+++ b/ConditioningControlPanel/Services/Race/TrackPlayer.cs
@@ -1,0 +1,24 @@
+using System;
+
+namespace ConditioningControlPanel.Services.Race;
+
+/// <summary>
+/// Plays the loaded track for the race: AudioFileReader + WaveOutEvent, the app's master volume,
+/// Play / Pause / Resume / Stop, PositionSec for the 250 ms clock, Ended when the file runs out.
+/// Owned by CaucusHostService. Filled in by PR c6.
+/// </summary>
+public sealed class TrackPlayer : IDisposable
+{
+    public event Action? Ended;
+
+    public double PositionSec => throw new NotImplementedException("PR c6: TrackPlayer.PositionSec");
+    public double DurationSec => throw new NotImplementedException("PR c6: TrackPlayer.DurationSec");
+    public bool IsPlaying => throw new NotImplementedException("PR c6: TrackPlayer.IsPlaying");
+
+    public void Load(string path) => throw new NotImplementedException("PR c6: TrackPlayer.Load");
+    public void Play() => throw new NotImplementedException("PR c6: TrackPlayer.Play");
+    public void Pause() => throw new NotImplementedException("PR c6: TrackPlayer.Pause");
+    public void Resume() => throw new NotImplementedException("PR c6: TrackPlayer.Resume");
+    public void Stop() => throw new NotImplementedException("PR c6: TrackPlayer.Stop");
+    public void Dispose() { Ended = null; }
+}

--- a/ConditioningControlPanel/Services/Race/TrackWordSpotter.cs
+++ b/ConditioningControlPanel/Services/Race/TrackWordSpotter.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using ConditioningControlPanel.Models.Race;
+
+namespace ConditioningControlPanel.Services.Race;
+
+/// <summary>
+/// The word pass on the bundled Vosk model (grammar recognizer over the lexicon, SetWords(true),
+/// 8000-sample chunks, word timings from result[]). No model on disk = an empty list and the chart
+/// says analysis.words = "none"; never an exception to the caller. Filled in by PR c5.
+/// </summary>
+public static class TrackWordSpotter
+{
+    public static bool ModelAvailable
+        => throw new NotImplementedException("PR c5: TrackWordSpotter.ModelAvailable");
+
+    public static List<TrackEvent> Spot(TrackPcm pcm, IReadOnlyList<string> lexicon, IProgress<double>? progress, CancellationToken ct)
+        => throw new NotImplementedException("PR c5: TrackWordSpotter.Spot");
+}
+
+/// <summary>
+/// Folds spotted words into a chart: trigger / word / count / drop / chant events per CHART.md,
+/// upgrades the acts, sets analysis.words and analysis.lexicon. Filled in by PR c5.
+/// </summary>
+public static class TrackChartWords
+{
+    public static void Apply(TrackChart chart, List<TrackEvent> words, IReadOnlyList<string> lexicon)
+        => throw new NotImplementedException("PR c5: TrackChartWords.Apply");
+}


### PR DESCRIPTION
## Racing Thoughts (ex Caucus Race) C# stack

Stacked on `feat/race-5-host`. Merge bottom-up.

### Commits
- feat(race): chart skeleton, the C# shapes the track chart stack fills in

`7 files changed, 224 insertions(+)`

### From the commit message
TrackChart POCOs (CHART.md v1 wire names) and stub entry points for the decoder,
energy analyzer, chart cache, lexicon, Vosk word spotter and the track player so
the c4 / c5 / c6 PRs build against one signature set. Every stub throws until its
PR lands; nothing calls them yet.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0166ij3Q8xyseVkhWajzkWG3
