### PR TITLE
feat(race): one clock face for the track, whatever is making the sound

### DIFF
--- a/ConditioningControlPanel/Services/Chaos/CaucusHostService.cs
+++ b/ConditioningControlPanel/Services/Chaos/CaucusHostService.cs
@@ -49,6 +49,9 @@ internal static class CaucusHostService
 
     // ---- track charts (CHART.md, PR c6) ----
     private static TrackPlayer? _player;
+    /// <summary>Whatever is making the sound right now: the local player, or the audio element the
+    /// player is driving in the BambiCloud window. Null with no track loaded.</summary>
+    private static ITrackClock? _clock;
     private static DispatcherTimer? _trackClock;
     private static CancellationTokenSource? _analysisCts;
     private static string _trackName = "";
@@ -538,6 +541,7 @@ internal static class CaucusHostService
             StopHeartbeatWatch();
             HookVideoEvents(false);
             StopTrack();
+            _clock = null;
             try { _player?.Dispose(); } catch { }
             _player = null;
             _devTrackPath = null;
@@ -654,6 +658,7 @@ internal static class CaucusHostService
             }
             _player.Stop();
             _player.Load(path);
+            _clock = new LocalTrackClock(_player);
             StartTrackClock();
             App.Logger?.Information("RaceHost: track loaded {Name} ({Dur:0.0}s)", _trackName, _player.DurationSec);
         }
@@ -692,6 +697,7 @@ internal static class CaucusHostService
             ct.ThrowIfCancellationRequested();
             chart.Analysis.Partial = true;
             PostChart(chart, partial: true);
+            App.Logger?.Information("RaceHost: partial chart for {Name}: {Events} events", name, chart.Events?.Count ?? 0);
 
             // The word pass is the slow one, which is why the page already has a playable chart.
             var lexicon = TrackLexicon.Build();
@@ -736,12 +742,13 @@ internal static class CaucusHostService
         catch (Exception ex) { App.Logger?.Debug("RaceHost.CancelAnalysis: {E}", ex.Message); }
     }
 
-    /// <summary>track-play: the run started, so the file starts from its own zero.</summary>
+    /// <summary>track-play: the run started, so a local file starts from its own zero. A source
+    /// that is already running is left exactly where it is.</summary>
     private static void TrackPlay()
     {
-        if (_player == null) return;
-        _player.RefreshVolume();
-        _player.Play();
+        var c = _clock;
+        if (c == null) return;
+        c.Start();
         StartTrackClock();
         PostClock();
     }
@@ -749,8 +756,9 @@ internal static class CaucusHostService
     /// <summary>track-pause {on}: the Brake, a host pause and a video pop all land here.</summary>
     private static void TrackPause(bool on)
     {
-        if (_player == null) return;
-        if (on) _player.Pause(); else _player.Resume();
+        var c = _clock;
+        if (c == null) return;
+        c.SetPaused(on);
         PostClock();
     }
 
@@ -760,7 +768,7 @@ internal static class CaucusHostService
     {
         StopTrackClock();
         CancelAnalysis(postCancelled: false);
-        try { _player?.Stop(); }
+        try { _clock?.Stop(); }
         catch (Exception ex) { App.Logger?.Debug("RaceHost.StopTrack: {E}", ex.Message); }
     }
 
@@ -794,14 +802,14 @@ internal static class CaucusHostService
 
     private static void PostClock()
     {
-        var p = _player;
-        if (p == null) { StopTrackClock(); return; }
+        var c = _clock;
+        if (c == null) { StopTrackClock(); return; }
         PostTrack(new
         {
             type = "track-clock",
-            t = Math.Round(p.PositionSec, 3),
-            playing = p.IsPlaying,
-            durationSec = Math.Round(p.DurationSec, 3),
+            t = Math.Round(c.PositionSec, 3),
+            playing = c.IsPlaying,
+            durationSec = Math.Round(c.DurationSec, 3),
         });
     }
 

--- a/ConditioningControlPanel/Services/Race/TrackClock.cs
+++ b/ConditioningControlPanel/Services/Race/TrackClock.cs
@@ -1,0 +1,108 @@
+using System;
+
+namespace ConditioningControlPanel.Services.Race;
+
+/// <summary>
+/// What the race's 250 ms clock needs from whatever is actually making the sound (CHART.md,
+/// "the clock is the file"). Two sources implement it: <see cref="LocalTrackClock"/> wraps the
+/// NAudio player a picked file plays through, and <see cref="CloudTrackClock"/> mirrors an
+/// audio element the player is driving on their own page in the BambiCloud window.
+///
+/// The host does not care which one it holds: it reads the three numbers for track-clock and
+/// routes the Brake through <see cref="SetPaused"/>.
+/// </summary>
+public interface ITrackClock
+{
+    /// <summary>Where the audio is, in seconds.</summary>
+    double PositionSec { get; }
+
+    /// <summary>The audio's whole length in seconds, 0 while it is still unknown.</summary>
+    double DurationSec { get; }
+
+    /// <summary>True only while sound is actually coming out.</summary>
+    bool IsPlaying { get; }
+
+    /// <summary>The run started (track-play). A local file rewinds and plays; a cloud element is
+    /// already running and is left exactly where the player put it.</summary>
+    void Start();
+
+    /// <summary>The Brake, a host pause or a video pop. true holds, false carries on.</summary>
+    void SetPaused(bool on);
+
+    /// <summary>End of run, exit or teardown.</summary>
+    void Stop();
+}
+
+/// <summary>The picked-file clock: a thin face over <see cref="TrackPlayer"/>, which stays the
+/// owner of the device and the reader. Nothing about the local path changed when the cloud
+/// source arrived.</summary>
+public sealed class LocalTrackClock : ITrackClock
+{
+    private readonly TrackPlayer _player;
+
+    public LocalTrackClock(TrackPlayer player) => _player = player ?? throw new ArgumentNullException(nameof(player));
+
+    public double PositionSec => _player.PositionSec;
+    public double DurationSec => _player.DurationSec;
+    public bool IsPlaying => _player.IsPlaying;
+
+    public void Start()
+    {
+        _player.RefreshVolume();
+        _player.Play();
+    }
+
+    public void SetPaused(bool on)
+    {
+        if (on) _player.Pause(); else _player.Resume();
+    }
+
+    public void Stop() => _player.Stop();
+}
+
+/// <summary>
+/// The BambiCloud clock: the player's own audio element is the authority, so this holds nothing
+/// but the last cloud-clock the watcher sent and pushes a pause back the other way.
+///
+/// Stop() deliberately does NOT silence the site. A lap ends when the track ends, and by then
+/// their playlist has usually already started the next one; pausing them there would fight the
+/// player for their own transport. The window closing is what stops their audio, and the window
+/// is torn down with the race host.
+/// </summary>
+public sealed class CloudTrackClock : ITrackClock
+{
+    private readonly Action<bool> _setPaused;
+    private double _t;
+    private double _dur;
+    private bool _playing;
+
+    /// <param name="setPaused">Sends cloud-set-paused {on} into the page.</param>
+    public CloudTrackClock(Action<bool> setPaused) => _setPaused = setPaused ?? throw new ArgumentNullException(nameof(setPaused));
+
+    /// <summary>A cloud-clock landed. Duration is kept when a tick reports 0 for it: their element
+    /// answers NaN until the metadata is in, and a run must not see the length flicker to nothing.</summary>
+    public void Update(double t, bool playing, double durationSec)
+    {
+        if (t >= 0 && !double.IsNaN(t) && !double.IsInfinity(t)) _t = t;
+        if (durationSec > 0 && !double.IsNaN(durationSec) && !double.IsInfinity(durationSec)) _dur = durationSec;
+        _playing = playing;
+    }
+
+    public double PositionSec => _t;
+    public double DurationSec => _dur;
+    public bool IsPlaying => _playing;
+
+    /// <summary>Nothing: the audio is already running over there, which is why the run started.</summary>
+    public void Start() { }
+
+    public void SetPaused(bool on)
+    {
+        // Optimistic locally so the very next track-clock already reads the new state; the
+        // watcher's own play / pause echo confirms it a moment later.
+        _playing = !on;
+        try { _setPaused(on); }
+        catch (Exception ex) { App.Logger?.Debug("CloudTrackClock.SetPaused: {E}", ex.Message); }
+    }
+
+    public void Stop() => _playing = false;
+}


### PR DESCRIPTION
Lane D1 of Racing Thoughts x BambiCloud, PR 1 of 4. Stack: **this** -> `feat/race-cloud-d1-window-frame` -> `feat/race-cloud-d1-follow` -> `feat/race-cloud-d1-chart`.

CHART.md says the clock is the file. Until now the file was always a local pick, so the host read `TrackPlayer` directly at `TrackPlay`, `TrackPause`, `StopTrack` and `PostClock`. The BambiCloud lane needs a second source the host reads the same way, so the three numbers a run cares about and the pause it sends back move behind `ITrackClock`.

- `LocalTrackClock` is a thin face over `TrackPlayer`, which stays the owner of the device and the reader. **Every existing "load a track" path behaves exactly as it did.**
- `CloudTrackClock` mirrors an audio element the player drives on their own page and pushes a pause the other way. Nothing wires it up in this PR.
- The partial chart now logs the way the full one already did, so the energy pass is visible in a session log instead of only the swap that follows it.

### Verified
`dotnet build` in `ConditioningControlPanel`: **0 errors** (366 warnings, the CA1416 baseline).

Runtime verification of the whole stack is in the last PR: the local pick path was left untouched by construction, and the cloud path was driven end to end against a public playlist.

### Size
~140 changed lines.

Rebased onto main after the web chain (#901-#914) on 2026-09-07; conflicts resolved: none (no file it touches was changed by the web chain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJ66hi5fRM1Dcjo38aSCa2
