### PR TITLE
race: the menu has music and blips

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/race/AUDIO.md
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/AUDIO.md
@@ -43,6 +43,35 @@ adds +500 Hz / +0.03, airborne opens it another 400 Hz and +40%; **hum** = a tri
 noise above 4.5 kHz whose gain is re-rolled every frame between 0.03 and 0.075 while drifting
 on the ground, 0 otherwise (that is the crackle). Nothing here is built while muted.
 
+## The menu
+
+`audio.menu(on)`, `audio.ui(name, value)` and `audio.setLevels({ music, sfx })` are the front
+door's three. race/menu.js calls them; race/cards.js calls `ui`.
+
+- **The theme.** No new file: `MENU_TRACK` is `ost_campus` ("Star Byte Loop", the tea garden's own
+  hub tune), played through the SAME chain and the same `MUSIC_LEVEL` as the run. `menu(true)`
+  writes it into the playlist under the pseudo-room `MENU_ROOM` and enters it like any other room,
+  so the fade in and the fade out are the ordinary `CROSSFADE_SEC` 1.5 s. `menu(false)` (the boot
+  calls it as the run starts) stops nothing: the first room's track crossfades over the theme, and
+  when that room is the Tea Garden the same tune simply plays on. Options and the story cards keep
+  it: only `show()` turns it on, nothing turns it off. Autoplay is the run's rule, unchanged: a
+  rejected `play()` arms the pointer/key retry, a missing file marks the track dead and never
+  throws. `duck('track')` still pulls it to `TRACK_DUCK` under a loaded file, and `M` covers it.
+  A different theme is one line: `MENU_TRACK`.
+- **The blips.** Five synth voices, no files, all on the shared context through `sfxBus`:
+  `tick` (a triangle 1180 -> 1130 Hz, 35 ms, 0.045: hover and focus, very quiet), `pick` (sine 660
+  then 990 Hz at 60 ms, two notes up), `back` (sine 620 then 415 Hz, two notes down), `step` (a
+  triangle at 520 Hz doubling to 1040 across the slider, 45 ms, so the ear hears the number move)
+  and `page` (a bandpass noise sweep 2200 -> 700 Hz over 160 ms with a soft triangle on top: the
+  story card turning). The name set is closed; anything else is dropped. Every blip is rate
+  limited to one per `UI_GAP_MS` 45 ms, so holding an arrow on a slider ticks, it does not fire.
+- **The levels.** `setLevels({ music, sfx })` takes 0..1 each (menu.js persists them under
+  `race.options`, the boot applies them once before the first frame, and the slider applies them
+  live). `music` multiplies `MUSIC_LEVEL` on the music chain's level node; `sfx` multiplies
+  `sfxBus`, which every in-page one-shot and every blip rides. The host legs are NOT scaled: those
+  play on the host's own mixer at its own volume. The speed bed rides its own bus and follows the
+  master, not the sfx slider.
+
 ## Event map
 
 | beat | source | in-page (WebAudio) | host leg (`sfx` name) |

--- a/ConditioningControlPanel/Resources/web/dtrh/race/audio.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/audio.js
@@ -4,6 +4,9 @@
  *   createRaceAudio({ bridge, hud, settings, input }) -> audio
  *   audio.sfx(name, scale)       the run's sfx() helper lands here: host legs + in-page beats
  *   audio.update(dt, live)       live = { world, run, kart }; once per step, after everything moved
+ *   audio.menu(on)               the menu theme: MENU_TRACK on the same chain, entered like a room
+ *   audio.ui(name, value)        the menu blips: 'tick' | 'pick' | 'back' | 'step' | 'page'
+ *   audio.setLevels({ music, sfx })  the two option sliders, live
  *   audio.duck(on, why)          'host' (native video) | 'brake' | 'end' | 'track'
  *                                'track' is the standing one: a loaded file (CHART.md) is the
  *                                soundtrack, so the OST and the bed sit under it until it is cleared
@@ -66,6 +69,11 @@ export function chimeFor(mult) {
   return { file: 'chime3', semis: clamp(Math.round((m - 4) * 1.5), 2, PITCH_CAP_SEMIS) };
 }
 
+/** A slider folded into a fixed base gain: 0..1 in, base * that out. A value that is not a number reads as 1. */
+export function levelGain(base, v) { const n = Number(v); return base * clamp(isFinite(n) ? n : 1, 0, 1); }
+/** The ui blip rate limit: true when `nowMs` is far enough past the last blip. */
+export function uiAllowed(nowMs, lastMs, gap = UI_GAP_MS) { return (nowMs - lastMs) >= gap; }
+
 /** Voice cap: the index of the quietest live voice (ties: the oldest). */
 export function pickVoiceToDrop(voices) {
   let at = -1, low = Infinity;
@@ -85,6 +93,12 @@ export const OST_BASE = '/arcademy/assets/sfx/';
 export const CROSSFADE_SEC = 1.5;
 export const MUSIC_LEVEL = 0.3;          // the OSTs sit at about -15.5 LUFS; this keeps them under the pops
 export const TRACK_DUCK = 0.12;          // where the OST sits under a loaded track: felt, never heard over her
+// The MENU. No new files: the tea garden's hub tune doubles as the menu theme, so the front door
+// and the first lap are one piece of music. Another theme is this one line.
+export const MENU_TRACK = 'ost_campus';
+export const MENU_ROOM = '__menu';       // the menu is just another room in the playlist, so it crossfades like one
+export const UI_GAP_MS = 45;             // a ui blip at most this often: key repeat on a slider must not machine-gun
+export const UI_NAMES = Object.freeze(['tick', 'pick', 'back', 'step', 'page']);
 export const TRACKS = Object.freeze([
   { name: 'ost_campus',          title: 'Star Byte Loop',     mood: 'soft', energy: 0.45, sec: 75,  start: 0 },
   { name: 'ost_deep_end',        title: 'Pixel Rush',         mood: 'loud', energy: 0.8,  sec: 77,  start: 0 },
@@ -133,6 +147,7 @@ export function createRaceAudio({ bridge, hud, settings = {}, input } = {}) {
   const log = (m) => { try { bridge && bridge.log && bridge.log('[audio] ' + m); } catch (e) { /* host gone */ } };
   const send = (m) => { try { bridge && bridge.send && bridge.send(m); } catch (e) { /* host gone */ } };
   const masterLevel = clamp((Number(settings.masterVolume) == null || isNaN(Number(settings.masterVolume)) ? 60 : Number(settings.masterVolume)) / 100, 0, 1);
+  const levels = { music: 1, sfx: 1 };   // the two option sliders (menu.js persists them); setLevels moves them
   const buffers = new Map();     // key -> AudioBuffer | 'pending' | 'failed'
   const voices = [];             // live one-shots: { src, gain, level, t0 }
   const live = { world: null, run: null, kart: null };   // what update() last saw (run/kart are live objects)
@@ -144,7 +159,7 @@ export function createRaceAudio({ bridge, hud, settings = {}, input } = {}) {
   let musicDuck = null, musicLp = null, musicHp = null, musicLevelNode = null, elementMode = false;
   let standing = 1;   // the level update() eases the music back to: 1, or TRACK_DUCK while a track is loaded
   const tracks = new Map();      // name -> { name, el, gain, bound, failed, vol, fadeTimer, pauseTimer }
-  const music = { cur: null, playlist: {}, dead: new Set(), duckTo: 1, duckWhy: null, lp: 20000, hp: 20, gesture: false, roomId: null };
+  const music = { cur: null, playlist: {}, dead: new Set(), duckTo: 1, duckWhy: null, lp: 20000, hp: 20, gesture: false, roomId: null, menu: false };
 
   setDucked(true);               // bubbles.js's kind-blind pop steps aside (see header)
 
@@ -156,11 +171,11 @@ export function createRaceAudio({ bridge, hud, settings = {}, input } = {}) {
     try {
       master = ctx.createGain(); master.gain.value = isMuted() ? 0 : masterLevel;
       master.connect(getMasterOut() || ctx.destination);
-      sfxBus = ctx.createGain(); sfxBus.gain.value = LEVELS.sfx; sfxBus.connect(master);
+      sfxBus = ctx.createGain(); sfxBus.gain.value = levelGain(LEVELS.sfx, levels.sfx); sfxBus.connect(master);
       musicDuck = ctx.createGain(); musicDuck.gain.value = 1;
       musicLp = ctx.createBiquadFilter(); musicLp.type = 'lowpass'; musicLp.frequency.value = 20000; musicLp.Q.value = 0.6;
       musicHp = ctx.createBiquadFilter(); musicHp.type = 'highpass'; musicHp.frequency.value = 20; musicHp.Q.value = 0.6;
-      musicLevelNode = ctx.createGain(); musicLevelNode.gain.value = MUSIC_LEVEL;
+      musicLevelNode = ctx.createGain(); musicLevelNode.gain.value = levelGain(MUSIC_LEVEL, levels.music);
       musicDuck.connect(musicLp); musicLp.connect(musicHp); musicHp.connect(musicLevelNode); musicLevelNode.connect(master);
       const n = ctx.createBuffer(1, ctx.sampleRate, ctx.sampleRate);
       const data = n.getChannelData(0);
@@ -202,7 +217,7 @@ export function createRaceAudio({ bridge, hud, settings = {}, input } = {}) {
       t.el.volume = 1;
     } catch (e) { t.gain = null; elementMode = true; log('media element route failed, element volume mode: ' + e); }
   }
-  const elVol = (t) => clamp(t.vol * MUSIC_LEVEL * music.duckTo * (isMuted() ? 0 : masterLevel), 0, 1);
+  const elVol = (t) => clamp(t.vol * levelGain(MUSIC_LEVEL, levels.music) * music.duckTo * (isMuted() ? 0 : masterLevel), 0, 1);
   function fade(t, to, sec) {
     t.vol = to;
     if (t.gain && ctx) {
@@ -240,6 +255,22 @@ export function createRaceAudio({ bridge, hud, settings = {}, input } = {}) {
     fade(next, 1, prev ? CROSSFADE_SEC : 0.8);
     log('track ' + name + ' in (' + roomId + ')' + (prev ? ', ' + prev.name + ' out, crossfade ' + CROSSFADE_SEC + 's' : ''));
   }
+  /**
+   * The menu theme. It is entered exactly like a room, so the ordinary CROSSFADE_SEC fade carries it
+   * in and the run's first room carries it out. menu(false) stops nothing on purpose: the first room
+   * fades over it, and when that room draws MENU_TRACK itself the tune simply plays on.
+   * Autoplay is the run's: a rejected play() arms the same pointer/key retry (startEl -> armGesture).
+   */
+  function menuMusic(on) {
+    if (disposed) return;
+    music.menu = !!on;
+    log('menu theme ' + (on ? MENU_TRACK + ' requested' : 'released, the run takes the music'));
+    if (!on) return;
+    music.playlist[MENU_ROOM] = MENU_TRACK;
+    music.roomId = MENU_ROOM;
+    enterTrack(MENU_ROOM);
+  }
+
   // ---- the speed bed + drift sparks: loops under the music, outside the voice cap ----
   // wind = lowpassed noise whose cutoff and gain follow speed (boost and air open it up);
   // hum = a triangle under 200 Hz that climbs with speed; sparks = highpassed noise that
@@ -418,6 +449,25 @@ export function createRaceAudio({ bridge, hud, settings = {}, input } = {}) {
   function gateSting() { play('chime2', { level: LEVELS.chime * 0.75, semis: -3 }); }
   function endSting() { arpeggio(LEVELS.chime, 0.13); play('chime3', { level: LEVELS.chime * 0.8, semis: 5, at: 0.5 }); }
 
+  // ---- the menu blips. No files: five little synth voices on the shared context, all through
+  // sfxBus, so the sfx slider owns them and mute silences them. `value` (0..1) only means anything
+  // to 'step', where the tick climbs an octave with the slider so the ear hears the number move.
+  let lastUiAt = -1e9;
+  function ui(name, value) {
+    if (disposed || isMuted() || UI_NAMES.indexOf(name) < 0) return;
+    const nowMs = performance.now();
+    if (!uiAllowed(nowMs, lastUiAt)) return;
+    lastUiAt = nowMs;
+    const n = Number(value), v = clamp(isFinite(n) ? n : 0.5, 0, 1);
+    switch (name) {
+      case 'tick': synth({ kind: 'triangle', f0: 1180, f1: 1130, sec: 0.035, level: 0.045 }); break;
+      case 'pick': synth({ kind: 'sine', f0: 660, f1: 652, sec: 0.07, level: 0.15 }); synth({ kind: 'sine', f0: 990, f1: 978, sec: 0.11, level: 0.12, at: 0.06 }); break;
+      case 'back': synth({ kind: 'sine', f0: 620, f1: 612, sec: 0.07, level: 0.13 }); synth({ kind: 'sine', f0: 415, f1: 408, sec: 0.12, level: 0.11, at: 0.06 }); break;
+      case 'step': synth({ kind: 'triangle', f0: 520 * Math.pow(2, v), f1: 512 * Math.pow(2, v), sec: 0.045, level: 0.075 }); break;
+      case 'page': synth({ kind: 'noise', sec: 0.16, level: 0.09, filter: { type: 'bandpass', f0: 2200, f1: 700 }, q: 1.1 }); synth({ kind: 'triangle', f0: 880, f1: 700, sec: 0.06, level: 0.05, at: 0.02 }); break;
+    }
+  }
+
   // ---- the host legs (run.js sfx(name, scale) lands here) ----
   function sfx(name, scale = 0.8) {
     if (!HOST_SFX.has(name)) { log('unknown host sfx dropped: ' + name); return; }
@@ -464,7 +514,22 @@ export function createRaceAudio({ bridge, hud, settings = {}, input } = {}) {
     bedUpdate(k);
   }
 
-  // ---- duck / mute / dispose ----
+  // ---- levels / duck / mute / dispose ----
+  /**
+   * The two option sliders, live under a moving slider. music multiplies MUSIC_LEVEL on the music
+   * chain's level node; sfx multiplies sfxBus, which every in-page one-shot and every ui blip rides.
+   * The HOST legs are deliberately untouched: those play on the host's own mixer at its own volume.
+   */
+  function setLevels(l) {
+    if (disposed || !l || typeof l !== 'object') return;
+    if (l.music != null) levels.music = clamp(Number(l.music) || 0, 0, 1);
+    if (l.sfx != null) levels.sfx = clamp(Number(l.sfx) || 0, 0, 1);
+    const ease = (node, to) => { if (!node || !ctx) return; try { node.gain.setTargetAtTime(to, ctx.currentTime, 0.05); } catch (e) { try { node.gain.value = to; } catch (e2) { /* ignore */ } } };
+    ease(musicLevelNode, levelGain(MUSIC_LEVEL, levels.music));
+    ease(sfxBus, levelGain(LEVELS.sfx, levels.sfx));
+    for (const t of tracks.values()) if (!t.gain) { try { t.el.volume = elVol(t); } catch (e) { /* ignore */ } }   // element-volume mode
+    log('levels applied: music ' + levels.music.toFixed(2) + ' sfx ' + levels.sfx.toFixed(2));
+  }
   function duck(on, why) {
     if (why === 'track') { standing = on ? TRACK_DUCK : 1; setDuck(standing, on ? 'track' : null); return; }
     if (why === 'brake') { if (on) play('pop', { level: 0.3, semis: -7 }); else play('pop2', { level: 0.24, semis: 3 }); }
@@ -496,7 +561,7 @@ export function createRaceAudio({ bridge, hud, settings = {}, input } = {}) {
     master = null;
   }
 
-  return { sfx, update, duck, toggleMute, dispose, _voices: voices, _music: music };
+  return { sfx, ui, menu: menuMusic, setLevels, update, duck, toggleMute, dispose, _voices: voices, _music: music, _levels: levels };
 }
 
 // self-check: node --check is the bar; the pure parts (pitchSemis, chimeFor, pickVoiceToDrop)

--- a/ConditioningControlPanel/Resources/web/dtrh/race/cards.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/cards.js
@@ -111,9 +111,10 @@ export function createCards({ root, audio = null, reducedMotion = false, log = n
   let live = false, disposed = false, raf = 0, resolve = null;
   const padWas = {};
 
-  function click() {
+  function click(name) {
     if (!audio) return;
-    try { audio.sfx('ui_click', 0.5); } catch (e) { /* muted or gone */ }
+    try { audio.sfx('ui_click', 0.5); } catch (e) { /* muted or gone */ }   // the host leg, silent outside pause today
+    try { if (audio.ui) audio.ui(name || 'page'); } catch (e) { /* muted or gone */ }
   }
 
   function draw(animate) {
@@ -153,7 +154,7 @@ export function createCards({ root, audio = null, reducedMotion = false, log = n
     const what = KEYMAP[e.code];
     if (!what) return;
     e.preventDefault();
-    if (what === 'end') { click(); end('skipped'); }
+    if (what === 'end') { click('back'); end('skipped'); }
     else go(what === 'next' ? 1 : -1);
   }
   function onPointer(e) { if (live && e.button === 0) go(1); }

--- a/ConditioningControlPanel/Resources/web/dtrh/race/menu.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/menu.js
@@ -355,6 +355,8 @@ export function createMenu({ root, renderer, pixel, audio, settings = {}, log = 
   const el = (tag, cls, parent, text) => { const d = document.createElement(tag); d.className = cls; if (text != null) d.textContent = text; parent.appendChild(d); return d; };
   const hit = (node, cls) => { node.classList.remove(cls); void node.offsetWidth; node.classList.add(cls); };
   const canLevels = !!(audio && typeof audio.setLevels === 'function');
+  const ui = (n, v) => { try { if (audio && audio.ui) audio.ui(n, v); } catch (e) { /* audio gone */ } };   // the menu blips (race/audio.js)
+  const theme = (on) => { try { if (audio && audio.menu) audio.menu(on); } catch (e) { /* audio gone */ } };
 
   const layer = el('div', 'rm-root', root); layer.hidden = true; layer.setAttribute('role', 'dialog'); layer.setAttribute('aria-label', 'racing thoughts');
   const col = el('div', 'rm-col', layer);
@@ -389,8 +391,8 @@ export function createMenu({ root, renderer, pixel, audio, settings = {}, log = 
   function setPixel(n) { pixel.setBlock(n); pixel.retexture(stage.scene); options.pixel = pixel.block; }
   const ROWS = [
     { id: 'pixel', label: 'pixel block', get: () => (pixel.block ? `${pixel.block} px` : 'off'), move: (d) => setPixel(cyc(PIXEL_STEPS, pixel.block, d)) },
-    { id: 'music', label: 'music', get: () => pct(options.music), move: (d) => step('music', d * 0.1), dim: !canLevels, hint: 'wired in the audio pass' },
-    { id: 'sfx', label: 'sfx', get: () => pct(options.sfx), move: (d) => step('sfx', d * 0.1), dim: !canLevels, hint: 'wired in the audio pass' },
+    { id: 'music', label: 'music', get: () => pct(options.music), move: (d) => step('music', d * 0.1), dim: !canLevels },
+    { id: 'sfx', label: 'sfx', get: () => pct(options.sfx), move: (d) => step('sfx', d * 0.1), dim: !canLevels },
     { id: 'motion', label: 'reduced motion', get: () => options.motion, move: (d) => { options.motion = cyc(MOTIONS, options.motion, d); stage.setReduced(reduced()); layer.dataset.motion = options.motion; }, hint: 'stage and intro now, the run on the next launch' },
     { id: 'seed', label: 'seed', get: () => (options.seed === 'custom' ? `custom ${options.seedValue}` : options.seed), move: (d) => { options.seed = cyc(SEEDS, options.seed, d); seedIn.hidden = options.seed !== 'custom'; }, press: () => { if (options.seed === 'custom') seedIn.focus(); } },
     { id: 'back', label: 'back', get: () => '', press: () => open('main') },
@@ -414,7 +416,7 @@ export function createMenu({ root, renderer, pixel, audio, settings = {}, log = 
   const verbEls = VERBS.map(([id, label], i) => {
     const b = el('button', 'rm-btn', list, label); b.type = 'button'; b.dataset.id = id; b.setAttribute('role', 'menuitem');
     b.addEventListener('click', () => { idx.main = i; act('press'); });
-    b.addEventListener('pointerenter', () => { idx.main = i; refresh(); });
+    b.addEventListener('pointerenter', () => { idx.main = i; ui('tick'); refresh(); });
     return b;
   });
   const verbEl = (id) => verbEls[VERBS.findIndex(([v]) => v === id)];
@@ -458,7 +460,7 @@ export function createMenu({ root, renderer, pixel, audio, settings = {}, log = 
   let panel = 'main', shown = false, disposed = false, viewHeld = false;
   const idx = { main: 0, options: 0 };
   function open(p) { panel = p; list.hidden = p !== 'main'; optPanel.hidden = p !== 'options'; howPanel.hidden = p !== 'how'; if (p === 'options') idx.options = 0; refresh(); if (p !== 'options') seedIn.blur(); }
-  function focusRow(i) { idx.options = clamp(i, 0, ROWS.length - 1); refresh(); }
+  function focusRow(i) { idx.options = clamp(i, 0, ROWS.length - 1); ui('tick'); refresh(); }
   function refresh() {
     verbEls.forEach((b, i) => b.classList.toggle('is-focus', panel === 'main' && i === idx.main));
     ROWS.forEach((r, i) => { const v = r.get(); if (r.valEl.textContent !== v) r.valEl.textContent = v; rowEls[i].classList.toggle('is-focus', panel === 'options' && i === idx.options); });
@@ -467,20 +469,20 @@ export function createMenu({ root, renderer, pixel, audio, settings = {}, log = 
   function act(what) {
     if (!shown || disposed) return;
     if (panel === 'main') {
-      if (what === 'up' || what === 'down') { idx.main = stepVerb(idx.main, what === 'up' ? -1 : 1); refresh(); return; }
+      if (what === 'up' || what === 'down') { idx.main = stepVerb(idx.main, what === 'up' ? -1 : 1); ui('tick'); refresh(); return; }
       if (what !== 'press') return;
       const id = VERBS[idx.main][0];
       if (verbEls[idx.main].hidden) return;
-      hit(verbEls[idx.main], 'is-hit');
+      hit(verbEls[idx.main], 'is-hit'); ui('pick');
       if (id === 'options' || id === 'how') open(id); else pick(id);
       return;
     }
-    if (what === 'back') { open('main'); return; }
+    if (what === 'back') { ui('back'); open('main'); return; }
     if (panel === 'how') { if (what === 'press') open('main'); return; }
     const r = ROWS[idx.options];
     if (what === 'up' || what === 'down') { focusRow(idx.options + (what === 'up' ? -1 : 1)); return; }
-    if ((what === 'left' || what === 'right') && r.move) { r.move(what === 'left' ? -1 : 1); hit(rowEls[idx.options], 'is-hit'); }
-    else if (what === 'press') { if (r.press) r.press(); else if (r.move) r.move(1); hit(rowEls[idx.options], 'is-hit'); }
+    if ((what === 'left' || what === 'right') && r.move) { r.move(what === 'left' ? -1 : 1); ui('step', r.id === 'music' || r.id === 'sfx' ? options[r.id] : 0.5); hit(rowEls[idx.options], 'is-hit'); }
+    else if (what === 'press') { if (r.press) r.press(); else if (r.move) r.move(1); ui(r.id === 'back' ? 'back' : 'pick'); hit(rowEls[idx.options], 'is-hit'); }
     saveOptions(options); refresh();
   }
   const KEYMAP = { ArrowUp: 'up', KeyW: 'up', ArrowDown: 'down', KeyS: 'down', ArrowLeft: 'left', KeyA: 'left', ArrowRight: 'right', KeyD: 'right', Enter: 'press', Space: 'press', Escape: 'back', Backspace: 'back' };
@@ -516,7 +518,7 @@ export function createMenu({ root, renderer, pixel, audio, settings = {}, log = 
     options, stage: { update(dt) { if (shown) pollPad(dt); stage.update(dt); }, render: stage.render, dispose: stage.dispose, live: stage },
     onPick(cb) { if (typeof cb === 'function') picks.push(cb); },
     setTrack, get track() { return trackState; },
-    show() { shown = true; viewHeld = false; layer.hidden = false; stage.setMode('menu'); open('main'); onResize(); hit(layer, 'is-in'); },
+    show() { shown = true; viewHeld = false; layer.hidden = false; stage.setMode('menu'); open('main'); onResize(); hit(layer, 'is-in'); theme(true); },
     hide() { shown = false; layer.hidden = true; stage.setViewFraction(0.5); },
     /** Park the stage the way the column parks it, with the menu hidden: race/cards.js uses the same
      *  layout, so hide() sending her back to the middle of the frame would only be a jump and a jump

--- a/ConditioningControlPanel/Resources/web/dtrh/race/smoke/audio-check.mjs
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/smoke/audio-check.mjs
@@ -1,0 +1,75 @@
+/* ============================================================================
+ * race/smoke/audio-check.mjs - node self-check for the pure parts of race/audio.js.
+ *
+ *   node race/smoke/audio-check.mjs      (exits 0 on pass, 1 with a count of failures)
+ *
+ * audio.js touches WebAudio and <audio> only inside createRaceAudio, so the module
+ * itself imports clean in node and its exported helpers can be walked here: the combo
+ * pitch ladder, the chime ladder, the voice cap's choice, the per-run playlist roll,
+ * and (the audio pass) the level maths behind setLevels plus the ui blip rate limit.
+ * Nothing here makes a sound: real listening is the owner's, on real speakers.
+ * ==========================================================================*/
+
+import {
+  pitchSemis, chimeFor, pickVoiceToDrop, rollPlaylist, levelGain, uiAllowed,
+  PITCH_CAP_SEMIS, MUSIC_LEVEL, UI_GAP_MS, UI_NAMES, MENU_TRACK, MENU_ROOM, TRACK_BY_NAME, ROOM_POOLS,
+} from '../audio.js';
+
+let fails = 0;
+const ok = (cond, what) => { if (!cond) { console.error('FAIL ' + what); fails++; } else console.log('  ok  ' + what); };
+const near = (a, b) => Math.abs(a - b) < 1e-9;
+
+/* ---- 1. the combo and chime ladders ------------------------------------- */
+{
+  ok(pitchSemis(0) === 0 && pitchSemis(3) === 0 && pitchSemis(4) === 1, 'the pop pitch climbs one semitone every four combo');
+  ok(pitchSemis(999) === PITCH_CAP_SEMIS, 'and stops at the cap');
+  ok(chimeFor(2).file === 'chime1' && chimeFor(3).file === 'chime2' && chimeFor(4).file === 'chime3', 'the rung ladder walks chime1 -> chime2 -> chime3');
+  ok(chimeFor(8).semis > chimeFor(6).semis && chimeFor(99).semis <= PITCH_CAP_SEMIS, 'above x4 chime3 keeps rising, capped');
+}
+
+/* ---- 2. the voice cap picks the quietest -------------------------------- */
+{
+  ok(pickVoiceToDrop([{ level: 0.4 }, { level: 0.1 }, { level: 0.9 }]) === 1, 'the quietest live voice is the one dropped');
+  ok(pickVoiceToDrop([]) === -1, 'an empty rack drops nobody');
+}
+
+/* ---- 3. the per-run playlist -------------------------------------------- */
+{
+  const rooms = Object.keys(ROOM_POOLS);
+  const rng = () => 0.5;
+  const a = rollPlaylist(rng, rooms), b = rollPlaylist(rng, rooms);
+  ok(JSON.stringify(a) === JSON.stringify(b), 'the same rng rolls the same playlist twice');
+  ok(rooms.every((r) => !a[r] || TRACK_BY_NAME[a[r]]), 'every pick is a real track row');
+  const dead = new Set(['ost_campus']);
+  ok(rollPlaylist(rng, rooms, ROOM_POOLS, dead).teagarden === undefined, 'a dead track leaves its only room silent, it does not throw');
+}
+
+/* ---- 4. the menu theme -------------------------------------------------- */
+{
+  ok(!!TRACK_BY_NAME[MENU_TRACK], 'MENU_TRACK names a track that exists in TRACKS');
+  ok(!ROOM_POOLS[MENU_ROOM], 'MENU_ROOM is not a real room, so the run never draws it');
+  ok(UI_NAMES.length === 5 && UI_NAMES.indexOf('tick') === 0, 'the ui blip names are a closed set of five');
+}
+
+/* ---- 5. the level maths (setLevels) ------------------------------------- */
+{
+  ok(near(levelGain(MUSIC_LEVEL, 1), MUSIC_LEVEL), 'a slider at 1 leaves the base gain alone');
+  ok(near(levelGain(MUSIC_LEVEL, 0), 0), 'a slider at 0 is silence');
+  ok(near(levelGain(MUSIC_LEVEL, 0.5), MUSIC_LEVEL / 2), 'and half is half');
+  ok(near(levelGain(0.8, 2), 0.8) && near(levelGain(0.8, -3), 0), 'out of range clamps to 0..1');
+  ok(near(levelGain(0.8, undefined), 0.8) && near(levelGain(0.8, 'loud'), 0.8), 'a value that is not a number leaves the gain where it was');
+  ok(levelGain(MUSIC_LEVEL, 0.8) < MUSIC_LEVEL, 'the default option (0.8) sits under the mastered level');
+}
+
+/* ---- 6. the ui blip rate limit ------------------------------------------ */
+{
+  ok(uiAllowed(1000, 1000 - (UI_GAP_MS - 1)) === false, 'two blips inside the gap are one blip');
+  ok(uiAllowed(1000, 1000 - UI_GAP_MS) === true, 'exactly the gap passes');
+  ok(uiAllowed(1000, 500) === true, 'a slow move always sounds');
+  let last = -1e9, heard = 0;
+  for (let ms = 0; ms < 500; ms += 10) if (uiAllowed(ms, last)) { last = ms; heard++; }   // key repeat at 100 Hz
+  ok(heard <= Math.ceil(500 / UI_GAP_MS) + 1, `key repeat for 500 ms is ${heard} blips, not 50`);
+}
+
+if (fails) { console.error(`\naudio-check: ${fails} failure(s)`); process.exit(1); }
+console.log('\naudio-check: all good');

--- a/ConditioningControlPanel/Resources/web/dtrh/raceBoot.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/raceBoot.js
@@ -159,12 +159,14 @@ async function boot() {
     if (opts.pixel !== undefined) settings.pixel = opts.pixel;
     if (params.has('pixel') && params.get('pixel') !== '') settings.pixel = Number(params.get('pixel'));
     settings.reducedMotion = wantsReducedMotion(opts, settings.reducedMotion != null ? settings.reducedMotion : !!(matchMedia && matchMedia('(prefers-reduced-motion: reduce)').matches));
-    settings.musicVolume = opts.music; settings.sfxVolume = opts.sfx;   // for the audio pass; audio.js reads masterVolume today
+    settings.musicVolume = opts.music; settings.sfxVolume = opts.sfx;   // audio.js reads masterVolume; the two sliders go in through setLevels below
     settings.seedLock = seedFromOptions(opts);
     settings.trackPick = hosted;   // the file dialog is the host's; standalone loads a track off the query string
     seed = settings.seedLock != null ? settings.seedLock : rollSeed();
     note('the road is drawing');
     race = createRace({ root, bridge: host, media, settings, seed });
+    // the persisted option sliders, before the first frame: the menu theme comes up at the right level
+    try { if (race.audio && race.audio.setLevels) race.audio.setLevels({ music: opts.music, sfx: opts.sfx }); } catch (e) { host.log('levels: ' + e); }
     note('');
     host.log(`race booted: seed ${seed} (${opts.seed}), tier ${mode.tier}, hosted ${hosted}, manifest ${haveManifest}`);
     await standaloneTrack();
@@ -288,6 +290,8 @@ async function startRun(withIntro) {
   hideSplash();
   try {
     if (menu) { menu.hide(); menu.seedCheck(); }
+    // the menu theme keeps playing: the run's first room crossfades over it (race/AUDIO.md)
+    try { if (race.audio && race.audio.menu) race.audio.menu(false); } catch (e) { /* audio gone */ }
     if (menu && withIntro && params.get('intro') !== '0') {
       const { createIntro, cameraWhip } = await import('./race/intro.js');
       const reducedMotion = menu.options.motion === 'on' || (menu.options.motion === 'system' && settings.reducedMotion);


### PR DESCRIPTION
The front door was silent. It now plays a theme and answers every press.

audio.js grows three doors. menu(on) runs ost_campus, the tea garden's own hub tune so no new file ships, through the SAME chain and level as the run, under a pseudo-room so entering and leaving it is the ordinary crossfade and nothing new had to learn to fade. menu(false) stops nothing: the run's first room crossfades over the theme, and when that room draws the same tune it plays on. Autoplay, ducking and M are the run's rules unchanged.

ui(name, value) is five little synth voices, no files, on the shared context through sfxBus: tick for hover and focus, pick, back, step across a slider and page for the story card. Closed name set, rate limited to one blip per 45 ms so holding an arrow ticks instead of firing. setLevels multiplies the music chain and sfxBus, leaving the host legs on the host's own mixer; raceBoot applies the persisted options before the first frame and the sliders apply live, so the music and sfx rows lose their dim.

menu.js is ten one-line calls on handlers that already existed.

Verified: node --check clean, smoke/audio-check.mjs covers the level maths and the blip rate limit, headless chrome logs the theme requested, the track in and the levels applied with zero page errors. No listening was done, there is no sound in headless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0166ij3Q8xyseVkhWajzkWG3
