### PR TITLE
race: double tap jumps on a phone, and the how-to says so

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/race.html
+++ b/ConditioningControlPanel/Resources/web/dtrh/race.html
@@ -20,7 +20,9 @@
     <style>
       /* the root is the screen-shake target (game/screenShake.js transforms it); the canvas alone
          takes the mirror flip, so the two never share one style.transform */
-      #race-root { position: fixed; inset: 0; overflow: hidden; background: #12261f; }
+      /* touch-action here as well as on body: a double tap over the menu or the cards is
+         a jump or a pick, never an iOS zoom the player has no way back out of on a phone */
+      #race-root { position: fixed; inset: 0; overflow: hidden; background: #12261f; touch-action: manipulation; }
       #race-root > canvas { display: block; width: 100%; height: 100%; }
       /* boot splash, z30: a 1 s title flash above the HUD chrome (z3), the payload layers (z4 / z9) and the menu (z25); the menu is the resting state */
       .race-splash {

--- a/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
@@ -325,10 +325,26 @@ As built (PR 5 reality notes):
   (z25), the cards (z26) and the splash (z30), so every card still takes the tap first. Left `STEER_SIDE`
   (55%) of the width steers by horizontal drag from the touch-down point (`STEER_DEAD_PX` 6 dead,
   `STEER_LOCK_PX` 72 to full lock, zero on release, a ring-and-dot thumb pad while held); the rest of the
-  width taps (under `TAP_MS` 180 and `TAP_PX` 12 of travel) for one jump press and holds for drift.
+  width taps (under `TAP_MS` 220 and `TAP_PX` 14 of travel) for one jump press and holds for drift.
+  A DOUBLE TAP is a jump on EITHER half: two taps inside `DOUBLE_TAP_MS` (320), so a thumb already
+  mid-corner still has one. `TAP_ECHO_MS` (60) folds a lift reported twice into one tap. A press that
+  lands on a button is never a tap, so double tapping `use` spends the item twice and never jumps.
   Accel is never touched: nothing pressed is cruise, and there is no brake pedal on glass. Three buttons
   fire existing actions through `input.onAction`: pause (`'brake'`), mute (`'mute'`) and a use button
-  (`'item'`) that only appears while `.rh-item` carries `is-held`. Pointer Events only, never TouchEvent.
+  (`'item'`) that only appears while `.rh-item` carries `is-held`. Pointer Events drive steer and drift;
+  TouchEvent is a FLOOR under them, never a second scheme: `touchstart` preventDefault takes the gesture
+  away from WebKit (without it Safari cancels our pointers to run its own and no tap ever lands), a
+  `touchend` that looks like a tap raises the same tap, and the fingers still on the glass at a
+  `touchend` end any held id they do not account for (per half, so a right thumb lifting while a left
+  one steers still ends its drift) so a swallowed `pointerup` cannot strand one. `pointerup` /
+  `pointercancel` are heard on the window as well as the layer, and ONLY the wheel pointer is captured:
+  the jump hand is not, because `setPointerCapture` is one of the things WebKit hands back as a
+  `pointercancel` and an `inset: 0` layer had nowhere to lose that finger to anyway. `#race-root` carries
+  `touch-action: manipulation` (the layer itself `none`), so a double tap is a jump or a pick, never an
+  iOS zoom. None of this is verified on a real iPhone: `race/smoke/touch-check.mjs` walks the logic only.
+- The how-to card (`race/menu.js`) leads with the THUMB rows on a touchable page and keeps the keys and
+  the pad below them, and `race/hud.js` drops the `E` badge from the item hint there: an empty slot reads
+  `no item yet`, a full one `<name> tap to use`.
 - Space (pad B) is the jump: `read().jump` is true for exactly the frame of a fresh press, never on hold,
   and `kart.stepJump` turns it into 1.1 m of real height (`state.h`, so the pop box goes up with it).
   A press within 4 m of a ramp lip, or inside 0.12 s of one firing, boosts that launch by 1.3 and hands

--- a/ConditioningControlPanel/Resources/web/dtrh/race/hud.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/hud.js
@@ -15,6 +15,8 @@
  * pad and its pause / mute / use buttons) on a touchable page. It rides BELOW
  * the screens at z20, so a card still takes the tap first and nothing here has
  * to cooperate. The item button watches this file's `is-held` class on the slot.
+ * On a touchable page the item hint drops the `E` badge: an empty slot reads
+ * `no item yet` with nothing after it, and a full one reads `<name> tap to use`.
  * Copy is DtRH voice: lowercase, short.
  *
  * THE PICKUP (pass f3): a cube gives its item a card of its own, centre of the
@@ -30,6 +32,11 @@
  * ==========================================================================*/
 
 import { COMBO_HOLD_SEC, MULT_LADDER, KART_MAX_SPEED, KART_BASE_SPEED } from './consts.js';
+import { wantsTouch } from './touch.js';
+
+/** A phone has no E key, so the item hint must not point at one. Same test race/touch.js
+ *  uses to decide whether to build the layer at all, `?touch=1` / `?touch=0` included. */
+const TOUCH = wantsTouch();
 
 const FLICK_MS = 450;
 const TOAST_HOLD = { pop: 1100, almost: 1300, jackpot: 1800, bank: 1600, item: 1400, effect: 1400, recipe: 1700 };
@@ -118,8 +125,9 @@ export function createRaceHud(root) {
   const itemName = el('rh-item-name', item, 'no item yet');
   const itemKey = document.createElement('span');
   itemKey.className = 'rh-item-key';
-  itemKey.textContent = 'E';
-  itemName.appendChild(itemKey);
+  // on glass the badge is an instruction, not a key, and an empty slot has nothing to tap
+  itemKey.textContent = TOUCH ? 'tap to use' : 'E';
+  if (!TOUCH) itemName.appendChild(itemKey);
 
   // THE PICKUP: the item's own card. No per-item art ships, so the tile IS the picture: the room
   // colour, a soft glow and the glyph big. It rides in the chrome, so a freeze or a tape covers it.
@@ -361,7 +369,8 @@ export function createRaceHud(root) {
     item(glyph, name) {
       itemBox.textContent = glyph == null ? '·' : String(glyph);
       itemName.firstChild.textContent = (name || (glyph == null ? 'no item yet' : '')).toLowerCase();
-      itemName.appendChild(itemKey);
+      if (!TOUCH || glyph != null) itemName.appendChild(itemKey);
+      else if (itemKey.parentNode) itemKey.parentNode.removeChild(itemKey);
       item.classList.toggle('is-armed', glyph != null);
       item.classList.toggle('is-rolling', glyph === '?');
       if (glyph == null) item.classList.remove('is-held', 'is-inbound');

--- a/ConditioningControlPanel/Resources/web/dtrh/race/menu.css
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/menu.css
@@ -97,6 +97,12 @@
 }
 #race-root .rm-key span { color: #ffd6ea; }
 #race-root .rm-hint { font-size: 12px; color: rgba(255, 214, 234, 0.6); margin-top: 6px; }
+/* the how-to card is two halves on a phone (a thumb, then keys and a pad): this labels them */
+#race-root .rm-sub {
+  font-size: 12px; font-weight: 800; letter-spacing: 0.1em; margin: 8px 0 2px;
+  color: rgba(255, 214, 234, 0.55);
+}
+#race-root .rm-sub:first-of-type { margin-top: 2px; }
 /* the key card's own way out, for the hand that has no esc key */
 #race-root .rm-how-back { font-size: 17px; padding: 8px 16px 8px 30px; margin-top: 8px; align-self: flex-start; }
 #race-root .rm-btn[hidden] { display: none; }
@@ -230,6 +236,7 @@
   #race-root .rm-row { padding: 5px 12px; font-size: 15px; }
   #race-root .rm-row-hint, #race-root .rm-hint { font-size: 10px; margin-top: 2px; }
   #race-root .rm-key { grid-template-columns: 104px 1fr; font-size: 12px; }
+  #race-root .rm-sub { font-size: 10px; margin: 4px 0 0; }
   #race-root .rm-panel { gap: 4px; }
   #race-root .rm-track { margin-top: 8px; padding: 6px 12px; }
   #race-root .rm-plate { bottom: calc(10px + var(--rm-sa-b)); }

--- a/ConditioningControlPanel/Resources/web/dtrh/race/menu.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/menu.js
@@ -50,6 +50,9 @@
  * 100 ms (Law VIII): THE BOUNCE on the button, THE GLOW on focus.
  *
  * A FINGER CAN REACH EVERYTHING. There is no key card and no pad on a phone, so
+ * `how to drive` opens on a THUMB card (drag the left side, double tap to jump,
+ * hold the right side to drift, the use button, pause and sound) with the keys
+ * and the pad kept below it, and
  * every path a key takes has a target under it: `how to drive` carries its own
  * back row and a tap anywhere off the panel closes it, and each value row wears
  * a real left and right button around the number, so music and sfx go DOWN by
@@ -58,6 +61,7 @@
  * ==========================================================================*/
 
 import * as THREE from 'three';
+import { wantsTouch } from './touch.js';
 import { loadPack, preparePixel, toInstanceGeometry, flattenRig, setFace, FACES } from './gltf.js';
 import { PIXEL_STEPS, PIXEL_DEFAULT, normalizeBlock } from './pixel.js';
 import { createMenuFlashes } from './menuFlashes.js';
@@ -404,7 +408,24 @@ export function createMenu({ root, renderer, pixel, audio, settings = {}, log = 
   for (const a of [arrowL, arrowR]) { a.type = 'button'; const off = ROSTER.length === 1; a.disabled = off; a.setAttribute('aria-disabled', String(off)); a.title = off ? 'one racer for now' : 'next racer'; }
 
   // ---- how to drive ----
+  // A phone has no keys and no pad, so on glass the THUMB rows come first and say what
+  // the layer race/touch.js builds actually does. Same test that layer uses, `?touch=1`
+  // and `?touch=0` included, so the headless shot can ask for either card.
   el('h3', 'rm-h', howPanel, 'how to drive');
+  if (wantsTouch()) {
+    el('div', 'rm-sub', howPanel, 'with a thumb');
+    for (const [k, v] of [
+      ['left side', 'drag it. wherever your thumb lands is the wheel.'],
+      ['double tap', 'jump. two quick taps, anywhere on the glass.'],
+      ['right side', 'hold to drift, let go for turbo. one tap there jumps too.'],
+      ['use', 'the round button by the gauge spends your item.'],
+      ['ii / sound', 'pause and mute, top right.'],
+    ]) {
+      const row = el('div', 'rm-key', howPanel); el('kbd', '', row, k); el('span', '', row, v);
+    }
+    el('div', 'rm-row-hint', howPanel, 'you are always going. there is no pedal on glass.');
+    el('div', 'rm-sub', howPanel, 'or keys and a pad');
+  }
   for (const [k, v] of [['arrows / wasd', 'steer, throttle, brake'], ['shift', 'drift (hold, let go for turbo)'], ['space', 'jump (time it at a ramp for big air)'], ['e', 'use the item'], ['p', 'pixel look'], ['m', 'mute'], ['esc', 'the brake'], ['pad', 'stick steers, rt goes, a drifts, b jumps, x item, start brakes']]) {
     const row = el('div', 'rm-key', howPanel); el('kbd', '', row, k); el('span', '', row, v);
   }

--- a/ConditioningControlPanel/Resources/web/dtrh/race/race.css
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/race.css
@@ -355,6 +355,8 @@
 .race-hud .rh-touch {
   position: fixed; inset: 0; z-index: 12; touch-action: none; overscroll-behavior: none;
   -webkit-user-select: none; user-select: none; -webkit-tap-highlight-color: transparent;
+  /* the long-press callout is a gesture too: iOS cancels the pointer under it to raise one */
+  -webkit-touch-callout: none;
 }
 /* the thumb pad: a ring at the touch-down point, a dot that rides the drag */
 .race-hud .rt-pad {

--- a/ConditioningControlPanel/Resources/web/dtrh/race/smoke/touch-check.mjs
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/smoke/touch-check.mjs
@@ -7,12 +7,14 @@
  * jsdom-free on purpose: the DOM this needs is four methods wide, so it is stubbed
  * here (elements, classList, listeners, MutationObserver, a window with location /
  * navigator / matchMedia) and synthetic pointer events are dispatched straight at
- * the layer touch.js built. Date.now is driven by hand so a 180 ms hold costs no
- * wall clock. Nothing here proves the FEEL of the steering: that is the owner's,
+ * the layer touch.js built. Date.now is driven by hand so a hold costs no wall
+ * clock. Sections 5b and 5c walk the two rules the iPhone pass added: the double
+ * tap on either half, and the TouchEvent floor that still lands a tap when the
+ * pointerup never arrives. Nothing here proves the FEEL of the steering: that is the owner's,
  * on a real phone, with real thumbs.
  * ==========================================================================*/
 
-import { createTouch, wantsTouch, steerFromDx, STEER_LOCK_PX, STEER_DEAD_PX, TAP_MS, TAP_PX } from '../touch.js';
+import { createTouch, wantsTouch, steerFromDx, STEER_LOCK_PX, STEER_DEAD_PX, TAP_MS, TAP_PX, DOUBLE_TAP_MS } from '../touch.js';
 import { createInput } from '../input.js';
 
 let fails = 0;
@@ -185,6 +187,126 @@ const built = (() => {
   L.fire('pointerdown', { pointerId: 5, clientX: X, clientY: 300 });
   L.fire('pointercancel', { pointerId: 5, clientX: X, clientY: 300 });
   ok(t.read().jump === false, 'a cancelled press (a call, a system gesture) is no press at all');
+}
+
+/* ---- 5b. the double tap: two taps, either half, one jump ---------------- */
+{
+  const { t } = built;
+  const L = t.el, R = 700, LX = 100;
+  t.flush(); tick(500);
+  L.fire('pointerdown', { pointerId: 40, clientX: LX, clientY: 300 });
+  tick(60); L.fire('pointerup', { pointerId: 40, clientX: LX, clientY: 300 });
+  ok(t.read().jump === false, 'one tap on the wheel side is still not a jump');
+  tick(120);
+  L.fire('pointerdown', { pointerId: 41, clientX: LX, clientY: 300 });
+  tick(60); L.fire('pointerup', { pointerId: 41, clientX: LX, clientY: 300 });
+  ok(t.read().jump === true, 'two taps inside ' + DOUBLE_TAP_MS + ' ms are one jump, wheel side and all');
+
+  t.flush(); tick(500);
+  L.fire('pointerdown', { pointerId: 42, clientX: LX, clientY: 300 });
+  tick(60); L.fire('pointerup', { pointerId: 42, clientX: LX, clientY: 300 });
+  t.read();
+  tick(DOUBLE_TAP_MS + 40);
+  L.fire('pointerdown', { pointerId: 43, clientX: LX, clientY: 300 });
+  tick(60); L.fire('pointerup', { pointerId: 43, clientX: LX, clientY: 300 });
+  ok(t.read().jump === false, 'two taps further apart than that are two taps, not a jump');
+
+  t.flush(); tick(500);
+  L.fire('pointerdown', { pointerId: 44, clientX: R, clientY: 300 });
+  tick(60); L.fire('pointerup', { pointerId: 44, clientX: R, clientY: 300 });
+  ok(t.read().jump === true, 'a single tap on the right half still jumps on its own');
+  tick(100);
+  L.fire('pointerdown', { pointerId: 45, clientX: LX, clientY: 300 });
+  tick(60); L.fire('pointerup', { pointerId: 45, clientX: LX, clientY: 300 });
+  ok(t.read().jump === true, 'and a pair may cross the halves: right then left is still a jump');
+
+  t.flush(); tick(500);
+  for (const id of [46, 47]) {
+    L.fire('pointerdown', { pointerId: id, clientX: LX, clientY: 300 });
+    L.fire('pointermove', { pointerId: id, clientX: LX + STEER_LOCK_PX, clientY: 300 });
+    tick(60); L.fire('pointerup', { pointerId: id, clientX: LX + STEER_LOCK_PX, clientY: 300 });
+  }
+  ok(t.read().jump === false, 'two corners in a row are two corners, never a jump');
+}
+
+/* ---- 5c. the TouchEvent floor: the lift iOS may swallow ------------------ */
+{
+  const { t } = built;
+  const L = t.el, R = 700;
+  const tc = (id, x, y) => ({ identifier: id, clientX: x, clientY: y });
+
+  t.flush(); tick(500);
+  L.fire('touchstart', { changedTouches: [tc(1, R, 300)], touches: [tc(1, R, 300)] });
+  L.fire('pointerdown', { pointerId: 50, clientX: R, clientY: 300 });
+  tick(60);
+  L.fire('pointercancel', { pointerId: 50, clientX: R, clientY: 300 });
+  ok(t.read().jump === false, 'a cancelled pointer is still no press of its own');
+  L.fire('touchend', { changedTouches: [tc(1, R, 300)], touches: [] });
+  ok(t.read().jump === true, 'but the touchend behind it is the lift, so the tap lands anyway');
+
+  t.flush(); tick(500);
+  L.fire('touchstart', { changedTouches: [tc(2, R, 300)], touches: [tc(2, R, 300)] });
+  L.fire('pointerdown', { pointerId: 51, clientX: R, clientY: 300 });
+  tick(60);
+  L.fire('pointerup', { pointerId: 51, clientX: R, clientY: 300 });
+  L.fire('touchend', { changedTouches: [tc(2, R, 300)], touches: [] });
+  ok(t.read().jump === true, 'a pointerup and the touchend behind it are one lift');
+  ok(t.read().jump === false, 'counted exactly once, never twice');
+
+  t.flush(); tick(500);
+  L.fire('touchstart', { changedTouches: [tc(3, R, 300)], touches: [tc(3, R, 300)] });
+  L.fire('pointerdown', { pointerId: 52, clientX: R, clientY: 300 });
+  tick(TAP_MS);
+  ok(t.read().drift === true, 'a held thumb still drifts');
+  L.fire('touchend', { changedTouches: [tc(3, R, 300)], touches: [] });
+  ok(t.read().drift === false, 'and nothing on the glass ends it, even with the pointerup lost');
+
+  // the strand: the right thumb goes while the LEFT one is still steering, so the glass is
+  // never empty. Asking per half is the only way that held id ever comes back.
+  t.flush(); tick(500);
+  L.fire('touchstart', { changedTouches: [tc(4, 100, 300)], touches: [tc(4, 100, 300)] });
+  L.fire('pointerdown', { pointerId: 53, clientX: 100, clientY: 300 });
+  L.fire('touchstart', { changedTouches: [tc(5, R, 300)], touches: [tc(4, 100, 300), tc(5, R, 300)] });
+  L.fire('pointerdown', { pointerId: 54, clientX: R, clientY: 300 });
+  tick(TAP_MS);
+  ok(t.read().drift === true, 'two thumbs down: the right one is drifting');
+  L.fire('touchend', { changedTouches: [tc(5, R, 300)], touches: [tc(4, 100, 300)] });   // pointerup swallowed
+  ok(t.read().drift === false, 'the right thumb lifting ends the drift even with a thumb still steering');
+  L.fire('pointerdown', { pointerId: 55, clientX: R, clientY: 300 });
+  tick(60);
+  L.fire('pointerup', { pointerId: 55, clientX: R, clientY: 300 });
+  ok(t.read().jump === true, 'and the next tap on that half still jumps: nothing was left holding the slot');
+}
+
+/* ---- 5d. the buttons keep their own presses ----------------------------- */
+{
+  const { t } = built;
+  const L = t.el, R = 700;
+  const use = L.children.find((c) => c.attrs['aria-label'] === 'use item');
+  const tc = (id, x, y, target) => ({ identifier: id, clientX: x, clientY: y, target });
+
+  // two fingers in ONE touchstart: e.target is only the first of them, so the button test
+  // has to be asked of each touch or the finger on `use` becomes a tap under it
+  t.flush(); tick(500);
+  L.fire('touchstart', { changedTouches: [tc(6, R, 300), tc(7, R, 700, use)], touches: [tc(6, R, 300), tc(7, R, 700, use)] });
+  tick(60);
+  L.fire('touchend', { changedTouches: [tc(7, R, 700, use)], touches: [tc(6, R, 300)] });
+  ok(t.read().jump === false, 'a finger on the use button is the button\'s, never a tap on the road under it');
+  L.fire('touchend', { changedTouches: [tc(6, R, 300)], touches: [] });
+  ok(t.read().jump === true, 'while the finger beside it on the road still lands its tap');
+
+  // and double tapping `use` spends the item twice, never a jump
+  t.flush(); tick(500);
+  const acts = built.acts; acts.length = 0;
+  for (let i = 0; i < 2; i++) {
+    L.fire('touchstart', { changedTouches: [tc(8 + i, R, 700, use)], touches: [tc(8 + i, R, 700, use)], target: use });
+    use.fire('pointerdown', { pointerId: 60 + i });
+    tick(60);
+    L.fire('touchend', { changedTouches: [tc(8 + i, R, 700, use)], touches: [] });
+    tick(100);
+  }
+  ok(acts.join(',') === 'item,item', 'double tapping use spends the item twice');
+  ok(t.read().jump === false, 'and never jumps while doing it');
 }
 
 /* ---- 6. both thumbs at once --------------------------------------------- */

--- a/ConditioningControlPanel/Resources/web/dtrh/race/touch.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/touch.js
@@ -27,26 +27,65 @@
  *              lock at +-STEER_LOCK_PX, nothing inside STEER_DEAD_PX, zero the
  *              moment the thumb lifts. A ring marks the touch-down point and a
  *              dot rides the drag, so the player can see the wheel they are on.
- *   RIGHT      a TAP (under TAP_MS, under TAP_PX of travel) is one jump press,
- *              exactly like Space. Anything longer or further is DRIFT, held
- *              for as long as the thumb stays down. Accel is untouched: nothing
- *              pressed is cruise, and a phone never needs the brake pedal.
+ *   ANYWHERE   a DOUBLE TAP is a jump. Two taps inside DOUBLE_TAP_MS, either
+ *              half, whatever the thumbs are already doing. This is the rule
+ *              the how-to panel teaches, because it is the one that survives a
+ *              thumb already mid-corner.
+ *   RIGHT      a single TAP (under TAP_MS, under TAP_PX of travel) is one jump
+ *              press too, exactly like Space. Anything longer or further is
+ *              DRIFT, held for as long as the thumb stays down. Accel is
+ *              untouched: nothing pressed is cruise, and a phone never needs
+ *              the brake pedal.
  *   BUTTONS    pause (fires 'brake', which opens the Brake screen and its own
  *              tappable buttons), mute, and an item button that only appears
  *              while the slot is `is-held`. 48 px minimum, anchored on the
- *              existing --rh-in-* safe-area insets.
+ *              existing --rh-in-* safe-area insets. A press that lands on a
+ *              button is never a tap, so double tapping `use` spends the item
+ *              twice and never jumps.
  *
- * Pointer Events only, never TouchEvent, and the pointer is captured so a drag
- * that wanders off the zone still belongs to the finger that started it.
+ * WHY THE TAP DIED ON AN IPHONE. A jump used to need one exact thing to happen:
+ * a `pointerup`, on the right half, inside 180 ms, on a captured pointer. Every
+ * one of those four is something WebKit is allowed to take away.
+ *   - `touch-action: none` in the stylesheet does not, on its own, stop Safari
+ *     arming its own recognisers over a layer whose `touchstart` default was
+ *     never prevented. The moment it decides the gesture is a zoom, a pan or a
+ *     long-press callout it sends `pointercancel` instead of `pointerup`, and a
+ *     cancel is deliberately no press at all.
+ *   - `setPointerCapture` is the API it hands back as that same cancel.
+ *   - 180 ms is under a deliberate thumb press on glass.
+ *   - and the right half is the half a right thumb is already busy holding.
+ * So none of the four is load bearing any more:
+ *   - the layer prevents the default of `touchstart` itself (non-passive, and
+ *     skipped over the buttons so they keep their own press),
+ *   - only the WHEEL pointer is captured; the jump hand is not, because the
+ *     layer is inset: 0 and had nowhere to lose it to anyway,
+ *   - a TouchEvent floor sits under the LIFT: a `touchend` that looks like a tap
+ *     raises the same tap the pointer path would have, and two taps closer
+ *     together than TAP_ECHO_MS are one lift reported twice,
+ *   - the fingers left on the glass at a `touchend` end any held id they do not
+ *     account for, so a swallowed `pointerup` cannot strand a drift that eats
+ *     every jump after it,
+ *   - `pointerup` / `pointercancel` are heard on the window as well as on the
+ *     layer, so a lift that lands elsewhere still ends the gesture,
+ *   - the tap window is 220 ms, not 180,
+ *   - and a DOUBLE TAP jumps from either half, so the hand that is free is
+ *     always the right hand.
+ * None of this is proven on a real iPhone from here. The node smoke walks the
+ * logic; the phone is the owner's.
  * ==========================================================================*/
 
 /** Full steering lock, css px of horizontal drag from the touch-down point. */
 export const STEER_LOCK_PX = 72;
 /** Dead zone: a thumb resting on the glass is not a turn. */
 export const STEER_DEAD_PX = 6;
-/** A press shorter than this, and stiller than TAP_PX, is a jump; longer is a drift. */
-export const TAP_MS = 180;
-export const TAP_PX = 12;
+/** A press shorter than this, and stiller than TAP_PX, is a tap; longer is a drift. */
+export const TAP_MS = 220;
+export const TAP_PX = 14;
+/** Two taps this close together, on EITHER half, are a jump. The owner's rule. */
+export const DOUBLE_TAP_MS = 320;
+/** One physical lift can be reported twice (a pointerup, then the touchend behind it).
+ *  Taps closer than this are that echo, counted once. Well under a real double tap. */
+export const TAP_ECHO_MS = 60;
 /** The left fraction of the width that steers. The rest jumps and drifts. */
 export const STEER_SIDE = 0.55;
 
@@ -121,9 +160,26 @@ export function createTouch({ root = null, fire = () => {}, win = null, doc = nu
   syncItem();
 
   const out = { steer: 0, drift: false, jump: false };
-  let steerId = -1, steerX0 = 0, steer = 0;
+  let steerId = -1, steerX0 = 0, steerY0 = 0, steerT0 = 0, steerMoved = false, steer = 0;
   let actId = -1, actT0 = 0, actX0 = 0, actY0 = 0, actMoved = false;
   let jumpQ = false, disposed = false;
+  /** the double tap: when the last counted tap landed, and when the last lift was counted */
+  let lastTapT = 0, tapEchoT = 0;
+  /** the TouchEvent floor's own book: identifier -> where and when that finger went down */
+  const touchDown = new Map();
+
+  const onBtn = (t) => !!(t && typeof t.closest === 'function' && t.closest('.rt-btn'));
+
+  /** One completed tap, from the pointer path or the touch floor under it. A tap on the
+   *  right half is a jump on its own; two taps on EITHER half inside DOUBLE_TAP_MS are a
+   *  jump too, which is the rule that still answers with a thumb already mid-corner. */
+  function tapped(now, rightSide) {
+    if (tapEchoT && now - tapEchoT < TAP_ECHO_MS) return;      // the same lift, reported twice
+    tapEchoT = now;
+    const dbl = lastTapT > 0 && now - lastTapT <= DOUBLE_TAP_MS;
+    lastTapT = dbl ? 0 : now;                                  // a pair is spent: three taps are one jump and a fresh first
+    if (rightSide || dbl) jumpQ = true;
+  }
 
   const at = (e) => {
     const r = layer.getBoundingClientRect();
@@ -137,18 +193,23 @@ export function createTouch({ root = null, fire = () => {}, win = null, doc = nu
 
   function onDown(e) {
     if (disposed) return;
-    const t = e.target;
-    if (t && typeof t.closest === 'function' && t.closest('.rt-btn')) return;   // the buttons speak for themselves
+    if (onBtn(e.target)) return;                                               // the buttons speak for themselves
     const p = at(e);
     if (p.x < p.w * STEER_SIDE) {
       if (steerId >= 0) return;
-      steerId = e.pointerId; steerX0 = e.clientX; steer = 0;
+      steerId = e.pointerId; steerX0 = e.clientX; steerY0 = e.clientY;
+      steerT0 = Date.now(); steerMoved = false; steer = 0;
       showPad(p.x, p.y);
+      // capture only the WHEEL: a steering thumb wanders and has to keep its pointer
+      try { layer.setPointerCapture(e.pointerId); } catch (err) { /* no capture: the listeners still fire */ }
     } else {
       if (actId >= 0) return;
       actId = e.pointerId; actT0 = Date.now(); actX0 = e.clientX; actY0 = e.clientY; actMoved = false;
+      // and NOT the jump hand. The layer is inset: 0, so there is nowhere that finger can go
+      // that this element is not already under, and capture is the thing WebKit hands back as
+      // a `pointercancel` when it changes its mind about who owns the gesture. One less way
+      // to lose a tap, for a capture that was never buying anything.
     }
-    try { layer.setPointerCapture(e.pointerId); } catch (err) { /* no capture: the listeners still fire */ }
     if (e.cancelable) e.preventDefault();
   }
 
@@ -156,6 +217,7 @@ export function createTouch({ root = null, fire = () => {}, win = null, doc = nu
     if (disposed) return;
     if (e.pointerId === steerId) {
       const dx = e.clientX - steerX0;
+      if (Math.abs(dx) > TAP_PX || Math.abs(e.clientY - steerY0) > TAP_PX) steerMoved = true;   // a drag is not a tap
       steer = steerFromDx(dx);
       dot.style.transform = 'translate(' + clamp(dx, -STEER_LOCK_PX, STEER_LOCK_PX) + 'px, 0px)';
     } else if (e.pointerId === actId) {
@@ -166,15 +228,73 @@ export function createTouch({ root = null, fire = () => {}, win = null, doc = nu
 
   function onUp(e) {
     if (disposed) return;
+    const now = Date.now();
     if (e.pointerId === steerId) {
-      steerId = -1; steer = 0;
+      // a still, short press on the wheel side turns nothing, but it still counts toward
+      // the double tap: the rule is anywhere, not one half
+      if (e.type === 'pointerup' && !steerMoved && now - steerT0 < TAP_MS) tapped(now, false);
+      steerId = -1; steer = 0; steerMoved = false;
       layer.classList.remove('is-steering');
     } else if (e.pointerId === actId) {
       // a tap is one jump press; a cancel (a call, a system gesture) is no press at all
-      if (e.type === 'pointerup' && !actMoved && Date.now() - actT0 < TAP_MS) jumpQ = true;
+      if (e.type === 'pointerup' && !actMoved && now - actT0 < TAP_MS) tapped(now, true);
       actId = -1;
     } else return;
     try { layer.releasePointerCapture(e.pointerId); } catch (err) { /* already gone */ }
+  }
+
+  /* ---- the TouchEvent floor under the pointer path -------------------------
+   * Not a second input scheme. `touchstart` only takes the default away from
+   * WebKit's gesture recognisers, and `touchend` only reports a LIFT the pointer
+   * path may never have been told about: the tap it raises, and the held id it
+   * ends. Where a wheel goes and how far is still the pointer path's alone. */
+  /** Which half of the layer a raw Touch is on, or null if it is over a button (a button
+   *  press is the button's, never a tap and never a wheel). */
+  function sideOf(c) {
+    if (!c || onBtn(c.target)) return null;
+    const r = layer.getBoundingClientRect();
+    return (c.clientX - r.left) >= (r.width || 1) * STEER_SIDE ? 'right' : 'left';
+  }
+
+  function onTouchStart(e) {
+    if (disposed) return;
+    // this preventDefault IS the fix: without it Safari keeps its own zoom / pan / callout
+    // recognisers armed over the road and cancels our pointers to go and run one instead.
+    // It is skipped over the buttons so they keep their own press.
+    if (!onBtn(e.target) && e.cancelable) e.preventDefault();
+    const list = e.changedTouches || [];
+    for (let i = 0; i < list.length; i++) {
+      const c = list[i];
+      // per touch, not per event: two fingers can land in one touchstart and only e.target
+      // belongs to the first of them, so the button test has to be asked of each one
+      const side = sideOf(c);
+      if (!side) continue;
+      touchDown.set(c.identifier, { t0: Date.now(), x0: c.clientX, y0: c.clientY, right: side === 'right' });
+    }
+  }
+  function onTouchEnd(e) {
+    if (disposed) return;
+    const now = Date.now();
+    const list = e.changedTouches || [];
+    for (let i = 0; i < list.length; i++) {
+      const c = list[i];
+      const s = touchDown.get(c.identifier);
+      touchDown.delete(c.identifier);
+      if (!s || e.type !== 'touchend') continue;                // touchcancel is no press, same as pointercancel
+      if (now - s.t0 < TAP_MS && Math.abs(c.clientX - s.x0) <= TAP_PX && Math.abs(c.clientY - s.y0) <= TAP_PX) tapped(now, s.right);
+    }
+    // A `pointerup` Safari swallowed would otherwise strand a held id forever: the drift never
+    // ends and `onDown` refuses every press after it, which is a jump that never comes back.
+    // The fingers still on the glass are the truth, so ask them, per half.
+    const rest = e.touches || [];
+    let onLeft = false, onRight = false;
+    for (let i = 0; i < rest.length; i++) {
+      const side = sideOf(rest[i]);
+      if (side === 'right') onRight = true; else if (side === 'left') onLeft = true;
+    }
+    if (!onLeft && steerId >= 0) { steerId = -1; steer = 0; steerMoved = false; layer.classList.remove('is-steering'); }
+    if (!onRight) actId = -1;
+    if (!onLeft && !onRight) touchDown.clear();
   }
 
   const noMenu = (e) => { if (e.cancelable) e.preventDefault(); };   // no long-press menu over the road
@@ -183,6 +303,14 @@ export function createTouch({ root = null, fire = () => {}, win = null, doc = nu
   layer.addEventListener('pointerup', onUp);
   layer.addEventListener('pointercancel', onUp);
   layer.addEventListener('contextmenu', noMenu);
+  layer.addEventListener('touchstart', onTouchStart, { passive: false });
+  layer.addEventListener('touchend', onTouchEnd, { passive: false });
+  layer.addEventListener('touchcancel', onTouchEnd, { passive: false });
+  // a lift that lands anywhere else still ends the gesture; onUp ignores every id it does not hold
+  if (w && typeof w.addEventListener === 'function') {
+    w.addEventListener('pointerup', onUp, true);
+    w.addEventListener('pointercancel', onUp, true);
+  }
 
   /** Drift is decided here, not in a handler: a thumb held perfectly still sends no
    *  move event, and the hold still has to become a drift on its own. */
@@ -194,7 +322,8 @@ export function createTouch({ root = null, fire = () => {}, win = null, doc = nu
   }
 
   function flush() {
-    steerId = -1; actId = -1; steer = 0; jumpQ = false; actMoved = false;
+    steerId = -1; actId = -1; steer = 0; jumpQ = false; actMoved = false; steerMoved = false;
+    lastTapT = 0; tapEchoT = 0; touchDown.clear();
     layer.classList.remove('is-steering');
   }
 
@@ -205,6 +334,13 @@ export function createTouch({ root = null, fire = () => {}, win = null, doc = nu
     layer.removeEventListener('pointerup', onUp);
     layer.removeEventListener('pointercancel', onUp);
     layer.removeEventListener('contextmenu', noMenu);
+    layer.removeEventListener('touchstart', onTouchStart);
+    layer.removeEventListener('touchend', onTouchEnd);
+    layer.removeEventListener('touchcancel', onTouchEnd);
+    if (w && typeof w.removeEventListener === 'function') {
+      w.removeEventListener('pointerup', onUp, true);
+      w.removeEventListener('pointercancel', onUp, true);
+    }
     if (mo) { try { mo.disconnect(); } catch (err) { /* observer already dead */ } mo = null; }
     if (layer.parentNode) layer.parentNode.removeChild(layer);
     flush();


### PR DESCRIPTION
## what

Owner's iPhone test of the web build: "i cant jump, double tap should jump" and "the how to play doesnt tell how to play from phone".

A jump needed one exact thing: a `pointerup`, on the right half, inside 180 ms, on a captured pointer. WebKit can take away every one of those (its own zoom/pan recognisers turn the lift into `pointercancel` when `touchstart` is not prevented, `setPointerCapture` is one of the APIs it answers with that cancel, 180 ms is under a deliberate thumb press, and a swallowed lift stranded the act id so no press after it ever registered). None of the four is load-bearing any more:

- `touchstart` preventDefault (non-passive, skipped over the buttons); `-webkit-touch-callout: none`; `#race-root { touch-action: manipulation }` so a double tap is never an iOS zoom.
- capture only the wheel pointer, never the jump hand; `pointerup`/`pointercancel` also heard on `window`.
- a `touchend` that looks like a tap raises the same tap (one physical lift counted once, 60 ms echo window).
- stranding clear is per half, so a right thumb lifting while the left one steers still ends its drift.
- `TAP_MS` 180 -> 220, `TAP_PX` 14, and the owner's rule: two taps within 320 ms, either half, = jump. Right-half single tap still jumps, hold is still drift, left drag is still the wheel. Double tapping `use` fires the item twice and never jumps.

"how to drive" on a touch page shows a "with a thumb" section first (left side / double tap / right side / use / ii sound), then "or keys and a pad" with the old rows. HUD item hint on touch: "no item yet" with no key badge, "tap to use" when holding one.

## verification

`touch-check` 77 assertions pass (new: two-thumb strand, next tap after it, a button under a second finger, double tapping use); audio/chart/fov/gltf/poses/track-run smokes green; `node --check` clean. Phone-viewport screenshots of the how-to card and the in-run HUD taken headless. WebKit behaviour itself is unverified without a real iPhone: the double tap is the path that depends on the fewest suspects, so it is the one to try first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0166ij3Q8xyseVkhWajzkWG3
