### PR TITLE
feat(race-web): W2c - wire the real charts in, read the next track ahead, and check it

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/race/cloud.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/cloud.js
@@ -59,6 +59,14 @@ export const REFUSED_LINE = 'that is a page link, not a track link. open it over
 
 /** The host's own cadence (CHART.md), and the two waits a load is allowed. */
 export const TICK_MS = 250;
+/**
+ * How close to the end of the file counts AS the end of it. run.js ends a tracked run
+ * at `durationSec - 0.25` (CHART.md), which is BEFORE the element fires `ended`, and
+ * ending the run posts `track-stop`, which pauses the element so `ended` never comes at
+ * all. So a stop this close to the end is the file running out, and the lap rolls on to
+ * the next track; a stop anywhere else is a player leaving, and it does not.
+ */
+export const END_SLOP = 1.2;
 export const LOAD_TIMEOUT_MS = 15000;
 export const RETRY_MS = 900;
 
@@ -124,7 +132,8 @@ const elm = (tag, cls, parent, text) => {
  * @param {object}   o
  * @param {object}   o.settings   the host's `init.settings`
  * @param {object}   o.hooks      clock(t, playing), ended(), chart(info)->Promise<chart>,
- *                                track(chart|null, info|null), toast(line), pause(on), refresh()
+ *                                track(chart|null, info|null), prefetch(info|null), toast(line),
+ *                                pause(on), refresh()
  * @param {function} [o.log]
  * @param {function} [o.ui]       the menu blips
  * @param {function} [o.makeAudio] url -> element. The smoke's seam; the page uses `new Audio`.
@@ -139,6 +148,7 @@ export function createCloud({ settings = {}, hooks = {}, log = null, ui = null, 
 
   let list = [], at = -1, el = null, timer = 0, tries = 0, retry = 0, gen = 0;
   let played = false;                 // a run has actually played this element, so `pause` means something
+  let rolled = false;                 // this element has already handed the lap on
   let view = 'paste', busy = false, disposed = false;
   let input = null, countEl = null, nextEl = null, rows = [], els = [], slotEl = null;
   let onPickRow = null, onClose = null, onRefresh = null;
@@ -198,7 +208,7 @@ export function createCloud({ settings = {}, hooks = {}, log = null, ui = null, 
     if (!e || !e.url || e.locked || e.failed || disposed) return false;
     const mine = ++gen;
     dropEl();
-    at = i; busy = true; played = false; paint();
+    at = i; busy = true; played = false; rolled = false; paint();
     let a = null;
     try {
       a = makeAudio ? makeAudio(e.url) : new Audio();
@@ -221,8 +231,20 @@ export function createCloud({ settings = {}, hooks = {}, log = null, ui = null, 
     blip('tick');
     say(`${e.title}: ${Math.round(dur)}s, ${at + 1} of ${list.length}`);
     call('track', chart, info());
+    armPrefetch();
     paint();
     return true;
+  }
+
+  /**
+   * Name the next playable track while this one is being driven, so whatever charts
+   * it can start now rather than at the moment the lap rolls over. `null` means
+   * there is nothing after this one and anything in flight can be let go.
+   */
+  function armPrefetch() {
+    const nx = nextPlayable(at + 1);
+    const e = nx >= 0 ? list[nx] : null;
+    call('prefetch', e ? { id: e.id, url: e.url, title: e.title } : null);
   }
 
   /** One retry, then stop. Nothing here ever schedules a second one. */
@@ -244,8 +266,10 @@ export function createCloud({ settings = {}, hooks = {}, log = null, ui = null, 
     return false;
   }
 
-  /** The file ran out: end this lap, then walk to the next playable track. */
+  /** The file ran out: end this lap, then walk to the next playable track. Once per element. */
   function onEnded() {
+    if (rolled) return;                 // the run ended AND the element ended: one rollover, not two
+    rolled = true;
     stopTick();
     call('clock', el ? Number(el.duration) || 0 : 0, false);
     call('ended');
@@ -275,7 +299,9 @@ export function createCloud({ settings = {}, hooks = {}, log = null, ui = null, 
       call('clock', Number(el.currentTime) || 0, m.on === false);
     } else if (t === 'track-stop') {
       stopTick();
+      const left = Number(el.duration) - (Number(el.currentTime) || 0);
       try { el.pause(); } catch (e) { /* already gone */ }
+      if (played && isFinite(left) && left <= END_SLOP) { onEnded(); return; }
     }
     paint();
   }
@@ -325,12 +351,14 @@ export function createCloud({ settings = {}, hooks = {}, log = null, ui = null, 
     view = list.length ? 'list' : 'paste';
     paint();
     if (at < 0) { const nx = nextPlayable(0); if (nx >= 0) load(nx); }
+    else armPrefetch();                 // a link pasted mid run may be the next lap
   }
 
   function forget() {
     dropEl();
     gen++; list = []; at = -1; tries = 0; busy = false; view = 'paste';
     call('track', null, null);
+    call('prefetch', null);
     paint();
   }
 
@@ -414,6 +442,7 @@ export function createCloud({ settings = {}, hooks = {}, log = null, ui = null, 
     dispose() {
       disposed = true;
       if (retry) { clearTimeout(retry); retry = 0; }
+      call('prefetch', null);
       dropEl();
       list = []; els = []; rows = [];
     },

--- a/ConditioningControlPanel/Resources/web/dtrh/race/smoke/cloud-chart-check.mjs
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/smoke/cloud-chart-check.mjs
@@ -1,0 +1,346 @@
+/* ============================================================================
+ * race/smoke/cloud-chart-check.mjs - the W2 half of the BambiCloud lane: the
+ * road a real file gets, and the three doors it can come through first.
+ *
+ *   node race/smoke/cloud-chart-check.mjs     (0 on pass, 1 with a count of failures)
+ *
+ * cloud-check.mjs holds the player down: the panel, the clock, the pause, the
+ * playlist walk. This one holds down what the player is handed - and half of it
+ * is pure, so sections 1 and 2 run in node before Chrome is even started.
+ *
+ * IT NEVER TOUCHES BAMBICLOUD. The two tracks are WAV files this file writes in
+ * memory, and section 8 fails if a single request left localhost.
+ *
+ * The authored index is served BY THIS FILE, not shipped: `race/charts/index.json`
+ * in the repo stays empty, and the server below answers that one path with a test
+ * row instead. A smoke must never need a fixture in the product.
+ *
+ * What it holds:
+ *   1. cloudIdFrom and the CHART.md hash, pure
+ *   2. the wordless road, pure: energy bins, build/peak/release, quiet where the
+ *      file is quiet, NO fog on the start line, and more than one room
+ *   3. normalizeChart keeps `hand`, `rules` and per-event hand/cue/note
+ *   4. a real file decoded in the browser gives a real road
+ *   5. an authored chart WINS: it is used as written, it keeps `hand`, and the
+ *      chart pipeline never asks the CDN for the file at all
+ *   6. the second load of the same file is a cache hit, with no decode
+ *   7. the plate still names the track
+ *   8. nothing left localhost
+ *
+ * CHROME: `CHROME_PATH` if it is set, else the usual Windows install.
+ * ==========================================================================*/
+
+import { spawn } from 'node:child_process';
+import { createServer } from 'node:http';
+import { readFile } from 'node:fs/promises';
+import { mkdtempSync, rmSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, extname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { cloudIdFrom, hashBytes, findAuthored, isAuthored } from '../chartSource.js';
+import { roadFromPeaks, quietFromEnergy, actsFromEnergy, BIN_SEC, QUIET_LEVEL } from '../cloudChart.js';
+import { normalizeChart } from '../chart.js';
+
+let fails = 0;
+const ok = (cond, what) => { if (!cond) { console.error('FAIL ' + what); fails++; } else console.log('  ok  ' + what); };
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const HERE = resolve(fileURLToPath(import.meta.url), '..');
+const WEB = resolve(HERE, '../../..');          // Resources/web
+const PORT = 8863;
+const CHROME = process.env.CHROME_PATH || 'C:/Program Files/Google/Chrome/Application/chrome.exe';
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.mjs': 'text/javascript', '.css': 'text/css', '.json': 'application/json', '.glb': 'model/gltf-binary', '.png': 'image/png', '.webp': 'image/webp', '.jpg': 'image/jpeg', '.mp3': 'audio/mpeg', '.wav': 'audio/wav', '.svg': 'image/svg+xml', '.woff2': 'font/woff2' };
+
+/* ---- the test file ------------------------------------------------------- */
+/**
+ * A 90 second file shaped like a hypno track and nothing like music: it opens at
+ * a speaking level (so there is nothing quiet at t=0 to fog), swells twice, and
+ * has two long quiet stretches and a loud way out. Over 1 MiB on purpose, so the
+ * hash really does read a head and not a whole file.
+ */
+const DUR = 90, RATE = 8000;
+function levelAt(t) {
+  if (t < 8) return 0.45;
+  if (t < 16) return 0.45 + 0.5 * ((t - 8) / 8);       // the first climb
+  if (t < 18) return 0.95;
+  if (t < 24) return 0.95 - 0.9 * ((t - 18) / 6);      // and the fall away from it
+  if (t < 34) return 0.02;                             // ten seconds of nothing
+  if (t < 40) return 0.45;
+  if (t < 50) return 0.45 + 0.5 * ((t - 40) / 10);     // the second climb
+  if (t < 52) return 0.95;
+  if (t < 58) return 0.95 - 0.9 * ((t - 52) / 6);
+  if (t < 70) return 0.02;                             // twelve more
+  return 0.85;                                          // the way up, louder than the file's mean
+}
+function wav(seconds = DUR, rate = RATE) {
+  const n = seconds * rate, body = Buffer.alloc(n * 2);
+  for (let i = 0; i < n; i++) {
+    const t = i / rate;
+    body.writeInt16LE(Math.round(32000 * levelAt(t) * Math.sin((2 * Math.PI * 220 * i) / rate)), i * 2);
+  }
+  const head = Buffer.alloc(44);
+  head.write('RIFF', 0); head.writeUInt32LE(36 + body.length, 4); head.write('WAVEfmt ', 8);
+  head.writeUInt32LE(16, 16); head.writeUInt16LE(1, 20); head.writeUInt16LE(1, 22);
+  head.writeUInt32LE(rate, 24); head.writeUInt32LE(rate * 2, 28); head.writeUInt16LE(2, 32); head.writeUInt16LE(16, 34);
+  head.write('data', 36); head.writeUInt32LE(body.length, 40);
+  return Buffer.concat([head, body]);
+}
+const TRACK = wav();
+
+/** The authored stub, and the index row that points at it. Served, never shipped. */
+const HAND_CHART = {
+  version: 1, hand: true, rules: { density: 'as written' }, binSec: 0.5,
+  energy: new Array(Math.ceil(DUR / 0.5)).fill(0.4),
+  acts: [{ t0: 0, t1: DUR, kind: 'mantra', name: 'by hand' }],
+  events: [
+    { id: 'h1', t: 5, kind: 'trigger', label: 'good girl', hand: true, cue: 'spiral', note: 'placed by hand' },
+    { id: 'h2', t: 40, kind: 'drop', label: 'sink', strength: 1, hand: true },
+  ],
+  source: { name: 'the authored one', hash: '', durationSec: DUR, sampleRate: 16000 },
+  analysis: { energy: 'hand', words: 'hand', generatedAt: '', partial: false },
+};
+const TEST_INDEX = { version: 1, tracks: [{ cloudId: 'hand', title: 'the authored one', durationSec: DUR, chart: 'charts/hand-stub.chart.json' }] };
+
+/* ============================================================================
+ * 1. the two names a track has (pure)
+ * ==========================================================================*/
+ok(cloudIdFrom('https://cdn.bambicloud.com/files/0f4c2a18-9d3b-4c77-b0e1-6a2d5f8c1234/track.mp3') === '0f4c2a18-9d3b-4c77-b0e1-6a2d5f8c1234',
+  'a uuid anywhere in the path is the id, not the file name that can be renamed under it');
+ok(cloudIdFrom('https://cdn.bambicloud.com/audio/The-Settle.MP3') === 'the-settle', 'a plain url is its last segment, lower case, with the extension off');
+ok(cloudIdFrom('not a url') === '' && cloudIdFrom('https://cdn.bambicloud.com/') === '', 'a url with no path at all is no id rather than a throw');
+{
+  const bytes = new Uint8Array(3000);
+  for (let i = 0; i < bytes.length; i++) bytes[i] = (i * 31) & 255;
+  const want = new Uint8Array(8 + bytes.length);
+  new DataView(want.buffer).setBigUint64(0, BigInt(bytes.length), true);
+  want.set(bytes, 8);
+  const wantHex = [...new Uint8Array(await crypto.subtle.digest('SHA-1', want))].map((b) => b.toString(16).padStart(2, '0')).join('');
+  ok(await hashBytes(bytes, bytes.length) === wantHex, 'the hash off a range is CHART.md\'s own: the length as 8 bytes LE plus the head');
+  ok(await hashBytes(bytes, 0) === '', 'and a file with no length at all is no hash rather than a wrong one');
+}
+ok(findAuthored(TEST_INDEX, { cloudId: 'HAND' }).by === 'cloudId', 'the index is matched on cloudId first, and case is ignored');
+ok(findAuthored(TEST_INDEX, { cloudId: 'nope', hash: 'nope' }) === null, 'a track nobody wrote a chart for finds nothing');
+ok(isAuthored(HAND_CHART) === true && isAuthored({ version: 1 }) === false, '`hand: true` is the whole authored test');
+
+/* ============================================================================
+ * 2. the wordless road (pure)
+ * ==========================================================================*/
+{
+  const per = 50, peaks = new Float32Array(DUR * per * 2);
+  for (let i = 0; i < DUR * per; i++) { const a = levelAt(i / per); peaks[i * 2] = -a; peaks[i * 2 + 1] = a; }
+  const road = roadFromPeaks({ peaks, perSec: per, durationSec: DUR, name: 'the test file', hash: 'abc' });
+  const kinds = (k) => road.events.filter((e) => e.kind === k);
+  ok(road.energy.length === Math.ceil(DUR / BIN_SEC), `the curve is one number per ${BIN_SEC}s bin (${road.energy.length})`);
+  ok(road.energy.some((v) => v > 0.8) && road.energy.some((v) => v < QUIET_LEVEL), 'the curve reaches the loud end and the quiet end of the file');
+  ok(kinds('build').length >= 2 && kinds('peak').length >= 2 && kinds('release').length >= 2,
+    `both swells became a build, a peak and a release (${kinds('build').length}/${kinds('peak').length}/${kinds('release').length})`);
+  ok(kinds('silence').length === 2, `the two quiet stretches are the only quiet on the road (${kinds('silence').length})`);
+  ok(!road.events.some((e) => e.kind === 'silence' && e.t < 1), 'and NOTHING fogs the start line: no words is not the same as no sound');
+  ok(road.acts.length >= 2 && new Set(road.acts.map((a) => a.kind)).size >= 2,
+    `the file is more than one room (${road.acts.map((a) => a.kind).join(' -> ')})`);
+  ok(road.acts[0].t0 === 0 && road.acts[road.acts.length - 1].t1 === DUR, 'and the rooms cover the whole file');
+  ok(road.analysis.words === 'none', 'the road says out loud that nobody heard any words in it');
+  const n = normalizeChart(road);
+  ok(n.events.length === road.events.length && n.hand === false, 'the whole road comes back out of normalizeChart, and it is not authored');
+}
+{
+  const flat = new Array(400).fill(0.5);
+  ok(quietFromEnergy(flat, BIN_SEC, 100).length === 0, 'a file that is never quiet gets no silence at all');
+  const tail = new Array(400).fill(0.5); for (let i = 320; i < 400; i++) tail[i] = 0.01;
+  ok(quietFromEnergy(tail, BIN_SEC, 100).length === 0, 'and a fade out at the end is not fog on the finish line');
+  ok(actsFromEnergy(new Array(400).fill(0.5), BIN_SEC, 100)[0].kind === 'induction', 'every file starts in the settle');
+}
+
+/* ============================================================================
+ * 3. what normalizeChart is allowed to throw away (pure)
+ * ==========================================================================*/
+{
+  const n = normalizeChart(HAND_CHART);
+  ok(n.hand === true, '`hand: true` survives the validation pass, so an authored chart stays authored');
+  ok(n.rules && n.rules.density === 'as written', 'and so does the `rules` block an author wrote');
+  const e = n.events.find((x) => x.id === 'h1');
+  ok(e && e.hand === true && e.cue === 'spiral' && e.note === 'placed by hand', 'an event an author placed keeps its hand, its cue and its note');
+  const d = n.events.find((x) => x.id === 'h2');
+  ok(d && d.hand === true && d.strength === 1, 'and the fields the kind already had are still there beside them');
+}
+
+/* ============================================================================
+ * the browser half
+ * ==========================================================================*/
+const asks = [];                                 // { method, path, ranged }
+const server = createServer(async (req, res) => {
+  const path = decodeURIComponent(new URL(req.url, 'http://x').pathname);
+  asks.push({ method: req.method, path, ranged: !!req.headers.range });
+  // The authored index and its chart: served here so the shipped index stays empty.
+  if (path === '/dtrh/race/charts/index.json' || path === '/dtrh/race/charts/hand-stub.chart.json') {
+    const body = Buffer.from(JSON.stringify(path.endsWith('index.json') ? TEST_INDEX : HAND_CHART));
+    res.writeHead(200, { 'content-type': 'application/json', 'content-length': body.length });
+    return res.end(req.method === 'HEAD' ? undefined : body);
+  }
+  if (path === '/stub/gen.wav' || path === '/stub/hand.wav') {
+    const m = /^bytes=(\d+)-(\d*)$/.exec(req.headers.range || '');
+    if (m) {
+      const a = Number(m[1]), b = Math.min(TRACK.length - 1, m[2] ? Number(m[2]) : TRACK.length - 1);
+      const cut = TRACK.subarray(a, b + 1);
+      res.writeHead(206, { 'content-type': 'audio/wav', 'content-length': cut.length, 'accept-ranges': 'bytes', 'content-range': `bytes ${a}-${b}/${TRACK.length}` });
+      return res.end(req.method === 'HEAD' ? undefined : cut);
+    }
+    res.writeHead(200, { 'content-type': 'audio/wav', 'content-length': TRACK.length, 'accept-ranges': 'bytes' });
+    return res.end(req.method === 'HEAD' ? undefined : TRACK);
+  }
+  if (path.indexOf('..') >= 0) { res.writeHead(400); return res.end(); }
+  try {
+    const body = await readFile(join(WEB, path));
+    res.writeHead(200, { 'content-type': MIME[extname(path).toLowerCase()] || 'application/octet-stream' });
+    res.end(req.method === 'HEAD' ? undefined : body);
+  } catch (e) { res.writeHead(404, { 'content-type': 'text/plain' }); res.end('no'); }
+});
+
+if (!existsSync(CHROME)) { console.error('FAIL no chrome at ' + CHROME + ' (set CHROME_PATH)'); process.exit(1); }
+await new Promise((r) => server.listen(PORT, '127.0.0.1', r));
+
+const prof = mkdtempSync(join(tmpdir(), 'race-chart-'));
+const chrome = spawn(CHROME, [
+  '--headless=new', '--remote-debugging-port=9335', `--user-data-dir=${prof}`,
+  '--no-first-run', '--no-default-browser-check', '--disable-gpu', '--mute-audio',
+  '--enable-unsafe-swiftshader', '--autoplay-policy=no-user-gesture-required',
+  '--window-size=1280,800', 'about:blank',
+], { stdio: 'ignore' });
+
+let page = null;
+for (let i = 0; i < 60 && !page; i++) {
+  await sleep(250);
+  try { page = (await (await fetch('http://127.0.0.1:9335/json/list')).json()).find((t) => t.type === 'page'); } catch (e) { /* not up */ }
+}
+if (!page) { console.error('FAIL chrome never answered on the debug port'); await done(1); }
+
+const ws = new WebSocket(page.webSocketDebuggerUrl);
+await new Promise((r) => { ws.onopen = r; });
+let msgId = 0;
+const waits = new Map(), logs = [], net = [];
+ws.onmessage = (e) => {
+  const m = JSON.parse(e.data);
+  if (m.id && waits.has(m.id)) { waits.get(m.id)(m); waits.delete(m.id); }
+  if (m.method === 'Network.requestWillBeSent') net.push(m.params.request.url);
+  if (m.method === 'Runtime.consoleAPICalled') logs.push(m.params.args.map((a) => a.value ?? a.description ?? '?').join(' '));
+};
+const cdp = (method, params) => new Promise((res) => { const i = ++msgId; waits.set(i, res); ws.send(JSON.stringify({ id: i, method, params })); });
+const ev = async (x) => (await cdp('Runtime.evaluate', { expression: x, returnByValue: true, awaitPromise: true })).result?.result?.value;
+const json = async (x) => JSON.parse(await ev(`JSON.stringify(${x})`));
+const click = (sel) => ev(`(()=>{const b=document.querySelector(${JSON.stringify(sel)}); if(!b) return 0; b.click(); return 1;})()`);
+const said = (s, from = 0) => logs.slice(from).some((l) => l.indexOf(s) >= 0);
+const heads = (p) => asks.filter((a) => a.method === 'HEAD' && a.path === p).length;
+
+async function bootAt(url) {
+  await cdp('Page.navigate', { url });
+  for (let i = 0; i < 80; i++) {
+    await sleep(250);
+    const up = await ev(`!!(window.__race && window.__race.menu) && !!document.querySelector('.rm-root') && !document.querySelector('.rm-root').hidden`);
+    if (up) { await sleep(300); return true; }
+  }
+  return false;
+}
+/**
+ * Clear the list, paste `links` and wait until the run is holding the chart called
+ * `wantName`. The clear matters: `addTracks` only starts a track when nothing is
+ * loaded, so without it a second paste sits in the list and this would pass on the
+ * chart that was already there.
+ */
+async function play(links, wantName) {
+  await click('.rm-cloud .rm-cloud-btn[data-id=forget]');
+  await sleep(300);
+  await ev(`(()=>{const i=document.querySelector('.rm-cloud-in'); i.value=${JSON.stringify(links)}; return 1;})()`);
+  await click('.rm-cloud .rm-cloud-btn[data-id=add]');
+  for (let i = 0; i < 120; i++) {
+    await sleep(250);
+    const got = await ev(`(()=>{const t=window.__race.race.track; return t && !t.chart.analysis.partial ? t.chart.source.name : '';})()`);
+    if (got === wantName) return true;
+  }
+  return false;
+}
+const site = `http://127.0.0.1:${PORT}`;
+const openPanel = async () => { await click('.rm-list .rm-btn[data-id=cloud]'); await sleep(400); };
+
+await cdp('Runtime.enable'); await cdp('Page.enable'); await cdp('Network.enable');
+
+/* ---- 4. a real file gets a real road ------------------------------------- */
+ok(await bootAt(`${site}/dtrh/race.html?cloud=1&intro=0&cards=0`), 'the page boots to the menu with ?cloud=1');
+await openPanel();
+ok(await play(`${site}/stub/gen.wav`, 'gen'), 'a pasted file is decoded and charted in the browser');
+{
+  const c = await json(`(()=>{const c=window.__race.race.track.chart; const k={}; for(const e of c.events) k[e.kind]=(k[e.kind]||0)+1;
+    return { hand:c.hand, bins:c.energy.length, kinds:k, acts:c.acts.map(a=>a.kind), words:c.analysis.words, dur:c.source.durationSec, hash:c.source.hash, first:c.events.length?c.events[0].t:-1 };})()`);
+  ok(c.bins > 300, `the chart carries an energy curve off the real file (${c.bins} bins)`);
+  ok((c.kinds.build || 0) >= 2 && (c.kinds.peak || 0) >= 2 && (c.kinds.release || 0) >= 2,
+    `and both swells are a build, a peak and a release (${JSON.stringify(c.kinds)})`);
+  ok((c.kinds.silence || 0) >= 1 && c.first > 1, `the quiet stretches are quiet and the start line is not fogged (${c.kinds.silence || 0} of them)`);
+  ok(new Set(c.acts).size >= 2, `the file is more than one room (${c.acts.join(' -> ')})`);
+  ok(c.words === 'none' && c.hand === false, 'it says it heard no words, and it is not pretending to be authored');
+  ok(/^[0-9a-f]{40}$/.test(c.hash), 'and it is stamped with the CHART.md hash of the file: ' + String(c.hash).slice(0, 12));
+  ok(Math.abs(c.dur - DUR) < 1, `the road is the length of the file (${c.dur}s)`);
+  ok(said('generated in'), 'the log says which door it came through');
+  ok(heads('/stub/gen.wav') === 1, `the hash was worked out from one HEAD and a range, not from a second download (${heads('/stub/gen.wav')} HEADs)`);
+  ok(asks.some((a) => a.path === '/stub/gen.wav' && a.ranged && a.method === 'GET'), 'the head of the file was read with a Range, before the file was');
+}
+
+/* ---- 5. an authored chart wins ------------------------------------------- */
+{
+  const mark = logs.length;
+  ok(await play(`${site}/stub/hand.wav`, 'the authored one'), 'a track with an authored chart loads');
+  const c = await json(`(()=>{const c=window.__race.race.track.chart; const e=c.events.find(x=>x.label==='good girl');
+    return { hand:c.hand, rules:c.rules, name:c.source.name, acts:c.acts.map(a=>a.kind), n:c.events.length, ev:e||null };})()`);
+  ok(c.hand === true, 'and it is used AS WRITTEN: the chart the run holds is the authored one');
+  ok(c.n === 2 && c.acts.join() === 'mantra', 'nothing generated was merged into it: its two events and its one room are what is on the road');
+  ok(c.ev && c.ev.hand === true && c.ev.cue === 'spiral' && c.ev.note === 'placed by hand', 'the author\'s own marks on an event came through the load');
+  ok(c.rules && c.rules.density === 'as written', 'and so did the rules block');
+  ok(said('authored by cloudId', mark), 'the log says it came in through the index, by cloudId');
+  // The HEAD is the tell. The <audio> element ranges the file all by itself because that is
+  // how a media element streams, and it has to: it is the clock. What must not happen is the
+  // CHART pipeline going near it, and the pipeline's first move is always a HEAD.
+  ok(heads('/stub/hand.wav') === 0, 'the chart pipeline never asked the CDN for that file: an authored track costs no download');
+  ok(asks.some((a) => a.path === '/dtrh/race/charts/hand-stub.chart.json'), 'it read the authored chart instead, off our own origin');
+}
+
+/* ---- 5b. the next track is read while this one plays ---------------------- */
+{
+  const mark = logs.length;
+  ok(await play(`${site}/stub/gen.wav ${site}/stub/hand.wav`, 'gen'), 'two links pasted, the first one is the lap being driven');
+  let ahead = false;
+  for (let i = 0; i < 20 && !ahead; i++) { await sleep(250); ahead = said('reading ahead: hand', mark); }
+  ok(ahead, 'and the NEXT one is already being read, so the next lap starts with its road in hand');
+  ok(heads('/stub/hand.wav') === 0, 'reading it ahead still cost no download: it is authored, and the url alone said so');
+}
+
+/* ---- 6. the second time, no decode --------------------------------------- */
+{
+  ok(await bootAt(`${site}/dtrh/race.html?cloud=1&intro=0&cards=0`), 'the page is loaded again, fresh');
+  const mark = logs.length;
+  await openPanel();
+  ok(await play(`${site}/stub/gen.wav`, 'gen'), 'the same file loads a second time');
+  ok(said('cached in', mark), 'and the road comes out of the cache this time, not out of a decode');
+  ok(!said('generated in', mark), 'nothing was generated: the cache is keyed on the hash and the hash still names that file');
+  const c = await json(`(()=>{const c=window.__race.race.track.chart; return { bins:c.energy.length, n:c.events.length, hand:c.hand };})()`);
+  ok(c.bins > 300 && c.n > 4 && c.hand === false, 'the cached road is the same road, and it is still not authored');
+}
+
+/* ---- 7. the plate -------------------------------------------------------- */
+ok((await ev(`document.querySelector('.rm-track-name').textContent`)) === 'gen', 'the plate still names the real track');
+
+/* ---- 8. nothing left this machine ---------------------------------------- */
+{
+  const away = net.filter((u) => u.indexOf('http') === 0 && u.indexOf('127.0.0.1') < 0 && u.indexOf('localhost') < 0);
+  ok(away.length === 0, 'not one request left localhost in the whole run' + (away.length ? ': ' + away.slice(0, 3).join(', ') : ''));
+}
+
+await done(fails ? 1 : 0);
+
+async function done(code) {
+  try { ws && ws.close(); } catch (e) { /* never opened */ }
+  try { chrome.kill(); } catch (e) { /* already gone */ }
+  await new Promise((r) => server.close(r));
+  await sleep(300);
+  try { rmSync(prof, { recursive: true, force: true }); } catch (e) { /* chrome still has a lock */ }
+  if (code) console.error(`\n${fails} failure${fails === 1 ? '' : 's'}`);
+  else console.log('\ncloud-chart-check: all good');
+  process.exit(code);
+}

--- a/ConditioningControlPanel/Resources/web/dtrh/race/smoke/cloud-check.mjs
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/smoke/cloud-check.mjs
@@ -177,7 +177,11 @@ await sleep(3000);
   ok(st.at === 0 && st.busy === false, 'the first playable track is the one in hand');
   const words = await rowIds();
   ok(words.some((w) => w.indexOf('locked on bambicloud') >= 0), 'the locked row says why: ' + words.filter((w) => w.startsWith('trk-2'))[0]);
-  ok(hits.get('/stub/one.wav') >= 1 && !hits.has('/stub/two.wav'), 'only the track being played is fetched: the rest of the list waits');
+  ok(hits.get('/stub/one.wav') >= 1, 'the track being played is fetched');
+  // Lane W2 reads the NEXT playable track ahead while this one plays, so `two.wav` may
+  // already be on the wire here. The locked entry is the one that must never be touched,
+  // and it is checked on its own above.
+  ok(!hits.has('/playlist/aaaa'), 'and the rest of the list is walked without ever touching the locked entry');
 }
 
 /* ---- 5. the plate -------------------------------------------------------- */
@@ -222,8 +226,9 @@ for (let i = 0; i < 60; i++) {
 {
   const st = await json(`window.__race.cloud.state`);
   ok(st.at === 1, 'the end of the file rolls the player on to the next track');
-  ok(hits.get('/stub/two.wav') >= 1, 'which is fetched only now, when it is its turn');
-  ok((await ev(`window.__race.race.track.name`)) === 'two', 'and the run is holding the next track\'s chart, ready for the next lap');
+  ok(hits.get('/stub/two.wav') >= 1, 'which lane W2 had already read ahead, so the lap starts with its road in hand');
+  const held = await json(`(()=>{const t=window.__race.race.track; return { name: t ? t.name : null, dur: t ? t.durationSec : 0, ev: t ? t.chart.events.length : -1 };})()`);
+  ok(held.name === 'two', 'and the run holds the next chart, ready for the next lap ' + JSON.stringify(held));
 }
 
 /* ---- 9. nothing left this machine ---------------------------------------- */

--- a/ConditioningControlPanel/Resources/web/dtrh/raceBoot.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/raceBoot.js
@@ -144,6 +144,8 @@ const settingEchoes = [];           // `setting` echoes that landed before there
 let settings = {}, seed = 0;
 let trackProgress = null, trackReady = null, errorTimer = 0, startTrackClock = null, trackTimer = 0, trackAudio = null;
 let cloud = null;                   // race/cloud.js, when the host says this build has it
+let cloudSource = null;             // race/cloudChart.js, the thing that answers hooks.chart
+let cloudWhere = '';                // ' · 3 of 9', kept so an upgraded chart repaints the same plate
 
 const note = (t) => { if (waitEl) waitEl.textContent = t || ''; };
 function fail(err) {
@@ -228,6 +230,7 @@ function surface() {
   stopTrackClock();
   if (errorTimer) clearTimeout(errorTimer);
   try { if (cloud) cloud.dispose(); } catch (e) { host.log('cloud dispose: ' + e); }
+  try { if (cloudSource) cloudSource.dispose(); } catch (e) { host.log('cloud source dispose: ' + e); }
   try { if (menu) menu.dispose(); } catch (e) { host.log('menu dispose: ' + e); }
   try { if (race) race.dispose(); } catch (e) { host.log('exit dispose: ' + e); }
   host.send({ type: 'exit' });
@@ -363,17 +366,58 @@ async function standaloneTrack() {
  * player, and wired to the run through hooks only: the mini-player never sees `race`, so it stays
  * importable in node and the smoke can drive it with a stub element.
  *
- *   chart  the W2 SEAM. Lane W2 decodes the file and charts it for real; until then a demo chart
- *          cut to the element's own duration keeps the road and the clock honest end to end.
+ *   chart  race/cloudChart.js: an authored chart if one is written for this track, else the one
+ *          this browser cached for it, else a road decoded and generated from the file itself.
+ *          It answers inside a couple of seconds whatever happens, on a plain road if it has
+ *          to, and swaps the real one in through onUpgrade when it lands.
  *   track  the chart landing: the run takes it and the menu plate says which track, and where in
  *          the list it is ("3 of 9"), with the next one named under it.
+ *   prefetch  the next playable track, named while this one plays, so the next lap starts with
+ *          its road already in hand. One at a time; closing the panel lets it go.
  *   pause  the panel's own pause goes through the run, which posts track-pause straight back here,
  *          so there is ONE pause path and the file and the road can never disagree.
  */
+/**
+ * The plate for a cloud track: the name, where it sits in the list, and how much of
+ * the file the road actually found. A partial road says so, because "0 treats" on a
+ * plain road is a number the player would otherwise read as a broken track.
+ */
+function showTrack(chart) {
+  const st = race && race.trackStats ? race.trackStats() : null;
+  const partial = !!(chart.analysis && chart.analysis.partial);
+  trackReady = { stage: 'ready', name: chart.source.name + cloudWhere, durationSec: chart.source.durationSec,
+    countable: st ? st.countable : 0, partial };
+  plate(trackReady);
+}
+
 async function makeCloud() {
   if (!settings.cloud) return null;
-  let mod = null;
-  try { mod = await import('./race/cloud.js'); } catch (err) { host.log('cloud: ' + ((err && err.message) || err)); return null; }
+  let mod = null, chartMod = null, cacheMod = null;
+  try {
+    mod = await import('./race/cloud.js');
+    chartMod = await import('./race/cloudChart.js');
+    cacheMod = await import('./race/chartCache.js');
+  } catch (err) { host.log('cloud: ' + ((err && err.message) || err)); return null; }
+  const toast = (line) => {
+    const msg = String(line || '').slice(0, 80).toLowerCase();
+    host.log('cloud toast: ' + msg);
+    try { if (race && race.hud) race.hud.toast(msg.slice(0, 60), 'effect'); } catch (e) { /* no hud yet */ }
+  };
+  // The cache is the only piece here that can be missing (a private window, blocked site
+  // data): it opens to a stub that answers null, and every track is charted fresh.
+  const cache = await cacheMod.openCache({ log: host.log });
+  cloudSource = chartMod.createChartSource({
+    indexUrl: new URL('race/charts/index.json', import.meta.url).href,
+    cache, log: host.log, toast,
+    // The road landing on a plain one: `replaceTrack` while a lap is live keeps everything
+    // already fired and adopts only the future, which is CHART.md's partial rule.
+    onUpgrade(chart) {
+      if (!race) return;
+      try { (race.track && started) ? race.replaceTrack(chart) : race.setTrack(chart); }
+      catch (err) { host.log('cloud upgrade: ' + ((err && err.message) || err)); return; }
+      showTrack(chart);
+    },
+  });
   return mod.createCloud({
     settings,
     log: host.log,
@@ -383,27 +427,16 @@ async function makeCloud() {
       clock: (t, playing) => { if (race) race.trackClock(t, playing); },
       ended: () => { if (race) race.trackEnded(); },
       pause: (on) => { if (race) race.setPaused(!!on); },
-      async chart({ title, durationSec }) {
-        const mk = await import('./race/chart.js');
-        const demo = mk.demoChart({ durationSec });
-        // the shape is the demo road; the NAME is the real track, because the plate, the marquee
-        // and the results card all read source.name and none of them should say "the demo track".
-        return mk.normalizeChart({ ...demo, source: { ...demo.source, name: title || demo.source.name, hash: '' } });
-      },
+      chart: (info) => cloudSource.chartFor(info),
+      prefetch: (info) => (info ? cloudSource.prefetch(info) : cloudSource.cancel()),
       track(chart, info) {
         if (!race) return;
+        cloudWhere = info && info.total > 1 ? ` · ${info.pos} of ${info.total}` : '';
         if (!chart) { race.setTrack(null); trackReady = null; plate(null); return; }
         try { race.setTrack(chart); } catch (err) { trackError('chart: ' + ((err && err.message) || err)); return; }
-        const st = race.trackStats ? race.trackStats() : null;
-        const where = info && info.total > 1 ? ` · ${info.pos} of ${info.total}` : '';
-        trackReady = { stage: 'ready', name: chart.source.name + where, durationSec: chart.source.durationSec, countable: st ? st.countable : 0, partial: false };
-        plate(trackReady);
+        showTrack(chart);
       },
-      toast(line) {
-        const msg = String(line || '').slice(0, 80).toLowerCase();
-        host.log('cloud toast: ' + msg);
-        try { if (race && race.hud) race.hud.toast(msg.slice(0, 60), 'effect'); } catch (e) { /* no hud yet */ }
-      },
+      toast,
     },
   });
 }


### PR DESCRIPTION
Lane W2, part 3 of 3. **Stacked on #908**, which is stacked on #907, which is stacked on #902.

### The wiring

`raceBoot.js` points `hooks.chart` at `race/cloudChart.js` instead of at a demo chart cut to the duration, opens the IndexedDB cache, and takes the upgraded road through `race.replaceTrack` on a live lap or `race.setTrack` otherwise.

### Reading ahead

`race/cloud.js` names the next playable track through a new `prefetch` hook when a track starts, so the road for the next lap is read while this one is being driven. One in flight at a time; forgetting the list, closing the panel or disposing lets it go. `chartFor` on the next lap takes the prefetched promise rather than starting again.

### A hole the demo chart was hiding

`demoChart` clamps its duration to 40 s minimum, so on W1's four second smoke tracks the chart outlived the file and the element fired `ended`. With honest durations, `run.js` ends a tracked run at `durationSec - 0.25` (CHART.md) and posts `track-stop`, which pauses the element, so `ended` never comes and **the playlist stops dead on the first track**. Fixed: a `track-stop` within `END_SLOP` of the end of the file is the file running out and hands the lap on; a stop anywhere else is a player leaving and does not. One rollover per element, whichever of the two arrives first.

### The check

`race/smoke/cloud-chart-check.mjs`, in the W1 style. Sections 1 to 3 are pure and run in node before Chrome is started: the `cloudId` derivation, the CHART.md hash, the wordless road, and what `normalizeChart` is allowed to throw away. Then headless Chrome over a synthesized 90 second WAV that opens at a speaking level, swells twice and has two long quiet stretches:

- a real decode gives a real road: 360 energy bins, 3 builds, 3 peaks, 3 releases, 2 silences, more than one room, **nothing on the start line**, stamped with the file's hash
- the hash cost one HEAD and one `Range`, before the file itself was read
- an authored chart **wins**, is used as written, keeps `hand` / `rules` / per event `hand` / `cue` / `note`, and the chart pipeline never asks the CDN for that file at all
- the next track is read ahead while this one plays
- the second load of the same file is a cache hit with no decode
- **not one request left localhost**

Its authored index is served by the smoke, never shipped: `race/charts/index.json` in the repo stays empty.

`cloud-check.mjs`: two assertions updated, because prefetch is now supposed to fetch the next track early.

465 changed lines.

### Verified

| command | result |
| --- | --- |
| `node race/smoke/cloud-chart-check.mjs` | 55 checks, all good |
| `node race/smoke/cloud-check.mjs` | all good (W1's own check, on this stack) |
| `node race/smoke/chart-check.mjs` | all good |
| `node chart/smoke/generate-check.mjs` | all good |
| `node race/smoke/track-run-check.mjs` | all good |
| `node race/smoke/audio-check.mjs` | all good |
| `node race/smoke/touch-check.mjs` | all good |
| `node race/smoke/poses-smoke.mjs` / `fov-check` / `spiral-pool-check` / `ost-resident-check` | all good |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJ66hi5fRM1Dcjo38aSCa2
