### PR TITLE
feat(race): the energy pass - decode, chart, cache

### DIFF
--- a/ConditioningControlPanel/App.xaml.cs
+++ b/ConditioningControlPanel/App.xaml.cs
@@ -2713,6 +2713,40 @@ namespace ConditioningControlPanel
                 else Logger?.Information("--race ignored: {Reason}", raceGate.Reason);
             }
 
+            // `--race-chart <file>`: chart a hypno file from the command line - decode, the energy
+            // pass, the word pass when it is available, then write the chart to the cache and quit.
+            // The rig for eyeballing a chart's numbers without opening the race at all.
+            if (e.Args.Contains("--race-chart"))
+            {
+                var trackArg = Array.IndexOf(e.Args, "--race-chart") + 1;
+                var trackPath = trackArg > 0 && trackArg < e.Args.Length ? e.Args[trackArg] : "";
+                try
+                {
+                    var charting = Stopwatch.StartNew();
+                    var pcm = Services.Race.TrackDecoder.Decode(trackPath, null, CancellationToken.None);
+                    var chart = Services.Race.TrackAnalyzer.Energy(pcm, null, CancellationToken.None);
+                    try
+                    {
+                        var lexicon = Services.Race.TrackLexicon.Build();
+                        var words = Services.Race.TrackWordSpotter.Spot(pcm, lexicon, null, CancellationToken.None);
+                        Services.Race.TrackChartWords.Apply(chart, words, lexicon);
+                    }
+                    catch (Exception wordsEx)
+                    {
+                        Logger?.Information("race-chart: words pass unavailable ({Message})", wordsEx.Message);
+                    }
+                    Services.Race.TrackChartCache.Save(chart);
+                    var reloaded = Services.Race.TrackChartCache.TryLoad(chart.Source.Hash);
+                    var kinds = string.Join(", ", chart.Events.GroupBy(v => v.Kind).OrderBy(g => g.Key).Select(g => g.Key + " " + g.Count()));
+                    Logger?.Information("race-chart: {Name} {Duration:F1}s -> {Path} ({Acts} acts, {Events} events [{Kinds}], reload {Reload}) in {Ms} ms",
+                        chart.Source.Name, chart.Source.DurationSec, Services.Race.TrackChartCache.PathFor(chart.Source.Hash),
+                        chart.Acts.Count, chart.Events.Count, kinds, reloaded?.Events.Count ?? -1, charting.ElapsedMilliseconds);
+                }
+                catch (Exception ex) { Logger?.Error(ex, "race-chart failed for {Path}", trackPath); }
+                Shutdown();
+                return;
+            }
+
             // Goon Game browser client, dev shortcut: `--goon` opens the web duel window straight
             // away (same shape as `--dtrh`). Needs MainWindow to exist first — the host owns its
             // window natively above main and ducks main out of the way at launch.

--- a/ConditioningControlPanel/Services/Race/TrackActs.cs
+++ b/ConditioningControlPanel/Services/Race/TrackActs.cs
@@ -1,0 +1,179 @@
+using System;
+using System.Collections.Generic;
+using ConditioningControlPanel.Models.Race;
+
+namespace ConditioningControlPanel.Services.Race;
+
+/// <summary>
+/// Acts cut from the energy shape alone: split at the long silences and at the biggest sustained
+/// level changes, then labelled by position and by which way the act's own energy leans. The words
+/// pass (PR c5) upgrades kinds afterwards; the rooms follow CHART.md's ACT_ROOM mapping and never
+/// repeat back to back.
+/// </summary>
+internal static class TrackActs
+{
+    /// <summary>A silence this long is a scene change, not a breath.</summary>
+    private const double SilenceCutSec = 6.0;
+    /// <summary>Roughly one act per this many seconds: a 30 minute file lands at 7, a 3 minute one at 2.</summary>
+    private const double SecondsPerAct = 270.0;
+    private const int MaxActs = 8;
+    /// <summary>How much an act's second half has to lean before it is a build or a deepening.</summary>
+    private const double LeanLevel = 0.03;
+
+    /// <summary>ACT_ROOM from CHART.md; the rotation below walks this order to break a repeat.</summary>
+    private static readonly string[] RoomOrder =
+        { "teagarden", "undertow", "toybox", "chapel", "mirrors", "greyward", "coronation", "casino" };
+
+    private static readonly Dictionary<string, string> ActRoom = new()
+    {
+        ["induction"] = "teagarden",
+        ["deepening"] = "undertow",
+        ["triggers"] = "toybox",
+        ["mantra"] = "chapel",
+        ["build"] = "mirrors",
+        ["silence"] = "greyward",
+        ["wake"] = "coronation",
+        ["free"] = "casino"
+    };
+
+    private static readonly Dictionary<string, string> ActName = new()
+    {
+        ["induction"] = "the settle",
+        ["deepening"] = "the undertow",
+        ["triggers"] = "the toybox",
+        ["mantra"] = "the chant",
+        ["build"] = "the climb",
+        ["silence"] = "the hush",
+        ["wake"] = "the waking",
+        ["free"] = "the drift"
+    };
+
+    /// <summary>Contiguous acts covering 0 .. <paramref name="durationSec"/>, in order.</summary>
+    internal static List<TrackAct> Build(double[] e, double durationSec, List<TrackEvent> events)
+    {
+        int n = e.Length;
+        int target = Math.Clamp((int)Math.Round(durationSec / SecondsPerAct), 2, MaxActs);
+        double minActSec = Math.Max(20.0, Math.Min(45.0, durationSec / (target + 1)));
+        int minBins = Math.Max(1, (int)Math.Round(minActSec / TrackAnalyzer.BinSec));
+
+        var cuts = Cuts(e, events, target, minBins, n);
+        var acts = new List<TrackAct>();
+        double middle = Mean(e, (int)(n * 0.25), (int)(n * 0.75));
+        double tail = Mean(e, (int)(n * 0.9), n);
+
+        for (int i = 0; i <= cuts.Count; i++)
+        {
+            int from = i == 0 ? 0 : cuts[i - 1];
+            int to = i == cuts.Count ? n : cuts[i];
+            var act = new TrackAct
+            {
+                Id = i,
+                T0 = TrackAnalyzer.Round(from * TrackAnalyzer.BinSec),
+                T1 = i == cuts.Count ? durationSec : TrackAnalyzer.Round(to * TrackAnalyzer.BinSec),
+                Kind = "free"
+            };
+            if (i == 0) act.Kind = "induction";
+            else if (i == cuts.Count) act.Kind = tail < middle ? "wake" : "free";
+            else act.Kind = Lean(e, from, to);
+            acts.Add(act);
+        }
+
+        string previous = "";
+        foreach (var act in acts)
+        {
+            act.Room = Room(act.Kind, previous);
+            act.Name = ActName.TryGetValue(act.Kind, out var name) ? name : "the drift";
+            previous = act.Room;
+        }
+        return acts;
+    }
+
+    /// <summary>
+    /// The bins to split at: the longest silences first (they are unarguable scene changes), then
+    /// the biggest before-and-after level changes until the file has the act count its length asks
+    /// for. Every cut keeps at least one minimum act length from its neighbours and from both ends.
+    /// </summary>
+    private static List<int> Cuts(double[] e, List<TrackEvent> events, int target, int minBins, int n)
+    {
+        var cuts = new List<int>();
+        var silences = new List<TrackEvent>();
+        foreach (var ev in events)
+            if (ev.Kind == "silence" && ev.Dur >= SilenceCutSec) silences.Add(ev);
+        silences.Sort((a, b) => b.Dur.CompareTo(a.Dur));
+
+        foreach (var ev in silences)
+        {
+            if (cuts.Count >= target - 1) break;
+            int bin = (int)Math.Round(ev.T / TrackAnalyzer.BinSec);
+            if (Fits(cuts, bin, minBins, n)) cuts.Add(bin);
+        }
+
+        while (cuts.Count < target - 1)
+        {
+            int bin = BiggestChange(e, cuts, minBins, n);
+            if (bin < 0) break;
+            cuts.Add(bin);
+        }
+
+        cuts.Sort();
+        return cuts;
+    }
+
+    /// <summary>The bin whose 30 s before and 30 s after differ most, among the bins still free.</summary>
+    private static int BiggestChange(double[] e, List<int> cuts, int minBins, int n)
+    {
+        int window = Math.Min(60, minBins);
+        int best = -1;
+        double bestScore = -1;
+        for (int i = minBins; i <= n - minBins; i++)
+        {
+            if (!Fits(cuts, i, minBins, n)) continue;
+            double score = Math.Abs(Mean(e, i - window, i) - Mean(e, i, i + window));
+            if (score <= bestScore) continue;
+            bestScore = score;
+            best = i;
+        }
+        return best;
+    }
+
+    private static bool Fits(List<int> cuts, int bin, int minBins, int n)
+    {
+        if (bin < minBins || bin > n - minBins) return false;
+        foreach (int c in cuts) if (Math.Abs(c - bin) < minBins) return false;
+        return true;
+    }
+
+    /// <summary>Which way the act leans: rising is a build, falling a deepening, flat a free run.</summary>
+    private static string Lean(double[] e, int from, int to)
+    {
+        int mid = from + (to - from) / 2;
+        double delta = Mean(e, mid, to) - Mean(e, from, mid);
+        if (delta > LeanLevel) return "build";
+        if (delta < -LeanLevel) return "deepening";
+        return "free";
+    }
+
+    /// <summary>The act's room, rotated on along ROOM_IDS when it would repeat the last one.</summary>
+    private static string Room(string kind, string previous)
+    {
+        string room = ActRoom.TryGetValue(kind, out var mapped) ? mapped : "casino";
+        if (room != previous) return room;
+        int at = Array.IndexOf(RoomOrder, room);
+        for (int step = 1; step <= RoomOrder.Length; step++)
+        {
+            string next = RoomOrder[(at + step + RoomOrder.Length) % RoomOrder.Length];
+            if (next != previous) return next;
+        }
+        return room;
+    }
+
+    private static double Mean(double[] e, int from, int to)
+    {
+        from = Math.Clamp(from, 0, e.Length);
+        to = Math.Clamp(to, 0, e.Length);
+        if (to <= from) return 0;
+        double sum = 0;
+        for (int i = from; i < to; i++) sum += e[i];
+        return sum / (to - from);
+    }
+}

--- a/ConditioningControlPanel/Services/Race/TrackAnalyzer.cs
+++ b/ConditioningControlPanel/Services/Race/TrackAnalyzer.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Globalization;
 using System.Threading;
 using ConditioningControlPanel.Models.Race;
 
@@ -7,12 +9,199 @@ namespace ConditioningControlPanel.Services.Race;
 /// <summary>
 /// The energy pass: RMS per bin normalised to the 98th percentile, then build / peak / release /
 /// silence events and a first cut of the acts from the energy shape alone (CHART.md thresholds).
-/// Filled in by PR c4.
 /// </summary>
 public static class TrackAnalyzer
 {
     public const double BinSec = 0.5;
 
+    /// <summary>A build is a rise held for at least this long.</summary>
+    private const double BuildMinSec = 8.0;
+    /// <summary>...that gains more than this much of full scale across the rise.</summary>
+    private const double BuildRise = 0.25;
+    /// <summary>A rise survives a dip this deep below its best level so far; RMS is never smooth.</summary>
+    private const double BuildSlack = 0.05;
+    /// <summary>A rise that has stopped making new highs for this long has ended, plateau or not.</summary>
+    private const double BuildStallSec = 4.0;
+    private const double PeakLevel = 0.8;
+    private const double PeakGapSec = 4.0;
+    private const double ReleaseDrop = 0.4;
+    private const double ReleaseWindowSec = 3.0;
+    private const double SilenceLevel = 0.06;
+    private const double SilenceMinSec = 3.0;
+
+    /// <summary>
+    /// Charts <paramref name="pcm"/> from its energy alone: the normalised curve, the four energy
+    /// event kinds and the acts. The words pass (PR c5) folds its own events into the same chart.
+    /// </summary>
     public static TrackChart Energy(TrackPcm pcm, IProgress<double>? progress, CancellationToken ct)
-        => throw new NotImplementedException("PR c4: TrackAnalyzer.Energy");
+    {
+        if (pcm == null) throw new ArgumentNullException(nameof(pcm));
+
+        var curve = Curve(pcm, progress, ct);
+        var events = Events(curve);
+        var duration = Math.Round(pcm.DurationSec, 3);
+
+        var chart = new TrackChart
+        {
+            Version = TrackChart.CurrentVersion,
+            BinSec = BinSec,
+            Source = new TrackSource
+            {
+                Name = pcm.Name,
+                Hash = pcm.Hash,
+                DurationSec = duration,
+                SampleRate = TrackPcm.SampleRate
+            },
+            Analysis = new TrackAnalysis
+            {
+                Energy = "rms-flux-v1",
+                Words = "none",
+                Lexicon = new List<string>(),
+                GeneratedAt = DateTime.UtcNow,
+                Partial = false
+            },
+            Energy = new List<double>(curve.Length),
+            Acts = TrackActs.Build(curve, duration, events),
+            Events = events
+        };
+
+        foreach (var v in curve) chart.Energy.Add(Round(v));
+        progress?.Report(1);
+        return chart;
+    }
+
+    /// <summary>
+    /// RMS per <see cref="BinSec"/> bin, normalised so the file's 98th percentile is 1 and clamped
+    /// into 0..1. Length is ceil(durationSec / BinSec), the length CHART.md promises the page.
+    /// </summary>
+    private static double[] Curve(TrackPcm pcm, IProgress<double>? progress, CancellationToken ct)
+    {
+        int binSamples = (int)Math.Round(BinSec * TrackPcm.SampleRate);
+        int bins = Math.Max(1, (int)Math.Ceiling(pcm.Mono16k.Length / (double)binSamples));
+        var rms = new double[bins];
+
+        for (int b = 0; b < bins; b++)
+        {
+            ct.ThrowIfCancellationRequested();
+            int from = b * binSamples;
+            int to = Math.Min(from + binSamples, pcm.Mono16k.Length);
+            double sum = 0;
+            for (int i = from; i < to; i++) sum += (double)pcm.Mono16k[i] * pcm.Mono16k[i];
+            rms[b] = to > from ? Math.Sqrt(sum / (to - from)) : 0;
+            if (progress != null && (b & 0xFF) == 0) progress.Report(b / (double)bins);
+        }
+
+        var sorted = (double[])rms.Clone();
+        Array.Sort(sorted);
+        double p98 = sorted[Math.Clamp((int)Math.Round(0.98 * (sorted.Length - 1)), 0, sorted.Length - 1)];
+        // A near-silent file (or one whose top 2 percent is all there is) still has to normalise to
+        // something; fall back to the loudest bin, and to a flat zero curve when even that is silent.
+        if (p98 <= 1e-9) p98 = sorted[sorted.Length - 1];
+        if (p98 <= 1e-9) return rms;
+
+        for (int b = 0; b < bins; b++) rms[b] = Math.Clamp(rms[b] / p98, 0, 1);
+        return rms;
+    }
+
+    /// <summary>The four energy event kinds, sorted by time with ids "e1", "e2", ... in that order.</summary>
+    private static List<TrackEvent> Events(double[] e)
+    {
+        var events = new List<TrackEvent>();
+        Builds(e, events);
+        var peaks = Peaks(e);
+        foreach (int p in peaks) events.Add(Point("peak", p));
+        Releases(e, peaks, events);
+        Silences(e, events);
+
+        events.Sort((a, b) => a.T != b.T
+            ? a.T.CompareTo(b.T)
+            : string.CompareOrdinal(a.Kind, b.Kind));
+        for (int i = 0; i < events.Count; i++)
+            events[i].Id = "e" + (i + 1).ToString(CultureInfo.InvariantCulture);
+        return events;
+    }
+
+    /// <summary>RMS rising for 8 s or more and gaining more than 0.25 of full scale: one per rise.</summary>
+    private static void Builds(double[] e, List<TrackEvent> events)
+    {
+        int minBins = (int)Math.Round(BuildMinSec / BinSec);
+        int stallBins = (int)Math.Round(BuildStallSec / BinSec);
+        int i = 0;
+        while (i < e.Length - 1)
+        {
+            // Walk forward while the curve keeps making new highs, allowing a shallow dip, and take
+            // the highest bin reached as the top of the rise. The stall window is what stops a long
+            // flat plateau from being read as one enormous build because it crept up a hundredth.
+            double best = e[i];
+            int top = i;
+            int j = i + 1;
+            while (j < e.Length && e[j] >= best - BuildSlack && j - top <= stallBins)
+            {
+                if (e[j] >= best) { best = e[j]; top = j; }
+                j++;
+            }
+            if (top - i >= minBins && e[top] - e[i] > BuildRise)
+                events.Add(new TrackEvent
+                {
+                    Kind = "build",
+                    T = Round(i * BinSec),
+                    Dur = Round((top - i) * BinSec)
+                });
+            i = Math.Max(top, i + 1);
+        }
+    }
+
+    /// <summary>Local maxima above 0.8, thinned to the loudest one inside each 4 s window.</summary>
+    private static List<int> Peaks(double[] e)
+    {
+        var peaks = new List<int>();
+        int gapBins = (int)Math.Round(PeakGapSec / BinSec);
+        for (int i = 1; i < e.Length - 1; i++)
+        {
+            if (e[i] <= PeakLevel || e[i] < e[i - 1] || e[i] < e[i + 1]) continue;
+            if (peaks.Count > 0 && i - peaks[peaks.Count - 1] < gapBins)
+            {
+                if (e[i] > e[peaks[peaks.Count - 1]]) peaks[peaks.Count - 1] = i;
+                continue;
+            }
+            peaks.Add(i);
+        }
+        return peaks;
+    }
+
+    /// <summary>A fall of more than 0.4 within 3 s of a peak, at the bin where the fall lands.</summary>
+    private static void Releases(double[] e, List<int> peaks, List<TrackEvent> events)
+    {
+        int windowBins = (int)Math.Round(ReleaseWindowSec / BinSec);
+        foreach (int p in peaks)
+        {
+            for (int i = p + 1; i <= p + windowBins && i < e.Length; i++)
+            {
+                if (e[p] - e[i] <= ReleaseDrop) continue;
+                events.Add(Point("release", i));
+                break;
+            }
+        }
+    }
+
+    /// <summary>Runs under 0.06 lasting 3 s or more; t is the start of the run.</summary>
+    private static void Silences(double[] e, List<TrackEvent> events)
+    {
+        int i = 0;
+        while (i < e.Length)
+        {
+            if (e[i] >= SilenceLevel) { i++; continue; }
+            int start = i;
+            while (i < e.Length && e[i] < SilenceLevel) i++;
+            double dur = (i - start) * BinSec;
+            if (dur >= SilenceMinSec)
+                events.Add(new TrackEvent { Kind = "silence", T = Round(start * BinSec), Dur = Round(dur) });
+        }
+    }
+
+    private static TrackEvent Point(string kind, int bin)
+        => new TrackEvent { Kind = kind, T = Round(bin * BinSec) };
+
+    /// <summary>Three decimals everywhere: the chart travels as JSON and nobody needs bin 1743.0000001.</summary>
+    internal static double Round(double v) => Math.Round(v, 3, MidpointRounding.AwayFromZero);
 }

--- a/ConditioningControlPanel/Services/Race/TrackChartCache.cs
+++ b/ConditioningControlPanel/Services/Race/TrackChartCache.cs
@@ -1,17 +1,55 @@
 using System;
 using System.IO;
 using ConditioningControlPanel.Models.Race;
+using Newtonsoft.Json;
 
 namespace ConditioningControlPanel.Services.Race;
 
-/// <summary>Charts keyed by source hash under %LOCALAPPDATA%/ConditioningControlPanel/race/charts. PR c4.</summary>
+/// <summary>Charts keyed by source hash under %LOCALAPPDATA%/ConditioningControlPanel/race/charts.</summary>
 public static class TrackChartCache
 {
     public static string Root => Path.Combine(App.UserDataPath, "race", "charts");
 
-    public static TrackChart? TryLoad(string hash)
-        => throw new NotImplementedException("PR c4: TrackChartCache.TryLoad");
+    /// <summary>The file a chart with this source hash lives at.</summary>
+    public static string PathFor(string hash) => Path.Combine(Root, hash + ".json");
 
+    /// <summary>
+    /// The cached chart for a source hash, or null when there is none, it will not parse, or it was
+    /// written by an older chart version. Never throws: a bad cache entry is a cache miss.
+    /// </summary>
+    public static TrackChart? TryLoad(string hash)
+    {
+        if (string.IsNullOrWhiteSpace(hash)) return null;
+        try
+        {
+            string path = PathFor(hash);
+            if (!File.Exists(path)) return null;
+            var chart = JsonConvert.DeserializeObject<TrackChart>(File.ReadAllText(path));
+            if (chart == null || chart.Version != TrackChart.CurrentVersion) return null;
+            return chart;
+        }
+        catch (Exception ex)
+        {
+            App.Logger?.Information("race-chart: cached chart {Hash} unreadable ({Message})", hash, ex.Message);
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Writes the chart under its source hash. Goes to a .tmp first and moves over the top, so a
+    /// crash mid-write cannot leave a half chart where the next run will read one.
+    /// </summary>
     public static void Save(TrackChart chart)
-        => throw new NotImplementedException("PR c4: TrackChartCache.Save");
+    {
+        if (chart == null) throw new ArgumentNullException(nameof(chart));
+        string hash = chart.Source.Hash;
+        if (string.IsNullOrWhiteSpace(hash))
+            throw new ArgumentException("The chart has no source hash to key the cache by", nameof(chart));
+
+        Directory.CreateDirectory(Root);
+        string path = PathFor(hash);
+        string temp = path + ".tmp";
+        File.WriteAllText(temp, JsonConvert.SerializeObject(chart, Formatting.Indented));
+        File.Move(temp, path, overwrite: true);
+    }
 }

--- a/ConditioningControlPanel/Services/Race/TrackPcm.cs
+++ b/ConditioningControlPanel/Services/Race/TrackPcm.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Security.Cryptography;
 using System.Threading;
+using NAudio.Wave;
+using NAudio.Wave.SampleProviders;
 
 namespace ConditioningControlPanel.Services.Race;
 
@@ -20,14 +25,147 @@ public sealed class TrackPcm
 /// <summary>
 /// Decodes an audio file to <see cref="TrackPcm"/> with NAudio: MediaFoundationReader first,
 /// AudioFileReader as the fallback, then stereo to mono and a WDL resample to 16 kHz.
-/// Filled in by PR c4.
 /// </summary>
 public static class TrackDecoder
 {
+    /// <summary>Samples pulled per block; big enough that the read loop is not the cost.</summary>
+    private const int BlockSamples = 64 * 1024;
+
+    /// <summary>
+    /// Decodes <paramref name="path"/> to mono 16 kHz float PCM. Progress is bytes decoded over the
+    /// reader's length, 0..1. Cancellation is checked between blocks and throws
+    /// <see cref="OperationCanceledException"/>.
+    /// </summary>
     public static TrackPcm Decode(string path, IProgress<double>? progress, CancellationToken ct)
-        => throw new NotImplementedException("PR c4: TrackDecoder.Decode");
+    {
+        if (string.IsNullOrWhiteSpace(path) || !File.Exists(path))
+            throw new FileNotFoundException("Track file not found", path ?? "");
+
+        // Media Foundation reads mp3 / m4a / wav / wma out of the box. Formats it refuses (or a
+        // machine with the codec pack stripped) fall through to NAudio's own readers.
+        WaveStream reader;
+        try
+        {
+            reader = new MediaFoundationReader(path);
+        }
+        catch (Exception ex)
+        {
+            App.Logger?.Information("race-chart: MediaFoundation could not open {Name} ({Message}), using AudioFileReader",
+                System.IO.Path.GetFileName(path), ex.Message);
+            reader = new AudioFileReader(path);
+        }
+
+        using (reader)
+        {
+            ISampleProvider samples = reader.ToSampleProvider();
+            if (samples.WaveFormat.Channels > 1) samples = ToMono(samples);
+            if (samples.WaveFormat.SampleRate != TrackPcm.SampleRate)
+                samples = new WdlResamplingSampleProvider(samples, TrackPcm.SampleRate);
+
+            long streamLength = 0;
+            try { streamLength = reader.Length; }
+            catch { /* some readers refuse a length; progress then simply never moves */ }
+
+            var block = new float[BlockSamples];
+            var mono = new List<float>(EstimateSamples(reader));
+            int read;
+            while ((read = samples.Read(block, 0, block.Length)) > 0)
+            {
+                ct.ThrowIfCancellationRequested();
+                for (int i = 0; i < read; i++) mono.Add(block[i]);
+                if (progress != null && streamLength > 0)
+                {
+                    long pos = 0;
+                    try { pos = reader.Position; } catch { }
+                    progress.Report(Math.Clamp(pos / (double)streamLength, 0, 1));
+                }
+            }
+            progress?.Report(1);
+
+            var pcm = mono.ToArray();
+            return new TrackPcm
+            {
+                Mono16k = pcm,
+                DurationSec = pcm.Length / (double)TrackPcm.SampleRate,
+                Hash = HashFile(path),
+                Name = System.IO.Path.GetFileName(path),
+                Path = path
+            };
+        }
+    }
 
     /// <summary>The cache key: SHA1 of the length prefix + the first 1 MiB, so a rename keeps its chart.</summary>
     public static string HashFile(string path)
-        => throw new NotImplementedException("PR c4: TrackDecoder.HashFile");
+    {
+        long length = new FileInfo(path).Length;
+        var head = new byte[1024 * 1024];
+        int filled = 0;
+        using (var file = File.OpenRead(path))
+        {
+            int got;
+            while (filled < head.Length && (got = file.Read(head, filled, head.Length - filled)) > 0)
+                filled += got;
+        }
+
+        var prefix = BitConverter.GetBytes(length);
+        if (!BitConverter.IsLittleEndian) Array.Reverse(prefix);
+
+        using var sha = SHA1.Create();
+        sha.TransformBlock(prefix, 0, prefix.Length, null, 0);
+        sha.TransformFinalBlock(head, 0, filled);
+        return Convert.ToHexString(sha.Hash ?? Array.Empty<byte>()).ToLowerInvariant();
+    }
+
+    /// <summary>Stereo goes through NAudio's averaging provider; anything wider gets the downmix below.</summary>
+    private static ISampleProvider ToMono(ISampleProvider source)
+        => source.WaveFormat.Channels == 2
+            ? new StereoToMonoSampleProvider(source)
+            : new DownmixSampleProvider(source);
+
+    /// <summary>A capacity hint so the sample list does not regrow a hundred times on a long file.</summary>
+    private static int EstimateSamples(WaveStream reader)
+    {
+        try
+        {
+            double sec = reader.TotalTime.TotalSeconds;
+            if (sec > 0 && sec < 24 * 3600) return (int)(sec * TrackPcm.SampleRate) + TrackPcm.SampleRate;
+        }
+        catch { /* an unknown length is not worth an exception; fall through to the default */ }
+        return TrackPcm.SampleRate * 60;
+    }
+
+    /// <summary>
+    /// Averages any channel count down to mono. StereoToMonoSampleProvider only takes two channels,
+    /// and a 5.1 m4a would throw on the way in.
+    /// </summary>
+    private sealed class DownmixSampleProvider : ISampleProvider
+    {
+        private readonly ISampleProvider _source;
+        private readonly int _channels;
+        private float[] _frames = Array.Empty<float>();
+
+        public DownmixSampleProvider(ISampleProvider source)
+        {
+            _source = source;
+            _channels = Math.Max(1, source.WaveFormat.Channels);
+            WaveFormat = WaveFormat.CreateIeeeFloatWaveFormat(source.WaveFormat.SampleRate, 1);
+        }
+
+        public WaveFormat WaveFormat { get; }
+
+        public int Read(float[] buffer, int offset, int count)
+        {
+            int wanted = count * _channels;
+            if (_frames.Length < wanted) _frames = new float[wanted];
+            int read = _source.Read(_frames, 0, wanted);
+            int frames = read / _channels;
+            for (int f = 0; f < frames; f++)
+            {
+                float sum = 0;
+                for (int c = 0; c < _channels; c++) sum += _frames[f * _channels + c];
+                buffer[offset + f] = sum / _channels;
+            }
+            return frames;
+        }
+    }
 }


### PR DESCRIPTION
## Racing Thoughts (ex Caucus Race) C# stack

Stacked on `feat/race-c3-skel`. Merge bottom-up.

### Commits
- feat(race): the energy pass - decode, chart, cache

`5 files changed, 586 insertions(+), 8 deletions(-)`

### From the commit message
PR c4 fills in the C# half of the track chart: NAudio decodes any file the
race is handed to mono 16 kHz float PCM, the analyzer turns that into the
0..1 energy curve plus the build, peak, release and silence events, and the
acts fall out of the curve's own silences and level changes. Charts are cached
by a hash of the file so a renamed or moved track keeps the chart it already
paid for. `--race-chart <file>` runs the whole pass from the command line.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0166ij3Q8xyseVkhWajzkWG3
