### PR TITLE
fix(race): EMI's face goes white on iPhone, stop re-uploading the atlas

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/race/assets/README.md
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/assets/README.md
@@ -77,8 +77,21 @@ map.repeat.x = 5 / 7;                        // gltf.js BAKED_FRAMES / FACES.len
 map.offset.x = frame / 7;                    // frame 0..6, gltf.js setFace does both
 ```
 
-If the png never arrives, the embedded five-frame strip stays and frames 5 and 6 clamp to 4:
-`gltf.js` `faceFrames(texture)` reads the width off the texture, never off `FACES`.
+**The strip is repainted into a padded texture on load.** `gltf.js` `padAtlasToPot` draws this
+png into a power of two 2048x256 canvas (top left, or bottom left when flipY is on, so the strip
+always lands at the uv origin) and hands the material a CanvasTexture instead. Two reasons, both
+of them phones: an `<img>` can have its decoded pixels dropped by mobile Safari between uploads,
+and the glass has no base map, so one blank emissive sample paints the whole screen white; and
+1064x137 is not a power of two, which puts RepeatWrapping and mipmaps out of bounds on any
+WebGL1 context. So repeat and offset are both multiplied by the pad scale (1064/2048, 137/256),
+which `gltf.js` `atlasScale(texture)` reads off `userData` and `setFace` applies: the numbers in
+the table above are still the frame indices, they just get squeezed. Sampling never leaves the
+strip, so the padded texture is ClampToEdge on both axes, and `setFace` never flags
+`needsUpdate` (an offset is a uniform, not pixels, and a version bump re-uploads the atlas).
+
+If the png never arrives, the embedded five-frame strip stays, gets padded the same way, and
+frames 5 and 6 clamp to 4: `gltf.js` `faceFrames(texture)` reads the width off the texture,
+never off `FACES`.
 
 The material ships with `emissiveMap` = atlas, `emissive` = white, `emissiveIntensity` = 1
 (the race renders with no tone mapping, so the pink is exact at 1.0; the AgX studio render

--- a/ConditioningControlPanel/Resources/web/dtrh/race/emi.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/emi.js
@@ -19,7 +19,7 @@
 // the pack lands. Needs feat/race-b4-props-glb underneath for the file itself.
 
 import * as THREE from 'three';
-import { loadPack, setFace as packSetFace, preparePixel, flattenRig, faceFrames } from './gltf.js';
+import { loadPack, setFace as packSetFace, preparePixel, flattenRig, faceFrames, atlasScale, forceAtlasSampler } from './gltf.js';
 import { createPoseLayer } from './emiPoses.js';
 import { SAUCER_R } from './consts.js';
 
@@ -306,11 +306,10 @@ export function createEmiRig({ scene, reducedMotion = false, pixel = null }) {
       const tex = m && m.emissiveMap;
       if (!tex) continue;
       const n = faceFrames(tex);          // the strip that loaded, not the one the glb shipped
-      tex.wrapS = THREE.RepeatWrapping;
-      tex.magFilter = THREE.NearestFilter; tex.minFilter = THREE.NearestFilter;
-      tex.generateMipmaps = false;
-      tex.offset.x = Math.min(n - 1, Math.max(0, i | 0)) / n;
-      tex.needsUpdate = true; hit = true;
+      forceAtlasSampler(tex);             // a raw strip only: a padded one already has its sampler
+      // offset is a uniform: flagging needsUpdate here would re-upload the atlas every face change
+      tex.offset.x = (Math.min(n - 1, Math.max(0, i | 0)) / n) * atlasScale(tex).x;
+      hit = true;
     }
     return hit;
   }

--- a/ConditioningControlPanel/Resources/web/dtrh/race/gltf.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/gltf.js
@@ -154,9 +154,10 @@ export function disposePack(url) {
  * left alone: flipY, colour space, the UV channel and wrapT all come off the embedded texture, so
  * only the width of one frame changes. A miss (no glass, no map, a 404) resolves false and the
  * embedded strip stays, which is why setFace reads the frame count off the texture rather than
- * off FACES: a fallback atlas is still five frames wide and indices past it clamp.
+ * off FACES: a fallback atlas is still five frames wide and indices past it clamp. That fallback
+ * gets padded in place (hardenAtlas) so the phone-safe sampler holds either way.
  * The orphaned embedded texture is never uploaded (the swap lands before the pack resolves), so
- * it costs nothing on the GPU and is left for disposePack's material walk to miss harmlessly.
+ * it costs nothing on the GPU and is disposed here rather than left for disposePack to find.
  */
 function swapFaceAtlas(pack) {
   if (!pack || !pack.scene || !pack.url) return Promise.resolve(false);
@@ -171,8 +172,11 @@ function swapFaceAtlas(pack) {
   return new Promise((resolve) => {
     new THREE.TextureLoader().load(url, resolve, undefined, () => resolve(null));
   }).then((tex) => {
-    if (!tex) return false;
     const src = slots[0].m[slots[0].key];
+    if (!tex) { hardenAtlas(slots, src, src.repeat.x, 0); return false; }   // no sibling png: pad the baked strip
+    const wide = src.repeat.x * BAKED_FRAMES / FACES.length;               // one live frame over the authored UVs
+    const potted = padAtlasToPot(src, tex.image, wide, FACES.length);
+    if (potted) { tex.dispose(); for (const slot of slots) { slot.m[slot.key] = potted; slot.m.needsUpdate = true; } src.dispose(); return true; }
     tex.flipY = src.flipY;                       // glTF images are not flipped; TextureLoader's are
     tex.colorSpace = src.colorSpace;
     tex.channel = src.channel;
@@ -180,13 +184,22 @@ function swapFaceAtlas(pack) {
     tex.wrapS = THREE.RepeatWrapping; tex.wrapT = src.wrapT;
     tex.magFilter = THREE.NearestFilter; tex.minFilter = THREE.NearestFilter;
     tex.generateMipmaps = false;
-    tex.repeat.set(src.repeat.x * BAKED_FRAMES / FACES.length, src.repeat.y);
+    tex.repeat.set(wide, src.repeat.y);
     tex.offset.set(0, src.offset.y);
     tex.userData.faceFrames = FACES.length;
     tex.needsUpdate = true;
     for (const slot of slots) { slot.m[slot.key] = tex; slot.m.needsUpdate = true; }
     return true;
   }).catch(() => false);
+}
+
+/** Pad whatever strip a material already carries and put it back in the same slots. Returns
+ *  nothing: the caller's true/false is about the sibling atlas, not about this. */
+function hardenAtlas(slots, src, repeatX, frames) {
+  const potted = padAtlasToPot(src, src.image, repeatX, frames);
+  if (!potted) return;
+  for (const slot of slots) { slot.m[slot.key] = potted; slot.m.needsUpdate = true; }
+  src.dispose();
 }
 
 // ---- merge to a roomProps-shaped instance geometry --------------------------------------
@@ -355,11 +368,88 @@ export function faceFrames(tex) {
   return n > 0 ? n : BAKED_FRAMES;
 }
 
+const ONE_SCALE = { x: 1, y: 1 };
+const MAX_ATLAS_POT = 4096;    // past this we would be trading a white face for an out of memory
+
+/** The (x, y) the frame math is squeezed by once the strip sits in a padded texture, or 1, 1 when
+ *  it is still the raw strip. Exported for the smoke; setFace is the only caller that matters. */
+export function atlasScale(tex) {
+  const s = tex && tex.userData && tex.userData.atlasScale;
+  return s && s.x > 0 && s.y > 0 ? s : ONE_SCALE;
+}
+
+function potCeil(n) { return Math.pow(2, Math.ceil(Math.log2(Math.max(1, n)))); }
+
+/**
+ * Redraw a face strip into a POWER OF TWO CanvasTexture and hand back a texture that is legal
+ * under the strictest sampler rules there are, and whose pixels live in a <canvas>.
+ *
+ * WHY. emi_glass carries the atlas on emissiveMap with an emissive factor of 1,1,1 and no base
+ * map at all, so anything that makes that one sample come back blank paints the glass a SOLID
+ * WHITE RECTANGLE, which is what the owner's iPhone shows on the home screen. Two things fed
+ * that, and this kills both:
+ *   1. setFace used to flag the texture needsUpdate on every frame change, and a source version
+ *      bump makes three re-upload the whole image. Measured: 21 face changes, 21 full
+ *      texSubImage2D calls of the 1064x137 strip. Mobile Safari is free to drop the decoded
+ *      bitmap of an <img> that is not in the document once it wants the memory back, and a
+ *      re-upload after that hands GL nothing. A canvas keeps its own backing store, and setFace
+ *      no longer asks for a re-upload at all.
+ *   2. 1064x137 is not a power of two, and the strip was sampled with RepeatWrapping. That pair
+ *      is illegal on a WebGL1 context (NPOT wants clamp to edge, no mipmaps and a non mipmapping
+ *      min filter) and is the kind of thing a driver is allowed to be unhappy about. Padded and
+ *      clamped, nothing about this sampler is exotic anywhere.
+ *
+ * The frame math rides along. The strip goes in the corner that ends up at uv 0,0 whichever way
+ * flipY points, so repeat and offset scale by the same (w/W, h/H) and every sampled uv stays
+ * inside the strip: EMI_glass's authored u span is 0.0007 .. 0.1993 and the widest frame window
+ * lands at 0.9995 before padding, so no wrap mode is ever exercised in the first place.
+ *
+ * Returns null (caller keeps the raw strip) with nothing to draw on (the node smoke), on a
+ * source carrying a uv transform we would have to compose with, or on a silly padded size.
+ */
+function padAtlasToPot(src, image, repeatX, frames) {
+  if (typeof document === 'undefined' || !document.createElement) return null;
+  const w = image && (image.width || image.naturalWidth), h = image && (image.height || image.naturalHeight);
+  if (!w || !h) return null;
+  if (src.center.x !== 0 || src.center.y !== 0 || src.rotation !== 0) return null;
+  const W = potCeil(w), H = potCeil(h);
+  if (W > MAX_ATLAS_POT || H > MAX_ATLAS_POT) return null;
+  let canvas;
+  try {
+    canvas = document.createElement('canvas');
+    canvas.width = W; canvas.height = H;
+    const ctx = canvas.getContext('2d', { willReadFrequently: false });
+    if (!ctx) return null;
+    // flipY flips the whole upload, so the strip goes wherever it ends up at the uv origin
+    ctx.drawImage(image, 0, src.flipY ? H - h : 0, w, h);
+  } catch (e) { return null; }                 // an undrawable or tainted source is not worth a throw
+  const sx = w / W, sy = h / H;
+  const tex = new THREE.CanvasTexture(canvas);
+  tex.flipY = src.flipY;                       // glTF images are not flipped; a loaded png is
+  tex.colorSpace = src.colorSpace;
+  tex.channel = src.channel;
+  tex.wrapS = THREE.ClampToEdgeWrapping;       // the sampled uv never leaves the strip, so clamping
+  tex.wrapT = THREE.ClampToEdgeWrapping;       // costs nothing and is legal on every context there is
+  tex.magFilter = THREE.NearestFilter;
+  tex.minFilter = THREE.NearestFilter;         // Nearest takes no mipmaps, which is the other NPOT rule
+  tex.generateMipmaps = false;
+  tex.repeat.set(repeatX * sx, src.repeat.y * sy);
+  tex.offset.set(0, src.offset.y * sy);
+  tex.userData.atlasScale = { x: sx, y: sy };
+  if (frames > 0) tex.userData.faceFrames = frames;
+  return tex;
+}
+
 /**
  * Point EMI_glass's map at one atlas frame. The atlas is a horizontal strip and the authored UVs
  * span frame 0 of the BAKED strip, so the frame width is already in the mesh (plus the repeat.x
  * swapFaceAtlas set) and all we move is the offset. An index past the end of the strip actually
  * loaded clamps to its last frame. Returns true if a glass mesh with a map was found.
+ *
+ * The offset is a uniform, not pixels, so NOTHING here flags the texture needsUpdate: that used
+ * to re-upload the whole atlas on every single face change (see padAtlasToPot). A raw strip that
+ * never went through padAtlasToPot still gets its sampler forced, but only once, and only when
+ * something is actually wrong with it, because sampler state only lands on an upload.
  */
 export function setFace(model, index) {
   if (!model || !model.traverse) return false;
@@ -373,16 +463,25 @@ export function setFace(model, index) {
   for (const m of mats) for (const key of ['map', 'emissiveMap']) {
     const tex = m && m[key];
     if (!tex) continue;
-    tex.wrapS = THREE.RepeatWrapping;
-    tex.magFilter = THREE.NearestFilter;
-    tex.minFilter = THREE.NearestFilter;
-    tex.generateMipmaps = false;
+    forceAtlasSampler(tex);
     const n = faceFrames(tex);
-    tex.offset.x = Math.min(n - 1, Math.max(0, index | 0)) / n;
-    tex.needsUpdate = true;
+    tex.offset.x = (Math.min(n - 1, Math.max(0, index | 0)) / n) * atlasScale(tex).x;
     hit = true;
   }
   return hit;
+}
+
+/** A strip that never went through padAtlasToPot (the node smoke, a browser with no 2D canvas)
+ *  still wants the sampler a bare atlas needs. One upload, and only if it is not already right. */
+export function forceAtlasSampler(tex) {
+  if (!tex || (tex.userData && tex.userData.atlasScale)) return;
+  if (tex.wrapS === THREE.RepeatWrapping && tex.magFilter === THREE.NearestFilter
+    && tex.minFilter === THREE.NearestFilter && tex.generateMipmaps === false) return;
+  tex.wrapS = THREE.RepeatWrapping;
+  tex.magFilter = THREE.NearestFilter;
+  tex.minFilter = THREE.NearestFilter;
+  tex.generateMipmaps = false;
+  tex.needsUpdate = true;                   // sampler state only lands on an upload
 }
 
 // ---- the pixel pass ---------------------------------------------------------------------

--- a/ConditioningControlPanel/Resources/web/dtrh/race/smoke/gltf-smoke.mjs
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/smoke/gltf-smoke.mjs
@@ -36,7 +36,7 @@ registerHooks({
 });
 
 const THREE = await import('three');
-const { makePack, toInstanceGeometry, setFace, preparePixel, flattenRig, disposePack, FACES, faceFrames } = await import('../gltf.js');
+const { makePack, toInstanceGeometry, setFace, preparePixel, flattenRig, disposePack, FACES, faceFrames, atlasScale, forceAtlasSampler } = await import('../gltf.js');
 const { GLTFLoader } = await import('three/addons/loaders/GLTFLoader.js');
 
 // ---- the tiny assert kit ----------------------------------------------------------------
@@ -247,6 +247,41 @@ delete tex.userData.faceFrames;
 setFace(emi, 0);
 ok(setFace(new THREE.Group(), 1) === false, 'no EMI_glass, no throw, just false');
 ok(setFace(null, 1) === false, 'setFace(null) is false');
+
+// ---- the padded atlas ------------------------------------------------------------------------
+// padAtlasToPot needs a document, so node never takes that branch; what the smoke CAN hold is the
+// contract setFace reads off the far side of it. The live strip is 1064x137 in a 2048x256 canvas.
+ok(atlasScale(tex).x === 1 && atlasScale(tex).y === 1, 'a raw strip reports a 1,1 atlas scale');
+const SX = 1064 / 2048, SY = 137 / 256;
+tex.userData.atlasScale = { x: SX, y: SY };
+tex.userData.faceFrames = FACES.length;
+ok(atlasScale(tex).x === SX, 'a padded strip reports the scale it was padded by');
+for (let i = 0; i < FACES.length; i++) {
+  setFace(emi, i);
+  ok(near(tex.offset.x, (i / FACES.length) * SX), 'padded frame ' + i + ' sits at ' + i + '/7 squeezed into the pad');
+}
+setFace(emi, 99);
+ok(near(tex.offset.x, ((FACES.length - 1) / FACES.length) * SX), 'the clamp still lands on the last frame when padded');
+// the authored EMI_glass u span is 0.00066 .. 0.19934 over one baked frame, so with repeat.x
+// squeezed the same way the last window must stop inside the strip: never in the pad, and never
+// over a wrap seam, which is what lets the padded texture be ClampToEdge
+ok(0.19934 * (5 / FACES.length) * SX + tex.offset.x < SX, 'the last frame window stops inside the strip, not in the pad');
+// the pixel budget: setFace must never ask for a re-upload of the atlas
+tex.wrapS = THREE.ClampToEdgeWrapping;
+const ver = tex.version;
+setFace(emi, 3);
+ok(tex.version === ver, 'setFace never bumps the texture version (an offset is a uniform, not pixels)');
+ok(tex.wrapS === THREE.ClampToEdgeWrapping, 'setFace leaves a padded texture clamped');
+forceAtlasSampler(tex);
+ok(tex.wrapS === THREE.ClampToEdgeWrapping, 'forceAtlasSampler skips a padded texture');
+delete tex.userData.atlasScale;
+forceAtlasSampler(tex);
+ok(tex.wrapS === THREE.RepeatWrapping && tex.generateMipmaps === false, 'forceAtlasSampler fixes a raw strip');
+const ver2 = tex.version;
+forceAtlasSampler(tex);
+ok(tex.version === ver2, 'a sampler that is already right costs no second upload');
+delete tex.userData.faceFrames;
+setFace(emi, 0);
 
 // ---- preparePixel ----------------------------------------------------------------------------
 const seen = [];


### PR DESCRIPTION
## what

Owner's iPhone report, item two: EMI's glass face rendered as a solid white rectangle on the home screen.

The white is the material. `emi_glass` in emi.glb is a MeshPhysicalMaterial with `emissiveFactor [1,1,1]`, the face atlas on `emissiveTexture`, a near-black base colour and no base map, so a blank emissive sample paints the glass white. What blanked the sample: `setFace` flagged `needsUpdate` on every face change, which bumps the texture source version and makes three re-upload the whole 1064x137 image each time. Measured in headless Chrome on `texSubImage2D`: 21 face changes, 21 full re-uploads. The menu idle show drives that constantly. Mobile Safari may discard the decoded pixels of an image that is not in the document, and a re-upload after that hands GL nothing, for an offset that only ever needed a uniform.

Two other hypotheses were checked and dropped: the vendored three requests `webgl2` only and hardcodes `isWebGL2`, so there is no WebGL1 path to fall into; and `disposePack` has no live caller, so no swap ordering could fire.

## fix

On load, `padAtlasToPot` in gltf.js repaints the strip into a power-of-two 2048x256 CanvasTexture: ClampToEdge on both axes, no mipmaps, Nearest min and mag (keeps the crisp pixel face), same flipY, colour space and channel, with `repeat` and `offset` scaled by the pad and stashed in `userData.atlasScale`. `setFace` applies the scale and never flags `needsUpdate` again. The embedded five-frame fallback gets the same padding when the sibling png does not arrive. A raw un-padded strip keeps the old forced sampler once rather than per call. FACES and BAKED_FRAMES semantics and the past-the-end clamp are unchanged. The result is legal under the strictest NPOT rules regardless of context.

| file | lines |
|---|---|
| `race/gltf.js` | +109 / -10 |
| `race/smoke/gltf-smoke.mjs` | +36 / -1 |
| `race/assets/README.md` | +15 / -2 |
| `race/emi.js` | +5 / -6 |

## verification

Before and after in the same headless Chrome: texture goes from HTMLImageElement 1064x137 non-POT with Repeat wrap to a 2048x256 canvas with ClampToEdge; uploads for 21 face changes go from 21 to 0; the texture version stays at 1. The seven sampled windows after padding are evenly spaced and the last stops inside the strip edge, so no window touches the pad. Indices 7 and 8 clamp onto frame 6. All seven frames shot via `?face=N` in the authored order, crisp, no bleed. `gltf-smoke` grows from 53 to 69 assertions, including "setFace never bumps the texture version". All 8 smokes pass on the rebased tree (`touch-check` flaked once under load and passed three reruns, the known timing sensitivity).

## not proven without a real iPhone

Headless Chrome never reproduced the white, so the mechanism is inferred from the material and the measured re-uploads rather than watched on Safari. The change removes the re-upload entirely and makes the sampler legal everywhere, so both candidate mechanisms are gone, but the confirmation is the owner's phone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0166ij3Q8xyseVkhWajzkWG3
