### PR TITLE
race: touch controls, part 1 - the thumb pad and the input merge

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
@@ -309,8 +309,26 @@ through the `fire-payload` bridge message exactly like `chaosRun.js` does today.
 (pause + end screen). Run end sends `run-ended` (below).
 
 As built (PR 5 reality notes):
-- `race/input.js` is the single reader of keyboard + gamepad: `createInput() -> { read(), onAction(cb), flush(), dispose() }`,
+- `race/input.js` is the single reader of keyboard + gamepad + touch:
+  `createInput({ root }) -> { read(), onAction(cb), flush(), dispose(), touchEl }`,
   `read()` = `{ steer, accel, brake, drift, jump }` with `accel` defaulting to 1 when nothing is pressed.
+  The three sources are ADDITIVE and never remap one another (Law II): `steer` takes whichever source
+  has the larger magnitude (an analog source, stick or thumb, also turns the digital easing off),
+  `accel` / `brake` take the max, `drift` is an OR, and `jump` plus the ACTIONS are edges, so any
+  source may raise one and each is exactly one press. `flush()` clears all three.
+- `race/touch.js` is that third source and the ONLY pointer path into the run:
+  `createTouch({ root, fire }) -> null | { el, read(), flush(), dispose() }`. It returns null unless the
+  page is touchable (`(pointer: coarse)` or `navigator.maxTouchPoints > 0`), so a mouse desktop and the
+  WebView2 desktop build build not one node of it; `?touch=1` forces it on (the headless screenshot aid)
+  and `?touch=0` forces it off. The layer is `.rh-touch` at z12 inside `.race-hud`: above the chrome (z3)
+  and the payload layers (z4 / z9), below the Brake and End screens (z20), the countdown (z21), the menu
+  (z25), the cards (z26) and the splash (z30), so every card still takes the tap first. Left `STEER_SIDE`
+  (55%) of the width steers by horizontal drag from the touch-down point (`STEER_DEAD_PX` 6 dead,
+  `STEER_LOCK_PX` 72 to full lock, zero on release, a ring-and-dot thumb pad while held); the rest of the
+  width taps (under `TAP_MS` 180 and `TAP_PX` 12 of travel) for one jump press and holds for drift.
+  Accel is never touched: nothing pressed is cruise, and there is no brake pedal on glass. The pause /
+  mute / use buttons that hang off the same layer are the sibling pass. Pointer Events only, never
+  TouchEvent.
 - Space (pad B) is the jump: `read().jump` is true for exactly the frame of a fresh press, never on hold,
   and `kart.stepJump` turns it into 1.1 m of real height (`state.h`, so the pop box goes up with it).
   A press within 4 m of a ramp lip, or inside 0.12 s of one firing, boosts that launch by 1.3 and hands

--- a/ConditioningControlPanel/Resources/web/dtrh/race/hud.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/hud.js
@@ -10,7 +10,11 @@
  * JACKPOT is a gold flash and a REVEAL, BANK flies tokens into the score and
  * ticks the counter as they land). flicker() is the Stat Flicker: the face
  * lies for 450 ms, the ledger never does (Law I). The Brake and the End card
- * are the only pointer targets. Copy is DtRH voice: lowercase, short.
+ * are the chrome's own pointer targets; since the touch pass they are no longer
+ * the page's only ones, because race/touch.js adds .rh-touch at z12 (the thumb
+ * pad, and its buttons in the sibling pass) on a touchable page. It rides BELOW
+ * the screens at z20, so a card still takes the tap first and nothing here has
+ * to cooperate. Copy is DtRH voice: lowercase, short.
  *
  * THE PICKUP (pass f3): a cube gives its item a card of its own, centre of the
  * view just above the cup. It rolls a `?` while items.js rolls, flips to the

--- a/ConditioningControlPanel/Resources/web/dtrh/race/input.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/input.js
@@ -1,11 +1,14 @@
 /* ============================================================================
  * race/input.js - the wheel. Implements CONTRACT.md "race/run.js + raceBoot.js"
- * (PR 5, integration): the one place keyboard and gamepad are read.
+ * (PR 5, integration): the one place keyboard, gamepad and touch are read.
  *
  * Keyboard: arrows / WASD steer + accel + brake, Shift drift, Space jump, E item,
  * Esc brake, P cycles the pixel look.
  * Gamepad (navigator.getGamepads, standard map): left stick steer, RT accel,
  * LT brake, A drift, B jump, X item, Start brake.
+ * Touch (race/touch.js, only on a touchable page): the left half drags the wheel,
+ * the right half taps to jump and holds to drift.
+ * `createInput({ root })` needs the race root or the touch layer is never built.
  *
  *   read() -> { steer:-1..1, accel:0..1, brake:0..1, drift:bool, jump:bool }
  *   onAction(cb)   cb(action) for the ACTIONS table below ('item' | 'brake' | 'pixel' | 'mute'), edge-triggered, never repeats on hold
@@ -24,7 +27,15 @@
  * (Law VIII) without a hard snap. The mirror item flips the picture, never
  * the hand: there is no flip/mirror API here and none may be added (the
  * owner's law: left stays left).
+ *
+ * THE MERGE: keys, pad and touch are three ADDITIVE sources, never a remap of
+ * one another. steer takes whichever source has the larger magnitude (an analog
+ * source, stick or thumb, also turns the easing off because it is already
+ * continuous); accel and brake take the max; drift is an OR; jump and the
+ * ACTIONS are edges, so any source may raise one and each is one press.
  * ==========================================================================*/
+
+import { createTouch } from './touch.js';
 
 const KEYS = {
   ArrowLeft: 'left', KeyA: 'left', ArrowRight: 'right', KeyD: 'right',
@@ -53,7 +64,7 @@ const AID_JUMP = (() => {
 })();
 const clamp = (v, a, b) => Math.max(a, Math.min(b, v));
 
-export function createInput({ target = window } = {}) {
+export function createInput({ target = window, root = null } = {}) {
   const down = new Set();
   const acts = [];
   const out = { steer: 0, accel: 1, brake: 0, drift: false, jump: false };
@@ -62,6 +73,9 @@ export function createInput({ target = window } = {}) {
   const padWas = { item: false, start: false, jump: false };
 
   const fire = (name) => { for (const cb of acts) { try { cb(name); } catch (e) { /* a listener never breaks the wheel */ } } };
+
+  /** The third source. null on a mouse desktop: not one node is built there. */
+  const touch = createTouch({ root });
 
   function onKey(e) {
     if (disposed || e.altKey || e.metaKey || e.ctrlKey) return;
@@ -126,6 +140,12 @@ export function createInput({ target = window } = {}) {
       if (jmp && !padWas.jump) jump = true;                    // pad B, edge-triggered like the key
       padWas.item = item; padWas.start = start; padWas.jump = jmp;
     }
+    if (touch) {
+      const t = touch.read();
+      if (Math.abs(t.steer) > Math.abs(steer)) { steer = t.steer; digital = false; }   // the thumb is analog too
+      drift = drift || t.drift;
+      if (t.jump) jump = true;                                 // one tap, one press
+    }
     if (digital) steerE += (steer - steerE) * Math.min(1, dt * 14);
     else steerE = steer;
     if (Math.abs(steerE) < 0.002) steerE = 0;
@@ -142,6 +162,7 @@ export function createInput({ target = window } = {}) {
   function flush() {
     down.clear(); jumpQ = false;
     padWas.item = false; padWas.start = false; padWas.jump = false;
+    if (touch) touch.flush();   // and a thumb still on the glass starts the run neutral
   }
 
   function dispose() {
@@ -149,6 +170,7 @@ export function createInput({ target = window } = {}) {
     target.removeEventListener('keydown', onKey);
     target.removeEventListener('keyup', onKey);
     target.removeEventListener('blur', onBlur);
+    if (touch) touch.dispose();
     down.clear(); acts.length = 0;
     jumpQ = false; jumpHeld = false;
   }
@@ -156,6 +178,8 @@ export function createInput({ target = window } = {}) {
   return {
     read,
     flush,
+    /** The touch layer element, or null where none was built. Test aid only. */
+    get touchEl() { return touch ? touch.el : null; },
     onAction(cb) { if (typeof cb === 'function') acts.push(cb); return () => { const i = acts.indexOf(cb); if (i >= 0) acts.splice(i, 1); }; },
     dispose,
   };

--- a/ConditioningControlPanel/Resources/web/dtrh/race/race.css
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/race.css
@@ -5,7 +5,9 @@
  * (--rh-font, --pink); nothing new is loaded. Layers: the chrome sits at z3,
  * above the canvas (z0) and BELOW every payloadFx layer (.sf-pfx z4, the
  * video card in .sf-pfx-front z9) so a freeze or a tape always covers it. The
- * Brake and End screens are the only pointer targets and ride at z20.
+ * Brake and End screens ride at z20. On a touchable page race/touch.js adds a
+ * second pointer target, .rh-touch at z12 (the thumb pad and its buttons), so
+ * the screens are no longer the only ones; a mouse desktop never builds it.
  * The .race-hud root itself must stay unpositioned so its children own z-index.
  *
  * Second pass: every corner block anchors off --rh-inset (plus the notch
@@ -317,7 +319,7 @@
 }
 .race-hud .rh-vignette.is-beat { animation: rhBeat var(--rh-beat, 1.1s) ease-in-out infinite; }
 
-/* ---- screens: the Brake and the End card. The only pointer targets. ---- */
+/* ---- screens: the Brake and the End card. Pointer targets, above the touch layer. ---- */
 .race-hud .rh-screen {
   position: fixed; inset: 0; z-index: 20; display: none; place-items: center; pointer-events: auto;
   background: rgba(8, 4, 14, 0.72); backdrop-filter: blur(6px); -webkit-backdrop-filter: blur(6px);
@@ -343,6 +345,33 @@
 .race-hud .rh-btn--quiet { border-color: rgba(255, 255, 255, 0.25); background: transparent; opacity: 0.8; }
 .race-hud .rh-hints { margin-top: 16px; font-size: 0.72rem; opacity: 0.55; line-height: 1.6; }
 
+/* ---- THE TOUCH LAYER (race/touch.js), z12: the phone's hands ----------------
+   Built only on a touchable page (or `?touch=1`), so a mouse desktop and the
+   WebView2 build stay pixel identical. It sits above the chrome (z3) and the
+   payload layers (z4 / z9) and BELOW the Brake and End screens (z20), the
+   countdown (z21), the menu (z25), the cards (z26) and the splash (z30), so
+   every card still takes the tap first. Left 55% steers, the rest jumps and
+   drifts; the pause / mute / use buttons are a sibling pass. */
+.race-hud .rh-touch {
+  position: fixed; inset: 0; z-index: 12; touch-action: none; overscroll-behavior: none;
+  -webkit-user-select: none; user-select: none; -webkit-tap-highlight-color: transparent;
+}
+/* the thumb pad: a ring at the touch-down point, a dot that rides the drag */
+.race-hud .rt-pad {
+  position: absolute; left: 0; top: 0; width: 0; height: 0;
+  opacity: 0; pointer-events: none; transition: opacity 0.22s ease-out;
+}
+.race-hud .rh-touch.is-steering .rt-pad { opacity: 1; }
+.race-hud .rt-ring {
+  position: absolute; left: -46px; top: -46px; width: 92px; height: 92px; border-radius: 50%;
+  border: 2px solid rgba(255, 214, 234, 0.45);
+  box-shadow: 0 0 18px rgba(255, 105, 180, 0.32), inset 0 0 20px rgba(255, 105, 180, 0.16);
+}
+.race-hud .rt-dot {
+  position: absolute; left: -17px; top: -17px; width: 34px; height: 34px; border-radius: 50%;
+  background: rgba(255, 105, 180, 0.5); border: 2px solid rgba(255, 255, 255, 0.82);
+  box-shadow: 0 0 16px rgba(255, 105, 180, 0.7);
+}
 /* ---- motion ---- */
 @keyframes rhThud { 0% { transform: scale(1); } 20% { transform: scale(1.32); } 60% { transform: scale(0.92); } 100% { transform: scale(1); } }
 @keyframes rhPulse { 0% { transform: scale(1); } 30% { transform: scale(1.4); } 100% { transform: scale(1); } }

--- a/ConditioningControlPanel/Resources/web/dtrh/race/run.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/run.js
@@ -109,7 +109,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
   const lane = createMediaLane(sfHud);   // re-homes payload cards off the road
   const shake = createScreenShake({ el: root });
   if (reducedMotion) shake.setEnabled(false);
-  const input = createInput();
+  const input = createInput({ root });   // root: the touch layer, on a phone, is built inside its .race-hud
   const audio = createRaceAudio({ bridge, hud, settings, input });
   const speedFx = createSpeedFx({ scene, camera, root, reducedMotion });
   const camOut = { pos: new THREE.Vector3(), look: new THREE.Vector3(), up: new THREE.Vector3(0, 1, 0), roll: 0 };

--- a/ConditioningControlPanel/Resources/web/dtrh/race/smoke/touch-check.mjs
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/smoke/touch-check.mjs
@@ -1,0 +1,287 @@
+/* ============================================================================
+ * race/smoke/touch-check.mjs - node self-check for race/touch.js and the merge
+ * race/input.js does with it.
+ *
+ *   node race/smoke/touch-check.mjs      (exits 0 on pass, 1 with a count of failures)
+ *
+ * jsdom-free on purpose: the DOM this needs is four methods wide, so it is stubbed
+ * here (elements, classList, listeners, MutationObserver, a window with location /
+ * navigator / matchMedia) and synthetic pointer events are dispatched straight at
+ * the layer touch.js built. Date.now is driven by hand so a 180 ms hold costs no
+ * wall clock. Nothing here proves the FEEL of the steering: that is the owner's,
+ * on a real phone, with real thumbs.
+ * ==========================================================================*/
+
+import { createTouch, wantsTouch, steerFromDx, STEER_LOCK_PX, STEER_DEAD_PX, TAP_MS, TAP_PX } from '../touch.js';
+import { createInput } from '../input.js';
+
+let fails = 0;
+const ok = (cond, what) => { if (!cond) { console.error('FAIL ' + what); fails++; } else console.log('  ok  ' + what); };
+const near = (a, b) => Math.abs(a - b) < 1e-9;
+
+/* ---- the stub DOM ------------------------------------------------------- */
+const VW = 800, VH = 400;
+
+class Elem {
+  constructor(tag) {
+    this.tagName = String(tag || 'div').toUpperCase();
+    this.children = []; this.parentNode = null; this.style = {}; this.textContent = '';
+    this.attrs = {}; this._l = new Map(); this._cls = new Set(); this._obs = [];
+  }
+  get className() { return [...this._cls].join(' '); }
+  set className(v) { this._cls = new Set(String(v).split(/\s+/).filter(Boolean)); }
+  get classList() {
+    const self = this;
+    return {
+      add: (...c) => { for (const x of c) self._cls.add(x); self._bump(); },
+      remove: (...c) => { for (const x of c) self._cls.delete(x); self._bump(); },
+      contains: (c) => self._cls.has(c),
+      toggle: (c, on) => {
+        const want = on === undefined ? !self._cls.has(c) : !!on;
+        if (want) self._cls.add(c); else self._cls.delete(c);
+        self._bump(); return want;
+      },
+    };
+  }
+  _bump() { for (const cb of this._obs.slice()) cb([{ type: 'attributes', attributeName: 'class' }]); }
+  setAttribute(k, v) { this.attrs[k] = v; }
+  appendChild(n) { n.parentNode = this; this.children.push(n); return n; }
+  removeChild(n) { const i = this.children.indexOf(n); if (i >= 0) this.children.splice(i, 1); n.parentNode = null; return n; }
+  addEventListener(t, fn) { if (!this._l.has(t)) this._l.set(t, []); this._l.get(t).push(fn); }
+  removeEventListener(t, fn) { const a = this._l.get(t); if (a) { const i = a.indexOf(fn); if (i >= 0) a.splice(i, 1); } }
+  getBoundingClientRect() { return { left: 0, top: 0, width: VW, height: VH }; }
+  setPointerCapture() { } releasePointerCapture() { }
+  closest(sel) { const c = sel.replace('.', ''); let n = this; while (n) { if (n._cls.has(c)) return n; n = n.parentNode; } return null; }
+  querySelector(sel) {
+    const c = sel.replace('.', '');
+    const walk = (n) => { for (const k of n.children) { if (k._cls.has(c)) return k; const r = walk(k); if (r) return r; } return null; };
+    return walk(this);
+  }
+  /** how many listeners are still hooked up (dispose has to leave none) */
+  get listenerCount() { let n = 0; for (const a of this._l.values()) n += a.length; return n; }
+  fire(type, props = {}) {
+    const e = { type, target: this, cancelable: true, preventDefault() { }, stopPropagation() { }, ...props };
+    for (const fn of (this._l.get(type) || []).slice()) fn(e);
+    return e;
+  }
+}
+
+class MO {
+  constructor(cb) { this.cb = cb; this.t = null; }
+  observe(el) { this.t = el; el._obs.push(this.cb); }
+  disconnect() { if (this.t) this.t._obs = this.t._obs.filter((f) => f !== this.cb); }
+}
+
+const doc = { createElement: (t) => new Elem(t) };
+const makeWin = ({ search = '', maxTouchPoints = 0, coarse = false } = {}) => ({
+  location: { search }, navigator: { maxTouchPoints }, MutationObserver: MO, document: doc,
+  matchMedia: (q) => ({ matches: !!coarse && /coarse/.test(String(q)) }),
+  addEventListener() { }, removeEventListener() { },
+});
+/** a race root with the .race-hud host and the item slot hud.js owns */
+const makeRoot = () => {
+  const root = new Elem('div'); root.className = 'race-root';
+  const hud = new Elem('div'); hud.className = 'race-hud'; root.appendChild(hud);
+  const slot = new Elem('div'); slot.className = 'rh-item'; hud.appendChild(slot);
+  return { root, hud, slot };
+};
+
+// the clock the hold test drives by hand
+const realNow = Date.now;
+let clock = 1600000000000;
+Date.now = () => clock;
+const tick = (ms) => { clock += ms; };
+/** input.js eases DIGITAL steer against performance.now(), which is not stubbed, so the
+ *  merge test spends real milliseconds to let that easing land. Nothing else waits. */
+const settle = (input, ms = 800) => {
+  const t0 = performance.now();
+  let r = input.read();
+  while (performance.now() - t0 < ms) r = input.read();
+  return r;
+};
+
+/* ---- 1. the steering curve ---------------------------------------------- */
+{
+  ok(steerFromDx(0) === 0 && steerFromDx(STEER_DEAD_PX) === 0 && steerFromDx(-STEER_DEAD_PX) === 0, 'a thumb inside the dead zone is not a turn');
+  ok(steerFromDx(STEER_LOCK_PX) === 1 && steerFromDx(-STEER_LOCK_PX) === -1, 'full lock at +-' + STEER_LOCK_PX + ' px');
+  ok(steerFromDx(999) === 1 && steerFromDx(-999) === -1, 'and it never passes 1');
+  ok(steerFromDx(-40) < 0 && steerFromDx(40) > 0, 'left is left and right is right (no flip, Law II)');
+  const half = STEER_DEAD_PX + (STEER_LOCK_PX - STEER_DEAD_PX) / 2;
+  ok(near(steerFromDx(half), 0.5), 'the ramp between the dead zone and the lock is linear');
+}
+
+/* ---- 2. who gets a layer at all ----------------------------------------- */
+{
+  ok(wantsTouch(makeWin({ maxTouchPoints: 5 })) === true, 'a page with touch points is touchable');
+  ok(wantsTouch(makeWin({ coarse: true })) === true, 'so is a coarse pointer');
+  ok(wantsTouch(makeWin({})) === false, 'a mouse desktop is not');
+  ok(wantsTouch(makeWin({ search: '?touch=1' })) === true, '?touch=1 forces the layer on (the screenshot aid)');
+  ok(wantsTouch(makeWin({ search: '?touch=0', maxTouchPoints: 5, coarse: true })) === false, '?touch=0 forces it off on a phone');
+  const { root } = makeRoot();
+  ok(createTouch({ root, win: makeWin({}), doc }) === null, 'and a mouse desktop builds not one node');
+}
+
+/* ---- 3. the layer it does build ----------------------------------------- */
+const built = (() => {
+  const { root, hud, slot } = makeRoot();
+  const t = createTouch({ root, win: makeWin({ coarse: true }), doc });
+  return { root, hud, slot, t };
+})();
+{
+  const { hud, t } = built;
+  ok(!!t && t.el && t.el.classList.contains('rh-touch'), 'a touchable page gets the .rh-touch layer');
+  ok(hud.children.some((c) => c === t.el), 'built inside .race-hud, so it inherits the safe insets');
+  ok(!!t.el.querySelector('.rt-pad') && !!t.el.querySelector('.rt-ring') && !!t.el.querySelector('.rt-dot'), 'with a thumb pad: a ring and a dot');
+}
+
+/* ---- 4. steering: the left 55% ------------------------------------------ */
+{
+  const { t } = built;
+  const L = t.el;
+  L.fire('pointerdown', { pointerId: 1, clientX: 100, clientY: 300 });
+  ok(L.classList.contains('is-steering'), 'a thumb down on the left shows the pad');
+  ok(t.read().steer === 0, 'and starts at zero, wherever it landed');
+  L.fire('pointermove', { pointerId: 1, clientX: 100 + STEER_LOCK_PX, clientY: 300 });
+  ok(t.read().steer === 1, 'dragging a full lock right reads +1');
+  L.fire('pointermove', { pointerId: 1, clientX: 100 - 999, clientY: 300 });
+  ok(t.read().steer === -1, 'and a long drag left is clamped to -1, never past it');
+  L.fire('pointermove', { pointerId: 1, clientX: 100 + STEER_DEAD_PX - 1, clientY: 300 });
+  ok(t.read().steer === 0, 'back inside the dead zone is straight again');
+  L.fire('pointerup', { pointerId: 1, clientX: 160, clientY: 300 });
+  ok(t.read().steer === 0 && !L.classList.contains('is-steering'), 'released is zero and the pad fades');
+  ok(t.read().jump === false, 'a left-zone press is never a jump');
+}
+
+/* ---- 5. the right zone: tap jumps, hold drifts --------------------------- */
+{
+  const { t } = built;
+  const L = t.el, X = 700;   // right of STEER_SIDE * 800
+  L.fire('pointerdown', { pointerId: 2, clientX: X, clientY: 300 });
+  ok(t.read().jump === false && t.read().drift === false, 'a fresh press is neither yet');
+  tick(TAP_MS - 40);
+  ok(t.read().drift === false, 'still inside the tap window, still not a drift');
+  L.fire('pointerup', { pointerId: 2, clientX: X + 2, clientY: 301 });
+  const r = t.read();
+  ok(r.jump === true, 'a short still tap is one jump press');
+  ok(t.read().jump === false, 'and exactly one: the next read is clean (the JUMP_KEY rule)');
+  ok(r.steer === 0, 'a right-zone tap never steers');
+
+  L.fire('pointerdown', { pointerId: 3, clientX: X, clientY: 300 });
+  tick(TAP_MS);
+  ok(t.read().drift === true, 'held past ' + TAP_MS + ' ms it becomes a drift, with no move event needed');
+  L.fire('pointerup', { pointerId: 3, clientX: X, clientY: 300 });
+  ok(t.read().drift === false && t.read().jump === false, 'letting a drift go is not a jump');
+
+  L.fire('pointerdown', { pointerId: 4, clientX: X, clientY: 300 });
+  L.fire('pointermove', { pointerId: 4, clientX: X + TAP_PX + 6, clientY: 300 });
+  ok(t.read().drift === true, 'a press that travels is a drift at once, however short');
+  L.fire('pointerup', { pointerId: 4, clientX: X + TAP_PX + 6, clientY: 300 });
+  ok(t.read().jump === false, 'and never a jump');
+
+  L.fire('pointerdown', { pointerId: 5, clientX: X, clientY: 300 });
+  L.fire('pointercancel', { pointerId: 5, clientX: X, clientY: 300 });
+  ok(t.read().jump === false, 'a cancelled press (a call, a system gesture) is no press at all');
+}
+
+/* ---- 6. both thumbs at once --------------------------------------------- */
+{
+  const { t } = built;
+  const L = t.el;
+  L.fire('pointerdown', { pointerId: 10, clientX: 120, clientY: 300 });
+  L.fire('pointermove', { pointerId: 10, clientX: 120 - STEER_LOCK_PX, clientY: 300 });
+  L.fire('pointerdown', { pointerId: 11, clientX: 700, clientY: 300 });
+  tick(TAP_MS);
+  const r = t.read();
+  ok(r.steer === -1 && r.drift === true, 'one thumb steers while the other drifts: the two zones do not fight');
+  t.flush();
+  const f = t.read();
+  ok(f.steer === 0 && f.drift === false && f.jump === false, 'flush() drops everything the thumbs were holding');
+}
+
+/* ---- 8. dispose leaves nothing behind ----------------------------------- */
+{
+  const { root, hud, slot } = makeRoot();
+  const t = createTouch({ root, win: makeWin({ coarse: true }), doc });
+  const layer = t.el;
+  t.dispose();
+  ok(layer.parentNode === null && !hud.children.includes(layer), 'dispose() takes the layer out of the page');
+  ok(layer.listenerCount === 0, 'and unhooks every pointer listener');
+  slot.classList.add('is-held');   // the observer is gone: this must not throw
+  ok(true, 'and disconnects the slot observer');
+}
+
+/* ---- 9. THE MERGE: input.js reads all three sources ---------------------- */
+{
+  const win = makeWin({ coarse: true });
+  const prevWindow = globalThis.window;
+  globalThis.window = win;                       // createTouch's default win/doc
+  const { root } = makeRoot();
+  const target = new Elem('div');                // stands in for the key target
+  const input = createInput({ target, root });
+  const L = input.touchEl;
+  ok(!!L, 'createInput({ root }) builds the touch layer on a touchable page');
+
+  // the thumb alone
+  L.fire('pointerdown', { pointerId: 1, clientX: 100, clientY: 300 });
+  L.fire('pointermove', { pointerId: 1, clientX: 100 - STEER_LOCK_PX, clientY: 300 });
+  let r = input.read();
+  ok(r.steer === -1, 'a thumb at full lock reaches read().steer with no easing (it is analog)');
+  ok(r.accel === 1 && r.brake === 0, 'and accel is still cruise: the phone never touches the pedals');
+
+  // a key the other way loses to the bigger magnitude, and wins when it is bigger
+  L.fire('pointermove', { pointerId: 1, clientX: 100 - 12, clientY: 300 });   // a barely-left thumb
+  target.fire('keydown', { code: 'ArrowRight', type: 'keydown' });
+  r = settle(input);
+  ok(r.steer > 0.9, 'a full key beats a barely-held thumb: steer takes the larger magnitude, never a remap');
+  // a digital key is magnitude 1, so a thumb can only take it back once the key is up
+  target.fire('keyup', { code: 'ArrowRight', type: 'keyup' });
+  L.fire('pointermove', { pointerId: 1, clientX: 100 - STEER_LOCK_PX, clientY: 300 });
+  ok(input.read().steer === -1, 'and with the key up the thumb takes it straight back, unsmoothed');
+
+  // drift is an OR
+  L.fire('pointerup', { pointerId: 1, clientX: 88, clientY: 300 });
+  L.fire('pointerdown', { pointerId: 2, clientX: 700, clientY: 300 });
+  tick(TAP_MS);
+  ok(input.read().drift === true, 'a held right thumb drifts through the merge');
+  target.fire('keydown', { code: 'ShiftLeft', type: 'keydown' });
+  ok(input.read().drift === true, 'and Shift on top of it is still one drift (an OR)');
+  target.fire('keyup', { code: 'ShiftLeft', type: 'keyup' });
+  L.fire('pointerup', { pointerId: 2, clientX: 700, clientY: 300 });
+
+  // the jump edge survives the merge, once
+  L.fire('pointerdown', { pointerId: 3, clientX: 700, clientY: 300 });
+  tick(20);
+  L.fire('pointerup', { pointerId: 3, clientX: 700, clientY: 300 });
+  ok(input.read().jump === true, 'a tap raises read().jump');
+  ok(input.read().jump === false, 'for exactly one frame, like Space');
+
+  // flush() and dispose() reach the touch source too
+  L.fire('pointerdown', { pointerId: 4, clientX: 100, clientY: 300 });
+  L.fire('pointermove', { pointerId: 4, clientX: 300, clientY: 300 });
+  input.flush();
+  // the thumb is dropped at once; the eased value then falls to a hard zero the way a
+  // released key's already does (flush has never reset the easing, for keys either)
+  ok(settle(input).steer === 0, 'input.flush() clears a thumb still on the glass');
+  input.dispose();
+  ok(L.parentNode === null, 'input.dispose() takes the layer with it');
+
+  globalThis.window = prevWindow;
+}
+
+/* ---- 10. and a mouse desktop is untouched -------------------------------- */
+{
+  const prevWindow = globalThis.window;
+  globalThis.window = makeWin({});               // no touch points, no coarse pointer
+  const { root, hud } = makeRoot();
+  const input = createInput({ target: new Elem('div'), root });
+  ok(input.touchEl === null, 'a mouse desktop gets no touch layer from createInput');
+  ok(hud.children.length === 1, 'and not one extra node in .race-hud (the WebView2 build stays identical)');
+  const r = input.read();
+  ok(r.steer === 0 && r.accel === 1 && r.drift === false && r.jump === false, 'and read() is exactly what it was');
+  input.dispose();
+  globalThis.window = prevWindow;
+}
+
+Date.now = realNow;
+console.log(fails ? '\n' + fails + ' FAILED' : '\nall touch checks pass');
+process.exit(fails ? 1 : 0);

--- a/ConditioningControlPanel/Resources/web/dtrh/race/touch.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/touch.js
@@ -1,0 +1,186 @@
+/* ============================================================================
+ * race/touch.js - the phone's hands. A THIRD input source for race/input.js.
+ *
+ * Law II (input honesty) says nothing may remap an axis and no mirror/flip API
+ * may exist. This file adds neither: it is a new source that produces the same
+ * steer / drift / jump a key or a stick produces, and race/input.js merges it
+ * with the other two (max of magnitudes for steer, OR for drift, one press per
+ * tap for jump). Left stays left.
+ *
+ *   createTouch({ root }) -> null on a mouse desktop, else
+ *     { el, read(), flush(), dispose() }
+ *   read() -> { steer:-1..1, drift:bool, jump:bool }   (jump is one frame, one tap)
+ *
+ * Nothing is built unless the page is actually touchable: `(pointer: coarse)`
+ * or `navigator.maxTouchPoints > 0`. `?touch=1` forces the layer on (the
+ * headless screenshot aid), `?touch=0` forces it off. A mouse desktop and the
+ * WebView2 desktop build therefore get not one node of this.
+ *
+ * The layer rides at z12 inside `.race-hud`: above the chrome (z3) and the
+ * payload layers (z4 / z9), BELOW the Brake and End screens (z20), the
+ * countdown (z21), the menu (z25), the cards (z26) and the boot splash (z30),
+ * so every card and screen still takes the tap first and needs no cooperation
+ * from here.
+ *
+ * The hands:
+ *   LEFT 55%   steering. Drag horizontally from wherever the thumb lands: full
+ *              lock at +-STEER_LOCK_PX, nothing inside STEER_DEAD_PX, zero the
+ *              moment the thumb lifts. A ring marks the touch-down point and a
+ *              dot rides the drag, so the player can see the wheel they are on.
+ *   RIGHT      a TAP (under TAP_MS, under TAP_PX of travel) is one jump press,
+ *              exactly like Space. Anything longer or further is DRIFT, held
+ *              for as long as the thumb stays down. Accel is untouched: nothing
+ *              pressed is cruise, and a phone never needs the brake pedal.
+ *   BUTTONS    pause, mute and use are a sibling pass (feat/race-w2b-touch-hud):
+ *              they hang off this same layer and fire the ACTIONS input.js
+ *              already routes, so nothing below has to change to take them.
+ *
+ * Pointer Events only, never TouchEvent, and the pointer is captured so a drag
+ * that wanders off the zone still belongs to the finger that started it.
+ * ==========================================================================*/
+
+/** Full steering lock, css px of horizontal drag from the touch-down point. */
+export const STEER_LOCK_PX = 72;
+/** Dead zone: a thumb resting on the glass is not a turn. */
+export const STEER_DEAD_PX = 6;
+/** A press shorter than this, and stiller than TAP_PX, is a jump; longer is a drift. */
+export const TAP_MS = 180;
+export const TAP_PX = 12;
+/** The left fraction of the width that steers. The rest jumps and drifts. */
+export const STEER_SIDE = 0.55;
+
+const clamp = (v, a, b) => Math.max(a, Math.min(b, v));
+
+/** The steering curve, pulled out so race/smoke/touch-check.mjs can walk it. */
+export function steerFromDx(dx, lock = STEER_LOCK_PX, dead = STEER_DEAD_PX) {
+  const m = Math.abs(dx);
+  if (!(m > dead)) return 0;
+  const v = Math.min(1, (m - dead) / Math.max(1, lock - dead));
+  return dx < 0 ? -v : v;
+}
+
+/** Should this page build the layer at all? `?touch=1` / `?touch=0` override the device. */
+export function wantsTouch(win) {
+  const w = win || (typeof window !== 'undefined' ? window : null);
+  if (!w) return false;
+  try {
+    const q = new URLSearchParams(w.location.search).get('touch');
+    if (q === '1' || q === 'on') return true;
+    if (q === '0' || q === 'off') return false;
+  } catch (e) { /* no location, or a page that hides it: fall through to the device test */ }
+  const nav = w.navigator;
+  if (nav && typeof nav.maxTouchPoints === 'number' && nav.maxTouchPoints > 0) return true;
+  try { return !!(typeof w.matchMedia === 'function' && w.matchMedia('(pointer: coarse)').matches); }
+  catch (e) { return false; }
+}
+
+export function createTouch({ root = null, win = null, doc = null } = {}) {
+  const w = win || (typeof window !== 'undefined' ? window : null);
+  const d = doc || (w && w.document) || null;
+  if (!root || !d || !wantsTouch(w)) return null;
+
+  const host = root.querySelector('.race-hud') || root;
+  const mk = (cls, parent, text) => {
+    const n = d.createElement('div');
+    n.className = cls;
+    if (text != null) n.textContent = text;
+    parent.appendChild(n);
+    return n;
+  };
+  const layer = mk('rh-touch', host);
+  const pad = mk('rt-pad', layer);
+  mk('rt-ring', pad);
+  const dot = mk('rt-dot', pad);
+
+  const out = { steer: 0, drift: false, jump: false };
+  let steerId = -1, steerX0 = 0, steer = 0;
+  let actId = -1, actT0 = 0, actX0 = 0, actY0 = 0, actMoved = false;
+  let jumpQ = false, disposed = false;
+
+  const at = (e) => {
+    const r = layer.getBoundingClientRect();
+    return { x: e.clientX - r.left, y: e.clientY - r.top, w: r.width || 1 };
+  };
+  const showPad = (x, y) => {
+    pad.style.left = x + 'px'; pad.style.top = y + 'px';
+    dot.style.transform = 'translate(0px, 0px)';
+    layer.classList.add('is-steering');
+  };
+
+  function onDown(e) {
+    if (disposed) return;
+    const p = at(e);
+    if (p.x < p.w * STEER_SIDE) {
+      if (steerId >= 0) return;
+      steerId = e.pointerId; steerX0 = e.clientX; steer = 0;
+      showPad(p.x, p.y);
+    } else {
+      if (actId >= 0) return;
+      actId = e.pointerId; actT0 = Date.now(); actX0 = e.clientX; actY0 = e.clientY; actMoved = false;
+    }
+    try { layer.setPointerCapture(e.pointerId); } catch (err) { /* no capture: the listeners still fire */ }
+    if (e.cancelable) e.preventDefault();
+  }
+
+  function onMove(e) {
+    if (disposed) return;
+    if (e.pointerId === steerId) {
+      const dx = e.clientX - steerX0;
+      steer = steerFromDx(dx);
+      dot.style.transform = 'translate(' + clamp(dx, -STEER_LOCK_PX, STEER_LOCK_PX) + 'px, 0px)';
+    } else if (e.pointerId === actId) {
+      if (Math.abs(e.clientX - actX0) > TAP_PX || Math.abs(e.clientY - actY0) > TAP_PX) actMoved = true;
+    } else return;
+    if (e.cancelable) e.preventDefault();
+  }
+
+  function onUp(e) {
+    if (disposed) return;
+    if (e.pointerId === steerId) {
+      steerId = -1; steer = 0;
+      layer.classList.remove('is-steering');
+    } else if (e.pointerId === actId) {
+      // a tap is one jump press; a cancel (a call, a system gesture) is no press at all
+      if (e.type === 'pointerup' && !actMoved && Date.now() - actT0 < TAP_MS) jumpQ = true;
+      actId = -1;
+    } else return;
+    try { layer.releasePointerCapture(e.pointerId); } catch (err) { /* already gone */ }
+  }
+
+  const noMenu = (e) => { if (e.cancelable) e.preventDefault(); };   // no long-press menu over the road
+  layer.addEventListener('pointerdown', onDown);
+  layer.addEventListener('pointermove', onMove);
+  layer.addEventListener('pointerup', onUp);
+  layer.addEventListener('pointercancel', onUp);
+  layer.addEventListener('contextmenu', noMenu);
+
+  /** Drift is decided here, not in a handler: a thumb held perfectly still sends no
+   *  move event, and the hold still has to become a drift on its own. */
+  function read() {
+    out.steer = clamp(steer, -1, 1);
+    out.drift = actId >= 0 && (actMoved || Date.now() - actT0 >= TAP_MS);
+    out.jump = jumpQ; jumpQ = false;
+    return out;
+  }
+
+  function flush() {
+    steerId = -1; actId = -1; steer = 0; jumpQ = false; actMoved = false;
+    layer.classList.remove('is-steering');
+  }
+
+  function dispose() {
+    disposed = true;
+    layer.removeEventListener('pointerdown', onDown);
+    layer.removeEventListener('pointermove', onMove);
+    layer.removeEventListener('pointerup', onUp);
+    layer.removeEventListener('pointercancel', onUp);
+    layer.removeEventListener('contextmenu', noMenu);
+    if (layer.parentNode) layer.parentNode.removeChild(layer);
+    flush();
+  }
+
+  return { el: layer, read, flush, dispose };
+}
+
+// self-check: node --check is the bar (window/navigator/document are only touched inside
+// wantsTouch and createTouch, so race/smoke/touch-check.mjs can import this file in node).


### PR DESCRIPTION
New race/touch.js: a pointer-events layer created only on coarse pointers or touch devices (?touch=1/0 overrides). Left 55 percent steers by drag from the touch-down point (6px dead, 72px lock) with a ring-and-dot pad; right side taps to jump and holds to drift. input.js merges it as a third source (max magnitude for steer, OR for drift, edges for jump) with no axis remap; flush and dispose reach it. race/consts.js and kart.js untouched.

Verified: touch-check smoke (57 assertions), headless via the DevTools protocol at a true 390x844 with synthetic touches steering the kart; desktop 1280x720 without touch has no layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0166ij3Q8xyseVkhWajzkWG3
