### PR TITLE
feat(track maker): M5+M6 generate the road, the run in the bottom row (7/7)

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/chart/MAKER.md
+++ b/ConditioningControlPanel/Resources/web/dtrh/chart/MAKER.md
@@ -12,6 +12,7 @@ the author plays it and slides what is off.
 | `maker.html` | the whole page: a top bar, three lines under one ruler, a side panel, a bottom bar |
 | `maker.css` | the look. Its own tokens, shared with nothing. Nothing on the page is under 13 px |
 | `maker/model.js` | pure: recipes, placement, the min gap clamp, the pick line, the chart it writes |
+| `maker/generate.js` | pure: the road. the energy curve, the acts, the analyzer events |
 | `maker/audio.js` | decode once, keep the peaks, drop the buffer, play through an `<audio>` |
 | `maker/words.js` | find the words file, read it, run `maker/triggers.js detect` over the catalogue |
 | `maker/timeline.js` | the three lines, the ruler, the waveform, the playhead |
@@ -38,6 +39,12 @@ Shared, never copied: `editor/audio.js` (`peaksFromChannels`, `hashFile`),
 4. A ticked set places its recipe at every hit, first bubble at `word - 0.15 s`, spaced
    `max(min gap, recipe gap)`. Changing a recipe or a tick re-places that trigger from
    scratch, hand moved bubbles of it included, and the status line says so.
+5. Then the one card in the tool: the track name, `m:ss, N trigger words in M sets`, and
+   **generate the track**. `start empty` (or `esc`) places the recipes and nothing else,
+   the way it worked before M5. A track this machine already saved offers **pick up where
+   you left off** instead, with **generate again** beside it, which puts every trigger back
+   on its recipe and replaces what was saved. The card is the only modal here; while it is
+   up it owns the keyboard, and everything under it keeps working the moment it goes.
 
 ## The pieces
 
@@ -49,6 +56,32 @@ Shared, never copied: `editor/audio.js` (`peaksFromChannels`, `hashFile`),
 - Six canned recipes, the whole choice there is: shimmer (`S F S F S F wall:melt`), drain
   (`BD BD wall:blackout`), blink (`wall:blink`), snap (`F wall:snap`), triple (`S S S`),
   pink wash (`pink pink wall:flash`).
+
+## The road (`maker/generate.js`)
+
+The recipes are the hand cues; the road is everything between them, and without it a twelve
+minute file is empty tarmac. `generate` reads the peaks already in memory and the aligned
+words, and writes the three things `race/chart.js` schedules and `race/cues.js` spends:
+
+1. `energy`, one 0..1 number per 0.5 s, RMS-ish off the min/max peaks, divided by the 92nd
+   percentile of the file rather than by its loudest moment, so one clap cannot flatten it.
+2. `word` at every trigger the maker heard (label = the set, conf from the words), then the
+   structure words, then any clear word over three letters, thinned to one per 2.2 s.
+3. `drop` on a run of `DROP_WORDS` (`now` only right after a countdown), merged 8 s apart.
+4. `count` on a run of three spoken numbers or more, `n`, `of` and `last` filled in.
+5. `chant` on a phrase said 3+ times inside 20 s on a beat of 5 s or tighter.
+6. `build` / `peak` / `release` off the smoothed curve: a rise of 0.18 over 4 s or more into
+   a local max, and the fall back to half of it. One set per 20 s at most.
+7. `silence` on any gap over 4 s with nothing said in it.
+8. `acts` in 20 s windows, scored on where the structure words, the triggers, the chants and
+   the drops fall: induction, deepening, triggers, mantra, wake, free. A window that scores
+   nothing keeps the room it was in, short runs fold into the one before them.
+9. Nothing it writes is stamped `hand`, so the density knob thins the road and never the
+   recipes, and a second run replaces the road with every hand moved bubble left alone.
+10. `generate` in the top bar, or `g`, does that second run. The status line counts it.
+
+The road draws on the bubbles line as small faint dots, one per event, under everything the
+hand can grab. They are not pickable and never will be: they belong to the algorithm.
 
 ## Picking and sliding
 
@@ -84,6 +117,10 @@ and `race/cues.js` runs (see `race/CHART.md`):
   `sure: true`, and `run.js` plays the frame effect with them.
 - `source` = `{ name, hash, durationSec, sampleRate: 16000 }`, so the chart says which file
   it was written against.
+- once the track has been generated: `energy`, `binSec`, `acts` and the road's own events in
+  the same `events` list, sorted by time, plus
+  `analysis: { energy: 'maker', words: 'whisper', generatedAt }`. The road goes into the
+  autosave too, so picking up where you left off brings it back.
 
 The working state also autosaves to `localStorage` under `trackmaker:<audio hash>` and comes
 back when the same mp3 is picked again (`picked up where you left off`). `start over` in the
@@ -100,8 +137,10 @@ in a draw path.
 ## Checks
 
 `node chart/smoke/maker-check.mjs` from `Resources/web/dtrh` covers the pure half:
-placement spacing, the min gap clamp, `alike`, the recipe catalogue, and the exported
-chart through `normalizeChart`. `chart/smoke/tokens-check.mjs` holds the 13 px floor in
+placement spacing, the min gap clamp, `alike`, the recipe catalogue, the exported chart
+through `normalizeChart`, and the road: the length of the energy curve, the percentile that
+keeps a quiet file readable, every event kind present, every road event through `cueFor`,
+and a second run leaving the hand moved bubbles exactly where they were. `chart/smoke/tokens-check.mjs` holds the 13 px floor in
 `maker.css` and the house rules over every file under `chart/`.
 
 `chart/words/` is where the aligned transcripts live. It is gitignored and excluded from

--- a/ConditioningControlPanel/Resources/web/dtrh/chart/MAKER.md
+++ b/ConditioningControlPanel/Resources/web/dtrh/chart/MAKER.md
@@ -18,6 +18,7 @@ the author plays it and slides what is off.
 | `maker/timeline.js` | the three lines, the ruler, the waveform, the playhead |
 | `maker/pick.js` | picking, sliding, walls, the effect grid, undo |
 | `maker/save.js` | the chart file it writes, and the autosave that survives a reload |
+| `maker/preview.js` | the race in the bottom row: the frame, the bridge, the letterbox |
 | `smoke/maker-check.mjs` | the pure half under node: placement, clamping, the export shape |
 
 Shared, never copied: `editor/audio.js` (`peaksFromChannels`, `hashFile`),
@@ -45,6 +46,8 @@ Shared, never copied: `editor/audio.js` (`peaksFromChannels`, `hashFile`),
    you left off** instead, with **generate again** beside it, which puts every trigger back
    on its recipe and replaces what was saved. The card is the only modal here; while it is
    up it owns the keyboard, and everything under it keeps working the moment it goes.
+6. Generating fills the bottom line with the run itself and it stays there. Play and the
+   kart drives the track under the words; scrub and it jumps with you.
 
 ## The pieces
 
@@ -82,6 +85,26 @@ words, and writes the three things `race/chart.js` schedules and `race/cues.js` 
 
 The road draws on the bubbles line as small faint dots, one per event, under everything the
 hand can grab. They are not pickable and never will be: they belong to the algorithm.
+
+## The preview (`maker/preview.js`)
+
+The fifth line under the words is `race.html` in an iframe, on the bridge the race
+itself answers under `?bridge=parent` (`raceBoot.js`, THE PREVIEW BRIDGE): the maker posts
+`chart` 300 ms behind every edit, `clock` four times a second while the file plays and on
+every play or pause, and `seek` the moment the author scrubs. The frame answers once with
+`race-ready`. Same origin both ways, nothing else is listened to.
+
+- **One sound source.** The frame runs `?music=0`, so the only thing playing is the
+  maker's own `<audio>`. The race keeps its own effects.
+- **Nothing until there is something to watch.** The row is empty until the first
+  generation, so an empty page never boots a 3D world.
+- **Watch only.** A transparent sheet sits over the frame and the frame is `tabindex="-1"`,
+  so a click lands on the maker and `space` never stops meaning play. **pop out** opens the
+  same track in a tab, on its own clock, for anyone who wants to drive it.
+- **Letterboxed.** `fitBox` gives the biggest 16:9 box that fits the row, centred, dark
+  around it. It follows the row through a `ResizeObserver`.
+- **No WebGL, no preview.** The row says `no preview here` and everything above it carries
+  on, the same if the frame never answers within 24 s.
 
 ## Picking and sliding
 
@@ -140,7 +163,9 @@ in a draw path.
 placement spacing, the min gap clamp, `alike`, the recipe catalogue, the exported chart
 through `normalizeChart`, and the road: the length of the energy curve, the percentile that
 keeps a quiet file readable, every event kind present, every road event through `cueFor`,
-and a second run leaving the hand moved bubbles exactly where they were. `chart/smoke/tokens-check.mjs` holds the 13 px floor in
+and a second run leaving the hand moved bubbles exactly where they were. The preview's pure
+half is there too: the frame's url, the letterbox at every shape of row, and the WebGL
+question answered three ways. `chart/smoke/tokens-check.mjs` holds the 13 px floor in
 `maker.css` and the house rules over every file under `chart/`.
 
 `chart/words/` is where the aligned transcripts live. It is gitignored and excluded from

--- a/ConditioningControlPanel/Resources/web/dtrh/chart/editor/audio.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/chart/editor/audio.js
@@ -1,7 +1,7 @@
 /* ============================================================================
  * editor/audio.js - the pure half: peaks and the file hash (chart/EDITOR.md, PR E1).
  *
- * CARVE-OUT: the canonical copy of this file lives on the Chart Room / Track
+ * CARVE-OUT: the full copy of this file lives on the shelved chart room / Track
  * Maker chain and also carries install() (the <audio> element, the clock, the
  * decode). Only the functions that touch no DOM are here, so the web build can
  * import the waveform walk and CHART.md's hash from app main before the rest

--- a/ConditioningControlPanel/Resources/web/dtrh/chart/maker.css
+++ b/ConditioningControlPanel/Resources/web/dtrh/chart/maker.css
@@ -28,6 +28,7 @@ button:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
 button.primary { background: var(--pink); color: #1a0a14; border-color: var(--pink); }
 button.small { padding: 4px 10px; font-size: 14px; }
 button[disabled] { opacity: .45; cursor: default; }
+button[hidden] { display: none; }        /* display: inline-flex above outruns the browser's [hidden] */
 kbd { font: 700 13px var(--body); background: #0d0c18; border: 1px solid var(--line); border-radius: 5px; padding: 1px 6px; color: var(--dim); }
 a { color: var(--violet); }
 
@@ -71,6 +72,15 @@ canvas { display: block; width: 100%; height: 100%; }
 .bub.sel { border-color: var(--gold); box-shadow: 0 0 0 3px rgba(255,210,90,.35); z-index: 3; }
 .bub:hover { filter: brightness(1.15); }
 
+/* the road: what generate.js placed, faint, under the bubbles, nobody's to drag */
+.road { position: absolute; bottom: 8px; width: 7px; height: 7px; border-radius: 50%; background: var(--dim); opacity: .45; transform: translateX(-50%); pointer-events: none; }
+.road.drop, .road.count { background: var(--gold); opacity: .7; height: 11px; border-radius: 4px; }
+.road.chant { background: var(--pink); opacity: .6; }
+.road.build, .road.peak, .road.release { background: var(--mint); opacity: .6; }
+.road.silence { background: #4a4870; opacity: .8; width: 11px; }
+.g .key { display: flex; align-items: center; gap: 6px; margin-top: 3px; }
+.g .key .road { position: static; transform: none; opacity: .55; }
+
 .tag { position: absolute; transform: translateX(-50%); padding: 5px 10px; border-radius: 999px; font: 700 15px var(--body); background: #2a2646; color: var(--text); border: 2px solid transparent; cursor: grab; user-select: none; white-space: nowrap; }
 .tag::after { content: ""; position: absolute; left: 50%; top: -12px; width: 2px; height: 12px; background: var(--dim); opacity: .6; }
 .tag.sel { border-color: var(--gold); }
@@ -95,6 +105,17 @@ canvas { display: block; width: 100%; height: 100%; }
 .gap b { font: 800 17px var(--display); }
 .gap .v { font: 800 20px var(--display); color: var(--pink); font-variant-numeric: tabular-nums; min-width: 52px; text-align: center; }
 .startover { font-size: 13px; margin-left: auto; }
+
+/* the one card in the tool: what to do with the file that just landed */
+#ask { position: absolute; left: 50%; top: 96px; transform: translateX(-50%); z-index: 24; width: 420px; max-width: calc(100% - 280px);
+  background: var(--panel); border: 2px solid var(--pink); border-radius: 18px; padding: 22px; text-align: center;
+  box-shadow: 0 18px 60px rgba(0,0,0,.7); display: flex; flex-direction: column; align-items: center; gap: 10px; }
+#ask[hidden] { display: none; }
+#ask h2 { font: 800 24px/1.2 var(--display); margin: 0; overflow-wrap: anywhere; }
+#ask p { color: var(--dim); font-size: 15px; margin: 0; }
+#ask p.warn { color: var(--gold); font-size: 13px; }
+#ask button { font-size: 18px; padding: 12px 20px; }
+#ask #askskip { font-size: 14px; }
 
 /* the effect grid */
 #fx { position: absolute; z-index: 20; background: var(--panel); border: 2px solid var(--gold); border-radius: 16px; padding: 12px; box-shadow: 0 12px 40px rgba(0,0,0,.6); width: 372px; }

--- a/ConditioningControlPanel/Resources/web/dtrh/chart/maker.css
+++ b/ConditioningControlPanel/Resources/web/dtrh/chart/maker.css
@@ -43,6 +43,7 @@ a { color: var(--violet); }
 
 #lines { display: grid; grid-template-columns: var(--gutter) 1fr 240px; grid-template-rows: 28px 150px 150px 64px 1fr; position: relative; min-height: 0; overflow: hidden; }
 .g { background: var(--panel); border-right: 1px solid var(--line); border-bottom: 1px solid var(--line); padding: 8px 12px; display: flex; flex-direction: column; justify-content: center; }
+.g[hidden] { display: none; }            /* display: flex above outruns the browser's [hidden] */
 .g b { font: 800 19px/1.1 var(--display); }
 .g span { color: var(--dim); font-size: 13px; }
 .row { position: relative; border-bottom: 1px solid var(--line); overflow: hidden; background: var(--ink); }
@@ -105,6 +106,14 @@ canvas { display: block; width: 100%; height: 100%; }
 .gap b { font: 800 17px var(--display); }
 .gap .v { font: 800 20px var(--display); color: var(--pink); font-variant-numeric: tabular-nums; min-width: 52px; text-align: center; }
 .startover { font-size: 13px; margin-left: auto; }
+
+/* the race in the bottom row: letterboxed, centred, watch only */
+.row.preview { background: #07070f; display: grid; place-items: center; }
+.pvbox { position: relative; background: #000; border: 1px solid var(--line); border-radius: 8px; overflow: hidden; }
+.pvframe { display: block; width: 100%; height: 100%; border: 0; background: #000; }
+.pvguard { position: absolute; inset: 0; cursor: default; }
+.pvnote { position: absolute; margin: 0; color: var(--dim); font-size: 15px; text-align: center; padding: 0 16px; }
+#pvg .small { margin-top: 6px; align-self: flex-start; }
 
 /* the one card in the tool: what to do with the file that just landed */
 #ask { position: absolute; left: 50%; top: 96px; transform: translateX(-50%); z-index: 24; width: 420px; max-width: calc(100% - 280px);

--- a/ConditioningControlPanel/Resources/web/dtrh/chart/maker.html
+++ b/ConditioningControlPanel/Resources/web/dtrh/chart/maker.html
@@ -38,8 +38,8 @@
   <div class="g" style="grid-row:4"><b>words</b><span>the triggers, as heard</span></div>
   <div class="row words" id="words" style="grid-row:4"></div>
 
-  <div class="g" style="grid-row:5"></div>
-  <div class="row" style="grid-row:5"></div>
+  <div class="g" id="pvg" style="grid-row:5" hidden><b>preview</b><span>what the run looks like</span><button class="small" id="pvpop">pop out</button></div>
+  <div class="row preview" id="preview" style="grid-row:5"></div>
 
   <aside id="side">
     <h2>what each trigger gets</h2>

--- a/ConditioningControlPanel/Resources/web/dtrh/chart/maker.html
+++ b/ConditioningControlPanel/Resources/web/dtrh/chart/maker.html
@@ -16,6 +16,7 @@
   <button class="primary" id="pick">&#127925; pick the mp3</button>
   <span class="name">track: <b id="trackname">nothing yet</b><small id="sub">pick an mp3, or drop one on the page.</small></span>
   <span class="grow"></span>
+  <button id="gen">&#10024; generate <kbd>g</kbd></button>
   <button id="addwall">&#129521; wall at playhead <kbd>w</kbd></button>
   <button id="play">&#9654; play <kbd>space</kbd></button>
   <span class="time" id="time">0:00.0</span>
@@ -28,7 +29,7 @@
   <div class="g" style="grid-row:1"><span>time</span></div>
   <div class="row ruler" id="ruler" style="grid-row:1"></div>
 
-  <div class="g" style="grid-row:2"><b>bubbles</b><span>drag any to slide what is picked. shift click = all of the same.</span></div>
+  <div class="g" style="grid-row:2"><b>bubbles</b><span>drag any to slide what is picked. shift click = all of the same.</span><span class="key"><i class="road"></i> road</span></div>
   <div class="row" id="seqs" style="grid-row:2"></div>
 
   <div class="g" style="grid-row:3"><b>audio</b><span>click to jump</span></div>
@@ -51,6 +52,15 @@
       <a href="#" id="startover" class="startover" hidden>start over</a>
     </div>
   </aside>
+
+  <div id="ask" hidden>
+    <h2 id="askname">this track</h2>
+    <p id="askline">0:00, no trigger words yet</p>
+    <button class="primary" id="askgo">generate the track</button>
+    <button id="askalt" hidden>generate again</button>
+    <p class="warn" id="askwarn" hidden>generating again puts every trigger back on its recipe and replaces the track you saved.</p>
+    <a href="#" id="askskip">start empty</a>
+  </div>
 
   <div id="playhead"></div>
   <span class="note" id="status" hidden></span>

--- a/ConditioningControlPanel/Resources/web/dtrh/chart/maker/app.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/chart/maker/app.js
@@ -11,17 +11,18 @@ import { loadAudio, createPlayer, isAudioFile } from './audio.js';
 import * as pick from './pick.js';
 import * as save from './save.js';
 import { findWords, hashNote, isWords, scan } from './words.js';
+import { generate, roadLine } from './generate.js';
 import * as tl from './timeline.js';
 import {
   DEFAULT_ON, DEFAULT_RECIPE, EFFECTS, KINDS, MIN_GAP_DEF, MIN_GAP_HI, MIN_GAP_LO, MIN_GAP_STEP,
-  RECIPE_BY_ID, byT, clamp, isOn, pickLine, placeAll, placeHit, recipeFor, resetIds,
+  RECIPE_BY_ID, byT, clamp, fmtShort, isOn, pickLine, placeAll, placeHit, recipeFor, resetIds,
 } from './model.js';
 
 const $ = (id) => document.getElementById(id);
 
 export const state = {
   audio: null, words: null, rows: [], setById: new Map(),
-  hits: [], bubs: [], sel: new Set(),
+  hits: [], bubs: [], sel: new Set(), road: null,
   cfg: {}, minGap: MIN_GAP_DEF, durationSec: 0, peaks: null, perSec: 50,
 };
 
@@ -127,18 +128,78 @@ export function setGap(v) {
   $('gapv').textContent = state.minGap.toFixed(1) + ' s';
 }
 
+/* ---- the road ------------------------------------------------------------ */
+
+/**
+ * Run maker/generate.js over the peaks and the words and keep what it says.
+ * The road only: every bubble the author placed or moved stays exactly where it
+ * is, which is why `g` is safe to lean on while the file is playing.
+ */
+export function generateRoad(quiet = false) {
+  if (!state.audio || !state.words) { if (!quiet) status('pick an mp3 with its words first'); return null; }
+  state.road = generate({
+    peaks: state.peaks, perSec: state.perSec, durationSec: state.durationSec,
+    words: state.words, hits: state.hits, setById: state.setById,
+  });
+  render();
+  if (!quiet) status(roadLine(state.road.counts));
+  return state.road;
+}
+
+/* ---- the one card -------------------------------------------------------- */
+
+/**
+ * The file landed and the words were found: say what is in it and ask the one
+ * question worth asking. It is the only modal in the tool, esc says start empty
+ * and everything under it keeps working the moment it goes.
+ */
+export const card = {
+  get open() { return !$('ask').hidden; },
+  show(saved) {
+    $('askname').textContent = (state.audio && state.audio.stem) || 'this track';
+    $('askline').textContent = fmtShort(state.durationSec || 0) + ', ' + state.hits.length
+      + ' trigger word' + (state.hits.length === 1 ? '' : 's') + ' in ' + state.rows.length + ' set' + (state.rows.length === 1 ? '' : 's');
+    $('askgo').textContent = saved ? 'pick up where you left off' : 'generate the track';
+    $('askalt').hidden = !saved;
+    $('askwarn').hidden = !saved;
+    $('ask').hidden = false;
+    $('askgo').focus();
+  },
+  hide() { $('ask').hidden = true; },
+};
+
+function cardGo() {
+  const saved = !$('askalt').hidden;
+  card.hide();
+  if (saved) return status('picked up where you left off: ' + state.bubs.length + ' on the track.', true);
+  generateRoad();
+}
+function cardAgain() {
+  card.hide();
+  save.forget(state.audio.hash);
+  useWords(state.words, 'again');
+  const road = generateRoad(true);
+  status('generated again. every trigger is back on its recipe. ' + (road ? roadLine(road.counts) : ''), true);
+}
+function cardSkip() {
+  card.hide();
+  status('started empty. the triggers are placed, the road is not: press g when you want it.', true);
+}
+
 /* ---- loading ------------------------------------------------------------- */
 
 /** Throw the autosave away and place the whole track again from the recipes. */
 export function startOver() {
   if (!state.audio || !state.words) return status('nothing to start over yet');
   save.forget(state.audio.hash);
+  state.road = null;
   useWords(state.words, 'again');
-  status('started over. every trigger is back on its recipe.');
+  status('started over. every trigger is back on its recipe, and the road is gone. press g for a new one.');
 }
 
 function useWords(json, via) {
   state.words = json;
+  if (via === 'again') state.road = null;
   if (!state.durationSec) state.durationSec = Number(json.source && json.source.durationSec) || 0;
   state.rows = scan(json, state.durationSec || Infinity);
   state.setById = new Map(state.rows.map((r) => [r.set.id, r.set]));
@@ -168,8 +229,8 @@ function restoreSaved() {
   tl.render();
   bar();
   $('startover').hidden = false;
-  status('picked up where you left off: ' + state.bubs.length + ' on the track. start over is on the right.', true);
-  return true;
+  return true;                                   // what to do about it is the card's question
+
 }
 
 async function onAudioFile(file) {
@@ -190,7 +251,7 @@ async function onAudioFile(file) {
   renderPanel();
   status('finding the words for it', true);
   const found = await findWords(a.stem, a.hash);
-  if (found) { useWords(found.json, found.via); return restoreSaved() || true; }
+  if (found) { useWords(found.json, found.via); card.show(restoreSaved()); return true; }
   $('sub').textContent = 'no words for this file yet. drop its .words.json here.';
   status('no words for this file yet. drop its .words.json here.', true);
   return false;
@@ -201,7 +262,9 @@ async function onJsonFile(file) {
   try { json = JSON.parse(await file.text()); } catch (e) { json = null; }
   if (!isWords(json)) return status('that json is not a words file');
   if (!state.audio) return status('pick the mp3 first, then drop the words on it');
-  return useWords(json, 'dropped');
+  useWords(json, 'dropped');
+  card.show(false);
+  return true;
 }
 
 const takeFile = (f) => (isAudioFile(f) ? onAudioFile(f) : /\.json$/i.test(f.name || '') ? onJsonFile(f) : status('that is not an mp3 or a words file'));
@@ -238,6 +301,10 @@ function init() {
   $('pick').addEventListener('click', () => $('file').click());
   $('file').addEventListener('change', (ev) => { const f = ev.target.files[0]; if (f) takeFile(f); ev.target.value = ''; });
   $('play').addEventListener('click', () => { player.toggle(); playLabel(); });
+  $('gen').addEventListener('click', () => generateRoad());
+  $('askgo').addEventListener('click', cardGo);
+  $('askalt').addEventListener('click', cardAgain);
+  $('askskip').addEventListener('click', (ev) => { ev.preventDefault(); cardSkip(); });
   player.el.addEventListener('play', playLabel);
   player.el.addEventListener('pause', playLabel);
   $('zin').addEventListener('click', () => tl.zoomAt(1.25, null));
@@ -274,7 +341,9 @@ function init() {
 
   document.addEventListener('keydown', (ev) => {
     if (ev.target && /^(INPUT|TEXTAREA)$/.test(ev.target.tagName)) return;
-    if (ev.code === 'Space') { ev.preventDefault(); player.toggle(); playLabel(); }
+    if (card.open) { if (ev.code === 'Escape') { ev.preventDefault(); cardSkip(); } return; }
+    if (ev.code === 'KeyG' && !ev.ctrlKey && !ev.metaKey) { ev.preventDefault(); generateRoad(); }
+    else if (ev.code === 'Space') { ev.preventDefault(); player.toggle(); playLabel(); }
     else if (ev.code === 'Home') { ev.preventDefault(); tl.setView(0); seekTo(0); }
     else if (ev.code === 'End') { ev.preventDefault(); tl.setView(state.durationSec - tl.spanSec() * 0.5); }
     else if (ev.code === 'Equal' || ev.code === 'NumpadAdd') { ev.preventDefault(); tl.zoomAt(1.25, null); }
@@ -282,8 +351,8 @@ function init() {
   });
 
   const shared = {
-    state, status, bar, renderPanel, replaceSet, setGap, startOver,
-    beads, render, pps: () => tl.view.pps, time: () => player.time,
+    state, status, bar, renderPanel, replaceSet, setGap, startOver, generateRoad,
+    beads, render, pps: () => tl.view.pps, time: () => player.time, modal: () => card.open,
   };
   pick.install(shared);
   save.install(shared);
@@ -293,4 +362,5 @@ function init() {
 init();
 
 /* the headless checks drive the page through this, exactly as a hand would. */
-window.trackMaker = { state, tl, player, pick, save, status, replaceSet, renderPanel, seekTo, bar, startOver, RECIPE_BY_ID };
+window.trackMaker = { state, tl, player, pick, save, status, replaceSet, renderPanel, seekTo, bar, startOver,
+  generateRoad, card, RECIPE_BY_ID };

--- a/ConditioningControlPanel/Resources/web/dtrh/chart/maker/app.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/chart/maker/app.js
@@ -9,6 +9,7 @@
 
 import { loadAudio, createPlayer, isAudioFile } from './audio.js';
 import * as pick from './pick.js';
+import * as preview from './preview.js';
 import * as save from './save.js';
 import { findWords, hashNote, isWords, scan } from './words.js';
 import { generate, roadLine } from './generate.js';
@@ -28,6 +29,7 @@ export const state = {
 
 const player = createPlayer();
 let statusTimer = 0;
+let pv = null;                          // the race in the bottom row, once there is a road
 
 /* ---- the status line ----------------------------------------------------- */
 
@@ -121,7 +123,7 @@ export function renderPanel() {
 export function bar() { $('what').textContent = pickLine(state); }
 
 /** Every edit goes through here: draw it, then let the autosave catch up. */
-export function render() { tl.render(); save.touch(); }
+export function render() { tl.render(); save.touch(); if (pv) pv.onEdit(); }
 
 export function setGap(v) {
   state.minGap = Number(clamp(v, MIN_GAP_LO, MIN_GAP_HI).toFixed(1));
@@ -141,6 +143,7 @@ export function generateRoad(quiet = false) {
     peaks: state.peaks, perSec: state.perSec, durationSec: state.durationSec,
     words: state.words, hits: state.hits, setById: state.setById,
   });
+  if (pv) pv.ensure();                   // the first road is what turns the preview on
   render();
   if (!quiet) status(roadLine(state.road.counts));
   return state.road;
@@ -279,6 +282,7 @@ function loop() {
     lastT = t;
     if (playing && tl.shouldFollow(t)) tl.follow(t);
     tl.moveHead(t);
+    if (pv) pv.clock(t, playing);         // the frame's own clock is 4 Hz, not per frame
   }
   requestAnimationFrame(loop);
 }
@@ -287,11 +291,14 @@ function loop() {
 
 function playLabel() {
   $('play').innerHTML = (player.playing ? '⏸ pause' : '▶ play') + ' <kbd>space</kbd>';
+  if (pv) pv.clock(player.time, player.playing);   // play and pause are news the frame wants now
 }
 
 export function seekTo(t) {
-  player.seek(clamp(t, 0, state.durationSec || 0));
+  const at = clamp(t, 0, state.durationSec || 0);
+  player.seek(at);
   lastT = -1;
+  if (pv) pv.seek(at, player.playing);
 }
 
 function init() {
@@ -356,6 +363,8 @@ function init() {
   };
   pick.install(shared);
   save.install(shared);
+  pv = preview.install(shared);
+  if (state.road) pv.ensure();            // a restored track already has a road to watch
   requestAnimationFrame(loop);
 }
 
@@ -363,4 +372,4 @@ init();
 
 /* the headless checks drive the page through this, exactly as a hand would. */
 window.trackMaker = { state, tl, player, pick, save, status, replaceSet, renderPanel, seekTo, bar, startOver,
-  generateRoad, card, RECIPE_BY_ID };
+  generateRoad, card, preview: () => pv, RECIPE_BY_ID };

--- a/ConditioningControlPanel/Resources/web/dtrh/chart/maker/generate.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/chart/maker/generate.js
@@ -17,10 +17,9 @@
  * recipes sit on top as hand cues and the density knob leaves them alone while
  * it thins the road. Re-running this replaces the road and never the recipes.
  *
- * CARVE-OUT: the canonical copy of this file lives on the Track Maker chain
- * (feat/race-m5-generate and up). This copy exists so the web build can import
- * the road generator from app main before the maker itself lands; keep it byte
- * for byte in step with the chain and fix bugs there first.
+ * This file landed on main ahead of the rest of the maker (PR #873) so the web
+ * build could import the road generator early; the maker in this folder is now
+ * the one and only copy.
  * ==========================================================================*/
 
 import { DROP_WORDS, STRUCTURE_WORDS } from '../../race/chart.js';

--- a/ConditioningControlPanel/Resources/web/dtrh/chart/maker/pick.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/chart/maker/pick.js
@@ -200,6 +200,7 @@ function removePick() {
 
 function onKey(ev) {
   if (ev.target && /^(INPUT|TEXTAREA)$/.test(ev.target.tagName)) return;
+  if (api.modal && api.modal()) return;             // the card is up: it owns the keyboard
   const ctrl = ev.ctrlKey || ev.metaKey;
   if (ctrl && ev.code === 'KeyZ' && !ev.shiftKey) { ev.preventDefault(); return undo(); }
   if (ctrl && (ev.code === 'KeyY' || (ev.code === 'KeyZ' && ev.shiftKey))) { ev.preventDefault(); return redo(); }

--- a/ConditioningControlPanel/Resources/web/dtrh/chart/maker/preview.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/chart/maker/preview.js
@@ -1,0 +1,196 @@
+/* ============================================================================
+ * chart/maker/preview.js - the race in the bottom row (chart/MAKER.md, PR M6).
+ *
+ * The fifth line under the words is the run itself. Once there is a road to
+ * look at, the row fills with an iframe of race.html on the bridge raceBoot.js
+ * already answers (`?bridge=parent`): `chart` behind every edit,
+ * `clock` four times a second while the file plays, `seek` the moment the
+ * author scrubs. The maker's own <audio> is the only sound source in the room,
+ * so the frame runs with its music off and its own effects on.
+ *
+ * Watch only, on purpose: a transparent sheet sits over the frame so a click
+ * lands on the maker and space never stops meaning play. "pop out" opens the
+ * same run in a tab for anyone who wants to drive it.
+ *
+ * The sizing and the url are pure and run under chart/smoke/maker-check.mjs.
+ * ==========================================================================*/
+
+import { buildChart } from './model.js';
+
+/* ---- the bridge, pure ---------------------------------------------------- */
+
+/** The contract URL, relative to maker.html. Every switch is deliberate: no
+ *  pixel block, no intro, and the run starts on its own. Music is 0 because the
+ *  author is listening to their own file, and PREVIEW_URL below is this url at 0,
+ *  which the smoke pins. */
+export function raceUrl(music = 0) {
+  const m = Math.round(Math.max(0, Math.min(1, Number(music) || 0)) * 100) / 100;
+  return '../race.html?bridge=parent&autostart=1&pixel=0&intro=0&music=' + m;
+}
+export const CHART_DEBOUNCE_MS = 300;
+export const CLOCK_MS = 250;          // 4 Hz, the host's own cadence
+export const READY_TIMEOUT_MS = 8000;
+
+const t3 = (t) => Math.round((Number(t) || 0) * 1000) / 1000;
+
+export function clockMessage(t, playing) { return { type: 'clock', t: t3(t), playing: !!playing }; }
+export function seekMessage(t, playing) { return { type: 'seek', t: t3(t), playing: !!playing }; }
+
+/** A message is ours only when it came from our own frame, on our own origin, with a body. */
+export function accepts(ev, origin, source) {
+  return !!ev && ev.origin === origin && !!source && ev.source === source
+    && !!ev.data && typeof ev.data === 'object' && typeof ev.data.type === 'string';
+}
+
+/** Trailing debounce. `cancel()` drops a pending call, for when the frame goes away. */
+export function debounce(fn, ms) {
+  let timer = 0;
+  const run = (...args) => { clearTimeout(timer); timer = setTimeout(() => { timer = 0; fn(...args); }, ms); };
+  run.cancel = () => { clearTimeout(timer); timer = 0; };
+  return run;
+}
+
+const $ = (id) => document.getElementById(id);
+
+/** No music: the author is listening to their own file. Effects stay on. */
+export const PREVIEW_URL = raceUrl(0);
+export const HINT = 'what the run looks like';
+/** The frame boots a whole 3D world from cold, which is slower than an edit. */
+export const WAIT_MS = READY_TIMEOUT_MS * 3;
+export const ASPECT_W = 16, ASPECT_H = 9;
+export const PAD = 8;
+
+/** Letterbox: the biggest ASPECT_W:ASPECT_H box that fits, centred, whole pixels. */
+export function fitBox(width, height, aw = ASPECT_W, ah = ASPECT_H, pad = PAD) {
+  const w = Math.max(0, width - pad), h = Math.max(0, height - pad);
+  const s = Math.min(w / aw, h / ah);
+  return { w: Math.max(0, Math.floor(aw * s)), h: Math.max(0, Math.floor(ah * s)) };
+}
+
+/** True when this browser can draw the race at all. No context, no preview. */
+export function canDraw(make) {
+  try {
+    const c = make ? make() : document.createElement('canvas');
+    return !!(c.getContext('webgl2') || c.getContext('webgl'));
+  } catch (e) { return false; }
+}
+
+export function install(api) {
+  const S = api.state;
+  let frame = null, box = null, note = null, guard = null;
+  let live = false, on = false, waitTimer = 0, lastClock = 0, lastPlaying = false, offMessage = null;
+
+  const say = (text) => { if (note) { note.textContent = text || ''; note.hidden = !text; } };
+
+  function post(msg) {
+    if (!frame || !frame.contentWindow) return;
+    try { frame.contentWindow.postMessage(msg, location.origin); }
+    catch (e) { say('the preview would not take that: ' + ((e && e.message) || e)); }
+  }
+
+  /** The chart the frame runs is exactly the file "save track" writes. */
+  function postChart() {
+    if (!live || !S.audio || !S.durationSec) return;
+    try { post({ type: 'chart', chart: buildChart(S) }); }
+    catch (e) { say('that track would not build: ' + ((e && e.message) || e)); }
+  }
+  const postChartSoon = debounce(postChart, CHART_DEBOUNCE_MS);
+
+  function onMessage(ev) {
+    if (!frame || !accepts(ev, location.origin, frame.contentWindow)) return;
+    if (ev.data.type !== 'race-ready') return;
+    clearTimeout(waitTimer); waitTimer = 0;
+    live = true;
+    say('');
+    postChart();
+    post(clockMessage(api.time(), false));
+  }
+
+  /** The frame is a picture, not a toy: whatever it does, the keys stay here. */
+  function keepFocus() {
+    if (frame && document.activeElement === frame) { try { frame.blur(); } catch (e) { /* gone */ } window.focus(); }
+  }
+
+  function fit() {
+    if (!box || !box.parentElement) return;
+    const r = box.parentElement.getBoundingClientRect();
+    const f = fitBox(r.width, r.height);
+    box.style.width = f.w + 'px';
+    box.style.height = f.h + 'px';
+  }
+
+  /** The first road turns the row on. Nothing above is built until then. */
+  function ensure() {
+    if (on) return;
+    on = true;
+    const host = $('preview');
+    $('pvg').hidden = false;
+    note = document.createElement('p');
+    note.className = 'pvnote';
+    if (!canDraw()) { host.replaceChildren(note); say('no preview here. this browser cannot draw the race.'); return; }
+    box = document.createElement('div');
+    box.className = 'pvbox';
+    frame = document.createElement('iframe');
+    frame.className = 'pvframe';
+    frame.title = 'the race';
+    frame.tabIndex = -1;
+    frame.setAttribute('allow', 'autoplay');
+    frame.setAttribute('referrerpolicy', 'same-origin');
+    frame.src = PREVIEW_URL;
+    guard = document.createElement('div');
+    guard.className = 'pvguard';
+    guard.title = 'watch only. pop out to drive it.';
+    guard.addEventListener('pointerdown', (ev) => { ev.preventDefault(); keepFocus(); window.focus(); });
+    box.append(frame, guard);
+    host.replaceChildren(box, note);
+    say('the road is drawing');
+    window.addEventListener('message', onMessage);
+    offMessage = () => window.removeEventListener('message', onMessage);
+    waitTimer = setTimeout(() => {
+      waitTimer = 0;
+      if (live) return;
+      host.replaceChildren(note);
+      if (offMessage) { offMessage(); offMessage = null; }
+      frame = null; box = null; guard = null;
+      say('no preview here. the race never answered.');
+    }, WAIT_MS);
+    fit();
+    if (window.ResizeObserver) new ResizeObserver(fit).observe(host);
+    else window.addEventListener('resize', fit);
+  }
+
+  /* ---- what the maker tells it ----------------------------------------- */
+
+  const onEdit = () => { if (live) postChartSoon(); };
+  /** 4 Hz while it plays, and the truth at once when play or pause changes. */
+  function clock(t, playing) {
+    if (!live) return;
+    keepFocus();
+    const now = performance.now();
+    if (!!playing === lastPlaying && now - lastClock < CLOCK_MS) return;
+    lastClock = now; lastPlaying = !!playing;
+    post(clockMessage(t, playing));
+  }
+  function seek(t, playing) {
+    if (!live) return;
+    lastClock = performance.now(); lastPlaying = !!playing;
+    post(seekMessage(t, playing));
+  }
+
+  function popOut() {
+    if (!S.audio || !S.durationSec) return api.status('generate a track first');
+    let url = '';
+    try {
+      const json = JSON.stringify(buildChart(S));
+      url = URL.createObjectURL(new Blob([json], { type: 'application/json' }));
+    } catch (e) { return api.status('that track would not build: ' + ((e && e.message) || e)); }
+    window.open('../race.html?chart=' + encodeURIComponent(url) + '&autostart=1&intro=0&pixel=0&music=0', '_blank');
+    api.status('popped out. that tab runs the track on its own clock.');
+    setTimeout(() => URL.revokeObjectURL(url), 60000);
+  }
+
+  $('pvpop').addEventListener('click', popOut);
+  $('pvg').hidden = true;
+
+  return { ensure, onEdit, clock, seek, popOut, isOn: () => on, isLive: () => live };
+}

--- a/ConditioningControlPanel/Resources/web/dtrh/chart/maker/timeline.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/chart/maker/timeline.js
@@ -82,6 +82,17 @@ function drawRuler() {
 function drawBubbles() {
   const f = document.createDocumentFragment();
   const wallW = 30 / view.pps;
+  // the road first, so it sits under everything the author can actually grab. These are not
+  // pickable and never will be: they belong to generate.js, not to the hand (MAKER.md, M5).
+  for (const e of (S.road && S.road.events) || []) {
+    const x = xOf(e.t);
+    if (x < -10 || x > W + 10) continue;
+    const d = document.createElement('i');
+    d.className = 'road ' + e.kind;
+    d.style.left = x.toFixed(1) + 'px';
+    d.title = e.kind + (e.label ? ' ' + e.label : '');
+    f.append(d);
+  }
   for (const [g, list] of groupsOf(S.bubs)) {
     const last = list[list.length - 1];
     const t0 = list[0].t, t1 = last.t + (last.kind === 'wall' ? wallW : 0);

--- a/ConditioningControlPanel/Resources/web/dtrh/chart/smoke/maker-check.mjs
+++ b/ConditioningControlPanel/Resources/web/dtrh/chart/smoke/maker-check.mjs
@@ -20,6 +20,7 @@ import {
   placeAll, placeHit, recipeFor, resetIds, slide, snapshotState,
 } from '../maker/model.js';
 import { BIN_SEC, countRuns, chantRuns, energyFromPeaks, generate, readWords, roadLine } from '../maker/generate.js';
+import { ASPECT_H, ASPECT_W, HINT, PREVIEW_URL, WAIT_MS, canDraw, fitBox } from '../maker/preview.js';
 import { normalizeChart } from '../../race/chart.js';
 import { cueFor } from '../../race/cues.js';
 
@@ -213,14 +214,35 @@ const rc2 = normalizeChart(JSON.parse(JSON.stringify(buildChart({ ...full, bubs:
 eq(rc2.events.filter((e) => e.hand === true).length, moved.length, 'a second run keeps every hand moved bubble');
 ok(rc2.events.some((e) => e.hand === true && Math.abs(e.t - moved[0].t) < 1e-6), 'exactly where the hand left it');
 
-/* ---- 8. the modules keep their promises ---------------------------------- */
+/* ---- 8. the preview row: the url, the letterbox, the way out -------------- */
+ok(PREVIEW_URL.startsWith('../race.html?'), 'the preview points at the race beside the maker');
+for (const bit of ['bridge=parent', 'autostart=1', 'pixel=0', 'intro=0', 'music=0']) {
+  ok(PREVIEW_URL.includes(bit), 'the preview url carries ' + bit);
+}
+eq(ASPECT_W / ASPECT_H, 16 / 9, 'the frame letterboxes at 16:9');
+const wideRow = fitBox(1000, 300);
+eq(wideRow.h, 292, 'a wide short row is capped by its height');
+ok(wideRow.w / wideRow.h > 1.77 && wideRow.w / wideRow.h < 1.79, 'and keeps the shape');
+const tallRow = fitBox(400, 900);
+eq(tallRow.w, 392, 'a narrow tall row is capped by its width');
+eq(fitBox(0, 0).w, 0, 'a row with no room asks for no frame');
+eq(fitBox(4, 4).h, 0, 'and neither does one smaller than its own padding');
+ok(WAIT_MS > 8000, 'the frame gets longer than an edit to boot a whole world');
+ok(canDraw(() => ({ getContext: () => null })) === false, 'no webgl, no preview');
+ok(canDraw(() => ({ getContext: (n) => (n === 'webgl2' ? {} : null) })) === true, 'webgl2 is enough');
+ok(canDraw(() => { throw new Error('blocked'); }) === false, 'a browser that throws at us is a no as well');
+eq(HINT, 'what the run looks like', 'the gutter says what the row is');
+
+/* ---- 9. the modules keep their promises ---------------------------------- */
 const src = (f) => readFileSync(join(MAKER, f), 'utf8');
 ok(!/getComputedStyle/.test(src('timeline.js')), 'nothing reads layout inside the draw loop');
 ok(!/decodeAudioData/.test(src('app.js')), 'the decode stays in audio.js, and the buffer never leaves it');
 ok(/peaks/.test(src('audio.js')), 'audio.js keeps the peaks');
 ok(/fetch\(/.test(src('words.js')) && !/fetch\(/.test(src('audio.js')), 'the audio is read off disk, never uploaded');
 ok(!/document\.|window\./.test(src('generate.js')), 'generate.js is pure: it never reaches for the page');
-for (const f of ['model.js', 'audio.js', 'words.js', 'timeline.js', 'app.js', 'pick.js', 'save.js', 'generate.js']) {
+ok(typeof PREVIEW_URL === 'string' && PREVIEW_URL.length > 0, 'preview.js loads with no page at all: node just imported it');
+ok(/postMessage/.test(src('preview.js')) && !/fetch\(/.test(src('preview.js')), 'the preview talks to its frame and to nothing else');
+for (const f of ['model.js', 'audio.js', 'words.js', 'timeline.js', 'app.js', 'pick.js', 'save.js', 'generate.js', 'preview.js']) {
   ok(src(f).startsWith('/* ====='), f + ' says what it is at the top');
 }
 

--- a/ConditioningControlPanel/Resources/web/dtrh/raceBoot.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/raceBoot.js
@@ -33,7 +33,7 @@
  * reading range after that time and is a screenshot aid for the pickup card;
  * `?panel=howto` opens the menu on the key card (race/menu.js); `?music=N`
  * (0..1, 0 = silent music) beats the saved music slider the same way and
- * `?bridge=parent` is the Chart Room preview (armParentBridge below).
+ * `?bridge=parent` is the Track Maker preview (armParentBridge below).
  *
  * `?back=<same-origin path>` is WHERE THE MENU'S `surface` VERB GOES when there
  * is no host to hand the page back to. Hosted, `surface` posts exit + exit-done
@@ -76,7 +76,7 @@ function resolveBack() {
   return null;
 }
 const standaloneExit = hosted ? null : resolveBack();
-/** The Chart Room embeds this page and drives the clock itself (armParentBridge below). */
+/** The Track Maker embeds this page and drives the clock itself (armParentBridge below). */
 const toParent = params.get('bridge') === 'parent' && window.parent && window.parent !== window;
 const host = hosted ? bridge : {
   on: bridge.on,


### PR DESCRIPTION
M5 and M6 of the Track Maker: the generated road and the run itself in the bottom row. This is the tip of the stack.

- `maker/app.js` - when a file lands with its words, the page asks once: generate the road? `generate` (`g`) runs `chart/maker/generate.js` (already on main from #873) over the peaks and the words: energy bins, acts, and the word / count / drop / chant / build / peak / release / silence events the race schedules between the hand bubbles. Road events are drawn as dots under the bubble lane and never pretend to be hand-placed.
- `maker/preview.js` (new) - the race in an iframe on the `?bridge=parent` bridge from the hand-cues PR: `chart` behind every edit, `clock` on play, `seek` on a scrub; `?music=0` so the author hears their own file, not ours. `pop out` opens the same chart in a full race tab. If the race never answers, the row says so.
- `maker/timeline.js`, `maker/pick.js`, `maker.css`, `maker.html`, `MAKER.md` - the road dots, the ask card, the preview row.
- The comment sweep: every note in `raceBoot.js`, `editor/audio.js` and `generate.js` now says Track Maker, not Chart Room. The chart room editor is shelved and not in this stack.

Checked end to end in headless Chrome on this branch after the rebase: drop a file, words found and placed, generate, road drawn, preview live, play and scrub in sync, hand cue lines in the race log, and the export normalizes with its walls and fx.

---
Track Maker stack, merge bottom up: #873 (merged) > hand-cues > maker-words > mk1 > mk2 > mk3 > mk4 > mk5. Each PR is based on the one before it and stays under 600 changed lines. No audio, words, transcript or output from any real file is in any of them (`chart/words/` is gitignored and excluded from the csproj).

Smokes, from `ConditioningControlPanel/Resources/web/dtrh`: `for f in chart/smoke/*.mjs race/smoke/*.mjs; do node "$f"; done` is green on every branch of the stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CRXVViHCxrTnrYFD7M1g8o
