### PR TITLE
feat(track maker): the trigger catalogue and the detector, pure (2/7)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -199,3 +199,9 @@ marketing/
 
 # Release-notes drafts (the text lives in the GitHub release body; keep the file local)
 notes-v*.txt
+
+# Track Maker transcripts (ConditioningControlPanel/Resources/web/dtrh/chart/words/).
+# Aligned *.words.json for the mp3s an author works on: someone's session audio turned
+# into text, several hundred KB each, and useless to anyone without the audio. Local
+# only, and excluded from the csproj too so a build never carries them either.
+ConditioningControlPanel/Resources/web/dtrh/chart/words/

--- a/ConditioningControlPanel/ConditioningControlPanel.csproj
+++ b/ConditioningControlPanel/ConditioningControlPanel.csproj
@@ -545,6 +545,14 @@
       $(MSBuildProjectDirectory)\Resources\web\arcademy\emi\demo.html;
       $(MSBuildProjectDirectory)\Resources\web\arcademy\shell\recordsroom.demo.html
     </ArcademyHarnessExcludeAbs>
+    <!-- Track Maker transcripts (Resources\web\dtrh\chart\words\*.words.json, see
+         chart\MAKER.md). An author's own aligned transcripts of their own audio,
+         hundreds of KB each and meaningless without it. Gitignored, so a clean clone
+         has none; excluded here AND from the CopyContentAfterPublish WebFiles glob,
+         so a build on the machine that HAS them never carries them into the output
+         or the installer. -->
+    <ChartWordsExclude>Resources\web\dtrh\chart\words\**\*</ChartWordsExclude>
+    <ChartWordsExcludeAbs>$(MSBuildProjectDirectory)\Resources\web\dtrh\chart\words\**\*</ChartWordsExcludeAbs>
   </PropertyGroup>
 
   <ItemGroup>
@@ -575,6 +583,7 @@
     <Content Include="Resources\web\**\*"
              Exclude="Resources\web\**\CLAUDE.md;Resources\web\**\CAPTCHA_*.md;Resources\web\**\BUILD_PLAN.md;
                       $(ArcademyHarnessExclude);
+                      $(ChartWordsExclude);
                       $(ContentPackWebExclude)">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
@@ -659,7 +668,8 @@
       <WebFiles Include="$(ProjectDir)Resources\web\**\*"
                 Exclude="$(ProjectDir)Resources\web\**\CLAUDE.md;$(ProjectDir)Resources\web\**\CAPTCHA_*.md;$(ProjectDir)Resources\web\**\BUILD_PLAN.md;
                          $(ContentPackWebExcludeAbs);
-                         $(ArcademyHarnessExcludeAbs)" />
+                         $(ArcademyHarnessExcludeAbs);
+                         $(ChartWordsExcludeAbs)" />
       <SubAudioFiles Include="$(ProjectDir)Resources\sub_audio\**\*" />
       <AwarenessPresetFiles Include="$(ProjectDir)Resources\AwarenessPresets\**\*" />
       <DeeperDemoFiles Include="$(ProjectDir)Resources\DeeperDemos\**\*" />

--- a/ConditioningControlPanel/Resources/web/dtrh/chart/editor/triggerSets.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/chart/editor/triggerSets.js
@@ -1,0 +1,84 @@
+/* ============================================================================
+ * editor/triggerSets.js - the trigger catalogue, as data (chart/EDITOR.md, PR U5).
+ *
+ * Data only: no imports, no DOM, no window, so rules.js, triggers.js and
+ * model.js can all read it without a cycle. Every phrase was counted over the
+ * eleven aligned Bambi Sleep tracks, so a count of 0 in the tab means the file
+ * really does not say it, never that the phrase is wrong. One fixed hue per
+ * set, so a marker reads the same in every project (UX appendix B). Every hue
+ * here clears 5.2:1 against the ink `labelInk` gives it (PR U8).
+ *
+ * Shared with the Track Maker: chart/maker/triggers.js re-exports this whole
+ * catalogue, so a trigger means the same phrase, the same colour and the same
+ * cue on both pages. Change a set here and both tools change with it.
+ * ==========================================================================*/
+
+export const TRIGGER_SETS = [
+  { id: 'bambi-sleep', name: 'bambi sleep', group: 'named', phrase: 'bambi sleep', mode: 'exact', color: '#b080ff', preset: 'blackout' },
+  { id: 'good-girl', name: 'good girl', group: 'named', phrase: 'good girl', mode: 'exact', color: '#ff69b4', preset: 'pink-blink' },
+  { id: 'bimbo-doll', name: 'bimbo doll', group: 'named', phrase: 'bimbo doll', mode: 'exact', color: '#ff3da5', preset: 'pink-blink', cluster: 1.5 },
+  { id: 'bambi-freeze', name: 'bambi freeze', group: 'named', phrase: 'bambi freeze', mode: 'exact', color: '#8ae6ff', preset: 'freeze-snap' },
+  { id: 'bambi-reset', name: 'bambi reset', group: 'named', phrase: 'bambi reset', mode: 'exact', color: '#ffffff', preset: 'snap-shake' },
+  { id: 'uniform-lock', name: 'bambi uniform lock', group: 'named', phrase: 'uniform lock', mode: 'exact', color: '#ffd166', preset: 'glitch-shake' },
+  { id: 'drip-drop', name: 'drip drop', group: 'named', phrase: 'drip drop', mode: 'exact', color: '#78ffbe', preset: 'golden-rain' },
+  { id: 'snap-forget', name: 'snap and forget', group: 'named', phrase: 'snap and forget', mode: 'exact', color: '#f4f2ff', preset: 'snap-shake' },
+  { id: 'zap-cock-drain', name: 'zap cock drain', group: 'named', phrase: 'zap cock drain', mode: 'exact', color: '#ff5c6c', preset: 'flash-pulse' },
+  { id: 'primped', name: 'primped and pampered', group: 'named', phrase: 'primped and pampered', mode: 'exact', color: '#ffb3d9', preset: 'treats' },
+  { id: 'does-as-told', name: 'bambi does as she is told', group: 'named', phrase: "does as she(?:'s| is) told", mode: 'regex', color: '#c8a8ff', preset: 'spiral-air' },
+  { id: 'cockslut', name: 'bambi cockslut', group: 'named', phrase: 'cock ?slut', mode: 'regex', color: '#ee7078', preset: 'video' },
+  { id: 'takeover', name: 'bambi takeover', group: 'named', phrase: 'take(?:s|n)? ?over', mode: 'regex', color: '#4060c0', preset: 'melt' },
+  { id: 'awaken', name: 'bambi awaken', group: 'named', phrase: 'awaken|wake up|wide awake', mode: 'regex', color: '#ffd6a0', preset: 'flash-pulse' },
+  { id: 'giggle-time', name: 'giggle time', group: 'named', phrase: 'giggle ?time', mode: 'regex', color: '#ffe066', preset: 'treats' },
+  { id: 'sleep-now', name: 'sleep now', group: 'named', phrase: 'sleep now', mode: 'exact', color: '#6f4f9c', preset: 'blackout' },
+  { id: 'w-blank', name: 'blank', group: 'words', phrase: 'blank', mode: 'exact', color: '#ece8ff', preset: 'mark' },
+  { id: 'w-pink', name: 'pink', group: 'words', phrase: 'pink', mode: 'exact', color: '#ff3da5', preset: 'pink-wall' },
+  { id: 'w-obey', name: 'obey', group: 'words', phrase: 'obey', mode: 'exact', color: '#b080ff', preset: 'mark' },
+  { id: 'w-empty', name: 'empty', group: 'words', phrase: 'empty', mode: 'exact', color: '#8fd0ff', preset: 'mark' },
+  { id: 'w-sleep', name: 'sleep', group: 'words', phrase: 'sleep', mode: 'exact', color: '#6b8cff', preset: 'mark' },
+  { id: 'w-drop', name: 'drop', group: 'words', phrase: 'drop', mode: 'exact', color: '#78ffbe', preset: 'spiral-air' },
+  { id: 'w-dumb', name: 'dumb', group: 'words', phrase: 'dumb', mode: 'exact', color: '#ffd166', preset: 'mark' },
+  { id: 'w-mindless', name: 'mindless', group: 'words', phrase: 'mindless', mode: 'exact', color: '#c8a8ff', preset: 'mark' },
+  { id: 'w-forget', name: 'forget', group: 'words', phrase: 'forget', mode: 'exact', color: '#9a97b8', preset: 'mark' },
+  { id: 'w-trance', name: 'trance', group: 'words', phrase: 'trance', mode: 'exact', color: '#40d0c0', preset: 'mark' },
+  { id: 'w-relax', name: 'relax', group: 'words', phrase: 'relax', mode: 'exact', color: '#b8ffd9', preset: 'mark' },
+  { id: 'w-accept', name: 'accept', group: 'words', phrase: 'accept', mode: 'exact', color: '#ffb3d9', preset: 'mark' },
+  { id: 'w-giggle', name: 'giggle', group: 'words', phrase: 'giggl', mode: 'contains', color: '#ffe066', preset: 'treats' },
+  { id: 'w-lock', name: 'lock', group: 'words', phrase: 'lock', mode: 'exact', color: '#ffd6a0', preset: 'mark' },
+  { id: 'deeper', name: 'deeper and deeper', group: 'sequence', phrase: 'deeper and deeper', mode: 'exact', color: '#6b8cff', preset: 'melt' },
+  { id: 'countdown', name: 'countdown', group: 'sequence', mode: 'regex', color: '#ffd166', preset: 'blackout',
+    phrase: '\\b(?:ten|nine|eight|seven|six|five|four|three|two|one|10|9|8|7|6|5|4|3|2|1)\\b(?:[ ,]+\\b(?:nine|eight|seven|six|five|four|three|two|one|zero|9|8|7|6|5|4|3|2|1|0)\\b){2,}' },
+  { id: 'chant', name: 'chant (a word said 3+ times in a row)', group: 'sequence', mode: 'regex', color: '#ff69b4', preset: 'pink-wall',
+    phrase: '\\b(\\w+(?: \\w+)?)\\b(?: \\1\\b){2,}' },
+];
+
+/** The order the tab lists the groups in, and what it calls them. */
+export const SET_GROUPS = [['named', 'named triggers'], ['words', 'words'], ['sequence', 'sequences'], ['custom', 'yours']];
+
+/** The rotation a custom set takes its colour from, and the swatch cycles through. */
+export const SET_COLORS = ['#ff69b4', '#78ffbe', '#8fd0ff', '#ffd166', '#b080ff', '#ff5c6c',
+  '#ffe066', '#40d0c0', '#ffb3d9', '#6b8cff', '#c8a8ff', '#ece8ff'];
+
+const MODES = ['exact', 'contains', 'regex'];
+
+/** One custom set, filled out and made safe. Junk in the file gives null, not a broken row. */
+export function normalizeSet(s, i = 0) {
+  if (!s || typeof s !== 'object' || !s.phrase) return null;
+  return { id: String(s.id || 'c-' + i), name: String(s.name || s.phrase), group: 'custom',
+    phrase: String(s.phrase), mode: MODES.includes(s.mode) ? s.mode : 'exact',
+    color: /^#[0-9a-f]{6}$/i.test(String(s.color)) ? String(s.color) : SET_COLORS[i % SET_COLORS.length],
+    cluster: Number(s.cluster) > 0 ? Number(s.cluster) : 0 };
+}
+
+/** `project.triggers`, filled out: what is ticked, the author's own sets, the per-set options. */
+export function normalizeTriggers(json) {
+  const j = json && typeof json === 'object' ? json : {};
+  const seen = new Set();
+  const custom = (Array.isArray(j.custom) ? j.custom : [])
+    .map((s, i) => normalizeSet(s, i))
+    .filter((s) => s && !seen.has(s.id) && (seen.add(s.id), true));
+  const opts = {};
+  const src = j.opts && typeof j.opts === 'object' ? j.opts : {};
+  for (const k of Object.keys(src)) if (src[k] && typeof src[k] === 'object') opts[k] = { ...src[k] };
+  const on = [...new Set((Array.isArray(j.on) ? j.on : []).filter((id) => typeof id === 'string' && id))];
+  return { version: 1, on, custom, opts };
+}

--- a/ConditioningControlPanel/Resources/web/dtrh/chart/maker/triggers.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/chart/maker/triggers.js
@@ -1,0 +1,186 @@
+/* ============================================================================
+ * chart/maker/triggers.js - the trigger detector, pure and on its own
+ * (chart/MAKER.md).
+ *
+ * Everything the Track Maker needs to read a trigger out of an aligned
+ * transcript, and nothing else: match a phrase over the words, fold a chant
+ * into one moment, narrow by act or window or every-nth, and hand back a list
+ * of `{ i0, i1, t, dur, n, reps }`. No DOM, no window, no project state, so it
+ * imports cleanly in node and the smoke can run it with no browser.
+ *
+ * CARVE-OUT: the bodies below are copied byte for byte out of the shelved chart
+ * room editor - editor/words.js (normWord, findMatches, clusterSpans),
+ * editor/rules.js (actKindAt, matchRule) and editor/triggers.js (luminance,
+ * labelInk, setToRule, detect). The catalogue itself is not copied: it is
+ * imported from editor/triggerSets.js, which both tools share. If the chart
+ * room ever lands, these two copies have to stay in step, or a trigger starts
+ * meaning one thing on one page and something else on the other.
+ * ==========================================================================*/
+
+import { TRIGGER_SETS, SET_GROUPS, SET_COLORS, normalizeTriggers } from '../editor/triggerSets.js';
+
+export { TRIGGER_SETS, SET_GROUPS, SET_COLORS, normalizeTriggers };
+
+/** What a set matches over before its own options narrow it. */
+export const DEFAULT_SCOPE = { acts: null, t0: 0, t1: null, every: 1, offset: 0 };
+
+/* ---- matching, from editor/words.js ------------------------------------- */
+
+/** lowercase, punctuation stripped, exactly what align.py already writes. */
+export function normWord(w) {
+  return String(w == null ? '' : w).toLowerCase().replace(/[^a-z0-9' ]+/g, ' ').replace(/\s+/g, ' ').trim();
+}
+
+function wordArray(words) {
+  if (Array.isArray(words)) return words;
+  if (words && Array.isArray(words.words)) return words.words;
+  return [];
+}
+
+function span(ws, i0, i1) {
+  const a = ws[i0], b = ws[i1] || a;
+  const t = Number(a.t) || 0;
+  return { i0, i1, t, dur: Math.max(0, (Number(b.t) || 0) + (Number(b.d) || 0) - t) };
+}
+
+function regexMatches(ws, toks, src) {
+  let re;
+  try { re = new RegExp(src, 'gi'); } catch { return []; }
+  const joined = toks.join(' ');
+  const starts = []; let at = 0;
+  for (const t of toks) { starts.push(at); at += t.length + 1; }
+  const out = [];
+  let m, guard = 0;
+  while ((m = re.exec(joined)) && guard++ < 20000) {
+    if (!m[0].length) { re.lastIndex++; continue; }
+    const a = m.index, b = a + m[0].length;
+    let i0 = 0, i1 = 0;
+    for (let i = 0; i < starts.length; i++) { if (starts[i] <= a) i0 = i; if (starts[i] < b) i1 = i; }
+    out.push(span(ws, i0, Math.max(i0, i1)));
+  }
+  return out;
+}
+
+/**
+ * findMatches(words, phrase, mode) -> [{ i0, i1, t, dur }]
+ * A phrase is matched over consecutive words joined by single spaces,
+ * case insensitive, punctuation stripped. Matches never overlap.
+ *  - 'exact'    every phrase token equals its word
+ *  - 'contains' every phrase token is inside its word ("good" finds "goodness")
+ *  - 'regex'    the phrase runs over the joined text, mapped back to indices
+ */
+export function findMatches(words, phrase, mode = 'exact') {
+  const ws = wordArray(words);
+  const src = String(phrase == null ? '' : phrase);
+  if (!ws.length || !src.trim()) return [];
+  const toks = ws.map((w) => normWord(w.w));
+  if (mode === 'regex') return regexMatches(ws, toks, src);
+  const want = normWord(src).split(' ').filter(Boolean);
+  if (!want.length) return [];
+  const out = [];
+  for (let i = 0; i + want.length <= toks.length; i++) {
+    let ok = true;
+    for (let k = 0; k < want.length; k++) {
+      const t = toks[i + k];
+      if (mode === 'contains' ? !t.includes(want[k]) : t !== want[k]) { ok = false; break; }
+    }
+    if (!ok) continue;
+    out.push(span(ws, i, i + want.length - 1));
+    i += want.length - 1;
+  }
+  return out;
+}
+
+/** A chant is one moment, not three: a match starting within gapSec of the end of
+ * the one before is folded in, keeping the first t, growing to the last end and
+ * counting the run in `reps`. A gap of 0 leaves the list alone (PR U5). */
+export function clusterSpans(matches, gapSec) {
+  const gap = Number(gapSec) || 0;
+  if (!Array.isArray(matches)) return [];
+  if (!(gap > 0)) return matches;
+  const out = [];
+  for (const m of matches) {
+    const prev = out[out.length - 1];
+    if (prev && m.t <= prev.t + prev.dur + gap) {
+      prev.dur = Math.max(prev.dur, m.t + m.dur - prev.t);
+      prev.i1 = m.i1;
+      prev.reps++;
+    } else out.push({ ...m, reps: Number(m.reps) > 0 ? Number(m.reps) : 1 });
+  }
+  return out;
+}
+
+/* ---- scope, from editor/rules.js ---------------------------------------- */
+
+export function actKindAt(acts, t) {
+  for (const a of acts || []) if (t >= (a.t0 || 0) && t < (a.t1 == null ? Infinity : a.t1)) return a.kind;
+  return null;
+}
+
+/**
+ * Every span this rule claims, after clustering, acts / window / every-offset and
+ * the scope shift. `durationSec` clamps a shifted time back inside the file. A
+ * rule with no `match.cluster` and no `scope.shift` behaves exactly as it did.
+ */
+export function matchRule(words, rule, acts = [], durationSec = Infinity) {
+  if (!rule || !rule.match) return [];
+  const sc = rule.scope || {};
+  let out = findMatches(words, rule.match.phrase, rule.match.mode || 'exact');
+  if (Number(rule.match.cluster) > 0) out = clusterSpans(out, Number(rule.match.cluster));
+  const t0 = Number(sc.t0) || 0;
+  const t1 = sc.t1 == null || sc.t1 === '' ? Infinity : Number(sc.t1);
+  out = out.filter((m) => m.t >= t0 && m.t <= t1);
+  if (Array.isArray(sc.acts) && sc.acts.length) {
+    const want = new Set(sc.acts);
+    out = out.filter((m) => want.has(actKindAt(acts, m.t)));
+  }
+  const every = Math.max(1, Math.round(Number(sc.every) || 1));
+  const offset = Math.max(0, Math.round(Number(sc.offset) || 0));
+  if (every > 1 || offset) out = out.filter((_, i) => i >= offset && (i - offset) % every === 0);
+  const shift = Number(sc.shift) || 0;
+  if (shift) out = out.map((m) => ({ ...m, t: Math.max(0, Math.min(durationSec, m.t + shift)) }));
+  return out;
+}
+
+/* ---- ink and detect, from editor/triggers.js ---------------------------- */
+
+const INK_DARK = '#0f0f1c', INK_LIGHT = '#f4f2ff';
+const INK_DARK_L = 0.00526, INK_LIGHT_L = 0.90953;      // the two inks, measured once
+
+/** WCAG relative luminance of a #rgb or #rrggbb, -1 when it is neither. */
+export function luminance(hex) {
+  const h = String(hex || '').replace('#', '');
+  const full = h.length === 3 ? h[0] + h[0] + h[1] + h[1] + h[2] + h[2] : h;
+  if (!/^[0-9a-f]{6}$/i.test(full)) return -1;
+  const n = parseInt(full, 16);
+  const ch = (v) => { const c = v / 255; return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4); };
+  return 0.2126 * ch((n >> 16) & 255) + 0.7152 * ch((n >> 8) & 255) + 0.0722 * ch(n & 255);
+}
+
+/** Dark ink on a light fill, light ink on a dark one: whichever of the two the
+ *  fill holds at more contrast, measured the way the guidelines measure it, so
+ *  a mid green reads as well as a white one (PR U7 fixed the flat threshold). */
+export function labelInk(hex) {
+  const L = luminance(hex);
+  if (L < 0) return INK_DARK;
+  return (L + 0.05) / (INK_DARK_L + 0.05) >= (INK_LIGHT_L + 0.05) / (L + 0.05) ? INK_DARK : INK_LIGHT;
+}
+
+/** The rule a set is: `ts-<setId>`, its phrase and mode, the default scope. `opts`
+ * is `project.triggers.opts[setId]`; `scope.offsetSec` becomes `scope.shift`. */
+export function setToRule(set, opts = {}) {
+  const o = opts || {}, os = o.scope || {};
+  const scope = { ...DEFAULT_SCOPE, ...os };
+  delete scope.offsetSec;
+  scope.shift = Number(os.offsetSec == null ? os.shift : os.offsetSec) || 0;
+  return { id: 'ts-' + set.id, name: set.name, enabled: true, set: set.id,
+    match: { phrase: set.phrase, mode: set.mode || 'exact', cluster: Number(o.cluster == null ? set.cluster : o.cluster) || 0 },
+    scope, event: { kind: o.kind || 'trigger', label: set.name }, cue: null, preset: o.preset == null ? null : o.preset };
+}
+
+/** Every match of one set over the loaded words: `[{ i0, i1, t, dur, n, reps }]`. */
+export function detect(words, set, acts = [], opts = {}) {
+  if (!set || !set.phrase) return [];
+  return matchRule(words, setToRule(set, opts), acts, Number(opts && opts.durationSec) || Infinity)
+    .map((m, n) => ({ ...m, n, reps: Number(m.reps) > 0 ? Number(m.reps) : 1 }));
+}

--- a/ConditioningControlPanel/Resources/web/dtrh/chart/smoke/tokens-check.mjs
+++ b/ConditioningControlPanel/Resources/web/dtrh/chart/smoke/tokens-check.mjs
@@ -1,0 +1,80 @@
+/* ============================================================================
+ * chart/smoke/tokens-check.mjs - the house rules, checked without a browser.
+ *
+ *   node chart/smoke/tokens-check.mjs     (from Resources/web/dtrh; 0 on pass, 1 on any failure)
+ *
+ * Three rules that are easier to enforce than to remember: no long dash
+ * anywhere, never the word "bank" or "banked" in anything a reader sees, and
+ * nothing on the Track Maker drawn under 13 px (it is the one screen an author
+ * reads at a glance while the audio runs). Plus the shape of the page itself:
+ * the maker is one screen, so no tabs and no settings panel.
+ *
+ * CARVE-OUT: trimmed from the Track Maker chain's tokens-check.mjs. The chart
+ * room half (editor.css tokens, editor.html, the editor's own layout rules) is
+ * not on this branch, so those checks are not either. Every path below is
+ * optional: the maker page and MAKER.md land in later PRs, and a file that is
+ * not here yet is skipped, not failed.
+ * ==========================================================================*/
+
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const CHART = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+let fails = 0;
+const ok = (cond, what) => { if (!cond) { console.error('FAIL ' + what); fails++; } else console.log('  ok  ' + what); };
+const rel = (f) => f.slice(Math.max(0, f.indexOf('dtrh'))).replace(/\\/g, '/');
+const read = (f) => readFileSync(f, 'utf8');
+
+/* Every file this branch actually carries, out of the set the maker will own. */
+const walk = (dir, out = []) => {
+  if (!existsSync(dir)) return out;
+  for (const name of readdirSync(dir)) {
+    const p = join(dir, name);
+    if (statSync(p).isDirectory()) walk(p, out);
+    else if (/\.(js|mjs|css|html|md)$/.test(name)) out.push(p);
+  }
+  return out;
+};
+const only = (dir, re) => walk(dir).filter((f) => re.test(f));
+const FILES = [
+  ...walk(join(CHART, 'maker')),
+  ...only(join(CHART, 'editor'), /\.js$/),
+  ...only(join(CHART, 'smoke'), /\.mjs$/),
+  join(CHART, 'maker.html'), join(CHART, 'maker.css'), join(CHART, 'MAKER.md'),
+].filter((f) => existsSync(f));
+ok(FILES.length > 0, 'there is something to scan (' + FILES.length + ' files)');
+
+/* ---- 1. no long dash, no bank talk --------------------------------------- */
+const LONG_DASH = String.fromCharCode(0x2014);
+const RULE_LINE = /no bank|"bank|'bank|\\bbank/;      // a line that quotes the rule, not copy that breaks it
+const dashes = [], banks = [];
+for (const f of FILES) {
+  read(f).split('\n').forEach((line, i) => {
+    if (line.includes(LONG_DASH)) dashes.push(rel(f) + ':' + (i + 1));
+    if (/\bbanke?d?\b/i.test(line) && !RULE_LINE.test(line)) banks.push(rel(f) + ':' + (i + 1) + ' ' + line.trim().slice(0, 60));
+  });
+}
+ok(dashes.length === 0, 'no long dash anywhere' + (dashes.length ? ' (' + dashes.slice(0, 5).join(', ') + ')' : ''));
+ok(banks.length === 0, 'no bank talk anywhere' + (banks.length ? ' (' + banks.slice(0, 5).join(' / ') + ')' : ''));
+
+/* ---- 2. nothing is drawn under 13 px ------------------------------------- */
+const sheets = FILES.filter((f) => f.endsWith('.css'));
+const small = [];
+for (const f of sheets) {
+  for (const m of read(f).matchAll(/font(?:-size)?:\s*([^;}]+)/g)) {
+    for (const px of m[1].matchAll(/(\d+)px/g)) if (Number(px[1]) < 13) small.push(rel(f) + ' ' + m[0].trim());
+  }
+}
+ok(small.length === 0, sheets.length
+  ? 'no font size under 13 px' + (small.length ? ' (' + small.slice(0, 4).join(' | ') + ')' : '')
+  : 'no font size under 13 px (no stylesheet on this branch yet)');
+
+/* ---- 3. the maker stays one screen --------------------------------------- */
+const HTML = join(CHART, 'maker.html');
+if (!existsSync(HTML)) console.log('  ok  the maker is one screen: no tabs, no settings panel (maker.html lands in a later PR)');
+else ok(!/<nav|role="tab"|id="settings"/.test(read(HTML)), 'the maker is one screen: no tabs, no settings panel');
+
+console.log(fails ? '\ntokens-check: ' + fails + ' failed' : '\ntokens-check: all good');
+process.exit(fails ? 1 : 0);

--- a/ConditioningControlPanel/Resources/web/dtrh/chart/smoke/triggers-check.mjs
+++ b/ConditioningControlPanel/Resources/web/dtrh/chart/smoke/triggers-check.mjs
@@ -1,0 +1,133 @@
+/* ============================================================================
+ * chart/smoke/triggers-check.mjs - the trigger catalogue and the detector,
+ * checked under node with no browser.
+ *
+ *   node chart/smoke/triggers-check.mjs     (from Resources/web/dtrh; 0 on pass, 1 on any failure)
+ *
+ * CARVE-OUT: this is the pure half of chart/smoke/triggers-check.mjs from the
+ * Track Maker chain, trimmed to the two files this branch carries
+ * (maker/triggers.js, editor/triggerSets.js). Everything that wanted a project,
+ * a words file on disk, or the editor's walk / counts / allSets stays on the
+ * chain. What is left is what the maker leans on: if a phrase stops matching,
+ * or a chant stops folding into one moment, or a scope stops narrowing, the
+ * maker puts its bubbles in the wrong places and says nothing about it.
+ * ==========================================================================*/
+
+import { TRIGGER_SETS, SET_GROUPS, SET_COLORS, normalizeTriggers } from '../editor/triggerSets.js';
+import { clusterSpans, detect, findMatches, labelInk, matchRule, normWord, setToRule } from '../maker/triggers.js';
+
+let fails = 0;
+const ok = (cond, what) => { if (!cond) { console.error('FAIL ' + what); fails++; } else console.log('  ok  ' + what); };
+const eq = (got, want, what) => ok(got === want, what + ' (got ' + JSON.stringify(got) + ', want ' + JSON.stringify(want) + ')');
+const same = (got, want, what) => eq(JSON.stringify(got), JSON.stringify(want), what);
+const setById = (id) => TRIGGER_SETS.find((s) => s.id === id);
+const hex = (c) => /^#[0-9a-f]{6}$/i.test(c);
+
+/* ---- 1. the catalogue is sound ------------------------------------------- */
+const ids = TRIGGER_SETS.map((s) => s.id);
+eq(new Set(ids).size, ids.length, 'every set id is unique');
+ok(TRIGGER_SETS.every((s) => s.name && s.phrase && s.preset), 'every set has a name, a phrase and a preset');
+ok(TRIGGER_SETS.every((s) => hex(s.color)), 'every colour is a six digit hex');
+ok(TRIGGER_SETS.every((s) => SET_GROUPS.some((g) => g[0] === s.group)), 'every group is one of the four');
+ok(SET_COLORS.length === 12 && SET_COLORS.every(hex), 'the colour rotation is twelve hexes');
+const bad = TRIGGER_SETS.filter((s) => {
+  if (s.mode !== 'regex') return normWord(s.phrase) !== s.phrase;
+  try { new RegExp(s.phrase, 'gi'); return false; } catch (e) { return true; }
+});
+ok(!bad.length, 'every regex compiles and every plain phrase is already normalised' + (bad.length ? ' (' + bad.map((s) => s.id).join(',') + ')' : ''));
+eq(normWord('Good, GIRL!'), 'good girl', 'normWord lowercases and drops the punctuation');
+eq(normWord(null), '', 'normWord of nothing');
+eq(labelInk('#ffffff'), '#0f0f1c', 'dark ink on a light fill');
+eq(labelInk('#4060c0'), '#f4f2ff', 'light ink on a dark fill');
+eq(labelInk(''), '#0f0f1c', 'dark ink on junk');
+ok(TRIGGER_SETS.every((s) => labelInk(s.color) === '#0f0f1c' || labelInk(s.color) === '#f4f2ff'), 'every set colour picks one of the two inks');
+
+/* ---- 2. findMatches, all three modes ------------------------------------- */
+const SCRIPT = ('welcome good girl deeper drop and now good girl sink so soft drop listen pink '
+  + 'good girl empty float drop and you are here good girl now drop done goodness').split(' ');
+const WORDS = SCRIPT.map((w, i) => ({ i, t: i * 2, d: 0.5, w, conf: 0.9 }));
+const ACTS = [{ id: 0, t0: 0, t1: 20, kind: 'induction' }, { id: 1, t0: 20, t1: 60, kind: 'triggers' }];
+eq(findMatches(WORDS, 'good girl', 'exact').length, 4, 'exact matches the whole word only');
+eq(findMatches(WORDS, 'good', 'exact').length, 4, 'exact does not reach into goodness');
+eq(findMatches(WORDS, 'good', 'contains').length, 5, 'contains does');
+eq(findMatches(WORDS, 'goo\\w+ girl', 'regex').length, 4, 'regex runs over the joined text');
+eq(findMatches(WORDS, 'nope', 'exact').length, 0, 'a phrase the file never says');
+eq(findMatches(WORDS, '', 'exact').length + findMatches(null, 'good', 'exact').length, 0, 'no phrase or no words');
+eq(findMatches(WORDS, '((', 'regex').length, 0, 'a regex that does not compile is no matches, not a throw');
+same(findMatches(WORDS, 'good girl', 'exact')[0], { i0: 1, i1: 2, t: 2, dur: 2.5 }, 'a match carries its word indices and its span');
+
+/* ---- 3. detect: numbering, scope, the words wrapper ---------------------- */
+const gg = detect(WORDS, setById('good-girl'), ACTS, {});
+eq(gg.length, 4, 'good girl in the fixture');
+eq(gg[0].t, 2, 'the first one is at 2 s');
+eq(gg[3].n, 3, 'a marker carries its index');
+eq(gg[0].reps, 1, 'a lone match is one rep');
+eq(detect({ words: WORDS }, setById('good-girl'), [], {}).length, 4, 'detect takes a whole words file as well as an array');
+eq(detect(WORDS, setById('w-drop'), ACTS, {}).length, 4, 'drop in the fixture');
+eq(detect(WORDS, setById('uniform-lock'), ACTS, {}).length, 0, 'a set the file never says');
+eq(detect(null, setById('good-girl'), ACTS, {}).length + detect(WORDS, null, ACTS, {}).length, 0, 'no words or no set');
+eq(detect(WORDS, setById('good-girl'), ACTS, { scope: { acts: ['induction'] } }).length, 2, 'the acts scope narrows it');
+eq(detect(WORDS, setById('good-girl'), ACTS, { scope: { t0: 20 } }).length, 2, 'a window scope narrows it');
+
+/* ---- 4. clustering a chant ----------------------------------------------- */
+const CHANT = [0, 0.4, 0.8, 1.2, 1.6, 2.0, 10, 10.4].map((t, i) => ({ i, t, d: 0.35, w: i % 2 ? 'doll' : 'bimbo', conf: 1 }));
+eq(findMatches(CHANT, 'bimbo doll', 'exact').length, 4, 'four bimbo doll before clustering');
+const bd = detect(CHANT, setById('bimbo-doll'), [], {});
+eq(bd.length, 2, 'the chant is one marker plus the loner');
+eq(bd[0].reps, 3, 'the chant counts three reps');
+eq(bd[0].t, 0, 'the chant starts where it started');
+eq(Number(bd[0].dur.toFixed(2)), 2.35, 'the chant runs to the last word');
+eq(bd[1].reps + '@' + bd[1].t, '1@10', 'the loner is one rep at its own time');
+eq(clusterSpans(findMatches(CHANT, 'bimbo doll', 'exact'), 0).length, 4, 'a gap of zero leaves the list alone');
+eq(clusterSpans(null, 1.5).length, 0, 'clustering nothing');
+
+/* ---- 5. setToRule -------------------------------------------------------- */
+const r = setToRule(setById('good-girl'));
+eq(r.id, 'ts-good-girl', 'the rule id scheme');
+eq(r.set, 'good-girl', 'the rule carries the set id');
+eq(r.enabled, true, 'the rule is on');
+same(r.match, { phrase: 'good girl', mode: 'exact', cluster: 0 }, 'the match comes from the set');
+same(r.event, { kind: 'trigger', label: 'good girl' }, 'the event names the set');
+same(r.scope, { acts: null, t0: 0, t1: null, every: 1, offset: 0, shift: 0 }, 'the default scope');
+eq(setToRule(setById('bimbo-doll')).match.cluster, 1.5, 'a clustered set keeps its gap');
+const rOpt = setToRule(setById('good-girl'), { kind: 'chant', preset: 'pink-blink', scope: { every: 2, offset: 1, offsetSec: -0.2 } });
+eq(rOpt.event.kind, 'chant', 'opts pick the event kind');
+eq(rOpt.preset, 'pink-blink', 'opts pick the preset');
+eq(rOpt.scope.every, 2, 'opts pick every');
+eq(rOpt.scope.shift, -0.2, 'offsetSec becomes the scope shift');
+eq(rOpt.scope.offsetSec, undefined, 'offsetSec does not survive into the rule scope');
+
+/* ---- 6. matchRule: every, offset, shift, acts ---------------------------- */
+const scoped = (sc, dur) => matchRule(WORDS, setToRule(setById('good-girl'), { scope: sc }), ACTS, dur);
+eq(scoped({ every: 2 }).length, 2, 'every 2 keeps half of them');
+same(scoped({ every: 2 }).map((m) => m.t), [2, 30], 'and keeps the first and the third');
+same(scoped({ every: 2, offset: 1 }).map((m) => m.t), [14, 48], 'an offset starts the count later');
+same(scoped({ acts: ['triggers'] }).map((m) => m.t), [30, 48], 'the acts scope keeps only the ones inside that act');
+eq(scoped({ acts: ['wake'] }).length, 0, 'an act the file has none of');
+eq(scoped({ offsetSec: -0.5 }, 60)[1].t, 13.5, 'a shift moves every match');
+eq(scoped({ offsetSec: -0.5 }, 60)[0].t, 1.5, 'a shift clamps at the start of the file');
+eq(scoped({ offsetSec: 900 }, 60)[0].t, 60, 'a shift clamps at the end of the file');
+eq(scoped({ offsetSec: 900 }, undefined)[0].t, 902, 'no duration means no clamp');
+eq(matchRule(CHANT, { match: { phrase: 'bimbo doll', mode: 'exact', cluster: 1.5 } }, []).length, 2, 'match.cluster folds the run');
+eq(matchRule(CHANT, { match: { phrase: 'bimbo doll', mode: 'exact' } }, []).length, 4, 'no match.cluster leaves it alone');
+eq(matchRule(WORDS, null, []).length, 0, 'no rule is no matches');
+
+/* ---- 7. normalizeTriggers ------------------------------------------------ */
+same(normalizeTriggers(null), { version: 1, on: [], custom: [], opts: {} }, 'a blank one is the empty shape');
+const stored = {
+  version: 1, on: ['good-girl', 'bambi-sleep', 'good-girl', 7, ''],
+  custom: [{ id: 'c-sink', name: 'sink', group: 'custom', phrase: 'sink', mode: 'exact', color: '#78ffbe' },
+    { id: 'c-sink', phrase: 'sink again' }, { name: 'no phrase' }, null, 'junk'],
+  opts: { 'good-girl': { preset: 'pink-blink', strength: 0.8, scope: { every: 2 } }, bad: 3 },
+};
+const t = normalizeTriggers(stored);
+same(t.on, ['good-girl', 'bambi-sleep'], 'on is deduped and cleaned');
+eq(t.custom.length, 1, 'one custom set survives, the twin does not');
+eq(t.custom[0].phrase + ' ' + t.custom[0].color, 'sink #78ffbe', 'the custom set keeps its phrase and its colour');
+eq(t.opts['good-girl'].strength, 0.8, 'the options came through');
+eq(t.opts.bad, undefined, 'junk options are dropped');
+same(normalizeTriggers(t), t, 'a round trip is stable');
+eq(normalizeTriggers('nope').on.length, 0, 'junk in, empty out');
+
+console.log(fails ? '\n' + fails + ' FAILED' : '\ntriggers-check: all good');
+process.exit(fails ? 1 : 0);


### PR DESCRIPTION
The Track Maker's trigger vocabulary and the detector that finds them in a words file, as pure modules with no page behind them yet.

- `chart/editor/triggerSets.js` - the catalogue: id, name, the phrases it answers to, the default recipe.
- `chart/maker/triggers.js` - `detect(words, sets)` walks an aligned words file and returns hits with set id, time and index; multi-word phrases match across tokens; a countdown is one hit, a chant run is one hit.
- `chart/smoke/triggers-check.mjs` + `tokens-check.mjs`.
- `.gitignore` + `ConditioningControlPanel.csproj` - `chart/words/` (the aligned words files the author drops next to their audio) never enters git or the build. The maker reads them from disk at runtime only.

---
Track Maker stack, merge bottom up: #873 (merged) > hand-cues > maker-words > mk1 > mk2 > mk3 > mk4 > mk5. Each PR is based on the one before it and stays under 600 changed lines. No audio, words, transcript or output from any real file is in any of them (`chart/words/` is gitignored and excluded from the csproj).

Smokes, from `ConditioningControlPanel/Resources/web/dtrh`: `for f in chart/smoke/*.mjs race/smoke/*.mjs; do node "$f"; done` is green on every branch of the stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CRXVViHCxrTnrYFD7M1g8o
