### PR TITLE
race: touch controls, part 2 - pause, mute and the use button

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
@@ -326,9 +326,9 @@ As built (PR 5 reality notes):
   (55%) of the width steers by horizontal drag from the touch-down point (`STEER_DEAD_PX` 6 dead,
   `STEER_LOCK_PX` 72 to full lock, zero on release, a ring-and-dot thumb pad while held); the rest of the
   width taps (under `TAP_MS` 180 and `TAP_PX` 12 of travel) for one jump press and holds for drift.
-  Accel is never touched: nothing pressed is cruise, and there is no brake pedal on glass. The pause /
-  mute / use buttons that hang off the same layer are the sibling pass. Pointer Events only, never
-  TouchEvent.
+  Accel is never touched: nothing pressed is cruise, and there is no brake pedal on glass. Three buttons
+  fire existing actions through `input.onAction`: pause (`'brake'`), mute (`'mute'`) and a use button
+  (`'item'`) that only appears while `.rh-item` carries `is-held`. Pointer Events only, never TouchEvent.
 - Space (pad B) is the jump: `read().jump` is true for exactly the frame of a fresh press, never on hold,
   and `kart.stepJump` turns it into 1.1 m of real height (`state.h`, so the pop box goes up with it).
   A press within 4 m of a ramp lip, or inside 0.12 s of one firing, boosts that launch by 1.3 and hands

--- a/ConditioningControlPanel/Resources/web/dtrh/race/hud.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/hud.js
@@ -12,9 +12,10 @@
  * lies for 450 ms, the ledger never does (Law I). The Brake and the End card
  * are the chrome's own pointer targets; since the touch pass they are no longer
  * the page's only ones, because race/touch.js adds .rh-touch at z12 (the thumb
- * pad, and its buttons in the sibling pass) on a touchable page. It rides BELOW
+ * pad and its pause / mute / use buttons) on a touchable page. It rides BELOW
  * the screens at z20, so a card still takes the tap first and nothing here has
- * to cooperate. Copy is DtRH voice: lowercase, short.
+ * to cooperate. The item button watches this file's `is-held` class on the slot.
+ * Copy is DtRH voice: lowercase, short.
  *
  * THE PICKUP (pass f3): a cube gives its item a card of its own, centre of the
  * view just above the cup. It rolls a `?` while items.js rolls, flips to the

--- a/ConditioningControlPanel/Resources/web/dtrh/race/input.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/input.js
@@ -7,7 +7,7 @@
  * Gamepad (navigator.getGamepads, standard map): left stick steer, RT accel,
  * LT brake, A drift, B jump, X item, Start brake.
  * Touch (race/touch.js, only on a touchable page): the left half drags the wheel,
- * the right half taps to jump and holds to drift.
+ * the right half taps to jump and holds to drift, plus pause / mute / use buttons.
  * `createInput({ root })` needs the race root or the touch layer is never built.
  *
  *   read() -> { steer:-1..1, accel:0..1, brake:0..1, drift:bool, jump:bool }
@@ -75,7 +75,7 @@ export function createInput({ target = window, root = null } = {}) {
   const fire = (name) => { for (const cb of acts) { try { cb(name); } catch (e) { /* a listener never breaks the wheel */ } } };
 
   /** The third source. null on a mouse desktop: not one node is built there. */
-  const touch = createTouch({ root });
+  const touch = createTouch({ root, fire: (name) => fire(name) });
 
   function onKey(e) {
     if (disposed || e.altKey || e.metaKey || e.ctrlKey) return;

--- a/ConditioningControlPanel/Resources/web/dtrh/race/race.css
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/race.css
@@ -351,7 +351,7 @@
    payload layers (z4 / z9) and BELOW the Brake and End screens (z20), the
    countdown (z21), the menu (z25), the cards (z26) and the splash (z30), so
    every card still takes the tap first. Left 55% steers, the rest jumps and
-   drifts; the pause / mute / use buttons are a sibling pass. */
+   drifts; the buttons ride the same --rh-in-* safe insets as the chrome. */
 .race-hud .rh-touch {
   position: fixed; inset: 0; z-index: 12; touch-action: none; overscroll-behavior: none;
   -webkit-user-select: none; user-select: none; -webkit-tap-highlight-color: transparent;
@@ -372,6 +372,32 @@
   background: rgba(255, 105, 180, 0.5); border: 2px solid rgba(255, 255, 255, 0.82);
   box-shadow: 0 0 16px rgba(255, 105, 180, 0.7);
 }
+/* the buttons: 48 px of glass minimum, lowercase, no image files */
+.race-hud .rt-btn {
+  position: absolute; min-width: 48px; min-height: 48px; padding: 0 12px; border-radius: 14px;
+  display: grid; place-items: center; cursor: pointer; font-family: inherit;
+  font-size: 0.86rem; font-weight: 900; letter-spacing: 0.1em; line-height: 1; color: #ffd6ea;
+  background: rgba(8, 4, 14, 0.58); border: 1px solid rgba(255, 105, 180, 0.55);
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.42);
+  transition: transform 0.12s, background 0.2s, opacity 0.2s;
+}
+.race-hud .rt-btn:active { transform: scale(0.94); background: rgba(255, 105, 180, 0.32); }
+.race-hud .rt-pause { top: var(--rh-in-t); right: var(--rh-in-r); font-size: 1.05rem; letter-spacing: 0.16em; }
+.race-hud .rt-mute { top: var(--rh-in-t); right: calc(var(--rh-in-r) + 58px); font-size: 0.66rem; }
+/* the item button clears the speed gauge (bottom-right) and only shows while the
+   slot is `is-held`; it pulses the way the slot's ring does, so they read as one thing */
+.race-hud .rt-item {
+  right: var(--rh-in-r); bottom: calc(var(--rh-in-b) + 78px);
+  min-width: 64px; min-height: 64px; border-radius: 18px; font-size: 0.78rem;
+  opacity: 0; pointer-events: none; border-color: rgba(255, 214, 234, 0.9); color: #fff;
+  background: rgba(255, 105, 180, 0.3);
+}
+.race-hud .rt-item.is-on { opacity: 1; pointer-events: auto; animation: rtPulse 1.7s ease-in-out infinite; }
+@keyframes rtPulse {
+  0%, 100% { box-shadow: 0 6px 20px rgba(0, 0, 0, 0.42), 0 0 0 rgba(255, 105, 180, 0); }
+  50% { box-shadow: 0 6px 20px rgba(0, 0, 0, 0.42), 0 0 24px rgba(255, 105, 180, 0.85); }
+}
+
 /* ---- motion ---- */
 @keyframes rhThud { 0% { transform: scale(1); } 20% { transform: scale(1.32); } 60% { transform: scale(0.92); } 100% { transform: scale(1); } }
 @keyframes rhPulse { 0% { transform: scale(1); } 30% { transform: scale(1.4); } 100% { transform: scale(1); } }
@@ -416,6 +442,7 @@
   .race-hud .rh-token { transition: opacity 0.12s; }
   .race-hud .rh-count.is-on { animation: rhFade 0.45s linear forwards; }
   .race-hud .rh-screen.is-beside .rh-card { animation: none; }
+  .race-hud .rt-item.is-on { animation: none; }
   .race-hud .rh-strobe.is-on, .race-hud .rh-chip.is-in, .race-hud .rh-chip.is-bump, .race-hud .rh-chip-glyph.is-kick, .race-hud .rh-mixer-recipe.is-served { animation: none; }
   /* the pickup card never flies: it fades where it stands and the slot lights up at once */
   .race-hud .rh-pickup { transition: opacity 0.14s linear; }

--- a/ConditioningControlPanel/Resources/web/dtrh/race/smoke/touch-check.mjs
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/smoke/touch-check.mjs
@@ -124,14 +124,18 @@ const settle = (input, ms = 800) => {
 /* ---- 3. the layer it does build ----------------------------------------- */
 const built = (() => {
   const { root, hud, slot } = makeRoot();
-  const t = createTouch({ root, win: makeWin({ coarse: true }), doc });
-  return { root, hud, slot, t };
+  const acts = [];
+  const t = createTouch({ root, win: makeWin({ coarse: true }), doc, fire: (n) => acts.push(n) });
+  return { root, hud, slot, acts, t };
 })();
 {
   const { hud, t } = built;
   ok(!!t && t.el && t.el.classList.contains('rh-touch'), 'a touchable page gets the .rh-touch layer');
   ok(hud.children.some((c) => c === t.el), 'built inside .race-hud, so it inherits the safe insets');
   ok(!!t.el.querySelector('.rt-pad') && !!t.el.querySelector('.rt-ring') && !!t.el.querySelector('.rt-dot'), 'with a thumb pad: a ring and a dot');
+  const btns = t.el.children.filter((c) => c._cls.has('rt-btn'));
+  ok(btns.length === 3, 'and three buttons: pause, mute, use');
+  ok(btns.every((b) => b.tagName === 'BUTTON' && b.attrs['aria-label']), 'every button is a real <button> with a label');
 }
 
 /* ---- 4. steering: the left 55% ------------------------------------------ */
@@ -198,6 +202,29 @@ const built = (() => {
   ok(f.steer === 0 && f.drift === false && f.jump === false, 'flush() drops everything the thumbs were holding');
 }
 
+/* ---- 7. the buttons and the item gate ----------------------------------- */
+{
+  const { t, slot, acts } = built;
+  const byLabel = (l) => t.el.children.find((c) => c.attrs['aria-label'] === l);
+  acts.length = 0;
+  byLabel('brake').fire('pointerdown', { pointerId: 20 });
+  byLabel('mute').fire('pointerdown', { pointerId: 21 });
+  byLabel('use item').fire('pointerdown', { pointerId: 22 });
+  ok(acts.join(',') === 'brake,mute,item', 'the three buttons fire the actions input.js already routes');
+
+  const use = byLabel('use item');
+  ok(!use.classList.contains('is-on'), 'the use button is hidden while the slot is empty');
+  slot.classList.add('is-held');
+  ok(use.classList.contains('is-on'), 'and appears the moment hud.js marks the slot is-held');
+  slot.classList.remove('is-held');
+  ok(!use.classList.contains('is-on'), 'and goes again when the item is spent');
+
+  // a press that lands on a button must not also start a turn on the layer under it
+  t.flush();
+  t.el.fire('pointerdown', { pointerId: 23, clientX: 40, clientY: 40, target: byLabel('brake') });
+  ok(t.read().steer === 0 && !t.el.classList.contains('is-steering'), 'a press on a button never doubles as a steer');
+}
+
 /* ---- 8. dispose leaves nothing behind ----------------------------------- */
 {
   const { root, hud, slot } = makeRoot();
@@ -217,7 +244,9 @@ const built = (() => {
   globalThis.window = win;                       // createTouch's default win/doc
   const { root } = makeRoot();
   const target = new Elem('div');                // stands in for the key target
+  const seen = [];
   const input = createInput({ target, root });
+  input.onAction((a) => seen.push(a));
   const L = input.touchEl;
   ok(!!L, 'createInput({ root }) builds the touch layer on a touchable page');
 
@@ -254,6 +283,14 @@ const built = (() => {
   L.fire('pointerup', { pointerId: 3, clientX: 700, clientY: 300 });
   ok(input.read().jump === true, 'a tap raises read().jump');
   ok(input.read().jump === false, 'for exactly one frame, like Space');
+
+  // the buttons reach the same onAction run.js and audio.js already listen on
+  const btn = (l) => L.children.find((c) => c.attrs['aria-label'] === l);
+  seen.length = 0;
+  btn('brake').fire('pointerdown', { pointerId: 30 });
+  btn('use item').fire('pointerdown', { pointerId: 31 });
+  btn('mute').fire('pointerdown', { pointerId: 32 });
+  ok(seen.join(',') === 'brake,item,mute', 'pause / use / mute arrive as the existing brake / item / mute actions');
 
   // flush() and dispose() reach the touch source too
   L.fire('pointerdown', { pointerId: 4, clientX: 100, clientY: 300 });

--- a/ConditioningControlPanel/Resources/web/dtrh/race/touch.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/touch.js
@@ -7,7 +7,7 @@
  * with the other two (max of magnitudes for steer, OR for drift, one press per
  * tap for jump). Left stays left.
  *
- *   createTouch({ root }) -> null on a mouse desktop, else
+ *   createTouch({ root, fire }) -> null on a mouse desktop, else
  *     { el, read(), flush(), dispose() }
  *   read() -> { steer:-1..1, drift:bool, jump:bool }   (jump is one frame, one tap)
  *
@@ -31,9 +31,10 @@
  *              exactly like Space. Anything longer or further is DRIFT, held
  *              for as long as the thumb stays down. Accel is untouched: nothing
  *              pressed is cruise, and a phone never needs the brake pedal.
- *   BUTTONS    pause, mute and use are a sibling pass (feat/race-w2b-touch-hud):
- *              they hang off this same layer and fire the ACTIONS input.js
- *              already routes, so nothing below has to change to take them.
+ *   BUTTONS    pause (fires 'brake', which opens the Brake screen and its own
+ *              tappable buttons), mute, and an item button that only appears
+ *              while the slot is `is-held`. 48 px minimum, anchored on the
+ *              existing --rh-in-* safe-area insets.
  *
  * Pointer Events only, never TouchEvent, and the pointer is captured so a drag
  * that wanders off the zone still belongs to the finger that started it.
@@ -74,7 +75,7 @@ export function wantsTouch(win) {
   catch (e) { return false; }
 }
 
-export function createTouch({ root = null, win = null, doc = null } = {}) {
+export function createTouch({ root = null, fire = () => {}, win = null, doc = null } = {}) {
   const w = win || (typeof window !== 'undefined' ? window : null);
   const d = doc || (w && w.document) || null;
   if (!root || !d || !wantsTouch(w)) return null;
@@ -91,6 +92,33 @@ export function createTouch({ root = null, win = null, doc = null } = {}) {
   const pad = mk('rt-pad', layer);
   mk('rt-ring', pad);
   const dot = mk('rt-dot', pad);
+
+  const button = (cls, glyph, label, action) => {
+    const b = d.createElement('button');
+    b.type = 'button';
+    b.className = 'rt-btn ' + cls;
+    b.textContent = glyph;
+    b.setAttribute('aria-label', label);
+    // pointerdown, not click: on glass the press IS the answer, and waiting for a
+    // synthesised click reads as a dropped tap.
+    b.addEventListener('pointerdown', (e) => { if (e.cancelable) e.preventDefault(); e.stopPropagation(); fire(action); });
+    layer.appendChild(b);
+    return b;
+  };
+  button('rt-pause', 'II', 'brake', 'brake');
+  button('rt-mute', 'sound', 'mute', 'mute');
+  const itemBtn = button('rt-item', 'use', 'use item', 'item');
+
+  // the item button only exists while there is something to spend: the slot already
+  // carries `is-held` (race/hud.js), so watch that rather than invent a second truth
+  const slot = root.querySelector('.rh-item');
+  const syncItem = () => itemBtn.classList.toggle('is-on', !!(slot && slot.classList.contains('is-held')));
+  let mo = null;
+  if (slot && w && typeof w.MutationObserver === 'function') {
+    mo = new w.MutationObserver(syncItem);
+    mo.observe(slot, { attributes: true, attributeFilter: ['class'] });
+  }
+  syncItem();
 
   const out = { steer: 0, drift: false, jump: false };
   let steerId = -1, steerX0 = 0, steer = 0;
@@ -109,6 +137,8 @@ export function createTouch({ root = null, win = null, doc = null } = {}) {
 
   function onDown(e) {
     if (disposed) return;
+    const t = e.target;
+    if (t && typeof t.closest === 'function' && t.closest('.rt-btn')) return;   // the buttons speak for themselves
     const p = at(e);
     if (p.x < p.w * STEER_SIDE) {
       if (steerId >= 0) return;
@@ -175,6 +205,7 @@ export function createTouch({ root = null, win = null, doc = null } = {}) {
     layer.removeEventListener('pointerup', onUp);
     layer.removeEventListener('pointercancel', onUp);
     layer.removeEventListener('contextmenu', noMenu);
+    if (mo) { try { mo.disconnect(); } catch (err) { /* observer already dead */ } mo = null; }
     if (layer.parentNode) layer.parentNode.removeChild(layer);
     flush();
   }


### PR DESCRIPTION
Three 44px+ buttons on the touch layer, safe-area aware: pause (fires the existing brake action, opening the Brake screen), mute, and a use button that appears with the held item (watches the slot's is-held class). Text glyphs only, no images. Doc corrections in hud.js and CONTRACT.md.

Verified: geometry asserted at 390x844 (nothing overhangs), cards and screens still take the tap first, desktop HUD pixel-unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0166ij3Q8xyseVkhWajzkWG3
