### PR TITLE
feat(race): the run follows whatever is playing on bambicloud

### DIFF
--- a/ConditioningControlPanel/App.xaml.cs
+++ b/ConditioningControlPanel/App.xaml.cs
@@ -2802,6 +2802,17 @@ namespace ConditioningControlPanel
                     Logger?.Information("--race-track ignored: no file path after the arg");
             }
 
+            // `--race-cloud`: open the race and then the BambiCloud window straight away. The
+            // cloud path starts from a menu verb, and a browser frame cannot be driven by synthetic
+            // clicks, so this is the only way to exercise it end to end. A dev rig like
+            // `--race-track`: it opens the same page `--race` opens and gates nothing.
+            if (e.Args.Contains("--race-cloud"))
+            {
+                var cloudGate = Services.TierGate.RequiresLab("Down the Rabbit Hole", "dtrh");
+                if (cloudGate.Allowed) Services.Chaos.CaucusHostService.Launch(null, openCloud: true);
+                else Logger?.Information("--race-cloud ignored: {Reason}", cloudGate.Reason);
+            }
+
             // Goon Game browser client, dev shortcut: `--goon` opens the web duel window straight
             // away (same shape as `--dtrh`). Needs MainWindow to exist first — the host owns its
             // window natively above main and ducks main out of the way at launch.

--- a/ConditioningControlPanel/Resources/web/dtrh/race/menu.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/menu.js
@@ -671,7 +671,7 @@ export function createMenu({ root, renderer, pixel, audio, settings = {}, log = 
     for (let k = 0; k < VERBS.length; k++) { i = (i + dir + VERBS.length) % VERBS.length; if (!verbEls[i].hidden) return i; }
     return from;
   };
-  const STAGE_CAP = { picking: 'pick a file', decode: 'reading the file', energy: 'feeling the pulse', words: 'listening for the words', cancelled: '', error: '' };
+  const STAGE_CAP = { picking: 'pick a file', opening: 'over to bambicloud', fetching: 'pulling the audio down', decode: 'reading the file', energy: 'feeling the pulse', words: 'listening for the words', cancelled: '', error: '' };
   let trackState = null;
   /**
    * setTrack(state | null): the plate and the verbs follow the host. state = { stage, pct, name,

--- a/ConditioningControlPanel/Resources/web/dtrh/raceBoot.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/raceBoot.js
@@ -29,7 +29,10 @@
  * false` takes `surface` off when there is nowhere to go, and `hostSfx: false`
  * (read by race/audio.js) plays the eleven host cues in page instead of posting
  * `sfx` frames nothing answers. `mediaControls: true` is the fourth: it turns on
- * the menu's `your media` panel.
+ * the menu's `your media` panel. `cloud: true` is the fifth: it puts the
+ * `levels` panel on the menu. On a host that can open a browser window of its
+ * own (the desktop has one: Services/Race/RaceCloudWindow.cs) tapping a level
+ * asks the host to open that track's page, and the player presses play there.
  *
  * STANDALONE DEV MODE (no WebView2): `bridge.isHosted` is false, so `init` is
  * synthesised (masterVolume 60, reducedMotion from matchMedia, empty manifest)
@@ -209,6 +212,10 @@ bridge.on('track-chart', (m) => {
 bridge.on('track-clock', (m) => { if (race && m) race.trackClock(Number(m.t) || 0, m.playing !== false); });
 bridge.on('track-ended', () => { if (race) race.trackEnded(); });
 bridge.on('track-error', (m) => trackError((m && m.message) || 'the track would not load'));
+// bambicloud: the host saw their player start, so the run starts too - the audio over there is the
+// clock, and a run that waited for a menu press would already be behind it. The chart lands after,
+// through track-chart, the same swap-in a picked file's partial chart makes.
+bridge.on('cloud-run', () => { if (!started && !exiting && race) startRun(false); });
 bridge.on('track-progress', (m) => {
   trackProgress = m || null;
   host.log(`track-progress: ${(m && m.stage) || '?'} ${Math.round(((m && m.pct) || 0) * 100)}% ${(m && m.name) || ''}`);
@@ -491,9 +498,11 @@ async function makeLevels() {
     settings, sets, index, cloud, log: host.log,
     hooks: {
       play: (entries) => { if (cloud) cloud.setTracks(entries); },
-      // D1's cloud-open, with the track's own page on it. A host that only knows the bare
-      // message opens its window and ignores the url until it learns to read one.
-      open: (url) => host.send({ type: 'cloud-open', url }),
+      // cloud-open, with the track's own page on it: the desktop host lands its browser
+      // window there (Services/Race/RaceCloudWindow.cs) and the player presses play over
+      // there. A host that only knows the bare message ignores the url and opens the front
+      // door, which is still a working answer.
+      open: (url) => { host.send({ type: 'cloud-open', url }); if (settings.trackPick) plate({ stage: 'opening' }); },
       toast,
     },
   });

--- a/ConditioningControlPanel/Services/Chaos/CaucusHostService.cs
+++ b/ConditioningControlPanel/Services/Chaos/CaucusHostService.cs
@@ -63,19 +63,37 @@ internal static class CaucusHostService
     private static string? _devTrackPath;
     /// <summary>While the dev arg is active every track-* post is logged as JSON.</summary>
     private static bool _devTrackLog;
+    /// <summary>Set by the `--race-cloud` dev arg: open the BambiCloud window once the page is up,
+    /// so the cloud path can be exercised without driving the menu by hand.</summary>
+    private static bool _devOpenCloud;
+    /// <summary>The dev arg's Brake drive runs once, on the first cloud track of the session.</summary>
+    private static bool _devCloudDriven;
+
+    // ---- bambicloud (lane D1) ----
+    /// <summary>The on-demand browser frame, built the first time the page asks for it.</summary>
+    private static RaceCloudWindow? _cloud;
+    /// <summary>The cloud clock, kept across laps: one window, one audio element, one clock.</summary>
+    private static CloudTrackClock? _cloudClock;
+    /// <summary>True between "the next track started over there" and the run-ended that answers our
+    /// track-ended. The next lap already owns the clock, so that stop must not take it away.</summary>
+    private static bool _cloudSwapping;
 
     /// <summary>True while the race window is open.</summary>
     public static bool IsActive => _host != null;
 
     /// <summary>Open the race window (idempotent - refocuses if already open).</summary>
     /// <param name="devTrackPath">The `--race-track` dev arg's file, or null in a normal launch.</param>
-    public static void Launch(string? devTrackPath = null)
+    /// <param name="openCloud">The `--race-cloud` dev arg: open the BambiCloud window on its own.</param>
+    public static void Launch(string? devTrackPath = null, bool openCloud = false)
     {
-        if (_host != null) { _host.FocusWeb(); return; }
+        if (_host != null) { _host.FocusWeb(); if (openCloud) OpenCloudWindow(); return; }
         try
         {
             _devTrackPath = devTrackPath;
-            _devTrackLog = !string.IsNullOrEmpty(devTrackPath);
+            // Both dev args log every track-* post as JSON: that log IS the verification, and the
+            // cloud path has no other way to show the page what it was sent.
+            _devTrackLog = !string.IsNullOrEmpty(devTrackPath) || openCloud;
+            _devOpenCloud = openCloud;
             // EMI Desk: the ring learns from every open, not just its own cards.
             try { App.EmiDesk?.NoteOpen("race"); } catch { }
 
@@ -143,6 +161,7 @@ internal static class CaucusHostService
             StartHeartbeatWatch();
             _host.FocusWeb();
             if (_devTrackLog) ArmDevTrackDrive();
+            if (_devOpenCloud) DevAfter(3, () => OpenCloudWindow());
             App.Logger?.Information("CaucusHostService: launched");
         }
         catch (Exception ex)
@@ -195,6 +214,10 @@ internal static class CaucusHostService
                     // owns that resolution). Reduced and Off both read as reduced motion on the
                     // page: it has no third state to offer.
                     reducedMotion = SafeReducedMotion(),
+                    // The menu's `levels` panel. The desktop owns the browser window a level
+                    // opens in, so only the desktop host offers it; a host without one simply
+                    // leaves the key off.
+                    cloud = true,
                 },
                 modId = SafeActiveModId(),
                 // Creator mods: the mod's own DTRH content as ccp.mod URLs; null = no mod
@@ -275,6 +298,11 @@ internal static class CaucusHostService
                 break;
             case "track-cancel":
                 CancelAnalysis(postCancelled: true);
+                break;
+            case "cloud-open":
+                // `url` is optional: the levels panel names the track's own page, and a page
+                // that does not send one just gets the site's front door.
+                OpenCloudWindow((string?)o["url"]);
                 break;
             case "exit":       // page-initiated: it winds itself down, then exit-done
                 _exiting = true;
@@ -540,7 +568,12 @@ internal static class CaucusHostService
             CancelExitWatchdog();
             StopHeartbeatWatch();
             HookVideoEvents(false);
+            _cloudSwapping = false;
+            _devCloudDriven = false;
             StopTrack();
+            try { _cloud?.Dispose(); } catch { }
+            _cloud = null;
+            _cloudClock = null;
             _clock = null;
             try { _player?.Dispose(); } catch { }
             _player = null;
@@ -742,8 +775,8 @@ internal static class CaucusHostService
         catch (Exception ex) { App.Logger?.Debug("RaceHost.CancelAnalysis: {E}", ex.Message); }
     }
 
-    /// <summary>track-play: the run started, so a local file starts from its own zero. A source
-    /// that is already running is left exactly where it is.</summary>
+    /// <summary>track-play: the run started, so a local file starts from its own zero. A cloud
+    /// element is already running (that is what started the run) and is left alone.</summary>
     private static void TrackPlay()
     {
         var c = _clock;
@@ -753,7 +786,9 @@ internal static class CaucusHostService
         PostClock();
     }
 
-    /// <summary>track-pause {on}: the Brake, a host pause and a video pop all land here.</summary>
+    /// <summary>track-pause {on}: the Brake, a host pause and a video pop all land here. On the
+    /// cloud source this is the frame that pauses their player, which is the other half of the
+    /// bargain their own pause button makes when it pauses the race.</summary>
     private static void TrackPause(bool on)
     {
         var c = _clock;
@@ -763,9 +798,13 @@ internal static class CaucusHostService
     }
 
     /// <summary>End of run, exit or teardown: the audio stops, the clock stops and any analysis
-    /// still grinding away is dropped.</summary>
+    /// still grinding away is dropped. A cloud lap turnover is the one stop that passes straight
+    /// through: the next track already owns the clock and its chart is already on the way.</summary>
     private static void StopTrack()
     {
+        bool swapping = _cloudSwapping;
+        _cloudSwapping = false;
+        if (swapping) return;
         StopTrackClock();
         CancelAnalysis(postCancelled: false);
         try { _clock?.Stop(); }
@@ -827,6 +866,18 @@ internal static class CaucusHostService
         DevAfter(14, StopTrack);
     }
 
+    /// <summary>The `--race-cloud` arg's other half: once a cloud track is running, hold the Brake
+    /// at 10 s and let it go at 16 s. That is the only way to watch C# pause their own player,
+    /// because the race window will not take a synthetic key press.</summary>
+    private static void ArmDevCloudDrive()
+    {
+        if (!_devOpenCloud || _devCloudDriven) return;
+        _devCloudDriven = true;
+        App.Logger?.Information("RaceHost dev: --race-cloud brake at 10s, released at 16s");
+        DevAfter(10, () => { App.Logger?.Information("RaceHost dev: brake on"); TrackPause(true); });
+        DevAfter(16, () => { App.Logger?.Information("RaceHost dev: brake off"); TrackPause(false); });
+    }
+
     private static void DevAfter(double sec, Action act)
     {
         var t = new DispatcherTimer { Interval = TimeSpan.FromSeconds(sec) };
@@ -837,6 +888,152 @@ internal static class CaucusHostService
             catch (Exception ex) { App.Logger?.Warning("RaceHost dev step: {E}", ex.Message); }
         };
         t.Start();
+    }
+
+    // ============================ bambicloud (lane D1) ============================
+    //
+    // The player signs in over there and drives their own playlist. We open a plain browser frame
+    // on the site, watch the audio element their page is already playing, and follow it: their
+    // pause pauses the race, the Brake pauses them, the next track is the next lap.
+    //
+    // READ-ONLY GUEST. Nothing here calls their API, logs anybody in, or reads anything of theirs
+    // beyond the audio element's own state and the tab title. See RaceCloudWindow for the window
+    // and for the watcher, which is the only code of ours that runs inside their page.
+
+    /// <summary>The one message the player ever sees when the site is not answering. Plain, and it
+    /// points at the path that always works.</summary>
+    private const string CloudDownMessage = "bambicloud is not answering, load a file instead";
+
+    /// <summary>cloud-open: a level tapped on the menu. Opens the window on that track's page, or
+    /// brings it back if the player closed it (closing hides it, so their playlist survives). A
+    /// null or off-site url falls back to the site's front door.</summary>
+    private static void OpenCloudWindow(string? url = null)
+    {
+        var disp = Application.Current?.Dispatcher;
+        if (disp == null || disp.HasShutdownStarted) return;
+        disp.BeginInvoke(() =>
+        {
+            try
+            {
+                if (_cloud == null)
+                {
+                    _cloud = new RaceCloudWindow();
+                    _cloud.Message += OnCloudMessage;
+                    _cloud.Hidden += OnCloudHidden;
+                }
+                _cloud.ShowOrFocus(RaceCloudWindow.IsSiteUri(url) ? url : null);
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Warning("RaceHost.cloud-open: {E}", ex.Message);
+                PostTrack(new { type = "track-error", message = CloudDownMessage });
+            }
+        });
+    }
+
+    /// <summary>The window was closed (hidden) with no cloud track in hand: take the menu's
+    /// "opening" plate back down so it is not left waiting for something that is not coming.</summary>
+    private static void OnCloudHidden()
+    {
+        if (_clock is CloudTrackClock) return;
+        PostProgress("cancelled", 0, "", force: true);
+    }
+
+    /// <summary>Every cloud-* frame the watcher posts, on the UI thread.</summary>
+    private static void OnCloudMessage(JObject o)
+    {
+        try
+        {
+            switch ((string?)o["type"])
+            {
+                case "cloud-track":
+                    OnCloudTrack(o);
+                    break;
+                case "cloud-clock":
+                    if (_cloudClock == null || !ReferenceEquals(_clock, _cloudClock)) break;
+                    _cloudClock.Update((double?)o["t"] ?? 0, (bool?)o["playing"] ?? false, (double?)o["durationSec"] ?? 0);
+                    break;
+                case "cloud-play":
+                    OnCloudPlay();
+                    break;
+                case "cloud-pause":
+                    if (_cloudClock == null || !ReferenceEquals(_clock, _cloudClock)) break;
+                    _cloudClock.Update(_cloudClock.PositionSec, false, _cloudClock.DurationSec);
+                    PostClock();   // the run reads playing:false and holds where it is
+                    break;
+                case "cloud-ended":
+                    OnCloudEnded();
+                    break;
+                case "cloud-failed":
+                    PostTrack(new { type = "track-error", message = CloudDownMessage });
+                    break;
+            }
+        }
+        catch (Exception ex) { App.Logger?.Warning("RaceHost.OnCloudMessage: {E}", ex.Message); }
+    }
+
+    /// <summary>A new source started playing over there. It becomes the clock straight away, so the
+    /// run follows the voice from the first second, on the plain seeded road. Charting what they
+    /// are playing is the next commit in this stack.</summary>
+    private static void OnCloudTrack(JObject o)
+    {
+        string src = (string?)o["src"] ?? "";
+        string title = ((string?)o["title"] ?? "").Trim();
+        double dur = (double?)o["durationSec"] ?? 0;
+        if (string.IsNullOrWhiteSpace(src)) return;
+
+        // A new track while a run is live is the next lap: end this one the way the file running
+        // out does. The run-ended that answers must not take the new clock away, hence the flag.
+        bool live = _runActive && _clock is CloudTrackClock;
+        CancelAnalysis(postCancelled: false);
+        try { _player?.Stop(); } catch (Exception ex) { App.Logger?.Debug("RaceHost.cloud stop local: {E}", ex.Message); }
+
+        _trackName = string.IsNullOrWhiteSpace(title) ? "bambicloud" : title;
+        _lastProgressUtc = DateTime.MinValue;
+        _cloudClock ??= new CloudTrackClock(SetCloudPaused);
+        _cloudClock.Update(0, true, dur);
+        _clock = _cloudClock;
+        if (live)
+        {
+            _cloudSwapping = true;
+            PostTrack(new { type = "track-ended" });
+        }
+        StartTrackClock();
+        PostClock();
+        App.Logger?.Information("RaceHost: cloud track {Name} ({Dur:0.0}s){Lap}",
+            _trackName, dur, live ? ", next lap" : "");
+        ArmDevCloudDrive();
+    }
+
+    /// <summary>Their player started. If the race is still sitting on the menu, this is what starts
+    /// the run: the audio is the clock, so the run begins when the audio does.</summary>
+    private static void OnCloudPlay()
+    {
+        if (_cloudClock == null || !ReferenceEquals(_clock, _cloudClock)) return;
+        _cloudClock.Update(_cloudClock.PositionSec, true, _cloudClock.DurationSec);
+        if (!_runActive) PostTrack(new { type = "cloud-run" });
+        StartTrackClock();
+        PostClock();
+    }
+
+    /// <summary>Their element ran out. Same ending a local file gets: the page winds the lap up and
+    /// the next cloud-track starts the next one.</summary>
+    private static void OnCloudEnded()
+    {
+        if (!ReferenceEquals(_clock, _cloudClock) || _cloudClock == null) return;
+        _cloudClock.Stop();
+        StopTrackClock();
+        PostTrack(new { type = "track-ended" });
+        App.Logger?.Information("RaceHost: cloud track ended");
+    }
+
+    /// <summary>The Brake's half of the bargain: cloud-set-paused into their page.</summary>
+    private static void SetCloudPaused(bool on)
+    {
+        var disp = Application.Current?.Dispatcher;
+        if (disp == null || disp.HasShutdownStarted) return;
+        if (disp.CheckAccess()) _cloud?.PostToPage(new { type = "cloud-set-paused", on });
+        else disp.BeginInvoke(() => _cloud?.PostToPage(new { type = "cloud-set-paused", on }));
     }
 
     // ============================ settings reads ============================

--- a/ConditioningControlPanel/Services/Race/RaceCloudWindow.cs
+++ b/ConditioningControlPanel/Services/Race/RaceCloudWindow.cs
@@ -36,6 +36,9 @@ internal sealed class RaceCloudWindow : IDisposable
     private WebView2? _web;
     private bool _initStarted;
     private bool _coreReady;
+    /// <summary>The page to open on, when the levels panel named one. Read once by
+    /// InitWebAsync, so a window built for a track lands on that track and not the front door.</summary>
+    private string? _openOn;
     private bool _disposed;
 
     /// <summary>Every cloud-* frame the watcher posts. Raised on the UI thread.</summary>
@@ -47,13 +50,19 @@ internal sealed class RaceCloudWindow : IDisposable
 
     public bool IsOpen => _window != null && _window.IsVisible;
 
-    /// <summary>Open the window, or bring it back if it was closed to the tray of the mind.</summary>
-    public void ShowOrFocus()
+    /// <summary>Open the window, or bring it back if it was closed to the tray of the mind.
+    /// <paramref name="url"/> is the page to land on (a track's own page, from the levels
+    /// panel); null keeps whatever is already loaded, or the site's front door on a fresh
+    /// window. Checked against the site here as well, never trusted from the caller.</summary>
+    public void ShowOrFocus(string? url = null)
     {
         if (_disposed) return;
         try
         {
-            if (_window == null) Build();
+            var want = IsSiteUri(url) ? url : null;
+            if (_window == null) { _openOn = want; Build(); }
+            else if (want != null && _coreReady && _web?.CoreWebView2 != null) _web.CoreWebView2.Navigate(want);
+            else if (want != null) _openOn = want;   // still starting up: InitWebAsync takes it
             if (_window == null) return;
             if (!_window.IsVisible) _window.Show();
             _window.Activate();
@@ -190,7 +199,8 @@ internal sealed class RaceCloudWindow : IDisposable
             core.WebMessageReceived += OnWebMessageReceived;
             core.ProcessFailed += OnProcessFailed;
             _coreReady = true;
-            core.Navigate(StartUrl);
+            var landing = _openOn; _openOn = null;
+            core.Navigate(IsSiteUri(landing) ? landing! : StartUrl);
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
Lane D1 of Racing Thoughts x BambiCloud, PR 3 of 4. Base is #904. Stack: `feat/race-cloud-d1-clock` -> `feat/race-cloud-d1-window-frame` -> **this** -> `feat/race-cloud-d1-chart`.

The menu gains one lowercase verb, `play from bambicloud`, shown only when the host's init settings carry `cloud: true`. The desktop host sets it because the desktop owns the window; a web host that leaves the key off simply never shows the verb, and one that sets it answers `cloud-open` its own way.

Host side:

- `cloud-open` opens or refocuses the window.
- A cloud track becomes the clock the moment it starts, so the run follows the voice from the first second, on the plain seeded road.
- Their play starts the run if it has not started; their pause holds the race where it is (`track-clock playing:false`); the Brake pauses them back through `cloud-set-paused`; their track ending ends the lap.
- Their next track is the next lap: the live run ends the way a file running out ends it, and the `run-ended` that answers is let through the stop, because the next track already owns the clock.

Also adds `--race-cloud`, a dev rig beside `--race-track`: it opens the race and the window, logs every `track-*` post as JSON, and holds the Brake once at 10 s so the pause round trip can be watched. A browser frame will not take a synthetic key press, so there is no other way to see that half. It gates nothing and opens the same page `--race` opens.

### Verified
`dotnet build`: **0 errors**. Runtime evidence is in the last PR, where the whole path runs.

### Size
~237 changed lines. (`menu.js` also carries the `fetching` stage caption, which the next PR is the first to send.)

Rebased onto main after the web chain (#901-#914) on 2026-09-07; conflicts resolved: race/menu.js (the duplicate `play from bambicloud` verb is dropped, main's single `levels` verb wins, and the `opening` / `fetching` stage captions are kept), raceBoot.js (the verb's pick handler is dropped and its "over to bambicloud" plate moved onto the levels panel's `open` hook, which already posts `cloud-open` with the track's page url; the `cloud-run` handler is unchanged). Follow-on: `cloud-open` now reads that url, so `OpenCloudWindow` / `RaceCloudWindow.ShowOrFocus` take an optional page to land on and fall back to the site front door.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJ66hi5fRM1Dcjo38aSCa2
