### PR TITLE
feat(race): the host refuses a video payload

### DIFF
--- a/ConditioningControlPanel/Services/Chaos/CaucusHostService.cs
+++ b/ConditioningControlPanel/Services/Chaos/CaucusHostService.cs
@@ -285,7 +285,8 @@ internal static class CaucusHostService
     }
 
     /// <summary>fire-payload {kind, strength, durationMult} -> the REAL desktop effects through
-    /// the shared factory. Video and audio only: every visual effect is in-world on the page.</summary>
+    /// the shared factory. Audio only now: every visual effect is in-world on the page, and the video
+    /// kind is dark at both ends (the page never spawns one, this refuses it if one ever asks).</summary>
     private static void FirePayload(JObject o)
     {
         try
@@ -293,10 +294,16 @@ internal static class CaucusHostService
             var kindStr = (string?)o["kind"];
             if (string.IsNullOrWhiteSpace(kindStr)) return;
 
-            EffectPayload payload;
+            // Video bubbles are dark (race/bubbleKinds.js spawn:false, 2026-09-06): a mandatory video
+            // has no business interrupting a lap, so refuse the message even if a page still asks.
             if (string.Equals(kindStr, "video", StringComparison.OrdinalIgnoreCase))
-                payload = EffectPayloadFactory.Build(EffectBubblePayloadKind.Video);
-            else if (string.Equals(kindStr, "audio", StringComparison.OrdinalIgnoreCase))
+            {
+                App.Logger?.Information("RaceHost: video payload refused, video bubbles are dark");
+                return;
+            }
+
+            EffectPayload payload;
+            if (string.Equals(kindStr, "audio", StringComparison.OrdinalIgnoreCase))
                 payload = EffectPayloadFactory.Build(EffectBubblePayloadKind.Audio);
             else
             {


### PR DESCRIPTION
## Racing Thoughts (ex Caucus Race) C# stack

Stacked on `feat/race-c9-name`. Merge bottom-up.

### Commits
- feat(race): the host refuses a video payload

`1 file changed, 11 insertions(+), 4 deletions(-)`

### From the commit message
The page no longer spawns a video bubble, but the host should not be the
only thing standing between a player and a mandatory video: refuse the
message here too, so an older page, a stale cache or a hand-sent bridge
message cannot interrupt a lap.
The refusal returns before anything is built or fired and sends no pause,
so nothing is left half-armed. HookVideoEvents is untouched on purpose: a
video started anywhere else in the app should still pause the kart.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0166ij3Q8xyseVkhWajzkWG3
