### PR TITLE
race: the menu answers a finger, and a landscape phone can reach all of it

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
@@ -393,7 +393,7 @@ are centred on their mounting plate and keep it by merging it in; shoulder props
 
 ### `race/menu.js` + `race/intro.js` (pass five, the front door)
 ```js
-createMenu({ root, renderer, pixel, audio, settings, log }) -> { show(), hide(), onPick(cb), options, stage: { update(dt), render(), dispose(), live }, dispose() }
+createMenu({ root, renderer, pixel, audio, settings, log }) -> { show(), hide(), onPick(cb), options, hideVerb(id), stage: { update(dt), render(), dispose(), live }, dispose() }
 createIntro({ stage, hud, audio, reducedMotion, log }) -> { play(): Promise, skip(), update(dt), render(), dispose() }
 cameraWhip(sec) / resultsCamera({ tier, reducedMotion }) / preRollCamera() -> fn(camera, dt, w, camOut), `false` when done
 resultTier(total, best, personalBest) -> 0..4 (the face index)
@@ -401,6 +401,15 @@ resultTier(total, best, personalBest) -> 0..4 (the face index)
 - Boot order: splash (a 1 s title flash) -> menu (the resting state) -> `race` -> intro on the menu stage -> run under the
   camera whip. `?autostart=1` skips menu and intro (the headless checks depend on it), `?intro=0` skips the intro only,
   `?scene=intro` boots straight into the intro. `surface` from the menu sends the same `exit` + `exit-done` the End screen does.
+- `surface` UNHOSTED: nothing takes the window away in a plain browser, so raceBoot picks a destination once at load.
+  `?back=<path>` wins when it resolves same origin, then a same-origin `document.referrer` (`history.back()`), and with
+  neither the boot calls `menu.hideVerb('surface')` so the verb is not on the list at all. Cross-origin values are ignored:
+  the switch is never an open redirect. `?panel=howto` (or `options`) opens the menu on that panel, a screenshot aid.
+- TOUCH: every keyboard path has a target under it. The key card carries a `back` row and a tap off the panel closes it;
+  each value row wears real `‹` / `›` buttons around the number, so music and sfx come DOWN by touch as well as up (a
+  whole-row press still steps up, the way the pad does). `.rm-col` / `.rc-col` scroll inside themselves and pad off
+  `env(safe-area-inset-*)`; `@media (max-height: 480px)` packs the seven verbs into a 390 px landscape phone and
+  `@media (pointer: coarse)` puts every verb, value arrow and roster arrow on a 44 px target.
 - The stage is a second `THREE.Scene` drawn by the race's renderer + pixelizer through `race.setStage(s)`: while set,
   `frame()` calls `s.update(dt)` + `s.render()` and the world is not drawn. `setStage(null)` retextures the world for any
   pixel block the menu changed. No second canvas.

--- a/ConditioningControlPanel/Resources/web/dtrh/race/menu.css
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/menu.css
@@ -1,14 +1,23 @@
 /* race/menu.css - the main menu of Racing Thoughts (.rm-*). Scoped under #race-root.
  * Same pixel look as the HUD: hard plates, stepped shadows, Poppins, lowercase.
  * The left column is DOM; the right side is a hole the stage shows through.
- * THE BOUNCE on press (Law VIII, inside 100 ms), THE GLOW on focus, springs never linear tweens (Law XI). */
+ * THE BOUNCE on press (Law VIII, inside 100 ms), THE GLOW on focus, springs never linear tweens (Law XI).
+ *
+ * PHONE: the column scrolls itself rather than spilling past #race-root's overflow:hidden (a landscape
+ * 844x390 used to lose the top and bottom verbs with no way to reach them), it keeps clear of the notch
+ * through env(safe-area-inset-*), a short-viewport rule packs the seven verbs into 390 px, and
+ * @media (pointer: coarse) puts every verb, value arrow and roster arrow on a 44 px target. */
 
 #race-root .rm-root {
   position: fixed; inset: 0; z-index: 25;
-  display: grid; grid-template-columns: minmax(300px, 38%) 1fr;
+  /* one row exactly the height of the screen: an auto row would grow to the content and the column
+     would spill under the clip instead of scrolling inside itself */
+  display: grid; grid-template-columns: minmax(300px, 38%) 1fr; grid-template-rows: minmax(0, 1fr);
   font-family: var(--rh-font, 'Poppins', 'Segoe UI', system-ui, sans-serif);
   color: #fff1f8; text-transform: lowercase; user-select: none;
   pointer-events: auto;
+  --rm-sa-t: env(safe-area-inset-top, 0px); --rm-sa-b: env(safe-area-inset-bottom, 0px);
+  --rm-sa-l: env(safe-area-inset-left, 0px); --rm-sa-r: env(safe-area-inset-right, 0px);
 }
 #race-root .rm-root[hidden] { display: none; }
 #race-root .rm-root.is-in .rm-col { animation: rmIn 0.42s cubic-bezier(0.2, 1.4, 0.4, 1) both; }
@@ -17,8 +26,13 @@
 
 /* ---- the column ---- */
 #race-root .rm-col {
-  display: flex; flex-direction: column; gap: 14px; justify-content: center;
-  padding: 6vh 28px 6vh 5vw; min-width: 0;
+  display: flex; flex-direction: column; gap: 14px;
+  /* `safe center` so a column taller than the screen starts at the top and scrolls, instead of
+     centring and putting the first verbs above the scrollable area where nothing can reach them */
+  justify-content: center; justify-content: safe center;
+  padding: calc(6vh + var(--rm-sa-t)) calc(28px + var(--rm-sa-r)) calc(6vh + var(--rm-sa-b)) calc(5vw + var(--rm-sa-l));
+  min-width: 0; overflow-y: auto; overscroll-behavior: contain; -webkit-overflow-scrolling: touch;
+  scrollbar-width: thin; scrollbar-color: rgba(255, 105, 180, 0.5) transparent;
   background: linear-gradient(90deg, rgba(18, 11, 36, 0.92) 0%, rgba(18, 11, 36, 0.86) 78%, rgba(18, 11, 36, 0) 100%);
 }
 #race-root .rm-title {
@@ -30,6 +44,9 @@
 
 /* ---- verbs ---- */
 #race-root .rm-list { display: flex; flex-direction: column; gap: 8px; }
+/* `display: flex` beats the UA's [hidden] rule, so open('options') and open('how') left the verbs
+   standing above the panel and pushed the panel itself off the bottom of a short screen. */
+#race-root .rm-list[hidden] { display: none; }
 #race-root .rm-btn {
   position: relative; text-align: left; font: inherit; font-size: 22px; font-weight: 700;
   padding: 10px 18px 10px 34px; border: 0; cursor: pointer;
@@ -56,9 +73,16 @@
 #race-root .rm-row.is-hit { animation: rmBounce 0.28s cubic-bezier(0.2, 1.6, 0.4, 1); }
 #race-root .rm-row.is-dim { opacity: 0.45; }
 #race-root .rm-row-val { color: #ffd6ea; font-weight: 800; font-variant-numeric: tabular-nums; }
-#race-root .rm-row.is-focus .rm-row-val::before { content: '‹ '; color: var(--pink, #ff69b4); }
-#race-root .rm-row.is-focus .rm-row-val::after { content: ' ›'; color: var(--pink, #ff69b4); }
-#race-root .rm-row[data-id="back"] .rm-row-val::before, #race-root .rm-row[data-id="back"] .rm-row-val::after { content: none; }
+/* the two arrows used to be ::before / ::after on the value: drawn, never touchable. They are real
+   buttons now, hidden until the row has focus so the resting look is the one it always had. */
+#race-root .rm-row-ctl { display: flex; align-items: center; gap: 2px; }
+#race-root .rm-row-arrow {
+  font: inherit; font-size: 16px; font-weight: 800; line-height: 1; padding: 0; border: 0;
+  min-width: 20px; align-self: stretch; cursor: pointer;
+  color: var(--pink, #ff69b4); background: none; opacity: 0; transition: opacity 0.1s;
+}
+#race-root .rm-row.is-focus .rm-row-arrow { opacity: 1; }
+#race-root .rm-row.is-dim .rm-row-arrow { cursor: default; }
 #race-root .rm-row-hint { grid-column: 1 / -1; font-size: 11px; font-weight: 500; color: rgba(255, 214, 234, 0.6); }
 #race-root .rm-seed {
   font: inherit; font-size: 16px; font-weight: 700; color: #fff; width: 160px; padding: 6px 10px;
@@ -73,6 +97,8 @@
 }
 #race-root .rm-key span { color: #ffd6ea; }
 #race-root .rm-hint { font-size: 12px; color: rgba(255, 214, 234, 0.6); margin-top: 6px; }
+/* the key card's own way out, for the hand that has no esc key */
+#race-root .rm-how-back { font-size: 17px; padding: 8px 16px 8px 30px; margin-top: 8px; align-self: flex-start; }
 #race-root .rm-btn[hidden] { display: none; }
 
 /* ---- the track plate: a file in hand, or the host still reading it ---- */
@@ -111,9 +137,13 @@
 @keyframes rmIn { from { opacity: 0; transform: translateX(-22px); } to { opacity: 1; transform: none; } }
 @keyframes rmBounce { 0% { transform: translateX(4px) scale(1); } 35% { transform: translateX(4px) scale(0.96); } 100% { transform: translateX(4px) scale(1); } }
 
+/* portrait phones: one column, the stage folds away, the notch insets stay on */
 @media (max-width: 720px) {
   #race-root .rm-root { grid-template-columns: 1fr; }
-  #race-root .rm-col { padding: 4vh 22px; background: linear-gradient(180deg, rgba(18, 11, 36, 0.94) 0%, rgba(18, 11, 36, 0.86) 70%, rgba(18, 11, 36, 0) 100%); }
+  #race-root .rm-col {
+    padding: calc(4vh + var(--rm-sa-t)) calc(22px + var(--rm-sa-r)) calc(4vh + var(--rm-sa-b)) calc(22px + var(--rm-sa-l));
+    background: linear-gradient(180deg, rgba(18, 11, 36, 0.94) 0%, rgba(18, 11, 36, 0.86) 70%, rgba(18, 11, 36, 0) 100%);
+  }
   #race-root .rm-stage { display: none; }
 }
 
@@ -130,15 +160,20 @@
    so EMI keeps the right half of the frame while the four cards read. */
 #race-root .rc-root {
   position: fixed; inset: 0; z-index: 26;
-  display: grid; grid-template-columns: minmax(300px, 38%) 1fr;
+  display: grid; grid-template-columns: minmax(300px, 38%) 1fr; grid-template-rows: minmax(0, 1fr);
   font-family: var(--rh-font, 'Poppins', 'Segoe UI', system-ui, sans-serif);
   color: #fff1f8; text-transform: lowercase; user-select: none;
   pointer-events: auto; cursor: pointer;
+  --rm-sa-t: env(safe-area-inset-top, 0px); --rm-sa-b: env(safe-area-inset-bottom, 0px);
+  --rm-sa-l: env(safe-area-inset-left, 0px); --rm-sa-r: env(safe-area-inset-right, 0px);
 }
 #race-root .rc-root[hidden] { display: none; }
 #race-root .rc-col {
-  display: flex; flex-direction: column; gap: 14px; justify-content: center;
-  padding: 6vh 28px 6vh 5vw; min-width: 0;
+  display: flex; flex-direction: column; gap: 14px;
+  justify-content: center; justify-content: safe center;
+  padding: calc(6vh + var(--rm-sa-t)) calc(28px + var(--rm-sa-r)) calc(6vh + var(--rm-sa-b)) calc(5vw + var(--rm-sa-l));
+  min-width: 0; overflow-y: auto; overscroll-behavior: contain; -webkit-overflow-scrolling: touch;
+  scrollbar-width: thin; scrollbar-color: rgba(255, 105, 180, 0.5) transparent;
   background: linear-gradient(90deg, rgba(18, 11, 36, 0.92) 0%, rgba(18, 11, 36, 0.86) 88%, rgba(18, 11, 36, 0) 100%);
 }
 #race-root .rc-deck { display: flex; flex-direction: column; min-height: 46vh; justify-content: center; }
@@ -174,7 +209,43 @@
 
 @media (max-width: 720px) {
   #race-root .rc-root { grid-template-columns: 1fr; }
-  #race-root .rc-col { padding: 4vh 22px; background: linear-gradient(180deg, rgba(18, 11, 36, 0.94) 0%, rgba(18, 11, 36, 0.86) 70%, rgba(18, 11, 36, 0) 100%); }
+  #race-root .rc-col {
+    padding: calc(4vh + var(--rm-sa-t)) calc(22px + var(--rm-sa-r)) calc(4vh + var(--rm-sa-b)) calc(22px + var(--rm-sa-l));
+    background: linear-gradient(180deg, rgba(18, 11, 36, 0.94) 0%, rgba(18, 11, 36, 0.86) 70%, rgba(18, 11, 36, 0) 100%);
+  }
+}
+
+/* ---- a short screen (a phone on its side, 390 px tall): the seven verbs still all fit ----
+   The keyboard footer and the tagline are the two lines a thumb never needs, so they go first. */
+@media (max-height: 480px) {
+  #race-root .rm-col, #race-root .rc-col {
+    gap: 8px; padding-top: calc(8px + var(--rm-sa-t)); padding-bottom: calc(8px + var(--rm-sa-b));
+  }
+  #race-root .rm-title, #race-root .rc-word { font-size: clamp(20px, 3.2vw, 26px); }
+  #race-root .rm-tag, #race-root .rm-foot { display: none; }
+  #race-root .rm-list { gap: 4px; }
+  #race-root .rm-btn { font-size: 16px; padding: 6px 14px 6px 28px; }
+  #race-root .rm-how-back { font-size: 15px; padding: 6px 14px 6px 28px; margin-top: 4px; }
+  #race-root .rm-h { margin-bottom: 2px; font-size: 16px; }
+  #race-root .rm-row { padding: 5px 12px; font-size: 15px; }
+  #race-root .rm-row-hint, #race-root .rm-hint { font-size: 10px; margin-top: 2px; }
+  #race-root .rm-key { grid-template-columns: 104px 1fr; font-size: 12px; }
+  #race-root .rm-panel { gap: 4px; }
+  #race-root .rm-track { margin-top: 8px; padding: 6px 12px; }
+  #race-root .rm-plate { bottom: calc(10px + var(--rm-sa-b)); }
+  #race-root .rc-deck { min-height: 0; }
+  #race-root .rc-card { gap: 8px; }
+  #race-root .rc-h { font-size: clamp(18px, 2.4vw, 24px); }
+  #race-root .rc-line { font-size: clamp(13px, 1.4vw, 16px); line-height: 1.4; }
+}
+
+/* ---- a finger, not a mouse: nothing tappable under 44 px, and the arrows stop hiding ---- */
+@media (pointer: coarse) {
+  #race-root .rm-btn { min-height: 44px; }
+  #race-root .rm-row { min-height: 44px; }
+  #race-root .rm-row-arrow { min-width: 44px; min-height: 44px; opacity: 1; }
+  #race-root .rm-arrow { width: 44px; height: 44px; }
+  #race-root .rm-foot { display: none; }   /* keys and a pad, neither of which is in the room */
 }
 
 /* Law VI again: no card holds anyone. The system preference or the menu's own switch. */

--- a/ConditioningControlPanel/Resources/web/dtrh/race/menu.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/menu.js
@@ -25,7 +25,8 @@
  * no one-shots, no flashes, no crossfade pops.
  *
  * Screenshot aid: `?face=N` pins the stage face at atlas frame N, so one frame
- * can be shot on its own while the clips keep running.
+ * can be shot on its own while the clips keep running. `?panel=howto` (and
+ * `?panel=options`) opens the menu on that panel, the way `?card=N` opens a card.
  *
  * Props: race/assets/props.glb (podium, kart_cup, kart_saucer, floor_tile)
  * dresses the stage when it resolves; otherwise the lathe cup from the old
@@ -47,6 +48,13 @@
  * Keyboard (arrows, enter, esc), pointer and the gamepad (polled every frame,
  * the way the splash polled pads) all drive it. Every press answers inside
  * 100 ms (Law VIII): THE BOUNCE on the button, THE GLOW on focus.
+ *
+ * A FINGER CAN REACH EVERYTHING. There is no key card and no pad on a phone, so
+ * every path a key takes has a target under it: `how to drive` carries its own
+ * back row and a tap anywhere off the panel closes it, and each value row wears
+ * a real left and right button around the number, so music and sfx go DOWN by
+ * touch as well as up (a whole-row press still steps up the way the pad does).
+ * menu.css sizes all three to 44 px under `@media (pointer: coarse)`.
  * ==========================================================================*/
 
 import * as THREE from 'three';
@@ -97,6 +105,13 @@ const FACE_PIN = (() => {
     if (v === null || v === '' || !Number.isFinite(+v)) return -1;
     return clamp(+v | 0, 0, FACES.length - 1);
   } catch (e) { return -1; }              // no location (a node import), no pin
+})();
+/** Screenshot aid: `?panel=howto | options` opens the menu on that panel instead of the verbs. */
+const PANEL_PIN = (() => {
+  try {
+    const v = (new URLSearchParams(location.search).get('panel') || '').toLowerCase();
+    return v === 'howto' || v === 'how' ? 'how' : v === 'options' ? 'options' : null;
+  } catch (e) { return null; }           // no location (a node import), no pin
 })();
 
 // ---- options ------------------------------------------------------------------------------
@@ -393,7 +408,10 @@ export function createMenu({ root, renderer, pixel, audio, settings = {}, log = 
   for (const [k, v] of [['arrows / wasd', 'steer, throttle, brake'], ['shift', 'drift (hold, let go for turbo)'], ['space', 'jump (time it at a ramp for big air)'], ['e', 'use the item'], ['p', 'pixel look'], ['m', 'mute'], ['esc', 'the brake'], ['pad', 'stick steers, rt goes, a drifts, b jumps, x item, start brakes']]) {
     const row = el('div', 'rm-key', howPanel); el('kbd', '', row, k); el('span', '', row, v);
   }
-  el('div', 'rm-hint', howPanel, 'nothing is lost. you cannot fail. esc or enter goes back.');
+  el('div', 'rm-hint', howPanel, 'nothing is lost. you cannot fail.');
+  // the way out for a finger: the keyboard has esc and enter, a phone has this row and the backdrop
+  const howBack = el('button', 'rm-btn rm-how-back', howPanel, 'back'); howBack.type = 'button'; howBack.setAttribute('role', 'menuitem');
+  howBack.addEventListener('click', (e) => { e.stopPropagation(); ui('back'); hit(howBack, 'is-hit'); open('main'); });
 
   // ---- options: each row is a value with left / right and a press ----
   const pct = (v) => `${Math.round(v * 100)}%`;
@@ -412,9 +430,21 @@ export function createMenu({ root, renderer, pixel, audio, settings = {}, log = 
   el('h3', 'rm-h', optPanel, 'options');
   const rowEls = ROWS.map((r) => {
     const row = el('div', `rm-row${r.dim ? ' is-dim' : ''}`, optPanel); row.dataset.id = r.id; row.setAttribute('role', 'menuitem');
-    el('span', 'rm-row-label', row, r.label); r.valEl = el('span', 'rm-row-val rh-num', row, r.get());
+    el('span', 'rm-row-label', row, r.label);
+    // the value wears its own left / right buttons: a tap on the number alone can only ever step ONE
+    // way (the pad's press), so music and sfx would ratchet up and never come down on a phone.
+    const ctl = el('div', 'rm-row-ctl', row);
+    const arrow = (dir, cls, glyph, label) => {
+      const b = el('button', `rm-row-arrow ${cls}`, ctl, glyph); b.type = 'button'; b.tabIndex = -1;
+      b.setAttribute('aria-label', `${label} ${r.label}`);
+      b.addEventListener('click', (e) => { e.stopPropagation(); focusRow(ROWS.indexOf(r)); act(dir); });
+      return b;
+    };
+    if (r.move) arrow('left', 'is-dec', '‹', 'lower');
+    r.valEl = el('span', 'rm-row-val rh-num', ctl, r.get());
+    if (r.move) arrow('right', 'is-inc', '›', 'raise');
     if (r.hint) el('span', 'rm-row-hint', row, r.hint);
-    row.addEventListener('click', () => { focusRow(ROWS.indexOf(r)); act('press'); });
+    row.addEventListener('click', (e) => { e.stopPropagation(); focusRow(ROWS.indexOf(r)); act('press'); });
     row.addEventListener('pointerenter', () => focusRow(ROWS.indexOf(r)));
     return row;
   });
@@ -427,7 +457,7 @@ export function createMenu({ root, renderer, pixel, audio, settings = {}, log = 
   const VERBS = [['race', 'race'], ['track', 'load a track'], ['clear', 'just the road'], ['options', 'options'], ['how', 'how to drive'], ['story', 'the story'], ['surface', 'surface']];
   const verbEls = VERBS.map(([id, label], i) => {
     const b = el('button', 'rm-btn', list, label); b.type = 'button'; b.dataset.id = id; b.setAttribute('role', 'menuitem');
-    b.addEventListener('click', () => { idx.main = i; act('press'); });
+    b.addEventListener('click', (e) => { e.stopPropagation(); idx.main = i; act('press'); });
     b.addEventListener('pointerenter', () => { idx.main = i; ui('tick'); refresh(); });
     return b;
   });
@@ -526,6 +556,10 @@ export function createMenu({ root, renderer, pixel, audio, settings = {}, log = 
     stage.setViewFraction(parked ? ((col.offsetWidth || w * 0.38) / w + 1) / 2 + 0.03 : 0.5);
   }
   const onPointer = (e) => { if (shown && e.clientX > window.innerWidth * 0.5) stage.emi.peek(); };
+  // the backdrop closes the key card. Every verb and every row stops its own click, so the only
+  // clicks that reach the layer are the ones that landed on nothing.
+  const onBackdrop = (e) => { if (shown && panel === 'how' && !howPanel.contains(e.target)) { ui('back'); open('main'); } };
+  layer.addEventListener('click', onBackdrop);
   window.addEventListener('keydown', onKey);
   const unbindResize = bindViewportResize(onResize);
   stageEl.addEventListener('pointerenter', onPointer);
@@ -535,7 +569,15 @@ export function createMenu({ root, renderer, pixel, audio, settings = {}, log = 
     options, stage: { update(dt) { if (shown) pollPad(dt); stage.update(dt); }, render: stage.render, dispose: stage.dispose, live: stage },
     onPick(cb) { if (typeof cb === 'function') picks.push(cb); },
     setTrack, get track() { return trackState; },
-    show() { shown = true; viewHeld = false; layer.hidden = false; stage.setMode('menu'); open('main'); onResize(); hit(layer, 'is-in'); theme(true); },
+    /** hideVerb(id): take a verb off the list for good. raceBoot hides `surface` when the page is not
+     *  hosted and has nowhere to surface to, so nobody taps their way to a blank screen. */
+    hideVerb(id) {
+      const b = verbEl(id); if (!b) return;
+      b.hidden = true;
+      if (verbEls[idx.main].hidden) idx.main = stepVerb(idx.main, 1);
+      refresh();
+    },
+    show() { shown = true; viewHeld = false; layer.hidden = false; stage.setMode('menu'); open(PANEL_PIN || 'main'); onResize(); hit(layer, 'is-in'); theme(true); },
     hide() { shown = false; layer.hidden = true; stage.setViewFraction(0.5); },
     /** Park the stage the way the column parks it, with the menu hidden: race/cards.js uses the same
      *  layout, so hide() sending her back to the middle of the frame would only be a jump and a jump

--- a/ConditioningControlPanel/Resources/web/dtrh/race/smoke/menu-touch.html
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/smoke/menu-touch.html
@@ -1,0 +1,117 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+  <title>race menu touch smoke</title>
+  <!-- race/smoke/menu-touch.html - the touch paths of race/menu.js, driven in a browser.
+
+       node has no DOM and menu.js builds one, so this check runs where the menu runs:
+
+         python -m http.server 8804 --bind 127.0.0.1     (from Resources/web)
+         chrome --headless=new --enable-unsafe-swiftshader --use-gl=angle --use-angle=swiftshader
+                --enable-logging=stderr --virtual-time-budget=15000
+                --screenshot=out.png "http://127.0.0.1:8804/dtrh/race/smoke/menu-touch.html"
+
+       It stands up a real menu on a stubbed pixelizer and a silent audio (no renderer is ever
+       touched: the stage is only built, never drawn), then taps its way through the two traps this
+       page exists for - the value arrows that only ever went UP, and a key card whose only exit was
+       a keyboard. Every line prints to the console AND lands on the page, so the screenshot is the
+       report. The title ends 'PASS' or 'FAIL n'. -->
+  <link rel="stylesheet" href="/dtrh/styles.css">
+  <link rel="stylesheet" href="/dtrh/race/race.css">
+  <link rel="stylesheet" href="/dtrh/race/menu.css">
+  <script type="importmap">
+  { "imports": { "three": "/dtrh/vendor/three/three.module.min.js", "three/addons/": "/dtrh/vendor/three/addons/" } }
+  </script>
+  <style>
+    body { margin: 0; background: #12261f; font-family: 'Segoe UI', system-ui, sans-serif; }
+    #race-root { position: fixed; inset: 0; overflow: hidden; }
+    #out { position: fixed; right: 0; top: 0; z-index: 90; width: 46%; max-height: 100%; overflow: auto;
+           padding: 10px 14px; background: rgba(8, 6, 16, 0.94); color: #d6ffe4; font-size: 13px; line-height: 1.5; }
+    #out b { display: block; margin-bottom: 6px; font-size: 15px; color: #ffd6ea; }
+    #out .fail { color: #ff6a88; font-weight: 700; }
+  </style>
+</head>
+<body>
+  <div id="race-root"><div class="race-hud is-lobby"></div></div>
+  <div id="out"><b>race menu touch smoke</b></div>
+  <script type="module">
+    import { createMenu, OPTIONS_KEY } from '/dtrh/race/menu.js';
+
+    const out = document.getElementById('out');
+    let fails = 0;
+    const ok = (cond, what) => {
+      if (!cond) fails++;
+      const line = document.createElement('div');
+      line.className = cond ? '' : 'fail';
+      line.textContent = (cond ? '  ok  ' : 'FAIL  ') + what;
+      out.appendChild(line);
+      console.log((cond ? 'ok   ' : 'FAIL ') + what);
+    };
+    window.addEventListener('error', (e) => ok(false, 'page error: ' + e.message));
+    window.addEventListener('unhandledrejection', (e) => ok(false, 'page rejection: ' + e.reason));
+
+    // music starts at the top so a tap on the left arrow has somewhere to go
+    try { localStorage.setItem(OPTIONS_KEY, JSON.stringify({ pixel: 0, music: 1, sfx: 0.8, motion: 'off', seed: 'daily', seedValue: 7 })); } catch (e) { /* private mode */ }
+
+    const pixel = { block: 0, setBlock(n) { this.block = n | 0; }, retexture() {}, render() {} };
+    const audio = { ui() {}, menu() {}, setLevels() {} };
+    const menu = createMenu({ root: document.getElementById('race-root'), renderer: null, pixel, audio, settings: {}, log: () => {} });
+    menu.show();
+
+    const tap = (node) => node.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+    const q = (sel) => document.querySelector('#race-root ' + sel);
+    const val = (id) => { const r = q(`.rm-row[data-id="${id}"] .rm-row-val`); return r ? r.textContent : '(no row)'; };
+    const shown = (node) => !!node && !node.hidden;
+
+    // ---- trap 1: a tap could only ever step the value UP ----
+    tap(q('.rm-btn[data-id="options"]'));
+    ok(shown(q('.rm-options')), 'the options verb opens the options panel');
+    ok(val('music') === '100%', 'music starts at 100%');
+    const dec = q('.rm-row[data-id="music"] .rm-row-arrow.is-dec');
+    const inc = q('.rm-row[data-id="music"] .rm-row-arrow.is-inc');
+    ok(!!dec && !!inc, 'the music row carries a left and a right button');
+    tap(dec);
+    ok(val('music') === '90%', 'a tap on the left arrow lowers music 100% -> 90% (was: only up)');
+    tap(dec);
+    ok(val('music') === '80%', 'a second tap keeps lowering it, 90% -> 80%');
+    tap(inc);
+    ok(val('music') === '90%', 'a tap on the right arrow raises it again, 80% -> 90%');
+    tap(q('.rm-row[data-id="music"] .rm-row-label'));
+    ok(val('music') === '100%', 'a press on the row itself still steps up, the way the pad does');
+    tap(q('.rm-row[data-id="back"]'));
+    ok(shown(q('.rm-list')) && !shown(q('.rm-options')), 'the options back row returns to the verbs');
+
+    // ---- trap 2: the key card had no way out but a keyboard ----
+    tap(q('.rm-btn[data-id="how"]'));
+    ok(shown(q('.rm-how')), 'the how to drive verb opens the key card');
+    const back = q('.rm-how .rm-how-back');
+    ok(!!back, 'the key card carries a back row');
+    tap(back);
+    ok(!shown(q('.rm-how')) && shown(q('.rm-list')), 'the back row closes the key card');
+    tap(q('.rm-btn[data-id="how"]'));
+    ok(shown(q('.rm-how')), 'the key card opens again (the verb tap does not close it on the way in)');
+    tap(q('.rm-stage'));
+    ok(!shown(q('.rm-how')) && shown(q('.rm-list')), 'a tap off the panel closes the key card');
+
+    // ---- the verbs a finger has to be able to reach ----
+    const verbs = [...document.querySelectorAll('#race-root .rm-list .rm-btn:not([hidden])')];
+    ok(verbs.length >= 5 && verbs.every((b) => b.getBoundingClientRect().height > 0), `every visible verb has a box to hit (${verbs.length} of them)`);
+    ok(getComputedStyle(q('.rm-col')).overflowY === 'auto', 'the column scrolls itself instead of spilling under the clip');
+    // the landscape phone. Run this page at 844x390 and the number below is the whole point of the
+    // short-viewport rule: all SEVEN verbs (track and clear only ever show under a host) in 390 px.
+    // Only asserted while the short-viewport rule is live, so the same page passes on a desktop too.
+    for (const b of document.querySelectorAll('#race-root .rm-list .rm-btn')) b.hidden = false;
+    const col = q('.rm-col'), short = matchMedia('(max-height: 480px)').matches;
+    ok(!short || col.scrollHeight <= 390, `all seven verbs in 390 px: ${col.scrollHeight} px${short ? '' : ' (tall screen, not asserted)'}`);
+
+    const head = document.createElement('div');
+    head.textContent = fails ? `FAIL ${fails}` : 'PASS';
+    head.className = fails ? 'fail' : '';
+    out.appendChild(head);
+    document.title = 'race menu touch smoke ' + (fails ? `FAIL ${fails}` : 'PASS');
+    console.log('menu-touch smoke: ' + (fails ? `FAIL ${fails}` : 'PASS'));
+  </script>
+</body>
+</html>

--- a/ConditioningControlPanel/Resources/web/dtrh/raceBoot.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/raceBoot.js
@@ -30,7 +30,17 @@
  * opens them on card N (1..4, a screenshot aid the way `?hold=` is one);
  * `?pixel=N` (0 = off) beats `race.options` which beats `settings.pixel` from
  * the host init; `?itembox=ms` breaks the next sugar cube that comes into
- * reading range after that time and is a screenshot aid for the pickup card.
+ * reading range after that time and is a screenshot aid for the pickup card;
+ * `?panel=howto` opens the menu on the key card (race/menu.js).
+ *
+ * `?back=<same-origin path>` is WHERE THE MENU'S `surface` VERB GOES when there
+ * is no host to hand the page back to. Hosted, `surface` posts exit + exit-done
+ * and the shell takes the window away. In a plain browser there is no shell, so
+ * the old build disposed everything and left a black page. Now: `?back=` first,
+ * then a same-origin `document.referrer` (history.back()), and with neither the
+ * verb is taken off the list entirely, so no tap can reach a dead end. A
+ * cross-origin `?back=` or referrer is ignored: this never becomes an open
+ * redirect.
  *
  * TRACK CHARTS (CHART.md): the host posts track-progress / track-chart /
  * track-clock / track-ended / track-error and this file hands them to the run.
@@ -48,6 +58,22 @@ import { createHostMediaSource } from './hostMedia.js';
 const INIT_TIMEOUT_MS = 4000, SPLASH_MS = 1000, TRACK_TICK_MS = 250;
 const params = new URLSearchParams(location.search);
 const hosted = bridge.isHosted;
+/**
+ * Where `surface` goes with no host under the page: `?back=<path>` if it is same origin, else a
+ * same-origin referrer, else null and the verb comes off the list. Same origin only, always, so the
+ * query string can never point a player somewhere else.
+ */
+function resolveBack() {
+  const want = params.get('back');
+  if (want) {
+    try { const u = new URL(want, location.href); if (u.origin === location.origin) return () => { location.href = u.href; }; }
+    catch (e) { /* not a url, fall through */ }
+  }
+  try { const r = document.referrer; if (r && new URL(r).origin === location.origin) return () => history.back(); }
+  catch (e) { /* no referrer */ }
+  return null;
+}
+const standaloneExit = hosted ? null : resolveBack();
 const host = hosted ? bridge : {
   on: bridge.on,
   isHosted: false,
@@ -142,6 +168,9 @@ function surface() {
   try { if (race) race.dispose(); } catch (e) { host.log('exit dispose: ' + e); }
   host.send({ type: 'exit' });
   host.send({ type: 'exit-done' });
+  // no host means nothing takes the window away, so the page has to leave on its own or the tear-down
+  // above is all anyone sees. The verb is hidden when there is nowhere to go, so this is never null here.
+  if (!hosted && standaloneExit) { try { standaloneExit(); } catch (e) { host.log('back: ' + e); } }
 }
 
 function synthInit() {
@@ -181,6 +210,7 @@ async function boot() {
     if (params.get('autostart') === '1') { startRun(false); debugItemBox(); return; }
     if (hudRoot) hudRoot.classList.add('is-lobby');   // the run's chrome stays out of the menu and the intro
     menu = createMenu({ root, renderer: race.renderer, pixel: race.pixel, audio: race.audio, settings, log: host.log });
+    if (!hosted && !standaloneExit) { menu.hideVerb('surface'); host.log('surface hidden: no host and no ?back='); }
     menu.onPick((id) => {
       if (id === 'race') startRun(true);
       else if (id === 'surface') surface();


### PR DESCRIPTION
how to drive gets a back button and a backdrop tap; value rows get real left/right arrow buttons (tap left lowers music, whole-row press still steps up for pad parity); .rm-col/.rc-col scroll with safe-area padding, a short-viewport rule fits seven verbs in 390px, coarse pointers get 44px rows. Also fixes .rm-list ignoring [hidden]. Unhosted surface: ?back=<same-origin path>, else same-origin referrer, else the verb hides (never a cross-origin redirect).

Verified: race/smoke/menu-touch.html (15 assertions incl. music 100 to 90 by tap), headless shots at three sizes, zero page errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0166ij3Q8xyseVkhWajzkWG3
