### PR TITLE
race: reduced motion is a setting, not a boot blocker

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
@@ -296,6 +296,9 @@ As built (PR 5 reality notes):
 - `again` on the end screen rebuilds the world in place (spine, tunnel, fx, dresser, field, kart, score,
   items) with a fresh seed; renderer, HUD, input, payloadFx and shake persist for the page's life.
 - Extra `run-ended` fields: `nearMisses`, `personalBest`. `exit` is followed by `exit-done` once torn down.
+- Boot and reduced motion: `raceBoot.js` calls `detectMode({ reducedIs3d: true })`, so `prefers-reduced-motion: reduce`
+  boots the 3D race and only turns motion down through `settings.reducedMotion`; a boot error is reserved for a real
+  hard wall (no WebGL, no import maps).
 
 ### `race/cocktail.js` (pass three, THE MIX)
 ```js

--- a/ConditioningControlPanel/Resources/web/dtrh/raceBoot.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/raceBoot.js
@@ -3,7 +3,9 @@
  * "race/run.js + raceBoot.js + race.html (PR 5, integration)" and the
  * "race/menu.js + race/intro.js" section (the front door).
  *
- * Order: capability detect -> quality tier -> bridge handlers -> announceReady
+ * Order: capability detect (reduced motion does not block the boot: the race
+ * turns its own motion down through settings.reducedMotion) -> quality tier ->
+ * bridge handlers -> announceReady
  * -> wait for `init` (+ `manifest`, `favorites`) with a 4 s timeout -> hostMedia
  * -> createRace + createMenu -> the splash is a 1 s title flash (it covers the
  * module import, the world build and the glb fetch, and hosts the wait note
@@ -83,7 +85,13 @@ window.addEventListener('unhandledrejection', (e) => {
 });
 
 // ---- capability -> quality tier ----
-const mode = detectMode();
+// reducedIs3d: prefers-reduced-motion is NOT a boot blocker here. The race owns
+// a complete reduced path (menu stage, HUD, flashes, cards, intro and the run's
+// own shake/whip all read settings.reducedMotion, which boot() resolves from the
+// host init, the menu's motion option and matchMedia), so "reduce" turns the
+// motion down inside the 3D scene instead of showing a boot error. Only a real
+// hard wall - no WebGL, no import maps - still fails.
+const mode = detectMode({ reducedIs3d: true });
 if (mode.hardBlock || !mode.canTry3d) {
   fail('no webgl here: ' + (mode.reason || mode.mode));
 } else {

--- a/ConditioningControlPanel/Resources/web/dtrh/shared/capability.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/shared/capability.js
@@ -1,10 +1,13 @@
 /* ============================================================================
  * capability.js — decide 3D vs 2D BEFORE any heavy three.js work.
  *
- * Returns { mode: '2d' | '3d', reason: string, canTry3d, tier }.
+ * Returns { mode: '2d' | '3d', reason: string, canTry3d, tier, hardBlock, reduced }.
  *   - ?mode=2d / ?mode=3d query param forces a mode (testing / opt-in).
  *   - No WebGL                       -> 2d
- *   - prefers-reduced-motion: reduce -> 2d
+ *   - prefers-reduced-motion: reduce -> 2d, UNLESS the caller passes
+ *     detectMode({ reducedIs3d: true }): a page that owns a complete
+ *     reduced-motion path (Racing Thoughts) reads `reduced` and turns its own
+ *     motion down inside the 3D scene instead of being refused the engine.
  *   - few cores AND low memory       -> 2d (genuinely weak hardware)
  * Phones/tablets (coarse pointer / small viewport) DO dive — they get
  * tier 'mobile', which scene.start feeds to quality.js for a lighter scene.
@@ -27,15 +30,19 @@ function supportsImportMap() {
   return HTMLScriptElement.supports && HTMLScriptElement.supports('importmap');
 }
 
-export function detectMode() {
+export function detectMode(opts) {
+  // reducedIs3d: the caller owns a complete reduced-motion path of its own, so
+  // "reduce" is a setting to honour inside the 3D scene rather than a reason to
+  // refuse it. Off by default, so every other page keeps the old rule.
+  const reducedIs3d = !!(opts && opts.reducedIs3d);
   const params = new URLSearchParams(location.search);
   const forced = params.get('mode');
   const webgl = hasWebGL();
   const importmap = supportsImportMap();
   const reduced = !!(window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches);
   // 3D can be offered as an opt-in whenever it's technically possible and the
-  // user hasn't asked for reduced motion.
-  const canTry3d = webgl && importmap && !reduced;
+  // user hasn't asked for reduced motion (or the caller handles it itself).
+  const canTry3d = webgl && importmap && (reducedIs3d || !reduced);
 
   const coarse = window.matchMedia && window.matchMedia('(pointer: coarse)').matches;
   const smallViewport = Math.min(window.innerWidth, window.innerHeight) < 720;
@@ -49,18 +56,19 @@ export function detectMode() {
   // opt-in in those cases, but never when hardBlock is true.
   const hardBlock = !webgl || !importmap;
 
-  if (forced === '2d') return { mode: '2d', reason: 'forced via ?mode=2d', canTry3d, tier, hardBlock };
-  if (forced === '3d') return { mode: '3d', reason: 'forced via ?mode=3d', canTry3d, tier, hardBlock };
+  if (forced === '2d') return { mode: '2d', reason: 'forced via ?mode=2d', canTry3d, tier, hardBlock, reduced };
+  if (forced === '3d') return { mode: '3d', reason: 'forced via ?mode=3d', canTry3d, tier, hardBlock, reduced };
 
-  if (!webgl) return { mode: '2d', reason: 'no WebGL', canTry3d: false, tier, hardBlock };
-  if (!importmap) return { mode: '2d', reason: 'no importmap support', canTry3d: false, tier, hardBlock };
-  if (reduced) return { mode: '2d', reason: 'prefers-reduced-motion', canTry3d: false, tier, hardBlock };
+  if (!webgl) return { mode: '2d', reason: 'no WebGL', canTry3d: false, tier, hardBlock, reduced };
+  if (!importmap) return { mode: '2d', reason: 'no importmap support', canTry3d: false, tier, hardBlock, reduced };
+  if (reduced && !reducedIs3d) return { mode: '2d', reason: 'prefers-reduced-motion', canTry3d: false, tier, hardBlock, reduced };
 
   // Both signals together = genuinely weak hardware; either alone (e.g. a
   // 4-core flagship phone) still handles the mobile-tier scene fine.
   if (fewCores && lowMemory) {
-    return { mode: '2d', reason: 'low-end hardware', canTry3d, tier, hardBlock };
+    return { mode: '2d', reason: 'low-end hardware', canTry3d, tier, hardBlock, reduced };
   }
 
-  return { mode: '3d', reason: tier === 'mobile' ? 'capable (mobile tier)' : 'capable', canTry3d, tier, hardBlock };
+  const capable = tier === 'mobile' ? 'capable (mobile tier)' : 'capable';
+  return { mode: '3d', reason: reduced ? capable + ', reduced motion' : capable, canTry3d, tier, hardBlock, reduced };
 }


### PR DESCRIPTION
On a phone with Reduce Motion on the kart showed a boot error even though a full reduced path exists. detectMode() takes an options bag; raceBoot passes reducedIs3d so the race boots in 3D with its reduced path, while boot.js and every other dtrh page keep the old answer byte for byte. Hard wall (no webgl or import maps) and the fewCores+lowMemory soft downgrade unchanged.

Verified: node --check, all race smokes, headless Chrome with --force-prefers-reduced-motion before (boot-error) and after (3D, zero errors); index.html console identical before/after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0166ij3Q8xyseVkhWajzkWG3
