### PR TITLE
feat(track maker): M1 the page, the file, the words it finds by itself (3/7)

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/chart/MAKER.md
+++ b/ConditioningControlPanel/Resources/web/dtrh/chart/MAKER.md
@@ -1,0 +1,109 @@
+# Track Maker (`chart/maker.html`)
+
+One screen that turns an mp3 plus its aligned transcript into a race track chart for
+The Caucus Race. One page, one job: no tabs, no options panel, no rules table. Pick the
+file, the maker finds the words, places a run of bubbles at every trigger it heard, and
+the author plays it and slides what is off.
+
+## Files
+
+| file | what |
+|------|------|
+| `maker.html` | the whole page: a top bar, three lines under one ruler, a side panel, a bottom bar |
+| `maker.css` | the look. Its own tokens, shared with nothing. Nothing on the page is under 13 px |
+| `maker/model.js` | pure: recipes, placement, the min gap clamp, the pick line, the chart it writes |
+| `maker/audio.js` | decode once, keep the peaks, drop the buffer, play through an `<audio>` |
+| `maker/words.js` | find the words file, read it, run `maker/triggers.js detect` over the catalogue |
+| `maker/timeline.js` | the three lines, the ruler, the waveform, the playhead |
+| `maker/pick.js` | picking, sliding, walls, the effect grid, undo |
+| `maker/save.js` | the chart file it writes, and the autosave that survives a reload |
+| `smoke/maker-check.mjs` | the pure half under node: placement, clamping, the export shape |
+
+Shared, never copied: `editor/audio.js` (`peaksFromChannels`, `hashFile`),
+`maker/triggers.js` (`detect`, `TRIGGER_SETS`, `labelInk`) over the catalogue in
+`editor/triggerSets.js`, and `race/chart.js` (`normalizeChart`, in the smoke).
+
+## The flow
+
+1. Pick an mp3 (button or drop). It is hashed (CHART.md's recipe), decoded once in a
+   throwaway 16 kHz context for the min/max peaks, and then the AudioBuffer is dropped.
+   Playback is an object URL on an `<audio>`; the browser owns the clock.
+2. The words are looked for at `./words/<stem>.words.json`, then by name and finally by
+   hash through an optional `./words/index.json` manifest. Nothing found and the page
+   says `no words for this file yet. drop its .words.json here.` and takes a dropped one.
+   A words file whose `source.hash` is not this audio's still loads, with a line saying so.
+3. Every set in the trigger catalogue that the file actually says gets a row in the side
+   panel, most said first: tick box, name, `N in file`, the recipe as beads, `change`.
+   Ticked to start: good girl, bambi sleep, drop, blank, empty, obey.
+4. A ticked set places its recipe at every hit, first bubble at `word - 0.15 s`, spaced
+   `max(min gap, recipe gap)`. Changing a recipe or a tick re-places that trigger from
+   scratch, hand moved bubbles of it included, and the status line says so.
+
+## The pieces
+
+- `hit` = `{ id: 'h:<setId>:<n>', t, setId, n }`, one per trigger word heard.
+- `bub` = `{ id, t, kind, eff, group, trig }`. `kind` is a race bubble id
+  (`subliminal`, `flash`, `braindrain`, `pink`) or `'wall'`; a wall carries `eff`, one of
+  `melt, blink, blackout, shake, snap, flash`. `group` is the hit it belongs to, or null
+  for a wall dropped by hand.
+- Six canned recipes, the whole choice there is: shimmer (`S F S F S F wall:melt`), drain
+  (`BD BD wall:blackout`), blink (`wall:blink`), snap (`F wall:snap`), triple (`S S S`),
+  pink wash (`pink pink wall:flash`).
+
+## Picking and sliding
+
+Click picks one, ctrl+click adds or removes, shift+click picks every one like it (a wall:
+every wall on that effect), a band picks its group and shift+band every group of that
+trigger, a tag picks that word and shift+tag every word of that trigger. Drag anything
+picked, or press left / right (0.1 s, shift 1 s), and the whole pick slides together,
+tags included. Picked bubbles never land closer than the min gap to one that stays put:
+the delta is clamped, so a pick pushed into a neighbour stops rather than stacking.
+`del` removes the pick, `esc` clears it, ctrl+z undoes (50 deep), ctrl+shift+z or ctrl+y
+redoes. The min gap control changes what is placed and dragged next, never what is
+already down.
+
+Clicking a wall that is already the only thing picked opens the effect grid; one tap sets
+every picked wall. `w` or the button drops a free wall at the playhead and opens the grid.
+
+## Zoom and pan
+
+`+` / `-` (buttons or keys) zoom around the middle, ctrl+wheel zooms around the pointer
+and keeps the time under it still, a plain wheel pans, `home` and `end` jump to the ends.
+6 to 120 px per second.
+
+## What it writes
+
+`<stem>.chart.json`, chart JSON v1, the shape `race/chart.js normalizeChart` validates
+and `race/cues.js` runs (see `race/CHART.md`):
+
+- one event per bubble, `kind: 'trigger'` (`'mark'` for a free wall), `hand: true`,
+  `label` = the trigger name, `cue.spawn: [{ kindId, placement: 'lane', x: 0, h: 1, at: 0 }]`.
+  `race/cues.js` stamps `sure: true` on hand spawns, so the density knob leaves them alone.
+- one event per wall, `cue.wall: 'pink'` plus `cue.fx: [{ id, strength: 1, dur: FX_DUR[id] }]`.
+  `run.js` expands a wall into five road bubbles and one over the top, and the first pop of
+  the row is the one that counts for the event.
+- `source` = `{ name, hash, durationSec, sampleRate: 16000 }`, so the chart says which file
+  it was written against.
+
+The working state also autosaves to `localStorage` under `trackmaker:<audio hash>` and comes
+back when the same mp3 is picked again (`picked up where you left off`). `start over` in the
+panel clears it and places everything again from the recipes.
+
+## Performance
+
+The owner's browser is Firefox and a busy timeline lags there, so: per frame the page
+writes the playhead transform and the time, and the time only when the string changed.
+Rows and the waveform are rebuilt on a view change or a track change, never on the clock.
+Only what is on screen is built. The decoded audio is never kept. No `getComputedStyle`
+in a draw path.
+
+## Checks
+
+`node chart/smoke/maker-check.mjs` from `Resources/web/dtrh` covers the pure half:
+placement spacing, the min gap clamp, `alike`, the recipe catalogue, and the exported
+chart through `normalizeChart`. `chart/smoke/tokens-check.mjs` holds the 13 px floor in
+`maker.css` and the house rules over every file under `chart/`.
+
+`chart/words/` is where the aligned transcripts live. It is gitignored and excluded from
+the csproj: those files are someone's session audio turned into text and they never go
+into the repo or the installer.

--- a/ConditioningControlPanel/Resources/web/dtrh/chart/maker.css
+++ b/ConditioningControlPanel/Resources/web/dtrh/chart/maker.css
@@ -1,0 +1,115 @@
+/* ============================================================================
+ * chart/maker.css - Track Maker, one screen (chart/MAKER.md, PR M1).
+ *
+ * The mockup is the spec: same tokens, same palette, same three lines under one
+ * ruler. Its tokens are its own and shared with no other stylesheet, so nothing
+ * else on the site can drag this page around. Big type is the point: the
+ * smallest thing on the page is 13 px and chart/smoke/tokens-check.mjs holds
+ * that line. No animation, no transitions in the timeline: the playhead is the
+ * only thing that moves per frame and it moves on a transform.
+ * ==========================================================================*/
+
+:root {
+  --ink: #12111f; --panel: #1c1b30; --panel-2: #262441; --line: #34325a;
+  --text: #f4f0ff; --dim: #aaa5cc; --pink: #ff69b4; --violet: #b080ff; --mint: #78ffbe; --gold: #ffd25a;
+  --sub: #ff8fcf; --flash: #fff6fb; --drain: #9d7bff; --wall: #ff4fa5;
+  --display: "Baloo 2", "Segoe UI", system-ui, sans-serif;
+  --body: "Atkinson Hyperlegible", "Segoe UI", system-ui, sans-serif;
+  --gutter: 120px; --sp: 10px;
+}
+* { box-sizing: border-box; }
+body { background: var(--ink); color: var(--text); font: 16px/1.4 var(--body); margin: 0; height: 100vh; display: grid; grid-template-rows: auto minmax(0, 1fr) auto; overflow: hidden; }
+button { font: 700 16px var(--body); color: var(--text); background: var(--panel-2); border: 1px solid var(--line); border-radius: 10px; padding: 8px 14px; cursor: pointer; display: inline-flex; align-items: center; gap: 8px; }
+button:hover { border-color: var(--violet); }
+button:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+button.primary { background: var(--pink); color: #1a0a14; border-color: var(--pink); }
+button.small { padding: 4px 10px; font-size: 14px; }
+button[disabled] { opacity: .45; cursor: default; }
+kbd { font: 700 13px var(--body); background: #0d0c18; border: 1px solid var(--line); border-radius: 5px; padding: 1px 6px; color: var(--dim); }
+a { color: var(--violet); }
+
+#top { display: flex; align-items: center; gap: var(--sp); padding: 12px 16px; background: var(--panel); border-bottom: 1px solid var(--line); flex-wrap: nowrap; }
+#top .name { font: 800 22px var(--display); color: var(--text); min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+#top #pick { display: inline-block; max-width: 300px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; line-height: 1.4; }
+#top button { flex: none; }
+#top .name small { font: 400 14px var(--body); color: var(--dim); margin-left: 10px; }
+#top .time { font: 800 30px/1 var(--display); font-variant-numeric: tabular-nums; color: var(--pink); margin: 0 6px; min-width: 120px; text-align: center; }
+#top .grow { flex: 1; }
+#top .zoom { display: inline-flex; gap: 4px; }
+
+#lines { display: grid; grid-template-columns: var(--gutter) 1fr 240px; grid-template-rows: 28px 150px 150px 64px 1fr; position: relative; min-height: 0; overflow: hidden; }
+.g { background: var(--panel); border-right: 1px solid var(--line); border-bottom: 1px solid var(--line); padding: 8px 12px; display: flex; flex-direction: column; justify-content: center; }
+.g b { font: 800 19px/1.1 var(--display); }
+.g span { color: var(--dim); font-size: 13px; }
+.row { position: relative; border-bottom: 1px solid var(--line); overflow: hidden; background: var(--ink); }
+.row.ruler { background: var(--panel); }
+.row.audio { background: #0e0e1c; }
+.row.words { background: #15142a; }
+#side { grid-column: 3; grid-row: 1 / -1; background: var(--panel); border-left: 1px solid var(--line); padding: 14px; overflow: auto; display: flex; flex-direction: column; }
+#playhead { position: absolute; top: 0; bottom: 0; width: 0; border-left: 2px solid var(--pink); box-shadow: 0 0 10px rgba(255,105,180,.8); pointer-events: none; z-index: 6; will-change: transform; }
+#playhead::before { content: ""; position: absolute; top: 0; left: -7px; border: 6px solid transparent; border-top: 10px solid var(--pink); }
+canvas { display: block; width: 100%; height: 100%; }
+.tick { position: absolute; top: 4px; font: 700 13px var(--body); color: var(--dim); font-variant-numeric: tabular-nums; }
+.tick::before { content: ""; position: absolute; left: 0; top: 18px; height: 6px; border-left: 1px solid var(--line); }
+
+/* blocks are just a band behind the bubbles that belong together */
+.band { position: absolute; top: 18px; height: 116px; border-radius: 14px; background: var(--panel-2); border: 2px solid var(--line); cursor: grab; user-select: none; }
+.band:hover { border-color: var(--violet); }
+.band.sel { border-color: var(--gold); background: #2f2a3d; }
+.band .lbl { position: absolute; left: 10px; top: 6px; font: 800 17px/1 var(--display); color: var(--dim); white-space: nowrap; pointer-events: none; }
+.band .anchor { position: absolute; left: -2px; bottom: -8px; border: 6px solid transparent; border-bottom: 8px solid var(--pink); }
+.bub { position: absolute; top: 62px; transform: translateX(-50%); width: 34px; height: 34px; border-radius: 50%; display: grid; place-items: center; font: 800 13px var(--display); color: #1a0a14; cursor: grab; user-select: none; border: 3px solid transparent; z-index: 2; }
+.bub.sub { background: var(--sub); }
+.bub.flash { background: var(--flash); }
+.bub.drain { background: var(--drain); color: #fff; }
+.bub.pink { background: var(--pink); }
+.bub.wall { background: var(--wall); border-radius: 8px; width: 30px; height: 96px; top: 30px; font-size: 22px; color: #fff; flex-direction: column; gap: 4px; }
+.bub.wall::after { content: attr(data-name); font: 700 13px var(--body); color: #ffd5ea; writing-mode: vertical-rl; transform: rotate(180deg); }
+.bub.sel { border-color: var(--gold); box-shadow: 0 0 0 3px rgba(255,210,90,.35); z-index: 3; }
+.bub:hover { filter: brightness(1.15); }
+
+.tag { position: absolute; transform: translateX(-50%); padding: 5px 10px; border-radius: 999px; font: 700 15px var(--body); background: #2a2646; color: var(--text); border: 2px solid transparent; cursor: grab; user-select: none; white-space: nowrap; }
+.tag::after { content: ""; position: absolute; left: 50%; top: -12px; width: 2px; height: 12px; background: var(--dim); opacity: .6; }
+.tag.sel { border-color: var(--gold); }
+.tag:hover { filter: brightness(1.15); }
+
+#side h2 { font: 800 18px var(--display); margin: 0 0 4px; }
+#side p { color: var(--dim); font-size: 13px; margin: 0 0 12px; }
+.recipe { display: grid; grid-template-columns: 22px 1fr auto; gap: 8px; align-items: center; padding: 10px 0; border-top: 1px solid var(--line); }
+.recipe input { width: 20px; height: 20px; accent-color: var(--pink); margin: 0; }
+.recipe .who { font: 800 17px/1.1 var(--display); }
+.recipe .n { color: var(--dim); font-size: 13px; font-variant-numeric: tabular-nums; }
+.recipe .beads { grid-column: 2 / -1; display: flex; gap: 4px; align-items: center; flex-wrap: wrap; }
+.mini { width: 22px; height: 22px; border-radius: 50%; display: grid; place-items: center; font: 800 13px var(--display); color: #1a0a14; }
+.mini.sub { background: var(--sub); }
+.mini.flash { background: var(--flash); }
+.mini.drain { background: var(--drain); color: #fff; }
+.mini.pink { background: var(--pink); }
+.mini.wall { background: var(--wall); border-radius: 4px; width: 30px; color: #fff; font-size: 14px; }
+.recipe .change { font: 700 13px var(--body); color: var(--violet); margin-left: 4px; cursor: pointer; background: none; border: 0; padding: 2px 4px; }
+.recipe .change:hover { text-decoration: underline; }
+.gap { margin-top: auto; border-top: 1px solid var(--line); padding-top: 12px; display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+.gap b { font: 800 17px var(--display); }
+.gap .v { font: 800 20px var(--display); color: var(--pink); font-variant-numeric: tabular-nums; min-width: 52px; text-align: center; }
+.startover { font-size: 13px; margin-left: auto; }
+
+/* the effect grid */
+#fx { position: absolute; z-index: 20; background: var(--panel); border: 2px solid var(--gold); border-radius: 16px; padding: 12px; box-shadow: 0 12px 40px rgba(0,0,0,.6); width: 372px; }
+#fx[hidden] { display: none; }
+#fx h3 { margin: 0 0 10px; font: 800 17px var(--display); }
+#fx .grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 8px; }
+#fx .tile { display: flex; flex-direction: column; align-items: center; gap: 4px; padding: 10px 6px; border-radius: 12px; background: var(--panel-2); border: 2px solid var(--line); cursor: pointer; font: 700 14px var(--body); color: var(--text); text-align: center; }
+#fx .tile:hover { border-color: var(--violet); }
+#fx .tile.on { border-color: var(--gold); background: #2f2a3d; }
+#fx .tile .gl { font-size: 30px; line-height: 1; }
+#fx .tile small { color: var(--dim); font-size: 13px; font-weight: 400; }
+#fx .tile .beads { display: flex; gap: 3px; align-items: center; justify-content: center; flex-wrap: wrap; min-height: 24px; }
+
+#bar { display: flex; align-items: center; gap: 14px; padding: 10px 16px; background: var(--panel); border-top: 1px solid var(--line); min-height: 58px; }
+#bar .what { font: 800 20px var(--display); color: var(--gold); }
+#bar .how { color: var(--dim); font-size: 14px; display: flex; gap: 14px; flex-wrap: wrap; }
+#bar .how b { color: var(--text); }
+#bar .grow { flex: 1; }
+.note { position: absolute; right: 256px; top: 34px; z-index: 7; font-size: 13px; color: var(--text); background: rgba(18,17,31,.9); border: 1px solid var(--line); padding: 4px 10px; border-radius: 6px; max-width: 46ch; }
+.note[hidden] { display: none; }
+body.dropping #lines { outline: 3px dashed var(--pink); outline-offset: -6px; }

--- a/ConditioningControlPanel/Resources/web/dtrh/chart/maker.html
+++ b/ConditioningControlPanel/Resources/web/dtrh/chart/maker.html
@@ -1,0 +1,69 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Track Maker</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@600;800&family=Atkinson+Hyperlegible:wght@400;700&display=swap">
+<link rel="stylesheet" href="maker.css">
+</head>
+<body>
+
+<header id="top">
+  <input type="file" id="file" accept="audio/*,.json" hidden>
+  <button class="primary" id="pick">&#127925; pick the mp3</button>
+  <span class="name">track: <b id="trackname">nothing yet</b><small id="sub">pick an mp3, or drop one on the page.</small></span>
+  <span class="grow"></span>
+  <button id="addwall">&#129521; wall at playhead <kbd>w</kbd></button>
+  <button id="play">&#9654; play <kbd>space</kbd></button>
+  <span class="time" id="time">0:00.0</span>
+  <span class="zoom"><button id="zin" title="zoom in">&#65291;</button><button id="zout" title="zoom out">&#65293;</button></span>
+  <button id="undo">&#8630; undo <kbd>ctrl z</kbd></button>
+  <button id="export">save track <kbd>ctrl s</kbd></button>
+</header>
+
+<section id="lines">
+  <div class="g" style="grid-row:1"><span>time</span></div>
+  <div class="row ruler" id="ruler" style="grid-row:1"></div>
+
+  <div class="g" style="grid-row:2"><b>bubbles</b><span>drag any to slide what is picked. shift click = all of the same.</span></div>
+  <div class="row" id="seqs" style="grid-row:2"></div>
+
+  <div class="g" style="grid-row:3"><b>audio</b><span>click to jump</span></div>
+  <div class="row audio" id="audio" style="grid-row:3"><canvas id="wave"></canvas></div>
+
+  <div class="g" style="grid-row:4"><b>words</b><span>the triggers, as heard</span></div>
+  <div class="row words" id="words" style="grid-row:4"></div>
+
+  <div class="g" style="grid-row:5"></div>
+  <div class="row" style="grid-row:5"></div>
+
+  <aside id="side">
+    <h2>what each trigger gets</h2>
+    <p>ticked ones are placed for you at every word. untick to clear them.</p>
+    <div id="recipes"><p class="empty">no track yet.</p></div>
+    <div class="gap">
+      <b>bubbles stay</b><button class="small" id="gapm" title="closer">&#65293;</button>
+      <span class="v" id="gapv">0.4 s</span>
+      <button class="small" id="gapp" title="further apart">&#65291;</button><b>apart</b>
+      <a href="#" id="startover" class="startover" hidden>start over</a>
+    </div>
+  </aside>
+
+  <div id="playhead"></div>
+  <span class="note" id="status" hidden></span>
+  <div id="fx" hidden><h3>what the wall does</h3><div class="grid" id="fxgrid"></div></div>
+</section>
+
+<footer id="bar">
+  <span class="what" id="what">nothing picked</span>
+  <span class="how"><span><b>click</b> a bubble, a wall, a block or a word</span><span><b>shift click</b> picks every one like it</span><span><b>ctrl click</b> adds to the pick</span><span><b>drag</b> or <kbd>&#8592;</kbd><kbd>&#8594;</kbd> slides the whole pick</span><span><kbd>del</kbd> removes</span></span>
+  <span class="grow"></span>
+  <span class="how"><span id="showing">nothing loaded</span></span>
+</footer>
+
+<script type="module" src="maker/app.js"></script>
+</body>
+</html>

--- a/ConditioningControlPanel/Resources/web/dtrh/chart/maker/audio.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/chart/maker/audio.js
@@ -1,0 +1,63 @@
+/* ============================================================================
+ * chart/maker/audio.js - the file, the peaks, the clock (chart/MAKER.md, M1).
+ *
+ * The audio never leaves the machine. It is decoded once in a throwaway 16 kHz
+ * context, turned into the min/max peaks the waveform draws from, and then the
+ * AudioBuffer is dropped on the floor: a forty minute file is 46 MB decoded and
+ * 290 KB as peaks, and holding the buffer is what makes a page like this crawl.
+ * Playback is a plain <audio> on an object URL, so the browser owns the clock.
+ * ==========================================================================*/
+
+import { peaksFromChannels, hashFile } from '../editor/audio.js';
+
+const PEAKS_PER_SEC = 50;
+const DECODE_RATE = 16000;
+export const AUDIO_EXT = /\.(mp3|wav|ogg|oga|m4a|aac|flac|webm|opus)$/i;
+export const isAudioFile = (f) => !!f && ((f.type || '').startsWith('audio/') || AUDIO_EXT.test(f.name || ''));
+export const stemOf = (name) => String(name || '').replace(/\.[^.]+$/, '');
+
+/**
+ * Decode, measure, hash, and hand back everything the page needs but the buffer.
+ * `onStatus` gets a line per step, because a long file takes a few seconds.
+ */
+export async function loadAudio(file, onStatus = () => {}) {
+  const name = file.name || 'track';
+  onStatus('reading ' + name);
+  const [hash, bytes] = await Promise.all([hashFile(file), file.arrayBuffer()]);
+  onStatus('listening to it once, for the waveform');
+  const Ctx = window.OfflineAudioContext || window.webkitOfflineAudioContext;
+  let peaks = null, durationSec = 0;
+  try {
+    const ctx = new Ctx(1, 1, DECODE_RATE);
+    const buf = await ctx.decodeAudioData(bytes);
+    const chans = [];
+    for (let c = 0; c < buf.numberOfChannels; c++) chans.push(buf.getChannelData(c));
+    peaks = peaksFromChannels(chans, buf.length, buf.sampleRate, PEAKS_PER_SEC);
+    durationSec = buf.duration;
+    chans.length = 0;                       // and the buffer goes with the scope
+  } catch (e) {
+    onStatus('that file will not decode here: ' + (e && e.message ? e.message : 'unknown'));
+  }
+  return { file, name, stem: stemOf(name), hash, durationSec, peaks, perSec: PEAKS_PER_SEC, url: URL.createObjectURL(file) };
+}
+
+/** The <audio> element and the four things the page asks of it. */
+export function createPlayer() {
+  const el = new Audio();
+  el.preload = 'auto';
+  let url = null;
+  return {
+    el,
+    open(next) {
+      if (url) URL.revokeObjectURL(url);
+      url = next;
+      el.src = url;
+      el.currentTime = 0;
+    },
+    get time() { return el.currentTime || 0; },
+    get playing() { return !el.paused && !el.ended; },
+    seek(t) { try { el.currentTime = Math.max(0, t); } catch (e) { /* not seekable yet */ } },
+    toggle() { if (el.paused) el.play().catch(() => {}); else el.pause(); },
+    stop() { el.pause(); },
+  };
+}

--- a/ConditioningControlPanel/Resources/web/dtrh/chart/maker/model.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/chart/maker/model.js
@@ -1,0 +1,160 @@
+/* ============================================================================
+ * chart/maker/model.js - what a track is made of (chart/MAKER.md, PR M1).
+ *
+ * Pure: no DOM, no window, no clock, so chart/smoke/maker-check.mjs imports it
+ * under node. A track is two lists that share one time axis:
+ *
+ *   hits    { id, t, setId, n }                 one per trigger word heard
+ *   bubs    { id, t, kind, eff, group, trig }   what the racer meets
+ *
+ * `kind` is a race bubble id ('subliminal', 'flash', 'braindrain', 'pink') or
+ * the string 'wall', and a wall carries `eff`, one of the six frame effects.
+ * A recipe is the little run of bubbles one trigger word gets; changing a
+ * recipe re-places that trigger, hand-moved bubbles included, which is why
+ * placement is a function of (hits, recipe, gap) and never of the old list.
+ * ==========================================================================*/
+
+/** The six frame effects a wall can carry, in the order the grid shows them. */
+export const EFFECTS = {
+  melt: ['\u{1FAE0}', 'melt', 'brain drain'],
+  blink: ['\u{1F441}', 'blink', 'eyes shut a beat'],
+  blackout: ['⬛', 'blackout', 'lights out'],
+  shake: ['〰️', 'shake', 'screen judders'],
+  snap: ['⚡', 'snap', 'one hard cut'],
+  flash: ['✨', 'flash', 'white burst'],
+};
+export const FX_IDS = Object.keys(EFFECTS);
+/** How long each frame effect runs, in seconds. Matches race/frameFx.js. */
+export const FX_DUR = { blink: 0.45, blackout: 1.2, snap: 0.12, shake: 0.4, melt: 0.6, flash: 0.3 };
+
+/** The bubble kinds a recipe may ask for: the race id, the css class, the glyph, the name. */
+export const KINDS = {
+  subliminal: { cls: 'sub', glyph: 'S', name: 'subliminal' },
+  flash: { cls: 'flash', glyph: 'F', name: 'flash' },
+  braindrain: { cls: 'drain', glyph: 'BD', name: 'brain drain' },
+  pink: { cls: 'pink', glyph: 'P', name: 'pink' },
+};
+
+/** Six canned recipes, the whole choice there is. `wall:<eff>` is a full row block. */
+export const RECIPES = [
+  { id: 'shimmer', name: 'shimmer', gap: 0.45, seq: ['subliminal', 'flash', 'subliminal', 'flash', 'subliminal', 'flash', 'wall:melt'] },
+  { id: 'drain', name: 'drain', gap: 0.6, seq: ['braindrain', 'braindrain', 'wall:blackout'] },
+  { id: 'blink', name: 'blink', gap: 1, seq: ['wall:blink'] },
+  { id: 'snap', name: 'snap', gap: 0.5, seq: ['flash', 'wall:snap'] },
+  { id: 'triple', name: 'triple', gap: 0.5, seq: ['subliminal', 'subliminal', 'subliminal'] },
+  { id: 'pinkwash', name: 'pink wash', gap: 0.5, seq: ['pink', 'pink', 'wall:flash'] },
+];
+export const RECIPE_BY_ID = Object.fromEntries(RECIPES.map((r) => [r.id, r]));
+
+/** Ticked the moment a file loads. Everything else starts off. */
+export const DEFAULT_ON = ['good-girl', 'bambi-sleep', 'w-drop', 'w-blank', 'w-empty', 'w-obey'];
+/** The recipe a set starts on. Anything not named here starts on 'triple'. */
+export const DEFAULT_RECIPE = {
+  'good-girl': 'shimmer', 'bambi-sleep': 'drain', 'w-blank': 'drain',
+  'w-empty': 'blink', 'w-drop': 'blink', 'w-obey': 'snap', 'bimbo-doll': 'pinkwash', 'w-pink': 'pinkwash',
+};
+export const LEAD_SEC = 0.15;          // the first bubble lands this far before the word
+export const MIN_GAP_LO = 0.1, MIN_GAP_HI = 2, MIN_GAP_STEP = 0.1, MIN_GAP_DEF = 0.4;
+
+export const recipeFor = (cfg, setId) => RECIPE_BY_ID[(cfg[setId] || {}).recipe] || RECIPE_BY_ID[DEFAULT_RECIPE[setId] || 'triple'];
+export const isOn = (cfg, setId) => !!(cfg[setId] && cfg[setId].on);
+export const byT = (list) => list.slice().sort((a, b) => a.t - b.t || (a.id < b.id ? -1 : 1));
+export const clamp = (v, lo, hi) => (v < lo ? lo : v > hi ? hi : v);
+
+/** m:ss.d, the only time format on the page. */
+export function fmt(t) {
+  const s = Math.max(0, t);
+  return Math.floor(s / 60) + ':' + String(Math.floor(s % 60)).padStart(2, '0') + '.' + Math.floor((s % 1) * 10);
+}
+/** m:ss, for the ruler and the "showing" line. */
+export function fmtShort(t) {
+  const s = Math.max(0, t);
+  return Math.floor(s / 60) + ':' + String(Math.floor(s % 60)).padStart(2, '0');
+}
+
+let seq = 0;
+export const newId = (p) => p + (seq++);
+export const resetIds = () => { seq = 0; };
+
+/** The bubbles one hit gets: the recipe's run, from `t - LEAD_SEC`, never tighter than minGap. */
+export function placeHit(hit, recipe, minGap) {
+  const out = [];
+  let t = Math.max(0, hit.t - LEAD_SEC);
+  const step = Math.max(minGap, recipe.gap);
+  for (const s of recipe.seq) {
+    const [kind, eff] = s.split(':');
+    out.push({ id: newId('b'), t, kind, eff: eff || null, group: hit.id, trig: hit.setId });
+    t += step;
+  }
+  return out;
+}
+
+/** Every bubble of every ticked set, placed from scratch. Free walls are the caller's to keep. */
+export function placeAll(hits, cfg, minGap) {
+  const out = [];
+  for (const h of hits) if (isOn(cfg, h.setId)) out.push(...placeHit(h, recipeFor(cfg, h.setId), minGap));
+  return byT(out);
+}
+
+/**
+ * How far the pick may really slide. Picked bubbles never land closer than
+ * minGap to one that stays put; nothing goes past 0 or past the end of the file.
+ * Both lists come in sorted, so this is one walk, not a pass per pair.
+ */
+export function clampSlide(bubs, sel, dt, minGap, durationSec = Infinity) {
+  const picked = [], still = [];
+  for (const b of bubs) (sel.has(b.id) ? picked : still).push(b);
+  if (!picked.length) return 0;
+  let lo = -Infinity, hi = Infinity, j = 0;
+  for (const p of picked) {
+    while (j < still.length && still[j].t < p.t) j++;
+    if (j < still.length) hi = Math.min(hi, still[j].t - minGap - p.t);
+    if (j > 0) lo = Math.max(lo, still[j - 1].t + minGap - p.t);
+  }
+  lo = Math.max(lo, -picked[0].t);
+  if (isFinite(durationSec)) hi = Math.min(hi, durationSec - picked[picked.length - 1].t);
+  return Math.max(lo, Math.min(hi, dt));
+}
+
+/** Move the pick: bubbles by the clamped delta, tags along with them. */
+export function slide(state, dt) {
+  const d = clampSlide(state.bubs, state.sel, dt, state.minGap, state.durationSec);
+  if (!d) return 0;
+  for (const b of state.bubs) if (state.sel.has(b.id)) b.t += d;
+  for (const h of state.hits) if (state.sel.has(h.id)) h.t = Math.max(0, h.t + d);
+  state.bubs = byT(state.bubs);
+  state.hits = byT(state.hits);
+  return d;
+}
+
+/** shift click: every bubble of that kind (a wall: of that effect), or every tag of that trigger. */
+export function alike(state, id) {
+  const b = state.bubs.find((x) => x.id === id);
+  if (b) return state.bubs.filter((x) => x.kind === b.kind && (b.kind !== 'wall' || x.eff === b.eff)).map((x) => x.id);
+  const h = state.hits.find((x) => x.id === id);
+  return h ? state.hits.filter((x) => x.setId === h.setId).map((x) => x.id) : [id];
+}
+
+/** group -> its bubbles, in time order, for the bands behind them. */
+export function groupsOf(bubs) {
+  const out = new Map();
+  for (const b of bubs) {
+    if (!b.group) continue;
+    if (!out.has(b.group)) out.set(b.group, []);
+    out.get(b.group).push(b);
+  }
+  return out;
+}
+
+/** What the bottom bar says about the pick. */
+export function pickLine(state) {
+  if (!state.sel.size) return 'nothing picked';
+  const n = new Map();
+  let words = 0;
+  const bump = (k) => n.set(k, (n.get(k) || 0) + 1);
+  for (const b of state.bubs) if (state.sel.has(b.id)) bump(b.kind === 'wall' ? 'wall' : KINDS[b.kind].name);
+  for (const h of state.hits) if (state.sel.has(h.id)) words++;
+  const parts = [...n].map(([k, c]) => c + ' ' + k + (c > 1 && (k === 'wall' || k === 'flash') ? 's' : ''));
+  if (words) parts.push(words + ' word' + (words > 1 ? 's' : ''));
+  return parts.join(', ') + ' picked. drag one, all slide.';
+}

--- a/ConditioningControlPanel/Resources/web/dtrh/chart/maker/words.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/chart/maker/words.js
@@ -1,0 +1,79 @@
+/* ============================================================================
+ * chart/maker/words.js - find the words, read the triggers (MAKER.md, PR M1).
+ *
+ * The author picked an mp3; the maker goes and finds the aligned transcript for
+ * it rather than asking. First `./words/<stem>.words.json`, then any name in an
+ * optional `./words/index.json`, first by name and then by the audio hash, so a
+ * renamed file still finds its own words. Detection is `maker/triggers.js`
+ * `detect()` over the catalogue in `editor/triggerSets.js`, so a trigger word
+ * means the same thing here as it does in the race.
+ * ==========================================================================*/
+
+import { detect, TRIGGER_SETS, labelInk } from './triggers.js';
+
+const seg = (s) => encodeURIComponent(String(s));
+const loose = (s) => String(s || '').toLowerCase().replace(/[^a-z0-9]+/g, '');
+export const wordsUrl = (stem) => './words/' + seg(stem + '.words.json');
+
+async function getJson(url) {
+  try {
+    const r = await fetch(url, { cache: 'no-store' });
+    if (!r.ok) return null;
+    return await r.json();
+  } catch (e) { return null; }
+}
+
+/** True when this looks like an align.py words file and not some other json. */
+export function isWords(json) {
+  return !!(json && typeof json === 'object' && Array.isArray(json.words) && json.words.length
+    && typeof json.words[0].t === 'number' && typeof json.words[0].w === 'string');
+}
+
+/**
+ * The words for this audio, or null. `via` says how it was found, so the page
+ * can be honest about it: 'name', 'manifest' (a name in index.json) or 'hash'.
+ */
+export async function findWords(stem, hash) {
+  const direct = await getJson(wordsUrl(stem));
+  if (isWords(direct)) return { json: direct, via: 'name' };
+
+  const index = await getJson('./words/index.json');
+  const names = Array.isArray(index) ? index : (index && Array.isArray(index.files) ? index.files : []);
+  const urls = names.slice(0, 60).map((n) => './words/' + seg(String(n).replace(/\.words\.json$/i, '') + '.words.json'));
+  const want = loose(stem);
+  for (const u of urls) {
+    if (!loose(decodeURIComponent(u)).includes(want) || !want) continue;
+    const j = await getJson(u);
+    if (isWords(j)) return { json: j, via: 'manifest' };
+  }
+  if (!hash) return null;
+  for (const u of urls) {
+    const j = await getJson(u);
+    if (isWords(j) && j.source && j.source.hash === hash) return { json: j, via: 'hash' };
+  }
+  return null;
+}
+
+/** '' when the words were made from this very file, else the line to put on screen. */
+export function hashNote(json, hash) {
+  const h = json && json.source && json.source.hash;
+  return (h && hash && h !== hash) ? 'words file was made from a different copy of this audio' : '';
+}
+
+/**
+ * Every set the file actually says, most said first: `[{ set, hits }]` where a
+ * hit is `{ id, t, setId, n }`. A set with no hits is never shown, so a row on
+ * screen is always a row worth ticking.
+ */
+export function scan(json, durationSec) {
+  const rows = [];
+  for (const set of TRIGGER_SETS) {
+    const ms = detect(json, set, [], { durationSec });
+    if (!ms.length) continue;
+    rows.push({ set, hits: ms.map((m, n) => ({ id: 'h:' + set.id + ':' + n, t: m.t, setId: set.id, n })) });
+  }
+  rows.sort((a, b) => b.hits.length - a.hits.length || a.set.name.localeCompare(b.set.name));
+  return rows;
+}
+
+export { TRIGGER_SETS, labelInk };


### PR DESCRIPTION
M1 of the Track Maker page: `chart/maker.html`. Drop or pick an mp3, the waveform is drawn, and the words file for it is found by hash without asking (`chart/words/<hash>.words.json`, or drop the `.words.json` on the page).

- `maker.html`, `maker.css` - one screen: top bar (file, generate, wall at playhead, play, time, zoom, undo, save), three timeline lanes, the preview row, the trigger panel.
- `maker/audio.js` - decode, peaks, the player clock.
- `maker/model.js` - the state, the recipes (what each trigger gets), `placeAll` (a hit becomes its bubbles, `LEAD_SEC` before the word, `MIN_GAP` apart), `FX_DUR`, formatting helpers.
- `maker/words.js` - words file lookup by the CHART.md hash and the drop path.
- `MAKER.md` - how it fits together.

The timeline, picking, saving, generate and preview are the next four PRs; on this one alone the page loads a file and shows the words it found.

---
Track Maker stack, merge bottom up: #873 (merged) > hand-cues > maker-words > mk1 > mk2 > mk3 > mk4 > mk5. Each PR is based on the one before it and stays under 600 changed lines. No audio, words, transcript or output from any real file is in any of them (`chart/words/` is gitignored and excluded from the csproj).

Smokes, from `ConditioningControlPanel/Resources/web/dtrh`: `for f in chart/smoke/*.mjs race/smoke/*.mjs; do node "$f"; done` is green on every branch of the stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CRXVViHCxrTnrYFD7M1g8o
