### PR TITLE
perf(race): the phone perf pass (wp1-wp6)

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/engine/loomSpirals.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/engine/loomSpirals.js
@@ -18,6 +18,27 @@ let spirals = [];   // [{ slug, url, params }]
 const BUNDLED_BASE = '/dtrh/assets/bubbles/effects/spirals/';
 export const BUNDLED_SPIRALS = ['sp1.gif', 'sp2.webp', 'sp3.gif', 'sp4.webp', 'sp5.gif', 'sp6.gif', 'sp7.gif']
   .map((f) => BUNDLED_BASE + f);
+// the two lightest of those (sp6.gif 123 KB, sp7.gif 721 KB; the other five weigh 2.2-5.3 MB each,
+// sizes on disk 2026-09): the pool a phone draws from once the race asks (setBundledSpiralPool)
+export const LEAN_SPIRALS = ['sp6.gif', 'sp7.gif'].map((f) => BUNDLED_BASE + f);
+let bundledPool = BUNDLED_SPIRALS;
+
+/** Opt-in: narrow the bundled pool every pickSpiralUrl() draws from (null / empty restores the whole
+ *  set). The race sets LEAN_SPIRALS on its mobile tier and prefetches them before the run, so a lap
+ *  never fetches a multi-megabyte gif mid-run; nothing else calls this and the Descent keeps the full
+ *  pool. The Loom's saved spirals are untouched by it. */
+export function setBundledSpiralPool(list) {
+  bundledPool = Array.isArray(list) && list.length ? list.slice() : BUNDLED_SPIRALS;
+}
+export function getBundledSpiralPool() { return bundledPool; }
+
+/** Warm the browser cache for a pool (one <img> per url, decoded off-thread); returns the urls asked
+ *  for. A page without a DOM (node) asks for nothing. */
+export function prefetchSpirals(list = bundledPool) {
+  if (typeof Image === 'undefined') return [];
+  for (const u of list) { try { const im = new Image(); im.decoding = 'async'; im.src = u; } catch (e) { /* a warm-up only */ } }
+  return list.slice();
+}
 
 export function setLoomSpirals(list) {
   spirals = Array.isArray(list) ? list.filter((s) => s && s.url) : [];
@@ -31,5 +52,5 @@ export function pickSpiralUrl() {
   if (spirals.length && Math.random() < 0.5) {
     return spirals[Math.floor(Math.random() * spirals.length)].url;
   }
-  return BUNDLED_SPIRALS[Math.floor(Math.random() * BUNDLED_SPIRALS.length)];
+  return bundledPool[Math.floor(Math.random() * bundledPool.length)];
 }

--- a/ConditioningControlPanel/Resources/web/dtrh/race/AUDIO.md
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/AUDIO.md
@@ -136,7 +136,14 @@ the two Midnight Statics, active: the rest") and the file lengths; re-order free
 Plus, in any room: the fraught state (effects stacked, `run.effects.length / 3`) eases a lowpass
 from open down to 800 Hz; tea time caps it at 1.4 kHz. Crossfade at every gate is 1.5 s (linear
 ramps on per-track gain nodes; the outgoing element pauses 200 ms after the ramp and resumes
-from where it was next lap). Each track is one `<audio>` element through a
+from where it was next lap). At most two elements are resident: the room's track and the next
+room's, which `residentTracks` names along the run's route (the dresser's spans, or a chart's acts
+via `audio.setRoute`, since a loaded chart re-orders the gates) and the gate prefetches (`preload=auto`, so it is buffered
+by the time its room comes). Every other element is released after its crossfade (src emptied,
+the file buffer with it; a lap of eight rooms used to hold all eight, 10-14 MB) and its position
+parked, so the resume-next-lap rule holds through a re-fetch. Nothing is fetched before the menu
+asks for its theme. The Arcademy mp3s (0.77-2.74 MB each) are the only variants shipped: there
+is no lower-bitrate set for phones. Each track is one `<audio>` element through a
 `MediaElementSource` into the chain `duck -> lowpass -> highpass -> level -> master`. If that
 route ever throws (it should not: the files are same-origin on `ccp.game`, the same route
 `engine/scene.js` uses for the drone) the player falls back to element volume with a 50 ms

--- a/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
@@ -181,6 +181,12 @@ Bubble kinds (mirror `game/variants.js` and `engine/bubbles.js`; sprites from
 | gifrain | effect | gifCascade | 25 | minIntensity 0.45 |
 | video | effect | video | 40 | DARK since 2026-09-06, never spawns (see below) |
 
+Spiral pops (`payloadFx.showSpiral`, untouched) take their url from `engine/loomSpirals.js`
+`pickSpiralUrl()`. On the mobile tier `Q.leanSpirals` has run.js narrow that module's bundled pool
+to `LEAN_SPIRALS` (sp6.gif 123 KB + sp7.gif 721 KB; the other five are 2.2-5.3 MB) with
+`setBundledSpiralPool` and prefetch both in `prepare()` (while the intro plays; `start()` covers
+`?autostart=1`), so a lap never fetches a spiral mid-run. Desktop keeps the full pool and the Descent
+never calls the setter.
 A row may carry `spawn: false`. Video bubbles are dark since 2026-09-06: `rollKind` leaves the row out
 of every pool and `field.spawnAt` returns -1 for it, so no roll, lane line, rain or track cue can put
 one on the road, and `CaucusHostService` refuses a `fire-payload {kind:'video'}` as well. The row, its

--- a/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
@@ -290,7 +290,7 @@ below every `.sf-pfx` layer, and the Brake/End screens at z20 pick their own sta
 ### `race/run.js` + `raceBoot.js` + `race.html` (PR 5, integration)
 ```js
 export function createRace({ root, bridge, media, settings, seed }) ->
-  { start(), setPaused(b), dispose(), setCameraOverride(fn), setStage(s), reseed(seed), renderer, pixel, audio, hud, camera,
+  { start(), prepare(), setPaused(b), dispose(), setCameraOverride(fn), setStage(s), reseed(seed), renderer, pixel, audio, hud, camera,
     setTrack(chart | null), replaceTrack(chart), trackClock(t, playing), trackEnded(), track }
 ```
 Track charts (PR c2, CHART.md): `setTrack` before `start()`; `replaceTrack` when the words pass lands
@@ -365,6 +365,10 @@ As built (PR 5 reality notes):
   never fight over one `style.transform`.
 - `again` on the end screen rebuilds the world in place (spine, tunnel, fx, dresser, field, kart, score,
   items) with a fresh seed; renderer, HUD, input, payloadFx and shake persist for the page's life.
+- The world is not built under the menu. `createRace` only resets the run state; `race.prepare()` builds it
+  (raceBoot calls it once `race` is pressed, after `seedCheck`, before the intro plays) and warms the
+  renderer's programs, and `start()` builds it if nothing did (`?autostart=1`). `reseed` on a world that was
+  never built only resets state, so the menu changing the seed rule costs nothing until `race`.
 - Extra `run-ended` fields: `nearMisses`, `personalBest`. `exit` is followed by `exit-done` once torn down.
 - Boot and reduced motion: `raceBoot.js` calls `detectMode({ reducedIs3d: true })`, so `prefers-reduced-motion: reduce`
   boots the 3D race and only turns motion down through `settings.reducedMotion`; a boot error is reserved for a real

--- a/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
@@ -124,6 +124,11 @@ Rooms: `teagarden, toybox, casino, undertow, mirrors, chapel, greyward, coronati
 carries `loud` (rollRoomOrder deals loud/soft alternately after the Tea Garden). `rooms` may be
 specs or ids. The dresser adds its own hemisphere + directional light (the props are Lambert; the
 tunnel shader ignores lights) and exposes `group`, `spans` (`{id, d0, d1}` per room) and `rooms`.
+Light budget: desktop runs 7 lights (run.js ambient + cupLight, the dresser's hemisphere + sun, EMI's
+screen / bead / cup points). On the mobile tier `Q.leanLights` hides the sun, run.js's cupLight and
+EMI's screen + bead points (`visible = false`, which three.js counts as absent): the ambient, the
+hemisphere (the pink sky the props and the cup are painted for; a directional in its place reads
+purple and flat) and EMI's cupLight are that tier's whole bill. Desktop is untouched.
 A crossed cube hides, throws its splits and puts a BILLBOARD flash on its spot: never a solid mesh,
 which used to read as a second, empty white box standing beside the shards.
 Road furniture (item box and its twelve splits, boost pad, ramp lip, air marker) takes its geometry

--- a/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
@@ -124,6 +124,9 @@ Rooms: `teagarden, toybox, casino, undertow, mirrors, chapel, greyward, coronati
 carries `loud` (rollRoomOrder deals loud/soft alternately after the Tea Garden). `rooms` may be
 specs or ids. The dresser adds its own hemisphere + directional light (the props are Lambert; the
 tunnel shader ignores lights) and exposes `group`, `spans` (`{id, d0, d1}` per room) and `rooms`.
+Bubble budget: `Q.bubbleCap` / `Q.bubbleShards` / `Q.bubbleViewAhead` (desktop 160 / 64 / 110, mobile
+100 / 32 / 76) size the sprite pools and the hide-ahead distance when the field is built; the art, the
+spawn rules and the pop box are the same on both tiers.
 Light budget: desktop runs 7 lights (run.js ambient + cupLight, the dresser's hemisphere + sun, EMI's
 screen / bead / cup points). On the mobile tier `Q.leanLights` hides the sun, run.js's cupLight and
 EMI's screen + bead points (`visible = false`, which three.js counts as absent): the ambient, the

--- a/ConditioningControlPanel/Resources/web/dtrh/race/audio.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/audio.js
@@ -597,7 +597,7 @@ export function createRaceAudio({ bridge, hud, settings = {}, input } = {}) {
     master = null;
   }
 
-  return { sfx, ui, menu: menuMusic, setLevels, update, duck, toggleMute, dispose, _voices: voices, _music: music, _levels: levels };
+  return { sfx, ui, menu: menuMusic, setLevels, update, duck, toggleMute, dispose, _voices: voices, _music: music, _levels: levels, _tracks: tracks };
 }
 
 // self-check: node --check is the bar; the pure parts (pitchSemis, chimeFor, pickVoiceToDrop)

--- a/ConditioningControlPanel/Resources/web/dtrh/race/audio.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/audio.js
@@ -7,11 +7,18 @@
  *   audio.menu(on)               the menu theme: MENU_TRACK on the same chain, entered like a room
  *   audio.ui(name, value)        the menu blips: 'tick' | 'pick' | 'back' | 'step' | 'page'
  *   audio.setLevels({ music, sfx })  the two option sliders, live
+ *   audio.setRoute(roomIds | null)  the order the run crosses the rooms in (a chart's acts); null = the spans
  *   audio.duck(on, why)          'host' (native video) | 'brake' | 'end' | 'track'
  *                                'track' is the standing one: a loaded file (CHART.md) is the
  *                                soundtrack, so the OST and the bed sit under it until it is cleared
  *   audio.toggleMute() -> bool   M key; shared with the dive's master mute (shared/audioMute.js)
  *   audio.dispose()
+ *
+ * Resident music: at most TWO <audio> elements live at once, the room's track and
+ * the next room's (residentTracks, prefetched at the gate so it is buffered by the
+ * time its room comes). Every other track is released after its crossfade (element
+ * emptied, its file buffer with it) and re-enters next lap from where it left off
+ * (its position is parked). Nothing is fetched before the menu asks for its theme.
  *
  * Two doors. The hot, latency-bound beats (pops, chimes, ticks, thumps, the
  * bed) are WebAudio in this page on the dive's shared context (engine/audioBus)
@@ -150,6 +157,21 @@ export function rollPlaylist(rng, roomOrder, pools = ROOM_POOLS, dead = new Set(
   return out;
 }
 
+/** The tracks that stay resident once `roomId` plays: its own and the following room's in `route`
+ *  (the lap wraps), so at most two <audio> elements are ever buffered. Names, deduplicated; a room
+ *  outside `route` (the menu) keeps only what plays. `pos` is the route index the run is at when a
+ *  route visits a room twice (a chart's acts); it is checked against `roomId` before it is trusted. */
+export function residentTracks(playlist, route, roomId, pos = -1) {
+  const keep = new Set();
+  if (!playlist) return keep;
+  const cur = playlist[roomId];
+  if (cur) keep.add(cur);
+  const list = Array.isArray(route) ? route : [];
+  const i = pos >= 0 && list[pos] === roomId ? pos : list.indexOf(roomId);
+  if (i >= 0) { const nxt = playlist[list[(i + 1) % list.length]]; if (nxt) keep.add(nxt); }
+  return keep;
+}
+
 export function createRaceAudio({ bridge, hud, settings = {}, input } = {}) {
   const log = (m) => { try { bridge && bridge.log && bridge.log('[audio] ' + m); } catch (e) { /* host gone */ } };
   const send = (m) => { try { bridge && bridge.send && bridge.send(m); } catch (e) { /* host gone */ } };
@@ -176,8 +198,12 @@ export function createRaceAudio({ bridge, hud, settings = {}, input } = {}) {
   // music: the chain is duck -> lowpass (fraught / Undertow / tea time) -> highpass (Grey Ward) -> level -> master
   let musicDuck = null, musicLp = null, musicHp = null, musicLevelNode = null, elementMode = false;
   let standing = 1;   // the level update() eases the music back to: 1, or TRACK_DUCK while a track is loaded
-  const tracks = new Map();      // name -> { name, el, gain, bound, failed, vol, fadeTimer, pauseTimer }
-  const music = { cur: null, playlist: {}, dead: new Set(), duckTo: 1, duckWhy: null, lp: 20000, hp: 20, gesture: false, roomId: null, menu: false };
+  const tracks = new Map();      // name -> { name, el, gain, bound, failed, vol, fadeTimer, pauseTimer } (resident: at most two)
+  const parked = new Map();      // name -> seconds a released track resumes from next lap
+  const music = { cur: null, playlist: {}, dead: new Set(), duckTo: 1, duckWhy: null, lp: 20000, hp: 20, gesture: false, roomId: null, menu: false, route: null, pos: -1 };
+  // music.order (the dresser's spans) rolls the playlist; music.route is the order the run will actually cross
+  // the rooms in when a chart's acts set it (setRoute), else the spans: the "next room" prefetch reads the route
+  const routeOf = () => music.route || music.order;
 
   setDucked(true);               // bubbles.js's kind-blind pop steps aside (see header)
 
@@ -211,7 +237,7 @@ export function createRaceAudio({ bridge, hud, settings = {}, input } = {}) {
     const el = new Audio();
     el.preload = 'auto'; el.loop = true; el.crossOrigin = 'anonymous';
     const first = audioUrl(OST_BASE + name + '.mp3');
-    const t = { name, el, gain: null, bound: false, failed: false, vol: 0, fadeTimer: 0, pauseTimer: 0, alt: hosted ? altAudioUrl(first) : null };
+    const t = { name, el, gain: null, src: null, bound: false, failed: false, vol: 0, fadeTimer: 0, pauseTimer: 0, alt: hosted ? altAudioUrl(first) : null, resumeAt: parked.get(name) || 0 };
     el.addEventListener('error', () => {
       if (t.alt) { const a = t.alt; t.alt = null; el.src = a; if (music.cur === t) el.play().catch(() => {}); return; }
       t.failed = true; music.dead.add(name);
@@ -231,7 +257,7 @@ export function createRaceAudio({ bridge, hud, settings = {}, input } = {}) {
     try {
       const src = ctx.createMediaElementSource(t.el);
       t.gain = ctx.createGain(); t.gain.gain.value = 0;
-      src.connect(t.gain); t.gain.connect(musicDuck);
+      src.connect(t.gain); t.gain.connect(musicDuck); t.src = src;
       t.el.volume = 1;
     } catch (e) { t.gain = null; elementMode = true; log('media element route failed, element volume mode: ' + e); }
   }
@@ -263,13 +289,28 @@ export function createRaceAudio({ bridge, hud, settings = {}, input } = {}) {
     const next = trackFor(name);
     if (!next || next.failed) return;
     const prev = music.cur;
-    if (prev) { fade(prev, 0, CROSSFADE_SEC); clearTimeout(prev.pauseTimer); prev.pauseTimer = setTimeout(() => { if (music.cur !== prev) { try { prev.el.pause(); } catch (e) { /* ignore */ } } }, CROSSFADE_SEC * 1000 + 200); }
+    if (prev) {
+      fade(prev, 0, CROSSFADE_SEC); clearTimeout(prev.pauseTimer);
+      prev.pauseTimer = setTimeout(() => {   // paused after the ramp, and released unless it is the next room's
+        if (music.cur === prev) return;
+        try { prev.el.pause(); } catch (e) { /* ignore */ }
+        if (!residentTracks(music.playlist, routeOf(), music.roomId, music.pos).has(prev.name)) release(prev);
+      }, CROSSFADE_SEC * 1000 + 200);
+    }
     music.cur = next;
     clearTimeout(next.pauseTimer);
     bind(next);
     const spec = TRACK_BY_NAME[name];
-    if (next.el.paused && spec.start > 0 && next.el.currentTime < spec.start) { try { next.el.currentTime = spec.start; } catch (e) { /* not seekable yet */ } }
+    const at = Math.max(spec.start || 0, next.resumeAt || 0);   // a skipped intro, or where a released track left off
+    next.resumeAt = 0;
+    if (next.el.paused && at > 0 && next.el.currentTime < at) { try { next.el.currentTime = at; } catch (e) { /* not seekable yet */ } }
     startEl(next);
+    const route = routeOf() || [];
+    let pos = route.indexOf(roomId, music.pos + 1); if (pos < 0) pos = route.indexOf(roomId);   // forward first: a route may repeat a room
+    music.pos = pos;
+    const keep = residentTracks(music.playlist, route, roomId, pos);
+    for (const t of [...tracks.values()]) if (t !== next && t !== prev && !keep.has(t.name)) release(t);
+    for (const n of keep) if (n !== name && !music.dead.has(n) && !tracks.has(n)) trackFor(n);   // the next room's, buffering now
     fade(next, 1, prev ? CROSSFADE_SEC : 0.8);
     log('track ' + name + ' in (' + roomId + ')' + (prev ? ', ' + prev.name + ' out, crossfade ' + CROSSFADE_SEC + 's' : ''));
   }
@@ -352,9 +393,19 @@ export function createRaceAudio({ bridge, hud, settings = {}, input } = {}) {
     else if (music.cur) fade(music.cur, music.cur.vol, 0.4);
     if (bedBus && ctx) { try { bedBus.gain.setTargetAtTime(to < 1 ? 0 : 1, ctx.currentTime, to < 1 ? 0.1 : 0.4); } catch (e) { /* ignore */ } }
   }
+  /** Free a track's <audio> (its buffered file with it), parking its position for the next lap. Never the one playing. */
+  function release(t) {
+    if (!t || music.cur === t || tracks.get(t.name) !== t) return;
+    clearInterval(t.fadeTimer); clearTimeout(t.pauseTimer);
+    try { if (t.el.currentTime > 0) parked.set(t.name, t.el.currentTime); } catch (e) { /* ignore */ }
+    try { if (t.src) t.src.disconnect(); if (t.gain) t.gain.disconnect(); } catch (e) { /* ignore */ }
+    try { t.el.pause(); t.el.removeAttribute('src'); t.el.load(); } catch (e) { /* ignore */ }
+    tracks.delete(t.name);
+    log('track ' + t.name + ' released (' + tracks.size + ' resident)');
+  }
   function stopMusic() {
     for (const t of tracks.values()) { clearInterval(t.fadeTimer); clearTimeout(t.pauseTimer); try { t.el.pause(); t.el.removeAttribute('src'); t.el.load(); } catch (e) { /* ignore */ } }
-    tracks.clear(); music.cur = null; music.roomId = null;
+    tracks.clear(); parked.clear(); music.cur = null; music.roomId = null;
   }
   /** Fetch + decode one file under SFX_BASE, once. Resolves to the buffer, or null when the
    *  clip is not there. The second host is only worth a try when there IS one: in a browser
@@ -524,8 +575,13 @@ export function createRaceAudio({ bridge, hud, settings = {}, input } = {}) {
     music.order = Object.keys(ROOM_POOLS);
     try { if (world.dresser && world.dresser.spans) music.order = world.dresser.spans.map((s) => s.id); } catch (e) { /* default order */ }
     reroll();
-    music.roomId = null;
+    music.roomId = null; music.pos = -1;
     log('attached to world seed ' + music.seed + ', playlist ' + music.order.map((r) => r + ':' + (music.playlist[r] || '-')).join(' '));
+  }
+  /** The order the run will cross the rooms in (a chart's acts, from run.js setTrack); null = the dresser's spans. */
+  function setRoute(ids) {
+    music.route = Array.isArray(ids) && ids.length ? ids.slice() : null; music.pos = -1;
+    if (music.route) log('route ' + music.route.join(' > '));
   }
   function reroll() { music.playlist = rollPlaylist(makeRng(((music.seed | 0) ^ 0xa11d10) >>> 0), music.order || Object.keys(ROOM_POOLS), ROOM_POOLS, music.dead); }
   function update(dt, l) {
@@ -597,7 +653,7 @@ export function createRaceAudio({ bridge, hud, settings = {}, input } = {}) {
     master = null;
   }
 
-  return { sfx, ui, menu: menuMusic, setLevels, update, duck, toggleMute, dispose, _voices: voices, _music: music, _levels: levels, _tracks: tracks };
+  return { sfx, ui, menu: menuMusic, setLevels, setRoute, update, duck, toggleMute, dispose, _voices: voices, _music: music, _levels: levels, _tracks: tracks };
 }
 
 // self-check: node --check is the bar; the pure parts (pitchSemis, chimeFor, pickVoiceToDrop)

--- a/ConditioningControlPanel/Resources/web/dtrh/race/bubbles.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/bubbles.js
@@ -17,15 +17,15 @@ import * as THREE from 'three';
 import { CEILING_H, POP_HIT_D, POP_HIT_X, POP_HIT_H, LANE_H, LANE_X_MAX, TREATS_ONLY_SEC } from './consts.js';
 import { BUBBLE_KINDS, KIND_BY_ID, rollKind } from './bubbleKinds.js';
 import { CRISP_LAYER } from './pixel.js';
+import { Q } from '../shared/quality.js';
 
 export { BUBBLE_KINDS };
 
 
-const CAP = 160;              // live bubbles, recycled farthest-first when full
-const SHARD_CAP = 64;
+// CAP (live bubbles, recycled farthest-first when full), SHARD_CAP and VIEW_AHEAD (sprites beyond this are
+// hidden, not freed: every visible sprite is a draw call, and past ~80 m the world has folded into fog anyway)
+// are shared/quality.js knobs read when the field is built: desktop 160 / 64 / 110, the mobile tier 100 / 32 / 76.
 const LANE_STEP = 3.2;        // metres between bubbles in a lane line
-const VIEW_AHEAD = 110;       // sprites beyond this are hidden, not freed (every visible sprite is a draw call,
-                              // and past ~80 m the world has folded into fog anyway)
 const MISS_BEHIND = 6;        // a treat this far behind the kart unpopped = miss
 const DROP_BEHIND = 12;       // freed once this far behind
 const PASS_FADE_M = 1.6;      // metres behind the pop box over which a passed bubble fades away (before it balloons into the seat)
@@ -80,6 +80,7 @@ export function createBubbleField({ scene, layout, media, getIntensity, getRoom,
   }
 
   // ---- pools ---------------------------------------------------------------
+  const CAP = Q.bubbleCap || 160, SHARD_CAP = Q.bubbleShards || 64, VIEW_AHEAD = Q.bubbleViewAhead || 110;
   const group = new THREE.Group();
   group.name = 'race-bubbles';
   scene.add(group);

--- a/ConditioningControlPanel/Resources/web/dtrh/race/emi.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/emi.js
@@ -22,6 +22,7 @@ import * as THREE from 'three';
 import { loadPack, setFace as packSetFace, preparePixel, flattenRig, faceFrames, atlasScale, forceAtlasSampler } from './gltf.js';
 import { createPoseLayer } from './emiPoses.js';
 import { SAUCER_R } from './consts.js';
+import { Q } from '../shared/quality.js';
 
 const PINK = 0xff69b4, GOLD = 0xF2C14E, PALE = 0xB3C7FF, PORCELAIN = 0xF6E7C8;
 const BREATH_SEC = 3.9;      // the one breath on screen (Law III)
@@ -215,6 +216,9 @@ export function createEmiRig({ scene, reducedMotion = false, pixel = null }) {
   const bead = new THREE.Mesh(new THREE.SphereGeometry(0.055, 12, 10), beadMat); bead.position.y = KINK_L + 0.01; kink.add(bead);
   const beadLight = new THREE.PointLight(PINK, 0.5, 2); bead.add(beadLight);
   const cupLight = new THREE.PointLight(PINK, 1.4, 14); cupLight.position.y = 1.2; group.add(cupLight);
+  // Q.leanLights (mobile): the screen and bead points stay in the rig (the glb mount moves them) but
+  // invisible, which three.js counts as absent; this cupLight is the one point light that tier keeps
+  screenLight.visible = beadLight.visible = !Q.leanLights;
 
   // ---- sweat (pale blue drops) and drift sparks, both world-space pools ----
   const sweat = makePool(SWEAT_N, new THREE.SphereGeometry(0.04, 8, 6), new THREE.MeshBasicMaterial({ color: 0xCFF6FF }));

--- a/ConditioningControlPanel/Resources/web/dtrh/race/rooms.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/rooms.js
@@ -23,6 +23,7 @@
 
 import * as THREE from 'three';
 import { makeRng, CAM_BACK, KERB_INNER_W, KERB_OUTER_W } from './consts.js';
+import { Q } from '../shared/quality.js';
 import { biomeById } from '../game/biomes.js';
 import { createRoomProps, pixelTex } from './roomProps.js';
 import { propPack, packGeo, geoSize } from './propPack.js';
@@ -524,6 +525,7 @@ ${sh.fragmentShader}`.replace('#include <emissivemap_fragment>', `#include <emis
   // ---- light so the Lambert props read (the tunnel shader ignores lights) ---------
   const hemi = new THREE.HemisphereLight(0xffd6ee, 0x1a1a2e, 1.1);
   const sun = new THREE.DirectionalLight(0xf6e7c8, 0.6); sun.position.set(0.3, 1, 0.2);
+  sun.visible = !Q.leanLights;   // an invisible light is not counted: the lit shaders compile one light shorter
   group.add(hemi, sun);
   scene.add(group);
 

--- a/ConditioningControlPanel/Resources/web/dtrh/race/run.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/run.js
@@ -41,6 +41,7 @@ import { Q } from '../shared/quality.js';
 import { createTunnel, FOG_DENSITY } from '../engine/tunnel.js';
 import { createFx } from '../engine/fx.js';
 import { createPayloadFx } from '../game/payloadFx.js';
+import { setBundledSpiralPool, prefetchSpirals, LEAN_SPIRALS } from '../engine/loomSpirals.js';
 import { createScreenShake } from '../game/screenShake.js';
 import { INTENSITY_RAMP_SEC, TREATS_ONLY_SEC, KART_BASE_SPEED, MULT_LADDER, makeRng } from './consts.js';
 import { createSpine } from './spine.js';
@@ -120,6 +121,11 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
   const hud = createRaceHud(hudRoot);
   const fxProxy = { pulseFlash: (a) => { if (W) W.fx.pulseFlash(a); } };   // fx is rebuilt on "again"
   const payloadFx = createPayloadFx({ hud: sfHud, fx: fxProxy, media });
+  // Q.leanSpirals (mobile): spiral pops draw from the two lightest bundled gifs, fetched while the intro plays
+  // (warmFx) rather than 2-5 MB mid-lap; the desktop pool and the Loom's own spirals are untouched
+  setBundledSpiralPool(Q.leanSpirals ? LEAN_SPIRALS : null);
+  let fxWarm = false;
+  function warmFx() { if (fxWarm || !Q.leanSpirals) return; fxWarm = true; prefetchSpirals(LEAN_SPIRALS); }
   const lane = createMediaLane(sfHud);   // re-homes payload cards off the road
   const shake = createScreenShake({ el: root });
   if (reducedMotion) shake.setEnabled(false);
@@ -602,6 +608,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
    *  frame pays for it; the renderer compiles the world's programs in the same breath. A no-op once built. */
   function prepare() {
     if (S.disposed || W) return;
+    warmFx();
     W = build(S.seed);
     try { renderer.compile(scene, camera); } catch (e) { /* a warm-up only: the first frame compiles what this missed */ }
   }
@@ -627,7 +634,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
 
   function start() {
     if (S.started || S.disposed) return;
-    if (!W) W = build(S.seed);
+    if (!W) { warmFx(); W = build(S.seed); }   // ?autostart=1 skipped prepare(): the warm-up rides the first seconds
     S.started = true; S.running = true; S.ended = false;
     input.flush();          // a space that closed the last introduction card is not a jump on frame one
     S.bestAtStart = W.score.state.best;

--- a/ConditioningControlPanel/Resources/web/dtrh/race/run.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/run.js
@@ -96,8 +96,12 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
   scene.background = new THREE.Color(0x12261f);
   scene.fog = new THREE.FogExp2(0x12261f, FOG_DENSITY);
   const camera = new THREE.PerspectiveCamera(FOV_BASE, 1, 0.1, 400);
+  // Q.leanLights (mobile): the dresser's sun, EMI's screen / bead points and this cupLight are hidden
+  // (three.js does not count an invisible light); the ambient, the dresser's hemisphere (the pink sky the
+  // props and the cup are painted for) and EMI's own cupLight are that tier's whole light bill
   scene.add(new THREE.AmbientLight(0x8a70a8, 1.0));
   const cupLight = new THREE.PointLight(0xff69b4, 1.4, 14);
+  cupLight.visible = !Q.leanLights;
   scene.add(cupLight);
   // the vertical fov this window shape needs to hold FOV_BASE's 16:9 width of road; the per-frame
   // kick rides on top of it, and a resize slides S.fov by the same delta so the kick survives a flip

--- a/ConditioningControlPanel/Resources/web/dtrh/race/run.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/run.js
@@ -24,6 +24,11 @@
  * curve and the acts; race/cues.js says what each spoken word is worth; everything
  * below only spends those on the world it already owns. Without a track not one
  * line of this changes: the seeded run is the else branch throughout.
+ *
+ * PERF (raceBoot `?perf=1`): `race.perf()` is one snapshot of the last frame,
+ * summed over the pixelizer's passes: draw calls, triangles, the programs the
+ * renderer holds, live geometries / textures, the biggest texture edge in the
+ * run scene, resident <audio> elements and the governor's device pixel ratio.
  * ==========================================================================*/
 
 import * as THREE from 'three';
@@ -655,8 +660,29 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
   resetRunState(seed);
   raf = requestAnimationFrame(frame);
   function setCameraOverride(fn) { camOverride = typeof fn === 'function' ? fn : null; }
+  /** One perf snapshot (the `?perf=1` aid). Never throws: a missing counter reads as -1. */
+  function perf() {
+    const info = renderer.info || {}, mem = info.memory || {}, st = pixel.stats || {};
+    let texMax = 0;
+    try {
+      scene.traverse((o) => {
+        const mats = Array.isArray(o.material) ? o.material : o.material ? [o.material] : [];
+        for (const m of mats) for (const k of ['map', 'emissiveMap', 'alphaMap']) {
+          const im = m[k] && m[k].image;
+          if (im && im.width) texMax = Math.max(texMax, im.width, im.height || 0);
+        }
+      });
+    } catch (e) { texMax = -1; }
+    return {
+      calls: st.calls == null ? -1 : st.calls, triangles: st.triangles == null ? -1 : st.triangles, passes: st.passes || 0,
+      frameMs: st.frameMs || 0, programs: info.programs ? info.programs.length : -1,
+      geometries: mem.geometries == null ? -1 : mem.geometries, textures: mem.textures == null ? -1 : mem.textures, texMax,
+      audio: audio._tracks ? audio._tracks.size : -1, dpr: renderer.getPixelRatio(), block: pixel.block,
+      world: !!W, stage: !!stage, running: S.running, bubbles: W ? W.field.liveCount : 0,
+    };
+  }
   function setStage(s) { stage = s && typeof s.update === 'function' ? s : null; if (!stage) pixel.retexture(scene); }   // the menu may have changed the block
-  return { start, setPaused, dispose, setCameraOverride, setStage, reseed, renderer, pixel, audio, hud, camera,
+  return { start, setPaused, dispose, setCameraOverride, setStage, reseed, renderer, pixel, audio, hud, camera, perf,
     // track charts (CHART.md): setTrack before start(), replaceTrack for the words pass landing live,
     // trackClock for the host's 250 ms tick, trackEnded when the file runs out at the host's end
     setTrack, replaceTrack: (chart) => TR.replace(chart), trackClock: (t, playing) => TR.clock(t, playing),

--- a/ConditioningControlPanel/Resources/web/dtrh/race/run.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/run.js
@@ -29,6 +29,11 @@
  * summed over the pixelizer's passes: draw calls, triangles, the programs the
  * renderer holds, live geometries / textures, the biggest texture edge in the
  * run scene, resident <audio> elements and the governor's device pixel ratio.
+ * The world is NOT built under the menu: `prepare()` (raceBoot calls it once
+ * "race" is pressed, before the intro) or the first `start()` builds it, and
+ * `reseed` under the menu only resets the run state. The menu never pays for
+ * the tunnel, the props' glb or the bubble textures, and the run's first frame
+ * does not compile the world's programs: prepare() warms them.
  * ==========================================================================*/
 
 import * as THREE from 'three';
@@ -583,8 +588,16 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     if (S.disposed) return;
     if (pick === 'again') again(); else exit();
   }
-  /** Rebuild the world on a new seed (again, or the menu changing the seed rule). settings.seedLock pins again to one track. */
-  function reseed(runSeed) { teardown(); resetRunState(runSeed); W = build(runSeed); S.started = false; }
+  /** Rebuild the world on a new seed (again, or the menu changing the seed rule). settings.seedLock pins again to one track.
+   *  A world that was never built (the menu changing the rule before "race") stays unbuilt: prepare() / start() own that. */
+  function reseed(runSeed) { const had = !!W; teardown(); resetRunState(runSeed); if (had) W = build(runSeed); S.started = false; }
+  /** Build the world now (after "race" is pressed, before the intro) so neither the menu nor the run's first
+   *  frame pays for it; the renderer compiles the world's programs in the same breath. A no-op once built. */
+  function prepare() {
+    if (S.disposed || W) return;
+    W = build(S.seed);
+    try { renderer.compile(scene, camera); } catch (e) { /* a warm-up only: the first frame compiles what this missed */ }
+  }
   function again() {
     reseed(settings.seedLock != null ? settings.seedLock >>> 0 : (Date.now() ^ Math.floor(Math.random() * 0x7fffffff)) >>> 0);
     setCameraOverride(preRollCamera());   // again skips the intro: the chase seat, then 3 2 1
@@ -656,8 +669,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     return true;
   }
 
-  W = build(seed);
-  resetRunState(seed);
+  resetRunState(seed);          // the world waits for prepare() / start(): frame() draws the stage until then
   raf = requestAnimationFrame(frame);
   function setCameraOverride(fn) { camOverride = typeof fn === 'function' ? fn : null; }
   /** One perf snapshot (the `?perf=1` aid). Never throws: a missing counter reads as -1. */
@@ -682,7 +694,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     };
   }
   function setStage(s) { stage = s && typeof s.update === 'function' ? s : null; if (!stage) pixel.retexture(scene); }   // the menu may have changed the block
-  return { start, setPaused, dispose, setCameraOverride, setStage, reseed, renderer, pixel, audio, hud, camera, perf,
+  return { start, prepare, setPaused, dispose, setCameraOverride, setStage, reseed, renderer, pixel, audio, hud, camera, perf,
     // track charts (CHART.md): setTrack before start(), replaceTrack for the words pass landing live,
     // trackClock for the host's 250 ms tick, trackEnded when the file runs out at the host's end
     setTrack, replaceTrack: (chart) => TR.replace(chart), trackClock: (t, playing) => TR.clock(t, playing),

--- a/ConditioningControlPanel/Resources/web/dtrh/race/run.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/run.js
@@ -372,8 +372,11 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     trackSend('track-pause', { on: !!on });
   }
   /** Load a chart (null goes back to the seeded run). Call before start(), or live for an upgrade. */
+  // a chart's acts decide the room order at every gate (step: ts.act.room); the music prefetches by that route
+  const routeOf = (t) => { const acts = t && t.chart && Array.isArray(t.chart.acts) ? t.chart.acts : null; return acts ? acts.map((a) => a.room).filter((r, i, arr) => r && r !== arr[i - 1]) : null; };
   function setTrack(chart) {
     const t = TR.setTrack(chart);
+    audio.setRoute(routeOf(t));
     S.trackHold = 0; S.statsAt = 0;
     if (W) { W.field.setTracked(!!t); W.field.setDensity(1); if (!t) applyFog(W, 0); }
     audio.duck(!!t, 'track');   // the file is the soundtrack: the room OST sits under it until it is cleared
@@ -701,7 +704,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
   return { start, prepare, setPaused, dispose, setCameraOverride, setStage, reseed, renderer, pixel, audio, hud, camera, perf,
     // track charts (CHART.md): setTrack before start(), replaceTrack for the words pass landing live,
     // trackClock for the host's 250 ms tick, trackEnded when the file runs out at the host's end
-    setTrack, replaceTrack: (chart) => TR.replace(chart), trackClock: (t, playing) => TR.clock(t, playing),
+    setTrack, replaceTrack: (chart) => { TR.replace(chart); audio.setRoute(routeOf(TR.track)); }, trackClock: (t, playing) => TR.clock(t, playing),
     trackEnded: () => { TR.end(); if (TR.track && S.running) endRun(); }, trackStats: () => TR.stats(), debugItemBox,
     get track() { return TR.track; } };
 }

--- a/ConditioningControlPanel/Resources/web/dtrh/race/smoke/ost-resident-check.mjs
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/smoke/ost-resident-check.mjs
@@ -1,0 +1,54 @@
+/* ============================================================================
+ * race/smoke/ost-resident-check.mjs - node self-check for the resident-music rule in race/audio.js.
+ *
+ *   node race/smoke/ost-resident-check.mjs      (exits 0 on pass, 1 with a count of failures)
+ *
+ * residentTracks(playlist, order, roomId) names the <audio> elements the player keeps once a room
+ * plays: that room's track and the next room's (the lap wraps). Everything else is released after
+ * its crossfade. This walks a rolled playlist through a whole lap and the menu pseudo-room.
+ * ==========================================================================*/
+
+import { residentTracks, rollPlaylist, ROOM_POOLS, MENU_TRACK, MENU_ROOM } from '../audio.js';
+
+let fails = 0;
+const ok = (cond, what) => { if (!cond) { console.error('FAIL ' + what); fails++; } else console.log('  ok  ' + what); };
+
+const order = Object.keys(ROOM_POOLS);
+let s = 12345;
+const rng = () => { s = (s * 1664525 + 1013904223) >>> 0; return s / 4294967296; };
+const playlist = rollPlaylist(rng, order, ROOM_POOLS);
+
+/* ---- 1. a whole lap: never more than two, always the room's own and the next room's ---- */
+{
+  let maxKeep = 0;
+  for (let i = 0; i < order.length; i++) {
+    const room = order[i], next = order[(i + 1) % order.length];
+    const keep = residentTracks(playlist, order, room);
+    maxKeep = Math.max(maxKeep, keep.size);
+    ok(keep.has(playlist[room]), `${room}: keeps its own track ${playlist[room]}`);
+    ok(keep.has(playlist[next]), `${room}: keeps the next room's (${next}: ${playlist[next]})`);
+  }
+  ok(maxKeep <= 2, `at most two resident over the lap (saw ${maxKeep})`);
+  const last = order[order.length - 1];
+  ok(residentTracks(playlist, order, last).has(playlist[order[0]]), 'the last room prefetches the first: the lap wraps');
+}
+
+/* ---- 2. the menu and the odd cases ---- */
+{
+  const menuList = { [MENU_ROOM]: MENU_TRACK };
+  const keep = residentTracks(menuList, order, MENU_ROOM);
+  ok(keep.size === 1 && keep.has(MENU_TRACK), 'under the menu only the theme is resident: nothing is prefetched before race');
+  ok(residentTracks(playlist, order, null).size === 0, 'no room, nothing kept');
+  ok(residentTracks(null, order, order[0]).size === 0, 'no playlist, nothing kept (and no throw)');
+  ok(residentTracks(playlist, undefined, order[0]).size === 1, 'no order yet (before attach): just the room\'s own');
+  const dup = { a: 'ost_sort', b: 'ost_sort' };
+  ok(residentTracks(dup, ['a', 'b'], 'a').size === 1, 'the same track twice in a row is one element, not two');
+  const gap = { a: 'ost_sort', c: 'ost_prizes' };
+  ok(residentTracks(gap, ['a', 'b', 'c'], 'a').size === 1, 'a room with no track (all dead) prefetches nothing');
+  const twice = { a: 'ost_sort', b: 'ost_prizes', c: 'ost_records' };
+  ok(residentTracks(twice, ['a', 'b', 'a', 'c'], 'a', 2).has('ost_records'), 'a route that repeats a room: the position names the right neighbour');
+  ok(residentTracks(twice, ['a', 'b', 'a', 'c'], 'a', 1).has('ost_prizes'), 'and a position that does not match the room falls back to the first visit');
+}
+
+if (fails) { console.error(`\nost-resident-check: ${fails} failure(s)`); process.exit(1); }
+console.log('\nost-resident-check: all good');

--- a/ConditioningControlPanel/Resources/web/dtrh/race/smoke/spiral-pool-check.mjs
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/smoke/spiral-pool-check.mjs
@@ -1,0 +1,46 @@
+/* ============================================================================
+ * race/smoke/spiral-pool-check.mjs - node self-check for the bundled spiral pool switch in
+ * engine/loomSpirals.js (the race narrows it to LEAN_SPIRALS on the mobile tier).
+ *
+ *   node race/smoke/spiral-pool-check.mjs      (exits 0 on pass, 1 with a count of failures)
+ * ==========================================================================*/
+
+import {
+  BUNDLED_SPIRALS, LEAN_SPIRALS, setBundledSpiralPool, getBundledSpiralPool, prefetchSpirals, pickSpiralUrl, setLoomSpirals,
+} from '../../engine/loomSpirals.js';
+
+let fails = 0;
+const ok = (cond, what) => { if (!cond) { console.error('FAIL ' + what); fails++; } else console.log('  ok  ' + what); };
+
+ok(getBundledSpiralPool() === BUNDLED_SPIRALS, 'the pool starts as the whole bundled set (desktop, the Descent)');
+ok(LEAN_SPIRALS.length === 2 && LEAN_SPIRALS.every((u) => BUNDLED_SPIRALS.includes(u)), 'LEAN_SPIRALS is two of the bundled urls');
+ok(LEAN_SPIRALS.every((u) => /sp[67]\.gif$/.test(u)), 'and they are sp6 + sp7, the two lightest files');
+
+setLoomSpirals([]);
+{
+  const seen = new Set();
+  for (let i = 0; i < 400; i++) seen.add(pickSpiralUrl());
+  ok(seen.size === BUNDLED_SPIRALS.length, `the full pool draws every bundled spiral (${seen.size} of ${BUNDLED_SPIRALS.length})`);
+}
+setBundledSpiralPool(LEAN_SPIRALS);
+{
+  const seen = new Set();
+  for (let i = 0; i < 400; i++) seen.add(pickSpiralUrl());
+  ok(seen.size === 2 && [...seen].every((u) => LEAN_SPIRALS.includes(u)), 'the lean pool draws only sp6 + sp7');
+  ok(getBundledSpiralPool() !== LEAN_SPIRALS && getBundledSpiralPool().length === 2, 'the setter copies the list');
+}
+setLoomSpirals([{ slug: 'mine', url: 'ccp.spirals://mine.gif' }]);
+{
+  let loom = 0;
+  for (let i = 0; i < 400; i++) if (pickSpiralUrl() === 'ccp.spirals://mine.gif') loom++;
+  ok(loom > 100 && loom < 300, `the Loom's own spirals still mix in about half the time (${loom} of 400)`);
+}
+setLoomSpirals([]);
+setBundledSpiralPool(null);
+ok(getBundledSpiralPool() === BUNDLED_SPIRALS, 'null restores the whole set');
+setBundledSpiralPool([]);
+ok(getBundledSpiralPool() === BUNDLED_SPIRALS, 'so does an empty list');
+ok(Array.isArray(prefetchSpirals(LEAN_SPIRALS)) && prefetchSpirals(LEAN_SPIRALS).length === 0, 'prefetch asks for nothing without a DOM and never throws');
+
+if (fails) { console.error(`\nspiral-pool-check: ${fails} failure(s)`); process.exit(1); }
+console.log('\nspiral-pool-check: all good');

--- a/ConditioningControlPanel/Resources/web/dtrh/raceBoot.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/raceBoot.js
@@ -391,6 +391,7 @@ async function startRun(withIntro) {
   hideSplash();
   try {
     if (menu) { menu.hide(); menu.seedCheck(); }
+    if (race.prepare) race.prepare();   // the world is built here, not under the menu (race/CONTRACT.md); the intro's clock starts after
     // the menu theme keeps playing: the run's first room crossfades over it (race/AUDIO.md)
     try { if (race.audio && race.audio.menu) race.audio.menu(false); } catch (e) { /* audio gone */ }
     if (menu && withIntro && params.get('intro') !== '0') {

--- a/ConditioningControlPanel/Resources/web/dtrh/raceBoot.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/raceBoot.js
@@ -55,6 +55,16 @@
  * cross-origin `?back=` or referrer is ignored: this never becomes an open
  * redirect.
  *
+ * PERF AIDS: `?tier=mobile` / `?tier=desktop` overrides the quality tier
+ * capability.js detected (headless Chrome reads as a coarse pointer, so it
+ * lands on mobile at any window size; this pins either tier). `?perf=1` logs
+ * one `[race-perf]` line every 2 s: draw calls + triangles summed over the
+ * pixelizer's passes, programs, live geometries / textures, the biggest
+ * texture edge in the run scene, the JS heap (Chrome only), resident <audio>
+ * elements, the governor's device pixel ratio, the pixel block, whether the
+ * world is built and which of stage / run is drawing. Read the numbers off
+ * the console (standalone) or the host log.
+ *
  * TRACK CHARTS (CHART.md): the host posts track-progress / track-chart /
  * track-clock / track-ended / track-error and this file hands them to the run.
  * With no host - or under one that says `trackPick: false`, which is the browser
@@ -66,10 +76,10 @@
 
 import * as bridge from './bridge.js';
 import { detectMode } from './shared/capability.js';
-import { setQuality } from './shared/quality.js';
+import { setQuality, Q } from './shared/quality.js';
 import { createHostMediaSource } from './hostMedia.js';
 
-const INIT_TIMEOUT_MS = 4000, SPLASH_MS = 1000, TRACK_TICK_MS = 250;
+const INIT_TIMEOUT_MS = 4000, SPLASH_MS = 1000, TRACK_TICK_MS = 250, PERF_LOG_MS = 2000;
 const params = new URLSearchParams(location.search);
 const hosted = bridge.isHosted;
 /**
@@ -134,10 +144,11 @@ window.addEventListener('unhandledrejection', (e) => {
 // motion down inside the 3D scene instead of showing a boot error. Only a real
 // hard wall - no WebGL, no import maps - still fails.
 const mode = detectMode({ reducedIs3d: true });
+const tierParam = params.get('tier');
 if (mode.hardBlock || !mode.canTry3d) {
   fail('no webgl here: ' + (mode.reason || mode.mode));
 } else {
-  setQuality(mode.tier);
+  setQuality(tierParam === 'mobile' || tierParam === 'desktop' ? tierParam : mode.tier);
 }
 
 // ---- host wiring ----
@@ -234,7 +245,8 @@ async function boot() {
     // the persisted option sliders, before the first frame: the menu theme comes up at the right level
     try { if (race.audio && race.audio.setLevels) race.audio.setLevels({ music: opts.music, sfx: opts.sfx }); } catch (e) { host.log('levels: ' + e); }
     note('');
-    host.log(`race booted: seed ${seed} (${opts.seed}), tier ${mode.tier}, hosted ${hosted}, manifest ${haveManifest}`);
+    host.log(`race booted: seed ${seed} (${opts.seed}), tier ${Q.tier}${tierParam ? ' (?tier)' : ''}, hosted ${hosted}, manifest ${haveManifest}`);
+    if (params.get('perf') === '1') perfLog();
     await standaloneTrack();
     if (params.get('autostart') === '1') { startRun(false); debugItemBox(); return; }
     if (hudRoot) hudRoot.classList.add('is-lobby');   // the run's chrome stays out of the menu and the intro
@@ -315,6 +327,20 @@ function stopTrackClock() {
   if (trackAudio) { try { trackAudio.pause(); } catch (e) { /* already gone */ } }
 }
 
+/** `?perf=1`: one `[race-perf]` line every PERF_LOG_MS with the counters in the header. */
+function perfLog() {
+  const t0 = performance.now();
+  const tick = () => {
+    if (exiting || !race || !race.perf) return;
+    let p;
+    try { p = race.perf(); } catch (e) { host.log('perf: ' + e); return; }
+    const heap = (performance.memory && performance.memory.usedJSHeapSize) ? (performance.memory.usedJSHeapSize / 1048576).toFixed(1) + 'MB' : 'n/a';
+    host.log(`[race-perf] t+${((performance.now() - t0) / 1000).toFixed(0)}s calls ${p.calls} tris ${p.triangles} passes ${p.passes} frame ${p.frameMs.toFixed(1)}ms`
+      + ` progs ${p.programs} geos ${p.geometries} texs ${p.textures} texMax ${p.texMax} heap ${heap} audio ${p.audio} dpr ${p.dpr.toFixed(2)} block ${p.block}`
+      + ` bubbles ${p.bubbles} ${p.world ? 'world' : 'no-world'} ${p.stage ? 'stage' : p.running ? 'run' : 'idle'} tier ${Q.tier}`);
+  };
+  setInterval(tick, PERF_LOG_MS);
+}
 /** `?itembox=<ms>`: the screenshot aid. Waits for the run, then retries until a cube is in range. */
 function debugItemBox() {
   const at = Number(params.get('itembox'));

--- a/ConditioningControlPanel/Resources/web/dtrh/shared/quality.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/shared/quality.js
@@ -29,6 +29,7 @@ export const Q = {
   bubbleCap: 160,        // race: live bubble sprites (each visible one is a draw call on the crisp layer)
   bubbleShards: 64,      // race: pop shard sprites
   bubbleViewAhead: 110,  // race: metres ahead beyond which a live sprite is hidden (fog has eaten it by ~80 m)
+  leanSpirals: false,    // race: draw spiral pops from the two lightest bundled gifs, prefetched before the run
 };
 
 export function setQuality(tier) {
@@ -54,5 +55,6 @@ export function setQuality(tier) {
     bubbleCap: 100,      // the run holds 46-93 live on desktop's 160; the pool is 100 sprite materials smaller
     bubbleShards: 32,
     bubbleViewAhead: 76, // what the fog has already folded away is not drawn (a quarter fewer sprite draw calls)
+    leanSpirals: true,   // sp6 + sp7 (0.8 MB together) instead of a 2.2-5.3 MB gif fetched mid-lap
   });
 }

--- a/ConditioningControlPanel/Resources/web/dtrh/shared/quality.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/shared/quality.js
@@ -25,6 +25,7 @@ export const Q = {
   swirlCount: 90,        // orbiting particles per feature card
   veinRadial: 18,        // branch-vein tube radial segments
   deeperRadial: 20,      // Deeper flagship tube radial segments
+  leanLights: false,     // race: 7 lights -> 3 (ambient + the dresser's hemisphere + EMI's cupLight stay)
 };
 
 export function setQuality(tier) {
@@ -46,5 +47,6 @@ export function setQuality(tier) {
     swirlCount: 36,
     veinRadial: 12,
     deeperRadial: 14,
+    leanLights: true,    // 7 lights -> 3: every lit material's fragment loop shrinks with the light count
   });
 }

--- a/ConditioningControlPanel/Resources/web/dtrh/shared/quality.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/shared/quality.js
@@ -26,6 +26,9 @@ export const Q = {
   veinRadial: 18,        // branch-vein tube radial segments
   deeperRadial: 20,      // Deeper flagship tube radial segments
   leanLights: false,     // race: 7 lights -> 3 (ambient + the dresser's hemisphere + EMI's cupLight stay)
+  bubbleCap: 160,        // race: live bubble sprites (each visible one is a draw call on the crisp layer)
+  bubbleShards: 64,      // race: pop shard sprites
+  bubbleViewAhead: 110,  // race: metres ahead beyond which a live sprite is hidden (fog has eaten it by ~80 m)
 };
 
 export function setQuality(tier) {
@@ -48,5 +51,8 @@ export function setQuality(tier) {
     veinRadial: 12,
     deeperRadial: 14,
     leanLights: true,    // 7 lights -> 3: every lit material's fragment loop shrinks with the light count
+    bubbleCap: 100,      // the run holds 46-93 live on desktop's 160; the pool is 100 sprite materials smaller
+    bubbleShards: 32,
+    bubbleViewAhead: 76, // what the fog has already folded away is not drawn (a quarter fewer sprite draw calls)
   });
 }


### PR DESCRIPTION
## what

Phase D, the phone perf pass. Six commits, one per knob, kept separate so any one can be reverted alone; together they are 325 changed lines, so they ride in one PR rather than a six-deep stack. Desktop behaviour is byte-identical (see verification); every change is a mobile-tier knob or a measurement aid.

1. **wp1 measurement aid.** `?perf=1` logs `[race-perf]` counters every 2 s (draw calls, tris, programs, geometries, textures, heap, resident audio); `?tier=mobile|desktop` pins the tier so a run can be measured on a desktop.
2. **wp2 lazy world.** The world is built in `race.prepare()` when race is pressed, not under the menu. The home screen no longer carries the whole track: menu-only load drops from 73 GETs 4.55 MB to 64 GETs 3.89 MB, and the menu heap from 27-29 MB to 16 MB. `scene=intro` builds at prepare() and run-started lands at 10 s with no exceptions.
3. **wp3 lean lights.** 7 lights to 3 on the mobile tier (`Q.leanLights`: ambient, hemisphere, EMI's cup light). Calls and tris are unchanged as expected; the win is per-pixel shader time, which only a real GPU shows. The cup rim keeps its pink; EMI's screen glow is a touch dimmer.
4. **wp4 bubble budget.** Bubble pools 160/64 to 100/32 and the hide-ahead distance 110 m to 76 m as tier knobs (`Q.bubbleCap`, `Q.bubbleShards`, `Q.bubbleViewAhead`). About 4 draw calls a frame; the sprites past 76 m were few.
5. **wp5 OST resident.** Two OST elements stay resident, the current room and the next (`audio.setRoute`, parked resume). Before, every room's element was kept for the lap (4 resident by the fourth gate); now the max is 2, with 3 only inside the 1.5 s crossfade. No lower-bitrate OST exists so nothing is swapped; this is memory, not bytes.
6. **wp6 lean spirals.** Spiral pops on a phone draw from the two light gifs (sp6 + sp7), fetched before the run starts, instead of random pops pulling 2-5 MB gifs mid-run. A 150 s run drops from 82 GETs 22.35 MB to 79 GETs 11.22 MB.

## verification

Headless Chrome over CDP in real time (swiftshader, so frame ms is not a phone number; draw calls, tris, programs, geometries, textures, resident audio and network bytes are exact). Full tables in the session's PERF.md.

- Desktop determinism shots at 1280x720, 300 frames from run-started, versus the wp1 baseline: wp2 through wp6 all differ by exactly the 0.841% noise floor (the same 7747 pixels every pass; two passes of the same code differ by 0.835%). Desktop is unchanged.
- Mobile 390x844 shot wp3 vs pre-wp3 differs 4.697% (the lighting change), wp4 vs wp3 identical.
- All 10 `race/smoke/*.mjs` pass on the stack rebased onto main 12b208474 (two new: `ost-resident-check`, `spiral-pool-check`).
- 150 s three-gate runs at the mobile tier, same seed: route `teagarden > undertow > toybox > chapel > mirrors > greyward > coronation`, releases follow the route, each mp3 fetched once.

## not verified

No real phone. The shader-time win of wp3 and the real frame rate are only visible on a GPU. The rebase onto main (after #893 to #897) was conflict-free and the smokes pass, but the perf numbers were measured on the pre-wave tree at 59323e5e4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0166ij3Q8xyseVkhWajzkWG3
