### PR TITLE
fix(race): stop fullscreen notification echoes

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/race/smoke/fullscreen-check.mjs
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/smoke/fullscreen-check.mjs
@@ -1,0 +1,173 @@
+/*
+ * Node 22+ and a Chromium-family browser, no npm dependencies:
+ *   CHROME_BIN=chromium node race/smoke/fullscreen-check.mjs
+ *
+ * Loads the real race.html / raceBoot.js / bridge.js over loopback. Only the
+ * external WebView2 transport and timeout scheduler are fixture-controlled. The
+ * host withholds init/manifest and timers are held, keeping the page at its
+ * ready boundary without starting a renderer, audio or user media.
+ * Explicit requests use the public bridge.send API: the race currently has
+ * no fullscreen UI control. A fixture acknowledgement is NOT WPF execution.
+ */
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
+import { readFile, mkdtemp, rm } from 'node:fs/promises';
+import { createServer } from 'node:http';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+const webRoot = path.resolve(import.meta.dirname, '../../..');
+const profile = await mkdtemp(path.join(tmpdir(), 'race-fullscreen-'));
+const mime = { '.html': 'text/html', '.js': 'text/javascript', '.css': 'text/css' };
+const server = createServer(async (req, res) => {
+  const file = path.resolve(webRoot, '.' + new URL(req.url, 'http://localhost').pathname);
+  if (!file.startsWith(webRoot + path.sep)) { res.writeHead(403).end(); return; }
+  try {
+    const data = await readFile(file);
+    res.writeHead(200, { 'Content-Type': mime[path.extname(file)] || 'application/octet-stream' }).end(data);
+  } catch { res.writeHead(404).end(); }
+});
+let browser, socket;
+const pending = new Map();
+const deadline = setTimeout(() => {
+  console.error('FAIL fullscreen check timed out');
+  browser?.kill();
+  socket?.close();
+  server.closeAllConnections();
+  server.close();
+  process.exitCode = 1;
+}, 20000);
+try {
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+  const origin = `http://127.0.0.1:${server.address().port}`;
+  browser = spawn(process.env.CHROME_BIN || 'chromium', [
+    '--headless', '--remote-debugging-port=0', `--user-data-dir=${profile}`,
+    '--no-first-run', '--no-default-browser-check', '--disable-background-networking',
+    '--disable-component-update', '--disable-sync', '--metrics-recording-only',
+    '--use-angle=swiftshader', '--enable-unsafe-swiftshader',
+    '--host-resolver-rules=MAP * ~NOTFOUND, EXCLUDE 127.0.0.1', 'about:blank',
+  ], { stdio: ['ignore', 'ignore', 'pipe'] });
+  const endpoint = await new Promise((resolve, reject) => {
+    let stderr = '';
+    browser.on('error', reject);
+    browser.on('exit', (code, signal) => reject(new Error(`Browser exited before CDP: ${code ?? signal}\n${stderr}`)));
+    browser.stderr.on('data', (data) => {
+      stderr = (stderr + data).slice(-8000);
+      const match = stderr.match(/DevTools listening on (ws:\/\/[^\s]+)/);
+      if (match) resolve(new URL(match[1]).origin.replace('ws:', 'http:'));
+    });
+  });
+  const targets = await (await fetch(endpoint + '/json/list')).json();
+  socket = new WebSocket(targets.find((target) => target.type === 'page').webSocketDebuggerUrl);
+  await once(socket, 'open');
+  let id = 0;
+  socket.addEventListener('message', ({ data }) => {
+    const message = JSON.parse(data);
+    const waiter = pending.get(message.id);
+    if (!waiter) return;
+    pending.delete(message.id);
+    if (message.error) waiter.reject(new Error(JSON.stringify(message.error)));
+    else waiter.resolve(message.result);
+  });
+  socket.addEventListener('close', () => {
+    for (const waiter of pending.values()) waiter.reject(new Error('CDP closed'));
+    pending.clear();
+  });
+  function call(method, params = {}) {
+    return new Promise((resolve, reject) => {
+      pending.set(++id, { resolve, reject });
+      socket.send(JSON.stringify({ id, method, params }));
+    });
+  }
+  console.log('Environment:', process.version, process.platform,
+    (await call('Browser.getVersion')).product);
+  await call('Page.enable');
+  await call('Page.addScriptToEvaluateOnNewDocument', { source: `
+    window.setTimeout = () => 0; // Hold the external host-init timeout.
+    const transport = new EventTarget();
+    transport.outgoing = [];
+    transport.postMessage = (message) => transport.outgoing.push(structuredClone(message));
+    window.chrome.webview = transport;
+  ` });
+  const loaded = new Promise((resolve, reject) => {
+    socket.addEventListener('close', () => reject(new Error('Page did not finish loading')), { once: true });
+    socket.addEventListener('message', function listener({ data }) {
+      if (JSON.parse(data).method !== 'Page.loadEventFired') return;
+      socket.removeEventListener('message', listener);
+      resolve();
+    });
+  });
+  await call('Page.navigate', { url: origin + '/dtrh/race.html' });
+  await loaded;
+  const result = await call('Runtime.evaluate', {
+    awaitPromise: true, returnByValue: true,
+    expression: `(${async function () {
+      const bridge = await import('/dtrh/bridge.js');
+      const transport = window.chrome.webview;
+      const checks = [], trace = [];
+      function check(name, actual, expected) {
+        checks.push({ name, actual, expected, pass: JSON.stringify(actual) === JSON.stringify(expected) });
+      }
+      function receive(message) {
+        trace.push({ direction: 'host->page', ...message });
+        transport.dispatchEvent(new MessageEvent('message', { data: message }));
+      }
+      function drain() {
+        const messages = transport.outgoing.splice(0);
+        trace.push(...messages.filter((m) => m.type !== 'log').map((m) => ({ direction: 'page->host', ...m })));
+        return messages;
+      }
+      check('real page announced ready without boot errors',
+        drain().filter((m) => m.type !== 'log'), [{ type: 'ready', protocol: 1 }]);
+      check('hosted transport selected', bridge.isHosted, true);
+      for (const on of [true, true, false, false, true]) {
+        receive({ type: 'fullscreen', on });
+        check('notification on=' + on + ' emits no command', drain(), []);
+      }
+      // Model only the external host protocol: every request is acknowledged,
+      // even when the host state did not change. Bound delivery to catch the
+      // original endless exchange without hanging the test or hiding the echo.
+      for (const on of [true, true, false, false]) {
+        bridge.send({ type: 'fullscreen-set', on });
+        let requests = drain();
+        check('explicit request on=' + on + ' crosses transport', requests,
+          [{ type: 'fullscreen-set', on }]);
+        let acknowledgements = 0;
+        while (requests.length && acknowledgements < 4) {
+          for (const request of requests) {
+            if (request.type === 'fullscreen-set') {
+              acknowledgements++;
+              receive({ type: 'fullscreen', on: request.on });
+            }
+          }
+          requests = drain();
+        }
+        check('explicit request on=' + on + ' terminates after one acknowledgement',
+          { acknowledgements, remaining: requests }, { acknowledgements: 1, remaining: [] });
+      }
+      receive({ type: 'ping', t: 658 });
+      check('real boot handler still answers ping', drain(), [{ type: 'pong', t: 658 }]);
+      return { checks, trace };
+    }} )()` ,
+  });
+  assert.equal(result.exceptionDetails, undefined, JSON.stringify(result.exceptionDetails));
+  const { checks, trace } = result.result.value;
+  for (const check of checks) console.log(`${check.pass ? 'PASS' : 'FAIL'} ${check.name}`,
+    check.pass ? '' : JSON.stringify({ actual: check.actual, expected: check.expected }));
+  console.log('Protocol trace:', JSON.stringify(trace));
+  assert.ok(checks.every((check) => check.pass), 'fullscreen message boundary regression');
+  console.log(`PASS ${checks.length} checks (browser protocol fixture, not Windows host/UI)`);
+} finally {
+  clearTimeout(deadline);
+  socket?.close();
+  if (browser?.pid && browser.exitCode === null && browser.signalCode === null) {
+    const exited = once(browser, 'exit');
+    browser.kill();
+    await exited;
+  }
+  server.closeAllConnections();
+  await new Promise((resolve) => server.close(resolve));
+  await rm(profile, { recursive: true, force: true });
+}

--- a/ConditioningControlPanel/Resources/web/dtrh/raceBoot.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/raceBoot.js
@@ -14,7 +14,7 @@
  *
  * Host messages owned here: init, manifest, favorites, ping, exit-request,
  * fullscreen (run.js owns pause + payout-result). Sent here: pong, boot-error,
- * fullscreen-set, exit + exit-done on a host exit-request or a menu surface.
+ * exit + exit-done on a host exit-request or a menu surface.
  *
  * STANDALONE DEV MODE (no WebView2): `bridge.isHosted` is false, so `init` is
  * synthesised (masterVolume 60, reducedMotion from matchMedia, empty manifest)
@@ -94,7 +94,7 @@ bridge.on('init', (m) => { initMsg = m; maybeBoot(); });
 bridge.on('manifest', (m) => { try { media.setManifest(m); } catch (e) { host.log('manifest: ' + e); } haveManifest = true; maybeBoot(); });
 bridge.on('favorites', (m) => { try { media.setFavorites(m && m.names || []); } catch (e) { host.log('favorites: ' + e); } });
 bridge.on('ping', (m) => host.send({ type: 'pong', t: m && m.t }));
-bridge.on('fullscreen', (m) => host.send({ type: 'fullscreen-set', on: !!(m && m.on) }));
+bridge.on('fullscreen', () => { /* Acknowledgement only; no fullscreen UI to update. Never echo a command. */ });
 bridge.on('exit-request', surface);
 // ---- track charts (CHART.md host protocol). The run owns the clock; this only relays. ----
 bridge.on('track-chart', (m) => {


### PR DESCRIPTION
## Bounded follow-up

Follow-up to merged #658 for reviewed finding `076-F658-fullscreen-echo`. This is a new, single-layer follow-up based directly on integrated `main`, not a reopen or restack of historical branches.

`raceBoot.js` treated each incoming `fullscreen` state notification as a new `fullscreen-set` command. `CaucusHostService` acknowledges even unchanged-state requests, so a notification could sustain a feedback loop. Consume that acknowledgement without sending anything back. Explicit commands and the native acknowledgement path are unchanged; no fullscreen UI control is added.

Two-file diff: **175 additions, 2 deletions (177 changed lines)**. The maintained smoke loads the actual `race.html`, `raceBoot.js` and shared `bridge.js`, rather than copied callbacks, source-string assertions or mocked internal product modules. Only external WebView2 transport/time are controlled; host init/media are withheld.

- Pinned integrated-main base: `3b603f9725c1a4dd1ee6c03d9015cf4102aa7b39`
- Independently reviewed head: `55c76c1aa01f3cea389e56c58fc667e81fdf1fcf`
- Frozen historical WPF baseline `234c59fbae1809c9fd3e2226e57b043c7994550d` and original review evidence remain unchanged. They are not current-main verification.

## Executed local evidence

Linux, Node 22.23.2, headless Chromium 152.0.7977.82:

- Real RED before GREEN: five notification echoes and four non-terminating explicit exchanges on the pinned base. Independent reviewer reproduced that RED with the byte-identical maintained test against base Git blobs.
- GREEN on this exact repair: all 16 browser protocol checks pass. Notifications emit no commands; explicit true/false and repeated-state requests cross the transport and terminate after one fixture acknowledgement. Ready and ping/pong wiring remain intact.
- Command-loss sensitivity check fails when explicit sends are suppressed; the mutation is not in this patch.
- Existing chart, track-run, glTF and pose smokes pass (29, 56, 49 and 125 assertions); 35 JavaScript syntax checks and whitespace checks pass. Publisher reran local checks on the unchanged reviewed commit.
- Independent patch review found no blocking defects and accepted **draft publication only**, not repair completion.

Maintained regression, from the repository root (Node 22+ and installed Chromium required):

```sh
CHROME_BIN=chromium node ConditioningControlPanel/Resources/web/dtrh/race/smoke/fullscreen-check.mjs
```

## Pending requirements (not passes)

- [ ] Existing Windows CI `build` workflow: solution build and WPF test suite, tied to this published SHA. These JavaScript smokes are not automatically run by that workflow.
- [ ] Actual Windows WPF/WebView2 execution with rebuilt/copied web assets: Dispatcher/native acknowledgements for explicit true/false and unchanged-state requests, no notification echo, and validation of any real UI initiator. The local check invokes the public bridge API, not a UI click.
- [ ] Windows visual/layout, fullscreen/windowed transitions, focus/Esc, native-lifetime and performance evidence. The fixture does not render a run, execute the C# host or use real payloads.
- [ ] Maintainer/CODEOWNERS review and normal merge gates.

This remains a draft until required validation is complete. No comfort-policy changes, native lifetime redesign, unrelated repairs, historical restacking or full-port activation. Overall parity is not certified.

Stack metadata: local gh-stack v0.1.1 layer `(main) <- fix/fullscreen-notification-echo`. A one-PR layer has no remote Stack object in gh-stack (the API requires at least two PRs). Publication uses plain non-force Git push plus explicit draft creation, avoiding `gh stack submit`/`push`, which use force-with-lease. No extra PR is created merely to obtain a remote stack number.

## Publication CI snapshot

Observed **2026-09-06 18:03:43 UTC**: existing [Windows build run 34050395602](https://github.com/CodeBambi/Conditioning-Control-Panel---CSharp-WPF/actions/runs/34050395602) is associated with exact head `55c76c1aa01f3cea389e56c58fc667e81fdf1fcf`. Checkout and SDK setup succeeded; **Build solution is in progress; Test has not started**. No build/test pass is claimed. No polling loop or manual rerun was used.

The pull-request test merge is `5f97368be5077af54571821f58747811d5bdd1a1`, with the pinned base and reviewed head as parents and the identical tree `69fd3edbf118ef18fe524390ce0417fb3b89e164`. This distinguishes PR integration metadata from the branch head; completed runner checkout logs have not been obtained. Actual WPF/WebView2 UI and visual/performance requirements above remain pending regardless of CI outcome.
