### PR TITLE
fix(race): EMI's wave arm no longer stretches, strip the shoulder scale track at load

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/race/gltf.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/gltf.js
@@ -27,6 +27,7 @@
  *   flattenRig(root, animations, { keep })   one draw per pivot + material
  *   preparePixel(model, pixel)
  *   disposePack(url)
+ *   stripBoneScaleTracks(animations)         drops the scale tracks a bone may never have
  *
  * COLOUR SPACE. roomProps voxel() writes Color.setHex(hex).r/g/b into its
  * `color` attribute, and setHex decodes sRGB into the linear working space, so
@@ -51,6 +52,35 @@ const FACE_ATLAS = 'emi-faces.png';
 const GLASS = 'EMI_glass';
 const OUTLINE = 'outline';                 // material name: inverted hull, never re-wound
 const MAP_KEYS = ['map', 'emissiveMap', 'alphaMap', 'normalMap', 'roughnessMap', 'metalnessMap', 'aoMap'];
+
+/**
+ * Bones no clip may ever scale. A shoulder is a HINGE: the arm under it (armR, handR, thumbR,
+ * shoulder_capR) turns, it never grows. emi.glb's `wave` export bakes a y scale on shoulderR that
+ * runs up to 2.12, which stretches that whole arm to twice its length and out of the case for the
+ * length of the wave (the desktop build shows the same stretch, and every other clip holds both
+ * shoulders at 1). The glb belongs to the Blender pipeline, so the fix is here: the scale track is
+ * dropped at load and the bone sits at its rest scale of 1 while the rotation does the wave.
+ */
+export const NO_SCALE_BONES = ['shoulderL', 'shoulderR'];
+
+/**
+ * Drop every `.scale` track aimed at one of `bones` from every clip, in place. Rotation and
+ * translation are left alone: only the scale is the export mistake. Returns how many tracks went.
+ */
+export function stripBoneScaleTracks(animations, bones = NO_SCALE_BONES) {
+  const want = new Set(bones.map((b) => THREE.PropertyBinding.sanitizeNodeName(b)));
+  let dropped = 0;
+  for (const clip of animations || []) {
+    if (!clip || !Array.isArray(clip.tracks)) continue;
+    clip.tracks = clip.tracks.filter((t) => {
+      const parsed = t && t.name ? THREE.PropertyBinding.parseTrackName(t.name) : null;
+      const hit = parsed && parsed.propertyName === 'scale' && want.has(parsed.nodeName);
+      if (hit) dropped++;
+      return !hit;
+    });
+  }
+  return dropped;
+}
 
 const _cache = new Map();                  // url -> { promise, pack }
 const _mat = new THREE.Matrix4();
@@ -91,6 +121,7 @@ export function loadPack(url, { log } = {}) {
 export function makePack(gltf, url = '') {
   const scene = gltf.scene || (gltf.scenes && gltf.scenes[0]) || new THREE.Group();
   const animations = gltf.animations || [];
+  stripBoneScaleTracks(animations);       // one choke point: every pack, every clip, every caller
   const index = new Map();
   let nodes = 0, tris = 0;
   scene.traverse((o) => {

--- a/ConditioningControlPanel/Resources/web/dtrh/race/menu.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/menu.js
@@ -41,8 +41,11 @@
  * no one-shots, no flashes, no crossfade pops.
  *
  * Screenshot aid: `?face=N` pins the stage face at atlas frame N, so one frame
- * can be shot on its own while the clips keep running. `?panel=howto` (and
- * `?panel=options`) opens the menu on that panel, the way `?card=N` opens a card.
+ * can be shot on its own while the clips keep running. `?clip=NAME` pins one
+ * clip (wave / hop / peek / drum) on loop instead of the random 3..6 s beat, so
+ * a one-shot pose can be shot without waiting for it to come round (the flash
+ * idle show stands down with it, so nothing turns her mid-pose). `?panel=howto`
+ * (and `?panel=options`) opens the menu on that panel, the way `?card=N` opens a card.
  *
  * Props: race/assets/props.glb (podium, kart_cup, kart_saucer, floor_tile)
  * dresses the stage when it resolves; otherwise the lathe cup from the old
@@ -136,6 +139,15 @@ const FACE_PIN = (() => {
     if (v === null || v === '' || !Number.isFinite(+v)) return -1;
     return clamp(+v | 0, 0, FACES.length - 1);
   } catch (e) { return -1; }              // no location (a node import), no pin
+})();
+/** Screenshot aid: `?clip=NAME` pins one of the roster clips on loop (the random beat and the
+ *  pointer peek both stand down), so a one-shot pose can be shot without waiting for it to come
+ *  round. null = the idle show runs the way it always does. */
+const CLIP_PIN = (() => {
+  try {
+    const v = (new URLSearchParams(location.search).get('clip') || '').toLowerCase();
+    return v && v !== 'idle' ? v : null;
+  } catch (e) { return null; }           // no location (a node import), no pin
 })();
 /** Screenshot aid: `?panel=howto | options | media` opens the menu on that panel instead of the verbs. */
 const PANEL_PIN = (() => {
@@ -339,9 +351,18 @@ export function createStage({ renderer, pixel, reducedMotion = false, log = null
       if (k === 'idle') { a.setLoop(THREE.LoopRepeat, Infinity); a.play(); }
       else { a.setLoop(THREE.LoopOnce, 1); a.clampWhenFinished = true; }
     }
+    // the `?clip=` aid: that one clip loops on its own, over an idle held at weight 0
+    const pinned = CLIP_PIN ? emi.actions[CLIP_PIN] : null;
+    if (pinned && pinned !== emi.actions.idle) {
+      if (emi.actions.idle) emi.actions.idle.setEffectiveWeight(0);
+      pinned.setLoop(THREE.LoopRepeat, Infinity); pinned.clampWhenFinished = false;
+      pinned.reset().setEffectiveWeight(1).play();
+    }
     mixer.addEventListener('finished', (e) => { if (e.action !== emi.actions.idle) settle(e.action); });
-    face(character.faces.idle);
-    flashes.attach(model, pack.animations);
+    face(pinned && character.faces[CLIP_PIN] != null ? character.faces[CLIP_PIN] : character.faces.idle);
+    // a pinned clip is a screenshot, not the idle show: the flashes never arm, so nothing turns her
+    // body or swaps her face out from under the pose being shot
+    if (!pinned) flashes.attach(model, pack.animations);
     for (const cb of emi.ready) { try { cb(model); } catch (err) { /* a listener never breaks the stage */ } }
     emi.ready.length = 0;
     if (log) log(`[menu] ${character.id} on stage: ${Object.keys(emi.actions).join(' ')}`);
@@ -373,14 +394,14 @@ export function createStage({ renderer, pixel, reducedMotion = false, log = null
     if (character.faces[k] != null) face(character.faces[k]);
     return true;
   }
-  function peek() { if (reduced || mode !== 'menu' || emi.busy || t - emi.lastPeek < PEEK_GAP) return; emi.lastPeek = t; play('peek'); }
+  function peek() { if (CLIP_PIN || reduced || mode !== 'menu' || emi.busy || t - emi.lastPeek < PEEK_GAP) return; emi.lastPeek = t; play('peek'); }
   function rippleTea() { ripple.scale.setScalar(1); ripple.material.opacity = 0.9; }
 
   function update(dt) {
     if (flashes.frozen) return;   // the `?freeze` screenshot aid holds the whole stage on one frame
     t += dt;
     if (emi.mixer) emi.mixer.update(dt);
-    if (mode === 'menu' && !reduced && !emi.busy && !flashes.pending && t >= emi.nextAt) play(ONE_SHOTS[Math.floor(Math.random() * ONE_SHOTS.length)]);
+    if (!CLIP_PIN && mode === 'menu' && !reduced && !emi.busy && !flashes.pending && t >= emi.nextAt) play(ONE_SHOTS[Math.floor(Math.random() * ONE_SHOTS.length)]);
     flashCtx.t = t; flashCtx.mode = mode; flashCtx.reduced = reduced; flashCtx.busy = emi.busy;
     flashes.update(dt, flashCtx);   // after the mixer: the antenna offset rides on top of the clip
     sky.offset.x += dt * 0.004;    // scenery drifts; EMI is the one breath (Law III)

--- a/ConditioningControlPanel/Resources/web/dtrh/race/smoke/gltf-smoke.mjs
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/smoke/gltf-smoke.mjs
@@ -14,7 +14,8 @@
  *   3. parses it with GLTFLoader.parse(arrayBuffer, '', onLoad, onError);
  *   4. asserts names(), stats, toInstanceGeometry (vertex count, colours, the
  *      node-relative bake, outline winding), setFace on a hand-built
- *      EMI_glass + DataTexture, preparePixel, and the clip names.
+ *      EMI_glass + DataTexture, preparePixel, the clip names, and the shoulder
+ *      scale filter (hand-built clips, no GLB needed).
  *
  * SHIMS: none. three r169 and GLTFLoader both import clean under node 22+,
  * and the textureless GLB path never reaches createImageBitmap, ImageBitmap-
@@ -36,7 +37,7 @@ registerHooks({
 });
 
 const THREE = await import('three');
-const { makePack, toInstanceGeometry, setFace, preparePixel, flattenRig, disposePack, FACES, faceFrames, atlasScale, forceAtlasSampler } = await import('../gltf.js');
+const { makePack, toInstanceGeometry, setFace, preparePixel, flattenRig, disposePack, FACES, faceFrames, atlasScale, forceAtlasSampler, stripBoneScaleTracks, NO_SCALE_BONES } = await import('../gltf.js');
 const { GLTFLoader } = await import('three/addons/loaders/GLTFLoader.js');
 
 // ---- the tiny assert kit ----------------------------------------------------------------
@@ -150,6 +151,33 @@ ok(pack.clone('nope_not_here') === null, 'clone() returns null for a miss');
 // ---- animations --------------------------------------------------------------------------
 ok(pack.animations.length === 1 && pack.animations[0].name === 'idle', 'animations carry the clip names');
 ok(near(pack.animations[0].duration, 1), 'the clip is 1 second');
+
+// ---- the shoulder scale filter -------------------------------------------------------------
+// emi.glb's `wave` bakes a y scale up to 2.12 on shoulderR, which stretches the whole arm hanging
+// under it. A shoulder is a hinge and its rest scale is 1, so makePack drops those tracks at load.
+// Rotation and translation stay: the wave itself is the rotation.
+{
+  const wave = new THREE.AnimationClip('wave', 1, [
+    new THREE.VectorKeyframeTrack('shoulderR.scale', [0, 1], [1, 1, 1, 1, 2.12, 1]),
+    new THREE.VectorKeyframeTrack('shoulderR.position', [0, 1], [0.39, 0.49, -0.03, 0.39, 0.594, -0.03]),
+    new THREE.QuaternionKeyframeTrack('shoulderR.quaternion', [0, 1], [0, 0, 0, 1, 0, 0, 0.38, 0.92]),
+    new THREE.VectorKeyframeTrack('shoulderL.scale', [0, 1], [1, 1, 1, 1, 1, 1]),
+    new THREE.VectorKeyframeTrack('EMI_root.scale', [0, 1], [1, 1, 1, 1, 1.02, 1]),
+  ]);
+  const rigged = makePack({ scene: new THREE.Group(), animations: [wave] }, 'race/assets/rig.glb');
+  const tracksOf = (clip) => clip.tracks.map((t) => t.name);
+  const shoulderScale = (clips) => clips.some((c) => c.tracks.some((t) => {
+    const p = THREE.PropertyBinding.parseTrackName(t.name);
+    return p.propertyName === 'scale' && NO_SCALE_BONES.includes(p.nodeName);
+  }));
+  ok(!shoulderScale(rigged.animations), 'makePack leaves no scale track on a shoulder (' + tracksOf(rigged.animations[0]).join(' ') + ')');
+  ok(tracksOf(rigged.animations[0]).includes('shoulderR.quaternion'), 'the wave keeps its rotation track');
+  ok(tracksOf(rigged.animations[0]).includes('shoulderR.position'), 'and its translation track');
+  ok(tracksOf(rigged.animations[0]).includes('EMI_root.scale'), 'a scale on a node that is not a shoulder is left alone');
+  const twice = stripBoneScaleTracks(rigged.animations);
+  ok(twice === 0, 'the filter is idempotent: a second pass finds nothing');
+  ok(stripBoneScaleTracks(null) === 0 && stripBoneScaleTracks([null]) === 0, 'no clips, or a null clip, is a no-op not a throw');
+}
 
 // ---- toInstanceGeometry ------------------------------------------------------------------
 const geo = toInstanceGeometry(pack.byName('kart_cup'));


### PR DESCRIPTION
## what

Owner: "the emi arm length when she waves is too long". The cause is in the asset, not the web port: the `wave` clip in `race/assets/emi.glb` carries a scale track on `shoulderR` that stretches y to 2.0 for the whole raised-arm window (12 keys over 2 s: 1, 0.94, 2.12, 2.0 x6, 1.5, 1, 1). Every other clip, and `shoulderL` in all five, hold 1,1,1. The whole arm hangs under that bone, so it doubles in length during the wave. The desktop build shows the same stretch.

The glb is untouched (it is a Blender export owned by another pipeline). `gltf.js` gains `NO_SCALE_BONES = ['shoulderL', 'shoulderR']` and `stripBoneScaleTracks`, applied once inside `makePack`, the single choke point every consumer goes through (menu stage, in-race rig, intro, prop pack). The shoulder translation track is left alone on purpose: it is a 9 cm shrug that runs with the raise and returns with it, and it reads right with the scale gone.

`menu.js` gains a `?clip=NAME` screenshot aid next to `?face=N`: loops one roster clip, suppresses the pointer peek, does not arm the flash idle show.

| file | lines |
|---|---|
| `race/gltf.js` | +31 |
| `race/menu.js` | +27 / -6 |
| `race/smoke/gltf-smoke.mjs` | +30 / -2 |

## verification

After the filter the wave keeps `shoulderR.position`, `shoulderR.quaternion` and `EMI_root.scale`; both shoulder scale tracks are gone and nothing else is. `gltf-smoke` (75 assertions) now checks that `makePack` leaves no scale track on a shoulder, the wave keeps its rotation and translation, a scale on a non-shoulder node survives, the filter is idempotent, and null input is a no-op. All 10 smokes green on the first run. Before and after shots at four phases of the wave at 390x844 and 1280x720: the right arm is the same length as the left and stays inside the case footprint.

## worth your eye

The animator was likely using the stretch to make the wave read. At normal length the rotation swings the arm up and over the shoulder, and at 1280x720 the forearm tucks behind the case at two of four sampled phases. It still reads as a wave, just a smaller one. If it should be more visible, the fix is the rotation in Blender (bring the swing forward, off the body), not a scale.

## unverified

Desktop WPF build not launched (the in-race rig is pose-driven and never played the clip, so it is fixed by inspection). `hop`, `peek`, `drum` not visually re-checked; their dumps have no shoulder scale to lose. Headless SwiftShader only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0166ij3Q8xyseVkhWajzkWG3
