### PR TITLE
feat(race-web): the link tool for authored charts, and a real mp3 to chart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,6 +172,8 @@ ConditioningControlPanel/tools/*
 !ConditioningControlPanel/tools/asset_gen/
 !ConditioningControlPanel/tools/bark/
 !ConditioningControlPanel/tools/GenerateAwarenessSounds/
+!ConditioningControlPanel/tools/racechart/
+ConditioningControlPanel/tools/racechart/__pycache__/
 
 # Redistributables (re-downloadable from Microsoft; do not bloat the repo).
 # VC_redist.x64.exe is 25 MB and build-installer.bat fetches it on demand.

--- a/ConditioningControlPanel/Resources/web/dtrh/race/charts/README.md
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/charts/README.md
@@ -67,6 +67,21 @@ and `hash` still finds the track if it ever moves to another url.
 
 ## The link step
 
+Steps 2 to 4 are what `tools/racechart/link.py` is for. It computes both keys,
+copies the chart in and writes the row, so nobody types a SHA1 by hand:
+
+```
+python tools/racechart/link.py my.chart.json --url https://<cdn>/<path>.mp3 \
+    [--local my.mp3] [--title "the settle"] [--name the-settle]
+```
+
+It sets `"hand": true` if the chart is missing it, takes `cloudId` off the url by
+the rule above, and takes `hash` from the url with one HEAD and one ranged GET of
+the first megabyte. Add `--local` and it hashes your copy too and holds the two
+numbers up next to each other: when they disagree the local copy is a different
+encode, and the row gets the **cloud** hash, because the cloud copy is the one
+players hear. It prints which number it used either way.
+
 1. Write the chart. `chart/editor/` builds one; so does hand editing a generated
    chart out of the browser's cache. Set `"hand": true` at the top level.
 2. Save it as `race/charts/<name>.chart.json`.
@@ -74,7 +89,12 @@ and `hash` still finds the track if it ever moves to another url.
    `hash` is what `race/chartSource.js` `hashUrl()` logs for that track, and
    `tools/racechart/align.py` computes the same number from a local copy.
 4. Add the row to `index.json`.
-5. Load the track. The log says which door it came through:
+5. Check the index: `python tools/racechart/link.py --check`. It reads every row
+   and exits non-zero if a chart file is missing or unparseable, if one is missing
+   `hand: true`, if a hash is not 40 hex characters, if a row has neither key, or
+   if two rows fight over the same `cloudId`, `hash` or chart file. It never
+   touches the network, so it is safe to run anywhere.
+6. Load the track. The log says which door it came through:
    `chart: authored by cloudId`, `authored by hash`, `cached` or `generated`.
 
 ## The order every track is looked up in

--- a/ConditioningControlPanel/Resources/web/dtrh/race/smoke/real-audio-check.mjs
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/smoke/real-audio-check.mjs
@@ -1,0 +1,244 @@
+/* ============================================================================
+ * race/smoke/real-audio-check.mjs - the same road, off a real compressed file.
+ *
+ *   node race/smoke/real-audio-check.mjs            (0 on pass, 1 with a count)
+ *   RACE_REAL_URL=https://... node race/smoke/real-audio-check.mjs
+ *
+ * cloud-chart-check.mjs charts a WAV this machine wrote a second earlier. That
+ * proves the maths and proves nothing about mp3: a real file is compressed, its
+ * first megabyte is not its first seconds, decodeAudioData has to do real work,
+ * and the length the container claims and the length the decoder finds are two
+ * different numbers. This holds that down.
+ *
+ * BY DEFAULT IT TOUCHES NOTHING OFF THIS MACHINE. The track is a real mp3 already
+ * in the web folder, served back by a handler that behaves the way a public cdn
+ * behaves: `Access-Control-Allow-Origin: *`, `Accept-Ranges: bytes`, a 206 with a
+ * `Content-Range` for a ranged GET, and `Content-Range` exposed to the page. That
+ * is the contract chartSource.js hashUrl() is written against, and section 5
+ * fails if a single request left localhost.
+ *
+ * RACE_REAL_URL points it at a real cdn instead. That is the only way this file
+ * ever reaches the network, it is off by default, and it is the one thing the
+ * localhost stub cannot answer: whether a real cdn allows a cross origin HEAD,
+ * answers the `Range` preflight, and exposes `Content-Range`. With it set,
+ * section 0 prints the cdn's own headers and section 5 is skipped.
+ *
+ * What it records either way: the hash and which door it came through, how long
+ * the decode took, the bins, events and acts on the road, every console error,
+ * and whether the run actually rolled.
+ *
+ * CHROME: `CHROME_PATH` if it is set, else the usual Windows install.
+ * ==========================================================================*/
+
+import { spawn } from 'node:child_process';
+import { createServer } from 'node:http';
+import { readFile } from 'node:fs/promises';
+import { mkdtempSync, rmSync, existsSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, extname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+let fails = 0;
+const ok = (cond, what) => { if (!cond) { console.error('FAIL ' + what); fails++; } else console.log('  ok  ' + what); };
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const HERE = resolve(fileURLToPath(import.meta.url), '..');
+const WEB = resolve(HERE, '../../..');                     // Resources/web
+const TRACK_FILE = resolve(WEB, 'dtrh/assets/audio/drone1.mp3');
+const PORT = 8865;
+const REAL = process.env.RACE_REAL_URL || '';
+const CHROME = process.env.CHROME_PATH || 'C:/Program Files/Google/Chrome/Application/chrome.exe';
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.mjs': 'text/javascript', '.css': 'text/css', '.json': 'application/json', '.glb': 'model/gltf-binary', '.png': 'image/png', '.webp': 'image/webp', '.jpg': 'image/jpeg', '.mp3': 'audio/mpeg', '.wav': 'audio/wav', '.svg': 'image/svg+xml', '.woff2': 'font/woff2' };
+
+if (!existsSync(TRACK_FILE)) { console.error('FAIL no mp3 at ' + TRACK_FILE); process.exit(1); }
+const TRACK = readFileSync(TRACK_FILE);
+console.log(`the file: ${TRACK_FILE.slice(WEB.length + 1)}, ${TRACK.length} bytes (${(TRACK.length / 1048576).toFixed(2)} MiB)`);
+
+/* ============================================================================
+ * 0. the cdn's own headers, only when a real url was handed in
+ * ==========================================================================*/
+const SHOW = ['access-control-allow-origin', 'access-control-allow-headers', 'access-control-expose-headers', 'accept-ranges', 'content-range', 'content-length', 'content-type'];
+if (REAL) {
+  console.log('\nRACE_REAL_URL is set, so this run reaches a real cdn: ' + REAL);
+  for (const [what, init] of [['HEAD', { method: 'HEAD' }], ['ranged GET', { method: 'GET', headers: { Range: 'bytes=0-1048575' } }]]) {
+    try {
+      const res = await fetch(REAL, { ...init, headers: { Origin: 'https://app.cclabs.app', ...(init.headers || {}) } });
+      console.log(`  ${what} -> ${res.status}`);
+      for (const h of SHOW) { const v = res.headers.get(h); if (v) console.log(`    ${h}: ${v}`); }
+      if (what === 'ranged GET') ok(res.status === 206, 'the cdn answers a ranged GET with a 206, so the hash costs a megabyte and not a file');
+      else ok(res.ok, 'the cdn answers a cross origin HEAD');
+    } catch (e) { ok(false, `the cdn would not answer a ${what}: ${(e && e.message) || e}`); }
+  }
+}
+
+/* ============================================================================
+ * the server: the web folder, plus one path that behaves like a cdn
+ * ==========================================================================*/
+const asks = [];                                 // { method, path, ranged, status }
+const server = createServer(async (req, res) => {
+  const path = decodeURIComponent(new URL(req.url, 'http://x').pathname);
+  const ranged = !!req.headers.range;
+  const cdn = () => {
+    res.setHeader('access-control-allow-origin', '*');
+    res.setHeader('access-control-allow-headers', 'Range');
+    res.setHeader('access-control-expose-headers', 'Content-Range, Content-Length, Accept-Ranges');
+    res.setHeader('accept-ranges', 'bytes');
+  };
+  if (path === '/stub/real.mp3') {
+    asks.push({ method: req.method, path, ranged });
+    cdn();
+    if (req.method === 'OPTIONS') { res.writeHead(204, { 'content-length': 0 }); return res.end(); }
+    const m = /^bytes=(\d+)-(\d*)$/.exec(req.headers.range || '');
+    if (m) {
+      const a = Number(m[1]), b = Math.min(TRACK.length - 1, m[2] ? Number(m[2]) : TRACK.length - 1);
+      const cut = TRACK.subarray(a, b + 1);
+      res.writeHead(206, { 'content-type': 'audio/mpeg', 'content-length': cut.length, 'content-range': `bytes ${a}-${b}/${TRACK.length}` });
+      return res.end(req.method === 'HEAD' ? undefined : cut);
+    }
+    res.writeHead(200, { 'content-type': 'audio/mpeg', 'content-length': TRACK.length });
+    return res.end(req.method === 'HEAD' ? undefined : TRACK);
+  }
+  asks.push({ method: req.method, path, ranged });
+  if (path.indexOf('..') >= 0) { res.writeHead(400); return res.end(); }
+  try {
+    const body = await readFile(join(WEB, path));
+    res.writeHead(200, { 'content-type': MIME[extname(path).toLowerCase()] || 'application/octet-stream' });
+    res.end(req.method === 'HEAD' ? undefined : body);
+  } catch (e) { res.writeHead(404, { 'content-type': 'text/plain' }); res.end('no'); }
+});
+
+if (!existsSync(CHROME)) { console.error('FAIL no chrome at ' + CHROME + ' (set CHROME_PATH)'); process.exit(1); }
+await new Promise((r) => server.listen(PORT, '127.0.0.1', r));
+
+const prof = mkdtempSync(join(tmpdir(), 'race-real-'));
+const chrome = spawn(CHROME, [
+  '--headless=new', '--remote-debugging-port=9337', `--user-data-dir=${prof}`,
+  '--no-first-run', '--no-default-browser-check', '--disable-gpu', '--mute-audio',
+  '--enable-unsafe-swiftshader', '--autoplay-policy=no-user-gesture-required',
+  '--window-size=1280,800', 'about:blank',
+], { stdio: 'ignore' });
+
+let page = null;
+for (let i = 0; i < 60 && !page; i++) {
+  await sleep(250);
+  try { page = (await (await fetch('http://127.0.0.1:9337/json/list')).json()).find((t) => t.type === 'page'); } catch (e) { /* not up */ }
+}
+if (!page) { console.error('FAIL chrome never answered on the debug port'); await done(1); }
+
+const ws = new WebSocket(page.webSocketDebuggerUrl);
+await new Promise((r) => { ws.onopen = r; });
+let msgId = 0;
+const waits = new Map(), logs = [], errs = [], net = [];
+ws.onmessage = (e) => {
+  const m = JSON.parse(e.data);
+  if (m.id && waits.has(m.id)) { waits.get(m.id)(m); waits.delete(m.id); }
+  if (m.method === 'Network.requestWillBeSent') net.push(m.params.request.url);
+  if (m.method === 'Runtime.exceptionThrown') errs.push('thrown: ' + (m.params.exceptionDetails?.exception?.description || m.params.exceptionDetails?.text || '?'));
+  if (m.method === 'Runtime.consoleAPICalled') {
+    const line = m.params.args.map((a) => a.value ?? a.description ?? '?').join(' ');
+    logs.push(line);
+    if (m.params.type === 'error') errs.push(line);
+  }
+};
+const cdp = (method, params) => new Promise((res) => { const i = ++msgId; waits.set(i, res); ws.send(JSON.stringify({ id: i, method, params })); });
+const ev = async (x) => (await cdp('Runtime.evaluate', { expression: x, returnByValue: true, awaitPromise: true })).result?.result?.value;
+const json = async (x) => JSON.parse(await ev(`JSON.stringify(${x})`));
+const click = (sel) => ev(`(()=>{const b=document.querySelector(${JSON.stringify(sel)}); if(!b) return 0; b.click(); return 1;})()`);
+const heads = (p) => asks.filter((a) => a.method === 'HEAD' && a.path === p).length;
+
+await cdp('Runtime.enable'); await cdp('Page.enable'); await cdp('Network.enable');
+
+const site = `http://127.0.0.1:${PORT}`;
+const URL_UNDER_TEST = REAL || `${site}/stub/real.mp3`;
+
+/* ============================================================================
+ * 1. a real mp3 is decoded and charted in the browser
+ * ==========================================================================*/
+await cdp('Page.navigate', { url: `${site}/dtrh/race.html?cloud=1&intro=0&cards=0` });
+let up = false;
+for (let i = 0; i < 80 && !up; i++) {
+  await sleep(250);
+  up = await ev(`!!(window.__race && window.__race.menu) && !!document.querySelector('.rm-root') && !document.querySelector('.rm-root').hidden`);
+}
+ok(up, 'the page boots to the menu with ?cloud=1');
+await click('.rm-list .rm-btn[data-id=cloud]');
+await sleep(400);
+await click('.rm-cloud .rm-cloud-btn[data-id=forget]');
+await sleep(300);
+await ev(`(()=>{const i=document.querySelector('.rm-cloud-in'); i.value=${JSON.stringify(URL_UNDER_TEST)}; return 1;})()`);
+
+const t0 = Date.now();
+await click('.rm-cloud .rm-cloud-btn[data-id=add]');
+let charted = false;
+for (let i = 0; i < 240 && !charted; i++) {
+  await sleep(250);
+  charted = await ev(`(()=>{const t=window.__race.race.track; return !!(t && t.chart && !t.chart.analysis.partial);})()`);
+}
+const took = Date.now() - t0;
+ok(charted, `a real mp3 was decoded and charted in the browser (${(took / 1000).toFixed(1)}s from paste to full chart)`);
+if (!charted) await done(1);
+
+const c = await json(`(()=>{const c=window.__race.race.track.chart; const k={}; for(const e of c.events) k[e.kind]=(k[e.kind]||0)+1;
+  return { hand:c.hand, bins:c.energy.length, binSec:c.binSec, n:c.events.length, kinds:k, acts:c.acts.map(a=>a.kind),
+           words:c.analysis.words, dur:c.source.durationSec, hash:c.source.hash, name:c.source.name };})()`);
+console.log('\n  chart: ' + JSON.stringify(c) + '\n');
+ok(/^[0-9a-f]{40}$/.test(c.hash), 'the file is stamped with a CHART.md hash: ' + c.hash);
+ok(c.bins > 100, `the energy curve is real, not a stub (${c.bins} bins of ${c.binSec}s)`);
+ok(c.n > 0, `the road has events on it (${c.n}: ${JSON.stringify(c.kinds)})`);
+ok(c.acts.length >= 1, `the file is at least one room (${c.acts.join(' -> ')})`);
+ok(c.dur > 30, `the road is the length of the file (${c.dur}s), not the length of the megabyte the hash read`);
+ok(c.hand === false, 'and it is generated, so it does not claim to be authored');
+
+/* ============================================================================
+ * 2. the hash cost a megabyte, not a file
+ * ==========================================================================*/
+const timed = logs.filter((l) => /generated in|cached in|authored by/.test(l));
+console.log('  the door it came through: ' + (timed[timed.length - 1] || '(nothing said)'));
+if (!REAL) {
+  ok(heads('/stub/real.mp3') === 1, `one HEAD, not a second download (${heads('/stub/real.mp3')})`);
+  ok(asks.some((a) => a.path === '/stub/real.mp3' && a.ranged && a.method === 'GET'), 'and the head of the file was read with a Range before the file was');
+}
+
+/* ============================================================================
+ * 3. the run rolls on it
+ * ==========================================================================*/
+{
+  // The chart loading is not the lap starting: leave the panel and drive.
+  await click('.rm-cloud .rm-cloud-btn[data-id=back]');
+  await click('.rm-list .rm-btn[data-id=race]');
+  await sleep(2000);
+  const a = await json(`({ t: window.__race.race.track.t, playing: window.__race.race.track.playing })`);
+  await sleep(2500);
+  const b = await json(`({ el: window.__race.cloud.state.t, t: window.__race.race.track.t, playing: window.__race.race.track.playing })`);
+  ok(b.playing === true, 'the file is playing, so the race has a clock');
+  ok(b.t > a.t, `and the clock is moving, so the run rolled (${a.t.toFixed(2)}s -> ${b.t.toFixed(2)}s)`);
+  ok(Math.abs(b.el - b.t) < 0.5, `the run's clock is the file's clock, on a real mp3 (${b.t.toFixed(2)}s vs ${b.el.toFixed(2)}s)`);
+}
+
+/* ============================================================================
+ * 4. nothing went wrong out loud
+ * ==========================================================================*/
+ok(errs.length === 0, 'not one console error in the whole run' + (errs.length ? ':\n    ' + errs.slice(0, 5).join('\n    ') : ''));
+
+/* ============================================================================
+ * 5. nothing left this machine (only when no real url was asked for)
+ * ==========================================================================*/
+if (!REAL) {
+  const away = net.filter((u) => u.indexOf('http') === 0 && u.indexOf('127.0.0.1') < 0 && u.indexOf('localhost') < 0);
+  ok(away.length === 0, 'not one request left localhost' + (away.length ? ': ' + away.slice(0, 3).join(', ') : ''));
+} else {
+  console.log('  --  section 5 skipped: RACE_REAL_URL was set, so leaving this machine is the point');
+}
+
+await done(fails ? 1 : 0);
+
+async function done(code) {
+  try { ws && ws.close(); } catch (e) { /* never opened */ }
+  try { chrome.kill(); } catch (e) { /* already gone */ }
+  await new Promise((r) => server.close(r));
+  await sleep(300);
+  try { rmSync(prof, { recursive: true, force: true }); } catch (e) { /* chrome still has a lock */ }
+  if (code) console.error(`\n${fails} failure${fails === 1 ? '' : 's'}`);
+  else console.log('\nreal-audio-check: all good');
+  process.exit(code);
+}

--- a/ConditioningControlPanel/tools/racechart/link.py
+++ b/ConditioningControlPanel/tools/racechart/link.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+"""link.py - put an authored chart in the race's index, and check the index.
+
+    python link.py <chart.json> --url <cdn mp3 url> [--local <file.mp3>]
+                                [--title T] [--name slug]
+    python link.py --check
+
+AUTHORED CHARTS ALWAYS WIN. A chart in Resources/web/dtrh/race/charts/ with top
+level `hand: true` is used exactly as it was written, and the row in index.json
+is how the game finds it before it downloads a byte. This writes that row, so
+nobody computes a SHA1 by hand or guesses the id rule. Both keys are
+race/charts/README.md's:
+
+  cloudId  off the url alone. Ported from race/chartSource.js cloudIdFrom(): the
+           LAST path segment that is a uuid or 20+ id characters, else the last
+           segment with its extension off. Lower cased.
+  hash     CHART.md's: SHA1 of the byte length as 8 bytes little endian plus the
+           first 1 MiB. The same number as chartSource.js hashBytes(),
+           chart/editor/audio.js hashFile() and common.py file_hash().
+
+The hash comes off `--local` by reading a megabyte from disk, and off `--url` with
+one HEAD for content-length then ONE ranged GET of bytes=0-1048575 (public cdn, no
+credentials, no retries; a server that ignores the range sends the whole file and
+the hash is still right). Give both and they are compared: when they disagree the
+local copy is a DIFFERENT ENCODE, and the row gets the CLOUD hash, because the
+cloud copy is what players hear. It says which it used either way.
+
+Python 3, standard library only.
+"""
+
+import argparse
+import hashlib
+import json
+import re
+import struct
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+from urllib.parse import unquote, urlsplit
+
+MIB = 1024 * 1024
+HERE = Path(__file__).resolve().parent
+RACE = HERE.parent.parent / "Resources" / "web" / "dtrh" / "race"
+INDEX = RACE / "charts" / "index.json"
+ROW_KEYS = ["cloudId", "hash", "title", "durationSec", "chart"]
+
+UUID = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", re.I)
+IDISH = re.compile(r"^[A-Za-z0-9_-]+$")
+EXT = re.compile(r"\.[a-z0-9]{2,4}$", re.I)
+SHA1 = re.compile(r"^[0-9a-f]{40}$")
+ID_MIN = 20
+
+
+def cloud_id_from(url):
+    """race/chartSource.js cloudIdFrom(), ported. A url this cannot parse is ''."""
+    try:
+        parts = urlsplit(str(url))
+    except ValueError:
+        return ""
+    if not parts.scheme or not parts.netloc:
+        return ""
+    segs = []
+    for raw in parts.path.split("/"):
+        if not raw:
+            continue
+        try:
+            segs.append(unquote(raw))
+        except Exception:
+            segs.append(raw)
+    if not segs:
+        return ""
+    for seg in reversed(segs):
+        if UUID.match(seg) or (len(seg) >= ID_MIN and IDISH.match(seg)):
+            return seg.lower()
+    return EXT.sub("", segs[-1]).lower()
+
+
+def hash_bytes(head, total):
+    """CHART.md: SHA1 of the length as 8 bytes LE plus the first 1 MiB."""
+    if not total or total <= 0:
+        return ""
+    h = hashlib.sha1()
+    h.update(struct.pack("<Q", int(total)))
+    h.update(head[:MIB])
+    return h.hexdigest()
+
+
+def hash_local(path):
+    p = Path(path)
+    with p.open("rb") as fh:
+        return hash_bytes(fh.read(MIB), p.stat().st_size)
+
+
+def hash_url(url):
+    """One HEAD then one ranged GET. Answers (hash, total, how) or (None, None, why)."""
+    total = None
+    try:
+        head = urllib.request.Request(url, method="HEAD")
+        with urllib.request.urlopen(head, timeout=30) as res:
+            n = res.headers.get("content-length")
+            if n and int(n) > 0:
+                total = int(n)
+    except Exception as e:
+        print("  HEAD refused (%s), the range will have to carry the length" % e)
+    get = urllib.request.Request(url, headers={"Range": "bytes=0-%d" % (MIB - 1)})
+    try:
+        with urllib.request.urlopen(get, timeout=60) as res:
+            body = res.read(MIB + 1)
+            code = res.status
+            crange = res.headers.get("content-range") or ""
+    except urllib.error.HTTPError as e:
+        return None, None, "the cdn answered %s to a ranged GET" % e.code
+    except Exception as e:
+        return None, None, "the cdn would not answer a ranged GET (%s)" % e
+    ranged = code == 206
+    if not total:
+        m = re.search(r"/\s*(\d+)\s*$", crange)
+        if m and int(m.group(1)) > 0:
+            total = int(m.group(1))
+    if not ranged:
+        # A 200 to a ranged GET is the whole file, so its own length is the length.
+        if len(body) > MIB:
+            return None, None, "the cdn ignored the range and the file is bigger than a read"
+        total = len(body)
+    if not total or total <= 0:
+        return None, None, "no length anywhere, so this file cannot be named"
+    how = "HEAD + a 206 range" if ranged else "a full 200 body (the cdn ignored the range)"
+    return hash_bytes(body, total), total, how
+
+
+def read_json(path):
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+
+
+def write_json(path, data):
+    text = json.dumps(data, indent=2, ensure_ascii=False) + "\n"
+    Path(path).write_bytes(text.encode("utf-8"))
+
+
+def load_index():
+    if not INDEX.exists():
+        return {"version": 1, "tracks": []}
+    idx = read_json(INDEX)
+    if not isinstance(idx.get("tracks"), list):
+        idx["tracks"] = []
+    return idx
+
+
+def order_row(row):
+    out = {k: row[k] for k in ROW_KEYS if k in row and row[k] not in (None, "")}
+    for k in row:
+        if k not in out and row[k] not in (None, ""):
+            out[k] = row[k]
+    return out
+
+
+def check():
+    """Every row of index.json, or a non-zero exit. Nothing here touches the network."""
+    bad = 0
+
+    def no(msg):
+        nonlocal bad
+        bad += 1
+        print("  BAD  " + msg)
+
+    if not INDEX.exists():
+        print("no index at " + str(INDEX))
+        return 1
+    try:
+        idx = read_json(INDEX)
+    except Exception as e:
+        print("index.json does not parse: %s" % e)
+        return 1
+    rows = idx.get("tracks")
+    if not isinstance(rows, list):
+        print("index.json has no tracks list")
+        return 1
+    print("checking %d row%s in %s" % (len(rows), "" if len(rows) == 1 else "s", INDEX))
+    seen_id, seen_hash, seen_chart = {}, {}, {}
+    for i, row in enumerate(rows):
+        where = "row %d" % i
+        if not isinstance(row, dict):
+            no("%s is not an object" % where)
+            continue
+        cid = str(row.get("cloudId") or "").lower()
+        h = str(row.get("hash") or "").lower()
+        rel = str(row.get("chart") or "")
+        where = "row %d (%s)" % (i, cid or h or rel or "nameless")
+        if not cid and not h:
+            no("%s has neither a cloudId nor a hash, so nothing can ever match it" % where)
+        if h and not SHA1.match(h):
+            no("%s hash is not 40 hex characters: %r" % (where, row.get("hash")))
+        for what, key, seen in (("cloudId", cid, seen_id), ("hash", h, seen_hash), ("chart file", rel, seen_chart)):
+            if not key:
+                continue
+            if key in seen:
+                no("%s repeats the %s of row %d: only the first would ever win" % (where, what, seen[key]))
+            seen[key] = i
+        d = row.get("durationSec")
+        if d is not None and not (isinstance(d, (int, float)) and not isinstance(d, bool) and d > 0):
+            no("%s durationSec is not a positive number: %r" % (where, d))
+        if not rel:
+            no("%s names no chart file" % where)
+            continue
+        f = RACE / rel
+        if not f.exists():
+            no("%s points at %s, which is not there" % (where, rel))
+            continue
+        try:
+            chart = read_json(f)
+        except Exception as e:
+            no("%s chart %s does not parse: %s" % (where, rel, e))
+            continue
+        if chart.get("hand") is not True:
+            no("%s chart %s is missing `hand: true`, so the game would not treat it as authored" % (where, rel))
+        if not isinstance(chart.get("events"), list):
+            no("%s chart %s has no events list" % (where, rel))
+    if bad:
+        print("\n%d problem%s" % (bad, "" if bad == 1 else "s"))
+        return 1
+    print("index ok")
+    return 0
+
+
+def link(args):
+    chart_path = Path(args.chart)
+    chart = read_json(chart_path)
+    if chart.get("hand") is not True:
+        # Keep the author's key order, but put the flag where a reader looks for it.
+        rebuilt = {}
+        for k, v in chart.items():
+            rebuilt[k] = v
+            if k == "version":
+                rebuilt["hand"] = True
+        if "hand" not in rebuilt:
+            rebuilt = dict([("hand", True)] + list(chart.items()))
+        chart = rebuilt
+        print("set `hand: true` (it was not there)")
+
+    cloud_id = cloud_id_from(args.url)
+    if not cloud_id:
+        print("that url has no id in it: " + args.url)
+        return 1
+
+    local = hash_local(args.local) if args.local else None
+    # The cdn is always asked, even with --local, because "the local copy is a
+    # different encode" is only knowable by holding both numbers up next to
+    # each other. With no --local it is the only source there is.
+    cloud, total, how = hash_url(args.url)
+
+    if local and cloud and local != cloud:
+        print("WARNING: the local file is a different encode of this track.")
+        print("  local %s" % local)
+        print("  cloud %s" % cloud)
+        print("  the index gets the CLOUD hash, because the cloud copy is what players hear.")
+        digest, source = cloud, "the cdn (%s)" % how
+    elif cloud:
+        digest, source = cloud, "the cdn (%s)" % how
+        if local:
+            print("the local copy and the cloud copy are the same bytes")
+    elif local:
+        print("the cdn could not be hashed (%s), falling back to the local copy" % how)
+        digest, source = local, "the local file"
+    else:
+        print("no hash: %s, and no --local to fall back on" % how)
+        return 1
+    print("hash %s from %s" % (digest, source))
+
+    src = chart.get("source") or {}
+    duration = src.get("durationSec")
+    slug = args.name or EXT.sub("", chart_path.name.replace(".chart.json", "")) or cloud_id
+    slug = re.sub(r"[^a-z0-9._-]+", "-", str(slug).lower()).strip("-")
+    title = args.title or src.get("name") or slug
+    rel = "charts/%s.chart.json" % slug
+    out = RACE / rel
+    out.parent.mkdir(parents=True, exist_ok=True)
+    write_json(out, chart)
+    print("chart -> %s" % out)
+
+    row = order_row({"cloudId": cloud_id, "hash": digest, "title": title, "durationSec": duration, "chart": rel})
+    idx = load_index()
+    # cloudId first and hash second, the same order the game looks a track up in.
+    at = -1
+    for i, r in enumerate(idx["tracks"]):
+        if isinstance(r, dict) and (str(r.get("cloudId") or "").lower() == cloud_id
+                                    or (digest and str(r.get("hash") or "").lower() == digest)):
+            at = i
+            break
+    if at >= 0:
+        print("replacing row %d (it already had this track)" % at)
+        idx["tracks"][at] = row
+    else:
+        idx["tracks"].append(row)
+    idx["version"] = idx.get("version") or 1
+    write_json(INDEX, {"version": idx["version"], "tracks": idx["tracks"]})
+    print("index -> %s" % INDEX)
+    print(json.dumps(row, indent=2, ensure_ascii=False))
+    return 0
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description="link an authored chart into race/charts/index.json")
+    ap.add_argument("chart", nargs="?", help="the chart JSON to link")
+    ap.add_argument("--url", help="the cdn url the track plays from")
+    ap.add_argument("--local", help="a local copy of the same audio, to hash without the network")
+    ap.add_argument("--title", help="what the plate says (default: the chart's source.name)")
+    ap.add_argument("--name", help="the slug the chart is saved under (default: the chart's file name)")
+    ap.add_argument("--check", action="store_true", help="validate every row of index.json and exit")
+    args = ap.parse_args(argv)
+    if args.check:
+        return check()
+    if not args.chart or not args.url:
+        ap.error("a chart and a --url, or --check")
+    return link(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Lane W3 of Racing Thoughts x BambiCloud. Stacked on #907-#909 (base `feat/race-cloud-w2-wire`), so review after those.

Two things the lane was missing: a way to put an authored chart in the index without computing a SHA1 by hand, and any evidence at all that the charting works on real compressed audio.

## `tools/racechart/link.py` (python 3, stdlib only)

```
python tools/racechart/link.py my.chart.json --url https://<cdn>/<path>.mp3 \
    [--local my.mp3] [--title "the settle"] [--name the-settle]
python tools/racechart/link.py --check
```

Sets `hand: true` if the chart is missing it, derives `cloudId` by `race/charts/README.md`'s rule, takes the `CHART.md` hash, copies the chart into `race/charts/` and upserts the index row on `cloudId` first and `hash` second (pretty JSON, stable key order, LF).

The hash comes off `--local` by reading a megabyte from disk, and off `--url` with one HEAD plus ONE ranged GET of `bytes=0-1048575` (no credentials, no retries). Give it both and it holds the two numbers up next to each other: when they disagree the local copy is a different encode, and the row gets the **cloud** hash, because the cloud copy is the one players hear. It says which number it used either way.

`--check` reads every row and exits non-zero on a missing or unparseable chart file, a chart without `hand: true`, a hash that is not 40 hex characters, a row with neither key, or two rows fighting over the same `cloudId`, `hash` or chart file. It never touches the network. It is step 5 of the link step in the README now.

## `race/smoke/real-audio-check.mjs`

`cloud-chart-check.mjs` charts a WAV this machine wrote a second earlier. That proves the maths and nothing about mp3: a real file is compressed, its first megabyte is not its first seconds, and `decodeAudioData` has to do real work.

This one charts a real 3.02 MiB mp3 already in the web folder, served back by a handler that behaves the way a public cdn behaves (`Access-Control-Allow-Origin: *`, `Accept-Ranges: bytes`, a 206 with `Content-Range`, `Content-Range` exposed). **It reaches nothing off this machine by default** and section 5 fails if a single request left localhost. `RACE_REAL_URL=https://... node race/smoke/real-audio-check.mjs` points it at a real cdn instead and prints that cdn's own headers first.

## What was verified

`node race/smoke/real-audio-check.mjs` -> **all good**, exit 0:

```
the file: dtrh\assets\audio\drone1.mp3, 3163097 bytes (3.02 MiB)
  ok  a real mp3 was decoded and charted in the browser (1.6s from paste to full chart)
  chart: {"hand":false,"bins":527,"binSec":0.25,"n":15,
          "kinds":{"build":5,"peak":5,"release":5},"acts":["induction","triggers"],
          "words":"none","dur":131.73254,"hash":"b58114e0f6ac6473aabcfe4017f506a6f5825507"}
  the door it came through: chart: real: generated in 1.2s
  ok  one HEAD, not a second download (1)
  ok  and the head of the file was read with a Range before the file was
  ok  and the clock is moving, so the run rolled (2.00s -> 4.49s)
  ok  the run's clock is the file's clock, on a real mp3 (4.49s vs 4.52s)
  ok  not one console error in the whole run
  ok  not one request left localhost
```

Three-way hash agreement on that same file: the browser (`chartSource.js hashUrl` over HEAD + 206), `link.py --url` and `link.py --local` all answer `b58114e0f6ac6473aabcfe4017f506a6f5825507`.

`hashBytes` python vs JS on the same 3000 bytes: both `8ba82cb7be61865eb2cf86a9cbce42f509e65e01`. Both `cloudIdFrom` README examples pass in both languages.

`--check` against a deliberately broken index caught all 8 problems and exited 1. `node race/smoke/cloud-chart-check.mjs` still passes (no regression).

## What was NOT verified

**The real cdn was never contacted.** The brief's one authorized route to a track url was the app log, and there is no url in it: today's session logs carry `cloud track <name>` and `cloud audio down for <name> (N bytes)` but never the src, and `grep -i bambicloud` over every `.log` in the logs folder returns nothing. No other route was taken. So whether a real cdn answers a cross-origin HEAD, answers the `Range` preflight and exposes `Content-Range` is still open, and `RACE_REAL_URL` is the one command that closes it once someone has a url.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

