### PR TITLE
race: a your media panel for the web, and a manifest that lands late

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
@@ -492,6 +492,36 @@ Host -> page: `init {protocol, settings:{masterVolume, reducedMotion}, modId, mo
 `track-error {message}`. Standalone, `?chart=demo&dur=N` / `?chart=<url>` load a chart and
 `?audio=<url>` makes an `<audio>` element the clock (wall time without it).
 
+### The media surface (web only)
+
+The desktop host enumerates the user's preset and posts a `manifest`. A browser has no library to
+enumerate, so the player hands it one and the same `manifest` frame carries it. Extra frames:
+
+Page -> host: `set-setting {key, value}` with `key` `media.pickLocal` (`'gallery' | 'zip' | 'folder'`)
+or `media.clearLocal`. Posted from inside the click's own turn, because a file picker opens only
+while the tap's activation is alive.
+
+Host -> page: `setting {key, value}` (the echo; an action echoes `value: null`, and only the echo
+takes a button's pending paint back off), `local-media {images, videos, skipped, active}` after every
+ingest, a cancelled picker and a clear, plus a fresh `manifest` carrying the whole pile.
+
+Capability keys on `init.settings`, all absent (and so unchanged) on the desktop:
+
+| Key | Meaning |
+| --- | --- |
+| `mediaControls: true` | build the menu's `your media` panel. Strictly `true` or nothing renders |
+| `localMedia {images, videos, skipped, active, folder}` | the pile at boot; `folder:false` hides the folder button (iOS) |
+| `trackPick: false` | this host has no file dialog: take `load a track` off the menu, and leave the `?chart=` road open |
+| `canSurface: false` | this host cannot take the window away: take `surface` off |
+| `hostSfx: false` | this host cannot play `Resources/sounds/chaos`: play the vendored cue in page |
+
+The menu's `your media` panel goes: heading, the count line, the pickers, the two promises, then an
+empty `.rm-media-more` node (`menu.mediaSlot`) and `back`. The online-feed group builds into that
+node, so it lands under the pickers and `back` stays the last row a thumb or an arrow reaches.
+
+The browser host lives in the site repo at `scripts/race-web-ext/`; its `RACE-MEDIA-CONTRACT.md` is
+the other half of this table and owns the source-registry seam remote media plugs into.
+
 `sfx` names must exist in `Resources/sounds/chaos/*.mp3` (C# `ChaosSfx.Play(name, scale)`), e.g.
 `tunnel_powerup_collect`, `golden_pop`, `chain_pop`, `streak_milestone`, `pb_fanfare`,
 `rank_up`, `ui_click`, `ui_denied`, `surface`, `depth_change`, `time_slow_in`, `time_slow_out`.

--- a/ConditioningControlPanel/Resources/web/dtrh/race/audio.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/audio.js
@@ -155,7 +155,14 @@ export function createRaceAudio({ bridge, hud, settings = {}, input } = {}) {
   const send = (m) => { try { bridge && bridge.send && bridge.send(m); } catch (e) { /* host gone */ } };
   // WebView2 or a browser? Only a real host has the ccp.content mirror to retry a missing
   // clip against, and only a real host can play the HOST_SFX catalogue for us.
-  const hosted = !!(bridge && bridge.isHosted);
+  //
+  // `isHosted` alone is not that question any more. The web build installs a transport double so the
+  // page boots hosted (cclabs-web scripts/race-web-ext), and that host is JavaScript in this same
+  // tab: no ccp.content, no Resources/sounds/chaos. It says so with `hostSfx: false` in its init, and
+  // both roads below then take the unhosted branch, which is the one that works there - the eleven
+  // cues ship as ordinary files beside the page. The C# host never sets the key, so on the desktop it
+  // is undefined and this reads exactly as it always did.
+  const hosted = !!(bridge && bridge.isHosted) && settings.hostSfx !== false;
   const masterLevel = clamp((Number(settings.masterVolume) == null || isNaN(Number(settings.masterVolume)) ? 60 : Number(settings.masterVolume)) / 100, 0, 1);
   const levels = { music: 1, sfx: 1 };   // the two option sliders (menu.js persists them); setLevels moves them
   const buffers = new Map();     // key -> AudioBuffer | 'pending' | 'failed'

--- a/ConditioningControlPanel/Resources/web/dtrh/race/menu.css
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/menu.css
@@ -101,6 +101,15 @@
 #race-root .rm-how-back { font-size: 17px; padding: 8px 16px 8px 30px; margin-top: 8px; align-self: flex-start; }
 #race-root .rm-btn[hidden] { display: none; }
 
+/* ---- your media (web only): the pickers, and what is in the tab right now ---- */
+#race-root .rm-media-btn { font-size: 17px; padding: 8px 16px 8px 30px; align-self: flex-start; }
+/* posted, waiting on the host's `setting` echo. Dimmed and un-pressable, never hidden: the button
+   has to stay under the thumb that just left it. */
+#race-root .rm-media-btn.is-pending { opacity: 0.55; pointer-events: none; }
+#race-root .rm-media-count { font-size: 13px; color: #ffd6ea; letter-spacing: 0.02em; margin: 0 0 6px 2px; }
+/* the online feed group's mount point (PR C3). Nothing in it yet, so it takes no room. */
+#race-root .rm-media-more:empty { display: none; }
+
 /* ---- the track plate: a file in hand, or the host still reading it ---- */
 #race-root .rm-track {
   margin-top: 14px; padding: 10px 14px; background: rgba(18, 11, 36, 0.82);
@@ -226,6 +235,8 @@
   #race-root .rm-list { gap: 4px; }
   #race-root .rm-btn { font-size: 16px; padding: 6px 14px 6px 28px; }
   #race-root .rm-how-back { font-size: 15px; padding: 6px 14px 6px 28px; margin-top: 4px; }
+  #race-root .rm-media-btn { font-size: 15px; padding: 6px 14px 6px 28px; }
+  #race-root .rm-media-count { font-size: 11px; margin-bottom: 3px; }
   #race-root .rm-h { margin-bottom: 2px; font-size: 16px; }
   #race-root .rm-row { padding: 5px 12px; font-size: 15px; }
   #race-root .rm-row-hint, #race-root .rm-hint { font-size: 10px; margin-top: 2px; }

--- a/ConditioningControlPanel/Resources/web/dtrh/race/menu.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/menu.js
@@ -1,14 +1,24 @@
 /* ============================================================================
  * race/menu.js - the main menu and the character stage of Racing Thoughts.
  *
- *   createMenu({ root, renderer, pixel, audio, settings, log }) ->
+ *   createMenu({ root, renderer, pixel, audio, settings, log, send }) ->
  *     { show(), hide(), onPick(cb), options, stage: { update(dt), render(), dispose() }, dispose() }
  *   onPick yields 'race' | 'track' | 'clear' | 'story' | 'surface'; setTrack(state | null) drives the
  *   track plate (CHART.md: the host's track-progress and the chart that lands). refreshView() parks
  *   the stage where the column would park it even while the menu is hidden (race/cards.js borrows it).
+ *   setLocalMedia(frame) and settingEcho(frame) feed the media panel below; `send` is the only way out
+ *   to the host from in here, and only that panel uses it.
+ *
+ * YOUR MEDIA (web only). `settings.mediaControls === true` adds a `your media` verb and a panel of
+ * pickers: the browser host has no library of its own to enumerate, so the player hands it one. Each
+ * button posts `set-setting {key:'media.pickLocal' | 'media.clearLocal', value}` INSIDE the click's
+ * own turn (a file picker opens only while the tap's activation is alive) and paints pending until
+ * the host's `setting` echo lands. The count line follows the host's `local-media` push. On the
+ * desktop that flag is absent, the verb is hidden, the panel is never built and no media key is ever
+ * posted.
  *
  * Two halves. LEFT is a DOM column (menu.css, .rm-*): the title, the tagline,
- * the verbs (race / load a track / just the road / options / how to drive /
+ * the verbs (race / load a track / just the road / options / your media / how to drive /
  * the story / surface), options and the key card opening in place. `the story`
  * replays the four introduction cards of race/cards.js. RIGHT is the stage: a second THREE.Scene drawn through
  * the race's own renderer + pixelizer (no second canvas) by a menu camera
@@ -106,13 +116,16 @@ const FACE_PIN = (() => {
     return clamp(+v | 0, 0, FACES.length - 1);
   } catch (e) { return -1; }              // no location (a node import), no pin
 })();
-/** Screenshot aid: `?panel=howto | options` opens the menu on that panel instead of the verbs. */
+/** Screenshot aid: `?panel=howto | options | media` opens the menu on that panel instead of the verbs. */
 const PANEL_PIN = (() => {
   try {
     const v = (new URLSearchParams(location.search).get('panel') || '').toLowerCase();
-    return v === 'howto' || v === 'how' ? 'how' : v === 'options' ? 'options' : null;
+    return v === 'howto' || v === 'how' ? 'how' : v === 'options' ? 'options' : v === 'media' ? 'media' : null;
   } catch (e) { return null; }           // no location (a node import), no pin
 })();
+/** A media button paints pending until its `setting` echo lands. This is how long it waits for one
+ *  before giving up: a host that never answers must not leave a button dead on the screen. */
+const ECHO_WAIT_MS = 6000;
 
 // ---- options ------------------------------------------------------------------------------
 export function loadOptions() {
@@ -373,7 +386,7 @@ export function createStage({ renderer, pixel, reducedMotion = false, log = null
 }
 
 // ---- the menu ------------------------------------------------------------------------------------
-export function createMenu({ root, renderer, pixel, audio, settings = {}, log = null }) {
+export function createMenu({ root, renderer, pixel, audio, settings = {}, log = null, send = null }) {
   const options = loadOptions();
   const systemReduced = !!(typeof matchMedia === 'function' && matchMedia('(prefers-reduced-motion: reduce)').matches);
   const reduced = () => wantsReducedMotion(options, settings.reducedMotion != null ? settings.reducedMotion : systemReduced);
@@ -384,6 +397,7 @@ export function createMenu({ root, renderer, pixel, audio, settings = {}, log = 
   const canLevels = !!(audio && typeof audio.setLevels === 'function');
   const ui = (n, v) => { try { if (audio && audio.ui) audio.ui(n, v); } catch (e) { /* audio gone */ } };   // the menu blips (race/audio.js)
   const theme = (on) => { try { if (audio && audio.menu) audio.menu(on); } catch (e) { /* audio gone */ } };
+  const post = (m) => { try { if (send) send(m); } catch (e) { /* host gone */ } };
 
   const layer = el('div', 'rm-root', root); layer.hidden = true; layer.setAttribute('role', 'dialog'); layer.setAttribute('aria-label', 'racing thoughts');
   const col = el('div', 'rm-col', layer);
@@ -391,6 +405,7 @@ export function createMenu({ root, renderer, pixel, audio, settings = {}, log = 
   el('div', 'rm-tag', col, 'steer. pop. never stop.');
   const list = el('div', 'rm-list', col); list.setAttribute('role', 'menu');
   const optPanel = el('div', 'rm-panel rm-options', col); optPanel.hidden = true;
+  const mediaPanel = el('div', 'rm-panel rm-media', col); mediaPanel.hidden = true;
   const howPanel = el('div', 'rm-panel rm-how', col); howPanel.hidden = true;
   // ---- the track plate: what the host is doing with the file, then what it found ----
   const trackEl = el('div', 'rm-track', col); trackEl.hidden = true; trackEl.setAttribute('aria-live', 'polite');
@@ -412,6 +427,53 @@ export function createMenu({ root, renderer, pixel, audio, settings = {}, log = 
   // the way out for a finger: the keyboard has esc and enter, a phone has this row and the backdrop
   const howBack = el('button', 'rm-btn rm-how-back', howPanel, 'back'); howBack.type = 'button'; howBack.setAttribute('role', 'menuitem');
   howBack.addEventListener('click', (e) => { e.stopPropagation(); ui('back'); hit(howBack, 'is-hit'); open('main'); });
+
+  // ---- your media: the pickers, the count, and the promise under them ----
+  // Only a host that says `mediaControls` can serve this. The desktop never does, so nothing here is
+  // built there and no media key can be posted. Every button is one `set-setting`, posted in the
+  // click's own turn so the file picker still has the tap's activation to open on.
+  const webMedia = settings.mediaControls === true;
+  const pile = { images: 0, videos: 0, skipped: 0, active: false, folder: true, ...(settings.localMedia || {}) };
+  const MEDIA_ROWS = [
+    { id: 'gallery', label: 'add from your photos', key: 'media.pickLocal', value: 'gallery' },
+    { id: 'zip', label: 'add a zip', key: 'media.pickLocal', value: 'zip' },
+    { id: 'folder', label: 'add a folder', key: 'media.pickLocal', value: 'folder', off: pile.folder === false },
+    { id: 'clear', label: 'forget them', key: 'media.clearLocal', value: true },
+    { id: 'back', label: 'back', press: () => open('main') },
+  ].filter((r) => !r.off);
+  const plural = (n, one) => `${n} ${one}${n === 1 ? '' : 's'}`;
+  function mediaLine() {
+    if (!pile.images && !pile.videos) return pile.skipped ? `nothing here yet · ${pile.skipped} skipped` : 'nothing here yet';
+    const bits = [];
+    if (pile.images) bits.push(plural(pile.images, 'image'));
+    if (pile.videos) bits.push(plural(pile.videos, 'video'));
+    return `${bits.join(' and ')} kept in this tab${pile.skipped ? ` · ${pile.skipped} skipped` : ''}`;
+  }
+  let countEl = null, mediaEls = [], pendingEl = null, pendingTimer = 0;
+  function clearPending() {
+    if (pendingTimer) { clearTimeout(pendingTimer); pendingTimer = 0; }
+    if (pendingEl) { pendingEl.classList.remove('is-pending'); pendingEl = null; }
+  }
+  function setPending(node) { clearPending(); pendingEl = node; node.classList.add('is-pending'); pendingTimer = setTimeout(clearPending, ECHO_WAIT_MS); }
+  // The spot the ONLINE FEED group goes in (PR C3): its own heading, its consent row and its niche
+  // rows, built into this node so they sit under the pickers and above `back`, which stays the last
+  // thing a thumb or an arrow reaches. Empty until then - one div, no layout, no cost.
+  let mediaMore = null;
+  if (webMedia) {
+    el('h3', 'rm-h', mediaPanel, 'your media');
+    countEl = el('div', 'rm-media-count rh-num', mediaPanel, mediaLine()); countEl.setAttribute('aria-live', 'polite');
+    mediaEls = MEDIA_ROWS.map((r, i) => {
+      const b = el('button', 'rm-btn rm-media-btn', mediaPanel, r.label); b.type = 'button';
+      b.dataset.id = r.id; b.setAttribute('role', 'menuitem');
+      b.addEventListener('click', (e) => { e.stopPropagation(); idx.media = i; act('press'); });
+      b.addEventListener('pointerenter', () => { idx.media = i; ui('tick'); refresh(); });
+      return b;
+    });
+    el('div', 'rm-hint', mediaPanel, 'nothing is uploaded. your files stay in this tab and go when you close it.');
+    el('div', 'rm-hint', mediaPanel, 'the walls take them on your next run.');
+    mediaMore = el('div', 'rm-media-more', mediaPanel);
+    mediaPanel.appendChild(mediaEls[mediaEls.length - 1]);   // `back` was built with the rest: put it last again
+  }
 
   // ---- options: each row is a value with left / right and a press ----
   const pct = (v) => `${Math.round(v * 100)}%`;
@@ -454,7 +516,7 @@ export function createMenu({ root, renderer, pixel, audio, settings = {}, log = 
 
   // ---- the verbs. `track` only under a host (the file dialog is its), `clear` only once a file is in ----
   const canTrack = !!settings.trackPick;
-  const VERBS = [['race', 'race'], ['track', 'load a track'], ['clear', 'just the road'], ['options', 'options'], ['how', 'how to drive'], ['story', 'the story'], ['surface', 'surface']];
+  const VERBS = [['race', 'race'], ['track', 'load a track'], ['clear', 'just the road'], ['options', 'options'], ['media', 'your media'], ['how', 'how to drive'], ['story', 'the story'], ['surface', 'surface']];
   const verbEls = VERBS.map(([id, label], i) => {
     const b = el('button', 'rm-btn', list, label); b.type = 'button'; b.dataset.id = id; b.setAttribute('role', 'menuitem');
     b.addEventListener('click', (e) => { e.stopPropagation(); idx.main = i; act('press'); });
@@ -462,7 +524,7 @@ export function createMenu({ root, renderer, pixel, audio, settings = {}, log = 
     return b;
   });
   const verbEl = (id) => verbEls[VERBS.findIndex(([v]) => v === id)];
-  verbEl('track').hidden = !canTrack; verbEl('clear').hidden = true;
+  verbEl('track').hidden = !canTrack; verbEl('clear').hidden = true; verbEl('media').hidden = !webMedia;
   const stepVerb = (from, dir) => {   // the next visible verb in that direction, wrapping
     let i = from;
     for (let k = 0; k < VERBS.length; k++) { i = (i + dir + VERBS.length) % VERBS.length; if (!verbEls[i].hidden) return i; }
@@ -500,12 +562,17 @@ export function createMenu({ root, renderer, pixel, audio, settings = {}, log = 
 
   // ---- navigation: one focus index per panel, every input path lands on act() ----
   let panel = 'main', shown = false, disposed = false, viewHeld = false;
-  const idx = { main: 0, options: 0 };
-  function open(p) { panel = p; list.hidden = p !== 'main'; optPanel.hidden = p !== 'options'; howPanel.hidden = p !== 'how'; if (p === 'options') idx.options = 0; refresh(); if (p !== 'options') seedIn.blur(); }
+  const idx = { main: 0, options: 0, media: 0 };
+  function open(p) {
+    panel = p; list.hidden = p !== 'main'; optPanel.hidden = p !== 'options'; mediaPanel.hidden = p !== 'media'; howPanel.hidden = p !== 'how';
+    if (p === 'options') idx.options = 0; if (p === 'media') idx.media = 0;
+    refresh(); if (p !== 'options') seedIn.blur();
+  }
   function focusRow(i) { idx.options = clamp(i, 0, ROWS.length - 1); ui('tick'); refresh(); }
   function refresh() {
     verbEls.forEach((b, i) => b.classList.toggle('is-focus', panel === 'main' && i === idx.main));
     ROWS.forEach((r, i) => { const v = r.get(); if (r.valEl.textContent !== v) r.valEl.textContent = v; rowEls[i].classList.toggle('is-focus', panel === 'options' && i === idx.options); });
+    mediaEls.forEach((b, i) => b.classList.toggle('is-focus', panel === 'media' && i === idx.media));
   }
   function pick(id) { for (const cb of picks) { try { cb(id); } catch (e) { /* a listener never breaks the menu */ } } }
   function act(what) {
@@ -516,11 +583,23 @@ export function createMenu({ root, renderer, pixel, audio, settings = {}, log = 
       const id = VERBS[idx.main][0];
       if (verbEls[idx.main].hidden) return;
       hit(verbEls[idx.main], 'is-hit'); ui('pick');
-      if (id === 'options' || id === 'how') open(id); else pick(id);
+      if (id === 'options' || id === 'how' || id === 'media') open(id); else pick(id);
       return;
     }
     if (what === 'back') { ui('back'); open('main'); return; }
     if (panel === 'how') { if (what === 'press') open('main'); return; }
+    if (panel === 'media') {
+      if (what === 'up' || what === 'down') { idx.media = clamp(idx.media + (what === 'up' ? -1 : 1), 0, MEDIA_ROWS.length - 1); ui('tick'); refresh(); return; }
+      if (what !== 'press') return;
+      const r = MEDIA_ROWS[idx.media], node = mediaEls[idx.media];
+      hit(node, 'is-hit'); ui(r.id === 'back' ? 'back' : 'pick');
+      if (r.press) { r.press(); return; }
+      // the post goes out here, with nothing awaited in front of it: a picker only opens while the
+      // tap that got us here still counts as a gesture. The echo takes the pending paint back off.
+      setPending(node);
+      post({ type: 'set-setting', key: r.key, value: r.value });
+      return;
+    }
     const r = ROWS[idx.options];
     if (what === 'up' || what === 'down') { focusRow(idx.options + (what === 'up' ? -1 : 1)); return; }
     if ((what === 'left' || what === 'right') && r.move) { r.move(what === 'left' ? -1 : 1); ui('step', r.id === 'music' || r.id === 'sfx' ? options[r.id] : 0.5); hit(rowEls[idx.options], 'is-hit'); }
@@ -558,7 +637,11 @@ export function createMenu({ root, renderer, pixel, audio, settings = {}, log = 
   const onPointer = (e) => { if (shown && e.clientX > window.innerWidth * 0.5) stage.emi.peek(); };
   // the backdrop closes the key card. Every verb and every row stops its own click, so the only
   // clicks that reach the layer are the ones that landed on nothing.
-  const onBackdrop = (e) => { if (shown && panel === 'how' && !howPanel.contains(e.target)) { ui('back'); open('main'); } };
+  const onBackdrop = (e) => {
+    if (!shown) return;
+    if (panel === 'how' && !howPanel.contains(e.target)) { ui('back'); open('main'); }
+    else if (panel === 'media' && !mediaPanel.contains(e.target)) { ui('back'); open('main'); }
+  };
   layer.addEventListener('click', onBackdrop);
   window.addEventListener('keydown', onKey);
   const unbindResize = bindViewportResize(onResize);
@@ -569,6 +652,18 @@ export function createMenu({ root, renderer, pixel, audio, settings = {}, log = 
     options, stage: { update(dt) { if (shown) pollPad(dt); stage.update(dt); }, render: stage.render, dispose: stage.dispose, live: stage },
     onPick(cb) { if (typeof cb === 'function') picks.push(cb); },
     setTrack, get track() { return trackState; },
+    /** The host's `local-media` push: {images, videos, skipped, active}. Repaints the count line. */
+    setLocalMedia(m) {
+      if (!m) return;
+      for (const k of ['images', 'videos', 'skipped']) if (typeof m[k] === 'number') pile[k] = m[k] | 0;
+      pile.active = !!m.active;
+      if (countEl) countEl.textContent = mediaLine();
+    },
+    /** The host's `setting` echo. Contract law: only this takes the pending paint back off. */
+    settingEcho(m) { if (m && typeof m.key === 'string' && m.key.indexOf('media.') === 0) clearPending(); },
+    /** Where PR C3 builds its `online feed` group: inside the media panel, under the pickers and
+     *  above `back`. null on the desktop, where the panel is never built. */
+    get mediaSlot() { return mediaMore; },
     /** hideVerb(id): take a verb off the list for good. raceBoot hides `surface` when the page is not
      *  hosted and has nowhere to surface to, so nobody taps their way to a blank screen. */
     hideVerb(id) {
@@ -577,7 +672,11 @@ export function createMenu({ root, renderer, pixel, audio, settings = {}, log = 
       if (verbEls[idx.main].hidden) idx.main = stepVerb(idx.main, 1);
       refresh();
     },
-    show() { shown = true; viewHeld = false; layer.hidden = false; stage.setMode('menu'); open(PANEL_PIN || 'main'); onResize(); hit(layer, 'is-in'); theme(true); },
+    show() {
+      shown = true; viewHeld = false; layer.hidden = false; stage.setMode('menu');
+      open(PANEL_PIN === 'media' && !webMedia ? 'main' : (PANEL_PIN || 'main'));
+      onResize(); hit(layer, 'is-in'); theme(true);
+    },
     hide() { shown = false; layer.hidden = true; stage.setViewFraction(0.5); },
     /** Park the stage the way the column parks it, with the menu hidden: race/cards.js uses the same
      *  layout, so hide() sending her back to the middle of the frame would only be a jump and a jump
@@ -587,6 +686,7 @@ export function createMenu({ root, renderer, pixel, audio, settings = {}, log = 
     dispose() {
       if (disposed) return;
       disposed = true; shown = false;
+      clearPending();
       window.removeEventListener('keydown', onKey); unbindResize();
       stage.dispose(); layer.remove();
     },

--- a/ConditioningControlPanel/Resources/web/dtrh/raceBoot.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/raceBoot.js
@@ -15,8 +15,21 @@
  * the menu is the same exit the End screen takes.
  *
  * Host messages owned here: init, manifest, favorites, ping, exit-request,
- * fullscreen (run.js owns pause + payout-result). Sent here: pong, boot-error,
- * fullscreen-set, exit + exit-done on a host exit-request or a menu surface.
+ * fullscreen, local-media, setting (run.js owns pause + payout-result). Sent
+ * here: pong, boot-error, fullscreen-set, exit + exit-done on a host
+ * exit-request or a menu surface. A `manifest` that lands AFTER boot is honoured
+ * the same way the first one is: hostMedia swaps its pool, so a pile loaded from
+ * the menu is on the walls of the very next run.
+ *
+ * HOST CAPABILITIES on `init.settings`. `bridge.isHosted` says a host is on the
+ * other end, never which services it has. The browser host (cclabs-web
+ * scripts/race-web-ext) is a real transport with no C# behind it, so three keys
+ * say what it cannot do, all of them absent (and so unchanged) on the desktop:
+ * `trackPick: false` takes the file-dialog verb off the menu, `canSurface:
+ * false` takes `surface` off when there is nowhere to go, and `hostSfx: false`
+ * (read by race/audio.js) plays the eleven host cues in page instead of posting
+ * `sfx` frames nothing answers. `mediaControls: true` is the fourth: it turns on
+ * the menu's `your media` panel.
  *
  * STANDALONE DEV MODE (no WebView2): `bridge.isHosted` is false, so `init` is
  * synthesised (masterVolume 60, reducedMotion from matchMedia, empty manifest)
@@ -44,7 +57,8 @@
  *
  * TRACK CHARTS (CHART.md): the host posts track-progress / track-chart /
  * track-clock / track-ended / track-error and this file hands them to the run.
- * Standalone there is no host, so `?chart=demo&dur=240` builds the demo chart and
+ * With no host - or under one that says `trackPick: false`, which is the browser
+ * host - `?chart=demo&dur=240` builds the demo chart and
  * `?chart=<url>` fetches one; `?audio=<url>` plays an <audio> element and its
  * currentTime is the clock, and without it the clock is wall time. Either way the
  * page ticks race.trackClock on the host's own 250 ms cadence.
@@ -89,6 +103,8 @@ const waitEl = document.getElementById('race-wait');
 const media = createHostMediaSource();
 const rollSeed = () => (Date.now() ^ Math.floor(Math.random() * 0x7fffffff)) >>> 0;
 let initMsg = null, haveManifest = false, race = null, menu = null, booted = false, started = false, exiting = false;
+let localMedia = null;              // the last `local-media` push, replayed into the menu on boot
+const settingEchoes = [];           // `setting` echoes that landed before there was a menu to paint
 let settings = {}, seed = 0;
 let trackProgress = null, trackReady = null, errorTimer = 0, startTrackClock = null, trackTimer = 0, trackAudio = null;
 
@@ -128,6 +144,15 @@ if (mode.hardBlock || !mode.canTry3d) {
 bridge.on('init', (m) => { initMsg = m; maybeBoot(); });
 bridge.on('manifest', (m) => { try { media.setManifest(m); } catch (e) { host.log('manifest: ' + e); } haveManifest = true; maybeBoot(); });
 bridge.on('favorites', (m) => { try { media.setFavorites(m && m.names || []); } catch (e) { host.log('favorites: ' + e); } });
+// The media panel's two frames (race/menu.js "YOUR MEDIA"). Both can land before the menu exists -
+// the pickers are only reachable from the menu, but the host pushes the pile it already holds on
+// `ready` - so the last count is remembered and the echoes are queued, and boot() hands both over
+// the moment createMenu returns. After that they go straight through.
+bridge.on('local-media', (m) => { localMedia = m; if (menu) { try { menu.setLocalMedia(m); } catch (e) { host.log('local-media: ' + e); } } });
+bridge.on('setting', (m) => {
+  if (!menu) { if (settingEchoes.length < 24) settingEchoes.push(m); return; }
+  try { menu.settingEcho(m); } catch (e) { host.log('setting: ' + e); }
+});
 bridge.on('ping', (m) => host.send({ type: 'pong', t: m && m.t }));
 bridge.on('fullscreen', (m) => host.send({ type: 'fullscreen-set', on: !!(m && m.on) }));
 bridge.on('exit-request', surface);
@@ -198,7 +223,11 @@ async function boot() {
     settings.reducedMotion = wantsReducedMotion(opts, settings.reducedMotion != null ? settings.reducedMotion : !!(matchMedia && matchMedia('(prefers-reduced-motion: reduce)').matches));
     settings.musicVolume = opts.music; settings.sfxVolume = opts.sfx;   // audio.js reads masterVolume; the two sliders go in through setLevels below
     settings.seedLock = seedFromOptions(opts);
-    settings.trackPick = hosted;   // the file dialog is the host's; standalone loads a track off the query string
+    // The file dialog is the host's; standalone loads a track off the query string. A host may also
+    // say `trackPick: false` in its init: the browser host (cclabs-web scripts/race-web-ext) is
+    // hosted in every way the bridge can see and has no file dialog to open, and a verb that answers
+    // nothing is worse than no verb at all.
+    settings.trackPick = hosted && settings.trackPick !== false;
     seed = settings.seedLock != null ? settings.seedLock : rollSeed();
     note('the road is drawing');
     race = createRace({ root, bridge: host, media, settings, seed });
@@ -209,8 +238,12 @@ async function boot() {
     await standaloneTrack();
     if (params.get('autostart') === '1') { startRun(false); debugItemBox(); return; }
     if (hudRoot) hudRoot.classList.add('is-lobby');   // the run's chrome stays out of the menu and the intro
-    menu = createMenu({ root, renderer: race.renderer, pixel: race.pixel, audio: race.audio, settings, log: host.log });
-    if (!hosted && !standaloneExit) { menu.hideVerb('surface'); host.log('surface hidden: no host and no ?back='); }
+    menu = createMenu({ root, renderer: race.renderer, pixel: race.pixel, audio: race.audio, settings, log: host.log, send: host.send });
+    if (localMedia) { try { menu.setLocalMedia(localMedia); } catch (e) { host.log('local-media: ' + e); } }
+    while (settingEchoes.length) { try { menu.settingEcho(settingEchoes.shift()); } catch (e) { host.log('setting: ' + e); } }
+    // Nowhere to surface to: no host and no `?back=`, or a host that says outright it cannot take
+    // the window away (the browser host with neither a same-origin ?back= nor a same-origin referrer).
+    if ((!hosted && !standaloneExit) || settings.canSurface === false) { menu.hideVerb('surface'); host.log('surface hidden: nowhere to go'); }
     menu.onPick((id) => {
       if (id === 'race') startRun(true);
       else if (id === 'surface') surface();
@@ -241,7 +274,11 @@ async function boot() {
  */
 async function standaloneTrack() {
   const want = params.get('chart');
-  if (hosted || !want || !race) return;
+  // `settings.trackPick` is the resolved answer to "can this host open a file dialog", which is not
+  // the same question as `hosted`: the browser host (cclabs-web scripts/race-web-ext) is hosted and
+  // cannot, so the query-string chart road stays open under it exactly as it is with no host at all.
+  // A desktop host resolves it true and owns track loading outright, so nothing changes there.
+  if (settings.trackPick || !want || !race) return;
   let chart = null;
   try {
     const mod = await import('./race/chart.js');


### PR DESCRIPTION
## what

Owner's iPhone test of the web build: "I see no assets in there, no flash images or gifs, nor plastered in the wall ... and i dont see the scroller option or upload option". On desktop the WPF host posts the `manifest`; in a browser nothing did, so the walls drew only the fill placards. cclabs-web now ships a browser host (its PR) that answers the game's frames and ingests photos, a zip or a folder on the phone. This is the page side of that:

- a `your media` verb and panel, rendered only when `init.settings.mediaControls === true` (strictly; the C# host never sets it, so desktop renders exactly what it renders today): `add from your photos`, `add a zip`, `add a folder` (hidden when the host says folders are unsupported), `forget them`, a live count line fed by the `local-media` push, and two hints: "nothing is uploaded. your files stay in this tab and go when you close it." and "the walls take them on your next run." Every button posts `set-setting` and paints pending until its `setting` echo lands.
- `raceBoot.js` routes `local-media` and `setting` frames the way it routes `manifest`, and a manifest that lands late (after boot, while the menu is open) is honoured on the next run.
- `standaloneTrack()` was guarded on `hosted`, which would have silently killed `?chart=` on the site once the shim made the page look hosted; it is guarded on the resolved `settings.trackPick` now.
- an empty `.rm-media-more` slot (`menu.mediaSlot`) at the end of the panel is where the online feed group (next PR) mounts.

## verification

`node --check` clean; audio/chart/fov/gltf (53)/poses/track-run/touch smokes pass. Headless against the vendored site tree with the shim: gallery ingest of 2 png + 1 gif shows "3 images kept in this tab", `forget them` returns to zeros, `?autostart=1&chart=demo` boots hosted and the ingested image is plastered as tube-wall posters. iOS photo sheet, `webkitdirectory` on iOS and object-URL memory under a real phone's pressure are unverified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0166ij3Q8xyseVkhWajzkWG3
