### PR TITLE
race: aspect-aware camera so the road survives a phone

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
@@ -32,6 +32,42 @@ points from the road toward the tube centre).
 
 Constants live in `race/consts.js` (import them, do not redeclare).
 
+## Camera aspect rule
+
+**Every base fov in this game is a HORIZONTAL fov wearing a vertical number, and the number is
+measured at 16:9.** `THREE.PerspectiveCamera` takes a vertical fov, so a hard-coded one keeps the
+same height of picture at every window shape and lets the WIDTH go wherever the aspect drops it.
+That is fine on a desktop and wrong on a phone: the run's 72 collapses to about 37 horizontal at
+390x844, which turns the road into a slit and puts both side lanes off-screen, and blows out to
+about 118 at 844x390.
+
+`race/viewport.js` owns the fix and nothing else may re-derive it:
+
+```js
+import { vFovForAspect, hFovFor, bindViewportResize } from './viewport.js';
+vFovForAspect(baseVFov, aspect, maxVFov = MAX_VFOV) -> vertical fov, degrees
+hFovFor(vFov, aspect)                               -> the horizontal fov that pair covers
+bindViewportResize(fn)                              -> dispose()
+```
+
+- `hFov = 2 * atan(tan(base / 2) * 16 / 9)` is the constant being protected; the vertical is solved
+  back from it per aspect and clamped to `[MIN_VFOV, maxVFov]`.
+- **At 16:9 the two cancel exactly, so `vFovForAspect(base, 16 / 9) === base` and no desktop frame
+  moves by a pixel.** Every change to this file must keep that identity.
+- Narrower than 16:9 the vertical opens up to the clamp; wider it closes down, which is what stops
+  an ultrawide from being a fisheye.
+- `MAX_VFOV` is 102 for the road (picked on a 390x844 shot: wide enough for both lanes, short of a
+  tunnel that reads as a lens). The menu stage passes its own 86, because a character reads wrong at
+  a fov a tunnel still survives.
+- The kicks stay ADDITIVE on top of the solved base: `run.js` adds boost / drift / tea_time to
+  `fovBase`, never to `FOV_BASE`.
+- `bindViewportResize` is the only resize path. `resize` alone misses an iOS orientation flip (it
+  reports the OLD size) and misses a mobile URL bar sliding away (that only moves `visualViewport`),
+  so it binds `resize` + `orientationchange` + `visualViewport` and re-runs one frame after a flip.
+- Anything reading `camera.fov` per frame (`race/speed.js`) already follows for free: read it, never
+  assume a number.
+- `race/smoke/fov-check.mjs` is the guard: `node race/smoke/fov-check.mjs`.
+
 ## Modules and their exports
 
 ### `race/consts.js` (PR 1)
@@ -354,6 +390,10 @@ resultTier(total, best, personalBest) -> 0..4 (the face index)
   (the whip). `start()` clears the override; the boot installs the whip after `start()`.
 - `w.kart.emiModel()`, `w.kart.emiReady(cb)`, `w.kart.setFace(i)` are the kart's contract for the run's EMI; every call
   is guarded for null (the stage carries its own clone with its own glass material, so the two faces never fight).
+- The stage camera follows the **Camera aspect rule** above (base 42 at 16:9, its own 86 cap), and skips
+  `setViewOffset` entirely under `(max-width: 720px)`: menu.css collapses to one column and hides `.rm-stage`
+  there, so there is no right-hand column to park her beside and the offset would only shove her off the edge.
+  The canvas keeps rendering behind the single column, where she reads as the backdrop.
 - Options persist under the single localStorage key `race.options` (`pixel, music, sfx, motion, seed, seedValue`), not in
   `engine/settings.js`. Precedence for the block: `?pixel` > `race.options.pixel` > host `settings.pixel` > `PIXEL_DEFAULT`.
   The seed rule (daily / random / custom) sets `settings.seedLock`, which `again` honours; a change in the menu calls `reseed`.

--- a/ConditioningControlPanel/Resources/web/dtrh/race/menu.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/menu.js
@@ -53,6 +53,7 @@ import * as THREE from 'three';
 import { loadPack, preparePixel, toInstanceGeometry, flattenRig, setFace, FACES } from './gltf.js';
 import { PIXEL_STEPS, PIXEL_DEFAULT, normalizeBlock } from './pixel.js';
 import { createMenuFlashes } from './menuFlashes.js';
+import { vFovForAspect, bindViewportResize } from './viewport.js';
 
 export const OPTIONS_KEY = 'race.options';
 export const PROPS_URL = '/dtrh/race/assets/props.glb';
@@ -85,6 +86,8 @@ const MIST = 0x3a1c4e, FOG_NEAR = 9, FOG_FAR = 21, SKY_R = 44, FAR_PLUM = 0x4a24
 // far shapes: [x, z, scale, yaw]. The same cup profile, blown up and sat on the floor behind the gantry.
 const FAR_CUPS = [[-15, -28, 6, 0.5], [14, -33, 7, -0.8], [-6.5, -37, 6.4, 2.1]];
 const PAD = { a: 0, b: 1, up: 12, down: 13, left: 14, right: 15 };
+// the stage camera at 16:9, its own cap, and the one-column breakpoint menu.css already keeps
+const STAGE_FOV = 42, STAGE_MAX_VFOV = 86, ONE_COL_Q = '(max-width: 720px)';
 const clamp = (v, a, b) => Math.max(a, Math.min(b, v));
 /** Screenshot aid: `?face=N` pins the stage face so one atlas frame can be shot on its own.
  *  -1 (no param, an empty one, or anything unparseable) means the clips drive the face. */
@@ -153,7 +156,11 @@ export function createStage({ renderer, pixel, reducedMotion = false, log = null
   const scene = new THREE.Scene();
   scene.background = new THREE.Color(HAZE);
   scene.fog = new THREE.Fog(MIST, FOG_NEAR, FOG_FAR);
-  const camera = new THREE.PerspectiveCamera(42, 1, 0.1, 80);
+  // STAGE_FOV is the vertical fov at 16:9 only. race/viewport.js re-solves it per aspect so the
+  // stage keeps the same WIDTH of room at every window shape; a portrait phone opened it to about
+  // 112 unclamped, which put the camera inside her head, so the stage takes a tighter cap than the
+  // road does: a character reads wrong long before a tunnel does.
+  const camera = new THREE.PerspectiveCamera(STAGE_FOV, 1, 0.1, 80);
   camera.position.set(0, 1.0, 4.4); camera.lookAt(0, 0.6, 0);   // pulled back from the brief's (0, 0.9, 3.2): at block 3 she filled the frame
   const view = { w: 1, h: 1, frac: 0.5 };
   let t = 0, mode = 'menu', reduced = !!reducedMotion, disposed = false;
@@ -322,7 +329,12 @@ export function createStage({ renderer, pixel, reducedMotion = false, log = null
     if (ripple.material.opacity > 0) { ripple.scale.addScalar(dt * 4); ripple.material.opacity = Math.max(0, ripple.material.opacity - dt * 1.6); }
   }
   function render() { pixel.render(scene, camera); }
-  function resize(w, h) { view.w = Math.max(1, w | 0); view.h = Math.max(1, h | 0); camera.aspect = view.w / view.h; applyView(); }
+  function resize(w, h) {
+    view.w = Math.max(1, w | 0); view.h = Math.max(1, h | 0);
+    camera.aspect = view.w / view.h;
+    camera.fov = vFovForAspect(STAGE_FOV, camera.aspect, STAGE_MAX_VFOV);
+    applyView();
+  }
   /** Where the visible centre of the stage sits across the canvas (0.5 = the middle; the menu column pushes it right). */
   function setViewFraction(f) { view.frac = clamp(+f || 0.5, 0.3, 0.8); applyView(); }
   function applyView() {
@@ -500,17 +512,22 @@ export function createMenu({ root, renderer, pixel, audio, settings = {}, log = 
     const ax = g.axes || [], now = { up: btn(PAD.up) || ax[1] < -0.6, down: btn(PAD.down) || ax[1] > 0.6, left: btn(PAD.left) || ax[0] < -0.6, right: btn(PAD.right) || ax[0] > 0.6, press: btn(PAD.a), back: btn(PAD.b) };
     for (const k of Object.keys(now)) { if (now[k] && !padWas[k]) act(k); padWas[k] = now[k]; }
   }
+  /** menu.css collapses to one column at ONE_COL_Q and hides `.rm-stage`; the canvas keeps rendering
+   *  behind it, so there is no right-hand column to push her into and the offset would only shove her
+   *  off the side of a phone. One column = dead centre, and she reads as the backdrop she now is. */
+  const oneColumn = () => !!(typeof matchMedia === 'function' && matchMedia(ONE_COL_Q).matches);
   function onResize() {
     const w = root.clientWidth || window.innerWidth, h = root.clientHeight || window.innerHeight;
     stage.resize(w, h);
     // a hair right of the visible centre: room for the cup. `viewHeld` keeps that framing while the
     // menu is hidden but something else owns the same column (race/cards.js), so a late resize does
     // not walk her back to the middle of the frame.
-    stage.setViewFraction((shown || viewHeld) ? ((col.offsetWidth || w * 0.38) / w + 1) / 2 + 0.03 : 0.5);
+    const parked = (shown || viewHeld) && !oneColumn();
+    stage.setViewFraction(parked ? ((col.offsetWidth || w * 0.38) / w + 1) / 2 + 0.03 : 0.5);
   }
   const onPointer = (e) => { if (shown && e.clientX > window.innerWidth * 0.5) stage.emi.peek(); };
   window.addEventListener('keydown', onKey);
-  window.addEventListener('resize', onResize);
+  const unbindResize = bindViewportResize(onResize);
   stageEl.addEventListener('pointerenter', onPointer);
   layer.dataset.motion = options.motion;
 
@@ -528,7 +545,7 @@ export function createMenu({ root, renderer, pixel, audio, settings = {}, log = 
     dispose() {
       if (disposed) return;
       disposed = true; shown = false;
-      window.removeEventListener('keydown', onKey); window.removeEventListener('resize', onResize);
+      window.removeEventListener('keydown', onKey); unbindResize();
       stage.dispose(); layer.remove();
     },
   };

--- a/ConditioningControlPanel/Resources/web/dtrh/race/run.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/run.js
@@ -13,6 +13,12 @@
  * (video only), run-ended, exit, exit-done, and with a track loaded track-play,
  * track-pause, track-stop; listens to pause, payout-result.
  *
+ * CAMERA ASPECT (race/viewport.js): FOV_BASE is a HORIZONTAL field of view wearing
+ * a vertical number. 72 is what it measures at 16:9, and every other window shape
+ * solves back for the vertical fov that keeps that same width of road, clamped at
+ * MAX_VFOV so a tall phone stops short of a fisheye. Desktop 16:9 is untouched by
+ * definition. The boost/drift/tea_time kicks are added on top of that per frame.
+ *
  * TRACK CHARTS (CHART.md): setTrack(chart) hands the run a charted hypno file and
  * from then on the file is the clock. race/track.js holds the second, the energy
  * curve and the acts; race/cues.js says what each spoken word is worth; everything
@@ -43,10 +49,12 @@ import { createItems } from './items.js';
 import { createInput } from './input.js';
 import { createPixelizer, PIXEL_DEFAULT } from './pixel.js';
 import { createSpeedFx } from './speed.js';
+import { vFovForAspect, bindViewportResize } from './viewport.js';
 import { createRaceAudio } from './audio.js';
 import { resultTier, resultsCamera, preRollCamera } from './intro.js';
 
 const HEARTBEAT_MS = 2000, PAYOUT_WAIT_MS = 2000, NEAR_MISS_M = 1.15, FOV_BASE = 72;   // 1.6 read as ALMOST spam: the next lane over qualified
+// FOV_BASE is the VERTICAL fov at 16:9 only; race/viewport.js re-solves it per aspect (see the header).
 // effect lives are cocktail.js CATEGORIES (scaled by the pop's durationMult); a glitch re-pop wobbles
 // the world clock this hard, this long (only when tea_time is not already holding it)
 const WOBBLE_SCALE = 0.82, WOBBLE_SEC = 0.3;
@@ -81,11 +89,18 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
   scene.add(new THREE.AmbientLight(0x8a70a8, 1.0));
   const cupLight = new THREE.PointLight(0xff69b4, 1.4, 14);
   scene.add(cupLight);
+  // the vertical fov this window shape needs to hold FOV_BASE's 16:9 width of road; the per-frame
+  // kick rides on top of it, and a resize slides S.fov by the same delta so the kick survives a flip
+  let fovBase = FOV_BASE, fovLive = false;
   function resize() {
     const w = root.clientWidth || window.innerWidth, h = root.clientHeight || window.innerHeight;
-    pixel.resize(w, h); camera.aspect = w / h; camera.updateProjectionMatrix();
+    pixel.resize(w, h); camera.aspect = w / h;
+    const next = vFovForAspect(FOV_BASE, camera.aspect);
+    if (fovLive) { S.fov += next - fovBase; camera.fov = S.fov; } else camera.fov = next;
+    fovBase = next;
+    camera.updateProjectionMatrix();
   }
-  window.addEventListener('resize', resize); resize();
+  const unbindResize = bindViewportResize(resize); resize();
 
   // ---- the parts that outlive a run ----
   const hud = createRaceHud(hudRoot);
@@ -104,10 +119,11 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
   const S = {
     started: false, running: false, paused: false, hostPaused: false, ended: false, disposed: false,
     elapsed: 0, t: 0, intensity: intensityFloor, timeScale: 1, jackpotBias: 1, parasol: false, magnet: false,
-    flip: false, spawnT: SPAWN_T0, rainT: RAIN_T0, tunnelTime: 0, rush: 0, fov: 72, fovBoost: 0, gates: 0, room: null,
+    flip: false, spawnT: SPAWN_T0, rainT: RAIN_T0, tunnelTime: 0, rush: 0, fov: fovBase, fovBoost: 0, gates: 0, room: null,
     wasAirborne: false, airH: 0, effects: [], moodHeld: null, moodHold: 0, mood: 'calm', bestAtStart: 0, seed, wobble: 0,
     trackHold: 0, trackFog: 0, trackPaused: false, statsAt: 0, trackGap: 0,
   };
+  fovLive = true;   // S exists: resize() may shift S.fov from here on
   const mix = createCocktail({ now: () => S.elapsed });   // THE MIX: one live effect per category (cocktail.js); S.effects mirrors its live slots
   const TR = createTrackState();      // the loaded track chart: its clock, its energy, its acts (race/track.js)
   const hosted = bridge.isHosted !== false;   // the standalone page logs where the host would be told
@@ -492,7 +508,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     // FOV kick: boost snaps wide (to ~84) and eases back slowly; drift adds a smaller one; tea_time narrows
     const boostT = ks.boostSec > 0 ? 1 : 0;
     S.fovBoost += (boostT - S.fovBoost) * Math.min(1, dt * (boostT ? 9 : 2.2));
-    const fovT = FOV_BASE + (reducedMotion ? 5 : 12) * S.fovBoost + (ks.drift && !reducedMotion ? 3 : 0) - (S.timeScale < 1 ? 4 : 0);
+    const fovT = fovBase + (reducedMotion ? 5 : 12) * S.fovBoost + (ks.drift && !reducedMotion ? 3 : 0) - (S.timeScale < 1 ? 4 : 0);
     if (Math.abs(fovT - S.fov) > 0.05) { S.fov += (fovT - S.fov) * Math.min(1, dt * 6); camera.fov = S.fov; camera.updateProjectionMatrix(); }
     cupLight.position.copy(k.group.position).addScaledVector(_v.copy(camOut.up), 1.6);
     speedFx.update(dt, ks, lay);
@@ -603,7 +619,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     if (S.disposed) return;
     S.disposed = true;
     if (raf) cancelAnimationFrame(raf);
-    window.removeEventListener('resize', resize);
+    unbindResize();
     document.removeEventListener('visibilitychange', onVis);
     if (payoutResolve) payoutResolve(null);
     teardown();

--- a/ConditioningControlPanel/Resources/web/dtrh/race/smoke/fov-check.mjs
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/smoke/fov-check.mjs
@@ -1,0 +1,69 @@
+/* ============================================================================
+ * race/smoke/fov-check.mjs - node self-check for race/viewport.js.
+ *
+ *   node race/smoke/fov-check.mjs      (exits 0 on pass, 1 with a count of failures)
+ *
+ * viewport.js imports nothing, so this needs no three and no DOM. It checks the
+ * one promise CONTRACT.md "Camera aspect rule" makes: the HORIZONTAL fov is the
+ * constant, the vertical is whatever holds it. In order: 16:9 is the identity so
+ * the desktop look never moves; a 390x844 phone lands on the clamp; an 844x390
+ * phone comes back narrower than the base; the horizontal width is genuinely held
+ * everywhere the clamp is not biting; the run and menu base fovs both survive a
+ * round trip; and junk arguments do not produce NaN.
+ * ==========================================================================*/
+
+import { vFovForAspect, hFovFor, REF_ASPECT, MAX_VFOV, MIN_VFOV } from '../viewport.js';
+
+let fails = 0;
+const ok = (cond, what) => { if (!cond) { console.error('FAIL ' + what); fails++; } else console.log('  ok  ' + what); };
+const near = (a, b, eps = 1e-9) => Math.abs(a - b) <= eps;
+
+const RUN_BASE = 72, MENU_BASE = 42;
+const PORTRAIT = 390 / 844, LANDSCAPE = 844 / 390, DESK = 1280 / 720;
+
+/* ---- 1. 16:9 is the identity -------------------------------------------- */
+{
+  ok(near(vFovForAspect(RUN_BASE, REF_ASPECT), RUN_BASE), '16:9 gives back exactly 72 (desktop is untouched)');
+  ok(near(vFovForAspect(RUN_BASE, DESK), RUN_BASE), '1280x720 is 16:9, so it gives back exactly 72');
+  ok(near(vFovForAspect(MENU_BASE, REF_ASPECT, 66), MENU_BASE), 'the menu stage gives back exactly 42 at 16:9');
+}
+
+/* ---- 2. a tall phone opens up, onto the clamp --------------------------- */
+{
+  const v = vFovForAspect(RUN_BASE, PORTRAIT);
+  ok(near(PORTRAIT, 0.4621, 1e-3), '390x844 is an aspect of about 0.46');
+  ok(v === MAX_VFOV, `0.46 clamps to MAX_VFOV (${MAX_VFOV}), got ${v.toFixed(2)}`);
+  ok(vFovForAspect(RUN_BASE, PORTRAIT, 88) === 88, 'a caller with its own cap gets its own cap');
+  ok(hFovFor(v, PORTRAIT) > hFovFor(RUN_BASE, PORTRAIT) + 20, 'the clamped vertical still buys 20+ degrees of width back');
+}
+
+/* ---- 3. a wide phone closes down ---------------------------------------- */
+{
+  const v = vFovForAspect(RUN_BASE, LANDSCAPE);
+  ok(near(LANDSCAPE, 2.164, 1e-3), '844x390 is an aspect of about 2.16');
+  ok(v < RUN_BASE, `2.16 comes back below 72 (no fisheye), got ${v.toFixed(2)}`);
+  ok(v > 55 && v < 68, `2.16 lands in a sane band, got ${v.toFixed(2)}`);
+}
+
+/* ---- 4. the horizontal fov is the thing being held ----------------------- */
+{
+  const want = hFovFor(RUN_BASE, REF_ASPECT);
+  let held = true, clamped = 0;
+  for (const a of [0.5, 0.75, 1, 4 / 3, 16 / 10, REF_ASPECT, 2, 2.164, 21 / 9, 32 / 9]) {
+    const v = vFovForAspect(RUN_BASE, a);
+    if (v === MAX_VFOV || v === MIN_VFOV) { clamped++; continue; }
+    if (!near(hFovFor(v, a), want, 1e-6)) held = false;
+  }
+  ok(held, `every unclamped aspect holds the same ${want.toFixed(2)} degrees of width`);
+  ok(clamped >= 1 && clamped <= 3, 'only the extreme aspects need the clamp');
+  ok(want > 100 && want < 110, `72 at 16:9 is about ${want.toFixed(1)} degrees horizontal`);
+}
+
+/* ---- 5. junk in, no NaN out --------------------------------------------- */
+{
+  const bad = [vFovForAspect(RUN_BASE, 0), vFovForAspect(RUN_BASE, -3), vFovForAspect(RUN_BASE, NaN), vFovForAspect(NaN, 1.5)];
+  ok(bad.every((v) => Number.isFinite(v) && v >= MIN_VFOV && v <= MAX_VFOV), 'a bad aspect or base still returns a fov inside the clamp');
+}
+
+console.log(fails ? `\n${fails} failure(s)` : '\nfov-check: all good');
+process.exit(fails ? 1 : 0);

--- a/ConditioningControlPanel/Resources/web/dtrh/race/viewport.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/viewport.js
@@ -1,0 +1,83 @@
+/* ============================================================================
+ * race/viewport.js - the aspect rule and the resize plumbing every race camera
+ * shares. Implements CONTRACT.md "Camera aspect rule".
+ *
+ *   vFovForAspect(baseVFov, aspect, maxVFov) -> vertical fov in degrees
+ *   hFovFor(vFov, aspect)                    -> the horizontal fov that pair gives
+ *   bindViewportResize(fn)                   -> dispose()
+ *
+ * THE RULE. A THREE.PerspectiveCamera fov is VERTICAL, so a fixed number keeps
+ * the same amount of sky at every shape of window and throws the width away.
+ * On a 390x844 phone the run's 72 vertical collapses to about 37 horizontal:
+ * the road is a slit and both side lanes sit off-screen. So the run does not own
+ * a vertical fov at all, it owns a HORIZONTAL one, measured once at 16:9 from
+ * the number the desktop look was built on, and every other aspect solves back
+ * for the vertical that keeps that width:
+ *
+ *   hFov = 2 * atan(tan(base / 2) * 16 / 9)        (the constant we protect)
+ *   vFov = clamp(2 * atan(tan(hFov / 2) / aspect), MIN, max)
+ *
+ * At exactly 16:9 the two cancel and vFov === base, so nothing on a desktop
+ * moves by a pixel. Narrower than 16:9 the vertical opens up until the clamp;
+ * wider than 16:9 it closes down, which is what keeps an ultrawide from being
+ * a fisheye. The clamp is the whole safety net: without it a 9:19.5 phone asks
+ * for about 141 vertical and the road turns into a lens flare.
+ *
+ * Nothing here touches three or the DOM at import time, so race/smoke/fov-check.mjs
+ * can run it under bare node.
+ * ==========================================================================*/
+
+const DEG = Math.PI / 180;
+/** The shape the desktop look was authored at. Every base fov in the game is read as "at 16:9". */
+export const REF_ASPECT = 16 / 9;
+/** Past this the road stops reading as a road and starts reading as a fisheye tunnel (picked on a 390x844 shot). */
+export const MAX_VFOV = 102;
+/** A floor so an absurd ultrawide cannot squeeze the camera down to a telescope. */
+export const MIN_VFOV = 28;
+
+const clamp = (v, a, b) => Math.max(a, Math.min(b, v));
+
+/** The horizontal fov (degrees) a vertical fov covers at `aspect` (w / h). */
+export function hFovFor(vFovDeg, aspect) {
+  return 2 * Math.atan(Math.tan(vFovDeg * 0.5 * DEG) * Math.max(0.01, aspect)) / DEG;
+}
+
+/**
+ * The vertical fov (degrees) that holds `baseVFovDeg`'s 16:9 WIDTH at `aspect`.
+ * Returns `baseVFovDeg` unchanged at 16:9. Clamped to [MIN_VFOV, maxVFovDeg].
+ */
+export function vFovForAspect(baseVFovDeg, aspect, maxVFovDeg = MAX_VFOV) {
+  const a = Math.max(0.01, +aspect || REF_ASPECT);
+  const halfW = Math.tan(clamp(+baseVFovDeg || 1, 1, 175) * 0.5 * DEG) * REF_ASPECT;
+  const v = 2 * Math.atan(halfW / a) / DEG;
+  return clamp(v, MIN_VFOV, Math.max(MIN_VFOV, maxVFovDeg));
+}
+
+/**
+ * Every event that can change the shape of the viewport, in one place.
+ * `resize` alone misses an iOS orientation flip (it fires with the OLD size) and
+ * misses the URL bar sliding away on mobile Safari, which only moves
+ * `visualViewport`. So: listen to all three, and re-run one frame after an
+ * orientation flip because the first report is stale there.
+ * Returns a dispose() that takes every listener back off.
+ */
+export function bindViewportResize(fn) {
+  if (typeof window === 'undefined' || typeof fn !== 'function') return () => {};
+  let pending = 0;
+  const later = () => {
+    if (pending) cancelAnimationFrame(pending);
+    pending = requestAnimationFrame(() => { pending = 0; fn(); });
+  };
+  const onFlip = () => { fn(); later(); };
+  const vv = window.visualViewport || null;
+  window.addEventListener('resize', fn);
+  window.addEventListener('orientationchange', onFlip);
+  if (vv && vv.addEventListener) vv.addEventListener('resize', fn);
+  return () => {
+    if (pending) cancelAnimationFrame(pending);
+    pending = 0;
+    window.removeEventListener('resize', fn);
+    window.removeEventListener('orientationchange', onFlip);
+    if (vv && vv.removeEventListener) vv.removeEventListener('resize', fn);
+  };
+}


### PR DESCRIPTION
FOV_BASE 72 was vertical, so portrait gave a 37 degree slit. New race/viewport.js holds the horizontal fov constant (its 16:9 value) and solves the vertical per aspect, clamped at 102 for the road and 86 for the menu stage; desktop 16:9 is exactly 72 by construction. Resize also listens to orientationchange and visualViewport with a one-frame re-run. Menu skips setViewOffset under 720px.

Verified: fov-check smoke (14 assertions), headless shots at 390x844 / 844x390 / 1280x720 before and after; the 1280x720 road spans the same pixel columns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0166ij3Q8xyseVkhWajzkWG3
