### PR TITLE
chore(race): rename the kart game to "Racing Thoughts" in user-facing copy

### DIFF
--- a/ConditioningControlPanel/App.xaml.cs
+++ b/ConditioningControlPanel/App.xaml.cs
@@ -2703,7 +2703,7 @@ namespace ConditioningControlPanel
                 else Logger?.Information("--dtrh ignored: {Reason}", dtrhGate.Reason);
             }
 
-            // The Caucus Race (the kart run on the descent's media), dev shortcut: `--race` opens
+            // Racing Thoughts (the kart run on the descent's media), dev shortcut: `--race` opens
             // the race window straight away. Same door as `--dtrh` - the race is a DtRH sibling
             // and answers to the descent's tier gate, not one of its own.
             if (e.Args.Contains("--race"))

--- a/ConditioningControlPanel/MainWindow/MainWindow.Lab.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.Lab.cs
@@ -312,7 +312,7 @@ namespace ConditioningControlPanel
         }
 
         /// <summary>
-        /// Play tab, DtRH card -> "The Caucus Race": the kart run on the descent's media, hosted
+        /// Play tab, DtRH card -> "Racing Thoughts": the kart run on the descent's media, hosted
         /// as its own WebView2 window (CaucusHostService). Same tier-2 door as FALL IN, checked
         /// here for the same reason: the card's lockband is decoration, the handler is the wall.
         /// </summary>
@@ -326,7 +326,7 @@ namespace ConditioningControlPanel
             catch (Exception ex)
             {
                 App.Logger?.Error(ex, "BtnStartRace_Click failed");
-                MessageBox.Show("Couldn't start The Caucus Race:\n\n" + ex.Message, "The Caucus Race",
+                MessageBox.Show("Couldn't start Racing Thoughts:\n\n" + ex.Message, "Racing Thoughts",
                     MessageBoxButton.OK, MessageBoxImage.Warning);
             }
         }

--- a/ConditioningControlPanel/Models/Race/TrackChart.cs
+++ b/ConditioningControlPanel/Models/Race/TrackChart.cs
@@ -5,7 +5,7 @@ using Newtonsoft.Json;
 namespace ConditioningControlPanel.Models.Race;
 
 /// <summary>
-/// A hypno track's chart: the energy curve, the acts and the timed events the Caucus Race lays on
+/// A hypno track's chart: the energy curve, the acts and the timed events Racing Thoughts lays on
 /// the road. Mirrors Resources/web/dtrh/race/CHART.md (chart JSON version 1) field for field; the
 /// page reads this JSON as-is, so the names here are the wire names.
 /// </summary>

--- a/ConditioningControlPanel/Services/Chaos/CaucusHostService.cs
+++ b/ConditioningControlPanel/Services/Chaos/CaucusHostService.cs
@@ -14,8 +14,9 @@ using Newtonsoft.Json.Linq;
 namespace ConditioningControlPanel.Services.Chaos;
 
 /// <summary>
-/// Hosts THE CAUCUS RACE - the no-lose kart run that lives as a sibling page next to the
-/// DtRH game (<c>Resources/web/dtrh/race.html</c>). A stripped-down sibling of
+/// Hosts RACING THOUGHTS (called The Caucus Race until 2026-09-06; the class keeps its name):
+/// the no-lose kart run that lives as a sibling page next to the DtRH game
+/// (<c>Resources/web/dtrh/race.html</c>). A stripped-down sibling of
 /// <see cref="DtrhHostService"/>, the way <see cref="LoomHostService"/> is: one windowed,
 /// input-receiving <see cref="ChaosWebViewHost"/> with the SAME virtual-host mappings the
 /// descent registers (the race drives through the user's own media, so it needs ccp.assets,
@@ -123,7 +124,7 @@ internal static class CaucusHostService
                 // Glued above MainWindow like the descent, so a bark or a closing video window
                 // raising main can never bury the race.
                 OwnedByMainWindow = true,
-                WindowTitle = "The Caucus Race",
+                WindowTitle = "Racing Thoughts",
                 LogTag = "Race",
                 // The engine hum and the pop bed must start without a click.
                 ExtraBrowserArguments = "--autoplay-policy=no-user-gesture-required",

--- a/ConditioningControlPanel/Views/Tabs/PlayTabView.xaml
+++ b/ConditioningControlPanel/Views/Tabs/PlayTabView.xaml
@@ -488,11 +488,11 @@
                                             </Style>
                                         </Button.Resources>
                                     </Button>
-                                    <!-- The Caucus Race: the kart run on the same media, a DtRH sibling
+                                    <!-- Racing Thoughts: the kart run on the same media, a DtRH sibling
                                          page (dtrh/race.html). Same outline as Quick Drop and the same
                                          door - BtnStartRace_Click asks the descent's TierGate, so the
                                          lockband above needs no third exception. -->
-                                    <Button x:Name="BtnPlayRace" Content="☕ The Caucus Race" Cursor="Hand"
+                                    <Button x:Name="BtnPlayRace" Content="☕ Racing Thoughts" Cursor="Hand"
                                             Background="Transparent" Foreground="{DynamicResource PinkBrush}" FontWeight="SemiBold" FontSize="12"
                                             BorderBrush="{DynamicResource PinkBrush}" BorderThickness="1" Padding="14,6" Margin="0,8,0,0"
                                             HorizontalAlignment="Right" ToolTip="the tea party on wheels. beta"


### PR DESCRIPTION
## Racing Thoughts (ex Caucus Race) C# stack

Stacked on `feat/race-c6-host`. Merge bottom-up.

### Commits
- chore(race): rename the kart game to "Racing Thoughts" in user-facing copy

`5 files changed, 10 insertions(+), 9 deletions(-)`

### From the commit message
The owner renamed The Caucus Race to Racing Thoughts. Only strings the user
can see change: the Play tab button, the host window title and the failure
MessageBox (text and caption), plus the comments that named the old title.
Identifiers, class and file names, the `--race` dev args and the
"CaucusHostService:" log prefixes are untouched, so nothing downstream has to
move. The host's header comment records the old name and the date so the
mismatch between the class name and the game name reads as deliberate.
The Play tab button carries literal Content and ToolTip, no localization key,
so the language files need no edit.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0166ij3Q8xyseVkhWajzkWG3
