### PR TITLE
feat(race-web): W2a - authored charts always win (index, hash, cache)

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/race/CHART.md
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/CHART.md
@@ -79,6 +79,34 @@ is `wake` if its mean energy is above the file mean; a segment that is mostly si
 everything else `free`. The words pass upgrades: a segment holding 3+ `trigger` events becomes
 `triggers`; one holding a `chant` becomes `mantra`.
 
+## Authored charts (owner rule: they always win)
+
+A chart with top level `"hand": true` was written by a person. It is used exactly as written:
+never merged with a generated road, never regenerated over, never written into any cache of
+generated charts. `normalizeChart` keeps `hand`, keeps a top level `rules` object, and keeps
+`hand`, `cue` and `note` on individual events, so an author can mark the events they placed and
+leave notes in the file without the validation pass quietly eating them.
+
+The web build ships them in `race/charts/`, with `race/charts/index.json` as the lookup table:
+
+```json
+{ "version": 1, "tracks": [
+  { "cloudId": "<file id or cdn basename>", "hash": "<sha1>", "title": "the settle",
+    "durationSec": 1834.2, "chart": "charts/the-settle.chart.json" } ] }
+```
+
+Lookup order for every track, first answer wins:
+
+1. an index row matching `cloudId`, derived from the url (`race/chartSource.js` `cloudIdFrom`)
+2. an index row matching the `CHART.md` hash of the file
+3. the generated-chart cache (`race/chartCache.js`, IndexedDB, keyed by hash)
+4. generate a road from the audio
+
+Steps 1 and 2 both answer before the audio is downloaded, so an authored track costs no
+download: 1 needs only the url, and 2 needs a length and the first 1 MiB. `race/charts/README.md`
+is the format and the link step in full. The desktop host holds the same rule with its own
+`TrackChartCache`: an authored chart is never handed to `Save`.
+
 ## Page side
 
 ### `race/chart.js` (PR c1, pure, node self-check, no THREE)

--- a/ConditioningControlPanel/Resources/web/dtrh/race/chart.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/chart.js
@@ -80,6 +80,12 @@ export function normalizeChart(json) {
       energy: str(an.energy, ''), words: str(an.words, 'none'), generatedAt: str(an.generatedAt, ''), partial: an.partial === true,
       lexicon: Object.freeze((Array.isArray(an.lexicon) ? an.lexicon : []).filter((w) => typeof w === 'string')),
     }),
+    // AUTHORED CHARTS (race/charts/README.md). A chart a person wrote carries `hand: true`
+    // and may carry a `rules` object. Normalizing is a validation pass, not an edit, so both
+    // come back untouched: strip them and an authored chart stops being one the moment it
+    // goes through here, and it goes through here on every single load.
+    hand: json.hand === true,
+    rules: Object.freeze((json.rules && typeof json.rules === 'object') ? { ...json.rules } : null),
   });
 }
 
@@ -116,6 +122,12 @@ function normalizeEvents(raw, durationSec) {
       if (e.kind === 'count') { ev.n = num(e.n, 0); ev.of = num(e.of, 0); ev.last = e.last === true; }
       if (e.kind === 'drop') ev.strength = clamp01(num(e.strength, 1));
       if (e.kind === 'chant') { ev.reps = Math.max(1, Math.round(num(e.reps, 3))); ev.period = Math.max(0, num(e.period, 0)); }
+      // An author marks the events they placed by hand inside a road, names the cue they
+      // want on one, and leaves a note for the next author. Kept, for the same reason `hand`
+      // is kept above: this pass validates a chart, it does not rewrite one.
+      if (e.hand === true) ev.hand = true;
+      if (typeof e.cue === 'string' && e.cue) ev.cue = e.cue;
+      if (typeof e.note === 'string' && e.note) ev.note = e.note.slice(0, 200);
       return Object.freeze(ev);
     });
   return Object.freeze(out);

--- a/ConditioningControlPanel/Resources/web/dtrh/race/chartCache.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/chartCache.js
@@ -1,0 +1,157 @@
+/* ============================================================================
+ * race/chartCache.js - the IndexedDB cache for GENERATED charts. WEB ONLY.
+ *
+ *   openCache({ name, log }) -> { get, put, count, close }   (never throws)
+ *
+ * WHY IT EXISTS. Charting a track means downloading it and decoding it: tens of
+ * megabytes and several seconds of a phone's life. The second time a player runs
+ * the same file none of that has to happen again, because the chart is small
+ * (timestamps and labels) and the file it was written against has a name that
+ * cannot change under it: the CHART.md hash.
+ *
+ * WHAT IT NEVER HOLDS. Audio. A record is a chart and four small fields. Nothing
+ * in here is uploaded, and nothing in here leaves the browser that wrote it.
+ *
+ * WHAT IT NEVER HOLDS, PART TWO: an AUTHORED chart. A chart with `hand: true` was
+ * written by a person and lives in `race/charts/`, not here. `put` refuses one, so
+ * a generated chart can never end up masquerading as an authored one and an
+ * authored one can never be evicted by the cap.
+ *
+ * INVALIDATION. Every record carries `gen`, the generator id of the road that
+ * wrote it. Tune the road and that string changes, and every chart the old road
+ * wrote reads as a miss and is dropped on sight. There is no migration to write:
+ * the source of a generated chart is the file, and the file is still there.
+ *
+ * THE CAP. MAX_ENTRIES, least recently READ first (`at` is touched on a hit, not
+ * just on a write), so the track a player keeps coming back to outlives the one
+ * they tried once. The sweep runs after a write, never in front of a read.
+ *
+ * A BROWSER THAT SAYS NO. Private windows, blocked site data and the odd embedded
+ * webview all refuse IndexedDB, sometimes by throwing on `indexedDB.open` and
+ * sometimes by never answering it. Every call in here is wrapped and time boxed,
+ * and a cache that could not open answers `null` to every get and swallows every
+ * put. A player with no cache charts every track: slower, never broken.
+ * ==========================================================================*/
+
+/** Bump this when the on-disk shape changes. The old store is deleted, not migrated. */
+export const DB_VERSION = 1;
+export const DB_NAME = 'race-charts';
+export const STORE = 'charts';
+/** How many generated charts are kept. A chart is a few tens of kB, so this is small on disk. */
+export const MAX_ENTRIES = 50;
+/** A browser that refuses IndexedDB sometimes refuses it by never answering. */
+export const OPEN_TIMEOUT_MS = 4000;
+
+const now = () => Date.now();
+
+/** An IDBRequest as a promise. A failure is `null`, never a throw: the caller has a fallback. */
+function ask(req, timeoutMs = 0) {
+  return new Promise((res) => {
+    let done = false;
+    const end = (v) => { if (!done) { done = true; res(v); } };
+    const t = timeoutMs ? setTimeout(() => end(null), timeoutMs) : 0;
+    try {
+      req.onsuccess = () => { if (t) clearTimeout(t); end(req.result); };
+      req.onerror = () => { if (t) clearTimeout(t); end(null); };
+      req.onblocked = () => { if (t) clearTimeout(t); end(null); };
+    } catch (e) { if (t) clearTimeout(t); end(null); }
+  });
+}
+
+/**
+ * Open the cache. Resolves to a cache object whatever happens: if the store could
+ * not be opened the object is still there and every get answers null.
+ *
+ * @param {object}  [o]
+ * @param {string}  [o.name]     db name, so a smoke can use its own
+ * @param {function}[o.log]
+ * @param {object}  [o.idb]      the IDBFactory, for a test that hands in its own
+ */
+export async function openCache({ name = DB_NAME, log = null, idb = null } = {}) {
+  const say = (m) => { try { if (log) log('chart cache: ' + m); } catch (e) { /* no log */ } };
+  const factory = idb || (typeof indexedDB !== 'undefined' ? indexedDB : null);
+  let db = null;
+  if (factory) {
+    try {
+      const req = factory.open(name, DB_VERSION);
+      req.onupgradeneeded = () => {
+        const d = req.result;
+        // A version bump is a wipe: a chart is cheap to make again and a half migrated
+        // store is a bug that only shows up on somebody else's phone.
+        if (d.objectStoreNames.contains(STORE)) d.deleteObjectStore(STORE);
+        const st = d.createObjectStore(STORE, { keyPath: 'hash' });
+        st.createIndex('at', 'at');
+      };
+      db = await ask(req, OPEN_TIMEOUT_MS);
+    } catch (e) { say('would not open: ' + ((e && e.message) || e)); }
+  }
+  if (!db) say('not available, every track will be charted fresh');
+
+  /** One transaction, one store. `null` when there is no db, which every caller handles. */
+  const store = (mode) => {
+    if (!db) return null;
+    try { return db.transaction(STORE, mode).objectStore(STORE); } catch (e) { say(mode + ': ' + e); return null; }
+  };
+
+  /** Drop the oldest records until the store is back under the cap. Fire and forget. */
+  async function sweep() {
+    const st = store('readwrite');
+    if (!st) return;
+    const n = await ask(st.count());
+    if (!(n > MAX_ENTRIES)) return;
+    let over = n - MAX_ENTRIES;
+    await new Promise((res) => {
+      let cur;
+      try { cur = st.index('at').openCursor(); } catch (e) { return res(); }
+      cur.onerror = () => res();
+      cur.onsuccess = () => {
+        const c = cur.result;
+        if (!c || over <= 0) return res();
+        try { c.delete(); } catch (e) { /* gone under us */ }
+        over--;
+        c.continue();
+      };
+    });
+    say(`swept ${n - MAX_ENTRIES} old chart${n - MAX_ENTRIES === 1 ? '' : 's'}`);
+  }
+
+  return {
+    /**
+     * The chart written for `hash` by generator `gen`, or null. A record from an
+     * older generator is a miss AND a delete: the road changed, that chart is wrong.
+     */
+    async get(hash, gen) {
+      if (!hash || !db) return null;
+      const st = store('readonly');
+      if (!st) return null;
+      const rec = await ask(st.get(String(hash)));
+      if (!rec || !rec.chart) return null;
+      if (gen && rec.gen !== gen) {
+        const w = store('readwrite');
+        if (w) { try { w.delete(String(hash)); } catch (e) { /* gone under us */ } }
+        say('stale road for ' + String(hash).slice(0, 8) + ', dropped');
+        return null;
+      }
+      const touch = store('readwrite');                 // read counts as use: LRU, not first in first out
+      if (touch) { try { touch.put({ ...rec, at: now() }); } catch (e) { /* gone under us */ } }
+      return rec.chart;
+    },
+
+    /** Keep a GENERATED chart. An authored one is refused: those live in race/charts/. */
+    async put(hash, chart, gen) {
+      if (!hash || !chart || !db) return false;
+      if (chart.hand === true) { say('refused an authored chart: those are not cached'); return false; }
+      const st = store('readwrite');
+      if (!st) return false;
+      const okay = await ask(st.put({ hash: String(hash), gen: String(gen || ''), at: now(), chart })) !== null;
+      if (okay) sweep();
+      return okay;
+    },
+
+    async count() { const st = store('readonly'); return st ? (await ask(st.count())) || 0 : 0; },
+    get available() { return !!db; },
+    close() { try { if (db) db.close(); } catch (e) { /* already gone */ } db = null; },
+  };
+}
+
+export default openCache;

--- a/ConditioningControlPanel/Resources/web/dtrh/race/chartSource.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/chartSource.js
@@ -1,0 +1,187 @@
+/* ============================================================================
+ * race/chartSource.js - which chart a track gets, and the two names a track has.
+ *
+ *   cloudIdFrom(url)                   -> the stable name of the file on the CDN
+ *   hashBytes(head, byteLength)        -> the CHART.md hash, pure
+ *   hashUrl(url, { fetch })            -> the same hash WITHOUT downloading the file
+ *   loadIndex(url, { fetch })          -> race/charts/index.json, once
+ *   findAuthored(index, { cloudId, hash })
+ *   isAuthored(chart)
+ *
+ * THE ORDER (owner rule: AUTHORED CHARTS ALWAYS WIN). Every track is looked up
+ * four times and stops at the first answer:
+ *
+ *   a. the authored index, by `cloudId` off the url
+ *   b. the authored index, by the file hash
+ *   c. the generated-chart cache, by the file hash
+ *   d. nothing: generate one
+ *
+ * a and b are the point of this file. Both of them have to be able to answer
+ * BEFORE the file is downloaded, or "an authored chart costs no download" is a
+ * sentence and not a behaviour. a needs only the url. b needs the hash, and the
+ * hash is a length and the first 1 MiB, so `hashUrl` asks for a length and a
+ * megabyte instead of an hour of audio.
+ *
+ * WHAT AN AUTHORED CHART IS. Any chart JSON with top level `hand: true`. It is
+ * used exactly as it was written: never merged with a generated one, never
+ * regenerated, never written into the cache. `race/charts/README.md` is the
+ * format and the link step.
+ *
+ * THE HASH IS CHART.md's, unchanged: SHA1 of the byte length as 8 bytes little
+ * endian plus the first 1 MiB. `hashFile` in chart/editor/audio.js is the
+ * canonical body and it is IMPORTED here, not copied, so the browser, the desktop
+ * host and tools/racechart/align.py stay on one number.
+ *
+ * WHEN THE CDN WILL NOT COOPERATE. `Range` is not a CORS simple header, so a
+ * ranged GET needs a preflight the CDN may not answer, and `Content-Range` needs
+ * to be exposed before it can be read. Every one of those doors is tried and none
+ * of them is required: if they are all shut, `hashUrl` answers null and the
+ * caller hashes the body it had to download anyway. The cache still hits on the
+ * second run. Only the saved download is lost, and it is lost quietly.
+ * ==========================================================================*/
+
+import { hashFile } from '../chart/editor/audio.js';
+
+/** CHART.md: the hash reads the first 1 MiB and nothing else. */
+export const HASH_HEAD = 1024 * 1024;
+/** A path segment this long, made only of id characters, is an id and not a word. */
+const ID_MIN = 20;
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const IDISH = /^[A-Za-z0-9_-]+$/;
+
+/**
+ * The stable name of a file on the CDN, and the key an author writes in the index.
+ *
+ * A cdn url is a path to one file. The last segment is a file name and a file name
+ * can be renamed; an id segment cannot. So: if any segment of the path is a uuid,
+ * or is ID_MIN characters or more of `[A-Za-z0-9_-]`, the LAST such segment is the
+ * id. Otherwise it is the last segment with its extension taken off. Lower cased
+ * either way, because an index a person types by hand must not care about case.
+ *
+ * Pure: no network, no DOM. A url this cannot parse answers ''.
+ */
+export function cloudIdFrom(url) {
+  let u = null;
+  try { u = new URL(String(url)); } catch (e) { return ''; }
+  const segs = u.pathname.split('/').map((s) => { try { return decodeURIComponent(s); } catch (e) { return s; } }).filter(Boolean);
+  if (!segs.length) return '';
+  for (let i = segs.length - 1; i >= 0; i--) {
+    const s = segs[i];
+    if (UUID.test(s) || (s.length >= ID_MIN && IDISH.test(s))) return s.toLowerCase();
+  }
+  return segs[segs.length - 1].replace(/\.[a-z0-9]{2,4}$/i, '').toLowerCase();
+}
+
+/**
+ * The CHART.md hash of a file whose first bytes and total length are in hand.
+ * Delegates to chart/editor/audio.js so there is one implementation of the sum:
+ * `hashFile` wants `.size` and `.slice()`, and this is those two over a buffer we
+ * already hold rather than over a File the page never had.
+ *
+ * @param {Uint8Array|ArrayBuffer} head        the first HASH_HEAD bytes (or fewer, for a small file)
+ * @param {number} byteLength                  the WHOLE file's length, not the head's
+ */
+export function hashBytes(head, byteLength) {
+  const bytes = head instanceof Uint8Array ? head : new Uint8Array(head || 0);
+  const cut = bytes.length > HASH_HEAD ? bytes.subarray(0, HASH_HEAD) : bytes;
+  const total = Number(byteLength);
+  if (!(total > 0)) return Promise.resolve('');
+  return hashFile({ size: total, slice: () => ({ arrayBuffer: async () => cut.slice().buffer }) });
+}
+
+/** `Content-Range: bytes 0-1048575/54237184` -> 54237184. Null when it is not there or not that. */
+function totalFromRange(v) {
+  const m = /\/\s*(\d+)\s*$/.exec(String(v || ''));
+  const n = m ? Number(m[1]) : NaN;
+  return n > 0 ? n : null;
+}
+
+/**
+ * The file's hash without downloading the file.
+ *
+ *   1. HEAD for `content-length` (a CORS safelisted response header, so it reads
+ *      cross origin whenever the HEAD itself is allowed).
+ *   2. GET with `Range: bytes=0-<1 MiB - 1>`. A 206 gives the head bytes, and its
+ *      `Content-Range` gives the total length when step 1 could not.
+ *   3. If the server ignored the range and sent 200, that body IS the file: its
+ *      length is the total and its first 1 MiB is the head, so the hash is still
+ *      right (a full download happened, which is the cost of a server that will
+ *      not do ranges).
+ *
+ * Answers `{ hash, bytes, total, ranged }` or null when it could not be worked
+ * out at all. Never throws: every failure is a null and a log line.
+ */
+export async function hashUrl(url, { fetch: f = null, log = null, signal = null } = {}) {
+  const get = f || (typeof fetch !== 'undefined' ? fetch : null);
+  const say = (m) => { try { if (log) log('hash: ' + m); } catch (e) { /* no log */ } };
+  if (!get || !url) return null;
+  let total = null;
+  try {
+    const h = await get(url, { method: 'HEAD', mode: 'cors', credentials: 'omit', signal });
+    if (h && h.ok) { const n = Number(h.headers.get('content-length')); if (n > 0) total = n; }
+  } catch (e) { say('no HEAD (' + ((e && e.message) || e) + ')'); }
+  let res = null;
+  try {
+    res = await get(url, { method: 'GET', mode: 'cors', credentials: 'omit', signal, headers: { Range: `bytes=0-${HASH_HEAD - 1}` } });
+  } catch (e) { say('no ranged read (' + ((e && e.message) || e) + ')'); return null; }
+  if (!res || !res.ok) { say('ranged read answered ' + (res ? res.status : 'nothing')); return null; }
+  const ranged = res.status === 206;
+  if (!total) total = totalFromRange(res.headers.get('content-range'));
+  const bytes = new Uint8Array(await res.arrayBuffer());
+  // A 200 to a ranged GET is the whole file: its own length is the only length there is.
+  if (!ranged) total = bytes.length;
+  if (!(total > 0)) { say('no length anywhere, cannot name this file'); return null; }
+  const hash = await hashBytes(bytes, total);
+  return hash ? { hash, bytes, total, ranged } : null;
+}
+
+/* ---- the authored index -------------------------------------------------- */
+
+/** A chart JSON a person wrote. The one flag, checked in one place. */
+export function isAuthored(chart) {
+  return !!chart && typeof chart === 'object' && chart.hand === true;
+}
+
+const indexCache = new Map();        // url -> Promise<index>, so the file is fetched once a session
+
+/**
+ * `race/charts/index.json`, fetched once. An index that is missing or malformed is
+ * an EMPTY index and a log line: an authored chart nobody wrote is not an error,
+ * and a broken index must never stop a track from being charted.
+ */
+export function loadIndex(url, { fetch: f = null, log = null } = {}) {
+  const key = String(url);
+  if (indexCache.has(key)) return indexCache.get(key);
+  const get = f || (typeof fetch !== 'undefined' ? fetch : null);
+  const say = (m) => { try { if (log) log('charts index: ' + m); } catch (e) { /* no log */ } };
+  const p = (async () => {
+    if (!get) return { version: 1, tracks: [] };
+    try {
+      const res = await get(key, { credentials: 'omit' });
+      if (!res || !res.ok) { say('none (' + (res ? res.status : 'no answer') + ')'); return { version: 1, tracks: [] }; }
+      const json = await res.json();
+      const tracks = Array.isArray(json && json.tracks) ? json.tracks.filter((t) => t && typeof t === 'object' && t.chart) : [];
+      if (tracks.length) say(tracks.length + ' authored track' + (tracks.length === 1 ? '' : 's'));
+      return { version: Number(json && json.version) || 1, tracks };
+    } catch (e) { say('unreadable: ' + ((e && e.message) || e)); return { version: 1, tracks: [] }; }
+  })();
+  indexCache.set(key, p);
+  return p;
+}
+
+/** Forget the fetched index. For the smoke, which serves more than one of them. */
+export function forgetIndex(url) { if (url === undefined) indexCache.clear(); else indexCache.delete(String(url)); }
+
+/**
+ * The index row for a track, `cloudId` first and `hash` second, or null. Case is
+ * ignored on both because both are typed by hand into a JSON file.
+ */
+export function findAuthored(index, { cloudId = '', hash = '' } = {}) {
+  const rows = (index && Array.isArray(index.tracks)) ? index.tracks : [];
+  const id = String(cloudId || '').toLowerCase(), h = String(hash || '').toLowerCase();
+  if (id) { const r = rows.find((t) => String(t.cloudId || '').toLowerCase() === id); if (r) return { row: r, by: 'cloudId' }; }
+  if (h) { const r = rows.find((t) => String(t.hash || '').toLowerCase() === h); if (r) return { row: r, by: 'hash' }; }
+  return null;
+}
+
+export default { cloudIdFrom, hashBytes, hashUrl, loadIndex, findAuthored, isAuthored };

--- a/ConditioningControlPanel/Resources/web/dtrh/race/charts/README.md
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/charts/README.md
@@ -1,0 +1,89 @@
+# race/charts - authored charts
+
+A chart in this folder was written by a person. **Authored charts always win**: if
+a track has one, the race uses it and never generates a road for that track, never
+merges a generated road into it, and never writes it into the generated-chart
+cache. Nothing an automatic pass does can overwrite what is in here.
+
+Everything in this folder ships with the web build and is served from the same
+origin as the game, so reading one costs no third-party request.
+
+## The two files
+
+`index.json` is the lookup table. It ships empty and it is the only file the game
+reads at boot.
+
+```json
+{
+  "version": 1,
+  "tracks": [
+    {
+      "cloudId": "0f4c2a18-9d3b-4c77-b0e1-6a2d5f8c1234",
+      "hash": "3f2a9c1d84b6e0f5a7c2d9e3b1f408a6c5d7e920",
+      "title": "the settle",
+      "durationSec": 1834.2,
+      "chart": "charts/the-settle.chart.json"
+    }
+  ]
+}
+```
+
+| field | what it is |
+| --- | --- |
+| `cloudId` | the stable name of the file on the CDN, derived from its url (see below). Optional if `hash` is set. |
+| `hash` | the `CHART.md` hash of the audio file: SHA1 hex of the byte length as 8 bytes little endian plus the first 1 MiB. Optional if `cloudId` is set. |
+| `title` | what the plate and the results card say. The chart's own `source.name` wins if it has one. |
+| `durationSec` | the file's length in seconds. For the reader's benefit; the chart carries the number that counts. |
+| `chart` | the chart file, relative to `race/` (so `charts/<name>.chart.json`). |
+
+The chart file itself is `CHART.md` version 1 JSON with one extra top level flag:
+
+```json
+{ "version": 1, "hand": true, "source": { ... }, "acts": [ ... ], "events": [ ... ] }
+```
+
+`hand: true` is what makes it authored. `race/chart.js` `normalizeChart` keeps
+that flag, keeps a top level `rules` object, and keeps `hand`, `cue` and `note` on
+individual events, so an author can leave notes to the next author in the file and
+mark the events they placed by hand inside an otherwise generated road.
+
+## Deriving `cloudId` from a url
+
+One rule, implemented once in `race/chartSource.js` `cloudIdFrom()`:
+
+1. Split the url's path on `/` and drop the empty parts.
+2. If any part is a uuid (`8-4-4-4-12` hex) or is 20 characters or more of
+   `[A-Za-z0-9_-]`, the **last** such part is the id.
+3. Otherwise the id is the last part with its file extension removed.
+4. Lower case, always.
+
+So `https://cdn.bambicloud.com/files/0f4c2a18-9d3b-4c77-b0e1-6a2d5f8c1234/track.mp3`
+gives `0f4c2a18-9d3b-4c77-b0e1-6a2d5f8c1234`, and a plain
+`https://cdn.bambicloud.com/audio/the-settle.mp3` gives `the-settle`.
+
+An id survives a rename, which is why it is preferred over the file name. Set both
+`cloudId` and `hash` when you can: `cloudId` is checked first and costs nothing,
+and `hash` still finds the track if it ever moves to another url.
+
+## The link step
+
+1. Write the chart. `chart/editor/` builds one; so does hand editing a generated
+   chart out of the browser's cache. Set `"hand": true` at the top level.
+2. Save it as `race/charts/<name>.chart.json`.
+3. Get the two keys. `cloudId` comes off the url by the rule above.
+   `hash` is what `race/chartSource.js` `hashUrl()` logs for that track, and
+   `tools/racechart/align.py` computes the same number from a local copy.
+4. Add the row to `index.json`.
+5. Load the track. The log says which door it came through:
+   `chart: authored by cloudId`, `authored by hash`, `cached` or `generated`.
+
+## The order every track is looked up in
+
+1. `index.json` row matching `cloudId`
+2. `index.json` row matching `hash`
+3. the IndexedDB cache of generated charts, by `hash`
+4. generate one from the audio
+
+Steps 1 and 2 both answer before the audio is downloaded: 1 needs only the url,
+and 2 needs the hash, which is a length and the first megabyte. An authored track
+therefore costs no download at all.

--- a/ConditioningControlPanel/Resources/web/dtrh/race/charts/index.json
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/charts/index.json
@@ -1,0 +1,4 @@
+{
+  "version": 1,
+  "tracks": []
+}


### PR DESCRIPTION
Lane W2 of Racing Thoughts x BambiCloud, part 1 of 3. **Stacked on #902** (`feat/race-cloud-w1-smoke`), not on main, because it builds on W1's player. Merge W1 first, then this, then #W2b, then #W2c.

The three doors a track can come through before anything is generated, so an authored chart is used as written and costs no download.

- **`race/chartSource.js`** - `cloudIdFrom()` (the stable name of a file on the CDN: a uuid or long id segment if there is one, else the last path segment with its extension off, lower case), `hashUrl()` (the CHART.md hash from a HEAD and a 1 MiB `Range`, never the whole file, and a quiet null if the CDN will do neither), and the `race/charts/index.json` lookup by `cloudId` then by `hash`. The hash body is **imported** from `chart/editor/audio.js`, not copied, so the browser, the desktop host and `tools/racechart/align.py` stay on one number.
- **`race/chartCache.js`** - IndexedDB cache for GENERATED charts only, keyed by hash, carrying a generator id so a tuned road invalidates its own old entries, LRU capped at 50. `put` refuses a chart with `hand: true`. A browser that refuses IndexedDB charts every track instead: slower, never broken.
- **`race/charts/index.json`** (ships empty) + **`README.md`** - the format, the `cloudId` derivation, and the link step.
- **`race/chart.js`** - `normalizeChart` kept the shape and threw the rest away, so an authored chart stopped being authored the moment it was loaded, and it goes through there on every single load. It now keeps top level `hand` and `rules`, and per event `hand`, `cue` and `note`.
- **`CHART.md`** - the authored-charts rule and the four step lookup order.

Nothing here is wired up yet; W2b is the module that uses it and W2c wires it in.

477 changed lines.

Verified: `node race/smoke/chart-check.mjs`, `node chart/smoke/generate-check.mjs`, `node race/smoke/track-run-check.mjs` all green, and the three W2 units are held down by the pure sections of `cloud-chart-check.mjs` in W2c.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJ66hi5fRM1Dcjo38aSCa2
