### PR TITLE
feat(race-web): play from bambicloud, the mini-player behind a menu verb

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/race/cloud.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/cloud.js
@@ -1,0 +1,423 @@
+/* ============================================================================
+ * race/cloud.js - the BambiCloud mini-player. WEB ONLY.
+ *
+ *   cloudEnabled(settings) -> boolean            the verb's whole visibility rule
+ *   parseLinks(text, origin) -> entry[]          pure, no network, no DOM
+ *   createCloud({ settings, hooks, ... }) -> null | player
+ *
+ * WHAT IT IS. A menu panel behind the verb `play from bambicloud` that turns a
+ * link the player already has into the race's track clock. The page owns an
+ * <audio> element, that element's currentTime IS the clock, and the run follows
+ * it: the Brake pauses the file, resume resumes it, and the end of the file is
+ * the end of the lap. Paste several links and they are a playlist: the next
+ * track is the next lap.
+ *
+ * WHY THERE IS NO PLAYLIST BROWSER: the response shape of the site's public
+ * playlist collection was never confirmed (race/CLOUD.md has the endpoints and
+ * what the two probes answered), so this lane ships the paste box alone rather
+ * than a screen of guesses. `entry.locked` and its copy are still here and
+ * exercised: a listing that lands later hands entries to addTracks() and a
+ * locked one is shown, skipped and NEVER fetched.
+ *
+ * THE BRIGHT LINE. This page talks to the site directly or not at all. Nothing
+ * is proxied through CC Labs, nothing is uploaded, no credential is ever sent
+ * (`crossOrigin = 'anonymous'` is a no-cookie request), and only two kinds of
+ * url are ever loaded: one on the audio CDN, and a same-origin one. Anything
+ * else is refused WITHOUT a request, a link to a page on the site included:
+ * from here that track is locked, and locked is said out loud.
+ *
+ * WHERE THE FRAMES COME FROM. run.js already speaks the CHART.md host protocol:
+ * `track-play` on a start, `track-pause {on}` on the Brake and on a host pause,
+ * `track-stop` at the end. On the web nothing answers those, so this file does:
+ * raceBoot taps its own outbound send and hands every `track-*` frame to
+ * hostFrame(). That is the whole pause wiring, and it is the same protocol the
+ * desktop host implements in C#.
+ *
+ * THE CHART SEAM (lane W2 fills it). `hooks.chart({ id, url, title, durationSec,
+ * el })` returns the chart for a track. raceBoot's default answers demoChart cut
+ * to the element's real duration, so the road and the clock work end to end
+ * today and a real decode drops in without touching this file.
+ *
+ * FAIL LOUD, ONCE. A load that does not answer is retried exactly once. The
+ * second failure marks that entry, toasts FAIL_LINE and puts the panel back on
+ * the paste box. Nothing polls, nothing loops, nothing retries a locked entry.
+ * ==========================================================================*/
+
+/** The only third-party host a url may name. Its files answer `Access-Control-Allow-Origin: *`. */
+export const CDN_HOST = 'cdn.bambicloud.com';
+/** The verb, and the panel it opens. Lower case like every other verb in the menu. */
+export const VERB_ID = 'cloud';
+export const VERB_LABEL = 'play from bambicloud';
+/** The honest line under the heading: what this device is about to do, in full. */
+export const CONSENT_LINE = 'this device streams straight from bambicloud. none of it passes through cc labs and nothing is uploaded. paste a link to a track you can already play over there, one per line.';
+export const PASTE_LABEL = 'paste a playlist or track link';
+/** Said once, when a load has failed twice. */
+export const FAIL_LINE = 'bambicloud is not answering, load your own file instead';
+/** Said about an entry with no audio url. Never fetched, never retried. */
+export const LOCKED_WORD = 'locked on bambicloud';
+export const REFUSED_LINE = 'that is a page link, not a track link. open it over there and copy the track link.';
+
+/** The host's own cadence (CHART.md), and the two waits a load is allowed. */
+export const TICK_MS = 250;
+export const LOAD_TIMEOUT_MS = 15000;
+export const RETRY_MS = 900;
+
+/**
+ * The verb's whole visibility rule, exported so race/menu.js and the smoke read
+ * the SAME predicate instead of two copies that drift. `cloud` is the browser
+ * host's capability flag; `trackPick` true means a desktop host owns track
+ * loading outright and this panel would only be a second, worse door.
+ */
+export function cloudEnabled(settings) {
+  return !!settings && settings.cloud === true && settings.trackPick !== true;
+}
+
+/** A url this page may hand to an <audio> element: the audio CDN, or same origin. */
+function playable(u, origin) {
+  if (u.host === CDN_HOST) return true;
+  return !!origin && u.origin === origin;
+}
+
+/** The last path segment, made readable. A track with no name at all reads as its host. */
+function titleOf(u) {
+  const seg = u.pathname.split('/').filter(Boolean).pop() || '';
+  let s = seg;
+  try { s = decodeURIComponent(seg); } catch (e) { /* keep the raw segment */ }
+  s = s.replace(/\.[a-z0-9]{2,4}$/i, '').replace(/[_+-]+/g, ' ').trim().toLowerCase();
+  return (s || u.host).slice(0, 60);
+}
+
+/**
+ * Split pasted text into entries. PURE: no network, no DOM, no side effect. A url
+ * this page may not load becomes a LOCKED entry rather than being dropped, so the
+ * player is told why their link did nothing instead of watching it vanish.
+ *
+ * @param {string} text
+ * @param {string|null} origin  location.origin, so a same-origin url is playable
+ * @returns {{id:string,url:string|null,title:string,locked:boolean,failed:boolean}[]}
+ */
+export function parseLinks(text, origin = null) {
+  const out = [], seen = new Set();
+  for (const raw of String(text || '').split(/[\s,]+/)) {
+    const s = raw.trim();
+    if (!s) continue;
+    let u = null;
+    try { u = new URL(s); } catch (e) { u = null; }
+    if (!u || (u.protocol !== 'https:' && u.protocol !== 'http:')) continue;
+    if (seen.has(u.href)) continue;
+    seen.add(u.href);
+    const ok = playable(u, origin);
+    out.push({ id: u.href, url: ok ? u.href : null, title: titleOf(u), locked: !ok, failed: false });
+  }
+  return out;
+}
+
+const elm = (tag, cls, parent, text) => {
+  const d = document.createElement(tag);
+  d.className = cls;
+  if (text != null) d.textContent = text;
+  parent.appendChild(d);
+  return d;
+};
+
+/**
+ * @param {object}   o
+ * @param {object}   o.settings   the host's `init.settings`
+ * @param {object}   o.hooks      clock(t, playing), ended(), chart(info)->Promise<chart>,
+ *                                track(chart|null, info|null), toast(line), pause(on), refresh()
+ * @param {function} [o.log]
+ * @param {function} [o.ui]       the menu blips
+ * @param {function} [o.makeAudio] url -> element. The smoke's seam; the page uses `new Audio`.
+ * @param {string}   [o.origin]   location.origin
+ */
+export function createCloud({ settings = {}, hooks = {}, log = null, ui = null, makeAudio = null, origin = null }) {
+  if (!cloudEnabled(settings)) return null;
+
+  const say = (m) => { try { if (log) log('cloud: ' + m); } catch (e) { /* no log */ } };
+  const blip = (n) => { try { if (ui) ui(n); } catch (e) { /* audio gone */ } };
+  const call = (n, ...a) => { try { return typeof hooks[n] === 'function' ? hooks[n](...a) : undefined; } catch (e) { say(n + ': ' + e); return undefined; } };
+
+  let list = [], at = -1, el = null, timer = 0, tries = 0, retry = 0, gen = 0;
+  let played = false;                 // a run has actually played this element, so `pause` means something
+  let view = 'paste', busy = false, disposed = false;
+  let input = null, countEl = null, nextEl = null, rows = [], els = [], slotEl = null;
+  let onPickRow = null, onClose = null, onRefresh = null;
+
+  /* ---- the element and the clock ---------------------------------------- */
+  function stopTick() { if (timer) { clearInterval(timer); timer = 0; } }
+  function dropEl() {
+    stopTick();
+    if (!el) return;
+    try { el.pause(); } catch (e) { /* already gone */ }
+    try { el.removeAttribute('src'); } catch (e) { /* stub element */ }
+    el = null;
+  }
+  /** The 250 ms tick, the host's own cadence: the file is the authority on the second. */
+  function startTick() {
+    if (timer) return;
+    timer = setInterval(() => {
+      if (!el) { stopTick(); return; }
+      call('clock', Number(el.currentTime) || 0, !el.paused);
+    }, TICK_MS);
+  }
+
+  /** Resolve the element's real duration, or throw. The one wait in the whole file. */
+  function metadata(a) {
+    return new Promise((res, rej) => {
+      let done = false;
+      const end = (fn, v) => { if (done) return; done = true; clearTimeout(t); fn(v); };
+      const t = setTimeout(() => end(rej, new Error('timed out')), LOAD_TIMEOUT_MS);
+      const ready = () => { const d = Number(a.duration); end(d > 0 && isFinite(d) ? res : rej, d > 0 && isFinite(d) ? d : new Error('no duration')); };
+      if (Number(a.duration) > 0 && isFinite(a.duration)) return ready();
+      a.addEventListener('loadedmetadata', ready, { once: true });
+      a.addEventListener('error', () => end(rej, new Error('would not load')), { once: true });
+    });
+  }
+
+  /* ---- loading one entry ------------------------------------------------ */
+  /** The next entry at or after `from` that may be played at all. Locked and failed are skipped. */
+  function nextPlayable(from) {
+    for (let i = Math.max(0, from); i < list.length; i++) {
+      const e = list[i];
+      if (e.url && !e.locked && !e.failed) return i;
+    }
+    return -1;
+  }
+  function info() {
+    const e = list[at] || null;
+    const total = list.length, nx = nextPlayable(at + 1);
+    return e ? { title: e.title, pos: at + 1, total, nextTitle: nx >= 0 ? list[nx].title : null } : null;
+  }
+
+  /**
+   * Load entry `i`, chart it and hand the chart out. One retry, then the entry is
+   * marked, the toast is said once and the panel goes back to the paste box.
+   */
+  async function load(i) {
+    const e = list[i];
+    if (!e || !e.url || e.locked || e.failed || disposed) return false;
+    const mine = ++gen;
+    dropEl();
+    at = i; busy = true; played = false; paint();
+    let a = null;
+    try {
+      a = makeAudio ? makeAudio(e.url) : new Audio();
+      a.crossOrigin = 'anonymous';       // a no-cookie request: no credential ever reaches them
+      a.preload = 'auto';
+      a.src = e.url;
+      if (typeof a.load === 'function') a.load();
+    } catch (err) { return bail(i, err, mine); }
+    let dur = 0;
+    try { dur = await metadata(a); } catch (err) { return bail(i, err, mine); }
+    if (disposed || mine !== gen) return false;
+    let chart = null;
+    try { chart = await call('chart', { id: e.id, url: e.url, title: e.title, durationSec: dur, el: a }); }
+    catch (err) { return bail(i, err, mine); }
+    if (disposed || mine !== gen) return false;
+    if (!chart) return bail(i, new Error('no chart'), mine);
+    el = a;
+    el.addEventListener('ended', onEnded);
+    tries = 0; busy = false;
+    blip('tick');
+    say(`${e.title}: ${Math.round(dur)}s, ${at + 1} of ${list.length}`);
+    call('track', chart, info());
+    paint();
+    return true;
+  }
+
+  /** One retry, then stop. Nothing here ever schedules a second one. */
+  function bail(i, err, mine) {
+    if (disposed || mine !== gen) return false;
+    dropEl();
+    say(`${(list[i] && list[i].title) || 'track'}: ${(err && err.message) || err}`);
+    if (tries < 1) {
+      tries++;
+      retry = setTimeout(() => { retry = 0; if (!disposed) load(i); }, RETRY_MS);
+      return false;
+    }
+    tries = 0; busy = false; at = -1;
+    if (list[i]) list[i].failed = true;
+    view = 'paste';
+    call('track', null, null);
+    call('toast', FAIL_LINE);
+    paint();
+    return false;
+  }
+
+  /** The file ran out: end this lap, then walk to the next playable track. */
+  function onEnded() {
+    stopTick();
+    call('clock', el ? Number(el.duration) || 0 : 0, false);
+    call('ended');
+    const nx = nextPlayable(at + 1);
+    if (nx < 0) { say('playlist done'); paint(); return; }
+    call('toast', 'next: ' + list[nx].title);
+    load(nx);
+  }
+
+  /* ---- the frames run.js posts (CHART.md) -------------------------------- */
+  /**
+   * raceBoot hands every outbound `track-*` frame here. `track-play` means a run
+   * just started, so the file starts at the top - that is what makes "again" a
+   * replay and a rolled-over track the next lap.
+   */
+  function hostFrame(m) {
+    const t = m && m.type;
+    if (!el || !t) return;
+    if (t === 'track-play') {
+      played = true;
+      try { el.currentTime = 0; } catch (e) { /* not seekable yet */ }
+      const p = el.play(); if (p && p.catch) p.catch((e) => say('play: ' + e));
+      startTick();
+    } else if (t === 'track-pause') {
+      if (m.on === false) { const p = el.play(); if (p && p.catch) p.catch((e) => say('resume: ' + e)); }
+      else { try { el.pause(); } catch (e) { /* already gone */ } }
+      call('clock', Number(el.currentTime) || 0, m.on === false);
+    } else if (t === 'track-stop') {
+      stopTick();
+      try { el.pause(); } catch (e) { /* already gone */ }
+    }
+    paint();
+  }
+
+  /* ---- the panel -------------------------------------------------------- */
+  const paused = () => !!(el && el.paused);
+  function stateWord(e, i) {
+    if (e.locked) return LOCKED_WORD;
+    if (e.failed) return 'would not load';
+    if (i !== at) return 'ready';
+    if (busy) return 'loading';
+    if (!played) return 'loaded';     // in hand, waiting for `race` to start the lap
+    return paused() ? 'paused' : 'playing';
+  }
+  function countLine() {
+    if (!list.length) return 'nothing pasted yet';
+    if (at < 0) return `${list.length} link${list.length === 1 ? '' : 's'} · pick one`;
+    return `${list[at].title} · ${at + 1} of ${list.length}`;
+  }
+  function nextLine() {
+    const nx = nextPlayable(at + 1);
+    return nx >= 0 ? 'next up: ' + list[nx].title : '';
+  }
+
+  /** Read the box, refuse nothing silently, and start the first playable track. */
+  function addPasted() {
+    const text = input ? input.value : '';
+    const found = parseLinks(text, origin);
+    if (!found.length) { call('toast', REFUSED_LINE); return; }
+    addTracks(found);
+    if (input) input.value = '';
+  }
+
+  /**
+   * Take entries in a listing's own shape. The paste box uses it, and it is the
+   * door a playlist listing would come through: a locked entry is kept, shown and
+   * skipped, and its url is never touched because it does not have one.
+   */
+  function addTracks(entries) {
+    const have = new Set(list.map((e) => e.id));
+    for (const e of Array.isArray(entries) ? entries : []) {
+      if (!e || !e.id || have.has(e.id)) continue;
+      have.add(e.id);
+      list.push({ id: String(e.id), url: e.url ? String(e.url) : null, title: String(e.title || 'track').slice(0, 60), locked: !e.url || e.locked === true, failed: false });
+    }
+    if (list.some((e) => e.locked)) say(`${list.filter((e) => e.locked).length} locked, skipped`);
+    view = list.length ? 'list' : 'paste';
+    paint();
+    if (at < 0) { const nx = nextPlayable(0); if (nx >= 0) load(nx); }
+  }
+
+  function forget() {
+    dropEl();
+    gen++; list = []; at = -1; tries = 0; busy = false; view = 'paste';
+    call('track', null, null);
+    paint();
+  }
+
+  /** The rows the menu walks. Rebuilt on every paint: the list is what changes. */
+  function buildRows() {
+    const out = [];
+    out.push({ id: 'add', label: list.length ? 'add these links' : 'play these links', press: addPasted });
+    list.forEach((e, i) => out.push({ id: 'trk-' + i, label: e.title, press: () => { if (e.locked || e.failed) { call('toast', e.locked ? LOCKED_WORD : FAIL_LINE); return; } load(i); } }));
+    if (el && played) out.push({ id: 'pause', label: paused() ? 'resume' : 'pause', press: () => call('pause', !paused()) });
+    if (list.length) out.push({ id: 'forget', label: 'forget them', press: forget });
+    out.push({ id: 'back', label: 'back', press: () => { if (onClose) onClose(); } });
+    return out;
+  }
+
+  function paint() {
+    if (!slotEl || disposed) return;
+    if (input) input.hidden = false;                     // the box never goes away: a second link is always one paste off
+    if (countEl && countEl.textContent !== countLine()) countEl.textContent = countLine();
+    if (nextEl) { const l = nextLine(); if (nextEl.textContent !== l) nextEl.textContent = l; nextEl.hidden = !l; }
+    const want = buildRows();
+    // Only rebuild the buttons when the shape changed; a repaint on every frame must not
+    // churn the DOM under a finger that is already on a row.
+    const sig = want.map((r) => r.id).join('|');
+    if (sig !== paint.sig) {
+      paint.sig = sig;
+      for (const b of els) { try { b.remove(); } catch (e) { /* gone */ } }
+      els = want.map((r, i) => {
+        const b = elm('button', 'rm-btn rm-media-btn rm-cloud-btn', slotEl);
+        b.type = 'button'; b.dataset.id = r.id; b.setAttribute('role', 'menuitem');
+        elm('span', 'rm-cloud-label', b, r.label);
+        elm('span', 'rm-cloud-val', b, '');
+        b.addEventListener('click', (ev) => { ev.stopPropagation(); if (onPickRow) onPickRow(i); });
+        return b;
+      });
+    }
+    rows = want;
+    // the state word rides the row it belongs to, so nothing has to be looked up twice
+    let k = 1;
+    for (let i = 0; i < list.length; i++, k++) {
+      const b = els[k]; if (!b) continue;
+      const w = stateWord(list[i], i), v = b.lastChild;
+      if (v && v.textContent !== w) v.textContent = w;
+      b.classList.toggle('is-off', list[i].locked || list[i].failed);
+      b.classList.toggle('is-on', i === at);
+    }
+    if (onRefresh) onRefresh();
+  }
+  paint.sig = '';
+
+  /**
+   * Build the panel into the menu's slot. `pick(i)` is the menu's own act('press') for row i, so a
+   * finger, an arrow and the pad all land on the same line; `close` is the menu's way back to the
+   * verbs; `refresh` repaints the menu's focus after the list has changed shape under it.
+   */
+  function buildPanel({ slot, pick, close, refresh }) {
+    slotEl = slot;
+    onPickRow = typeof pick === 'function' ? pick : null;
+    onClose = typeof close === 'function' ? close : null;
+    onRefresh = typeof refresh === 'function' ? refresh : null;
+    elm('h3', 'rm-h', slot, VERB_LABEL);
+    elm('div', 'rm-hint rm-cloud-line', slot, CONSENT_LINE);
+    input = elm('input', 'rm-seed rm-cloud-in', slot);
+    input.type = 'text'; input.placeholder = PASTE_LABEL; input.setAttribute('aria-label', PASTE_LABEL);
+    input.addEventListener('keydown', (e) => { if (e.key === 'Enter') { e.preventDefault(); addPasted(); } if (e.key === 'Escape') { e.preventDefault(); input.blur(); } e.stopPropagation(); });
+    countEl = elm('div', 'rm-media-count rh-num', slot, countLine()); countEl.setAttribute('aria-live', 'polite');
+    nextEl = elm('div', 'rm-hint rm-cloud-next', slot, ''); nextEl.hidden = true;
+    paint();
+    return { rows: () => rows, els: () => els };
+  }
+
+  return {
+    buildPanel,
+    /** The menu asks for these two every time it walks the panel: the list is live. */
+    rows: () => rows,
+    els: () => els,
+    hostFrame,
+    addTracks,
+    paint,
+    /** For the smoke and for anything that wants to know what is loaded. */
+    get state() { return { view, at, busy, played, t: el ? Number(el.currentTime) || 0 : 0, playing: !!(el && !el.paused), list: list.map((e) => ({ ...e })) }; },
+    dispose() {
+      disposed = true;
+      if (retry) { clearTimeout(retry); retry = 0; }
+      dropEl();
+      list = []; els = []; rows = [];
+    },
+  };
+}
+
+export default createCloud;

--- a/ConditioningControlPanel/Resources/web/dtrh/race/menu.css
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/menu.css
@@ -131,6 +131,18 @@
    consent is a real thing to want and it costs no network. */
 #race-root .rm-feed-btn.is-off .rm-feed-label, #race-root .rm-feed-btn.is-off .rm-feed-val { opacity: 0.5; }
 
+/* ---- play from bambicloud: the paste box and the pasted list (race/cloud.js) ---- */
+#race-root .rm-cloud-line { margin-top: 0; margin-bottom: 6px; max-width: 42ch; line-height: 1.45; }
+#race-root .rm-cloud-in { width: 100%; max-width: 42ch; margin: 0 0 6px; }
+#race-root .rm-cloud-next { margin: 2px 0 6px 2px; color: rgba(255, 214, 234, 0.75); }
+#race-root .rm-cloud-next[hidden] { display: none; }
+#race-root .rm-cloud-btn { display: flex; gap: 10px; align-items: baseline; }
+#race-root .rm-cloud-val { color: #ffd6ea; font-weight: 800; letter-spacing: 0.06em; }
+/* a locked or a broken link is dimmed, never removed: the player has to be able to see which of
+   their links did nothing and why. The row is still pressable, and says so again when pressed. */
+#race-root .rm-cloud-btn.is-off .rm-cloud-label, #race-root .rm-cloud-btn.is-off .rm-cloud-val { opacity: 0.5; }
+#race-root .rm-cloud-btn.is-on .rm-cloud-label { color: #fff; }
+
 /* ---- the track plate: a file in hand, or the host still reading it ---- */
 #race-root .rm-track {
   margin-top: 14px; padding: 10px 14px; background: rgba(18, 11, 36, 0.82);
@@ -290,6 +302,8 @@
   #race-root .rm-feed-h { margin-top: 8px; padding-top: 6px; font-size: 13px; }
   #race-root .rm-feed-line { line-height: 1.35; }
   #race-root .rm-feed-sub { margin-top: 5px; }
+  #race-root .rm-cloud-line { line-height: 1.35; }
+  #race-root .rm-cloud-in { margin-bottom: 4px; }
   #race-root .rm-h { margin-bottom: 2px; font-size: 16px; }
   #race-root .rm-row { padding: 5px 12px; font-size: 15px; }
   #race-root .rm-row-hint, #race-root .rm-hint { font-size: 10px; margin-top: 2px; }

--- a/ConditioningControlPanel/Resources/web/dtrh/race/menu.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/menu.js
@@ -86,6 +86,7 @@ import { PIXEL_STEPS, PIXEL_DEFAULT, normalizeBlock } from './pixel.js';
 import { createMenuFlashes } from './menuFlashes.js';
 import { vFovForAspect, bindViewportResize } from './viewport.js';
 import { createFeedGroup } from './feedGroup.js';
+import { cloudEnabled, VERB_ID as CLOUD_VERB, VERB_LABEL as CLOUD_LABEL } from './cloud.js';
 
 export const OPTIONS_KEY = 'race.options';
 export const PROPS_URL = '/dtrh/race/assets/props.glb';
@@ -149,11 +150,11 @@ const CLIP_PIN = (() => {
     return v && v !== 'idle' ? v : null;
   } catch (e) { return null; }           // no location (a node import), no pin
 })();
-/** Screenshot aid: `?panel=howto | options | media` opens the menu on that panel instead of the verbs. */
+/** Screenshot aid: `?panel=howto | options | media | cloud` opens the menu on that panel instead of the verbs. */
 const PANEL_PIN = (() => {
   try {
     const v = (new URLSearchParams(location.search).get('panel') || '').toLowerCase();
-    return v === 'howto' || v === 'how' ? 'how' : v === 'options' ? 'options' : v === 'media' ? 'media' : null;
+    return v === 'howto' || v === 'how' ? 'how' : v === 'options' ? 'options' : v === 'media' ? 'media' : v === 'cloud' ? 'cloud' : null;
   } catch (e) { return null; }           // no location (a node import), no pin
 })();
 /** A media button paints pending until its `setting` echo lands. This is how long it waits for one
@@ -477,7 +478,7 @@ export function createStage({ renderer, pixel, reducedMotion = false, log = null
 }
 
 // ---- the menu ------------------------------------------------------------------------------------
-export function createMenu({ root, renderer, pixel, audio, settings = {}, log = null, send = null }) {
+export function createMenu({ root, renderer, pixel, audio, settings = {}, log = null, send = null, cloud = null }) {
   const options = loadOptions();
   const systemReduced = !!(typeof matchMedia === 'function' && matchMedia('(prefers-reduced-motion: reduce)').matches);
   const reduced = () => wantsReducedMotion(options, settings.reducedMotion != null ? settings.reducedMotion : systemReduced);
@@ -498,6 +499,9 @@ export function createMenu({ root, renderer, pixel, audio, settings = {}, log = 
   const optPanel = el('div', 'rm-panel rm-options', col); optPanel.hidden = true;
   const mediaPanel = el('div', 'rm-panel rm-media', col); mediaPanel.hidden = true;
   const howPanel = el('div', 'rm-panel rm-how', col); howPanel.hidden = true;
+  // The BambiCloud mini-player's panel (race/cloud.js). The node is always built - one empty
+  // div costs nothing - and stays empty on any host that does not carry the `cloud` flag.
+  const cloudPanel = el('div', 'rm-panel rm-cloud', col); cloudPanel.hidden = true;
   // ---- the track plate: what the host is doing with the file, then what it found ----
   const trackEl = el('div', 'rm-track', col); trackEl.hidden = true; trackEl.setAttribute('aria-live', 'polite');
   const trackName = el('div', 'rm-track-name', trackEl, '');
@@ -641,7 +645,11 @@ export function createMenu({ root, renderer, pixel, audio, settings = {}, log = 
 
   // ---- the verbs. `track` only under a host (the file dialog is its), `clear` only once a file is in ----
   const canTrack = !!settings.trackPick;
-  const VERBS = [['race', 'race'], ['track', 'load a track'], ['clear', 'just the road'], ['options', 'options'], ['media', 'your media'], ['how', 'how to drive'], ['story', 'the story'], ['surface', 'surface']];
+  // `cloud` is web only and its rule lives in race/cloud.js, so this file and the smoke read one
+  // predicate rather than two copies of it. A desktop host resolves it false and the verb never
+  // reaches the list.
+  const canCloud = cloudEnabled(settings) && !!cloud;
+  const VERBS = [['race', 'race'], ['track', 'load a track'], [CLOUD_VERB, CLOUD_LABEL], ['clear', 'just the road'], ['options', 'options'], ['media', 'your media'], ['how', 'how to drive'], ['story', 'the story'], ['surface', 'surface']];
   const verbEls = VERBS.map(([id, label], i) => {
     const b = el('button', 'rm-btn', list, label); b.type = 'button'; b.dataset.id = id; b.setAttribute('role', 'menuitem');
     b.addEventListener('click', (e) => { e.stopPropagation(); idx.main = i; act('press'); });
@@ -650,6 +658,14 @@ export function createMenu({ root, renderer, pixel, audio, settings = {}, log = 
   });
   const verbEl = (id) => verbEls[VERBS.findIndex(([v]) => v === id)];
   verbEl('track').hidden = !canTrack; verbEl('clear').hidden = true; verbEl('media').hidden = !webMedia;
+  verbEl(CLOUD_VERB).hidden = !canCloud;
+  // The panel builds itself into its own node and hands back its live rows: the list of tracks
+  // changes as links are pasted, so the menu asks for the rows each time it walks them.
+  // The panel is BUILT further down, after the focus index exists: buildPanel paints itself once,
+  // that paint asks the menu to refresh, and refresh reads idx and these two readers.
+  let cloudUi = null;
+  const cloudRows = () => (cloudUi ? cloudUi.rows() : []);
+  const cloudEls = () => (cloudUi ? cloudUi.els() : []);
   const stepVerb = (from, dir) => {   // the next visible verb in that direction, wrapping
     let i = from;
     for (let k = 0; k < VERBS.length; k++) { i = (i + dir + VERBS.length) % VERBS.length; if (!verbEls[i].hidden) return i; }
@@ -687,11 +703,20 @@ export function createMenu({ root, renderer, pixel, audio, settings = {}, log = 
 
   // ---- navigation: one focus index per panel, every input path lands on act() ----
   let panel = 'main', shown = false, disposed = false, viewHeld = false;
-  const idx = { main: 0, options: 0, media: 0 };
+  const idx = { main: 0, options: 0, media: 0, cloud: 0 };
+  if (canCloud) {
+    cloudUi = cloud.buildPanel({
+      slot: cloudPanel,
+      pick: (i) => { idx.cloud = i; act('press'); },
+      close: () => open('main'),
+      refresh: () => { const n = cloudRows().length; idx.cloud = n ? clamp(idx.cloud, 0, n - 1) : 0; refresh(); },
+    });
+  }
   // onResize re-reads the band: a panel opening or closing moves the edge she is framed against.
   function open(p) {
     panel = p; list.hidden = p !== 'main'; optPanel.hidden = p !== 'options'; mediaPanel.hidden = p !== 'media'; howPanel.hidden = p !== 'how';
-    if (p === 'options') idx.options = 0; if (p === 'media') idx.media = 0;
+    cloudPanel.hidden = p !== CLOUD_VERB;
+    if (p === 'options') idx.options = 0; if (p === 'media') idx.media = 0; if (p === CLOUD_VERB) idx.cloud = 0;
     refresh(); if (p !== 'options') seedIn.blur(); onResize();
   }
   function focusRow(i) { idx.options = clamp(i, 0, ROWS.length - 1); ui('tick'); refresh(); }
@@ -699,12 +724,16 @@ export function createMenu({ root, renderer, pixel, audio, settings = {}, log = 
     verbEls.forEach((b, i) => b.classList.toggle('is-focus', panel === 'main' && i === idx.main));
     ROWS.forEach((r, i) => { const v = r.get(); if (r.valEl.textContent !== v) r.valEl.textContent = v; rowEls[i].classList.toggle('is-focus', panel === 'options' && i === idx.options); });
     mediaEls.forEach((b, i) => b.classList.toggle('is-focus', panel === 'media' && i === idx.media));
+    cloudEls().forEach((b, i) => b.classList.toggle('is-focus', panel === CLOUD_VERB && i === idx.cloud));
     if (feed) feed.paint();   // equality-guarded, like the options rows above
     // The feed's niche rows make this panel taller than the column, which scrolls (menu.css
     // .rm-col). A pad or an arrow walking past the fold has to bring the row with it; `nearest` is
     // a no-op while the row is already on screen, so a finger scrolling by hand is left alone.
     if (panel === 'media' && mediaEls[idx.media]) {
       try { mediaEls[idx.media].scrollIntoView({ block: 'nearest' }); } catch (e) { /* jsdom, old webview */ }
+    }
+    if (panel === CLOUD_VERB && cloudEls()[idx.cloud]) {
+      try { cloudEls()[idx.cloud].scrollIntoView({ block: 'nearest' }); } catch (e) { /* jsdom, old webview */ }
     }
   }
   function pick(id) { for (const cb of picks) { try { cb(id); } catch (e) { /* a listener never breaks the menu */ } } }
@@ -716,11 +745,24 @@ export function createMenu({ root, renderer, pixel, audio, settings = {}, log = 
       const id = VERBS[idx.main][0];
       if (verbEls[idx.main].hidden) return;
       hit(verbEls[idx.main], 'is-hit'); ui('pick');
-      if (id === 'options' || id === 'how' || id === 'media') open(id); else pick(id);
+      if (id === 'options' || id === 'how' || id === 'media' || id === CLOUD_VERB) open(id); else pick(id);
       return;
     }
     if (what === 'back') { ui('back'); open('main'); return; }
     if (panel === 'how') { if (what === 'press') open('main'); return; }
+    if (panel === CLOUD_VERB) {
+      const r = cloudRows();
+      if (!r.length) { if (what === 'press') open('main'); return; }
+      idx.cloud = clamp(idx.cloud, 0, r.length - 1);
+      if (what === 'up' || what === 'down') { idx.cloud = clamp(idx.cloud + (what === 'up' ? -1 : 1), 0, r.length - 1); ui('tick'); refresh(); return; }
+      if (what !== 'press') return;
+      const node = cloudEls()[idx.cloud];
+      if (node) hit(node, 'is-hit');
+      ui(r[idx.cloud].id === 'back' ? 'back' : 'pick');
+      // the row's own press may rebuild the list under us, so nothing is read off `r` after it
+      if (typeof r[idx.cloud].press === 'function') r[idx.cloud].press();
+      return;
+    }
     if (panel === 'media') {
       if (what === 'up' || what === 'down') { idx.media = clamp(idx.media + (what === 'up' ? -1 : 1), 0, MEDIA_ROWS.length - 1); ui('tick'); refresh(); return; }
       if (what !== 'press') return;
@@ -739,9 +781,11 @@ export function createMenu({ root, renderer, pixel, audio, settings = {}, log = 
     else if (what === 'press') { if (r.press) r.press(); else if (r.move) r.move(1); ui(r.id === 'back' ? 'back' : 'pick'); hit(rowEls[idx.options], 'is-hit'); }
     saveOptions(options); refresh();
   }
+  /** A focused text box owns the keyboard: the seed row's number, and the cloud panel's paste box. */
+  const typing = () => { const a = document.activeElement; return !!a && (a === seedIn || a.tagName === 'INPUT' || a.tagName === 'TEXTAREA'); };
   const KEYMAP = { ArrowUp: 'up', KeyW: 'up', ArrowDown: 'down', KeyS: 'down', ArrowLeft: 'left', KeyA: 'left', ArrowRight: 'right', KeyD: 'right', Enter: 'press', Space: 'press', Escape: 'back', Backspace: 'back' };
   function onKey(e) {
-    if (!shown || e.repeat || e.altKey || e.ctrlKey || e.metaKey || document.activeElement === seedIn) return;
+    if (!shown || e.repeat || e.altKey || e.ctrlKey || e.metaKey || typing()) return;
     const what = KEYMAP[e.code]; if (!what) return;
     e.preventDefault(); act(what);
   }
@@ -826,6 +870,13 @@ export function createMenu({ root, renderer, pixel, audio, settings = {}, log = 
       if (feed && feed.settingEcho(m)) { refresh(); return; }
       if (m.key.indexOf('media.') === 0) clearPending();
     },
+    /** race/cloud.js repaints its own rows as links are pasted; the menu re-reads them and moves
+     *  its focus back inside the list when it shrank. */
+    cloudRefresh() {
+      const n = cloudRows().length;
+      idx.cloud = n ? clamp(idx.cloud, 0, n - 1) : 0;
+      refresh();
+    },
     /** Where PR C3 builds its `online feed` group: inside the media panel, under the pickers and
      *  above `back`. null on the desktop, where the panel is never built. */
     get mediaSlot() { return mediaMore; },
@@ -839,7 +890,8 @@ export function createMenu({ root, renderer, pixel, audio, settings = {}, log = 
     },
     show() {
       shown = true; viewHeld = false; layer.hidden = false; stage.setMode('menu');
-      open(PANEL_PIN === 'media' && !webMedia ? 'main' : (PANEL_PIN || 'main'));
+      const pin = (PANEL_PIN === 'media' && !webMedia) || (PANEL_PIN === CLOUD_VERB && !canCloud) ? 'main' : PANEL_PIN;
+      open(pin || 'main');
       onResize(); hit(layer, 'is-in'); theme(true);
     },
     hide() { shown = false; layer.hidden = true; stage.setViewFraction(0.5); stage.setBand(null); layer.classList.remove('is-band'); },

--- a/ConditioningControlPanel/Resources/web/dtrh/raceBoot.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/raceBoot.js
@@ -72,6 +72,14 @@
  * `?chart=<url>` fetches one; `?audio=<url>` plays an <audio> element and its
  * currentTime is the clock, and without it the clock is wall time. Either way the
  * page ticks race.trackClock on the host's own 250 ms cadence.
+ *
+ * PLAY FROM BAMBICLOUD (web only, race/cloud.js). A host that says `cloud: true`
+ * in its init - and cannot pick a file itself, so `trackPick: false` - gets a
+ * menu verb that pastes a link and plays it through an <audio> element in this
+ * page. That element becomes the clock exactly the way `?audio=` does, and the
+ * mini-player answers the track frames run.js posts, so the Brake pauses the
+ * file and the end of the file is the end of the lap. `?cloud=1` turns it on
+ * for a page with no host at all, which is how the smoke drives it.
  * ==========================================================================*/
 
 import * as bridge from './bridge.js';
@@ -98,12 +106,30 @@ function resolveBack() {
   return null;
 }
 const standaloneExit = hosted ? null : resolveBack();
-const host = hosted ? bridge : {
+const rawHost = hosted ? bridge : {
   on: bridge.on,
   isHosted: false,
   send: (m) => { try { console.log('[race->host]', JSON.stringify(m)); } catch (e) { console.log('[race->host]', m); } },
   log: (m) => console.log('[race->host] log', String(m)),
   announceReady: () => console.log('[race->host] ready (standalone)'),
+};
+/**
+ * The one send in the page, with an OUTBOUND TAP on it. run.js posts the CHART.md track frames
+ * (track-play on a start, track-pause on the Brake, track-stop at the end) to whatever it thinks is
+ * hosting the file. On the web that is race/cloud.js, living in this page, so the frames are handed
+ * to it on their way past. Everything else is unchanged and still goes out to the real host.
+ */
+const host = {
+  on: rawHost.on,
+  isHosted: rawHost.isHosted,
+  log: (m) => rawHost.log(m),
+  announceReady: () => rawHost.announceReady(),
+  send: (m) => {
+    if (cloud && m && typeof m.type === 'string' && m.type.indexOf('track-') === 0) {
+      try { cloud.hostFrame(m); } catch (e) { rawHost.log('cloud frame: ' + e); }
+    }
+    rawHost.send(m);
+  },
 };
 
 const root = document.getElementById('race-root');
@@ -117,6 +143,7 @@ let localMedia = null;              // the last `local-media` push, replayed int
 const settingEchoes = [];           // `setting` echoes that landed before there was a menu to paint
 let settings = {}, seed = 0;
 let trackProgress = null, trackReady = null, errorTimer = 0, startTrackClock = null, trackTimer = 0, trackAudio = null;
+let cloud = null;                   // race/cloud.js, when the host says this build has it
 
 const note = (t) => { if (waitEl) waitEl.textContent = t || ''; };
 function fail(err) {
@@ -200,6 +227,7 @@ function surface() {
   exiting = true;
   stopTrackClock();
   if (errorTimer) clearTimeout(errorTimer);
+  try { if (cloud) cloud.dispose(); } catch (e) { host.log('cloud dispose: ' + e); }
   try { if (menu) menu.dispose(); } catch (e) { host.log('menu dispose: ' + e); }
   try { if (race) race.dispose(); } catch (e) { host.log('exit dispose: ' + e); }
   host.send({ type: 'exit' });
@@ -239,9 +267,17 @@ async function boot() {
     // hosted in every way the bridge can see and has no file dialog to open, and a verb that answers
     // nothing is worse than no verb at all.
     settings.trackPick = hosted && settings.trackPick !== false;
+    // `cloud` is the browser host's capability flag; `?cloud=1` is the same switch for a page with
+    // no host under it, and it can never turn on where a desktop host already owns track loading.
+    settings.cloud = settings.cloud === true || (!settings.trackPick && params.get('cloud') === '1');
+    cloud = await makeCloud();
+    // run.js posts the track frames only when it believes something is hosting the file. With the
+    // mini-player on, something is: this page. audio.js reads the same flag to decide where the
+    // eleven host cues play, so an unhosted page is told outright to keep playing them itself.
+    if (cloud && !hosted) settings.hostSfx = false;
     seed = settings.seedLock != null ? settings.seedLock : rollSeed();
     note('the road is drawing');
-    race = createRace({ root, bridge: host, media, settings, seed });
+    race = createRace({ root, bridge: cloud ? { ...host, isHosted: true } : host, media, settings, seed });
     // the persisted option sliders, before the first frame: the menu theme comes up at the right level
     try { if (race.audio && race.audio.setLevels) race.audio.setLevels({ music: opts.music, sfx: opts.sfx }); } catch (e) { host.log('levels: ' + e); }
     note('');
@@ -250,7 +286,7 @@ async function boot() {
     await standaloneTrack();
     if (params.get('autostart') === '1') { startRun(false); debugItemBox(); return; }
     if (hudRoot) hudRoot.classList.add('is-lobby');   // the run's chrome stays out of the menu and the intro
-    menu = createMenu({ root, renderer: race.renderer, pixel: race.pixel, audio: race.audio, settings, log: host.log, send: host.send });
+    menu = createMenu({ root, renderer: race.renderer, pixel: race.pixel, audio: race.audio, settings, log: host.log, send: host.send, cloud });
     if (localMedia) { try { menu.setLocalMedia(localMedia); } catch (e) { host.log('local-media: ' + e); } }
     while (settingEchoes.length) { try { menu.settingEcho(settingEchoes.shift()); } catch (e) { host.log('setting: ' + e); } }
     // Nowhere to surface to: no host and no `?back=`, or a host that says outright it cannot take
@@ -322,6 +358,56 @@ async function standaloneTrack() {
   };
   host.log(`track: ${chart.source.name}, ${Math.round(dur)}s, clock ${trackAudio ? 'audio' : 'wall'}`);
 }
+/**
+ * PLAY FROM BAMBICLOUD (race/cloud.js). Built before the race so the menu can be handed a live
+ * player, and wired to the run through hooks only: the mini-player never sees `race`, so it stays
+ * importable in node and the smoke can drive it with a stub element.
+ *
+ *   chart  the W2 SEAM. Lane W2 decodes the file and charts it for real; until then a demo chart
+ *          cut to the element's own duration keeps the road and the clock honest end to end.
+ *   track  the chart landing: the run takes it and the menu plate says which track, and where in
+ *          the list it is ("3 of 9"), with the next one named under it.
+ *   pause  the panel's own pause goes through the run, which posts track-pause straight back here,
+ *          so there is ONE pause path and the file and the road can never disagree.
+ */
+async function makeCloud() {
+  if (!settings.cloud) return null;
+  let mod = null;
+  try { mod = await import('./race/cloud.js'); } catch (err) { host.log('cloud: ' + ((err && err.message) || err)); return null; }
+  return mod.createCloud({
+    settings,
+    log: host.log,
+    ui: (n) => { try { if (race && race.audio && race.audio.ui) race.audio.ui(n); } catch (e) { /* audio gone */ } },
+    origin: (typeof location !== 'undefined' && location.origin) || null,
+    hooks: {
+      clock: (t, playing) => { if (race) race.trackClock(t, playing); },
+      ended: () => { if (race) race.trackEnded(); },
+      pause: (on) => { if (race) race.setPaused(!!on); },
+      async chart({ title, durationSec }) {
+        const mk = await import('./race/chart.js');
+        const demo = mk.demoChart({ durationSec });
+        // the shape is the demo road; the NAME is the real track, because the plate, the marquee
+        // and the results card all read source.name and none of them should say "the demo track".
+        return mk.normalizeChart({ ...demo, source: { ...demo.source, name: title || demo.source.name, hash: '' } });
+      },
+      track(chart, info) {
+        if (!race) return;
+        if (!chart) { race.setTrack(null); trackReady = null; plate(null); return; }
+        try { race.setTrack(chart); } catch (err) { trackError('chart: ' + ((err && err.message) || err)); return; }
+        const st = race.trackStats ? race.trackStats() : null;
+        const where = info && info.total > 1 ? ` · ${info.pos} of ${info.total}` : '';
+        trackReady = { stage: 'ready', name: chart.source.name + where, durationSec: chart.source.durationSec, countable: st ? st.countable : 0, partial: false };
+        plate(trackReady);
+      },
+      toast(line) {
+        const msg = String(line || '').slice(0, 80).toLowerCase();
+        host.log('cloud toast: ' + msg);
+        try { if (race && race.hud) race.hud.toast(msg.slice(0, 60), 'effect'); } catch (e) { /* no hud yet */ }
+      },
+    },
+  });
+}
+
 function stopTrackClock() {
   if (trackTimer) { clearInterval(trackTimer); trackTimer = 0; }
   if (trackAudio) { try { trackAudio.pause(); } catch (e) { /* already gone */ } }
@@ -418,6 +504,15 @@ async function startRun(withIntro) {
     host.log('start: ' + ((err && err.stack) || err));
     try { race.setStage(null); race.start(); } catch (e) { fail(e); }
   }
+}
+
+// STANDALONE DEV HANDLE. With no host under the page there is nothing to ask the run's state of,
+// so the three live objects are hung on the window through getters (they are built inside boot()).
+// Gated on `hosted`: under a real host this is never defined and nothing can reach in.
+if (!hosted) {
+  try {
+    window.__race = { get race() { return race; }, get cloud() { return cloud; }, get menu() { return menu; }, get settings() { return settings; } };
+  } catch (e) { /* no window */ }
 }
 
 // ---- go ----


### PR DESCRIPTION
Lane W1 of Racing Thoughts x BambiCloud, part 1 of 2. Part 2 (`feat/race-cloud-w1-smoke`) stacks on this and carries `race/CLOUD.md` plus the headless check.

## What this does

The web build of the kart has no file dialog: its host sets `trackPick: false`, so `load a track` comes off the menu and there is no way to start a run on real audio. This adds one: a menu verb `play from bambicloud`, shown only when the host sets `cloud: true` and `trackPick` is not true.

The panel is a paste box. Every link pasted becomes an entry. A playable entry becomes an `<audio>` element in this page and that element's `currentTime` is the track clock, exactly the way the standalone `?audio=` road in `raceBoot.js` already works. Several links are a playlist: when a file ends the lap ends, and the next playable entry loads and charts, so the next track is the next lap. The panel shows the title, the position ("3 of 9") and a next-up line.

## The rules it holds

- **Direct or not at all.** The player's browser talks to the site. Nothing is proxied through CC Labs, nothing is uploaded, no chart or audio byte is sent anywhere. The element is `crossOrigin = 'anonymous'`, a no-cookie request, so no credential can reach them from here.
- **Two kinds of url and no others.** A url loads only if its host is `cdn.bambicloud.com` or it is same-origin. Everything else, including a link to a page on the site, becomes a **locked** entry: listed, worded `locked on bambicloud`, skipped by the playlist walk and never requested. Nothing works around a locked file.
- **Fail loud, once.** A load that does not answer inside 15 s is retried exactly once. The second failure marks the entry, says `bambicloud is not answering, load your own file instead` and puts the panel back on the paste box. Nothing polls and nothing loops.
- **No login, ever.** No session, token or account endpoint is called, named or linked.

**There is no playlist browser.** Discovery got the endpoint names and the field names out of the site's own public client bundle, but both GET probes against the public playlist collection failed (422, then 500), so the response shape is unconfirmed and a browser built on a guess breaks in front of the player. Per the brief's own fallback rule this ships paste-a-link only and says so. The seam for a future listing is `addTracks([{ id, url, title, locked }])`; hand it rows and the panel, the locked wording and the playlist walk already work.

## How the Brake reaches the file

`run.js` already speaks the `CHART.md` host protocol and posts `track-play`, `track-pause {on}` and `track-stop`. On the web nothing answers those. Rather than invent a second channel, `raceBoot.js` taps its own outbound `send` and hands every `track-*` frame to `cloud.hostFrame()`: the mini-player is the track host, living in the page. The panel's own pause goes the same way round, so there is one pause path and the file and the road cannot disagree. `track-play` seeks to 0, which is what makes "again" a replay and a rolled-over track a new lap.

## The chart seam (lane W2)

`cloud.js` never charts anything itself. It calls `hooks.chart({ id, url, title, durationSec, el })` once per track and hands the result to `race.setTrack`. The default in `raceBoot.js` `makeCloud()` is a `demoChart` cut to the real duration and renamed to the real track, so the road and the clock are honest end to end today. W2 replaces that one function body and touches nothing else. `CHART.md`'s authored-chart rule still wins.

## Files

- `Resources/web/dtrh/race/cloud.js` (new, 423) - the player, the panel and `cloudEnabled()`
- `Resources/web/dtrh/race/menu.js` (+70) - the verb, the panel slot and the keyboard walk
- `Resources/web/dtrh/race/menu.css` (+14) - mirrors the existing `.rm-feed-*` block
- `Resources/web/dtrh/raceBoot.js` (+101) - the hooks, the outbound tap, `?cloud=1`, and a standalone-only `window.__race` handle for the check

596 insertions, 12 deletions.

## Verified

`node race/smoke/cloud-check.mjs` (in part 2) is 30/30 green, run twice. It records every request the page makes and fails if one left localhost, so the direct-or-not-at-all rule is checked rather than asserted. All nine existing race smokes still pass; `touch-check.mjs` run twice, both exit 0.

Not verified: no headed run against a real bambicloud track. Both API probes failed, so no public track url was obtained GET-only, and the brief forbids probing further.

Needs `cloud: true` from the browser host to be reachable in production: CodeBambi/cclabs-web `feat/race-cloud-csp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJ66hi5fRM1Dcjo38aSCa2
