### PR TITLE
feat(race): the race plays hand-authored charts (Track Maker 1/7)

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/race/CHART.md
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/CHART.md
@@ -137,6 +137,33 @@ peak `cheer` (`smug` over intensity 0.7), release `drift`, silence a `. . .` toa
 A loaded track ducks the room OST to `TRACK_DUCK` (0.12) and the bed to silence via
 `audio.duck(on, 'track')`, the standing level `update()` eases back to, until the track is cleared.
 
+### Hand-authored charts (hand cues)
+
+A curated track is not analysis, it is authorship: someone sat with the audio and said what each
+second is worth. The chart file carries that as a few optional additions, and the version stays 1.
+A chart without them is an auto chart and plays exactly as the table above says.
+
+| where | field | what |
+|-------|-------|------|
+| chart | `hand` | the editor saved this file |
+| chart | `rules` | the editor's rule table, kept for the round trip; the race ignores it |
+| event | `kind: 'mark'` | a hand-placed beat with no analyzer meaning; with no `cue` it is worth nothing |
+| event | `rule`, `hand`, `note` | the rule that made it, the author's edit flag, free text (200 chars) |
+| event | `cue` | the override: `cueFor` builds from it and never opens the table |
+
+`cue` is the cue shape above plus `wall` (a bubble kind: five lane bubbles at `x = -2.2 .. 2.2` plus
+one in the air, all on the word, the row the kart cannot steer around) and `fx` (the full-frame
+beats `blink`, `blackout`, `snap`, `shake`, `melt`, `flash`). `race/chart.js` `sanitizeCue` drops
+every bubble kind, placement and fx name it does not know and clamps every number, because a hand
+chart is a file a stranger can hand you. `race/frameFx.js` owns the three beats that take the whole
+frame; run.js maps `shake` to the user's screen-shake dial, `melt` to a braindrain through THE MIX
+and `flash` to the engine pulse, and a `snap` holds the world still for 120 ms. Only one frame beat
+runs at a time. Reduced motion turns `blink` and `snap` into a plain pulse at half strength and caps
+a blackout at 0.5.
+
+One wall is one event: the first bubble of the row is the word the voice said, the other five are
+points. `node race/smoke/hand-cues-check.mjs` walks all of it.
+
 ### `race/bubbles.js` additions (PR c2)
 ```js
 field.spawnAt({ kindId, placement, d, x, h, eventId })   // an explicit placement; returns the slot id or -1 when the pool is full

--- a/ConditioningControlPanel/Resources/web/dtrh/race/bubbles.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/bubbles.js
@@ -215,17 +215,18 @@ export function createBubbleField({ scene, layout, media, getIntensity, getRoom,
    *  the pool is full (a cue never steals a live bubble), when the kind is dark (bubbleKinds.js
    *  spawn:false), or when density has gated this one out.
    *  Over 1, density is the chance of a second bubble beside the first. */
-  function spawnAt({ kindId, placement = 'lane', d, x = 0, h, eventId = null } = {}) {
+  function spawnAt({ kindId, placement = 'lane', d, x = 0, h, eventId = null, sure = false } = {}) {
     if (liveCount >= CAP) return -1;
     if (KIND_BY_ID[kindId] && KIND_BY_ID[kindId].spawn === false) return -1;   // a dark kind: no chart may place one
-    if (tracked) {
+    // `sure` spawns are hand-placed (a wall, an authored bubble): the density knob leaves them alone.
+    if (tracked && !sure) {
       if (density <= 0) return -1;
       if (density < 1 && Math.random() >= density) return -1;
     }
     const top = h == null ? (placement === 'rain' ? CEILING_H : placement === 'air' ? 2.6 : LANE_H) : h;
     const s = place(kindId, placement, d, x, top);
     s.eventId = eventId;
-    if (tracked && density > 1 && liveCount < CAP && Math.random() < density - 1) {
+    if (tracked && !sure && density > 1 && liveCount < CAP && Math.random() < density - 1) {
       place(kindId, placement, d + 2.4, x + (x > 0 ? -1.1 : 1.1), top).eventId = eventId;
     }
     return s.slot;

--- a/ConditioningControlPanel/Resources/web/dtrh/race/chart.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/chart.js
@@ -15,7 +15,8 @@
  * after its second is dropped and counted as missed, never spawned behind the kart.
  * ==========================================================================*/
 
-import { ROOM_IDS, KART_BASE_SPEED, makeRng } from './consts.js';
+import { ROOM_IDS, KART_BASE_SPEED, makeRng, CEILING_H, ROAD_HALF_W } from './consts.js';
+import { KIND_BY_ID } from './bubbleKinds.js';
 
 export const CHART_VERSION = 1;
 
@@ -31,7 +32,7 @@ export const STRUCTURE_WORDS = [
 /** A structure word outside a countdown that reads as a drop ('now' only right after a count). */
 export const DROP_WORDS = ['drop', 'dropping', 'sleep', 'asleep', 'deeper', 'sink', 'sinking', 'now'];
 
-export const EVENT_KINDS = ['trigger', 'word', 'count', 'drop', 'chant', 'build', 'peak', 'release', 'silence'];
+export const EVENT_KINDS = ['trigger', 'word', 'count', 'drop', 'chant', 'build', 'peak', 'release', 'silence', 'mark'];
 export const ACT_KINDS = ['induction', 'deepening', 'triggers', 'mantra', 'build', 'silence', 'wake', 'free'];
 
 /** Default act -> room. The analyzer may override a room to avoid repeating one back to back. */
@@ -51,6 +52,72 @@ const num = (v, d) => (typeof v === 'number' && isFinite(v) ? v : d);
 const clamp = (v, lo, hi) => (v < lo ? lo : v > hi ? hi : v);
 const clamp01 = (v) => clamp(v, 0, 1);
 const str = (v, d = '') => (typeof v === 'string' ? v : d);
+
+/* ---- hand cues (CHART.md) ----------------------------------------------- */
+
+/** The full-frame beats a hand cue may ask for. race/frameFx.js owns the table and the pixels;
+ *  the ids live here so chart.js can validate a cue without ever seeing the DOM. */
+export const FX_IDS = ['blink', 'blackout', 'snap', 'shake', 'melt', 'flash'];
+
+/** A hand spawn may only land where a spoken word could: on the road, in the air, out of the ceiling. */
+const CUE_PLACEMENTS = ['lane', 'air', 'rain'];
+/** The moods poke() answers to. Anything else is dropped rather than passed to EMI. */
+const CUE_MOODS = ['calm', 'streamed', 'fraught', 'smug', 'shock', 'jackpot'];
+/** How far ahead of or behind its own second a hand spawn may sit. */
+const CUE_AT_MIN = -5, CUE_AT_MAX = 30;
+/** Ceilings on the knobs a hand cue drives, so a bad file cannot launch the kart out of the tube. */
+const CUE_JUMP_MAX = 12, CUE_BOOST_MAX = 10, CUE_DENSITY_MAX = 4, CUE_FX_DUR_MAX = 10;
+const CUE_NOTE_MAX = 200;
+
+const has = (o, k) => Object.prototype.hasOwnProperty.call(o, k);
+const effectKind = (v) => (typeof v === 'string' && KIND_BY_ID[v] ? v : null);
+
+/**
+ * Sanitise the author's `cue` override off the wire. Everything is optional and everything is
+ * clamped: an unknown bubble kind, an unknown placement or an unknown fx id is dropped rather
+ * than played, because a hand chart is a file a stranger can hand you. Returns null when nothing
+ * survives, so `event.cue` is either a cue worth running or absent.
+ */
+export function sanitizeCue(cue, durationSec = 0) {
+  if (!cue || typeof cue !== 'object') return null;
+  const out = {};
+  const dur = Math.max(0, num(durationSec, 0));
+  if (Array.isArray(cue.spawn)) {
+    out.spawn = cue.spawn
+      .filter((s) => s && typeof s === 'object' && CUE_PLACEMENTS.includes(s.placement) && KIND_BY_ID[s.kindId])
+      .map((s) => ({
+        kindId: s.kindId, placement: s.placement,
+        x: clamp(num(s.x, 0), -ROAD_HALF_W + 0.4, ROAD_HALF_W - 0.4),
+        h: clamp(num(s.h, 0), 0, CEILING_H),
+        at: clamp(num(s.at, 0), CUE_AT_MIN, CUE_AT_MAX),
+      }));
+  }
+  if (has(cue, 'wall')) out.wall = (typeof cue.wall === 'string' && KIND_BY_ID[cue.wall]) ? cue.wall : null;
+  if (Array.isArray(cue.fx)) {
+    out.fx = cue.fx
+      .filter((f) => f && typeof f === 'object' && FX_IDS.includes(f.id))
+      .map((f) => {
+        const e = { id: f.id, strength: clamp01(num(f.strength, 1)) };
+        e.dur = has(f, 'dur') && isFinite(num(f.dur, NaN)) ? clamp(num(f.dur, 0), 0, CUE_FX_DUR_MAX) : null;
+        return e;
+      });
+  }
+  if (has(cue, 'jump')) out.jump = clamp(num(cue.jump, 0), 0, CUE_JUMP_MAX);
+  if (has(cue, 'mix')) out.mix = effectKind(cue.mix);
+  if (has(cue, 'mood')) out.mood = CUE_MOODS.includes(cue.mood) ? cue.mood : null;
+  if (has(cue, 'pose')) out.pose = typeof cue.pose === 'string' && cue.pose ? cue.pose : null;
+  if (has(cue, 'toast')) {
+    const t = cue.toast;
+    out.toast = (t && typeof t === 'object' && typeof t.text === 'string' && t.text)
+      ? { text: t.text.slice(0, CUE_NOTE_MAX), kind: str(t.kind, 'effect') } : null;
+  }
+  if (has(cue, 'word')) out.word = typeof cue.word === 'string' && cue.word ? cue.word : null;
+  if (has(cue, 'fog')) out.fog = isFinite(num(cue.fog, NaN)) ? clamp01(num(cue.fog, 0)) : null;
+  if (has(cue, 'boost')) out.boost = clamp(num(cue.boost, 0), 0, CUE_BOOST_MAX);
+  if (has(cue, 'density')) out.density = isFinite(num(cue.density, NaN)) ? clamp(num(cue.density, 1), 0, CUE_DENSITY_MAX) : null;
+  if (has(cue, 'holdSec')) out.holdSec = clamp(num(cue.holdSec, 0), 0, dur > 0 ? dur : CUE_AT_MAX);
+  return Object.keys(out).length ? out : null;
+}
 
 /* ---- normalize ---------------------------------------------------------- */
 
@@ -73,6 +140,10 @@ export function normalizeChart(json) {
 
   return Object.freeze({
     version: CHART_VERSION, binSec, energy: Object.freeze(energy),
+    // CHART.md: the editor stamps `hand` and carries its rule table along for the round trip.
+    // The race reads neither; it keeps them so a chart survives a load and a save unchanged.
+    hand: json.hand === true,
+    rules: Object.freeze(Array.isArray(json.rules) ? JSON.parse(JSON.stringify(json.rules)) : []),
     acts: normalizeActs(Array.isArray(json.acts) ? json.acts : [], durationSec),
     events: normalizeEvents(Array.isArray(json.events) ? json.events : [], durationSec),
     source: Object.freeze({ name: str(src.name, 'track'), hash: str(src.hash, ''), durationSec, sampleRate: num(src.sampleRate, 16000) }),
@@ -116,6 +187,12 @@ function normalizeEvents(raw, durationSec) {
       if (e.kind === 'count') { ev.n = num(e.n, 0); ev.of = num(e.of, 0); ev.last = e.last === true; }
       if (e.kind === 'drop') ev.strength = clamp01(num(e.strength, 1));
       if (e.kind === 'chant') { ev.reps = Math.max(1, Math.round(num(e.reps, 3))); ev.period = Math.max(0, num(e.period, 0)); }
+      // the hand-authored half (CHART.md): the override, where it came from, and the author's note
+      const cue = sanitizeCue(e.cue, durationSec);
+      if (cue) ev.cue = Object.freeze(cue);
+      if (e.rule != null) ev.rule = str(e.rule, '');
+      if (e.hand === true) ev.hand = true;
+      if (e.note != null) ev.note = str(e.note, '').slice(0, CUE_NOTE_MAX);
       return Object.freeze(ev);
     });
   return Object.freeze(out);
@@ -168,6 +245,9 @@ export function demoChart(opts = {}) {
       ev('drop', from + 9 * 1.4 + 1.1, { strength: 1, label: 'drop' });
     } else if (a.kind === 'triggers') {
       for (let k = 0, t = a.t0 + 4; t < a.t1 - 2; t += 6.5, k++) ev('trigger', t, { label: DEMO_TRIGGERS[k % DEMO_TRIGGERS.length], conf: 0.7 + rng() * 0.3 });
+      // hand-authored (CHART.md): a wall of pink nobody can steer around, and the lids close on the word
+      ev('trigger', a.t1 - 3.5, { label: 'good girl', conf: 1, hand: true, rule: 'demo-wall',
+        cue: { wall: 'pink', fx: [{ id: 'blink', strength: 0.8, dur: 0.45 }], word: 'good girl' } });
     } else if (a.kind === 'mantra') {
       const period = 2.4, reps = Math.max(3, Math.min(8, Math.floor((len - 6) / period)));
       ev('chant', a.t0 + 3, { label: 'good girl', reps, period, dur: reps * period });
@@ -178,6 +258,9 @@ export function demoChart(opts = {}) {
       ev('peak', a.t0 + 3 + dur, {});
       ev('drop', a.t0 + 3.2 + dur, { strength: 0.85, label: 'sink' });
       ev('release', a.t0 + 5.4 + dur, {});
+      // hand-authored: the finger snap on the second drop, a white frame and a jolt with no bubble at all
+      ev('mark', a.t0 + 4.2 + dur, { label: 'the snap', hand: true, note: 'finger snap, the second drop',
+        cue: { fx: [{ id: 'snap', strength: 1 }, { id: 'shake', strength: 0.6, dur: 0.4 }], jump: 7, mix: 'spiral', mood: 'streamed' } });
     } else if (a.kind === 'silence') {
       ev('silence', a.t0 + 0.5, { dur: Math.max(3, len - 1.5) });
     } else if (a.kind === 'wake') {

--- a/ConditioningControlPanel/Resources/web/dtrh/race/cues.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/cues.js
@@ -99,12 +99,13 @@ function fromHand(hand, ctx) {
     for (const sp of hand.spawn) {
       const placement = sp.placement || 'lane';
       const h = (sp.h != null) ? sp.h : (placement === 'rain' ? CEILING_H : placement === 'air' ? AIR_H : LANE_H);
-      cue.spawn.push({ kindId: sp.kindId, placement, x: Number(sp.x) || 0, h, at: Number(sp.at) || 0 });
+      cue.spawn.push({ kindId: sp.kindId, placement, x: Number(sp.x) || 0, h, at: Number(sp.at) || 0, sure: true });
     }
   }
+  // `sure`: the author placed these, so the density knob never thins them (bubbles.js spawnAt).
   if (hand.wall) {
-    for (const x of WALL_X) cue.spawn.push({ kindId: hand.wall, placement: 'lane', x, h: LANE_H, at: 0 });
-    cue.spawn.push({ kindId: hand.wall, placement: 'air', x: 0, h: WALL_AIR_H, at: 0 });
+    for (const x of WALL_X) cue.spawn.push({ kindId: hand.wall, placement: 'lane', x, h: LANE_H, at: 0, sure: true });
+    cue.spawn.push({ kindId: hand.wall, placement: 'air', x: 0, h: WALL_AIR_H, at: 0, sure: true });
   }
   if (Array.isArray(hand.fx)) cue.fx = hand.fx.map((f) => ({ id: f.id, strength: f.strength, dur: f.dur }));
   for (const k of HAND_FIELDS) if (hand[k] !== undefined) cue[k] = hand[k];

--- a/ConditioningControlPanel/Resources/web/dtrh/race/cues.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/cues.js
@@ -76,8 +76,39 @@ const roomId = (ctx) => (ctx.room && typeof ctx.room.id === 'string' ? ctx.room.
 
 /** Every field CHART.md promises, so run.js never has to test for one. */
 function blank() {
-  return { spawn: [], jump: 0, mix: null, mood: null, pose: null, toast: null,
+  return { spawn: [], fx: [], jump: 0, mix: null, mood: null, pose: null, toast: null,
     word: null, fog: null, boost: 0, density: null, holdSec: 0 };
+}
+
+/* ---- the hand override (CHART.md) --------------------------------------- */
+
+/** A wall is a full row the kart cannot steer around: the five road lanes plus one over the top. */
+const WALL_X = [-2.2, -1.1, 0, 1.1, 2.2];
+const WALL_AIR_H = AIR_H;
+/** The fields the author may set on a cue, copied straight through when they are present. */
+const HAND_FIELDS = ['jump', 'mix', 'mood', 'pose', 'toast', 'word', 'fog', 'boost', 'density', 'holdSec'];
+
+/**
+ * The author already said what this second is worth: build the cue from their words, not the table.
+ * `cue` has been through chart.js sanitizeCue, so every id, placement and number in here is already
+ * legal. The only thing left to do is expand `wall` into the six bubbles it stands for.
+ */
+function fromHand(hand, ctx) {
+  const cue = blank();
+  if (Array.isArray(hand.spawn)) {
+    for (const sp of hand.spawn) {
+      const placement = sp.placement || 'lane';
+      const h = (sp.h != null) ? sp.h : (placement === 'rain' ? CEILING_H : placement === 'air' ? AIR_H : LANE_H);
+      cue.spawn.push({ kindId: sp.kindId, placement, x: Number(sp.x) || 0, h, at: Number(sp.at) || 0 });
+    }
+  }
+  if (hand.wall) {
+    for (const x of WALL_X) cue.spawn.push({ kindId: hand.wall, placement: 'lane', x, h: LANE_H, at: 0 });
+    cue.spawn.push({ kindId: hand.wall, placement: 'air', x: 0, h: WALL_AIR_H, at: 0 });
+  }
+  if (Array.isArray(hand.fx)) cue.fx = hand.fx.map((f) => ({ id: f.id, strength: f.strength, dur: f.dur }));
+  for (const k of HAND_FIELDS) if (hand[k] !== undefined) cue[k] = hand[k];
+  return cue;
 }
 
 /** The bubble a spoken trigger wears: the chart's own map, else the room's effect, else the strobe. */
@@ -95,6 +126,9 @@ function triggerKind(label, ctx) {
  */
 export function cueFor(event, ctx = {}) {
   if (!event || typeof event.kind !== 'string') return null;
+  // the author's own reading of this second wins outright: no table, no roll, no room colour.
+  // A `mark` with no cue falls through the switch to null, which is the point of a mark.
+  if (event.cue) return fromHand(event.cue, ctx);
   const rng = typeof ctx.rng === 'function' ? ctx.rng : Math.random;
   const intensity = Number.isFinite(Number(ctx.intensity)) ? clamp(Number(ctx.intensity), 0, 1) : 0.5;
   const label = typeof event.label === 'string' ? event.label : '';

--- a/ConditioningControlPanel/Resources/web/dtrh/race/frameFx.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/frameFx.js
@@ -1,0 +1,146 @@
+/* ============================================================================
+ * race/frameFx.js - the full-frame beats a hand chart drops on the run.
+ * Implements CHART.md section `Hand-authored charts`: the `fx` half of a hand cue.
+ *
+ *   createFrameFx({ root, reducedMotion, sfx }) -> { play, tick, dispose, FX_KINDS }
+ *
+ * The auto charter only ever spends an event on the world: a bubble, a jump, a pour. An author
+ * wants the other thing, the beat that happens TO the player - the lids closing on a trigger, the
+ * frame going black under a mantra, one white flash on a finger snap. Those live here because they
+ * are the only race effects that are not the world: three lightweight divs over the whole viewport,
+ * driven by tick(dt) off the run's own frame loop so a paused run holds them exactly where they are.
+ *
+ * ONE AT A TIME, ALWAYS. play() cancels whatever was running first. Two lids and a veil stacking on
+ * each other is not a second effect, it is a blackout the author did not write, and on a hypno track
+ * a blackout nobody asked for is the difference between a beat and a scare.
+ *
+ * `shake`, `melt` and `flash` are in FX_KINDS but are NOT drawn here: run.js already owns a screen
+ * shake, THE MIX and the engine flash, so it maps those three itself and only the frame-owning
+ * three ever reach play().
+ * ==========================================================================*/
+
+import { FX_IDS } from './chart.js';
+
+export { FX_IDS };
+
+/** The table the editor palette reads and run.js dispatches on. `dur` is the default in seconds. */
+export const FX_KINDS = {
+  blink:    { id: 'blink',    label: 'blink',    dur: 0.45, frame: true,  what: 'two lids close over the whole frame and open again' },
+  blackout: { id: 'blackout', label: 'blackout', dur: 1.2,  frame: true,  what: 'the frame fades to black and back' },
+  snap:     { id: 'snap',     label: 'snap',     dur: 0.12, frame: true,  what: 'one white frame, then a short freeze of the world' },
+  shake:    { id: 'shake',    label: 'shake',    dur: 0.4,  frame: false, what: 'a jolt of the world (run.js: game/screenShake.js)' },
+  melt:     { id: 'melt',     label: 'melt',     dur: 0,    frame: false, what: 'the braindrain overlay through THE MIX (run.js)' },
+  flash:    { id: 'flash',    label: 'flash',    dur: 0.3,  frame: false, what: 'the engine pulse flash (run.js)' },
+};
+
+/** How long the world holds still after a snap. CHART.md: 120 ms. */
+export const SNAP_FREEZE_SEC = 0.12;
+/** A fully shut lid is half the frame from the top and half from the bottom. */
+const LID_MAX_PCT = 50;
+/** Of `dur`: the lids close over the first slice, hold shut, then open over the rest. */
+const BLINK_CLOSE = 0.4, BLINK_HOLD_SEC = 0.08;
+/** The darkest a blackout may ever get, and the cap again under reduced motion. */
+const BLACKOUT_MAX = 0.85, BLACKOUT_REDUCED = 0.5;
+/** Under reduced motion a lid beat becomes a plain pulse at this share of its strength. */
+const REDUCED_FLASH = 0.5;
+/** race/audio.js HOST_SFX is a closed set and a name outside it is silent on the host. There is no
+ *  `snap` in that catalogue, so the beat borrows the click, which is the fallback CHART.md names. */
+const SNAP_SFX = 'ui_click';
+
+const clamp = (v, a, b) => Math.max(a, Math.min(b, v));
+const ease = (p) => (p < 0.5 ? 2 * p * p : 1 - Math.pow(-2 * p + 2, 2) / 2);
+
+export function createFrameFx({ root, reducedMotion = false, sfx = null } = {}) {
+  let disposed = false;
+  let cur = null;   // { id, strength, dur, t }
+
+  // WHERE THIS SITS IN THE LADDER. race.html stacks #race-root as: the canvas (the world and the
+  // media on the tube walls), the race chrome at z3, #sf-hud at z10 carrying payloadFx's wash (z4)
+  // and its front card (z9), and the boot splash at z30. z8 puts the lids over the whole world and
+  // everything painted into it while leaving #sf-hud on top, so a blackout never swallows the video
+  // card, the pause menu or the score readouts the player needs to find their way back out.
+  const el = document.createElement('div');
+  el.className = 'race-framefx';
+  el.setAttribute('aria-hidden', 'true');
+  el.style.cssText = 'position:fixed;inset:0;z-index:8;pointer-events:none;overflow:hidden;';
+
+  const mk = (css) => { const d = document.createElement('div'); d.style.cssText = css; el.appendChild(d); return d; };
+  const lidTop = mk('position:absolute;left:0;right:0;top:0;height:0;background:#000;');
+  const lidBot = mk('position:absolute;left:0;right:0;bottom:0;height:0;background:#000;');
+  const veil = mk('position:absolute;inset:0;background:#000;opacity:0;');
+  if (root) root.appendChild(el);
+
+  function rest() {
+    cur = null;
+    lidTop.style.height = '0';
+    lidBot.style.height = '0';
+    veil.style.opacity = '0';
+    veil.style.background = '#000';
+  }
+
+  function lids(pct) {
+    const v = clamp(pct, 0, LID_MAX_PCT).toFixed(2) + '%';
+    lidTop.style.height = v;
+    lidBot.style.height = v;
+  }
+
+  /**
+   * Run one beat. Returns null, or what the run has to do about it:
+   *   { freezeSec } hold the world this long (a snap), { flash } pulse instead (reduced motion).
+   */
+  function play(id, strength = 1, dur = null) {
+    if (disposed) return null;
+    const kind = FX_KINDS[id];
+    if (!kind || !kind.frame) return null;
+    const s = clamp(isFinite(Number(strength)) ? Number(strength) : 1, 0, 1);
+    const secs = (dur != null && isFinite(Number(dur)) && Number(dur) > 0) ? Number(dur) : kind.dur;
+    rest();
+
+    if (reducedMotion && (id === 'blink' || id === 'snap')) return { flash: s * REDUCED_FLASH };
+
+    if (id === 'snap') {
+      // one white frame: painted now, cleared on the next tick, and the world stops dead behind it
+      veil.style.background = '#fff';
+      veil.style.opacity = String(s);
+      cur = { id, strength: s, dur: secs, t: 0 };
+      if (sfx) { try { sfx(SNAP_SFX, 0.9); } catch (e) { /* audio gone */ } }
+      return { freezeSec: SNAP_FREEZE_SEC };
+    }
+    cur = { id, strength: s, dur: Math.max(0.05, secs), t: 0 };
+    return null;
+  }
+
+  /** Walk the running beat on. Safe to call every frame with nothing running. */
+  function tick(dt) {
+    if (disposed || !cur) return;
+    const d = Number(dt) || 0;
+    cur.t += d;
+    if (cur.id === 'snap') { if (cur.t > 0) rest(); return; }   // one frame of white, then gone
+    if (cur.id === 'blink') {
+      const close = cur.dur * BLINK_CLOSE, open = cur.dur - close, shut = cur.strength * LID_MAX_PCT;
+      if (cur.t < close) lids(shut * ease(cur.t / close));
+      else if (cur.t < close + BLINK_HOLD_SEC) lids(shut);
+      else if (cur.t < close + BLINK_HOLD_SEC + open) lids(shut * (1 - ease((cur.t - close - BLINK_HOLD_SEC) / open)));
+      else rest();
+      return;
+    }
+    if (cur.id === 'blackout') {
+      const cap = Math.min(cur.strength, reducedMotion ? BLACKOUT_REDUCED : BLACKOUT_MAX);
+      const half = cur.dur / 2;
+      if (cur.t < half) veil.style.opacity = String(cap * ease(cur.t / half));
+      else if (cur.t < cur.dur) veil.style.opacity = String(cap * (1 - ease((cur.t - half) / half)));
+      else rest();
+    }
+  }
+
+  function dispose() {
+    if (disposed) return;
+    disposed = true;
+    rest();
+    if (el.parentNode) el.parentNode.removeChild(el);
+  }
+
+  return { play, tick, dispose, stop: rest, FX_KINDS, get live() { return !!cur; } };
+}
+
+export default createFrameFx;

--- a/ConditioningControlPanel/Resources/web/dtrh/race/run.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/run.js
@@ -41,6 +41,7 @@ import { createCocktail, CATEGORIES } from './cocktail.js';
 import { createBubbleField } from './bubbles.js';
 import { createTrackState } from './track.js';
 import { cueFor, resultTag } from './cues.js';
+import { createFrameFx } from './frameFx.js';
 import { createKart } from './kart.js';
 import { createScore } from './score.js';
 import { createRaceHud } from './hud.js';
@@ -112,6 +113,9 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
   const input = createInput({ root });   // root: the touch layer, on a phone, is built inside its .race-hud
   const audio = createRaceAudio({ bridge, hud, settings, input });
   const speedFx = createSpeedFx({ scene, camera, root, reducedMotion });
+  // the full-frame beats a hand chart drops (CHART.md): lids, a blackout, one white frame.
+  // Its own layer over the whole root, built once and disposed with the run like payloadFx.
+  const frameFx = createFrameFx({ root, reducedMotion, sfx });
   const camOut = { pos: new THREE.Vector3(), look: new THREE.Vector3(), up: new THREE.Vector3(0, 1, 0), roll: 0 };
   const _v = new THREE.Vector3();
 
@@ -121,9 +125,12 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     elapsed: 0, t: 0, intensity: intensityFloor, timeScale: 1, jackpotBias: 1, parasol: false, magnet: false,
     flip: false, spawnT: SPAWN_T0, rainT: RAIN_T0, tunnelTime: 0, rush: 0, fov: fovBase, fovBoost: 0, gates: 0, room: null,
     wasAirborne: false, airH: 0, effects: [], moodHeld: null, moodHold: 0, mood: 'calm', bestAtStart: 0, seed, wobble: 0,
-    trackHold: 0, trackFog: 0, trackPaused: false, statsAt: 0, trackGap: 0,
+    trackHold: 0, trackFog: 0, trackPaused: false, statsAt: 0, trackGap: 0, freezeSec: 0,
   };
   fovLive = true;   // S exists: resize() may shift S.fov from here on
+  /** Events whose first bubble has already been popped. A hand wall is six bubbles carrying ONE
+   *  event id: the first pop is the event, the other five are points (CHART.md). */
+  const takenEvents = new Set();
   const mix = createCocktail({ now: () => S.elapsed });   // THE MIX: one live effect per category (cocktail.js); S.effects mirrors its live slots
   const TR = createTrackState();      // the loaded track chart: its clock, its energy, its acts (race/track.js)
   const hosted = bridge.isHosted !== false;   // the standalone page logs where the host would be told
@@ -185,8 +192,8 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     Object.assign(S, { running: false, paused: false, ended: false, elapsed: 0, t: 0, intensity: intensityFloor, timeScale: 1,
       jackpotBias: 1, parasol: false, magnet: false, spawnT: SPAWN_T0, rainT: RAIN_T0, rush: 0, fovBoost: 0, gates: 0, room: null,
       wasAirborne: false, airH: 0, effects: [], moodHeld: null, moodHold: 0, mood: 'calm', seed: runSeed,
-      trackHold: 0, trackFog: 0, trackPaused: false, statsAt: 0, trackGap: 0 });
-    setFlip(false); trailClear();
+      trackHold: 0, trackFog: 0, trackPaused: false, statsAt: 0, trackGap: 0, freezeSec: 0 });
+    setFlip(false); trailClear(); takenEvents.clear(); frameFx.stop();
     mix.reset(); S.wobble = 0; clearMixChrome();
     hud.setScore(0); hud.setCombo(0, 1); hud.setBank(0); hud.setSpeed(0); hud.setFraught(0); hud.pickupClear(); hud.item(null, 'no item yet');
   }
@@ -216,9 +223,13 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     }
   }
   function onPop(w, p) {
-    if (p.eventId) TR.taken(p.eventId);
+    // one event, one meeting: the first bubble of a group is the word the voice said, the rest of a
+    // wall are just bubbles. Six pink pops in one row would otherwise be six pours at THE MIX.
+    const firstOfEvent = !p.eventId || !takenEvents.has(p.eventId);
+    if (p.eventId && firstOfEvent) { takenEvents.add(p.eventId); TR.taken(p.eventId); }
     w.kart.pulseTarget(); w.kart.pose('grab', { side: (p.x == null ? w.kart.state.x : p.x) >= w.kart.state.x ? 1 : -1 });
     if (p.kind === 'treat') return treat(w, p);
+    if (!firstOfEvent) { w.score.pop(p.points, 'treat'); return; }
     if (S.parasol) { S.parasol = false; hud.toast('parasol', 'item'); return treat(w, p); }
     // THE MIX: one live effect per category, each with its own re-pop rule (cocktail.js); 'held' scores as a treat
     const durationMult = 0.5 + 0.5 * S.intensity;
@@ -382,6 +393,34 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     pour(w, { id: k.id, payload: k.payload, overlayKind: k.overlayKind }, r, Math.round(clamp(k.strength, 0, 1) * 100), durationMult);
     if (r.recipe) serve(w, r.recipe);
   }
+  /**
+   * One full-frame beat off a hand cue (CHART.md FX_KINDS). Three of the six are verbs the
+   * run already owns and keeps owning: the shake is the user's own dial, the melt goes through THE
+   * MIX exactly as a popped braindrain would, the flash is the engine's. The rest belong to
+   * race/frameFx.js, which is the only thing here allowed to take the whole frame.
+   */
+  function playFx(w, f) {
+    if (!f || typeof f.id !== 'string') return;
+    const s = clamp(isFinite(Number(f.strength)) ? Number(f.strength) : 1, 0, 1);
+    const sec = (f.dur != null && isFinite(Number(f.dur)) && Number(f.dur) > 0) ? Number(f.dur) : null;
+    if (f.id === 'shake') { shake.shake(s, (sec || 0.4) * 1000); return; }
+    if (f.id === 'melt') { cueMix(w, 'braindrain'); return; }
+    if (f.id === 'flash') { w.fx.pulseFlash(s); return; }
+    const r = frameFx.play(f.id, s, sec);
+    if (!r) return;
+    if (r.freezeSec > 0) S.freezeSec = Math.max(S.freezeSec, r.freezeSec);   // a snap: the world holds
+    if (r.flash > 0) w.fx.pulseFlash(r.flash);                               // reduced motion: a pulse instead
+  }
+  /** The one line the standalone page prints when the author's own cue lands, so a headless run can
+   *  be grepped for it: `hand cue h7: wall pink, fx snap+shake`. */
+  function logHandCue(event, cue) {
+    if (!bridge.log) return;
+    const bits = [];
+    if (event.cue.wall) bits.push('wall ' + event.cue.wall);
+    if (cue.spawn.length && !event.cue.wall) bits.push(cue.spawn.length + ' spawn');
+    bits.push('fx ' + (cue.fx.length ? cue.fx.map((f) => f.id).join('+') : 'none'));
+    bridge.log(`hand cue ${event.id}: ${bits.join(', ')}`);
+  }
   /** One event off the scheduler, spent on the world. Every spawn goes in at the depth the kart will
    *  have reached when the voice says it, so the pop lands on the word whatever the throttle did. */
   function applyCue(w, due) {
@@ -392,6 +431,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
       const d = ks.d + ks.speed * Math.max(due.dueIn + (sp.at || 0), CUE_AHEAD_SEC);
       w.field.spawnAt({ kindId: sp.kindId, placement: sp.placement, d, x: sp.x, h: sp.h, eventId: due.event.id });
     }
+    for (const f of cue.fx) playFx(w, f);
     if (cue.jump) { ks.vh = Math.max(ks.vh, cue.jump); ks.h = Math.max(ks.h, 0.06); ks.airborne = true; w.kart.pose('air'); }
     if (cue.mix) cueMix(w, cue.mix);
     if (cue.mood) poke(cue.mood, Math.max(1.2, cue.holdSec));
@@ -402,6 +442,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     if (cue.boost) w.kart.applyBoost(cue.boost);
     if (cue.density != null) w.field.setDensity(cue.density);
     if (cue.holdSec > 0) S.trackHold = cue.holdSec;
+    if (due.event.cue) logHandCue(due.event, cue);
   }
   /** The act moved with no gate in reach: dress the new room where we stand and marquee its name. */
   function actMoved(w, act, ks) {
@@ -446,6 +487,9 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
   // ---- the frame ----
   function step(w, dt) {
     const k = w.kart, ks = k.state, lay = w.layout;
+    // a snap froze the world: the kart, the field and the clock-driven spawns all wait it out. The
+    // camera and frameFx still run in frame(), so the white frame is seen and the tube holds still.
+    if (S.freezeSec > 0) { S.freezeSec = Math.max(0, S.freezeSec - dt); return; }
     S.elapsed += dt;
     // with a track the intensity is the file's energy curve (smoothed, floored), not the clock ramp.
     // step() takes no delta: the voice runs on the wall, never on the run's clamped frame (track.js).
@@ -532,6 +576,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     last = now;
     if (stage) { try { stage.update(dt); stage.render(); } catch (e) { bridge.log && bridge.log('race stage: ' + (e && e.stack || e)); } return; }
     if (!W) return;
+    frameFx.tick(dt);   // outside the run gate on purpose: a brake mid-blink must not leave the lids shut
     if (S.running && !S.paused && !S.hostPaused) {
       try { step(W, dt); } catch (e) { bridge.log && bridge.log('race step: ' + (e && e.stack || e)); }
     }
@@ -624,7 +669,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     if (payoutResolve) payoutResolve(null);
     teardown();
     audio.dispose();
-    input.dispose(); hud.dispose(); shake.dispose(); payloadFx.dispose(); speedFx.dispose(); lane.dispose();
+    input.dispose(); hud.dispose(); shake.dispose(); payloadFx.dispose(); frameFx.dispose(); speedFx.dispose(); lane.dispose();
     pixel.dispose();
     scene.clear(); renderer.dispose();
     setFlip(false);

--- a/ConditioningControlPanel/Resources/web/dtrh/race/run.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/run.js
@@ -429,7 +429,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     if (!cue) { TR.skip(due.event.id); return; }   // a guess the feel pass threw out never counts against the player
     for (const sp of cue.spawn) {
       const d = ks.d + ks.speed * Math.max(due.dueIn + (sp.at || 0), CUE_AHEAD_SEC);
-      w.field.spawnAt({ kindId: sp.kindId, placement: sp.placement, d, x: sp.x, h: sp.h, eventId: due.event.id });
+      w.field.spawnAt({ kindId: sp.kindId, placement: sp.placement, d, x: sp.x, h: sp.h, eventId: due.event.id, sure: !!sp.sure });
     }
     for (const f of cue.fx) playFx(w, f);
     if (cue.jump) { ks.vh = Math.max(ks.vh, cue.jump); ks.h = Math.max(ks.h, 0.06); ks.airborne = true; w.kart.pose('air'); }

--- a/ConditioningControlPanel/Resources/web/dtrh/race/smoke/hand-cues-check.mjs
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/smoke/hand-cues-check.mjs
@@ -1,0 +1,122 @@
+/* ============================================================================
+ * race/smoke/hand-cues-check.mjs - node self-check for the hand-authored half of a chart.
+ *
+ *   node race/smoke/hand-cues-check.mjs      (exits 0 on pass, 1 with a count of failures)
+ *
+ * CHART.md is additive: a chart the auto charter wrote must normalize and cue EXACTLY as it
+ * did before this PR, and a chart the editor wrote must come through with its overrides intact and
+ * everything it made up thrown away. So this walks both: the untouched path first (no cue, no rule,
+ * no hand, no note, no rules table), then sanitizeCue's teeth (a bad placement, an unknown bubble,
+ * an unknown fx id, numbers off the road), then cueFor's override path (a wall is six bubbles, a
+ * mark with fx is the fx and nothing else, a mark with no cue is nothing at all).
+ * ==========================================================================*/
+
+import { normalizeChart, sanitizeCue, demoChart, FX_IDS, EVENT_KINDS } from '../chart.js';
+import { cueFor } from '../cues.js';
+import { LANE_H, CEILING_H, ROAD_HALF_W } from '../consts.js';
+import { KIND_BY_ID } from '../bubbleKinds.js';
+
+let fails = 0;
+const ok = (cond, what) => { if (!cond) { console.error('FAIL ' + what); fails++; } else console.log('  ok  ' + what); };
+
+const DUR = 120;
+const base = (events, extra = {}) => normalizeChart(Object.assign({
+  version: 1, binSec: 0.5, energy: [0.4, 0.4], acts: [{ t0: 0, t1: DUR, kind: 'free' }],
+  events, source: { name: 'hand', hash: 'h', durationSec: DUR },
+}, extra));
+
+/* ---- 1. the auto chart is untouched ------------------------------------- */
+{
+  const ch = base([{ id: 'a1', t: 10, kind: 'trigger', label: 'good girl' }]);
+  const e = ch.events[0];
+  ok(ch.hand === false && Array.isArray(ch.rules) && ch.rules.length === 0, 'a chart with no hand fields is hand:false with an empty rule table');
+  ok(!('cue' in e) && !('rule' in e) && !('hand' in e) && !('note' in e), 'and its events carry no cue, rule, hand or note at all');
+  const cue = cueFor(e, { rng: () => 0.5, triggerKinds: new Map() });
+  ok(cue.spawn.length === 1 && Array.isArray(cue.fx) && cue.fx.length === 0, 'cueFor still reads the auto table: one bubble, no full-frame beat');
+  ok(EVENT_KINDS.includes('mark'), 'EVENT_KINDS gained mark');
+  ok(FX_IDS.join() === 'blink,blackout,snap,shake,melt,flash', 'FX_IDS is the CHART.md table: ' + FX_IDS.join(', '));
+}
+
+/* ---- 2. normalizeChart keeps the hand-authored fields ------------------- */
+{
+  const ch = base([{ id: 'r3-12', t: 30, kind: 'trigger', label: 'good girl', rule: 'r3', hand: true,
+    note: 'x'.repeat(400), cue: { wall: 'pink', fx: [{ id: 'blink', strength: 0.8, dur: 0.45 }], word: 'good girl' } }],
+    { hand: true, rules: [{ id: 'r3', name: 'good girl', enabled: true }] });
+  const e = ch.events[0];
+  ok(ch.hand === true, 'a chart saved by the editor keeps hand:true');
+  ok(ch.rules.length === 1 && ch.rules[0].id === 'r3', 'and its rule table rides along for the round trip');
+  ok(e.rule === 'r3' && e.hand === true, 'the event keeps the rule that made it and the author edit flag');
+  ok(e.note.length === 200, 'the note is cut to 200 chars, never dropped: ' + e.note.length);
+  ok(e.cue.wall === 'pink' && e.cue.fx.length === 1 && e.cue.word === 'good girl', 'and the cue survives whole');
+  const marks = base([{ id: 'h7', t: 40, kind: 'mark', label: 'the snap', cue: { jump: 7 } }]);
+  ok(marks.events.length === 1 && marks.events[0].kind === 'mark', 'a mark is a legal event kind now');
+}
+
+/* ---- 3. sanitizeCue throws out what it does not know -------------------- */
+{
+  const c = sanitizeCue({
+    spawn: [
+      { kindId: 'pink', placement: 'lane', x: 0, h: LANE_H, at: 0 },
+      { kindId: 'pink', placement: 'kerb', x: 0, h: LANE_H, at: 0 },
+      { kindId: 'not-a-bubble', placement: 'air', x: 0, h: 2.6, at: 0 },
+      { kindId: 'golden', placement: 'air', x: 99, h: 999, at: 900 },
+    ],
+    fx: [{ id: 'blink' }, { id: 'seizure', strength: 1 }, { id: 'blackout', strength: 4, dur: 90 }],
+    wall: 'not-a-bubble', jump: 40, boost: 40, density: 40, holdSec: 4000, mood: 'furious', mix: 'nonsense',
+  }, DUR);
+  ok(c.spawn.length === 2, 'a bad placement and an unknown bubble kind are dropped: ' + c.spawn.length + ' of 4 kept');
+  ok(c.spawn.every((s) => KIND_BY_ID[s.kindId]), 'every surviving spawn names a real bubble');
+  const far = c.spawn[1];
+  ok(Math.abs(far.x) <= ROAD_HALF_W - 0.4 && far.h <= CEILING_H && far.at <= 30, 'x, h and at are clamped onto the road, into the tube and near the word');
+  ok(c.fx.length === 2 && c.fx.map((f) => f.id).join() === 'blink,blackout', 'an unknown fx id is dropped: ' + c.fx.map((f) => f.id).join(', '));
+  ok(c.fx[0].strength === 1 && c.fx[0].dur === null, 'a bare fx defaults to full strength and the table duration');
+  ok(c.fx[1].strength === 1 && c.fx[1].dur === 10, 'and strength and dur are clamped to 0..1 and 0..10');
+  ok(c.wall === null && c.mix === null && c.mood === null, 'an unknown wall, mix and mood all come back null, never played');
+  ok(c.jump === 12 && c.boost === 10 && c.density === 4 && c.holdSec === DUR, 'the knobs are capped: jump ' + c.jump + ', boost ' + c.boost + ', hold ' + c.holdSec);
+  ok(sanitizeCue(null) === null && sanitizeCue({}) === null && sanitizeCue(7) === null, 'nothing in, nothing out (no throw)');
+}
+
+/* ---- 4. cueFor takes the author at their word --------------------------- */
+{
+  const ctx = { rng: () => 0.5, triggerKinds: new Map() };
+  const wall = base([{ id: 'w1', t: 20, kind: 'trigger', label: 'good girl',
+    cue: { wall: 'pink', fx: [{ id: 'blink', strength: 0.8, dur: 0.45 }], word: 'good girl' } }]).events[0];
+  const wc = cueFor(wall, ctx);
+  ok(wc.spawn.length === 6, 'a wall is six bubbles the kart cannot steer around: ' + wc.spawn.length);
+  ok(wc.spawn.filter((s) => s.placement === 'lane').length === 5, 'five across the road');
+  ok(wc.spawn.map((s) => s.x).join() === '-2.2,-1.1,0,1.1,2.2,0', 'on the five lanes plus one over the top');
+  ok(wc.spawn.filter((s) => s.placement === 'lane').every((s) => s.h === LANE_H), 'the road row sits at LANE_H');
+  ok(wc.spawn.every((s) => s.kindId === 'pink' && s.at === 0), 'all six are the wall kind, all on the word');
+  ok(wc.fx.length === 1 && wc.fx[0].id === 'blink' && wc.fx[0].strength === 0.8, 'and the blink rides with it');
+  ok(wc.word === 'good girl' && wc.jump === 0 && wc.mix === null, 'the fields the author left alone stay at their defaults');
+
+  const mark = base([{ id: 'h7', t: 40, kind: 'mark', label: 'the snap', hand: true,
+    cue: { fx: [{ id: 'snap', strength: 1 }, { id: 'shake', strength: 0.6, dur: 0.4 }], jump: 7, mix: 'spiral', mood: 'streamed' } }]).events[0];
+  const mc = cueFor(mark, ctx);
+  ok(mc.spawn.length === 0, 'a mark can be a beat with no bubble at all');
+  ok(mc.fx.map((f) => f.id).join() === 'snap,shake', 'its fx come through in order: ' + mc.fx.map((f) => f.id).join(', '));
+  ok(mc.jump === 7 && mc.mix === 'spiral' && mc.mood === 'streamed', 'along with the jump, the mix and the mood');
+
+  const bare = base([{ id: 'h8', t: 50, kind: 'mark', label: 'nothing here' }]).events[0];
+  ok(cueFor(bare, ctx) === null, 'a mark with no cue is worth nothing: cueFor returns null');
+
+  const hand = sanitizeCue({ spawn: [{ kindId: 'golden', placement: 'air' }] }, DUR);
+  const hc = cueFor({ kind: 'mark', cue: hand }, ctx);
+  ok(hc.spawn[0].h === 0 && hc.spawn[0].at === 0, 'a spawn with no height keeps the one the author saved (0 is a choice)');
+}
+
+/* ---- 5. the demo track carries both, so the headless run covers them ---- */
+{
+  const ch = demoChart(240);
+  const hands = ch.events.filter((e) => e.cue);
+  ok(hands.length === 2, 'the demo track has two hand events: ' + hands.map((e) => e.kind).join(', '));
+  const wall = hands.find((e) => e.cue.wall), mark = hands.find((e) => e.kind === 'mark');
+  ok(!!wall && wall.cue.wall === 'pink' && wall.cue.fx[0].id === 'blink', 'a wall of pink with a blink, on a trigger');
+  ok(!!mark && mark.cue.fx.map((f) => f.id).join() === 'snap,shake' && mark.cue.jump === 7 && mark.cue.mix === 'spiral', 'and a mark that snaps, shakes, jumps and pours a spiral');
+  const wa = ch.acts.find((a) => a.t0 <= wall.t && wall.t < a.t1), ma = ch.acts.find((a) => a.t0 <= mark.t && mark.t < a.t1);
+  ok(wa && wa.kind === 'triggers', 'the wall lands in the toybox: ' + (wa && wa.kind));
+  ok(ma && ma.kind === 'build', 'the snap lands in the climb: ' + (ma && ma.kind));
+}
+
+console.log(fails ? '\nhand-cues-check: ' + fails + ' failure(s)' : '\nhand-cues-check: all good');
+process.exit(fails ? 1 : 0);

--- a/ConditioningControlPanel/Resources/web/dtrh/race/smoke/track-run-check.mjs
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/smoke/track-run-check.mjs
@@ -14,7 +14,8 @@
  * with a floor; the acts arrive in order, once each, never the opening one twice;
  * every event kind has a cue and every cue field is legal; a whole run spawns
  * everything ahead of the kart; the run ends inside END_PAD of the duration and the
- * summary counts what the player took; replace() keeps the clock and the taken ids.
+ * summary counts what the player took; replace() keeps the clock and the taken ids. The
+ * hand-authored half (cue overrides, walls, frame beats) is race/smoke/hand-cues-check.mjs.
  * ==========================================================================*/
 
 import { KART_BASE_SPEED, LANE_H, CEILING_H, ROAD_HALF_W, makeRng } from '../consts.js';
@@ -117,7 +118,7 @@ function chartEnergy(t) {
     if (cue.boost < 0 || cue.boost > 4) bad = bad || ('boost out of range ' + cue.boost);
   }
   ok(!bad, bad || 'every cue names a real bubble kind, placement, mood and mix');
-  ok(EVENT_KINDS.every((k) => seen.has(k)), 'the demo track exercised all nine event kinds');
+  ok(EVENT_KINDS.every((k) => seen.has(k)), 'the demo track exercised all ten event kinds, the hand-authored mark included');
   ok(cueFor(null, ctx) === null && cueFor({ kind: 'nonsense' }, ctx) === null, 'a junk event is null, never a throw');
 
   const t = cueFor({ kind: 'trigger', label: 'good girl' }, ctx);

--- a/ConditioningControlPanel/Resources/web/dtrh/raceBoot.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/raceBoot.js
@@ -31,7 +31,9 @@
  * `?pixel=N` (0 = off) beats `race.options` which beats `settings.pixel` from
  * the host init; `?itembox=ms` breaks the next sugar cube that comes into
  * reading range after that time and is a screenshot aid for the pickup card;
- * `?panel=howto` opens the menu on the key card (race/menu.js).
+ * `?panel=howto` opens the menu on the key card (race/menu.js); `?music=N`
+ * (0..1, 0 = silent music) beats the saved music slider the same way and
+ * `?bridge=parent` is the Chart Room preview (armParentBridge below).
  *
  * `?back=<same-origin path>` is WHERE THE MENU'S `surface` VERB GOES when there
  * is no host to hand the page back to. Hosted, `surface` posts exit + exit-done
@@ -74,6 +76,8 @@ function resolveBack() {
   return null;
 }
 const standaloneExit = hosted ? null : resolveBack();
+/** The Chart Room embeds this page and drives the clock itself (armParentBridge below). */
+const toParent = params.get('bridge') === 'parent' && window.parent && window.parent !== window;
 const host = hosted ? bridge : {
   on: bridge.on,
   isHosted: false,
@@ -91,6 +95,7 @@ const rollSeed = () => (Date.now() ^ Math.floor(Math.random() * 0x7fffffff)) >>>
 let initMsg = null, haveManifest = false, race = null, menu = null, booted = false, started = false, exiting = false;
 let settings = {}, seed = 0;
 let trackProgress = null, trackReady = null, errorTimer = 0, startTrackClock = null, trackTimer = 0, trackAudio = null;
+let parentArmed = false;
 
 const note = (t) => { if (waitEl) waitEl.textContent = t || ''; };
 function fail(err) {
@@ -195,6 +200,7 @@ async function boot() {
     settings = { ...((initMsg && initMsg.settings) || {}) };
     if (opts.pixel !== undefined) settings.pixel = opts.pixel;
     if (params.has('pixel') && params.get('pixel') !== '') settings.pixel = Number(params.get('pixel'));
+    if (params.has('music') && params.get('music') !== '') opts.music = Math.max(0, Math.min(1, Number(params.get('music')) || 0));
     settings.reducedMotion = wantsReducedMotion(opts, settings.reducedMotion != null ? settings.reducedMotion : !!(matchMedia && matchMedia('(prefers-reduced-motion: reduce)').matches));
     settings.musicVolume = opts.music; settings.sfxVolume = opts.sfx;   // audio.js reads masterVolume; the two sliders go in through setLevels below
     settings.seedLock = seedFromOptions(opts);
@@ -290,6 +296,38 @@ function debugItemBox() {
   }, at);
 }
 
+/**
+ * THE PREVIEW BRIDGE. `?bridge=parent` in an iframe: the
+ * page posts `race-ready` up once the run is going, then takes `chart` (setTrack, or replaceTrack
+ * when the run is already carrying one), `clock` and `seek`. There is no jump notion under
+ * track.js: `clock(t)` sets the second outright and the scheduler lets the future back in when the
+ * clock walks backwards, so a seek is a clock tick with a jump in it and nothing more.
+ * Same origin only, and only from our own opener. Nothing here runs hosted or standalone.
+ */
+async function armParentBridge() {
+  if (!toParent || parentArmed || !race) return;
+  parentArmed = true;
+  let normalizeChart = null;
+  try { ({ normalizeChart } = await import('./race/chart.js')); }
+  catch (err) { host.log('preview: no chart module: ' + ((err && err.message) || err)); return; }
+  window.addEventListener('message', (ev) => {
+    if (ev.origin !== location.origin || ev.source !== window.parent) return;
+    const m = ev.data;
+    if (!m || typeof m !== 'object' || !race) return;
+    try {
+      if (m.type === 'chart' && m.chart) {
+        const chart = normalizeChart(m.chart);
+        if (race.track && started) race.replaceTrack(chart); else race.setTrack(chart);
+      } else if (m.type === 'clock' || m.type === 'seek') {
+        race.trackClock(Number(m.t) || 0, m.playing !== false);
+      }
+    } catch (err) { host.log('preview ' + m.type + ': ' + ((err && err.message) || err)); }
+  });
+  try { window.parent.postMessage({ type: 'race-ready' }, location.origin); }
+  catch (err) { host.log('preview: the parent would not take race-ready: ' + ((err && err.message) || err)); }
+  host.log('preview bridge armed');
+}
+
 function hideSplash() {
   splash.classList.add('is-off');
   setTimeout(() => { splash.hidden = true; }, 600);
@@ -350,6 +388,7 @@ async function startRun(withIntro) {
       race.start();
       if (startTrackClock) startTrackClock();
     }
+    armParentBridge();
   } catch (err) {
     host.log('start: ' + ((err && err.stack) || err));
     try { race.setStage(null); race.start(); } catch (e) { fail(e); }


### PR DESCRIPTION
Race-side half of the Track Maker: the kart plays a chart with hand-placed bubbles, walls and full-frame effects, and it can run inside a frame with a parent driving its clock. Nothing in here changes a run that has no hand chart.

- `race/chart.js` - `normalizeChart` keeps a per-event `cue` (`spawn`, `wall`, `fx`, `jump`, `mix`, `mood`), `hand`, `sure`, `rule` and `note`; `sanitizeCue` clamps lanes, ids and durations; a new additive `mark` kind for effect-only moments. CHART.md documents the fields.
- `race/cues.js` - a hand `cue` short-circuits before the feel-pass gates (a wake word outside the wake act, a lone number), so what the author placed is what plays; `blank()` carries `fx: []`; `fromHand` builds the wall (five lane bubbles on `WALL_X` plus one in the air).
- `race/frameFx.js` (new) - blink, blackout, snap, shake, melt, flash: one layer over the run root, built once and disposed with it.
- `race/run.js` - a hand wall is six bubbles carrying one event id: the first pop is the event, the other five are points (`takenEvents`); a snap holds the world for `freezeSec`.
- `race/bubbles.js` - `spawnAt({ sure })` skips the density thinning for hand-placed bubbles, so the author never loses one to the knob.
- `raceBoot.js` - `?music=N` beats the saved music slider through `setLevels`; `?bridge=parent` in an iframe posts `race-ready` and takes `chart` / `clock` / `seek` from a same-origin parent (`armParentBridge`). Rebased over the touch, camera and menu-audio waves on main; the audio.js half of the old music dial went away because main's `setLevels` already does it.
- `race/smoke/hand-cues-check.mjs` (new) + `track-run-check.mjs`.

---
Track Maker stack, merge bottom up: #873 (merged) > hand-cues > maker-words > mk1 > mk2 > mk3 > mk4 > mk5. Each PR is based on the one before it and stays under 600 changed lines. No audio, words, transcript or output from any real file is in any of them (`chart/words/` is gitignored and excluded from the csproj).

Smokes, from `ConditioningControlPanel/Resources/web/dtrh`: `for f in chart/smoke/*.mjs race/smoke/*.mjs; do node "$f"; done` is green on every branch of the stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CRXVViHCxrTnrYFD7M1g8o
