### PR TITLE
race: the break flash is light, plus the item pickup card

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
@@ -88,6 +88,8 @@ Rooms: `teagarden, toybox, casino, undertow, mirrors, chapel, greyward, coronati
 carries `loud` (rollRoomOrder deals loud/soft alternately after the Tea Garden). `rooms` may be
 specs or ids. The dresser adds its own hemisphere + directional light (the props are Lambert; the
 tunnel shader ignores lights) and exposes `group`, `spans` (`{id, d0, d1}` per room) and `rooms`.
+A crossed cube hides, throws its splits and puts a BILLBOARD flash on its spot: never a solid mesh,
+which used to read as a second, empty white box standing beside the shards.
 Road furniture (item box and its twelve splits, boost pad, ramp lip, air marker) takes its geometry
 from `props.glb` through `race/propPack.js` once the pack resolves; before that, and forever if the
 pack or a node is missing, the hand-built voxel primitives stay. Placement, physics and animation
@@ -229,6 +231,9 @@ export function createRaceHud(root) -> hud
 hud.setScore(n) hud.setCombo(combo, mult) hud.setSpeed(ms) hud.setBank(n)
 hud.banner(name, tagline, colorHex)   // MARQUEE, once per gate
 hud.item(glyph | null, name)
+hud.pickupRoll()                      // THE PICKUP card: pops near the cup with the rolling '?' (on itemRoll)
+hud.pickupArm(glyph, name, onLand)    // flips to the decided item (on itemArm), holds, flies into the slot, onLand as it lands
+hud.pickupClear()                     // on itemUse or a reset: the card and the slot's highlight both go
 hud.toast(text, kind)                 // kind: 'pop' | 'almost' | 'jackpot' | 'bank' | 'item' | 'effect'
 hud.flicker()                         // Stat Flicker under glitch
 hud.setFraught(v)

--- a/ConditioningControlPanel/Resources/web/dtrh/race/hud.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/hud.js
@@ -12,6 +12,12 @@
  * lies for 450 ms, the ledger never does (Law I). The Brake and the End card
  * are the only pointer targets. Copy is DtRH voice: lowercase, short.
  *
+ * THE PICKUP (pass f3): a cube gives its item a card of its own, centre of the
+ * view just above the cup. It rolls a `?` while items.js rolls, flips to the
+ * decided item the moment items.js arms it (never earlier: Fake Shuffle),
+ * holds, then flies into the item slot and leaves the slot lit until the item
+ * is used. Under reduced motion the card fades in place instead of flying.
+ *
  * Pass three: THE MIXER rail above the item slot shows the live ingredients
  * of the mix (race/cocktail.js) as pixel chips with drain bars and charge
  * pips, and the served recipe's name while one is live. strobe() is the
@@ -110,6 +116,13 @@ export function createRaceHud(root) {
   itemKey.textContent = 'E';
   itemName.appendChild(itemKey);
 
+  // THE PICKUP: the item's own card. No per-item art ships, so the tile IS the picture: the room
+  // colour, a soft glow and the glyph big. It rides in the chrome, so a freeze or a tape covers it.
+  const pickup = el('rh-pickup', chrome);
+  const pickTile = el('rh-pickup-tile', pickup);
+  const pickGlyph = el('rh-pickup-glyph', pickTile, '?');
+  const pickName = el('rh-pickup-name', pickup, '');
+
   const speed = el('rh-speed rh-plate', chrome);
   const speedRow = el('rh-speed-row', speed);
   const speedN = document.createElement('span');
@@ -124,6 +137,41 @@ export function createRaceHud(root) {
   el('rh-speed-mark', speedBar).style.left = `${(KART_BASE_SPEED / KART_MAX_SPEED * 100).toFixed(1)}%`;
   el('rh-speed-tag', speed, 'boost');   // shown only while .is-boost is on
   let speedHot = false;
+
+  // ---- the pickup's own clock: roll -> flip -> hold -> flight -> the slot holds it ----
+  const PICK_HOLD_MS = 600, PICK_FLY_MS = 420;
+  let pickTimers = [], pickLive = false;
+  const pickLater = (fn, ms) => { const t = later(fn, ms); pickTimers.push(t); return t; };
+  /** Take the card off screen at once. A second cube may never stack a second card (no orphans). */
+  function endPickup() {
+    for (const t of pickTimers) { clearTimeout(t); timers.delete(t); }
+    pickTimers = [];
+    pickLive = false;
+    pickup.classList.remove('is-on', 'is-rolling', 'is-flip', 'is-fly');
+    pickup.style.transform = ''; pickup.style.transformOrigin = '';
+  }
+  /** The flight: the slot's rect is measured HERE, so the card lands right at any window size. */
+  function flyPickup(onLand) {
+    const land = () => {
+      pickLive = false;
+      item.classList.remove('is-inbound');
+      item.classList.add('is-held');
+      hit(item, 'is-bounce');
+      if (onLand) { try { onLand(); } catch (e) { /* a listener never breaks the run */ } }
+    };
+    if (reduced) { pickup.classList.add('is-fly'); pickLater(endPickup, 160); land(); return; }
+    try {
+      const from = pickTile.getBoundingClientRect(), to = itemBox.getBoundingClientRect(), card = pickup.getBoundingClientRect();
+      if (from.width > 0 && to.width > 0) {
+        const dx = (to.left + to.width / 2) - (from.left + from.width / 2);
+        const dy = (to.top + to.height / 2) - (from.top + from.height / 2);
+        pickup.style.transformOrigin = `${(from.left + from.width / 2 - card.left).toFixed(1)}px ${(from.top + from.height / 2 - card.top).toFixed(1)}px`;
+        pickup.style.transform = `translate(${dx.toFixed(1)}px, ${dy.toFixed(1)}px) scale(${(to.width / from.width).toFixed(3)})`;
+      }
+    } catch (e) { /* no layout yet: the card fades where it stands */ }
+    pickup.classList.add('is-fly');
+    pickLater(() => { endPickup(); land(); }, PICK_FLY_MS);
+  }
 
   const toasts = el('rh-toasts', chrome);
   const strobeEl = el('rh-strobe', chrome);
@@ -311,7 +359,33 @@ export function createRaceHud(root) {
       itemName.appendChild(itemKey);
       item.classList.toggle('is-armed', glyph != null);
       item.classList.toggle('is-rolling', glyph === '?');
+      if (glyph == null) item.classList.remove('is-held', 'is-inbound');
       hit(item, 'is-bounce');
+    },
+    /** THE PICKUP, on `itemRoll`: the card pops in near the cup with the rolling `?`. */
+    pickupRoll() {
+      endPickup();
+      pickGlyph.textContent = '?';
+      pickName.textContent = 'rolling';
+      void pickup.offsetWidth;                       // replay the pop when one card follows another
+      pickup.classList.add('is-on', 'is-rolling');
+      pickLive = true;
+    },
+    /** On `itemArm`: the card flips to the decided item, holds, then flies into the slot.
+     *  `onLand` fires as it lands, for the sound the run brain owns. */
+    pickupArm(glyph, name, onLand) {
+      if (!pickLive) { hud.pickupRoll(); }
+      pickup.classList.remove('is-rolling');
+      pickGlyph.textContent = glyph == null ? '?' : String(glyph);
+      pickName.textContent = String(name || '').toLowerCase();
+      hit(pickup, 'is-flip');
+      item.classList.add('is-inbound');              // the slot stays empty until the card lands in it
+      pickLater(() => flyPickup(onLand), reduced ? 200 : PICK_HOLD_MS);
+    },
+    /** On `itemUse` (or a reset): the card and the slot's highlight both go. */
+    pickupClear() {
+      endPickup();
+      item.classList.remove('is-held', 'is-inbound');
     },
     toast(text, kind) {
       kind = TOAST_HOLD[kind] ? kind : 'pop';

--- a/ConditioningControlPanel/Resources/web/dtrh/race/race.css
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/race.css
@@ -124,13 +124,32 @@
   opacity: 0.45; transition: opacity 0.25s;
 }
 .race-hud .rh-item.is-armed { opacity: 1; }
+/* while the pickup card is on its way the slot is still empty: it fills when the card lands in it */
+.race-hud .rh-item.is-inbound { opacity: 0.45; }
 .race-hud .rh-item-box {
+  position: relative;
   width: 52px; height: 52px; border-radius: 12px; display: grid; place-items: center;
   font-size: 1.6rem; font-weight: 900; color: #ffd6ea;
   background: rgba(255, 105, 180, 0.14); border: 2px solid rgba(255, 105, 180, 0.55);
   box-shadow: 0 0 0 rgba(255, 105, 180, 0); transition: box-shadow 0.3s;
 }
 .race-hud .rh-item.is-armed .rh-item-box { box-shadow: 0 0 18px rgba(255, 105, 180, 0.6); }
+.race-hud .rh-item.is-inbound .rh-item-box { color: transparent; box-shadow: 0 0 0 rgba(255, 105, 180, 0); }
+/* HELD: the item is in the slot and E will spend it. A brighter frame, a slow ring pulse (its own
+   pseudo element, so the landing bounce keeps the box's animation to itself) and the key hint lit. */
+.race-hud .rh-item.is-held { opacity: 1; }
+.race-hud .rh-item.is-held .rh-item-box {
+  color: #fff; border-color: rgba(255, 214, 234, 0.95); background: rgba(255, 105, 180, 0.26);
+  box-shadow: 0 0 26px rgba(255, 105, 180, 0.8);
+}
+.race-hud .rh-item.is-held .rh-item-box::after {
+  content: ''; position: absolute; inset: -5px; border-radius: 16px;
+  border: 2px solid rgba(255, 214, 234, 0.9); animation: rhHold 1.7s ease-in-out infinite;
+}
+.race-hud .rh-item.is-held .rh-item-key {
+  color: #fff; border-color: rgba(255, 255, 255, 0.9);
+  background: rgba(255, 105, 180, 0.4); box-shadow: 0 0 12px rgba(255, 105, 180, 0.75);
+}
 .race-hud .rh-item.is-rolling .rh-item-box { animation: rhRoll 0.18s steps(2) infinite; }
 .race-hud .rh-item.is-bounce .rh-item-box { animation: rhBounce 0.36s cubic-bezier(0.2, 1.6, 0.4, 1); }
 .race-hud .rh-item-name { font-size: 0.82rem; font-weight: 700; text-shadow: 0 1px 3px rgba(0, 0, 0, 0.8); }
@@ -138,6 +157,40 @@
   display: inline-block; margin-left: 6px; padding: 0 6px; border-radius: 4px; font-size: 0.66rem; font-weight: 800;
   border: 1px solid rgba(255, 255, 255, 0.5); color: rgba(255, 255, 255, 0.8); line-height: 1.4;
 }
+
+/* ---- THE PICKUP card: the item pops up near the cup, then slides into the slot ----
+   No per-item art ships with the game, so the tile IS the picture: the room colour, a soft glow
+   and the glyph big. The flight is one transform on the card, measured against the slot's live
+   rect in hud.js, so it lands right at any window size. */
+.race-hud .rh-pickup {
+  position: absolute; left: 50%; bottom: 47%; width: 172px; margin-left: -86px;
+  display: none; flex-direction: column; align-items: center; gap: 9px; text-align: center;
+  transition: transform 420ms cubic-bezier(0.32, 0.02, 0.2, 1), opacity 200ms linear 220ms;
+  will-change: transform;
+}
+.race-hud .rh-pickup.is-on { display: flex; }
+.race-hud .rh-pickup-tile {
+  position: relative; width: 116px; height: 116px; border-radius: 26px; display: grid; place-items: center;
+  background:
+    radial-gradient(circle at 50% 30%, rgba(255, 255, 255, 0.9), rgba(255, 255, 255, 0.26) 40%, rgba(255, 255, 255, 0) 66%),
+    linear-gradient(158deg, color-mix(in srgb, var(--rh-room) 68%, #fff) 0%, color-mix(in srgb, var(--rh-room) 72%, #2a0f24) 100%);
+  border: 3px solid rgba(255, 255, 255, 0.72);
+  box-shadow: 0 0 36px color-mix(in srgb, var(--rh-room) 65%, transparent), 0 14px 28px rgba(0, 0, 0, 0.45),
+    inset 0 2px 14px rgba(255, 255, 255, 0.32);
+}
+.race-hud .rh-pickup-glyph {
+  font-size: 3.4rem; line-height: 1; font-weight: 900; color: #fff;
+  text-shadow: 0 0 20px rgba(255, 255, 255, 0.85), 0 3px 0 rgba(0, 0, 0, 0.22);
+}
+.race-hud .rh-pickup-name {
+  font-size: 0.9rem; font-weight: 800; letter-spacing: 0.13em; color: #fff;
+  text-shadow: 0 0 14px var(--rh-room), 0 2px 4px rgba(0, 0, 0, 0.85); transition: opacity 160ms linear;
+}
+.race-hud .rh-pickup.is-on .rh-pickup-tile { animation: rhPickIn 0.36s cubic-bezier(0.2, 1.6, 0.4, 1); }
+.race-hud .rh-pickup.is-rolling .rh-pickup-glyph { animation: rhRoll 0.16s steps(2) infinite; }
+.race-hud .rh-pickup.is-flip .rh-pickup-tile { animation: rhPickPop 0.34s cubic-bezier(0.2, 1.6, 0.4, 1); }
+.race-hud .rh-pickup.is-fly { opacity: 0; }
+.race-hud .rh-pickup.is-fly .rh-pickup-name { opacity: 0; transition: opacity 120ms linear; }
 
 /* ---- speed, bottom-right: the pace number, a fat gauge and a boost state ---- */
 .race-hud .rh-speed {
@@ -309,6 +362,9 @@
 @keyframes rhBeat { 0%, 100% { opacity: var(--rh-fraught); } 12% { opacity: calc(var(--rh-fraught) + 0.25); } 24% { opacity: var(--rh-fraught); } 36% { opacity: calc(var(--rh-fraught) + 0.15); } }
 @keyframes rhCardIn { from { opacity: 0; transform: translateY(12px) scale(0.96); } }
 @keyframes rhChipIn { 0% { opacity: 0; transform: translateY(8px) scale(0.6); } 100% { opacity: 1; transform: none; } }
+@keyframes rhPickIn { 0% { opacity: 0; transform: translateY(26px) scale(0.42); } 62% { opacity: 1; transform: translateY(0) scale(1.08); } 100% { transform: scale(1); } }
+@keyframes rhPickPop { 0% { transform: scale(0.74); } 45% { transform: scale(1.16); } 100% { transform: scale(1); } }
+@keyframes rhHold { 0%, 100% { opacity: 0.3; transform: scale(0.95); } 50% { opacity: 1; transform: scale(1.04); } }
 /* the End card beside her: no blur, the right half stays crisp for the results camera, the card slides in from the left */
 .race-hud .rh-screen.is-beside { place-items: center start; padding-left: 8vw; backdrop-filter: none; -webkit-backdrop-filter: none; background: linear-gradient(90deg, rgba(8, 4, 14, 0.82) 0%, rgba(8, 4, 14, 0.5) 46%, rgba(8, 4, 14, 0) 72%); }
 .race-hud .rh-screen.is-beside .rh-card { animation: rhCardSlide 0.42s cubic-bezier(0.2, 1.4, 0.4, 1); }
@@ -332,6 +388,10 @@
   .race-hud .rh-count.is-on { animation: rhFade 0.45s linear forwards; }
   .race-hud .rh-screen.is-beside .rh-card { animation: none; }
   .race-hud .rh-strobe.is-on, .race-hud .rh-chip.is-in, .race-hud .rh-chip.is-bump, .race-hud .rh-chip-glyph.is-kick, .race-hud .rh-mixer-recipe.is-served { animation: none; }
+  /* the pickup card never flies: it fades where it stands and the slot lights up at once */
+  .race-hud .rh-pickup { transition: opacity 0.14s linear; }
+  .race-hud .rh-pickup.is-on .rh-pickup-tile, .race-hud .rh-pickup.is-flip .rh-pickup-tile,
+  .race-hud .rh-pickup.is-rolling .rh-pickup-glyph, .race-hud .rh-item.is-held .rh-item-box::after { animation: none; }
   .race-hud .rh-toast--recipe { animation: rhFade var(--rh-hold, 1.7s) linear forwards; }
 }
 

--- a/ConditioningControlPanel/Resources/web/dtrh/race/rooms.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/rooms.js
@@ -309,13 +309,36 @@ export function createRoomDresser({ scene, layout, rooms = ROOMS }) {
   const shards = new THREE.InstancedMesh(track(new THREE.BoxGeometry(CUBE * 0.24, CUBE * 0.24, CUBE * 0.24)), cubeMat, SHARD_N);
   const shard = []; for (let i = 0; i < SHARD_N; i++) shard.push({ life: 0, age: 0, spin: 0, p: new THREE.Vector3(), v: new THREE.Vector3(), g: new THREE.Vector3(), axis: new THREE.Vector3(0, 1, 0) });
   let shardCursor = 0, shardsLive = 0;
-  const flashMat = mat(new THREE.MeshBasicMaterial({ color: 0xffffff }));
-  const flashes = new THREE.InstancedMesh(track(new THREE.BoxGeometry(CUBE, CUBE, CUBE)), flashMat, FLASH_N);
-  const flash = []; for (let i = 0; i < FLASH_N; i++) flash.push({ life: 0, m: new THREE.Matrix4() });
+  // The break flash used to be a full-size CUBE of opaque white: it swelled past the box for a
+  // fifth of a second and read as a SECOND, empty white box standing beside the shards. A flash is
+  // light, not furniture, so it is now a billboard that always faces the seat, additive over the
+  // road and fading as it swells. It can never draw an edge, so it can never read as a box.
+  const flashTex = pixelTex(24, 24, (c, w, h) => {
+    c.fillStyle = '#000'; c.fillRect(0, 0, w, h);
+    const mid = (w - 1) / 2;
+    for (let y = 0; y < h; y++) for (let x = 0; x < w; x++) {
+      const r = Math.hypot(x - mid, y - mid) / mid;
+      const core = Math.max(0, 1 - r * 1.12);
+      const spoke = Math.max(0, 1 - Math.min(Math.abs(x - mid), Math.abs(y - mid)) / 1.6) * Math.max(0, 1 - r);
+      const k = Math.min(1, core * core + spoke * 0.8);
+      if (k <= 0.02) continue;
+      const v = Math.round(255 * k);
+      c.fillStyle = `rgb(${v},${v},${v})`; c.fillRect(x, y, 1, 1);
+    }
+  }, { clamp: true });
+  if (flashTex) texes.push(flashTex);
+  const flash = [];
+  for (let i = 0; i < FLASH_N; i++) {
+    const fm = mat(new THREE.SpriteMaterial({ map: flashTex, color: 0xffffff, transparent: true, opacity: 0, depthWrite: false, blending: THREE.AdditiveBlending }));
+    const sprite = new THREE.Sprite(fm);
+    sprite.name = 'race-cube-flash'; sprite.visible = false; sprite.frustumCulled = false;
+    group.add(sprite);
+    flash.push({ life: 0, sprite, fm });
+  }
   let flashCursor = 0, flashesLive = 0;
   const _q = new THREE.Quaternion(), _up = new THREE.Vector3(), _hide = new THREE.Vector3(0, -999, 0);
   const hideAll = (mesh, n) => { for (let i = 0; i < n; i++) mesh.setMatrixAt(i, _m.compose(_hide, _q.identity(), _s.setScalar(0.0001))); };
-  hideAll(shards, SHARD_N); hideAll(flashes, FLASH_N);
+  hideAll(shards, SHARD_N);
   let lastT = -1;
   /** Break the cube for feature f (or its index). Returns true when it was intact, false when
    *  it was already broken (the run brain hands out an item only on true). */
@@ -347,7 +370,7 @@ export function createRoomDresser({ scene, layout, rooms = ROOMS }) {
     }
     const fl = flash[flashCursor]; flashCursor = (flashCursor + 1) % FLASH_N;
     if (fl.life <= 0) flashesLive++;
-    fl.life = FLASH_SEC; roadMatrix(c.d, c.x, CUBE * 0.75, 0, 1, fl.m);
+    fl.life = FLASH_SEC; fl.sprite.position.copy(_p); fl.sprite.visible = true;
     return true;
   }
   function updateBreaks(t) {
@@ -367,20 +390,22 @@ export function createRoomDresser({ scene, layout, rooms = ROOMS }) {
       if (shardKinds) for (const k of shardKinds) { k.mesh.visible = live > 0; k.mesh.instanceMatrix.needsUpdate = true; }
       else shards.instanceMatrix.needsUpdate = true;
     }
-    if (flashesLive > 0) {                  // the flash: a white cube on the spot that swells and vanishes
+    if (flashesLive > 0) {                  // the flash: a burst of light on the spot that swells and fades out
       let live = 0;
       for (let i = 0; i < FLASH_N; i++) {
         const fl = flash[i];
         if (fl.life <= 0) continue;
         fl.life -= dt;
-        if (fl.life <= 0) { flashes.setMatrixAt(i, _m.compose(_hide, _q.identity(), _s.setScalar(0.0001))); continue; }
+        if (fl.life <= 0) { fl.sprite.visible = false; fl.fm.opacity = 0; continue; }
         live++;
-        flashes.setMatrixAt(i, _m.copy(fl.m).scale(_s.setScalar(1.15 + 0.9 * (1 - fl.life / FLASH_SEC))));
+        const u = fl.life / FLASH_SEC;       // 1 on the break, 0 as it goes
+        fl.fm.opacity = 0.9 * u;
+        fl.sprite.scale.setScalar(CUBE * (1.7 + 2.0 * (1 - u)));
       }
-      flashesLive = live; flashes.instanceMatrix.needsUpdate = true;
+      flashesLive = live;
     }
   }
-  for (const m of [wedges, lips, airDots, padMesh, cubeMesh, shards, flashes]) { m.frustumCulled = false; m.instanceMatrix.needsUpdate = true; group.add(m); }
+  for (const m of [wedges, lips, airDots, padMesh, cubeMesh, shards]) { m.frustumCulled = false; m.instanceMatrix.needsUpdate = true; group.add(m); }
   if (wedges.instanceColor) wedges.instanceColor.needsUpdate = true;
 
   // ---- the Blender pack takes the furniture over (race/assets/props.glb) -----------------
@@ -562,7 +587,8 @@ ${sh.fragmentShader}`.replace('#include <emissivemap_fragment>', `#include <emis
     for (const m of mats) m.dispose();
     for (const t of texes) t.dispose();
     props.dispose();
-    for (const m of [wedges, lips, airDots, padMesh, cubeMesh, shards, flashes]) m.dispose();
+    for (const fl of flash) group.remove(fl.sprite);
+    for (const m of [wedges, lips, airDots, padMesh, cubeMesh, shards]) m.dispose();
   }
 
   return { update, applyRoom, breakItemBox, dispose, group, spans, rooms: specs };

--- a/ConditioningControlPanel/Resources/web/dtrh/race/run.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/run.js
@@ -172,7 +172,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
       trackHold: 0, trackFog: 0, trackPaused: false, statsAt: 0, trackGap: 0 });
     setFlip(false); trailClear();
     mix.reset(); S.wobble = 0; clearMixChrome();
-    hud.setScore(0); hud.setCombo(0, 1); hud.setBank(0); hud.setSpeed(0); hud.setFraught(0); hud.item(null, 'no item yet');
+    hud.setScore(0); hud.setCombo(0, 1); hud.setBank(0); hud.setSpeed(0); hud.setFraught(0); hud.pickupClear(); hud.item(null, 'no item yet');
   }
 
   // ---- rooms ----
@@ -305,8 +305,16 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
   }
   function onItem(w, e) {
     switch (e.type) {
-      case 'itemArm': sfx('ui_click', 0.4); break;
-      case 'itemUse': sfx('tunnel_powerup_collect', 0.7); poke('smug', 0.8); w.kart.pose('throw'); break;
+      // THE PICKUP: the card pops with the rolling '?', flips when the cube arms (never earlier,
+      // Fake Shuffle), then flies into the slot and leaves it lit until the item is spent
+      case 'itemRoll': hud.pickupRoll(); break;
+      case 'itemArm': {
+        const it = w.items.byId(e.id);
+        sfx('ui_click', 0.4);
+        hud.pickupArm(it ? it.glyph : '?', it ? it.name : '', () => sfx('ui_click', 0.3));
+        break;
+      }
+      case 'itemUse': hud.pickupClear(); sfx('tunnel_powerup_collect', 0.7); poke('smug', 0.8); w.kart.pose('throw'); break;
       case 'timeScale': S.timeScale = e.value; sfx('time_slow_in', 0.8); break;
       case 'magnet': S.magnet = true; w.field.setReach(2.2); w.kart.setReach(2.2); break;
       case 'multBoost': w.score.boostMult(e.mult, e.sec); break;
@@ -606,6 +614,27 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     setFlip(false);
   }
 
+  /** Screenshot aid (`?itembox=<ms>` on the standalone page): break the nearest sugar cube ahead the
+   *  way a crossing does, so a headless shot catches the pickup without anyone steering. A cube too
+   *  far to read is pulled into view first (the kart's depth jumps): a dev-only warp, and the reason
+   *  this is never reachable from the host. Returns false when there is no cube to break. */
+  function debugItemBox() {
+    if (!W || !S.running || S.paused) return false;
+    const ks = W.kart.state, lay = W.layout, half = lay.totalDepth / 2;
+    let best = null, bestRel = Infinity;
+    for (const c of lay.chunks) for (const f of c.features || []) {
+      if (f.type !== 'itembox') continue;
+      const rel = lay.wrap(f.d - ks.d + half) - half;
+      if (rel > 5 && rel < bestRel) { bestRel = rel; best = f; }
+    }
+    if (!best) return false;
+    if (bestRel > 16) { ks.d = lay.wrap(best.d - 16); trailClear(); }
+    if (!W.dresser.breakItemBox(best)) return false;
+    shake.shake(0.2, 120);
+    if (W.items.roll(W.score.state.mult)) sfx('ui_click', 0.5);
+    return true;
+  }
+
   W = build(seed);
   resetRunState(seed);
   raf = requestAnimationFrame(frame);
@@ -615,7 +644,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     // track charts (CHART.md): setTrack before start(), replaceTrack for the words pass landing live,
     // trackClock for the host's 250 ms tick, trackEnded when the file runs out at the host's end
     setTrack, replaceTrack: (chart) => TR.replace(chart), trackClock: (t, playing) => TR.clock(t, playing),
-    trackEnded: () => { TR.end(); if (TR.track && S.running) endRun(); }, trackStats: () => TR.stats(),
+    trackEnded: () => { TR.end(); if (TR.track && S.running) endRun(); }, trackStats: () => TR.stats(), debugItemBox,
     get track() { return TR.track; } };
 }
 

--- a/ConditioningControlPanel/Resources/web/dtrh/raceBoot.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/raceBoot.js
@@ -27,7 +27,8 @@
  * either they show once, gated on localStorage `race.cards`), and `?card=N`
  * opens them on card N (1..4, a screenshot aid the way `?hold=` is one);
  * `?pixel=N` (0 = off) beats `race.options` which beats `settings.pixel` from
- * the host init.
+ * the host init; `?itembox=ms` breaks the next sugar cube that comes into
+ * reading range after that time and is a screenshot aid for the pickup card.
  *
  * TRACK CHARTS (CHART.md): the host posts track-progress / track-chart /
  * track-clock / track-ended / track-error and this file hands them to the run.
@@ -167,7 +168,7 @@ async function boot() {
     note('');
     host.log(`race booted: seed ${seed} (${opts.seed}), tier ${mode.tier}, hosted ${hosted}, manifest ${haveManifest}`);
     await standaloneTrack();
-    if (params.get('autostart') === '1') { startRun(false); return; }
+    if (params.get('autostart') === '1') { startRun(false); debugItemBox(); return; }
     if (hudRoot) hudRoot.classList.add('is-lobby');   // the run's chrome stays out of the menu and the intro
     menu = createMenu({ root, renderer: race.renderer, pixel: race.pixel, audio: race.audio, settings, log: host.log });
     menu.onPick((id) => {
@@ -235,6 +236,18 @@ async function standaloneTrack() {
 function stopTrackClock() {
   if (trackTimer) { clearInterval(trackTimer); trackTimer = 0; }
   if (trackAudio) { try { trackAudio.pause(); } catch (e) { /* already gone */ } }
+}
+
+/** `?itembox=<ms>`: the screenshot aid. Waits for the run, then retries until a cube is in range. */
+function debugItemBox() {
+  const at = Number(params.get('itembox'));
+  if (!(at > 0) || !race || !race.debugItemBox) return;
+  setTimeout(function tick() {
+    let hit = false;
+    try { hit = race.debugItemBox(); } catch (e) { host.log('itembox: ' + e); return; }
+    if (hit) host.log('itembox: broken at ' + Math.round(performance.now()) + ' ms');
+    else if (!exiting) setTimeout(tick, 90);
+  }, at);
 }
 
 function hideSplash() {


### PR DESCRIPTION
The white box beside the shards was the break flash itself: rooms.js drew it as an opaque white BoxGeometry sat on the broken cube's spot and swollen to 2x, never fading, so for a fifth of a second the player saw a full blank cube standing next to the shattering one. It is now four additive billboards, a soft spoke burst that always faces the seat and fades as it swells. A sprite cannot draw an edge, so it can never read as a box again.

The pickup card rides the same beat: a DOM tile pops above the cup in the room's colour, rolls a question mark while items.js rolls, and flips to the decided item exactly when items.js arms it, so Fake Shuffle still holds. It then flies into the item slot, measuring the slot's live rect at flight start so it lands right at any window size, and the slot stays lit until the item is spent. A second cube mid-flight finishes the old card at once, so nothing stacks. Reduced motion gets a fade in place and no flight.

items.js is untouched; run.js drives the card off the itemRoll / itemArm / itemUse events it already had.

Verified: node --check clean, race smokes green, headless chrome with ?itembox=<ms> breaking a cube in range, zero page errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0166ij3Q8xyseVkhWajzkWG3
