### PR TITLE
feat(race): the online feed group in the your media panel

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
@@ -546,6 +546,40 @@ The menu's `your media` panel goes: heading, the count line, the pickers, the tw
 empty `.rm-media-more` node (`menu.mediaSlot`) and `back`. The online-feed group builds into that
 node, so it lands under the pickers and `back` stays the last row a thumb or an arrow reaches.
 
+### The online feed (web only)
+
+`race/feedGroup.js` builds into `menu.mediaSlot`, and ONLY when the host ships `mediaControls: true`
+**and** a non-empty `remoteCatalog`. The desktop ships neither, so on the desktop the group does not
+exist and neither key below is ever posted.
+
+Page -> host: `set-setting {key, value}`
+
+| Key | Value | Meaning |
+| --- | --- | --- |
+| `media.remoteConsent` | `bool` | open or close the gate. Consent gates the NETWORK, not the disk: with it off the feed fetches nothing at all and the player's own picked files are untouched |
+| `media.niches` | `string[]` | the WHOLE selection, never a delta. The host sanitises to known catalog ids, de-duplicates, keeps order, and REFUSES an empty result, echoing the stored list unchanged |
+
+Host -> page: `setting {key, value}` carrying **what is stored**. Every row paints `pending` from the
+press until its echo lands, so a refusal snaps the row back to the truth rather than lying about it.
+Because `media.niches` is one key for the whole list, ticking any niche paints every niche row
+pending until the one echo lands.
+
+Extra `init.settings` keys that feed the group, all absent on the desktop:
+
+| Key | Meaning |
+| --- | --- |
+| `remoteCatalog` | `[{id, label}]` - the niches to paint. No catalog, no group |
+| `niches` | `string[]` - which of them are on right now |
+| `remoteConsent` | `bool` - the gate as stored |
+| `remoteMediaRatio` | `0..1` - the share of DOM draws that should prefer remote rows |
+
+The group asks for no manifest. The host rebuilds and re-posts one after a setting lands, and
+`raceBoot`'s `manifest` handler hands it to `hostMedia` whenever it arrives - the pool is mutable and
+`game/payloadFx.js` holds the same object - so a feed switched on with the menu open is on the walls
+of the very next run with nothing re-created. Remote rows carry an `online<pct>:` name marker and are
+split out by the url's ORIGIN, so they reach the DOM layer and never a WebGL texture.
+`race/smoke/remote-feed-check.mjs` holds both properties down.
+
 The browser host lives in the site repo at `scripts/race-web-ext/`; its `RACE-MEDIA-CONTRACT.md` is
 the other half of this table and owns the source-registry seam remote media plugs into.
 

--- a/ConditioningControlPanel/Resources/web/dtrh/race/feedGroup.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/feedGroup.js
@@ -1,0 +1,192 @@
+/* ============================================================================
+ * race/feedGroup.js - the ONLINE FEED group inside the menu's `your media`
+ * panel. Web only.
+ *
+ *   createFeedGroup({ slot, settings, post, ui }) ->
+ *     { rows, els, paint(), settingEcho(frame) -> bool, dispose() } | null
+ *
+ * WHERE IT LIVES. race/menu.js builds the `your media` panel and ends it with an
+ * empty `.rm-media-more` node (its `mediaSlot`). This group builds into that
+ * node, so the heading, the consent row and the niche rows sit under the
+ * pickers and above `back`, and `back` stays the last thing a thumb or an arrow
+ * reaches. `rows` and `els` are handed back so the menu can splice them into the
+ * panel's own walk; they are the shape MEDIA_ROWS already uses.
+ *
+ * WHEN IT EXISTS AT ALL. Two conditions, both from the host's `init.settings`:
+ * `mediaControls === true` (the capability flag) AND a non-empty
+ * `remoteCatalog`. The browser host shim (cclabs-web scripts/race-web-ext) ships
+ * both; the C# desktop host ships neither, so on the desktop this returns null,
+ * nothing is built and no `media.*` key can ever be posted. Same capability law
+ * the Arcademy campus settings room lives under, RACE-MEDIA-CONTRACT section 2.
+ *
+ * WHAT THE PLAYER IS AGREEING TO. The line under the heading is the whole
+ * truth and it is said plainly: the browser fetches api.scrolller.com ITSELF,
+ * no CC Labs server proxies a byte, and what comes back is adult media out of
+ * the public subreddits ticked underneath. Consent gates the NETWORK, not the
+ * disk: with it off nothing is fetched, and the player's own picked files (the
+ * pickers above) still work exactly as they did.
+ *
+ * ONLY THE ECHO MOVES A SETTING (RACE-MEDIA-CONTRACT section 0). A press posts
+ * `set-setting` and paints the row `pending`; the value only changes when the
+ * host's `setting` frame lands carrying WHAT IS STORED. So a refused list - the
+ * host refuses an empty one - snaps the row back to the truth instead of lying
+ * about it, and nothing in here keeps a local copy of the answer.
+ *
+ * `media.niches` is ONE key carrying the WHOLE list, so ticking any niche paints
+ * EVERY niche row pending until the one echo lands. That is the contract, not a
+ * shortcut.
+ *
+ * NOBODY ASKS FOR A MANIFEST FROM HERE. The host rebuilds and re-posts it after
+ * a setting lands, and raceBoot's `manifest` handler feeds hostMedia whenever a
+ * frame arrives - the pool is mutable and payloadFx holds the same object - so a
+ * feed switched on with the menu open is on the walls of the very next run with
+ * nothing re-created. race/smoke/remote-feed-check.mjs holds that property down.
+ * ==========================================================================*/
+
+/** The two `set-setting` keys this group owns (RACE-MEDIA-CONTRACT section 4). */
+export const CONSENT_KEY = 'media.remoteConsent';
+export const NICHES_KEY = 'media.niches';
+
+/** The heading, the one honest line, and the label over the niche rows. */
+export const HEADING = 'online feed';
+export const CONSENT_LINE = 'this device pulls the feed straight off the source site. none of it passes through cc labs. it is adult media, out of the public subreddits ticked below.';
+export const NICHES_LABEL = 'what it pulls';
+
+/** How long a row waits for its echo before it stops saying `pending`. A host
+ *  that never answers must not leave a row dead on the screen. Mirrors the
+ *  pickers' own wait in race/menu.js. */
+const ECHO_WAIT_MS = 6000;
+
+const elm = (tag, cls, parent, text) => {
+  const d = document.createElement(tag);
+  d.className = cls;
+  if (text != null) d.textContent = text;
+  parent.appendChild(d);
+  return d;
+};
+
+/**
+ * @param {object}   o
+ * @param {Element}  o.slot      the menu's `.rm-media-more` node (menu.mediaSlot)
+ * @param {object}   o.settings  the host's `init.settings`
+ * @param {function} o.post      send a frame to the host (menu's own `post`)
+ * @param {function} [o.ui]      the menu blips, so a press sounds like every other press
+ */
+export function createFeedGroup({ slot, settings = {}, post, ui = null }) {
+  if (!slot || typeof post !== 'function') return null;
+  // The capability flag is checked STRICTLY: a stringy true is still no.
+  if (settings.mediaControls !== true) return null;
+  const catalog = (Array.isArray(settings.remoteCatalog) ? settings.remoteCatalog : [])
+    .filter((r) => r && typeof r.id === 'string' && r.id)
+    // the panel speaks in lower case like the rest of the menu; the ID is never touched
+    .map((r) => ({ id: r.id, label: String(r.label == null ? r.id : r.label).toLowerCase() }));
+  if (!catalog.length) return null;
+
+  const known = new Set(catalog.map((c) => c.id));
+  let consent = settings.remoteConsent === true;
+  let picked = new Set((Array.isArray(settings.niches) ? settings.niches : [])
+    .filter((v) => typeof v === 'string' && known.has(v)));
+  const waiting = new Map();          // setting key -> the give-up timer
+  const blip = (n) => { try { if (typeof ui === 'function') ui(n); } catch (e) { /* audio gone */ } };
+
+  /* ---- the DOM ---------------------------------------------------------- */
+  elm('h3', 'rm-h rm-feed-h', slot, HEADING);
+  elm('div', 'rm-hint rm-feed-line', slot, CONSENT_LINE);
+  const consentRow = row('the feed');
+  elm('div', 'rm-hint rm-feed-sub', slot, NICHES_LABEL);
+  const nicheRows = catalog.map((c) => row(c.label));
+
+  /** One row: a button carrying its label and its state word, built the way the
+   *  panel's own picker buttons are so it inherits their focus, hit and pending
+   *  paint for free. */
+  function row(label) {
+    const b = elm('button', 'rm-btn rm-media-btn rm-feed-btn', slot);
+    b.type = 'button';
+    b.setAttribute('role', 'menuitem');
+    elm('span', 'rm-feed-label', b, label);
+    const val = elm('span', 'rm-feed-val', b, '');
+    return { el: b, val };
+  }
+
+  /* ---- what a row says -------------------------------------------------- */
+  const word = (key, on) => (waiting.has(key) ? 'pending' : (on ? 'on' : 'off'));
+
+  function paint() {
+    const c = word(CONSENT_KEY, consent);
+    if (consentRow.val.textContent !== c) consentRow.val.textContent = c;
+    consentRow.el.classList.toggle('is-pending', waiting.has(CONSENT_KEY));
+    for (let i = 0; i < catalog.length; i++) {
+      const r = nicheRows[i];
+      const v = word(NICHES_KEY, picked.has(catalog[i].id));
+      if (r.val.textContent !== v) r.val.textContent = v;
+      r.el.classList.toggle('is-pending', waiting.has(NICHES_KEY));
+      // the niches only mean anything while the feed is on, so they read as
+      // inert until it is. Still pressable: picking ahead of consent is a real
+      // thing to want, and it costs no network.
+      r.el.classList.toggle('is-off', !consent);
+    }
+  }
+
+  /* ---- pressing one ----------------------------------------------------- */
+  /** Post the key and paint pending. Nothing is stored here and nothing waits on
+   *  a reply: the echo is the only thing that moves a value. */
+  function send(key, value) {
+    if (waiting.has(key)) return;      // one ask at a time per key
+    const timer = setTimeout(() => { waiting.delete(key); paint(); }, ECHO_WAIT_MS);
+    waiting.set(key, timer);
+    try { post({ type: 'set-setting', key, value }); }
+    catch (e) { /* no host: the row simply stays pending, which is the truth */ }
+    paint();
+  }
+
+  /** The whole list, with this one flipped. `media.niches` carries every id the
+   *  player wants, never a delta, so the host stores exactly what it is shown. */
+  const toggled = (id) => catalog
+    .filter((c) => (c.id === id ? !picked.has(id) : picked.has(c.id)))
+    .map((c) => c.id);
+
+  const rows = [
+    { id: 'feed', label: 'the feed', press: () => send(CONSENT_KEY, !consent) },
+    ...catalog.map((c) => ({ id: `niche-${c.id}`, label: c.label, press: () => send(NICHES_KEY, toggled(c.id)) })),
+  ];
+  const els = [consentRow.el, ...nicheRows.map((r) => r.el)];
+
+  // A pointer press goes through the same act() the pad and the keyboard do, so
+  // the menu's own focus index follows the finger. The menu wires that up when
+  // it splices these rows in; here we only make the button reachable.
+  els.forEach((b, i) => { b.dataset.id = rows[i].id; });
+
+  paint();
+
+  return {
+    rows,
+    els,
+    paint,
+    /**
+     * The host's `setting` echo. Returns true when this group owned the key, so
+     * the menu knows not to hand it on to the pickers' own pending paint.
+     */
+    settingEcho(m) {
+      const key = m && typeof m.key === 'string' ? m.key : '';
+      if (key !== CONSENT_KEY && key !== NICHES_KEY) return false;
+      const timer = waiting.get(key);
+      if (timer) clearTimeout(timer);
+      waiting.delete(key);
+      // A `null` echo is a refusal with nothing stored to show, so the row keeps
+      // the value it had and simply stops saying pending.
+      if (key === CONSENT_KEY) { if (m.value != null) consent = m.value === true; }
+      else if (Array.isArray(m.value)) {
+        picked = new Set(m.value.filter((v) => typeof v === 'string' && known.has(v)));
+      }
+      paint();
+      blip('tick');
+      return true;
+    },
+    dispose() {
+      for (const t of waiting.values()) { try { clearTimeout(t); } catch (e) { /* noop */ } }
+      waiting.clear();
+    },
+  };
+}
+
+export default createFeedGroup;

--- a/ConditioningControlPanel/Resources/web/dtrh/race/menu.css
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/menu.css
@@ -116,8 +116,20 @@
    has to stay under the thumb that just left it. */
 #race-root .rm-media-btn.is-pending { opacity: 0.55; pointer-events: none; }
 #race-root .rm-media-count { font-size: 13px; color: #ffd6ea; letter-spacing: 0.02em; margin: 0 0 6px 2px; }
-/* the online feed group's mount point (PR C3). Nothing in it yet, so it takes no room. */
+/* the online feed group's mount point. Empty on a host that ships no catalog, so it takes no room. */
 #race-root .rm-media-more:empty { display: none; }
+/* ---- the online feed group inside that mount point (race/feedGroup.js) ----
+   A group heading is smaller than the panel's own, so the panel still reads as one list with a rule
+   through it rather than as two panels stacked. */
+#race-root .rm-media-more { display: flex; flex-direction: column; align-items: flex-start; gap: 4px; width: 100%; }
+#race-root .rm-feed-h { margin: 12px 0 2px; font-size: 15px; border-top: 2px solid rgba(255, 105, 180, 0.28); padding-top: 10px; align-self: stretch; }
+#race-root .rm-feed-line { margin-top: 0; margin-bottom: 4px; max-width: 42ch; line-height: 1.45; }
+#race-root .rm-feed-sub { margin-top: 8px; margin-bottom: 2px; color: rgba(255, 214, 234, 0.75); font-weight: 700; letter-spacing: 0.06em; }
+#race-root .rm-feed-btn { display: flex; gap: 10px; align-items: baseline; }
+#race-root .rm-feed-val { color: #ffd6ea; font-weight: 800; letter-spacing: 0.06em; }
+/* the niches only mean anything while the feed is on. Dimmed, never disabled: picking ahead of
+   consent is a real thing to want and it costs no network. */
+#race-root .rm-feed-btn.is-off .rm-feed-label, #race-root .rm-feed-btn.is-off .rm-feed-val { opacity: 0.5; }
 
 /* ---- the track plate: a file in hand, or the host still reading it ---- */
 #race-root .rm-track {
@@ -274,6 +286,10 @@
   #race-root .rm-how-back { font-size: 15px; padding: 6px 14px 6px 28px; margin-top: 4px; }
   #race-root .rm-media-btn { font-size: 15px; padding: 6px 14px 6px 28px; }
   #race-root .rm-media-count { font-size: 11px; margin-bottom: 3px; }
+  #race-root .rm-media-more { gap: 2px; }
+  #race-root .rm-feed-h { margin-top: 8px; padding-top: 6px; font-size: 13px; }
+  #race-root .rm-feed-line { line-height: 1.35; }
+  #race-root .rm-feed-sub { margin-top: 5px; }
   #race-root .rm-h { margin-bottom: 2px; font-size: 16px; }
   #race-root .rm-row { padding: 5px 12px; font-size: 15px; }
   #race-root .rm-row-hint, #race-root .rm-hint { font-size: 10px; margin-top: 2px; }

--- a/ConditioningControlPanel/Resources/web/dtrh/race/menu.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/menu.js
@@ -82,6 +82,7 @@ import { loadPack, preparePixel, toInstanceGeometry, flattenRig, setFace, FACES 
 import { PIXEL_STEPS, PIXEL_DEFAULT, normalizeBlock } from './pixel.js';
 import { createMenuFlashes } from './menuFlashes.js';
 import { vFovForAspect, bindViewportResize } from './viewport.js';
+import { createFeedGroup } from './feedGroup.js';
 
 export const OPTIONS_KEY = 'race.options';
 export const PROPS_URL = '/dtrh/race/assets/props.glb';
@@ -541,10 +542,11 @@ export function createMenu({ root, renderer, pixel, audio, settings = {}, log = 
     if (pendingEl) { pendingEl.classList.remove('is-pending'); pendingEl = null; }
   }
   function setPending(node) { clearPending(); pendingEl = node; node.classList.add('is-pending'); pendingTimer = setTimeout(clearPending, ECHO_WAIT_MS); }
-  // The spot the ONLINE FEED group goes in (PR C3): its own heading, its consent row and its niche
-  // rows, built into this node so they sit under the pickers and above `back`, which stays the last
-  // thing a thumb or an arrow reaches. Empty until then - one div, no layout, no cost.
-  let mediaMore = null;
+  // The spot the ONLINE FEED group goes in: its own heading, its consent row and its niche rows,
+  // built into this node so they sit under the pickers and above `back`, which stays the last
+  // thing a thumb or an arrow reaches. Empty on a host that ships no `remoteCatalog` - one div, no
+  // layout, no cost.
+  let mediaMore = null, feed = null;
   if (webMedia) {
     el('h3', 'rm-h', mediaPanel, 'your media');
     countEl = el('div', 'rm-media-count rh-num', mediaPanel, mediaLine()); countEl.setAttribute('aria-live', 'polite');
@@ -558,6 +560,22 @@ export function createMenu({ root, renderer, pixel, audio, settings = {}, log = 
     el('div', 'rm-hint', mediaPanel, 'nothing is uploaded. your files stay in this tab and go when you close it.');
     el('div', 'rm-hint', mediaPanel, 'the walls take them on your next run.');
     mediaMore = el('div', 'rm-media-more', mediaPanel);
+    // ---- the online feed, when the host ships a catalog to paint ----
+    // race/feedGroup.js builds its heading, its consent row and its niche rows into `mediaMore` and
+    // hands back rows in MEDIA_ROWS' own shape. They are spliced in ABOVE `back`, so the DOM order
+    // and the walk order stay the same one list. A host with no `remoteCatalog` (every C# host)
+    // returns null here and the panel is exactly what it was.
+    feed = createFeedGroup({ slot: mediaMore, settings, post, ui });
+    if (feed) {
+      const at = Math.max(0, MEDIA_ROWS.length - 1);
+      MEDIA_ROWS.splice(at, 0, ...feed.rows);
+      mediaEls.splice(at, 0, ...feed.els);
+      feed.els.forEach((b, i) => {
+        const at2 = at + i;
+        b.addEventListener('click', (e) => { e.stopPropagation(); idx.media = at2; act('press'); });
+        b.addEventListener('pointerenter', () => { idx.media = at2; ui('tick'); refresh(); });
+      });
+    }
     mediaPanel.appendChild(mediaEls[mediaEls.length - 1]);   // `back` was built with the rest: put it last again
   }
 
@@ -660,6 +678,13 @@ export function createMenu({ root, renderer, pixel, audio, settings = {}, log = 
     verbEls.forEach((b, i) => b.classList.toggle('is-focus', panel === 'main' && i === idx.main));
     ROWS.forEach((r, i) => { const v = r.get(); if (r.valEl.textContent !== v) r.valEl.textContent = v; rowEls[i].classList.toggle('is-focus', panel === 'options' && i === idx.options); });
     mediaEls.forEach((b, i) => b.classList.toggle('is-focus', panel === 'media' && i === idx.media));
+    if (feed) feed.paint();   // equality-guarded, like the options rows above
+    // The feed's niche rows make this panel taller than the column, which scrolls (menu.css
+    // .rm-col). A pad or an arrow walking past the fold has to bring the row with it; `nearest` is
+    // a no-op while the row is already on screen, so a finger scrolling by hand is left alone.
+    if (panel === 'media' && mediaEls[idx.media]) {
+      try { mediaEls[idx.media].scrollIntoView({ block: 'nearest' }); } catch (e) { /* jsdom, old webview */ }
+    }
   }
   function pick(id) { for (const cb of picks) { try { cb(id); } catch (e) { /* a listener never breaks the menu */ } } }
   function act(what) {
@@ -772,8 +797,14 @@ export function createMenu({ root, renderer, pixel, audio, settings = {}, log = 
       pile.active = !!m.active;
       if (countEl) countEl.textContent = mediaLine();
     },
-    /** The host's `setting` echo. Contract law: only this takes the pending paint back off. */
-    settingEcho(m) { if (m && typeof m.key === 'string' && m.key.indexOf('media.') === 0) clearPending(); },
+    /** The host's `setting` echo. Contract law: only this takes the pending paint back off. The
+     *  online feed owns two of the keys and its rows paint their own pending, so it gets first
+     *  refusal; anything else it does not own falls through to the pickers'. */
+    settingEcho(m) {
+      if (!m || typeof m.key !== 'string') return;
+      if (feed && feed.settingEcho(m)) { refresh(); return; }
+      if (m.key.indexOf('media.') === 0) clearPending();
+    },
     /** Where PR C3 builds its `online feed` group: inside the media panel, under the pickers and
      *  above `back`. null on the desktop, where the panel is never built. */
     get mediaSlot() { return mediaMore; },
@@ -800,6 +831,7 @@ export function createMenu({ root, renderer, pixel, audio, settings = {}, log = 
       if (disposed) return;
       disposed = true; shown = false;
       clearPending();
+      if (feed) feed.dispose();
       window.removeEventListener('keydown', onKey); unbindResize();
       stage.dispose(); layer.remove();
     },

--- a/ConditioningControlPanel/Resources/web/dtrh/race/smoke/remote-feed-check.mjs
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/smoke/remote-feed-check.mjs
@@ -1,0 +1,141 @@
+/* ============================================================================
+ * race/smoke/remote-feed-check.mjs - node self-check for the online feed's two
+ * ends inside the race: the manifest split in dtrh/hostMedia.js, and the menu
+ * group's read of `init.settings` in race/menu.js.
+ *
+ *   node race/smoke/remote-feed-check.mjs   (exits 0 on pass, 1 with a count)
+ *
+ * The two things it is here to hold:
+ *
+ *   1. A MANIFEST THAT LANDS AFTER BOOT IS LIVE IMMEDIATELY. run.js builds
+ *      payloadFx and the media lane ONCE, both holding this same media object,
+ *      and raceBoot's `manifest` handler calls setManifest on it whenever a
+ *      frame arrives. So a feed switched on with the menu open has to be in the
+ *      pool for the next run with nothing else re-created. That is a property of
+ *      a mutable pool, and a property nobody wrote down is a property somebody
+ *      refactors away.
+ *   2. A REMOTE ENTRY NEVER REACHES THE WebGL LAYER. draw(), drawKind(),
+ *      favorite() and urlByName() are the four doors the three.js side uses and
+ *      a CORS-tainted CDN url behind any of them is a SecurityError on upload.
+ *      Only drawDom() may see one (hostMedia.js's header has the full reason).
+ *
+ * hostMedia.js touches `window.__sfMedia` on construction, so the file stubs a
+ * window and nothing else. menu.js is not imported (it wants three and a DOM);
+ * its group-visibility rule is re-stated here as the predicate it compiles to,
+ * which is what a desktop regression would break.
+ * ==========================================================================*/
+
+globalThis.window = globalThis.window || {};
+
+const { createHostMediaSource } = await import('../../hostMedia.js');
+
+let fails = 0;
+const ok = (cond, what) => { if (!cond) { console.error('FAIL ' + what); fails++; } else console.log('  ok  ' + what); };
+
+/** What the browser host shim posts once the feed is on: absolute CDN urls with
+ *  the `online<share>:` share marker on the name (dtrh/hostMedia.js SHARE_RE). */
+const FEED = {
+  images: [
+    { name: 'online30:aaa111.jpg', url: 'https://cdn.scrolller.com/aaa111.jpg' },
+    { name: 'online30:bbb222.webp', url: 'https://cdn.scrolller.com/bbb222.webp' },
+  ],
+  videos: [{ name: 'online30:ccc333.mp4', url: 'https://cdn.scrolller.com/ccc333.mp4' }],
+  skipped: 0,
+};
+/** The player's own library, as the desktop host posts it. */
+const LOCAL = {
+  images: [{ name: 'mine1.png', url: 'https://ccp.assets/images/mine1.png' }],
+  videos: [{ name: 'mine2.mp4', url: 'https://ccp.assets/videos/mine2.mp4' }],
+  skipped: 1,
+};
+
+/* ---- 1. an empty boot manifest, the shape raceBoot posts when unhosted ---- */
+const media = createHostMediaSource();
+media.setManifest({ images: [], videos: [], skipped: 0 });
+ok(media.hasUserMedia() === false, 'an empty manifest is an empty local pool');
+ok(media.hasDomMedia() === false, 'and an empty DOM pool');
+ok(media.draw() === null, 'draw() on an empty pool is null, not a throw');
+ok(media.drawDom() === null, 'drawDom() on an empty pool is null, not a throw');
+
+/* ---- 2. the feed lands LATER, on the same object -------------------------- */
+media.setManifest(FEED);
+ok(media.hasDomMedia() === true, 'a manifest posted after boot fills the DOM pool with no rebuild');
+ok(media.hasUserMedia() === false, 'and leaves the local pool empty: a remote entry is not the player\'s own media');
+ok(media.stats().images === 0 && media.stats().videos === 0, 'stats() counts the LOCAL pool only, so the tube still reads as empty');
+
+/* ---- 3. the WebGL doors never see it -------------------------------------- */
+{
+  let leaked = 0;
+  for (let i = 0; i < 200; i++) {
+    if (media.draw()) leaked++;
+    if (media.drawKind('image')) leaked++;
+    if (media.drawKind('video')) leaked++;
+  }
+  ok(leaked === 0, '200 rounds of draw()/drawKind() hand out NOTHING from the remote pool');
+  media.setFavorites(['aaa111.jpg', 'ccc333.mp4']);
+  ok(media.favorite() === null, 'favorite() cannot name a remote entry');
+  ok(media.urlByName('aaa111.jpg') === null, 'urlByName() cannot resolve a remote entry');
+}
+
+/* ---- 4. drawDom() is the one door, and the marker comes off the name ------ */
+{
+  const seen = new Set();
+  let kinds = { image: 0, video: 0 };
+  for (let i = 0; i < 300; i++) {
+    const p = media.drawDom();
+    if (!p) continue;
+    seen.add(p.name);
+    kinds[p.kind] = (kinds[p.kind] | 0) + 1;
+  }
+  ok(kinds.image > 0 && kinds.video > 0, 'drawDom() serves both halves of the feed');
+  ok([...seen].every((n) => !/^online\d/.test(n)), 'the share marker is STRIPPED off the name it is parsed from');
+  ok(seen.has('aaa111.jpg') && seen.has('ccc333.mp4'), 'every feed entry is reachable through drawDom()');
+  const one = media.drawDom('image');
+  ok(one && one.kind === 'image' && one.remote === true, 'a remote draw is flagged `remote` so the caller can stay on the DOM road');
+}
+
+/* ---- 5. the mix: local media coming back does not evict the feed ---------- */
+{
+  const mixed = createHostMediaSource();
+  mixed.setManifest({ images: [...LOCAL.images, ...FEED.images], videos: [...LOCAL.videos, ...FEED.videos], skipped: 1 });
+  ok(mixed.hasUserMedia() === true && mixed.hasDomMedia() === true, 'both pools fill off one frame');
+  ok(mixed.stats().images === 1 && mixed.stats().videos === 1 && mixed.stats().skipped === 1, 'stats() counts only the local half plus the host\'s skip count');
+  let remote = 0, local = 0;
+  for (let i = 0; i < 600; i++) { const p = mixed.drawDom(); if (!p) continue; if (p.remote) remote++; else local++; }
+  ok(remote > 0 && local > 0, 'drawDom() mixes the two pools rather than picking one');
+  // the marker said 30, so roughly a third of the DOM draws should be remote.
+  const share = remote / (remote + local);
+  ok(share > 0.15 && share < 0.5, `the online30: marker steers the mix (${(share * 100).toFixed(0)}% remote over 600 draws)`);
+  let leaked = 0;
+  for (let i = 0; i < 300; i++) { const p = mixed.draw(); if (p && !/^mine/.test(p.name)) leaked++; }
+  ok(leaked === 0, 'and draw() still only ever hands out the player\'s own files');
+}
+
+/* ---- 6. the feed switched OFF: an empty manifest empties the pool --------- */
+{
+  media.setManifest({ images: [], videos: [], skipped: 0 });
+  ok(media.hasDomMedia() === false, 'consent revoked, the host posts an empty manifest, the pool is empty at once');
+  ok(media.drawDom() === null, 'and nothing is left behind to draw');
+}
+
+/* ---- 7. the menu group's visibility rule --------------------------------- */
+/* race/menu.js renders the online feed group only when the host claims the
+ * capability AND ships a catalog. The C# host ships neither, so the desktop
+ * must fall out of this on the first clause; the browser host shim ships both.
+ * Restated here because menu.js needs three and a DOM to import. */
+{
+  const shows = (s) => s.mediaControls === true
+    && Array.isArray(s.remoteCatalog)
+    && s.remoteCatalog.filter((r) => r && typeof r.id === 'string' && r.id).length > 0;
+  const CATALOG = [{ id: 'hypno', label: 'Hypno' }, { id: 'bimbo', label: 'Bimbo' }];
+  ok(shows({}) === false, 'the desktop (no mediaControls, no catalog) never renders the group');
+  ok(shows({ remoteCatalog: CATALOG }) === false, 'a catalog without the capability flag is not enough');
+  ok(shows({ mediaControls: true }) === false, 'the flag without a catalog is not enough');
+  ok(shows({ mediaControls: true, remoteCatalog: [] }) === false, 'an empty catalog is not enough');
+  ok(shows({ mediaControls: true, remoteCatalog: [{ label: 'no id' }] }) === false, 'a catalog of rows with no id is not enough');
+  ok(shows({ mediaControls: true, remoteCatalog: CATALOG }) === true, 'the browser host shim (flag + catalog) renders it');
+  ok(shows({ mediaControls: 'true', remoteCatalog: CATALOG }) === false, 'the flag is checked STRICTLY, so a stringy true is still no');
+}
+
+console.log(fails ? `\n${fails} failure(s)` : '\nremote-feed-check: all good');
+process.exit(fails ? 1 : 0);


### PR DESCRIPTION
## what

Phase C3, app side. The "your media" panel from #894 gains an "online feed" group, fed by the browser host's Scrolller source (cclabs-web `feat/race-c3-scrolller`, same seam as #176). The group is rendered from the host's `init` settings (`remoteCatalog`, `niches`, `remoteConsent`, `remoteMediaRatio`): a consent row ("the feed" off / pending / on) and one row per catalog niche. Every press posts `set-setting` and the row shows pending until the host echoes the STORED value, so a refused write (an empty niche list) snaps back to what the host kept. Nothing renders when the host sends no catalog, so the WebView2 build is unchanged.

Consent gates the network, not the disk: the page never fetches anything itself. The host source fetches api.scrolller.com straight from the phone, and remote rows only ever reach the DOM media lane (never WebGL), per the C1 contract.

With fourteen extra rows the panel is taller than a phone viewport, so the focused media row now scrolls into view for the pad and keyboard walk. No-op for a finger already scrolling.

Copy, verbatim: heading `online feed`; consent line `this device pulls the feed straight off the source site. none of it passes through cc labs. it is adult media, out of the public subreddits ticked below.`; niches under `what it pulls`. No em-dashes, no "bank" anywhere a player reads.

## files

| file | lines |
|---|---|
| `race/feedGroup.js` (new) | +192 |
| `race/smoke/remote-feed-check.mjs` (new) | +141 |
| `race/menu.js` | +44 / -7 |
| `race/CONTRACT.md` | +34 |
| `race/menu.css` | +18 / -1 |

Rebased onto main after #895; the band measure already counts the media panel as an open panel.

## verification

- `node --check` clean; all 8 `race/smoke/*.mjs` pass on the rebased tree (`touch-check` flaked once and passed three reruns, the known timing sensitivity)
- headless at 390x844 against the vendored web tree, 33 assertions with `--net`: the source registers itself, 13 niches arrive, default niches `hypno, bambisleep`, ratio 0.30, a closed gate fetched nothing from api.scrolller.com (checked on `Network.requestWillBeSent`), a held frame leaves the row pending with nothing written page-side, a niche press posts the whole list, an empty list is refused and the stored list echoes back, 40 entries (24 image, 16 video) once consent is on, every remote row wears `online30:`, every media origin is `*.scrolller.com`, no request went to a CC Labs address

## unverified

No real phone: the touch walk, scrolling a panel taller than the screen, and the pad focus order are headless only. The iOS mp4-only belt in provider.js was not exercised against real Safari. Cross-game consent (`arc-web:consent` set in the Arcademy settings room lighting the kart panel) follows from the shared key and shared provider.js but was only driven from the kart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0166ij3Q8xyseVkhWajzkWG3
