### PR TITLE
feat(race): a chart somebody wrote always wins

### DIFF
--- a/ConditioningControlPanel/Models/Race/TrackChart.cs
+++ b/ConditioningControlPanel/Models/Race/TrackChart.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace ConditioningControlPanel.Models.Race;
 
@@ -24,6 +25,13 @@ public sealed class TrackChart
     [JsonProperty("acts")] public List<TrackAct> Acts { get; set; } = new();
     /// <summary>Sorted by <see cref="TrackEvent.T"/>; ids unique within the chart.</summary>
     [JsonProperty("events")] public List<TrackEvent> Events { get; set; } = new();
+    /// <summary>
+    /// True on a chart a person wrote. An authored chart always wins: it is used instead of anything
+    /// generated, it is never merged into, never written over and never charted again.
+    /// </summary>
+    [JsonProperty("hand", NullValueHandling = NullValueHandling.Ignore)] public bool? Hand { get; set; }
+    /// <summary>Anything the chart carries that this build has no property for. Round trips.</summary>
+    [JsonExtensionData] public IDictionary<string, JToken> Extra { get; set; } = new Dictionary<string, JToken>();
 }
 
 public sealed class TrackSource
@@ -33,6 +41,11 @@ public sealed class TrackSource
     [JsonProperty("hash")] public string Hash { get; set; } = "";
     [JsonProperty("durationSec")] public double DurationSec { get; set; }
     [JsonProperty("sampleRate")] public int SampleRate { get; set; } = 16000;
+    /// <summary>Optional second key for an authored chart: the stable name of the file on the CDN,
+    /// derived from its url. Survives the file being renamed, which the hash does not.</summary>
+    [JsonProperty("cloudId", NullValueHandling = NullValueHandling.Ignore)] public string? CloudId { get; set; }
+    /// <summary>Anything the chart carries that this build has no property for. Round trips.</summary>
+    [JsonExtensionData] public IDictionary<string, JToken> Extra { get; set; } = new Dictionary<string, JToken>();
 }
 
 public sealed class TrackAnalysis
@@ -45,6 +58,8 @@ public sealed class TrackAnalysis
     [JsonProperty("generatedAt")] public DateTime GeneratedAt { get; set; } = DateTime.UtcNow;
     /// <summary>True on the chart posted after the energy pass and before the word pass lands.</summary>
     [JsonProperty("partial")] public bool Partial { get; set; }
+    /// <summary>Anything the chart carries that this build has no property for. Round trips.</summary>
+    [JsonExtensionData] public IDictionary<string, JToken> Extra { get; set; } = new Dictionary<string, JToken>();
 }
 
 /// <summary>kind: induction | deepening | triggers | mantra | build | silence | wake | free.</summary>
@@ -57,6 +72,8 @@ public sealed class TrackAct
     /// <summary>A room id from the page's consts.js ROOM_IDS.</summary>
     [JsonProperty("room")] public string Room { get; set; } = "";
     [JsonProperty("name")] public string Name { get; set; } = "";
+    /// <summary>Anything the chart carries that this build has no property for. Round trips.</summary>
+    [JsonExtensionData] public IDictionary<string, JToken> Extra { get; set; } = new Dictionary<string, JToken>();
 }
 
 /// <summary>
@@ -84,4 +101,7 @@ public sealed class TrackEvent
     // chant
     [JsonProperty("reps", NullValueHandling = NullValueHandling.Ignore)] public int? Reps { get; set; }
     [JsonProperty("period", NullValueHandling = NullValueHandling.Ignore)] public double? Period { get; set; }
+    // The Track Maker's per-event author fields (`hand`, `cue`, `note`) ride along in Extra below.
+    /// <summary>Anything the chart carries that this build has no property for. Round trips.</summary>
+    [JsonExtensionData] public IDictionary<string, JToken> Extra { get; set; } = new Dictionary<string, JToken>();
 }

--- a/ConditioningControlPanel/Resources/web/dtrh/race/CHART.md
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/CHART.md
@@ -207,9 +207,13 @@ Page -> host: `track-pick` (open the file dialog), `track-play` (the run started
 analysis in flight).
 
 Host -> page: `track-progress { stage: 'decode' | 'energy' | 'words', pct: 0..1, name }`,
-`track-chart { chart, partial }`, `track-clock { t, playing, durationSec }` every 250 ms while a
-track is loaded, `track-ended`, `track-error { message }` (dialog cancelled is not an error: the
-host posts `track-progress { stage: 'cancelled' }`).
+`track-chart { chart, partial, authored }`, `track-clock { t, playing, durationSec }` every 250 ms
+while a track is loaded, `track-ended`, `track-error { message }` (dialog cancelled is not an error:
+the host posts `track-progress { stage: 'cancelled' }`).
+
+`authored: true` on `track-chart` means a person wrote this chart. `raceBoot.js` puts it on the
+ready plate and `race/menu.js` shows it as a small `hand-tuned` mark. An authored chart is never
+partial and nothing fuller lands behind it.
 
 ## C# side
 
@@ -233,3 +237,40 @@ host posts `track-progress { stage: 'cancelled' }`).
   `WaveOutEvent`, master volume, `PositionSec`, `Play/Pause/Resume/Stop`, `Ended` event; the file
   dialog on the UI thread; the analysis on a worker with progress posts; the 250 ms clock timer;
   `track-stop` on `run-ended` and `exit`.
+
+### Authored charts on the desktop
+
+The shared rule, the index format and the `cloudId` derivation live in the **Authored charts**
+section above, written on `feat/race-cloud-w2-chart`; this is only what the C# host adds on top of
+it. If the two ever disagree, the shared section is right.
+
+- **Passthrough.** `TrackChart`, `TrackSource`, `TrackAnalysis`, `TrackAct` and `TrackEvent` each
+  carry a Newtonsoft `[JsonExtensionData]` bag, so a field this build has no property for survives
+  load -> post -> save untouched: the top level `rules`, the per-event `hand`, `cue` and `note`, and
+  whatever a newer chart version adds. `hand` and `source.cloudId` are typed as well, because the
+  lookup and the cache guard read them. A generated chart writes neither.
+- **A folder of your own.** `%LOCALAPPDATA%/ConditioningControlPanel/race/authored/*.json`. Any
+  chart file in there with `"hand": true` is indexed by `source.hash` and by `source.cloudId`, both
+  optional but not both missing, and matched case insensitively. The folder is re-scanned when it
+  changes and the chart is re-read on every hit, so dropping one in or editing one takes effect on
+  the next track without a restart.
+- **The order the host uses**, first answer wins, before anything is decoded:
+  1. your authored folder, by hash or `cloudId`
+  2. the shipped `race/charts/index.json`, by `cloudId` then hash (read off disk from
+     `Resources/web/dtrh/race/` next to the exe, the same tree the page is served out of)
+  3. `TrackChartCache`, by hash (the generated charts, under `race/charts/` in the user data folder)
+  4. chart the audio
+  The host logs one line per track: `RaceHost: chart for {Name} via {Door}`, where the door is
+  `authored (user folder)`, `authored by cloudId`, `authored by hash`, `cached` or `generated` - the
+  same four names the page logs, plus the one only the desktop has. An authored chart is posted with
+  `partial: false` and the analysis is never run for it.
+- **The cache cannot shadow an author.** `TrackChartCache.Save` refuses, with a log line and no
+  exception, when the chart handed to it is authored, or when an authored chart already answers for
+  that hash. The "re-chart a `none` chart once a Vosk model appears" rule skips authored charts too:
+  there is no better pass than the person who wrote it.
+
+**Known gap: no prefetch of the next track.** The desktop never reads the playlist over there, so it
+cannot know what is coming and cannot chart it early. Charting starts when the track does. In
+practice that is seconds of the seeded road before the partial chart swaps in, and none at all for a
+cache hit or an authored chart, which answer instantly. Closing it would mean reading their playlist
+UI, which this lane does not do.

--- a/ConditioningControlPanel/Resources/web/dtrh/race/menu.css
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/menu.css
@@ -181,6 +181,9 @@
 #race-root .rm-track.is-error .rm-track-bar { display: none; }
 #race-root .rm-track-cap { font-size: 12px; color: rgba(255, 214, 234, 0.75); }
 #race-root .rm-track.is-busy .rm-track-cap::after { content: '…'; animation: rmDots 1.2s steps(3, end) infinite; }
+/* The authored mark: a chart a person wrote, not one the analysis found. */
+#race-root .rm-track-mark { display: inline-block; margin-top: 6px; padding: 1px 6px; font-size: 10px; font-weight: 800; letter-spacing: 0.12em; color: #0d0a14; background: #5be7d8; }
+#race-root .rm-track-mark[hidden] { display: none; }
 @keyframes rmDots { from { opacity: 0.2; } to { opacity: 1; } }
 
 /* ---- the stage hole + nameplate ---- */

--- a/ConditioningControlPanel/Resources/web/dtrh/race/menu.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/menu.js
@@ -507,6 +507,8 @@ export function createMenu({ root, renderer, pixel, audio, settings = {}, log = 
   const trackName = el('div', 'rm-track-name', trackEl, '');
   const trackBar = el('div', 'rm-track-bar', trackEl); const trackFill = el('i', '', trackBar);
   const trackCap = el('div', 'rm-track-cap', trackEl, '');
+  // shown only for a chart a person wrote (host: track-chart authored:true)
+  const trackMark = el('div', 'rm-track-mark', trackEl, 'hand-tuned'); trackMark.hidden = true;
   el('div', 'rm-foot', col, 'arrows move · enter picks · esc back · p pixels · m mute');
   const stageEl = el('div', 'rm-stage', layer);
   const plate = el('div', 'rm-plate', stageEl);
@@ -675,8 +677,9 @@ export function createMenu({ root, renderer, pixel, audio, settings = {}, log = 
   let trackState = null;
   /**
    * setTrack(state | null): the plate and the verbs follow the host. state = { stage, pct, name,
-   * durationSec, countable, partial, message }; stage 'ready' is a chart in hand (partial while the
-   * words are still landing). Null clears the plate and the verbs read as the seeded run again.
+   * durationSec, countable, partial, authored, message }; stage 'ready' is a chart in hand (partial
+   * while the words are still landing, authored when a person wrote it rather than the analysis).
+   * Null clears the plate and the verbs read as the seeded run again.
    */
   function setTrack(state) {
     trackState = state && state.stage ? state : null;
@@ -694,6 +697,7 @@ export function createMenu({ root, renderer, pixel, audio, settings = {}, log = 
         trackCap.textContent = st.partial ? `${mins} min · still listening for the words` : `${mins} min · ${n ? `${n} to take` : 'nothing spoken, the pulse drives'}`;
       } else trackCap.textContent = st.stage === 'error' ? (st.message || 'the track would not load') : (STAGE_CAP[st.stage] || st.stage);
     }
+    trackMark.hidden = !(ready && st && st.authored);
     verbEl('race').textContent = ready ? 'race the track' : 'race';
     verbEl('track').textContent = ready ? 'another track' : 'load a track';
     verbEl('clear').hidden = !ready;

--- a/ConditioningControlPanel/Resources/web/dtrh/raceBoot.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/raceBoot.js
@@ -206,7 +206,9 @@ bridge.on('track-chart', (m) => {
   try { (race.track && started) ? race.replaceTrack(m.chart) : race.setTrack(m.chart); }
   catch (err) { host.log('track-chart: ' + ((err && err.message) || err)); trackError(String((err && err.message) || err)); return; }
   const t = race.track, st = race.trackStats ? race.trackStats() : null;
-  trackReady = t ? { stage: 'ready', name: t.name, durationSec: t.durationSec, countable: st ? st.countable : 0, partial: !!m.partial } : null;
+  // `authored` is the host saying a person wrote this chart: the plate marks it, and nothing
+  // fuller is coming behind it (an authored chart is never partial and never replaced).
+  trackReady = t ? { stage: 'ready', name: t.name, durationSec: t.durationSec, countable: st ? st.countable : 0, partial: !!m.partial, authored: !!m.authored } : null;
   plate(trackReady);
 });
 bridge.on('track-clock', (m) => { if (race && m) race.trackClock(Number(m.t) || 0, m.playing !== false); });

--- a/ConditioningControlPanel/Services/Chaos/CaucusHostService.cs
+++ b/ConditioningControlPanel/Services/Chaos/CaucusHostService.cs
@@ -628,11 +628,14 @@ internal static class CaucusHostService
 
     /// <summary>track-chart. The chart itself goes out whole; the dev log only gets a summary,
     /// since a full chart is thousands of lines of numbers.</summary>
-    private static void PostChart(TrackChart chart, bool partial)
+    /// <param name="authored">A person wrote this one. The plate says so, and the page knows not to
+    /// expect a fuller chart behind it: an authored chart is never partial and never replaced.</param>
+    private static void PostChart(TrackChart chart, bool partial, bool authored = false)
     {
         int events = chart.Events?.Count ?? 0;
-        PostTrack(new { type = "track-chart", chart, partial },
-            "{ type: track-chart, partial: " + (partial ? "true" : "false") + ", events: " + events + " }");
+        PostTrack(new { type = "track-chart", chart, partial, authored },
+            "{ type: track-chart, partial: " + (partial ? "true" : "false")
+                + (authored ? ", authored: true" : "") + ", events: " + events + " }");
     }
 
     /// <summary>track-pick: the file dialog on the UI thread. A cancelled dialog is not an error,
@@ -703,6 +706,37 @@ internal static class CaucusHostService
         }
     }
 
+    /// <summary>
+    /// Doors (a), (b) and (c) of the lookup: an authored chart the player wrote, an authored chart
+    /// we ship, or a generated one already in the cache. Answers true when one of them posted a
+    /// chart, in which case NOTHING is analysed: an authored chart is used exactly as it was
+    /// written, and a cache hit was that analysis already.
+    ///
+    /// A cached chart is only worth reusing if its word pass is as good as the one we could run now,
+    /// so a "none" chart is charted again once a Vosk model has appeared. An authored chart never is:
+    /// there is no better pass than the person who wrote it.
+    /// </summary>
+    private static bool TryChartWithoutAnalysis(string hash, string? cloudId, string name, string? displayName)
+    {
+        var authored = AuthoredCharts.Find(hash, cloudId, out string door);
+        if (authored != null)
+        {
+            if (string.IsNullOrWhiteSpace(authored.Source.Name) && !string.IsNullOrWhiteSpace(displayName))
+                authored.Source.Name = displayName!;
+            App.Logger?.Information("RaceHost: chart for {Name} via {Door}", name, door);
+            PostChart(authored, partial: false, authored: true);
+            return true;
+        }
+
+        var cached = TrackChartCache.TryLoad(hash);
+        if (cached == null) return false;
+        if (!AuthoredCharts.IsAuthored(cached) && cached.Analysis?.Words != "vosk-v1" && TrackWordSpotter.ModelAvailable)
+            return false;
+        App.Logger?.Information("RaceHost: chart for {Name} via {Door}", name, AuthoredCharts.DoorCache);
+        PostChart(cached, partial: false, authored: AuthoredCharts.IsAuthored(cached));
+        return true;
+    }
+
     /// <summary>The whole analysis, off the UI thread. Every call into the decoder, the analyzer,
     /// the cache and the word spotter sits inside this one try: a file NAudio hates, a missing
     /// Vosk model or a half-written cache entry becomes a track-error, never a crash.</summary>
@@ -710,8 +744,10 @@ internal static class CaucusHostService
     /// A cloud track lands in a temp file called a GUID, and its title is the better name for both
     /// the plate and the cache: pick the same audio up locally later and the chart still reads as
     /// the track, not as a download nobody kept.</param>
+    /// <param name="cloudId">The stable name of the file on the CDN, when the track came from
+    /// there. An authored chart may be keyed by it, and it survives the file being renamed.</param>
     private static void AnalyzeTrack(string path, string name, int gen, CancellationToken ct, CancellationTokenSource cts,
-        string? displayName = null)
+        string? displayName = null, string? cloudId = null)
     {
         try
         {
@@ -719,15 +755,8 @@ internal static class CaucusHostService
             PostProgress("decode", 0, name, force: true);
 
             string hash = TrackDecoder.HashFile(path);
-            var cached = TrackChartCache.TryLoad(hash);
-            // A cached chart is only worth reusing if its word pass is as good as the one we could
-            // run now: a "none" chart is charted again once a model has appeared.
-            if (cached != null && (cached.Analysis?.Words == "vosk-v1" || !TrackWordSpotter.ModelAvailable))
-            {
-                App.Logger?.Information("RaceHost: chart cache hit for {Name}", name);
-                PostChart(cached, partial: false);
-                return;
-            }
+            if (TryChartWithoutAnalysis(hash, cloudId, name, displayName)) return;
+            App.Logger?.Information("RaceHost: chart for {Name} via {Door}", name, AuthoredCharts.DoorGenerated);
 
             var pcm = TrackDecoder.Decode(path, new Progress<double>(v => PostProgress("decode", v, name)), ct);
             ct.ThrowIfCancellationRequested();
@@ -1078,11 +1107,16 @@ internal static class CaucusHostService
         string? temp = null;
         try
         {
+            // The doors before the download. (a) and (b) by cloudId need only the url, so an
+            // authored chart linked by cloudId costs no download at all.
+            string cloudId = AuthoredCharts.CloudIdFrom(src);
+            if (TryChartWithoutAnalysis("", cloudId, name, name)) return;
+
             temp = await DownloadCloudTrackAsync(src, name, ct).ConfigureAwait(false);
             ct.ThrowIfCancellationRequested();
             // From here it is the ordinary path, cache and all - the hash is computed off these
             // bytes by TrackDecoder.HashFile, so it matches a local chart of the same file.
-            AnalyzeTrack(temp, name, gen, ct, cts, displayName: name);
+            AnalyzeTrack(temp, name, gen, ct, cts, displayName: name, cloudId: cloudId);
         }
         catch (OperationCanceledException)
         {

--- a/ConditioningControlPanel/Services/Race/AuthoredCharts.cs
+++ b/ConditioningControlPanel/Services/Race/AuthoredCharts.cs
@@ -1,0 +1,301 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using ConditioningControlPanel.Models.Race;
+using Newtonsoft.Json;
+
+namespace ConditioningControlPanel.Services.Race;
+
+/// <summary>
+/// AUTHORED CHARTS ALWAYS WIN (owner rule). A chart a person wrote is used instead of anything the
+/// analysis could produce, it is never merged into, never written over and never charted again.
+/// This is the desktop half of the lookup the page does in <c>race/chartSource.js</c>, and the two
+/// read the same index file and derive the same <c>cloudId</c>, so a chart linked once answers on
+/// both sides.
+///
+/// Every track is looked up in this order and stops at the first answer:
+///   a. the player's own folder, <c>%LOCALAPPDATA%/ConditioningControlPanel/race/authored/*.json</c>
+///   b. the shipped index, <c>Resources/web/dtrh/race/charts/index.json</c>, by cloudId then hash
+///   c. the generated-chart cache, by hash (<see cref="TrackChartCache"/>)
+///   d. nothing: chart the audio
+///
+/// a and b answer with a url and a hash in hand, both of which are cheap: the hash is a length and
+/// the first megabyte, not the file. So an authored track never costs a download.
+///
+/// Nothing here throws. A folder that is not there, a chart that will not parse and an index row
+/// pointing at a file nobody shipped are all the same thing to a caller: no authored chart.
+/// </summary>
+public static class AuthoredCharts
+{
+    // The four door names the page logs, so a desktop log and a browser log read alike, plus the
+    // one door only the desktop has.
+    public const string DoorUserFolder = "authored (user folder)";
+    public const string DoorCloudId = "authored by cloudId";
+    public const string DoorHash = "authored by hash";
+    public const string DoorCache = "cached";
+    public const string DoorGenerated = "generated";
+
+    /// <summary>Where a player drops a chart of their own. Any *.json in here with `hand: true`.</summary>
+    public static string UserRoot => Path.Combine(App.UserDataPath, "race", "authored");
+
+    /// <summary>The race page's folder as it lands next to the exe (DtrhHostService maps this same
+    /// Resources/web tree to ccp.game), so the shipped index is read off disk, not over the bridge.</summary>
+    private static string RaceWebRoot => Path.Combine(AppContext.BaseDirectory, "Resources", "web", "dtrh", "race");
+
+    private static string ShippedIndexPath => Path.Combine(RaceWebRoot, "charts", "index.json");
+
+    /// <summary>What makes a chart authored, on both sides: a top level `hand: true`.</summary>
+    public static bool IsAuthored(TrackChart? chart) => chart?.Hand == true;
+
+    /// <summary>
+    /// The authored chart for this track, or null. <paramref name="door"/> names the door it came
+    /// through, ready for the one Information line the host logs per track.
+    /// </summary>
+    public static TrackChart? Find(string? hash, string? cloudId, out string door)
+    {
+        door = "";
+        string h = (hash ?? "").Trim().ToLowerInvariant();
+        string id = (cloudId ?? "").Trim().ToLowerInvariant();
+        if (h.Length == 0 && id.Length == 0) return null;
+
+        var mine = FindInUserFolder(h, id);
+        if (mine != null) { door = DoorUserFolder; return mine; }
+
+        var rows = ShippedRows();
+        if (rows.Count == 0) return null;
+        if (id.Length > 0)
+        {
+            var chart = LoadRow(rows.FirstOrDefault(r => Same(r.CloudId, id)));
+            if (chart != null) { door = DoorCloudId; return chart; }
+        }
+        if (h.Length > 0)
+        {
+            var chart = LoadRow(rows.FirstOrDefault(r => Same(r.Hash, h)));
+            if (chart != null) { door = DoorHash; return chart; }
+        }
+        return null;
+    }
+
+    /// <summary>Is there an authored chart for this track? The question TrackChartCache.Save asks
+    /// before it writes, so a generated chart can never shadow one somebody wrote.</summary>
+    public static bool ExistsFor(string? hash, string? cloudId = null) => Find(hash, cloudId, out _) != null;
+
+    // ---- cloudId, ported verbatim from race/chartSource.js cloudIdFrom() ----
+
+    /// <summary>A path segment this long, made only of id characters, is an id and not a word.</summary>
+    private const int IdMin = 20;
+    private static readonly Regex Uuid = new(@"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+    private static readonly Regex Idish = new(@"^[A-Za-z0-9_-]+$", RegexOptions.CultureInvariant);
+    private static readonly Regex Extension = new(@"\.[a-z0-9]{2,4}$", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+
+    /// <summary>
+    /// The stable name of a file on the CDN, and the key an author writes in the index. A file name
+    /// can be renamed, an id segment cannot: if any segment of the path is a uuid or is
+    /// <see cref="IdMin"/> characters or more of id characters, the LAST such segment is the id.
+    /// Otherwise it is the last segment with its extension taken off. Lower cased either way, so an
+    /// index a person types by hand does not have to care about case. A url this cannot parse
+    /// answers "", the same as the page.
+    /// </summary>
+    public static string CloudIdFrom(string? url)
+    {
+        Uri uri;
+        try { uri = new Uri(url ?? "", UriKind.Absolute); }
+        catch { return ""; }
+
+        var segments = uri.AbsolutePath.Split('/')
+            .Select(s => { try { return Uri.UnescapeDataString(s); } catch { return s; } })
+            .Where(s => s.Length > 0)
+            .ToList();
+        if (segments.Count == 0) return "";
+
+        for (int i = segments.Count - 1; i >= 0; i--)
+        {
+            string s = segments[i];
+            if (Uuid.IsMatch(s) || (s.Length >= IdMin && Idish.IsMatch(s))) return s.ToLowerInvariant();
+        }
+        return Extension.Replace(segments[^1], "").ToLowerInvariant();
+    }
+
+    // ---- the player's own folder ----
+
+    /// <summary>key (hash or cloudId, lower case) -> the file it was read out of.</summary>
+    private static Dictionary<string, string> _userIndex = new(StringComparer.OrdinalIgnoreCase);
+    /// <summary>The folder stamp the index was built off. A file appearing or going restamps it.</summary>
+    private static DateTime _userStamp = DateTime.MinValue;
+    private static bool _userScanned;
+    private static readonly object UserLock = new();
+
+    private static TrackChart? FindInUserFolder(string hash, string cloudId)
+    {
+        Dictionary<string, string> index;
+        lock (UserLock)
+        {
+            RescanUserFolderIfStale();
+            index = _userIndex;
+        }
+        // The chart is re-read on the hit rather than held, so editing one in place takes effect on
+        // the next track without a restart.
+        if (cloudId.Length > 0 && index.TryGetValue(cloudId, out var byId)) return Load(byId);
+        if (hash.Length > 0 && index.TryGetValue(hash, out var byHash)) return Load(byHash);
+        return null;
+    }
+
+    private static void RescanUserFolderIfStale()
+    {
+        try
+        {
+            string root = UserRoot;
+            if (!Directory.Exists(root))
+            {
+                if (_userScanned && _userIndex.Count == 0) return;
+                _userIndex = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                _userScanned = true;
+                _userStamp = DateTime.MinValue;
+                return;
+            }
+            var stamp = Directory.GetLastWriteTimeUtc(root);
+            if (_userScanned && stamp == _userStamp) return;
+
+            var map = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var file in Directory.EnumerateFiles(root, "*.json", SearchOption.TopDirectoryOnly))
+            {
+                var chart = Load(file);
+                if (!IsAuthored(chart)) continue;
+                string h = (chart!.Source?.Hash ?? "").Trim();
+                string id = (chart.Source?.CloudId ?? "").Trim();
+                if (h.Length > 0) map[h] = file;
+                if (id.Length > 0) map[id] = file;
+                if (h.Length == 0 && id.Length == 0)
+                    App.Logger?.Information("race-chart: authored chart {File} has no source.hash and no source.cloudId, so nothing can match it", Path.GetFileName(file));
+            }
+            _userIndex = map;
+            _userStamp = stamp;
+            _userScanned = true;
+            if (map.Count > 0) App.Logger?.Information("race-chart: {Keys} authored key(s) in {Root}", map.Count, root);
+        }
+        catch (Exception ex)
+        {
+            App.Logger?.Information("race-chart: authored folder unreadable ({Message})", ex.Message);
+            _userIndex = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            _userScanned = true;
+        }
+    }
+
+    // ---- the shipped index ----
+
+    /// <summary>One row of race/charts/index.json. See that folder's README for the format.</summary>
+    private sealed class IndexRow
+    {
+        [JsonProperty("cloudId")] public string? CloudId { get; set; }
+        [JsonProperty("hash")] public string? Hash { get; set; }
+        [JsonProperty("title")] public string? Title { get; set; }
+        [JsonProperty("durationSec")] public double DurationSec { get; set; }
+        /// <summary>Relative to race/, so "charts/&lt;name&gt;.chart.json".</summary>
+        [JsonProperty("chart")] public string? Chart { get; set; }
+    }
+
+    private sealed class IndexFile
+    {
+        [JsonProperty("version")] public int Version { get; set; } = 1;
+        [JsonProperty("tracks")] public List<IndexRow> Tracks { get; set; } = new();
+    }
+
+    private static List<IndexRow> _shipped = new();
+    private static DateTime _shippedStamp = DateTime.MinValue;
+    private static bool _shippedRead;
+    private static readonly object ShippedLock = new();
+
+    private static List<IndexRow> ShippedRows()
+    {
+        lock (ShippedLock)
+        {
+            try
+            {
+                string path = ShippedIndexPath;
+                if (!File.Exists(path))
+                {
+                    _shipped = new List<IndexRow>();
+                    _shippedRead = true;
+                    return _shipped;
+                }
+                var stamp = File.GetLastWriteTimeUtc(path);
+                if (_shippedRead && stamp == _shippedStamp) return _shipped;
+
+                var file = JsonConvert.DeserializeObject<IndexFile>(File.ReadAllText(path));
+                _shipped = (file?.Tracks ?? new List<IndexRow>())
+                    .Where(r => r != null && !string.IsNullOrWhiteSpace(r.Chart))
+                    .ToList();
+                _shippedStamp = stamp;
+                _shippedRead = true;
+                if (_shipped.Count > 0) App.Logger?.Information("race-chart: {N} authored track(s) in the shipped index", _shipped.Count);
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Information("race-chart: shipped chart index unreadable ({Message})", ex.Message);
+                _shipped = new List<IndexRow>();
+                _shippedRead = true;
+            }
+            return _shipped;
+        }
+    }
+
+    private static bool Same(string? a, string b)
+        => !string.IsNullOrWhiteSpace(a) && string.Equals(a.Trim(), b, StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>The chart a row points at, or null. A row is a path into the shipped race folder and
+    /// nowhere else: one that climbs out of it is a broken index, not a file to open.</summary>
+    private static TrackChart? LoadRow(IndexRow? row)
+    {
+        if (row?.Chart == null) return null;
+        try
+        {
+            string root = Path.GetFullPath(RaceWebRoot);
+            string full = Path.GetFullPath(Path.Combine(root, row.Chart.Replace('/', Path.DirectorySeparatorChar)));
+            if (!full.StartsWith(root + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase))
+            {
+                App.Logger?.Information("race-chart: index row {Chart} points outside the race folder, ignored", row.Chart);
+                return null;
+            }
+            var chart = Load(full);
+            if (chart == null) return null;
+            if (!IsAuthored(chart))
+            {
+                App.Logger?.Information("race-chart: index row {Chart} is not marked hand: true, ignored", row.Chart);
+                return null;
+            }
+            // The chart's own name wins; the row's title is the fallback, per the README.
+            if (string.IsNullOrWhiteSpace(chart.Source.Name) && !string.IsNullOrWhiteSpace(row.Title))
+                chart.Source.Name = row.Title!;
+            return chart;
+        }
+        catch (Exception ex)
+        {
+            App.Logger?.Information("race-chart: index row {Chart} unreadable ({Message})", row.Chart, ex.Message);
+            return null;
+        }
+    }
+
+    /// <summary>Read a chart file. A newer chart version is loaded rather than refused: the model's
+    /// extension bags carry whatever this build has no property for, and the page normalises.</summary>
+    private static TrackChart? Load(string path)
+    {
+        try
+        {
+            if (!File.Exists(path)) return null;
+            var chart = JsonConvert.DeserializeObject<TrackChart>(File.ReadAllText(path));
+            if (chart == null) return null;
+            if (chart.Version != TrackChart.CurrentVersion)
+                App.Logger?.Information("race-chart: authored chart {File} is version {V}, this build writes {Cur}",
+                    Path.GetFileName(path), chart.Version, TrackChart.CurrentVersion);
+            return chart;
+        }
+        catch (Exception ex)
+        {
+            App.Logger?.Information("race-chart: authored chart {File} unreadable ({Message})", Path.GetFileName(path), ex.Message);
+            return null;
+        }
+    }
+}

--- a/ConditioningControlPanel/Services/Race/TrackChartCache.cs
+++ b/ConditioningControlPanel/Services/Race/TrackChartCache.cs
@@ -38,6 +38,12 @@ public static class TrackChartCache
     /// <summary>
     /// Writes the chart under its source hash. Goes to a .tmp first and moves over the top, so a
     /// crash mid-write cannot leave a half chart where the next run will read one.
+    ///
+    /// Refuses, quietly, in the two cases that would put a generated chart where an authored one
+    /// belongs: the chart handed in is itself authored (nothing hand written is ever cached, it is
+    /// read from where its author put it), or a track already has an authored chart (a generated one
+    /// must not be sitting in the cache waiting for the day the authored one is moved). Refusing is
+    /// a log line, never an exception: a cache that will not take a write is not a failed analysis.
     /// </summary>
     public static void Save(TrackChart chart)
     {
@@ -45,6 +51,17 @@ public static class TrackChartCache
         string hash = chart.Source.Hash;
         if (string.IsNullOrWhiteSpace(hash))
             throw new ArgumentException("The chart has no source hash to key the cache by", nameof(chart));
+
+        if (AuthoredCharts.IsAuthored(chart))
+        {
+            App.Logger?.Information("race-chart: not caching {Hash}, it is an authored chart", hash);
+            return;
+        }
+        if (AuthoredCharts.ExistsFor(hash, chart.Source.CloudId))
+        {
+            App.Logger?.Information("race-chart: not caching {Hash}, an authored chart already answers for it", hash);
+            return;
+        }
 
         Directory.CreateDirectory(Root);
         string path = PathFor(hash);


### PR DESCRIPTION
Lane D2a of Racing Thoughts x BambiCloud. Stacked on #906 (`feat/race-cloud-d1-chart`), which is
itself the top of the D1 stack. Review after #903 to #906; #907 (`feat/race-cloud-d2-hash`) sits on
top of this one.

## The rule

AUTHORED CHARTS ALWAYS WIN. A chart JSON with a top level `hand: true` was written by a person. It
is used instead of anything generated, never merged into, never charted again and never written
over. Generated charts still try their best.

## What is here

**Passthrough, first, or none of the rest survives the trip.** `TrackChart`, `TrackSource`,
`TrackAnalysis`, `TrackAct` and `TrackEvent` each carry a Newtonsoft `[JsonExtensionData]` bag, so a
field this build has no property for comes back out of a C# round trip untouched: the Track Maker's
top level `rules`, its per-event `hand`, `cue` and `note`, and whatever a newer chart version adds.
`hand` and `source.cloudId` are typed as well, because the lookup and the cache guard read them. A
generated chart writes neither.

**The lookup**, for a local pick and a cloud track alike, before anything is decoded:

1. the player's own folder, `%LOCALAPPDATA%/ConditioningControlPanel/race/authored/*.json`, indexed
   lazily by `source.hash` and `source.cloudId`
2. the shipped `Resources/web/dtrh/race/charts/index.json`, by `cloudId` then hash
3. `TrackChartCache`, by hash (the generated charts)
4. chart the audio

One Information line per track says which door it came through, in the same words the page logs:
`authored (user folder)`, `authored by cloudId`, `authored by hash`, `cached`, `generated`. An
authored chart is posted with `partial: false` and the analysis is never run for it.

**The cache cannot shadow an author.** `TrackChartCache.Save` refuses, with a log line and no
exception, when the chart handed to it is authored or when an authored chart already answers for
that hash. The "re-chart a `none` chart once a Vosk model appears" rule skips authored charts for
the same reason.

**The plate.** `track-chart` carries `authored`, `raceBoot.js` puts it on the ready state and
`race/menu.js` shows a small lowercase `hand-tuned` mark.

## Shared with the web lane

The index format and the `cloudId` derivation are lane W2's (`race/charts/index.json`,
`race/chartSource.js` `cloudIdFrom`). `AuthoredCharts.CloudIdFrom` is that rule ported verbatim, and
`charts/index.json` here is W2's file byte for byte, so the two branches add the same file and read
the same rows. W2 owns the shared **Authored charts** section of `CHART.md`; this branch adds only a
short desktop subsection beneath it and says so.

## Verified

- `dotnet build`: 0 errors.
- A throwaway console harness (not committed) linking the real `TrackChart.cs` and
  `AuthoredCharts.cs`, 19 checks, all pass: a chart carrying `hand`, `rules`, per-event
  `hand`/`cue`/`note`, an unknown `source.author`, an unknown `analysis.tool` and a whole unknown
  top level object round trips value for value; a generated chart writes no `hand` and no `cloudId`;
  `cloudIdFrom` on both README examples plus a 20 character id segment and an unparseable url; every
  door, case insensitivity on both keys, a chart without `hand: true` ignored, and an index row
  whose path climbs out of `race/` refused.
- At runtime, `--race-track` on a file that ALREADY had a generated chart in the cache with
  `analysis.words = "none"` (so the re-chart rule would otherwise have fired), with a hand written
  chart for the same hash dropped in the authored folder:
  `chart for d2-drone.mp3 via authored (user folder)`, then
  `{ type: track-chart, partial: false, authored: true, events: 3 }`. No `energy` or `words`
  progress stage was ever posted, so no analysis ran. The plate showed the authored chart's own name
  rather than the file name, "2 min - 2 to take", and the `hand-tuned` mark; the menu read "race the
  track". The three cache files kept their original timestamps and `race/cloud/` stayed empty.

## Not verified

The cloud half of the lookup end to end. Starting a track over there means clicking inside their
page, which the brief does not allow automating and which synthetic clicks cannot drive anyway. The
`--race-cloud` window still opens clean. The desktop-side wiring it feeds is unit-checked above.

Rebased onto main after the web chain (#901-#914) on 2026-09-07; conflicts resolved: none; race/charts/index.json arrived identical on both lanes, so it is now main's file and has left this diff. CHART.md keeps both sections (main's shared **Authored charts** rule plus this PR's desktop section under it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

