### PR TITLE
feat(track maker): M4 save the track, resume, and the road under it (6/7)

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/chart/MAKER.md
+++ b/ConditioningControlPanel/Resources/web/dtrh/chart/MAKER.md
@@ -80,8 +80,8 @@ and `race/cues.js` runs (see `race/CHART.md`):
   `label` = the trigger name, `cue.spawn: [{ kindId, placement: 'lane', x: 0, h: 1, at: 0 }]`.
   `race/cues.js` stamps `sure: true` on hand spawns, so the density knob leaves them alone.
 - one event per wall, `cue.wall: 'pink'` plus `cue.fx: [{ id, strength: 1, dur: FX_DUR[id] }]`.
-  `run.js` expands a wall into five road bubbles and one over the top, and the first pop of
-  the row is the one that counts for the event.
+  `race/cues.js` opens a wall into five road bubbles and one over the top, all stamped
+  `sure: true`, and `run.js` plays the frame effect with them.
 - `source` = `{ name, hash, durationSec, sampleRate: 16000 }`, so the chart says which file
   it was written against.
 

--- a/ConditioningControlPanel/Resources/web/dtrh/chart/maker.css
+++ b/ConditioningControlPanel/Resources/web/dtrh/chart/maker.css
@@ -18,7 +18,10 @@
   --gutter: 120px; --sp: 10px;
 }
 * { box-sizing: border-box; }
-body { background: var(--ink); color: var(--text); font: 16px/1.4 var(--body); margin: 0; height: 100vh; display: grid; grid-template-rows: auto minmax(0, 1fr) auto; overflow: hidden; }
+/* The one column is pinned to the window on purpose: the top bar is a nowrap
+   row, so an `auto` column would size the whole page to the bar's own width and
+   push the side panel off the right edge. */
+body { background: var(--ink); color: var(--text); font: 16px/1.4 var(--body); margin: 0; height: 100vh; display: grid; grid-template-rows: auto minmax(0, 1fr) auto; grid-template-columns: minmax(0, 100%); overflow: hidden; }
 button { font: 700 16px var(--body); color: var(--text); background: var(--panel-2); border: 1px solid var(--line); border-radius: 10px; padding: 8px 14px; cursor: pointer; display: inline-flex; align-items: center; gap: 8px; }
 button:hover { border-color: var(--violet); }
 button:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
@@ -28,7 +31,7 @@ button[disabled] { opacity: .45; cursor: default; }
 kbd { font: 700 13px var(--body); background: #0d0c18; border: 1px solid var(--line); border-radius: 5px; padding: 1px 6px; color: var(--dim); }
 a { color: var(--violet); }
 
-#top { display: flex; align-items: center; gap: var(--sp); padding: 12px 16px; background: var(--panel); border-bottom: 1px solid var(--line); flex-wrap: nowrap; }
+#top { display: flex; align-items: center; gap: var(--sp); padding: 12px 16px; background: var(--panel); border-bottom: 1px solid var(--line); flex-wrap: nowrap; min-width: 0; overflow: hidden; }
 #top .name { font: 800 22px var(--display); color: var(--text); min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 #top #pick { display: inline-block; max-width: 300px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; line-height: 1.4; }
 #top button { flex: none; }

--- a/ConditioningControlPanel/Resources/web/dtrh/chart/maker/app.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/chart/maker/app.js
@@ -9,6 +9,7 @@
 
 import { loadAudio, createPlayer, isAudioFile } from './audio.js';
 import * as pick from './pick.js';
+import * as save from './save.js';
 import { findWords, hashNote, isWords, scan } from './words.js';
 import * as tl from './timeline.js';
 import {
@@ -92,7 +93,7 @@ export function renderPanel() {
     cb.addEventListener('change', () => {
       state.cfg[id].on = cb.checked;
       replaceSet(id);
-      tl.render();
+      render();
       status(cb.checked ? row.set.name + ' placed at all ' + row.hits.length + ' of them' : row.set.name + ' cleared');
     });
     const who = document.createElement('span');
@@ -118,12 +119,23 @@ export function renderPanel() {
 
 export function bar() { $('what').textContent = pickLine(state); }
 
+/** Every edit goes through here: draw it, then let the autosave catch up. */
+export function render() { tl.render(); save.touch(); }
+
 export function setGap(v) {
   state.minGap = Number(clamp(v, MIN_GAP_LO, MIN_GAP_HI).toFixed(1));
   $('gapv').textContent = state.minGap.toFixed(1) + ' s';
 }
 
 /* ---- loading ------------------------------------------------------------- */
+
+/** Throw the autosave away and place the whole track again from the recipes. */
+export function startOver() {
+  if (!state.audio || !state.words) return status('nothing to start over yet');
+  save.forget(state.audio.hash);
+  useWords(state.words, 'again');
+  status('started over. every trigger is back on its recipe.');
+}
 
 function useWords(json, via) {
   state.words = json;
@@ -146,6 +158,20 @@ function useWords(json, via) {
   return true;
 }
 
+/** A track this machine was working on before. Only offered for the same audio. */
+function restoreSaved() {
+  const saved = state.audio && save.read(state.audio.hash);
+  if (!saved) { $('startover').hidden = true; return false; }
+  save.restoreInto(state, saved);
+  setGap(saved.minGap || state.minGap);
+  renderPanel();
+  tl.render();
+  bar();
+  $('startover').hidden = false;
+  status('picked up where you left off: ' + state.bubs.length + ' on the track. start over is on the right.', true);
+  return true;
+}
+
 async function onAudioFile(file) {
   status('reading ' + file.name, true);
   const a = await loadAudio(file, (m) => status(m, true));
@@ -164,7 +190,7 @@ async function onAudioFile(file) {
   renderPanel();
   status('finding the words for it', true);
   const found = await findWords(a.stem, a.hash);
-  if (found) return useWords(found.json, found.via);
+  if (found) { useWords(found.json, found.via); return restoreSaved() || true; }
   $('sub').textContent = 'no words for this file yet. drop its .words.json here.';
   status('no words for this file yet. drop its .words.json here.', true);
   return false;
@@ -216,8 +242,8 @@ function init() {
   player.el.addEventListener('pause', playLabel);
   $('zin').addEventListener('click', () => tl.zoomAt(1.25, null));
   $('zout').addEventListener('click', () => tl.zoomAt(1 / 1.25, null));
-  $('gapm').addEventListener('click', () => setGap(state.minGap - MIN_GAP_STEP));
-  $('gapp').addEventListener('click', () => setGap(state.minGap + MIN_GAP_STEP));
+  $('gapm').addEventListener('click', () => { setGap(state.minGap - MIN_GAP_STEP); save.touch(); });
+  $('gapp').addEventListener('click', () => { setGap(state.minGap + MIN_GAP_STEP); save.touch(); });
 
   // click the audio row or the ruler to jump
   for (const id of ['audio', 'ruler']) {
@@ -255,15 +281,16 @@ function init() {
     else if (ev.code === 'Minus' || ev.code === 'NumpadSubtract') { ev.preventDefault(); tl.zoomAt(1 / 1.25, null); }
   });
 
-  pick.install({
-    state, status, bar, renderPanel, replaceSet, setGap,
-    beads, render: () => tl.render(),
-    pps: () => tl.view.pps, time: () => player.time,
-  });
+  const shared = {
+    state, status, bar, renderPanel, replaceSet, setGap, startOver,
+    beads, render, pps: () => tl.view.pps, time: () => player.time,
+  };
+  pick.install(shared);
+  save.install(shared);
   requestAnimationFrame(loop);
 }
 
 init();
 
 /* the headless checks drive the page through this, exactly as a hand would. */
-window.trackMaker = { state, tl, player, pick, status, replaceSet, renderPanel, seekTo, bar, RECIPE_BY_ID };
+window.trackMaker = { state, tl, player, pick, save, status, replaceSet, renderPanel, seekTo, bar, startOver, RECIPE_BY_ID };

--- a/ConditioningControlPanel/Resources/web/dtrh/chart/maker/model.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/chart/maker/model.js
@@ -163,3 +163,66 @@ export function pickLine(state) {
   if (words) parts.push(words + ' word' + (words > 1 ? 's' : ''));
   return parts.join(', ') + ' picked. drag one, all slide.';
 }
+
+/* ---- what it writes ------------------------------------------------------ */
+
+/** The name that goes on an event: the trigger it came from, else what it is. */
+export function labelOf(state, b) {
+  const set = state.setById && state.setById.get ? state.setById.get(b.trig) : null;
+  if (set && set.name) return set.name;
+  return b.kind === 'wall' ? 'wall' : KINDS[b.kind].name;
+}
+
+/**
+ * The chart the race reads (chart JSON v1, see race/CHART.md and race/chart.js):
+ * one event per bubble carrying a hand cue. A bubble is one lane spawn; a wall is
+ * `cue.wall` plus the frame effect, and race/cues.js expands it into the six
+ * bubbles of a full row and stamps `sure: true` so the density knob leaves them be.
+ *
+ * The generated road (maker/generate.js) rides underneath: its energy curve, its
+ * acts and its analyzer events go in the same file, with no `hand` on them, so
+ * race/cues.js reads the road off the table and the recipes off the author.
+ */
+export function buildChart(state, now = new Date()) {
+  const src = state.audio || {};
+  const durationSec = Number(state.durationSec) || Number(src.durationSec) || 0;
+  const road = (state.road && Array.isArray(state.road.events)) ? state.road : null;
+  const names = new Set();
+  const events = byT(state.bubs).map((b, i) => {
+    const label = labelOf(state, b);
+    if (b.trig) names.add(label);
+    const cue = b.kind === 'wall'
+      ? { wall: 'pink', fx: [{ id: b.eff, strength: 1, dur: FX_DUR[b.eff] }] }
+      : { spawn: [{ kindId: b.kind, placement: 'lane', x: 0, h: 1, at: 0 }] };
+    return { id: 'm' + i, t: Math.max(0, Math.min(durationSec, b.t)), kind: b.trig ? 'trigger' : 'mark',
+      label, conf: 1, dur: 0, weight: 1, hand: true, cue };
+  });
+  const road_ = road ? road.events.map((e, i) => ({ ...e, id: 'g' + i, t: clamp(e.t, 0, durationSec) })) : [];
+  return {
+    version: 1, hand: true,
+    binSec: road ? road.binSec : 0.5,
+    energy: road ? road.energy : [],
+    acts: road ? road.acts : [],
+    rules: [],
+    events: road_.concat(events).sort((a, b) => a.t - b.t),
+    source: { name: src.name || 'track', hash: src.hash || '', durationSec, sampleRate: 16000 },
+    analysis: { energy: road ? 'maker' : '', words: 'whisper', lexicon: [...names],
+      generatedAt: (road && road.generatedAt) || now.toISOString(), partial: false },
+  };
+}
+
+/** The whole working state, small enough to sit in localStorage. The road goes with
+ *  it: it is a minute of arithmetic to rebuild and the author already saw it. */
+export function snapshotState(state) {
+  return { v: 1, minGap: state.minGap, cfg: state.cfg, bubs: state.bubs, hits: state.hits, road: state.road || null };
+}
+
+/** Ids come back off a restore, so the next new wall cannot land on one of them. */
+export function bumpIds(bubs) {
+  let top = 0;
+  for (const b of bubs || []) {
+    const n = Number(String(b.id).slice(1));
+    if (isFinite(n) && n >= top) top = n + 1;
+  }
+  while (Number(newId('b').slice(1)) < top) { /* walk the counter past them */ }
+}

--- a/ConditioningControlPanel/Resources/web/dtrh/chart/maker/save.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/chart/maker/save.js
@@ -1,0 +1,99 @@
+/* ============================================================================
+ * chart/maker/save.js - keeping it, and handing it over (MAKER.md, PR M4).
+ *
+ * Two different things, on purpose. The autosave is the safety net: every edit
+ * writes the working state to localStorage under the audio's hash, so closing
+ * the tab and coming back to the same mp3 picks up where you left off, and
+ * "start over" throws that away. Saving the track is the deliverable: one
+ * <stem>.chart.json in the Downloads folder, chart JSON v1, the file race.html
+ * reads. Neither of them ever sends the audio anywhere.
+ * ==========================================================================*/
+
+import { buildChart, bumpIds, snapshotState } from './model.js';
+
+const $ = (id) => document.getElementById(id);
+const KEY = (hash) => 'trackmaker:' + hash;
+const WRITE_AFTER_MS = 800;
+
+let api = null, S = null, timer = 0;
+
+/* ---- the autosave -------------------------------------------------------- */
+
+/** localStorage throws when the browser is set to keep nothing. That is fine. */
+function write() {
+  if (!S.audio || !S.hits.length) return;
+  try {
+    localStorage.setItem(KEY(S.audio.hash), JSON.stringify(snapshotState(S)));
+    $('startover').hidden = false;
+  } catch (e) { /* no store, no net: the track is still exportable */ }
+}
+
+/** Called after every edit. Writes once the hand stops, not once per pixel. */
+export function touch() {
+  clearTimeout(timer);
+  timer = setTimeout(write, WRITE_AFTER_MS);
+}
+
+export function read(hash) {
+  try {
+    const raw = localStorage.getItem(KEY(hash));
+    const o = raw ? JSON.parse(raw) : null;
+    return o && o.v === 1 && Array.isArray(o.bubs) && Array.isArray(o.hits) ? o : null;
+  } catch (e) { return null; }
+}
+
+export function forget(hash) {
+  clearTimeout(timer);
+  try { localStorage.removeItem(KEY(hash)); } catch (e) { /* nothing to forget */ }
+  $('startover').hidden = true;
+}
+
+/**
+ * Put a saved state back over the freshly placed one. Ids come back with it, so
+ * the id counter walks past them before anything new is made.
+ */
+export function restoreInto(state, saved) {
+  state.bubs = saved.bubs;
+  state.hits = saved.hits;
+  state.cfg = saved.cfg || state.cfg;
+  state.road = saved.road || null;
+  state.sel.clear();
+  bumpIds(saved.bubs);
+  return saved;
+}
+
+/* ---- the track ----------------------------------------------------------- */
+
+export function chartName(state) {
+  const stem = (state.audio && state.audio.stem) || 'track';
+  return stem.replace(/[\\/:*?"<>|]+/g, '-') + '.chart.json';
+}
+
+/** Hand the browser the file. Nothing leaves the machine: it is a blob url. */
+export function exportChart() {
+  if (!S.audio) return api.status('pick an mp3 first');
+  if (!S.bubs.length && !S.road) return api.status('nothing on the track yet');
+  const json = JSON.stringify(buildChart(S), null, 1);
+  const url = URL.createObjectURL(new Blob([json], { type: 'application/json' }));
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = chartName(S);
+  document.body.append(a);
+  a.click();
+  a.remove();
+  setTimeout(() => URL.revokeObjectURL(url), 10000);
+  const walls = S.bubs.filter((b) => b.kind === 'wall').length;
+  const road = S.road ? ', ' + S.road.events.length + ' on the road' : '';
+  api.status('saved ' + chartName(S) + ': ' + (S.bubs.length - walls) + ' bubbles, ' + walls + ' wall' + (walls === 1 ? '' : 's') + road + '. drop it next to the mp3.');
+  return json;
+}
+
+export function install(theApi) {
+  api = theApi;
+  S = theApi.state;
+  $('export').addEventListener('click', exportChart);
+  $('startover').addEventListener('click', (ev) => { ev.preventDefault(); api.startOver(); });
+  document.addEventListener('keydown', (ev) => {
+    if ((ev.ctrlKey || ev.metaKey) && ev.code === 'KeyS') { ev.preventDefault(); exportChart(); }
+  });
+}

--- a/ConditioningControlPanel/Resources/web/dtrh/chart/smoke/maker-check.mjs
+++ b/ConditioningControlPanel/Resources/web/dtrh/chart/smoke/maker-check.mjs
@@ -1,0 +1,228 @@
+/* ============================================================================
+ * chart/smoke/maker-check.mjs - the Track Maker's pure half, checked without a
+ * browser (chart/MAKER.md, PR M4).
+ *
+ *   node chart/smoke/maker-check.mjs     (from Resources/web/dtrh; 0 on pass, 1 on any failure)
+ *
+ * Everything the maker does to a track is a function of (hits, recipe, gap) in
+ * maker/model.js, so the placing, the min gap and the exported chart can all be
+ * checked here. The last section is the one that matters most: the file this
+ * tool writes has to survive race/chart.js normalizeChart untouched, or the
+ * author gets a download the race quietly refuses.
+ * ==========================================================================*/
+
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  EFFECTS, FX_IDS, KINDS, LEAD_SEC, MIN_GAP_DEF, RECIPES, RECIPE_BY_ID,
+  buildChart, bumpIds, clampSlide, fmt, groupsOf, labelOf, newId, pickLine,
+  placeAll, placeHit, recipeFor, resetIds, slide, snapshotState,
+} from '../maker/model.js';
+import { BIN_SEC, countRuns, chantRuns, energyFromPeaks, generate, readWords, roadLine } from '../maker/generate.js';
+import { normalizeChart } from '../../race/chart.js';
+import { cueFor } from '../../race/cues.js';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const MAKER = join(HERE, '..', 'maker');
+
+let fails = 0;
+const ok = (cond, what) => { if (!cond) { console.error('FAIL ' + what); fails++; } else console.log('  ok  ' + what); };
+const eq = (got, want, what) => ok(got === want, what + ' (got ' + JSON.stringify(got) + ', want ' + JSON.stringify(want) + ')');
+const near = (got, want, what) => ok(Math.abs(got - want) < 1e-6, what + ' (got ' + got + ', want ' + want + ')');
+
+/* ---- 1. the recipes only ask for things that exist ------------------------ */
+for (const r of RECIPES) {
+  ok(r.seq.length > 0 && r.gap > 0, r.id + ' is a run with a gap');
+  for (const s of r.seq) {
+    const [kind, eff] = s.split(':');
+    if (kind === 'wall') ok(FX_IDS.includes(eff), r.id + ' asks for a real effect: ' + eff);
+    else ok(!!KINDS[kind], r.id + ' asks for a real bubble: ' + kind);
+  }
+}
+ok(FX_IDS.every((id) => EFFECTS[id] && EFFECTS[id].length === 3), 'every effect has a glyph, a name and a hint');
+
+/* ---- 2. placing ----------------------------------------------------------- */
+resetIds();
+const hit = { id: 'h:good-girl:0', t: 10, setId: 'good-girl', n: 0 };
+const shimmer = RECIPE_BY_ID.shimmer;
+const run = placeHit(hit, shimmer, 0.4);
+eq(run.length, shimmer.seq.length, 'a hit gets one bubble per step of its recipe');
+near(run[0].t, 10 - LEAD_SEC, 'the first bubble lands a beat before the word');
+near(run[1].t - run[0].t, Math.max(0.4, shimmer.gap), 'the run is spaced by max(min gap, recipe gap)');
+ok(run.every((b) => b.group === hit.id && b.trig === hit.setId), 'every bubble knows the word it came from');
+eq(run[run.length - 1].kind, 'wall', 'shimmer ends on a wall');
+eq(run[run.length - 1].eff, 'melt', 'and the wall carries the recipe effect');
+const wide = placeHit(hit, shimmer, 1.2);
+near(wide[1].t - wide[0].t, 1.2, 'a wider min gap wins over the recipe gap');
+near(placeHit({ ...hit, t: 0.05 }, shimmer, 0.4)[0].t, 0, 'a word in the first breath does not place before zero');
+
+const hits = [hit, { id: 'h:w-obey:0', t: 20, setId: 'w-obey', n: 0 }];
+const cfg = { 'good-girl': { on: true, recipe: 'shimmer' }, 'w-obey': { on: false, recipe: 'snap' } };
+let bubs = placeAll(hits, cfg, 0.4);
+eq(bubs.length, shimmer.seq.length, 'only ticked triggers are placed');
+cfg['w-obey'].on = true;
+bubs = placeAll(hits, cfg, 0.4);
+eq(bubs.length, shimmer.seq.length + RECIPE_BY_ID.snap.seq.length, 'ticking one places the rest of it');
+ok(bubs.every((b, i) => i === 0 || bubs[i - 1].t <= b.t), 'the list comes back in time order');
+eq(groupsOf(bubs).size, 2, 'two words, two blocks');
+eq(recipeFor({}, 'good-girl').id, 'shimmer', 'a set with no config falls back to its default recipe');
+
+/* ---- 3. the min gap is the only thing that says no ------------------------ */
+const two = [{ id: 'a', t: 10 }, { id: 'b', t: 11 }];
+near(clampSlide(two, new Set(['a']), 10, 0.4, 60), 0.6, 'a shove into a neighbour stops one min gap short');
+near(clampSlide(two, new Set(['a']), -100, 0.4, 60), -10, 'nothing slides past the start of the file');
+near(clampSlide(two, new Set(['b']), 100, 0.4, 12), 1, 'nothing slides past the end of the file');
+near(clampSlide(two, new Set(['a', 'b']), 5, 0.4, 60), 5, 'a whole pick moves together, unblocked by itself');
+const tight = [{ id: 'a', t: 10 }, { id: 'b', t: 10.1 }];
+ok(clampSlide(tight, new Set(['b']), 0.5, 0.4, 60) >= 0, 'a nudge right never answers by jumping left');
+ok(clampSlide(tight, new Set(['b']), -0.5, 0.4, 60) <= 0, 'and a nudge left never jumps right');
+
+const state = { bubs: [{ id: 'a', t: 10 }, { id: 'b', t: 12 }], hits: [{ id: 'h', t: 10.15, setId: 'x' }], sel: new Set(['a', 'h']), minGap: 0.4, durationSec: 60 };
+near(slide(state, 0.5), 0.5, 'a clear slide moves the whole delta');
+near(state.hits[0].t, 10.65, 'the word tag goes with the bubbles it placed');
+
+/* ---- 4. the bottom line reads like a person wrote it ---------------------- */
+const S2 = { bubs: [{ id: 'a', t: 1, kind: 'flash' }, { id: 'b', t: 2, kind: 'wall', eff: 'melt' }, { id: 'c', t: 3, kind: 'wall', eff: 'snap' }], hits: [{ id: 'h', t: 1, setId: 'x' }], sel: new Set(['a', 'b', 'c', 'h']) };
+eq(pickLine(S2), '1 flash, 2 walls, 1 word picked. drag one, all slide.', 'the pick line counts what is picked');
+eq(pickLine({ ...S2, sel: new Set() }), 'nothing picked', 'no pick, no line');
+eq(fmt(75.44), '1:15.4', 'the one time format on the page');
+
+/* ---- 5. ids survive a restore -------------------------------------------- */
+resetIds();
+const restored = [{ id: 'b7' }, { id: 'b3' }];
+bumpIds(restored);
+ok(!restored.some((b) => b.id === newId('b')), 'a new wall after a restore cannot land on a restored id');
+const shot = snapshotState({ minGap: 0.4, cfg, bubs, hits });
+ok(shot.v === 1 && shot.bubs.length === bubs.length && shot.hits.length === hits.length, 'the autosave carries the whole working state');
+
+/* ---- 6. the file it writes is a chart the race accepts -------------------- */
+resetIds();
+const full = {
+  audio: { name: '04 Bambi IQ Lock.mp3', stem: '04 Bambi IQ Lock', hash: 'abc123', durationSec: 300 },
+  durationSec: 300, hits, cfg, minGap: MIN_GAP_DEF, sel: new Set(),
+  setById: new Map([['good-girl', { id: 'good-girl', name: 'good girl' }], ['w-obey', { id: 'w-obey', name: 'obey' }]]),
+};
+full.bubs = placeAll(hits, cfg, MIN_GAP_DEF);
+full.bubs.push({ id: newId('b'), t: 100, kind: 'wall', eff: 'blackout', group: null, trig: null });
+const chart = buildChart(full, new Date(0));
+eq(chart.version, 1, 'chart JSON v1');
+eq(chart.events.length, full.bubs.length, 'one event per bubble');
+eq(chart.source.hash, 'abc123', 'the chart says which copy of the audio it was made from');
+eq(chart.source.name, '04 Bambi IQ Lock.mp3', 'and what it was called');
+ok(chart.analysis.lexicon.includes('good girl'), 'the words it heard are named in the chart');
+eq(labelOf(full, full.bubs[0]), 'good girl', 'an event is labelled with the trigger it came from');
+eq(chart.events[chart.events.length - 1].kind, 'mark', 'a wall placed by hand is a mark, not a trigger');
+eq(chart.events[0].kind, 'trigger', 'a bubble from a word is a trigger');
+ok(chart.events.every((e) => e.hand === true), 'every event is hand made, so nothing re-generates over it');
+ok(chart.events.every((e) => e.t >= 0 && e.t <= 300), 'nothing sits outside the audio');
+
+const norm = normalizeChart(JSON.parse(JSON.stringify(chart)));
+eq(norm.events.length, chart.events.length, 'normalizeChart keeps every event');
+eq(norm.source.durationSec, 300, 'and the length of the file');
+const wallEv = norm.events.find((e) => e.cue && e.cue.wall);
+ok(!!wallEv, 'a wall event survives with its wall');
+eq(wallEv.cue.fx[0].id, 'melt', 'the frame effect rides along');
+ok(wallEv.cue.fx[0].dur > 0, 'with the house duration for that effect');
+const spawnEv = norm.events.find((e) => e.cue && e.cue.spawn && e.cue.spawn.length);
+eq(spawnEv.cue.spawn[0].placement, 'lane', 'a bubble is one lane spawn');
+ok(!!KINDS[spawnEv.cue.spawn[0].kindId], 'of a kind the maker offers');
+const rows = cueFor(wallEv, {}).spawn;
+eq(rows.length, 6, 'race/cues.js opens a wall into a full row plus the air one');
+ok(cueFor(wallEv, {}).fx.length === 1, 'and hands the frame effect to the run');
+ok(rows.every((b) => b.sure === true), 'and stamps them sure, so the density knob leaves them alone');
+
+/* ---- 7. the road generate.js lays between the triggers -------------------- */
+/* A little file that says all of it: a countdown into a drop, a phrase chanted on a
+   beat, structure words, a quiet stretch at the end, and a swell in the audio for the
+   climb to bite on. Everything the maker writes has to come back out of normalizeChart
+   and through cueFor, or the author gets a road the race quietly refuses. */
+const DUR = 120, PER = 50;
+const peaks = new Float32Array(DUR * PER * 2);
+for (let i = 0; i < DUR * PER; i++) {
+  const t = i / PER;
+  const a = t > 95 ? 0.01 : 0.2 + 0.5 * Math.max(0, Math.sin((t - 20) / 12));
+  peaks[i * 2] = -a; peaks[i * 2 + 1] = a;
+}
+const spoken = [];
+let wt = 2;
+const say = (w, step = 0.5, conf = 0.99) => { spoken.push({ t: Number(wt.toFixed(2)), d: 0.3, w, conf }); wt += step; };
+for (const w of ['relax', 'breathe', 'listen', 'deeper', 'heavy', 'float', 'sinking']) say(w, 3);
+for (const w of ['ten', 'nine', 'eight', 'seven', 'six']) say(w, 1.4);
+say('drop', 2);
+for (let i = 0; i < 5; i++) { say('good', 0.4); say('girl', 2.2); }
+for (const w of ['obey', 'blank', 'empty', 'mindless', 'wake', 'awake', 'up']) say(w, 4);
+wt = 118; say('finished');
+const wordsFile = { version: 1, words: spoken.map((w, i) => ({ i, ...w })), source: { name: 'road.mp3', hash: 'road', durationSec: DUR } };
+
+const bins = energyFromPeaks(peaks, PER, DUR, BIN_SEC);
+eq(bins.length, Math.ceil(DUR / BIN_SEC), 'the energy curve is one number per half second of file');
+ok(bins.every((v) => v >= 0 && v <= 1), 'and every one of them is 0..1');
+ok(Math.max(...bins) > 0.9 && Math.min(...bins) < 0.2, 'the loud half and the quiet half do not flatten into each other');
+// a hundred seconds climbing from nothing to half, and one single second at full: dividing by
+// the loudest moment would leave the whole climb under 0.5, which is the flat file the owner sees.
+const clap = new Float32Array(101 * 2);
+for (let i = 0; i < 100; i++) { const a = 0.05 + 0.45 * (i / 99); clap[i * 2] = -a; clap[i * 2 + 1] = a; }
+clap[200] = -1; clap[201] = 1;
+const climb = energyFromPeaks(clap, 1, 101, 1);
+ok(climb[99] > 0.9, 'one loud clap does not push the rest of the file into the floor');
+ok(climb[0] < 0.2, 'and the quiet end is still quiet');
+
+eq(countRuns(readWords(wordsFile)).length, 1, 'five numbers in a row are one countdown');
+eq(chantRuns(readWords(wordsFile))[0].phrase, 'good girl', 'a phrase said five times on a beat is a chant');
+
+const road = generate({ peaks, perSec: PER, durationSec: DUR, words: wordsFile, now: new Date(0),
+  hits: [{ id: 'h:good-girl:0', t: 40, setId: 'good-girl', n: 0 }],
+  setById: new Map([['good-girl', { id: 'good-girl', name: 'good girl' }]]) });
+for (const kind of ['word', 'count', 'drop', 'chant', 'build', 'peak', 'release', 'silence']) {
+  ok(road.events.some((e) => e.kind === kind), 'the road carries a ' + kind);
+}
+ok(road.events.every((e, i) => i === 0 || road.events[i - 1].t <= e.t), 'and comes back in time order');
+ok(road.events.every((e) => e.hand !== true), 'nothing on the road pretends the author placed it');
+ok(road.acts.length >= 1 && road.acts[0].t0 === 0, 'the acts start at the start of the file');
+ok(road.acts[road.acts.length - 1].t1 === DUR, 'and run to the end of it');
+ok(/road placed: \d+/.test(roadLine(road.counts)), 'the status line counts what it placed');
+
+const withRoad = { ...full, road };
+const rc = normalizeChart(JSON.parse(JSON.stringify(buildChart(withRoad, new Date(0)))));
+eq(rc.energy.length, bins.length, 'the exported chart carries the whole curve');
+eq(rc.binSec, BIN_SEC, 'in the bins it was measured in');
+eq(rc.analysis.energy, 'maker', 'and says who measured it');
+eq(rc.events.length, road.events.length + full.bubs.length, 'the file holds the road and the hand cues together');
+eq(rc.events.filter((e) => e.hand === true).length, full.bubs.length, 'and only the hand ones are stamped by hand');
+ok(rc.acts.every((a) => a.room), 'every act picked a room');
+/* race/cues.js declines a few things on purpose: a mark, a lone number, a guess under the
+   confidence floor, and a wake word spoken before the way up. It reads the act to know that,
+   so hand it the act the event sits in, the way run.js does, and then everything the road
+   placed has to be worth something. */
+const actAt = (t) => rc.acts.find((a) => t >= a.t0 && t < a.t1) || null;
+const WAKE = new Set(['wake', 'awake', 'waking', 'up', 'open']);
+const mute = rc.events.filter((e) => !e.hand && e.kind !== 'mark' && cueFor(e, { act: actAt(e.t) }) === null);
+ok(mute.every((e) => e.kind === 'word' && WAKE.has(e.label)),
+  'race/cues.js spends every road event but a wake word before the way up'
+  + (mute.length ? ' (silent: ' + mute.slice(0, 4).map((e) => e.kind + ' ' + e.label).join(', ') + ')' : ''));
+const dropCue = cueFor(rc.events.find((e) => e.kind === 'drop'), {});
+ok(dropCue.jump > 0 && dropCue.spawn.length === 3, 'a drop is a jump and three rings');
+ok(cueFor(rc.events.find((e) => e.kind === 'word'), {}).spawn.length === 1, 'a word is one treat to drive through');
+
+/* the point of the generate key: a second run replaces the road and touches nothing else */
+const moved = full.bubs.map((b) => ({ ...b }));
+moved[0].t += 7;
+const again = generate({ peaks, perSec: PER, durationSec: DUR, words: wordsFile, hits: [], setById: null, now: new Date(0) });
+const rc2 = normalizeChart(JSON.parse(JSON.stringify(buildChart({ ...full, bubs: moved, road: again }, new Date(0)))));
+eq(rc2.events.filter((e) => e.hand === true).length, moved.length, 'a second run keeps every hand moved bubble');
+ok(rc2.events.some((e) => e.hand === true && Math.abs(e.t - moved[0].t) < 1e-6), 'exactly where the hand left it');
+
+/* ---- 8. the modules keep their promises ---------------------------------- */
+const src = (f) => readFileSync(join(MAKER, f), 'utf8');
+ok(!/getComputedStyle/.test(src('timeline.js')), 'nothing reads layout inside the draw loop');
+ok(!/decodeAudioData/.test(src('app.js')), 'the decode stays in audio.js, and the buffer never leaves it');
+ok(/peaks/.test(src('audio.js')), 'audio.js keeps the peaks');
+ok(/fetch\(/.test(src('words.js')) && !/fetch\(/.test(src('audio.js')), 'the audio is read off disk, never uploaded');
+ok(!/document\.|window\./.test(src('generate.js')), 'generate.js is pure: it never reaches for the page');
+for (const f of ['model.js', 'audio.js', 'words.js', 'timeline.js', 'app.js', 'pick.js', 'save.js', 'generate.js']) {
+  ok(src(f).startsWith('/* ====='), f + ' says what it is at the top');
+}
+
+console.log(fails ? '\nmaker-check: ' + fails + ' failed' : '\nmaker-check: all good');
+process.exit(fails ? 1 : 0);

--- a/ConditioningControlPanel/Resources/web/dtrh/chart/smoke/tokens-check.mjs
+++ b/ConditioningControlPanel/Resources/web/dtrh/chart/smoke/tokens-check.mjs
@@ -76,5 +76,23 @@ const HTML = join(CHART, 'maker.html');
 if (!existsSync(HTML)) console.log('  ok  the maker is one screen: no tabs, no settings panel (maker.html lands in a later PR)');
 else ok(!/<nav|role="tab"|id="settings"/.test(read(HTML)), 'the maker is one screen: no tabs, no settings panel');
 
+
+/* ---- 4. the maker's own sheet keeps its shape (PR M4) --------------------- */
+/* maker.css declares every token it spends, and the top bar stays one row: a
+   long track name is cut with an ellipsis rather than wrapping the bar in two. */
+const MCSS = join(CHART, 'maker.css');
+if (!existsSync(MCSS)) console.log('  ok  maker.css keeps its shape (it lands in a later PR)');
+else {
+  const css = read(MCSS);
+  const root = (css.match(/:root\s*\{([\s\S]*?)\n\}/) || [, ''])[1];
+  const TOKENS = ['ink', 'panel', 'panel-2', 'line', 'text', 'dim', 'pink', 'violet', 'mint', 'gold',
+    'sub', 'flash', 'drain', 'wall', 'display', 'body', 'gutter', 'sp'];
+  const miss = TOKENS.filter((t) => !new RegExp('--' + t + '\\s*:').test(root));
+  ok(miss.length === 0, 'maker.css declares every token it uses' + (miss.length ? ' (missing: ' + miss.join(', ') + ')' : ''));
+  const top = (css.match(/#top\s*\{([^}]*)\}/) || [, ''])[1];
+  ok(/flex-wrap:\s*nowrap/.test(top), 'the maker top bar stays one row, whatever the track is called');
+  ok(/#top\s+\.name\s*\{[^}]*text-overflow:\s*ellipsis/.test(css), 'a long track name is cut, not wrapped');
+}
+
 console.log(fails ? '\ntokens-check: ' + fails + ' failed' : '\ntokens-check: all good');
 process.exit(fails ? 1 : 0);


### PR DESCRIPTION
M4 of the Track Maker: save the track, pick up where you left off, and the road under the bubbles.

- `maker/save.js` - `ctrl s` / save track downloads the chart json named after the file; the session is kept in localStorage by file hash and restored on the next drop of the same file.
- `maker/model.js` - `buildChart(state)`: the export, in the shape `race/chart.js normalizeChart` takes (hand bubbles with `hand: true`, `sure: true`, walls with their cue and fx).
- `maker/app.js`, `maker.css`, `MAKER.md` - undo, the status line, the restore path.
- `chart/smoke/maker-check.mjs` (new) - the whole model under node: place, slide, wall, export, then through `normalizeChart` and `cueFor` on this branch's race.

---
Track Maker stack, merge bottom up: #873 (merged) > hand-cues > maker-words > mk1 > mk2 > mk3 > mk4 > mk5. Each PR is based on the one before it and stays under 600 changed lines. No audio, words, transcript or output from any real file is in any of them (`chart/words/` is gitignored and excluded from the csproj).

Smokes, from `ConditioningControlPanel/Resources/web/dtrh`: `for f in chart/smoke/*.mjs race/smoke/*.mjs; do node "$f"; done` is green on every branch of the stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CRXVViHCxrTnrYFD7M1g8o
