### PR TITLE
feat(track maker): M2 three lanes on one axis, the playhead, zoom (4/7)

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/chart/maker/app.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/chart/maker/app.js
@@ -1,0 +1,252 @@
+/* ============================================================================
+ * chart/maker/app.js - Track Maker, the wiring (chart/MAKER.md, PR M1).
+ *
+ * One screen: pick an mp3, the maker finds its words, places a run of bubbles
+ * at every trigger it heard, and gets out of the way. No tabs, no settings, no
+ * modes. The state lives here, the pure moves live in model.js and the drawing
+ * lives in timeline.js.
+ * ==========================================================================*/
+
+import { loadAudio, createPlayer, isAudioFile } from './audio.js';
+import { findWords, hashNote, isWords, scan } from './words.js';
+import * as tl from './timeline.js';
+import {
+  DEFAULT_ON, DEFAULT_RECIPE, EFFECTS, KINDS, MIN_GAP_DEF, MIN_GAP_HI, MIN_GAP_LO, MIN_GAP_STEP,
+  RECIPE_BY_ID, byT, clamp, isOn, placeAll, placeHit, recipeFor, resetIds,
+} from './model.js';
+
+const $ = (id) => document.getElementById(id);
+
+export const state = {
+  audio: null, words: null, rows: [], setById: new Map(),
+  hits: [], bubs: [], sel: new Set(),
+  cfg: {}, minGap: MIN_GAP_DEF, durationSec: 0, peaks: null, perSec: 50,
+};
+
+const player = createPlayer();
+let statusTimer = 0;
+
+/* ---- the status line ----------------------------------------------------- */
+
+export function status(text, sticky = false) {
+  const n = $('status');
+  clearTimeout(statusTimer);
+  if (!text) { n.hidden = true; return; }
+  n.textContent = text;
+  n.hidden = false;
+  if (!sticky) statusTimer = setTimeout(() => { n.hidden = true; }, 7000);
+}
+
+/* ---- placing ------------------------------------------------------------- */
+
+const hitsOf = (setId) => state.hits.filter((h) => h.setId === setId);
+
+/** One trigger, placed again from its recipe. Hand moved bubbles of it go too. */
+export function replaceSet(setId) {
+  state.bubs = state.bubs.filter((b) => b.trig !== setId);
+  if (isOn(state.cfg, setId)) {
+    const r = recipeFor(state.cfg, setId);
+    for (const h of hitsOf(setId)) state.bubs.push(...placeHit(h, r, state.minGap));
+  }
+  state.bubs = byT(state.bubs);
+}
+
+/* ---- the side panel ------------------------------------------------------ */
+
+function beads(recipe) {
+  const box = document.createElement('div');
+  box.className = 'beads';
+  for (const s of recipe.seq) {
+    const [kind, eff] = s.split(':');
+    const m = document.createElement('span');
+    if (kind === 'wall') {
+      m.className = 'mini wall';
+      m.textContent = EFFECTS[eff][0];
+      m.title = 'wall: ' + EFFECTS[eff][1];
+    } else {
+      m.className = 'mini ' + KINDS[kind].cls;
+      m.textContent = KINDS[kind].glyph;
+      m.title = KINDS[kind].name;
+    }
+    box.append(m);
+  }
+  return box;
+}
+
+export function renderPanel() {
+  const host = $('recipes');
+  if (!state.rows.length) {
+    host.replaceChildren(Object.assign(document.createElement('p'), { textContent: 'no track yet.' }));
+    return;
+  }
+  const f = document.createDocumentFragment();
+  for (const row of state.rows) {
+    const id = row.set.id;
+    const el = document.createElement('label');
+    el.className = 'recipe';
+    el.dataset.set = id;
+    const cb = document.createElement('input');
+    cb.type = 'checkbox';
+    cb.checked = isOn(state.cfg, id);
+    cb.addEventListener('change', () => {
+      state.cfg[id].on = cb.checked;
+      replaceSet(id);
+      tl.render();
+      status(cb.checked ? row.set.name + ' placed at all ' + row.hits.length + ' of them' : row.set.name + ' cleared');
+    });
+    const who = document.createElement('span');
+    who.className = 'who';
+    who.textContent = row.set.name;
+    who.style.color = row.set.color;
+    const n = document.createElement('span');
+    n.className = 'n';
+    n.textContent = row.hits.length + ' in file';
+    el.append(cb, who, n, beads(recipeFor(state.cfg, id)));
+    f.append(el);
+  }
+  host.replaceChildren(f);
+}
+
+function setGap(v) {
+  state.minGap = Number(clamp(v, MIN_GAP_LO, MIN_GAP_HI).toFixed(1));
+  $('gapv').textContent = state.minGap.toFixed(1) + ' s';
+}
+
+/* ---- loading ------------------------------------------------------------- */
+
+function useWords(json, via) {
+  state.words = json;
+  if (!state.durationSec) state.durationSec = Number(json.source && json.source.durationSec) || 0;
+  state.rows = scan(json, state.durationSec || Infinity);
+  state.setById = new Map(state.rows.map((r) => [r.set.id, r.set]));
+  state.hits = byT(state.rows.flatMap((r) => r.hits));
+  state.cfg = {};
+  for (const r of state.rows) state.cfg[r.set.id] = { on: DEFAULT_ON.includes(r.set.id), recipe: DEFAULT_RECIPE[r.set.id] || 'triple' };
+  resetIds();
+  state.bubs = placeAll(state.hits, state.cfg, state.minGap);
+  state.sel.clear();
+  renderPanel();
+  tl.render();
+  $('sub').textContent = 'words found and placed. play it, then slide what is off.';
+  const mismatch = hashNote(json, state.audio && state.audio.hash);
+  const heard = state.hits.length + ' trigger words in ' + state.rows.length + ' sets';
+  status(mismatch || (via === 'name' ? 'words found by name. ' + heard : 'words found. ' + heard), !!mismatch);
+  return true;
+}
+
+async function onAudioFile(file) {
+  status('reading ' + file.name, true);
+  const a = await loadAudio(file, (m) => status(m, true));
+  state.audio = a;
+  state.durationSec = a.durationSec || 0;
+  state.peaks = a.peaks;
+  state.perSec = a.perSec;
+  state.rows = []; state.hits = []; state.bubs = []; state.words = null;
+  state.setById = new Map();
+  state.sel.clear();
+  player.open(a.url);
+  $('pick').textContent = '\u{1F3B5} ' + a.name;
+  $('trackname').textContent = a.stem;
+  tl.setView(0);
+  tl.render();
+  renderPanel();
+  status('finding the words for it', true);
+  const found = await findWords(a.stem, a.hash);
+  if (found) return useWords(found.json, found.via);
+  $('sub').textContent = 'no words for this file yet. drop its .words.json here.';
+  status('no words for this file yet. drop its .words.json here.', true);
+  return false;
+}
+
+async function onJsonFile(file) {
+  let json = null;
+  try { json = JSON.parse(await file.text()); } catch (e) { json = null; }
+  if (!isWords(json)) return status('that json is not a words file');
+  if (!state.audio) return status('pick the mp3 first, then drop the words on it');
+  return useWords(json, 'dropped');
+}
+
+const takeFile = (f) => (isAudioFile(f) ? onAudioFile(f) : /\.json$/i.test(f.name || '') ? onJsonFile(f) : status('that is not an mp3 or a words file'));
+
+/* ---- the loop ------------------------------------------------------------ */
+
+let lastT = -1;
+function loop() {
+  const t = player.time;
+  const playing = player.playing;
+  if (t !== lastT || playing) {
+    lastT = t;
+    if (playing && tl.shouldFollow(t)) tl.follow(t);
+    tl.moveHead(t);
+  }
+  requestAnimationFrame(loop);
+}
+
+/* ---- wiring -------------------------------------------------------------- */
+
+function playLabel() {
+  $('play').innerHTML = (player.playing ? '⏸ pause' : '▶ play') + ' <kbd>space</kbd>';
+}
+
+export function seekTo(t) {
+  player.seek(clamp(t, 0, state.durationSec || 0));
+  lastT = -1;
+}
+
+function init() {
+  tl.init(state);
+  setGap(MIN_GAP_DEF);
+  renderPanel();
+  $('pick').addEventListener('click', () => $('file').click());
+  $('file').addEventListener('change', (ev) => { const f = ev.target.files[0]; if (f) takeFile(f); ev.target.value = ''; });
+  $('play').addEventListener('click', () => { player.toggle(); playLabel(); });
+  player.el.addEventListener('play', playLabel);
+  player.el.addEventListener('pause', playLabel);
+  $('zin').addEventListener('click', () => tl.zoomAt(1.25, null));
+  $('zout').addEventListener('click', () => tl.zoomAt(1 / 1.25, null));
+  $('gapm').addEventListener('click', () => setGap(state.minGap - MIN_GAP_STEP));
+  $('gapp').addEventListener('click', () => setGap(state.minGap + MIN_GAP_STEP));
+
+  // click the audio row or the ruler to jump
+  for (const id of ['audio', 'ruler']) {
+    $(id).addEventListener('pointerdown', (ev) => {
+      const r = $('seqs').getBoundingClientRect();
+      seekTo(tl.tOf(ev.clientX - r.left));
+      tl.moveHead(player.time);
+    });
+  }
+
+  // drop an mp3 or a words file anywhere
+  document.addEventListener('dragover', (ev) => { ev.preventDefault(); document.body.classList.add('dropping'); });
+  document.addEventListener('dragleave', (ev) => { if (ev.relatedTarget === null) document.body.classList.remove('dropping'); });
+  document.addEventListener('drop', (ev) => {
+    ev.preventDefault();
+    document.body.classList.remove('dropping');
+    const f = ev.dataTransfer && ev.dataTransfer.files && ev.dataTransfer.files[0];
+    if (f) takeFile(f);
+  });
+
+  // zoom on ctrl+wheel around the pointer, pan on a plain wheel
+  $('lines').addEventListener('wheel', (ev) => {
+    if (ev.target.closest('#side')) return;
+    ev.preventDefault();
+    if (ev.ctrlKey) tl.zoomAt(ev.deltaY < 0 ? 1.15 : 1 / 1.15, ev.clientX);
+    else tl.panBy((ev.deltaY || ev.deltaX) / tl.view.pps);
+  }, { passive: false });
+
+  document.addEventListener('keydown', (ev) => {
+    if (ev.target && /^(INPUT|TEXTAREA)$/.test(ev.target.tagName)) return;
+    if (ev.code === 'Space') { ev.preventDefault(); player.toggle(); playLabel(); }
+    else if (ev.code === 'Home') { ev.preventDefault(); tl.setView(0); seekTo(0); }
+    else if (ev.code === 'End') { ev.preventDefault(); tl.setView(state.durationSec - tl.spanSec() * 0.5); }
+    else if (ev.code === 'Equal' || ev.code === 'NumpadAdd') { ev.preventDefault(); tl.zoomAt(1.25, null); }
+    else if (ev.code === 'Minus' || ev.code === 'NumpadSubtract') { ev.preventDefault(); tl.zoomAt(1 / 1.25, null); }
+  });
+
+  requestAnimationFrame(loop);
+}
+
+init();
+
+/* the headless checks drive the page through this, exactly as a hand would. */
+window.trackMaker = { state, tl, player, status, replaceSet, renderPanel, seekTo, RECIPE_BY_ID };

--- a/ConditioningControlPanel/Resources/web/dtrh/chart/maker/timeline.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/chart/maker/timeline.js
@@ -1,0 +1,216 @@
+/* ============================================================================
+ * chart/maker/timeline.js - three lines, one time axis (MAKER.md, PR M1).
+ *
+ * Everything on screen is a function of `view` (t0 and pixels per second) and
+ * the state; nothing is a function of the clock. That is the whole performance
+ * story: the rows are rebuilt only when the view or the track changes, the
+ * waveform is repainted only then too, and per frame the page writes exactly
+ * two things, the playhead transform and the time, and the time only when the
+ * string it would write is different from the one already there. Only what is
+ * on screen is built, so a forty minute file has the same row count as a one
+ * minute one.
+ * ==========================================================================*/
+
+import { KINDS, EFFECTS, fmt, fmtShort, groupsOf, clamp } from './model.js';
+
+export const GUTTER = 120;              // the gutter column, in px (maker.css --gutter)
+export const PPS_LO = 6, PPS_HI = 120;
+export const view = { t0: 0, pps: 30 };
+
+const TICKS = [0.5, 1, 2, 5, 10, 15, 30, 60, 120, 300, 600];
+const el = (id) => document.getElementById(id);
+let S = null, W = 0, raf = 0;
+let ruler, seqs, wordsRow, wave, head, timeEl, showEl;
+let headOn = true, lastTime = '';
+
+export const xOf = (t) => (t - view.t0) * view.pps;
+export const tOf = (x) => view.t0 + x / view.pps;
+export const width = () => W;
+export const spanSec = () => W / view.pps;
+
+export function init(state) {
+  S = state;
+  ruler = el('ruler'); seqs = el('seqs'); wordsRow = el('words'); wave = el('wave');
+  head = el('playhead'); timeEl = el('time'); showEl = el('showing');
+  W = seqs.clientWidth;
+  window.addEventListener('resize', () => { W = seqs.clientWidth; render(); });
+}
+
+/** At most one rebuild per frame, however many wheel events landed in it. */
+export function scheduleRender() {
+  if (raf) return;
+  raf = requestAnimationFrame(() => { raf = 0; render(); });
+}
+
+export function setView(t0) {
+  const max = Math.max(0, (S.durationSec || 0) - spanSec() * 0.5);
+  view.t0 = clamp(t0, 0, max);
+  scheduleRender();
+}
+export function panBy(dt) { setView(view.t0 + dt); }
+export function zoomAt(factor, clientX) {
+  const r = seqs.getBoundingClientRect();
+  const x = clamp((clientX == null ? r.width / 2 : clientX - r.left), 0, r.width);
+  const t = tOf(x);
+  const next = clamp(view.pps * factor, PPS_LO, PPS_HI);
+  if (next === view.pps) return;
+  view.pps = next;
+  view.t0 = Math.max(0, t - x / view.pps);
+  scheduleRender();
+}
+
+/* ---- the rows ------------------------------------------------------------ */
+
+function tickStep() {
+  const want = 90 / view.pps;
+  return TICKS.find((s) => s >= want) || TICKS[TICKS.length - 1];
+}
+
+function drawRuler() {
+  const f = document.createDocumentFragment(), step = tickStep();
+  for (let t = Math.ceil(view.t0 / step) * step; xOf(t) < W; t += step) {
+    if (t < 0) continue;
+    const k = document.createElement('span');
+    k.className = 'tick';
+    k.style.left = xOf(t).toFixed(1) + 'px';
+    k.textContent = fmtShort(t);
+    f.append(k);
+  }
+  ruler.replaceChildren(f);
+}
+
+function drawBubbles() {
+  const f = document.createDocumentFragment();
+  const wallW = 30 / view.pps;
+  for (const [g, list] of groupsOf(S.bubs)) {
+    const last = list[list.length - 1];
+    const t0 = list[0].t, t1 = last.t + (last.kind === 'wall' ? wallW : 0);
+    if (xOf(t1) < -80 || xOf(t0) > W + 80) continue;
+    const b = document.createElement('div');
+    b.className = 'band' + (list.every((x) => S.sel.has(x.id)) ? ' sel' : '');
+    b.dataset.group = g;
+    b.style.left = (xOf(t0) - 22).toFixed(1) + 'px';
+    b.style.width = Math.max(80, xOf(t1) - xOf(t0) + 44).toFixed(1) + 'px';
+    const lbl = document.createElement('span');
+    lbl.className = 'lbl';
+    lbl.textContent = (S.setById.get(list[0].trig) || {}).name || 'wall';
+    const a = document.createElement('span');
+    a.className = 'anchor';
+    b.append(lbl, a);
+    f.append(b);
+  }
+  for (const b of S.bubs) {
+    const x = xOf(b.t);
+    if (x < -60 || x > W + 60) continue;
+    const d = document.createElement('div');
+    const kind = b.kind === 'wall' ? 'wall' : KINDS[b.kind].cls;
+    d.className = 'bub ' + kind + (S.sel.has(b.id) ? ' sel' : '');
+    d.dataset.id = b.id;
+    d.style.left = x.toFixed(1) + 'px';
+    if (b.kind === 'wall') {
+      const fx = EFFECTS[b.eff] || EFFECTS.melt;
+      d.textContent = fx[0];
+      d.dataset.name = fx[1];
+      d.title = 'wall: ' + fx[1] + '. click it again to change';
+      d.style.transform = 'none';
+    } else {
+      d.textContent = KINDS[b.kind].glyph;
+      d.title = KINDS[b.kind].name;
+    }
+    f.append(d);
+  }
+  seqs.replaceChildren(f);
+}
+
+function drawTags() {
+  const f = document.createDocumentFragment();
+  let row = 0, prevRight = -1e9;
+  for (const h of S.hits) {
+    const x = xOf(h.t);
+    if (x < -120 || x > W + 120) continue;
+    const set = S.setById.get(h.setId) || { name: h.setId, color: '#aaa5cc' };
+    const t = document.createElement('span');
+    t.className = 'tag' + (S.sel.has(h.id) ? ' sel' : '');
+    t.dataset.id = h.id;
+    t.textContent = set.name;
+    const w = set.name.length * 9 + 24;
+    row = x - w / 2 < prevRight ? 1 - row : 0;
+    prevRight = x + w / 2;
+    t.style.left = x.toFixed(1) + 'px';
+    t.style.top = (row ? 33 : 6) + 'px';
+    t.style.background = set.color + '2e';
+    t.style.color = set.color;
+    f.append(t);
+  }
+  wordsRow.replaceChildren(f);
+}
+
+function drawWave() {
+  const dpr = window.devicePixelRatio || 1;
+  const w = wave.clientWidth, h = wave.clientHeight;
+  if (!w || !h) return;
+  if (wave.width !== Math.round(w * dpr) || wave.height !== Math.round(h * dpr)) {
+    wave.width = Math.round(w * dpr); wave.height = Math.round(h * dpr);
+  }
+  const ctx = wave.getContext('2d');
+  ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+  ctx.clearRect(0, 0, w, h);
+  ctx.strokeStyle = '#2b2a48';
+  ctx.beginPath(); ctx.moveTo(0, h / 2 + 0.5); ctx.lineTo(w, h / 2 + 0.5); ctx.stroke();
+  const peaks = S.peaks;
+  if (peaks) {
+    const per = S.perSec || 50, bins = peaks.length / 2, half = h / 2 - 4;
+    const g = ctx.createLinearGradient(0, 0, 0, h);
+    g.addColorStop(0, '#78ffbe'); g.addColorStop(0.5, '#4fd6c8'); g.addColorStop(1, '#78ffbe');
+    ctx.fillStyle = g;
+    for (let x = 0; x < w; x++) {
+      let b0 = Math.floor(tOf(x) * per), b1 = Math.floor(tOf(x + 1) * per);
+      if (b1 <= b0) b1 = b0 + 1;
+      if (b1 <= 0 || b0 >= bins) continue;
+      b0 = Math.max(0, b0); b1 = Math.min(bins, b1);
+      let lo = 0, hi = 0;
+      for (let b = b0; b < b1; b++) {
+        const a = peaks[b * 2], c = peaks[b * 2 + 1];
+        if (a < lo) lo = a;
+        if (c > hi) hi = c;
+      }
+      const top = h / 2 - hi * half, bot = h / 2 - lo * half;
+      ctx.fillRect(x, top, 1, Math.max(1, bot - top));
+    }
+  }
+  ctx.fillStyle = 'rgba(255,105,180,.25)';
+  for (const hit of S.hits) {
+    const x = xOf(hit.t);
+    if (x < -2 || x > w + 2) continue;
+    ctx.fillRect(x - 1, 0, 2, h);
+  }
+}
+
+function drawShowing() {
+  const dur = S.durationSec || 0;
+  showEl.textContent = dur
+    ? 'showing ' + fmtShort(Math.max(0, view.t0)) + ' to ' + fmtShort(Math.min(dur, view.t0 + spanSec())) + ' of ' + fmtShort(dur)
+    : 'nothing loaded';
+}
+
+/** The whole picture, once. Called on a view change or a track change, never per frame. */
+export function render() {
+  if (!S) return;
+  W = seqs.clientWidth;
+  drawRuler(); drawBubbles(); drawTags(); drawWave(); drawShowing();
+}
+
+/* ---- the one thing that moves per frame ---------------------------------- */
+
+export function moveHead(t) {
+  const x = xOf(t);
+  head.style.transform = 'translateX(' + (GUTTER + x).toFixed(1) + 'px)';
+  const on = x >= -4 && x <= W + 4;
+  if (on !== headOn) { head.style.visibility = on ? '' : 'hidden'; headOn = on; }
+  const s = fmt(t);
+  if (s !== lastTime) { timeEl.textContent = s; lastTime = s; }
+}
+
+/** True when the playhead has walked far enough right that the view should follow. */
+export function shouldFollow(t) { return xOf(t) > W * 0.85 || xOf(t) < 0; }
+export function follow(t) { setView(t - (W * 0.15) / view.pps); }


### PR DESCRIPTION
M2 of the Track Maker: the three lanes drawn on one time axis, the playhead, zoom, and the page wiring.

- `maker/timeline.js` - canvas timeline: bubbles lane (what will be placed), audio lane (the peaks), words lane (the triggers as heard); one axis, `showing 0:00 to 0:38 of 12:06`; click the audio to jump.
- `maker/app.js` - boots the page, owns `window.trackMaker` (state, timeline, player, status), the file input and drop handlers, play / pause, zoom, the trigger panel rendering.

---
Track Maker stack, merge bottom up: #873 (merged) > hand-cues > maker-words > mk1 > mk2 > mk3 > mk4 > mk5. Each PR is based on the one before it and stays under 600 changed lines. No audio, words, transcript or output from any real file is in any of them (`chart/words/` is gitignored and excluded from the csproj).

Smokes, from `ConditioningControlPanel/Resources/web/dtrh`: `for f in chart/smoke/*.mjs race/smoke/*.mjs; do node "$f"; done` is green on every branch of the stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CRXVViHCxrTnrYFD7M1g8o
