### PR TITLE
race: the kart jumps with space

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
@@ -268,8 +268,13 @@ through the `fire-payload` bridge message exactly like `chaosRun.js` does today.
 (pause + end screen). Run end sends `run-ended` (below).
 
 As built (PR 5 reality notes):
-- `race/input.js` is the single reader of keyboard + gamepad: `createInput() -> { read(), onAction(cb), dispose() }`,
-  `read()` = `{ steer, accel, brake, drift }` with `accel` defaulting to 1 when nothing is pressed.
+- `race/input.js` is the single reader of keyboard + gamepad: `createInput() -> { read(), onAction(cb), flush(), dispose() }`,
+  `read()` = `{ steer, accel, brake, drift, jump }` with `accel` defaulting to 1 when nothing is pressed.
+- Space (pad B) is the jump: `read().jump` is true for exactly the frame of a fresh press, never on hold,
+  and `kart.stepJump` turns it into 1.1 m of real height (`state.h`, so the pop box goes up with it).
+  A press within 4 m of a ramp lip, or inside 0.12 s of one firing, boosts that launch by 1.3 and hands
+  out 0.5 s of speed once per ramp, and emits `{ type:'jump', big:true }`. Space is also the cards' "next",
+  so `run.js start()` calls `input.flush()`. `?jump=<ms>` fires one synthetic press: a screenshot aid.
 - `bridge.isHosted` is a BOOLEAN export, not a function. `raceBoot.js` reads it to pick standalone dev mode
   (synthesised `init`, every would-be host message logged as `[race->host]`).
 - `run.js` registers the `pause` and `payout-result` bridge handlers itself; `raceBoot.js` owns `init`,

--- a/ConditioningControlPanel/Resources/web/dtrh/race/cards.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/cards.js
@@ -46,7 +46,7 @@ export const CARDS = [
   },
   {
     head: 'the road',
-    line: 'the road is built from your own pictures. steer with the arrows, drift with shift, pop what you can reach. nothing here can be lost. it can only be missed.',
+    line: 'the road is built from your own pictures. steer with the arrows, drift with shift, jump with space, pop what you can reach. nothing here can be lost. it can only be missed.',
   },
   {
     head: 'the track',

--- a/ConditioningControlPanel/Resources/web/dtrh/race/input.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/input.js
@@ -2,14 +2,21 @@
  * race/input.js - the wheel. Implements CONTRACT.md "race/run.js + raceBoot.js"
  * (PR 5, integration): the one place keyboard and gamepad are read.
  *
- * Keyboard: arrows / WASD steer + accel + brake, Shift drift, E item, Esc brake,
- * P cycles the pixel look.
+ * Keyboard: arrows / WASD steer + accel + brake, Shift drift, Space jump, E item,
+ * Esc brake, P cycles the pixel look.
  * Gamepad (navigator.getGamepads, standard map): left stick steer, RT accel,
- * LT brake, A drift, X item, Start brake.
+ * LT brake, A drift, B jump, X item, Start brake.
  *
- *   read() -> { steer:-1..1, accel:0..1, brake:0..1, drift:bool }
+ *   read() -> { steer:-1..1, accel:0..1, brake:0..1, drift:bool, jump:bool }
  *   onAction(cb)   cb(action) for the ACTIONS table below ('item' | 'brake' | 'pixel' | 'mute'), edge-triggered, never repeats on hold
+ *   flush()        drop everything held or queued (run.js calls it as the run starts)
  *   dispose()
+ *
+ * `jump` is true for exactly the frame of a fresh press and never on hold, so one press is one
+ * jump (race/kart.js reads it straight off read()). Space is also the introduction cards' "next",
+ * so run.js flushes the wheel at start(): the press that closed the last card never also jumps.
+ * A focused button keeps its own space; everywhere else the press is swallowed so the page
+ * cannot scroll under the canvas.
  *
  * Law II (input honesty): nothing here ever remaps an axis. accel defaults to 1
  * when nothing is pressed, so a player who only ever steers still cruises.
@@ -32,21 +39,42 @@ const ACTIONS = {
   KeyM: 'mute',   // race/audio.js listens
 };
 const DEADZONE = 0.16;
-const PAD = { steer: 0, accelBtn: 7, brakeBtn: 6, drift: 0, item: 2, start: 9 };
+const PAD = { steer: 0, accelBtn: 7, brakeBtn: 6, drift: 0, jump: 1, item: 2, start: 9 };
+/** Space is the jump: not a held KEY and not an ACTION, the kart reads one press per frame. */
+const JUMP_KEY = 'Space';
+/** A space that belongs to a focused control (menu buttons) is left alone. */
+const CONTROLS = /^(BUTTON|INPUT|SELECT|TEXTAREA|A)$/;
+/** `?jump=<ms>` fires one synthetic jump press about that far into the run: a screenshot aid.
+ *  It counts frames at 60 Hz instead of reading the clock, so a headless page whose virtual time
+ *  stands still still gets its press. Nothing else about the wheel changes. */
+const AID_JUMP = (() => {
+  try { const v = +new URLSearchParams(location.search).get('jump') || 0; return v > 0 ? Math.max(1, Math.round(v / 16.7)) : 0; }
+  catch (e) { return 0; }                   // node, or a page with no location: the aid is simply off
+})();
 const clamp = (v, a, b) => Math.max(a, Math.min(b, v));
 
 export function createInput({ target = window } = {}) {
   const down = new Set();
   const acts = [];
-  const out = { steer: 0, accel: 1, brake: 0, drift: false };
+  const out = { steer: 0, accel: 1, brake: 0, drift: false, jump: false };
   let steerE = 0, lastT = 0, disposed = false;
-  const padWas = { item: false, start: false };
+  let jumpQ = false, jumpHeld = false, aidLeft = AID_JUMP;
+  const padWas = { item: false, start: false, jump: false };
 
   const fire = (name) => { for (const cb of acts) { try { cb(name); } catch (e) { /* a listener never breaks the wheel */ } } };
 
   function onKey(e) {
     if (disposed || e.altKey || e.metaKey || e.ctrlKey) return;
     const code = e.code || '';
+    if (code === JUMP_KEY) {                                  // space: the jump, one per press
+      const t = e.target;
+      if (t && t.tagName && CONTROLS.test(t.tagName)) return; // a focused button keeps its space
+      e.preventDefault();                                     // and the page never scrolls
+      if (e.type !== 'keydown') { jumpHeld = false; return; }
+      if (e.repeat || jumpHeld) return;                       // holding it is not a second jump
+      jumpHeld = true; jumpQ = true;
+      return;
+    }
     if (e.type === 'keydown') {
       if (e.repeat) { if (KEYS[code]) e.preventDefault(); return; }
       if (ACTIONS[code]) { fire(ACTIONS[code]); return; }
@@ -57,7 +85,7 @@ export function createInput({ target = window } = {}) {
       down.delete(KEYS[code]);
     }
   }
-  const onBlur = () => down.clear();
+  const onBlur = () => { down.clear(); jumpHeld = false; jumpQ = false; };
 
   target.addEventListener('keydown', onKey);
   target.addEventListener('keyup', onKey);
@@ -79,6 +107,8 @@ export function createInput({ target = window } = {}) {
     let accel = down.has('accel') ? 1 : 0;
     let brake = down.has('brake') ? 1 : 0;
     let drift = down.has('drift');
+    let jump = jumpQ; jumpQ = false;                           // one frame, one press
+    if (aidLeft > 0 && --aidLeft === 0) jump = true;            // `?jump=<ms>`, see the header
     let digital = true;
     const g = pad();
     if (g) {
@@ -90,10 +120,11 @@ export function createInput({ target = window } = {}) {
       accel = Math.max(accel, btn(g, PAD.accelBtn));
       brake = Math.max(brake, btn(g, PAD.brakeBtn));
       drift = drift || btn(g, PAD.drift) > 0.5;
-      const item = btn(g, PAD.item) > 0.5, start = btn(g, PAD.start) > 0.5;
+      const item = btn(g, PAD.item) > 0.5, start = btn(g, PAD.start) > 0.5, jmp = btn(g, PAD.jump) > 0.5;
       if (item && !padWas.item) fire('item');
       if (start && !padWas.start) fire('brake');
-      padWas.item = item; padWas.start = start;
+      if (jmp && !padWas.jump) jump = true;                    // pad B, edge-triggered like the key
+      padWas.item = item; padWas.start = start; padWas.jump = jmp;
     }
     if (digital) steerE += (steer - steerE) * Math.min(1, dt * 14);
     else steerE = steer;
@@ -102,7 +133,15 @@ export function createInput({ target = window } = {}) {
     out.accel = accel > 0 ? clamp(accel, 0, 1) : 1;          // nothing pressed = cruise
     out.brake = clamp(brake, 0, 1);
     out.drift = !!drift;
+    out.jump = !!jump;
     return out;
+  }
+
+  /** Drop everything held or queued. `jumpHeld` stays: a key still physically down only jumps
+   *  again once it has come up, so a space that closed the last card cannot jump twice either. */
+  function flush() {
+    down.clear(); jumpQ = false;
+    padWas.item = false; padWas.start = false; padWas.jump = false;
   }
 
   function dispose() {
@@ -111,10 +150,12 @@ export function createInput({ target = window } = {}) {
     target.removeEventListener('keyup', onKey);
     target.removeEventListener('blur', onBlur);
     down.clear(); acts.length = 0;
+    jumpQ = false; jumpHeld = false;
   }
 
   return {
     read,
+    flush,
     onAction(cb) { if (typeof cb === 'function') acts.push(cb); return () => { const i = acts.indexOf(cb); if (i >= 0) acts.splice(i, 1); }; },
     dispose,
   };

--- a/ConditioningControlPanel/Resources/web/dtrh/race/kart.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/kart.js
@@ -9,6 +9,7 @@
 //   { type:'driftBoost', tier, sec }  drift released with a charge: that many seconds of boost
 //   { type:'scrub', sec }             the road edge has been scrubbed for WALL_SCRUB_SEC (speed eases off a touch)
 //   { type:'trick', name, points, streak }   a ramp trick was thrown (one per launch): 'spin left' | 'spin right' | 'backflip'
+//   { type:'jump', big }             the jump key: a hop of the kart's own. big = the press took a ramp lip with it
 //   { type:'landing', clean, trick, streak } touched down; clean = not on the kerb; a clean trick landing boosts
 //   { type:'inverted', on }           roll past 120 degrees (inside THE BIG WHEEL) began / ended; state.inverted mirrors it
 //   { type:'lap', lap, sec }          the Tea Garden gate crossed again: a timed lap (the first crossing only starts the clock)
@@ -48,6 +49,14 @@ const DRIFT_SNAP = 1.6;       // m/s of counter-steer kick when a drift lets go 
 const WALL_SOFT = 0.7;        // metres from the road edge where the soft wall starts easing you back
 const WALL_SCRUB_MULT = 0.9;  // speed target while scrubbing the edge past WALL_SCRUB_SEC; the floor still holds
 const HOP_SEC = 0.28, HOP_H = 0.3;      // the drift-press hop: cosmetic, the pop box never leaves the road
+// The jump key (space / pad B, race/input.js). Unlike the drift hop this is real height: state.h
+// rises, so the pop box rises with it and anything hung in the air is reachable.
+const JUMP_H = 1.1;                     // metres. A ramp launches 3..4, so the jump reads clearly smaller
+const JUMP_RAMP_M = 4;                  // press within this many metres of a ramp lip and that launch is boosted
+const JUMP_RAMP_SEC = 0.12;             // ...or this soon after the lip already fired
+const JUMP_RAMP_SCALE = 1.3;            // the boosted launch goes this much higher
+const JUMP_RAMP_BOOST = 0.5;            // seconds of speed that come with it
+const JUMP_ARM_SEC = 0.35;              // how long a press stays armed for the lip it was aimed at
 const TRICK_SEC = 0.62;                 // one full rotation of the cup (spin about up, backflip about right)
 const TRICK_POINTS = { spin: 150, flip: 250 };
 const TRICK_STREAK_MAX = 4;             // consecutive clean trick landings scale trick points by 1 + 0.5 * streak
@@ -147,6 +156,7 @@ export function createKart({ scene, layout, reducedMotion = false, pixel = null 
   let vx = 0, lean = 0, pitch = 0, elapsed = 0, lastRampD = -1, driftSide = 1, camReady = false, camX = 0, camH = 0;
   let camBoost = 0, steerS = 0, hopT = 0, scrubSec = 0, sparkAcc = 0, driftWas = false;
   let airWas = false, steerWas = 0, trickArmed = false, trickKind = null, trickDir = 1, trickT = 1;
+  let jumpArm = 0, jumpPending = false, jumpBoostD = -1, launchT = -1e4;
   let gateLay = null, gateD = 0, lapTimed = false, lapMark = 0;
   const cam = { pos: new THREE.Vector3(), look: new THREE.Vector3(), up: new THREE.Vector3(0, 1, 0), roll: 0 };
   const ctx = { t: 0, up: _up, right: _right, tangent: _fwd, speedNorm: 0, airborne: false, steerVel: 0, drift: false, driftSide: 1, driftTier: 0, lean: 0 };
@@ -162,9 +172,52 @@ export function createKart({ scene, layout, reducedMotion = false, pixel = null 
   function launch(ramp) {
     const height = Math.max(0.5, +ramp.height || 2.4);
     const scale = clamp(state.speed / KART_BASE_SPEED, 0.7, 1.3);   // faster = higher, never a fail
-    state.vh = Math.sqrt(2 * GRAVITY * height * scale);
+    // a jump press aimed at this lip (stepJump armed it) takes the launch up a third, once per ramp
+    const big = jumpArm > 0 && Math.abs(ramp.d - jumpBoostD) > 0.01;
+    state.vh = Math.sqrt(2 * GRAVITY * height * scale * (big ? JUMP_RAMP_SCALE : 1));
     state.airborne = true;
     lastRampD = ramp.d;
+    launchT = elapsed;
+    if (big) {
+      jumpBoostD = ramp.d; jumpArm = 0; jumpPending = false;
+      applyBoost(JUMP_RAMP_BOOST);
+      emit({ type: 'jump', big: true });
+    }
+  }
+
+  /** The next ramp lip within `m` metres down the road, or null. */
+  function rampAhead(lay, m) {
+    const feats = lay && lay.featuresBetween ? lay.featuresBetween(state.d, state.d + m) : null;
+    if (feats) for (const f of feats) if (f.type === 'ramp') return f;
+    return null;
+  }
+
+  /** The jump key. input.jump is one frame per press (race/input.js), so this fires once. On the road
+   *  it is a hop of the kart's own; aimed at a ramp lip, or thrown in the moment after one fired, it
+   *  takes that launch higher and adds a little speed instead. Tricks arm the same way a ramp arms
+   *  them, so a drift press mid-jump still backflips. There is no fail state: a mistimed press is a
+   *  plain jump, or a plain ramp launch, and never nothing. */
+  function stepJump(dt, inp, lay) {
+    if (jumpArm > 0) {
+      jumpArm = Math.max(0, jumpArm - dt);
+      if (jumpArm === 0 && jumpPending) { jumpPending = false; emit({ type: 'jump', big: false }); }
+    }
+    if (!inp.jump) return;
+    if (state.airborne) {                                            // no double jump
+      if (elapsed - launchT <= JUMP_RAMP_SEC && Math.abs(lastRampD - jumpBoostD) > 0.01) {
+        state.vh *= Math.sqrt(JUMP_RAMP_SCALE);
+        jumpBoostD = lastRampD; jumpArm = 0; jumpPending = false;
+        applyBoost(JUMP_RAMP_BOOST);
+        emit({ type: 'jump', big: true });
+      }
+      return;
+    }
+    state.vh = Math.sqrt(2 * GRAVITY * JUMP_H);
+    state.airborne = true;
+    const near = rampAhead(lay, JUMP_RAMP_M);
+    // the hop happens either way; the lip, if it comes, launches boosted out of it (stepRamps)
+    if (near && Math.abs(near.d - jumpBoostD) > 0.01) { jumpArm = JUMP_ARM_SEC; jumpPending = true; }
+    else emit({ type: 'jump', big: false });
   }
 
   function stepSpeed(dt, input) {
@@ -242,9 +295,10 @@ export function createKart({ scene, layout, reducedMotion = false, pixel = null 
   }
 
   function stepRamps(dt, lay, prevD) {
-    if (!state.airborne) {
+    // an armed jump press still takes the lip: the hop it just made must not swallow the launch
+    if (!state.airborne || jumpArm > 0) {
       const here = lay.rampAt ? lay.rampAt(state.d) : null;
-      if (!here) lastRampD = -1;                                        // past the air line: re-arm for next lap
+      if (!here && !state.airborne) lastRampD = -1;                     // past the air line: re-arm for next lap
       let hit = null;
       const feats = lay.featuresBetween ? lay.featuresBetween(prevD, state.d) : null;
       if (feats) for (const f of feats) if (f.type === 'ramp' && Math.abs(f.d - lastRampD) > 0.01) { hit = f; break; }
@@ -398,7 +452,7 @@ export function createKart({ scene, layout, reducedMotion = false, pixel = null 
     lay = lay || layout;
     dt = clamp(+dt || 0, 0, 0.1);
     input = input || {};
-    const inp = { steer: +input.steer || 0, accel: clamp(+input.accel || 0, 0, 1), brake: clamp(+input.brake || 0, 0, 1), drift: !!input.drift };
+    const inp = { steer: +input.steer || 0, accel: clamp(+input.accel || 0, 0, 1), brake: clamp(+input.brake || 0, 0, 1), drift: !!input.drift, jump: !!input.jump };
     elapsed += dt;
     if (pulse > 0) pulse = Math.max(0, pulse - pulse * ease(7, dt) - 0.2 * dt);
     const driftPress = inp.drift && !driftWas;
@@ -409,6 +463,7 @@ export function createKart({ scene, layout, reducedMotion = false, pixel = null 
     if (d >= lay.totalDepth) state.lap += 1;
     d = lay.wrap(d);
     state.d = d;
+    stepJump(dt, inp, lay);
     stepRamps(dt, lay, prevD);
     stepTricks(dt, inp, driftPress);
     stepLaps(dt, lay, prevD);

--- a/ConditioningControlPanel/Resources/web/dtrh/race/menu.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/menu.js
@@ -338,7 +338,7 @@ export function createMenu({ root, renderer, pixel, audio, settings = {}, log = 
 
   // ---- how to drive ----
   el('h3', 'rm-h', howPanel, 'how to drive');
-  for (const [k, v] of [['arrows / wasd', 'steer, throttle, brake'], ['shift', 'drift (hold, let go for turbo)'], ['e', 'use the item'], ['p', 'pixel look'], ['m', 'mute'], ['esc', 'the brake'], ['pad', 'stick steers, rt goes, a drifts, x item, start brakes']]) {
+  for (const [k, v] of [['arrows / wasd', 'steer, throttle, brake'], ['shift', 'drift (hold, let go for turbo)'], ['space', 'jump (time it at a ramp for big air)'], ['e', 'use the item'], ['p', 'pixel look'], ['m', 'mute'], ['esc', 'the brake'], ['pad', 'stick steers, rt goes, a drifts, b jumps, x item, start brakes']]) {
     const row = el('div', 'rm-key', howPanel); el('kbd', '', row, k); el('span', '', row, v);
   }
   el('div', 'rm-hint', howPanel, 'nothing is lost. you cannot fail. esc or enter goes back.');

--- a/ConditioningControlPanel/Resources/web/dtrh/race/run.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/run.js
@@ -105,7 +105,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     started: false, running: false, paused: false, hostPaused: false, ended: false, disposed: false,
     elapsed: 0, t: 0, intensity: intensityFloor, timeScale: 1, jackpotBias: 1, parasol: false, magnet: false,
     flip: false, spawnT: SPAWN_T0, rainT: RAIN_T0, tunnelTime: 0, rush: 0, fov: 72, fovBoost: 0, gates: 0, room: null,
-    wasAirborne: false, effects: [], moodHeld: null, moodHold: 0, mood: 'calm', bestAtStart: 0, seed, wobble: 0,
+    wasAirborne: false, airH: 0, effects: [], moodHeld: null, moodHold: 0, mood: 'calm', bestAtStart: 0, seed, wobble: 0,
     trackHold: 0, trackFog: 0, trackPaused: false, statsAt: 0, trackGap: 0,
   };
   const mix = createCocktail({ now: () => S.elapsed });   // THE MIX: one live effect per category (cocktail.js); S.effects mirrors its live slots
@@ -168,7 +168,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
   function resetRunState(runSeed) {
     Object.assign(S, { running: false, paused: false, ended: false, elapsed: 0, t: 0, intensity: intensityFloor, timeScale: 1,
       jackpotBias: 1, parasol: false, magnet: false, spawnT: SPAWN_T0, rainT: RAIN_T0, rush: 0, fovBoost: 0, gates: 0, room: null,
-      wasAirborne: false, effects: [], moodHeld: null, moodHold: 0, mood: 'calm', seed: runSeed,
+      wasAirborne: false, airH: 0, effects: [], moodHeld: null, moodHold: 0, mood: 'calm', seed: runSeed,
       trackHold: 0, trackFog: 0, trackPaused: false, statsAt: 0, trackGap: 0 });
     setFlip(false); trailClear();
     mix.reset(); S.wobble = 0; clearMixChrome();
@@ -414,6 +414,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
       case 'landing': w.kart.pose(e.clean ? 'landing' : 'landingKerb'); if (e.trick) { hud.toast(e.clean ? (e.streak >= 3 ? 'hat trick, clean' : 'clean') : 'kerbed it', e.clean ? 'pop' : 'almost'); if (e.clean) sfx('surface', 0.5); } break;
       case 'inverted': w.score.setInverted(e.on); w.kart.pose(e.on ? 'tuck' : 'cruise'); if (e.on) { hud.toast('upside down', 'effect'); poke('shock', 0.8); } break;
       case 'lap': { const r = w.score.lap(e.sec); hud.toast(`lap ${r.text}`, 'item'); if (r.pb && r.prevBest > 0) { hud.toast('pb!', 'jackpot'); sfx('pb_fanfare', 0.9); poke('jackpot', 1.5); w.kart.pose('cheer'); } break; }
+      case 'jump': w.kart.pose('air', { hold: e.big ? 0.7 : 0.3 }); if (e.big) { hud.toast('big air', 'pop'); sfx('tunnel_powerup_collect', 0.6); poke('streamed', 0.9); } break;
       case 'split': w.score.pace(e.frac, e.sec); break;
     }
   }
@@ -460,7 +461,10 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
       else if (f.type === 'itembox' && Math.abs(f.x - ks.x) <= 1.2 && w.dresser.breakItemBox(f)) { shake.shake(0.2, 120); if (w.items.roll(w.score.state.mult)) sfx('ui_click', 0.5); }
       else if (f.type === 'gate') enterRoom(w, ts && ts.act ? ts.act.room : f.room, ts && ts.act ? ts.act.name : null);
     }
-    if (S.wasAirborne && !ks.airborne) { shake.shake(0.8, 300); poke('smug', 0.7); }
+    if (ks.airborne) S.airH = Math.max(S.airH, ks.h);
+    if (S.wasAirborne && !ks.airborne) {                        // the jolt is the flight's: a 1.1 m jump is not a ramp
+      shake.shake(0.8 * clamp(S.airH / 2.5, 0.3, 1), 300); poke('smug', 0.7); S.airH = 0;
+    }
     S.wasAirborne = ks.airborne;
     for (const n of w.score.drainNotes()) { hud.toast(n.text, n.kind); if (n.mood) poke(n.mood, 1.2); if (n.sfx) sfx(n.sfx, 0.9); }   // upside down, full circle, hot lap
 
@@ -576,6 +580,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     if (S.started || S.disposed) return;
     if (!W) W = build(S.seed);
     S.started = true; S.running = true; S.ended = false;
+    input.flush();          // a space that closed the last introduction card is not a jump on frame one
     S.bestAtStart = W.score.state.best;
     camOverride = null;
     S.room = W.dresser.applyRoom(W.fx, W.layout.roomAtDepth(0), 0.2);   // the gate 9 m in shows the banner


### PR DESCRIPTION
Space (and pad B) is a jump of the kart's own. input.js reads it edge triggered, one press one jump, never on hold, and preventDefault keeps the page from scrolling. run.js flushes the wheel at the start of a run so the space that closed the last card cannot also jump on frame one.

kart.js gains stepJump, called right before stepRamps. It puts 1.1 m of real height on state.h so the pop box rises with the kart and anything hung in the air stays reachable. Tricks arm the way a ramp arms them, so a drift press mid jump still backflips, and the landing squash is the existing one scaled by the flight's own peak so a hop is not read as a ramp jolt.

Aimed at a ramp the press pays: within 4 m of the lip, or 0.12 s after it fired, the launch goes a third higher and carries half a second of speed, once per ramp, with a big air toast and an EMI beat. A mistimed press is a normal jump or a normal launch, never nothing.

Verified: node --check clean, race smokes green, headless chrome run with ?jump=<ms> firing a synthetic press, zero page errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0166ij3Q8xyseVkhWajzkWG3
