### PR TITLE
race: the kerb holds the saucer, and a smaller saucer

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
@@ -17,6 +17,12 @@ Every gameplay object lives in **track space** `(d, x, h)`:
 |------|---------|-------|
 | `d`  | depth along the spine, metres, wraps at `layout.totalDepth` | `0 .. totalDepth` |
 | `x`  | lateral offset on the road, metres, +x = kart's right | `-ROAD_HALF_W .. +ROAD_HALF_W` |
+
+`ROAD_HALF_W` (3.2) is the lateral EXTENT of track space, not the edge of the asphalt: the road
+ribbon rooms.js draws runs out to `KERB_INNER_W` (2.875) and the kerb steps up from there to
+`KERB_OUTER_W` (3.5). Two derived limits fall out of that and both live in `consts.js`:
+`KART_X_MAX` is as far as the kart CENTRE may go before the saucer's rim would leave the asphalt,
+and `LANE_X_MAX` is as far out as a bubble may sit and still be poppable from there.
 | `h`  | height above the road surface, metres | `0` on the road, ceiling about `2*RADIUS - ROAD_DROP` |
 
 `layout.toWorld(d, x, h, out)` is the ONLY way to turn track space into a `THREE.Vector3`. Never
@@ -29,7 +35,8 @@ Constants live in `race/consts.js` (import them, do not redeclare).
 ## Modules and their exports
 
 ### `race/consts.js` (PR 1)
-`RADIUS`, `ROAD_DROP`, `ROAD_HALF_W`, `KART_BASE_SPEED`, `KART_MAX_SPEED`, `KART_MIN_SPEED`,
+`RADIUS`, `ROAD_DROP`, `ROAD_HALF_W`, `KERB_INNER_W`, `KERB_OUTER_W`, `SAUCER_R`, `SAUCER_R_ROAD`,
+`KART_X_MAX`, `LANE_X_MAX`, `KART_BASE_SPEED`, `KART_MAX_SPEED`, `KART_MIN_SPEED`,
 `GRAVITY`, `POP_HIT_D`, `POP_HIT_X`, `POP_HIT_H`, `MULT_LADDER`, `COMBO_HOLD_SEC`, `INTENSITY_RAMP_SEC`.
 
 ### `race/spine.js` (PR 1)
@@ -174,8 +181,10 @@ lathe cup, its rim torus, the handle tube, the saucer cylinder and its rim are t
 the tea disc, the pink saucer mark, `cupLight`, the seat and `TEA_Y` are shared by both paths.
 Speed: cruise `KART_BASE_SPEED`, cap `KART_MAX_SPEED`, floor `KART_MIN_SPEED`. Ramps: when
 `layout.rampAt(d)` matches the lip, give `vh` an upward impulse scaled by speed; `GRAVITY` pulls
-back; `airborne` while `h > 0.05`. Steering moves `x` with inertia, clamped to `ROAD_HALF_W`
-(soft wall, no bounce-off shock). Drift = tighter steer + sparks, no penalty. EMI: CRT body seen
+back; `airborne` while `h > 0.05`. Steering moves `x` with inertia, clamped to `KART_X_MAX` (soft wall,
+no bounce-off shock): THE KERB HOLDS THE SAUCER, NOT THE CUP, so the limit is measured from the
+saucer's outer rim (`KERB_INNER_W - SAUCER_R_ROAD - KERB_KISS` = 1.775 m) and the dish stops on the
+kerb line instead of hanging a metre and a half past it. Drift = tighter steer + sparks, no penalty. EMI: CRT body seen
 from behind, gloves on the rim, bead antenna with the six mood states, sweat particles when
 fraught, her face only as a mirrored emoticon in the tea (`:3`, `>_<`, `o_o`, `^_^`, `$_$`). Text
 emoticons only, never a drawn face, never a speech line.

--- a/ConditioningControlPanel/Resources/web/dtrh/race/bubbles.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/bubbles.js
@@ -14,7 +14,7 @@
  * ==========================================================================*/
 
 import * as THREE from 'three';
-import { ROAD_HALF_W, CEILING_H, POP_HIT_D, POP_HIT_X, POP_HIT_H, LANE_H, TREATS_ONLY_SEC } from './consts.js';
+import { CEILING_H, POP_HIT_D, POP_HIT_X, POP_HIT_H, LANE_H, LANE_X_MAX, TREATS_ONLY_SEC } from './consts.js';
 import { BUBBLE_KINDS, KIND_BY_ID, rollKind } from './bubbleKinds.js';
 import { CRISP_LAYER } from './pixel.js';
 
@@ -142,7 +142,7 @@ export function createBubbleField({ scene, layout, media, getIntensity, getRoom,
     const k = KIND_BY_ID[kindId] || KIND_BY_ID.treat;
     const s = takeSlot();
     s.kindId = k.id; s.placement = placement;
-    s.d = layout.wrap(d); s.x = clamp(x, -ROAD_HALF_W + 0.4, ROAD_HALF_W - 0.4); s.x0 = s.x;
+    s.d = layout.wrap(d); s.x = clamp(x, -LANE_X_MAX, LANE_X_MAX); s.x0 = s.x;
     s.h = h; s.baseH = h; s.phase = Math.random() * Math.PI * 2; s.age = 0;
     s.size = sizeOf(k.id); s.scale = placement === 'spawn' ? 0 : 1; s.popT = -1; s.missed = false; s.eventId = null;
     s.mat.map = texOf[k.id]; s.mat.color.set(k.tint); s.mat.opacity = 1; s.mat.needsUpdate = true;
@@ -205,10 +205,10 @@ export function createBubbleField({ scene, layout, media, getIntensity, getRoom,
   }
 
   function spawnAhead(kartD, n = 1) {
-    for (let i = 0; i < n; i++) place(roll('spawn'), 'spawn', kartD + rand(35, 60), rand(-ROAD_HALF_W + 0.6, ROAD_HALF_W - 0.6), LANE_H);
+    for (let i = 0; i < n; i++) place(roll('spawn'), 'spawn', kartD + rand(35, 60), rand(-LANE_X_MAX, LANE_X_MAX), LANE_H);
   }
   function rain(kartD, n = 1) {
-    for (let i = 0; i < n; i++) place(roll('rain'), 'rain', kartD + rand(18, 44), rand(-ROAD_HALF_W + 0.6, ROAD_HALF_W - 0.6), CEILING_H);
+    for (let i = 0; i < n; i++) place(roll('rain'), 'rain', kartD + rand(18, 44), rand(-LANE_X_MAX, LANE_X_MAX), CEILING_H);
   }
   /** An explicit placement from a track cue (CHART.md): the run has already worked the depth out at
    *  the kart's speed, so nothing is rolled or gated by intensity here. Returns the slot id, -1 when
@@ -296,7 +296,7 @@ export function createBubbleField({ scene, layout, media, getIntensity, getRoom,
         else if (s.placement === 'spawn') {
           const a = Math.min(1, s.age / 0.45);
           s.scale = 1 - (1 - a) * (1 - a);
-          s.x = clamp(s.x0 + 0.55 * Math.sin(t * 1.7 + s.phase), -ROAD_HALF_W + 0.4, ROAD_HALF_W - 0.4);
+          s.x = clamp(s.x0 + 0.55 * Math.sin(t * 1.7 + s.phase), -LANE_X_MAX, LANE_X_MAX);
           s.h = LANE_H + bob;
         } else if (s.placement === 'rain') {
           if (s.age < RAIN_FALL) { const k = s.age / RAIN_FALL; s.h = CEILING_H - (CEILING_H - LANE_H) * k * k; }

--- a/ConditioningControlPanel/Resources/web/dtrh/race/consts.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/consts.js
@@ -51,6 +51,32 @@ export const TREATS_ONLY_SEC = 45;
 /** The cup + EMI rig scale (the pitch demo cup read tiny at the chase camera). */
 export const KART_SCALE = 1.35;
 
+// ---- the road profile and what the kerb holds -------------------------------------------
+// Metres from the centre line, and the x the road ribbon in rooms.js is actually drawn to: the
+// asphalt runs out to KERB_INNER_W, then the kerb face steps KERB up and the chequered kerb top
+// carries on to KERB_OUTER_W. ROAD_HALF_W above is the track-space lateral EXTENT (bubbles, audio
+// pan, wall props), not the edge of the asphalt: it sits 0.325 m out on the kerb top.
+/** Outer edge of the kerb top. */
+export const KERB_OUTER_W = 3.5;
+/** The kerb face: the last x that is still asphalt. */
+export const KERB_INNER_W = 2.875;
+
+/** The saucer's outer radius in rig units (race/emi.js builds the dish to it, race/menu.js keeps
+ *  its own podium copy). Shrunk from 0.95 on 2026-09-06: the old dish read too wide on the road. */
+export const SAUCER_R = 0.8;
+/** The dish's radius once the rig is scaled up onto the road: 0.8 * 1.35 = 1.08 m. */
+export const SAUCER_R_ROAD = SAUCER_R * KART_SCALE;
+/** Metres of asphalt kept under the rim at the limit, so a float wobble never pokes the kerb face. */
+export const KERB_KISS = 0.02;
+/** How far the kart CENTRE may travel. THE KERB HOLDS THE SAUCER, NOT THE CUP: steering clamped
+ *  the centre to ROAD_HALF_W, which hung the whole 1.28 m dish over the kerb and let the kerb face
+ *  cut straight through it. The rim now stops on the kerb line instead.
+ *  2.875 - 1.08 - 0.02 = 1.775 m. */
+export const KART_X_MAX = KERB_INNER_W - SAUCER_R_ROAD - KERB_KISS;
+/** The widest a bubble may sit and still be poppable with the kart parked against the kerb:
+ *  KART_X_MAX plus 70 percent of the pop box's half width, 1.775 + 0.805 = 2.58 m. */
+export const LANE_X_MAX = KART_X_MAX + POP_HIT_X * 0.7;
+
 /** Camera seat behind the cup, track space offsets: low and close, the road fills the frame. */
 export const CAM_BACK = 5.8;
 export const CAM_UP = 2.45;

--- a/ConditioningControlPanel/Resources/web/dtrh/race/cues.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/cues.js
@@ -27,7 +27,7 @@
  *              peak; the count and the drop word go on the chrome.
  * ==========================================================================*/
 
-import { LANE_H, CEILING_H, ROAD_HALF_W } from './consts.js';
+import { LANE_H, CEILING_H, LANE_X_MAX } from './consts.js';
 
 /** A trigger phrase nobody has assigned a bubble to wears the room's own effect, else this. */
 const FALLBACK_TRIGGER = 'flash';
@@ -71,7 +71,7 @@ const clamp = (v, a, b) => Math.max(a, Math.min(b, v));
 const conf01 = (e) => (Number.isFinite(Number(e.conf)) ? clamp(Number(e.conf), 0, 1) : 1);
 const weight01 = (e) => (Number.isFinite(Number(e.weight)) ? clamp(Number(e.weight), 0, 1) : 1);
 const laneX = (rng) => LANE_X[Math.min(LANE_X.length - 1, (rng() * LANE_X.length) | 0)];
-const spread = (rng) => clamp((rng() * 2 - 1) * (ROAD_HALF_W - 0.8), -ROAD_HALF_W + 0.6, ROAD_HALF_W - 0.6);
+const spread = (rng) => clamp((rng() * 2 - 1) * LANE_X_MAX, -LANE_X_MAX, LANE_X_MAX);
 const roomId = (ctx) => (ctx.room && typeof ctx.room.id === 'string' ? ctx.room.id : (ctx.act && ctx.act.room) || null);
 
 /** Every field CHART.md promises, so run.js never has to test for one. */

--- a/ConditioningControlPanel/Resources/web/dtrh/race/emi.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/emi.js
@@ -21,6 +21,7 @@
 import * as THREE from 'three';
 import { loadPack, setFace as packSetFace, preparePixel, flattenRig, FACES } from './gltf.js';
 import { createPoseLayer } from './emiPoses.js';
+import { SAUCER_R } from './consts.js';
 
 const PINK = 0xff69b4, GOLD = 0xF2C14E, PALE = 0xB3C7FF, PORCELAIN = 0xF6E7C8;
 const BREATH_SEC = 3.9;      // the one breath on screen (Law III)
@@ -31,19 +32,26 @@ const PROPS_GLB = '/dtrh/race/assets/props.glb';
 // top of its glaze band, the cup is 0.695 to its rim with the band at 0.645..0.690, handle on +x.
 // The cup sits CUP_Y above the saucer base, the way the JS rig always sat it.
 const CUP_Y = 0.09, SAUCER_TOP = 0.125, CUP_RIM_TOP = 0.695;
-/** The saucer's outer radius in rig units (kart_saucer is 1.90 across, the JS dish 0.95 too).
- *  kart.js needs it to know how much air a pitch costs. */
-export const SAUCER_R = 0.95;
+/** The saucer's outer radius in rig units. consts.js owns the number now (kart.js clamps the
+ *  kart to it and needs it to know how much air a pitch costs); this re-export is the old door in.
+ *  Owner call 2026-09-06: a lil smaller, 0.95 down to 0.8. props.glb's kart_saucer is still
+ *  authored 1.90 across, so the dish clone is squeezed to SAUCER_R in x and z on mount and its
+ *  heights (SAUCER_TOP, CUP_Y) are left alone. */
+export { SAUCER_R };
+/** The radius kart_saucer is authored at, before DISH_SQUEEZE takes it down to SAUCER_R. */
+const SAUCER_R_GLB = 0.95, DISH_SQUEEZE = SAUCER_R / SAUCER_R_GLB;
 // THE CUP TIPS, THE SAUCER DOES NOT. kart.js hands its steer lean over as `ctx.lean` now instead
 // of rolling the whole kart about the forward axis: the group rides ON the road, so a banked
-// saucer put its outer edge sin(lean) * 0.95 * KART_SCALE under the surface, 0.84 m under it at a
+// saucer put its outer edge sin(lean) * SAUCER_R * KART_SCALE under the surface, most of a metre at a
 // drift lean. A saucer slides, it does not bank. So `body` alone turns, about the cup's foot on
 // the dish (CUP_PIVOT_Y), lifted by sin(tip) * CUP_FOOT_R so the low half of the foot kisses the
 // dish instead of cutting into it, and slid CUP_SLIDE * sin(tip) toward the outside of the turn so
 // the lean still reads as g-force. CUP_TIP_MAX saturates the angle (tanh, so small leans are one
 // for one and only the big ones are held back): the lift keeps the foot honest at any angle, but
 // the handle bows out to x 0.86 and reaches the road on its own at about 45 degrees, and a cup
-// tipped that far on a flat saucer reads as falling off it. At the 21 degree cap the foot clears
+// tipped that far on a flat saucer reads as falling off it. At the cap the cup rim's low side
+// reaches x 0.74 on the 0.8 dish, so the cup tips inside the saucer's own rim and never hangs
+// off it. At the 21 degree cap the foot clears
 // the road by 0.13 m, the handle by 0.24 m, and the cup rises 0.15 m off the dish at full lock.
 // This is geometry, not a transition, so reduced motion keeps every bit of it.
 const CUP_FOOT_R = 0.3, CUP_PIVOT_Y = CUP_Y, CUP_TIP_MAX = 0.38, CUP_SLIDE = 0.07;
@@ -147,9 +155,11 @@ export function createEmiRig({ scene, reducedMotion = false, pixel = null }) {
 
   // ---- saucer ----
   const saucer = new THREE.Group(); root.add(saucer);
-  const sc = new THREE.Mesh(new THREE.CylinderGeometry(0.95, 0.7, 0.09, 40), porcelain); sc.position.y = 0.05; saucer.add(sc);
-  const saucerRim = new THREE.Mesh(new THREE.TorusGeometry(0.93, 0.03, 8, 48), pinkGlow); saucerRim.rotation.x = Math.PI / 2; saucerRim.position.y = 0.09; saucer.add(saucerRim);
-  const saucerMark = new THREE.Mesh(new THREE.BoxGeometry(0.3, 0.02, 0.08), pinkGlow); saucerMark.position.set(0.7, 0.1, 0); saucer.add(saucerMark);
+  // every radius here is SAUCER_R times the ratio the dish was authored at, so the fallback dish
+  // and the glb one come out the same width and the mark keeps its place on the glaze band.
+  const sc = new THREE.Mesh(new THREE.CylinderGeometry(SAUCER_R, SAUCER_R * 0.737, 0.09, 40), porcelain); sc.position.y = 0.05; saucer.add(sc);
+  const saucerRim = new THREE.Mesh(new THREE.TorusGeometry(SAUCER_R * 0.979, 0.03, 8, 48), pinkGlow); saucerRim.rotation.x = Math.PI / 2; saucerRim.position.y = 0.09; saucer.add(saucerRim);
+  const saucerMark = new THREE.Mesh(new THREE.BoxGeometry(SAUCER_R * 0.316, 0.02, 0.08), pinkGlow); saucerMark.position.set(SAUCER_R * 0.737, 0.1, 0); saucer.add(saucerMark);
 
   // ---- cup ----
   const body = new THREE.Group(); root.add(body);
@@ -315,6 +325,7 @@ export function createEmiRig({ scene, reducedMotion = false, pixel = null }) {
     blackOutline(cup); blackOutline(dish);
     P = { cup, dish };
     retire(sc); retire(saucerRim);                  // pinkGlow still dresses the mark, so it lives on
+    dish.scale.set(DISH_SQUEEZE, 1, DISH_SQUEEZE);  // x and z only: SAUCER_TOP and CUP_Y stay true
     saucer.add(dish);
     saucerMark.position.y = SAUCER_TOP + 0.01;      // back on top of the new glaze band
     retire(cupMesh); retire(rim); retire(handle);

--- a/ConditioningControlPanel/Resources/web/dtrh/race/kart.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/kart.js
@@ -14,23 +14,33 @@
 //   { type:'lap', lap, sec }          the Tea Garden gate crossed again: a timed lap (the first crossing only starts the clock)
 //   { type:'split', frac, sec }       a quarter mark of the lap (0.25 / 0.5 / 0.75) passed at `sec` into the lap
 //
+// THE KERB HOLDS THE SAUCER, NOT THE CUP. Steering used to clamp the kart CENTRE to ROAD_HALF_W
+// (3.2), which is not even the edge of the asphalt: the ribbon in rooms.js runs out to KERB_INNER_W
+// (2.875) and the kerb face steps up from there. So at full lock the whole dish hung over the kerb
+// and the kerb face cut straight through it. The clamp is KART_X_MAX now (consts.js), measured off
+// the saucer's own rim, so the rim stops on the kerb line and the kart is as wide as it looks. The
+// feel is unchanged: the same WALL_SOFT bleed eases the outward push away over the last stretch and
+// the same vx damping catches the limit, so it is still a soft kerb and never a bounce.
+//
 // THE SAUCER NEVER BANKS. The steer lean used to roll the whole group about the forward axis, and
-// the group sits ON the road (h = 0), so the saucer's outer edge swung sin(lean) * 1.28 m straight
-// down through the road surface: 0.84 m under it at a drift lean. The lean now rides on `ctx.lean`
-// into race/emi.js, which tips the cup alone on a saucer that stays flat (a saucer slides, it does
+// the group sits ON the road (h = 0), so the saucer's outer edge swung sin(lean) * SAUCER_R_ROAD
+// straight down through the road surface, most of a metre under it at a drift lean. The lean now
+// rides on `ctx.lean` into race/emi.js, which tips the cup alone on a saucer that stays flat (a saucer slides, it does
 // not bank). Pitch is still the group's, capped here at what the height above the road allows.
 //
-// SCREENSHOT AID: `?lean=1` (steer right) / `?lean=-1` pins the lean at LEAN_MAX for as long as the
-// page is open, so a headless shot can be taken at full lock without holding a key. It only writes
-// `lean`; speed, steering and the pop box are untouched. Anything but -1..1 is ignored.
+// SCREENSHOT AIDS: `?lean=1` (steer right) / `?lean=-1` pins the lean at LEAN_MAX for as long as
+// the page is open, so a headless shot can be taken at full lock without holding a key. It only
+// writes `lean`; speed, steering and the pop box are untouched. Its sibling `?x=-1` / `?x=1` pins
+// the kart against the left / right kerb (state.x = -/+ KART_X_MAX) so a shot shows where the rim
+// actually sits. Both take -1..1 and scale, and anything else is ignored.
 
 import * as THREE from 'three';
 import {
-  KART_BASE_SPEED, KART_MAX_SPEED, KART_MIN_SPEED, GRAVITY, ROAD_HALF_W,
+  KART_BASE_SPEED, KART_MAX_SPEED, KART_MIN_SPEED, GRAVITY, KART_X_MAX, SAUCER_R_ROAD,
   CAM_BACK, CAM_UP, CAM_LOOK_AHEAD, CAM_LOOK_SPEED, KART_SCALE,
   POP_HIT_D, POP_HIT_X, POP_HIT_H, LANE_H, DRIFT_TIER_SEC, DRIFT_BOOST_SEC, WALL_SCRUB_SEC,
 } from './consts.js';
-import { createEmiRig, SAUCER_R } from './emi.js';
+import { createEmiRig } from './emi.js';
 
 const STEER_VMAX = 6.5;       // lateral m/s at full lock, cruise speed, no drift
 const DRIFT_STEER = 1.45;     // drift tightens the steer
@@ -42,23 +52,28 @@ const TRICK_SEC = 0.62;                 // one full rotation of the cup (spin ab
 const TRICK_POINTS = { spin: 150, flip: 250 };
 const TRICK_STREAK_MAX = 4;             // consecutive clean trick landings scale trick points by 1 + 0.5 * streak
 const LAND_BOOST_SEC = 0.7;             // a clean landing after a trick
-const LAND_CLEAN_M = 0.45;              // metres inside the road edge that still count as clean
+const LAND_CLEAN_M = 0.45;              // metres inside KART_X_MAX that still count as clean
+const SCRUB_EDGE_M = 0.12;              // metres of KART_X_MAX left: the rim is on the kerb, this is a scrub
 const INVERT_DEG = 120;                 // roll past this = upside down (pops count double, score.js)
 const TIER_COLORS = [0xFFD27A, 0x5BB8FF, 0xFF8A3D, 0xC46BFF];   // tier 0 (gold) is emi.js's own sparks
 const TARGET_AHEAD = POP_HIT_D * 0.5;   // the pop ring floats this far in front of the cup
 const TARGET_H = LANE_H - 0.15;         // ring centre: between the road box centre and a lane bubble
 const RING_ALPHA = 0.14;                // resting alpha; a pop pulses it up
 const CAM_BOOST_BACK = 0.7;             // the seat slides back a touch under boost
-// The saucer's outer radius in road metres (1.28), widened by the landing squash's fattest frame
-// (emi.js scales the rig 1.18 in x and z at squash 1) so the pitch cap below holds through a THUD.
-const SAUCER_R_W = SAUCER_R * KART_SCALE * 1.18;
+// The saucer's outer radius in road metres (SAUCER_R_ROAD, 1.08), widened by the landing squash's
+// fattest frame (emi.js scales the rig 1.18 in x and z at squash 1) so the pitch cap below holds
+// through a THUD. The steering clamp uses the resting rim (KART_X_MAX) rather than this one: a
+// squash lasts a fifth of a second and giving it 0.19 m of road either side all run would cost the
+// kerb its kiss.
+const SAUCER_R_W = SAUCER_R_ROAD * 1.18;
 // The steepest lean the physics below can reach: full lock at the speed floor, drifting, plus the
 // drift term. Only the screenshot aid uses it, and it is derived so it cannot go stale.
 const LEAN_MAX = STEER_VMAX * 1.15 * DRIFT_STEER * 0.07 + 0.1;
-const FORCE_LEAN = (() => {                 // `?lean=-1..1`, see the header. No DOM, no aid.
-  try { const v = +new URLSearchParams(location.search).get('lean') || 0; return Math.max(-1, Math.min(1, v)); }
+const forced = (key) => {                   // `?lean=-1..1` / `?x=-1..1`, see the header. No DOM, no aid.
+  try { const v = +new URLSearchParams(location.search).get(key) || 0; return Math.max(-1, Math.min(1, v)); }
   catch (e) { return 0; }                   // node, or a page with no location: the aid is simply off
-})();
+};
+const FORCE_LEAN = forced('lean'), FORCE_X = forced('x');
 const WORLD_UP = new THREE.Vector3(0, 1, 0), ZERO = new THREE.Vector3();
 const _m = new THREE.Matrix4(), _q = new THREE.Quaternion(), _v = new THREE.Vector3();
 const _fwd = new THREE.Vector3(), _up = new THREE.Vector3(), _right = new THREE.Vector3(), _lvl = new THREE.Vector3();
@@ -202,18 +217,21 @@ export function createKart({ scene, layout, reducedMotion = false, pixel = null 
     if (state.drift) auth *= DRIFT_STEER;
     if (state.airborne) auth *= 0.35;
     let vTarget = state.steer * STEER_VMAX * auth;
-    // soft wall: the last WALL_SOFT metres bleed the outward push away, no bounce shock
-    const edge = ROAD_HALF_W - Math.abs(state.x);
+    // soft wall: the last WALL_SOFT metres bleed the outward push away, no bounce shock. `edge` is
+    // road left under the saucer's RIM now, not under the cup, so the bleed starts where the dish
+    // starts running out of asphalt.
+    const edge = KART_X_MAX - Math.abs(state.x);
     const outward = state.steer !== 0 && Math.sign(state.steer) === Math.sign(state.x);
     if (edge < WALL_SOFT && outward) vTarget *= clamp(edge / WALL_SOFT, 0, 1);
     vx += (vTarget - vx) * ease(state.drift ? 9 : 6, dt);
     state.x += vx * dt;
-    if (Math.abs(state.x) > ROAD_HALF_W) {
-      state.x = Math.sign(state.x) * ROAD_HALF_W;
+    if (Math.abs(state.x) > KART_X_MAX) {
+      state.x = Math.sign(state.x) * KART_X_MAX;
       if (Math.sign(vx) === Math.sign(state.x)) vx *= 0.25;
     }
+    if (FORCE_X) { state.x = FORCE_X * KART_X_MAX; vx = 0; }           // screenshot aid, see the header
     // the kerb: leaning on the edge for WALL_SCRUB_SEC eases the speed target off a little (stepSpeed)
-    const scrubbing = edge < 0.12 && outward && Math.abs(state.steer) > 0.3 && !state.airborne;
+    const scrubbing = edge < SCRUB_EDGE_M && outward && Math.abs(state.steer) > 0.3 && !state.airborne;
     scrubSec = scrubbing ? scrubSec + dt : 0;
     const scrub = scrubSec >= WALL_SCRUB_SEC;
     if (scrub && !state.scrub) emit({ type: 'scrub', sec: scrubSec });
@@ -269,7 +287,7 @@ export function createKart({ scene, layout, reducedMotion = false, pixel = null 
       }
     }
     if (!state.airborne && airWas) {
-      const clean = Math.abs(state.x) < ROAD_HALF_W - LAND_CLEAN_M, trick = state.trick;
+      const clean = Math.abs(state.x) < KART_X_MAX - LAND_CLEAN_M, trick = state.trick;
       if (trick && clean) { applyBoost(LAND_BOOST_SEC); state.trickStreak = Math.min(state.trickStreak + 1, TRICK_STREAK_MAX + 1); }
       else state.trickStreak = 0;
       emit({ type: 'landing', clean, trick, streak: state.trickStreak });
@@ -324,8 +342,8 @@ export function createKart({ scene, layout, reducedMotion = false, pixel = null 
     ring.quaternion.copy(group.quaternion);                            // the ring never leans
     // The lean is emi.js's now (the cup tips, the saucer stays flat). Pitch is still the whole
     // kart's, but only as far as the air under the saucer allows: on the road the nose-up left
-    // over from a landing would otherwise drive the saucer's back edge sin(pitch) * 1.28 m under
-    // the surface, so it is capped at asin(clearance / SAUCER_R_W) and touches down level.
+    // over from a landing would otherwise drive the saucer's back edge sin(pitch) * SAUCER_R_W
+    // under the surface, so it is capped at asin(clearance / SAUCER_R_W) and touches down level.
     const clear = Math.asin(clamp((state.h + Math.max(0, hopH)) / SAUCER_R_W, 0, 1));
     group.quaternion.multiply(_q.setFromAxisAngle(AX_X, clamp(pitch, -clear, clear)));
     if (trickT < 1) {                                                  // the trick: one full turn, eased

--- a/ConditioningControlPanel/Resources/web/dtrh/race/rooms.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/rooms.js
@@ -22,7 +22,7 @@
  * ==========================================================================*/
 
 import * as THREE from 'three';
-import { makeRng, CAM_BACK } from './consts.js';
+import { makeRng, CAM_BACK, KERB_INNER_W, KERB_OUTER_W } from './consts.js';
 import { biomeById } from '../game/biomes.js';
 import { createRoomProps, pixelTex } from './roomProps.js';
 import { propPack, packGeo, geoSize } from './propPack.js';
@@ -112,8 +112,11 @@ function wedgeGeometry(halfW, len, hgt) {
 // is a tint mask, not transparency: 0.5 = multiply by the vertex colour (room tint),
 // 1.0 = keep the texel's own colour (white chequers, the cream centre dash).
 const TEXEL = 16, ROAD_W_PX = 112, ROAD_L_PX = 32, KERB_PX = 10, KERB_H = 0.16;
-const KERB_OUT = ROAD_W_PX / TEXEL / 2;            // 3.5 m: outer edge of the kerb top
-const KERB_IN = KERB_OUT - KERB_PX / TEXEL;        // 2.875 m: the kerb face
+// The ribbon's two x live in consts.js now, so kart.js can hold the saucer to the same asphalt
+// this draws. They are still exactly the texel maths they were: ROAD_W_PX / TEXEL / 2, and that
+// less KERB_PX / TEXEL. Move one and the other has to move with it.
+const KERB_OUT = KERB_OUTER_W;                     // 3.5 m: outer edge of the kerb top
+const KERB_IN = KERB_INNER_W;                      // 2.875 m: the kerb face
 function roadSheet(rng) {
   return pixelTex(ROAD_W_PX, ROAD_L_PX, (c, w, h) => {
     // every put() clears first: stacked half-alpha fills would composite to 0.75 and lose the mask


### PR DESCRIPTION
Steering hard left hung the kart off the road, the saucer overhanging the kerb with the road edge cutting through the dish. stepSteer clamped to ROAD_HALF_W 3.2, which is not even the asphalt edge (the ribbon runs to 2.875), so the cup centre sat on the kerb top with the whole dish past it.

consts.js now owns the road profile and derives one named limit off the saucer's own rim: KART_X_MAX = KERB_INNER_W - SAUCER_R_ROAD - KERB_KISS = 1.775 m, so the rim stops on the kerb line with 2 cm to spare. The soft wall, the scrub test and the clean-landing test all moved with it, so the feel is unchanged: still a soft kerb, never a bounce. SAUCER_R drops 0.95 to 0.8 per the owner, with props.glb's dish squeezed on mount so SAUCER_TOP and CUP_Y stay true.

Bubble lanes rebase on the new LANE_X_MAX 2.58 m, replacing four hand-tuned offsets, so every lane is still reachable with 30 percent of the pop box spare.

Verified: node --check clean on all files touched, chart-check / track-run-check / poses-smoke green, headless chrome at 1280x720 with left, right and straight kerb shots, zero page errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0166ij3Q8xyseVkhWajzkWG3
