### PR TITLE
feat(race): hash a cloud track before pulling it down

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/race/CHART.md
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/CHART.md
@@ -268,6 +268,13 @@ it. If the two ever disagree, the shared section is right.
   exception, when the chart handed to it is authored, or when an authored chart already answers for
   that hash. The "re-chart a `none` chart once a Vosk model appears" rule skips authored charts too:
   there is no better pass than the person who wrote it.
+- **Hash before download.** On the cloud path the host resolves doors 1 and 2 off the `cloudId` with
+  no request at all, then asks the CDN for a `Content-Length` (HEAD, or the total out of a one byte
+  range's `Content-Range`) and a `Range: bytes=0-1048575`, and hashes those with
+  `TrackDecoder.HashBytes(length, head)` - the same recipe `HashFile` uses over a whole file. Doors
+  1, 2 and 3 are all resolved off that hash before a byte of audio is fetched, so an authored or
+  already charted track costs no download. If ranges are refused, or anything else goes sideways,
+  the probe answers nothing and the full download happens as before. One retry, never more.
 
 **Known gap: no prefetch of the next track.** The desktop never reads the playlist over there, so it
 cannot know what is coming and cannot chart it early. Charting starts when the track does. In

--- a/ConditioningControlPanel/Services/Chaos/CaucusHostService.cs
+++ b/ConditioningControlPanel/Services/Chaos/CaucusHostService.cs
@@ -1107,10 +1107,15 @@ internal static class CaucusHostService
         string? temp = null;
         try
         {
-            // The doors before the download. (a) and (b) by cloudId need only the url, so an
-            // authored chart linked by cloudId costs no download at all.
+            // The doors before the download. (a) and (b) by cloudId need only the url, and all three
+            // of (a), (b) and (c) answer off the hash, which is a length and a megabyte. An authored
+            // or already charted track therefore costs no download at all.
             string cloudId = AuthoredCharts.CloudIdFrom(src);
             if (TryChartWithoutAnalysis("", cloudId, name, name)) return;
+
+            string? hash = await ProbeCloudHashAsync(src, name, ct).ConfigureAwait(false);
+            ct.ThrowIfCancellationRequested();
+            if (hash != null && TryChartWithoutAnalysis(hash, cloudId, name, name)) return;
 
             temp = await DownloadCloudTrackAsync(src, name, ct).ConfigureAwait(false);
             ct.ThrowIfCancellationRequested();
@@ -1135,6 +1140,78 @@ internal static class CaucusHostService
             if (ReferenceEquals(_analysisCts, cts)) _analysisCts = null;
             try { cts.Dispose(); } catch (Exception ex) { App.Logger?.Debug("RaceHost.cloud cts: {E}", ex.Message); }
         }
+    }
+
+    /// <summary>
+    /// The CHART.md hash of a track without downloading it: a HEAD for the length and a Range for
+    /// the first 1 MiB. <see cref="TrackDecoder.HashBytes"/> is the same recipe HashFile uses over a
+    /// file, so the number matches the one a local copy of the same audio would give.
+    ///
+    /// Null means "ask the ordinary way": no length, no ranges, a short read, anything. The caller
+    /// falls back to the full download and hashes the file, which is exactly what it did before this
+    /// existed. ONE retry and no more, the same bargain the download makes.
+    /// </summary>
+    private static async Task<string?> ProbeCloudHashAsync(string src, string name, CancellationToken ct)
+    {
+        if (!RaceCloudWindow.IsSiteUri(src)) return null;
+        try
+        {
+            long? length = await CloudLengthAsync(src, ct).ConfigureAwait(false);
+            if (length is not > 0) return null;
+
+            int want = (int)Math.Min(TrackDecoder.HashHead, length.Value);
+            using var req = new HttpRequestMessage(HttpMethod.Get, src);
+            req.Headers.Range = new System.Net.Http.Headers.RangeHeaderValue(0, want - 1);
+            using var resp = await CloudHttp.SendAsync(req, HttpCompletionOption.ResponseHeadersRead, ct).ConfigureAwait(false);
+            // A 200 here is the CDN ignoring the range and offering the whole file. Walk away: the
+            // download path is about to ask for it properly, with progress.
+            if (resp.StatusCode != System.Net.HttpStatusCode.PartialContent) return null;
+
+            var head = new byte[want];
+            using (var body = await resp.Content.ReadAsStreamAsync(ct).ConfigureAwait(false))
+            {
+                int filled = 0, got;
+                while (filled < want && (got = await body.ReadAsync(head.AsMemory(filled, want - filled), ct).ConfigureAwait(false)) > 0)
+                    filled += got;
+                if (filled != want) return null;
+            }
+
+            string hash = TrackDecoder.HashBytes(length.Value, head);
+            App.Logger?.Information("RaceHost: cloud hash for {Name} off {Bytes} bytes of {Total}: {Hash}", name, want, length.Value, hash);
+            return hash;
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }
+        catch (Exception ex)
+        {
+            App.Logger?.Information("RaceHost: cloud hash probe failed for {Name} ({E}), downloading instead", name, ex.Message);
+            return null;
+        }
+    }
+
+    /// <summary>The file's length: a HEAD, or the total out of a one-byte range's Content-Range for
+    /// a CDN that will not answer HEAD. Null when neither says.</summary>
+    private static async Task<long?> CloudLengthAsync(string src, CancellationToken ct)
+    {
+        try
+        {
+            using var head = new HttpRequestMessage(HttpMethod.Head, src);
+            using var resp = await CloudHttp.SendAsync(head, HttpCompletionOption.ResponseHeadersRead, ct).ConfigureAwait(false);
+            if (resp.IsSuccessStatusCode && resp.Content.Headers.ContentLength is > 0)
+                return resp.Content.Headers.ContentLength;
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }
+        catch (Exception ex) { App.Logger?.Debug("RaceHost.cloud head: {E}", ex.Message); }
+
+        try
+        {
+            using var req = new HttpRequestMessage(HttpMethod.Get, src);
+            req.Headers.Range = new System.Net.Http.Headers.RangeHeaderValue(0, 0);
+            using var resp = await CloudHttp.SendAsync(req, HttpCompletionOption.ResponseHeadersRead, ct).ConfigureAwait(false);
+            return resp.Content.Headers.ContentRange?.Length;
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }
+        catch (Exception ex) { App.Logger?.Debug("RaceHost.cloud range probe: {E}", ex.Message); }
+        return null;
     }
 
     /// <summary>Stream the audio to a temp file, reporting bytes as track-progress. ONE retry and no

--- a/ConditioningControlPanel/Services/Race/TrackPcm.cs
+++ b/ConditioningControlPanel/Services/Race/TrackPcm.cs
@@ -94,11 +94,14 @@ public static class TrackDecoder
         }
     }
 
+    /// <summary>CHART.md: the hash reads the first 1 MiB and nothing else.</summary>
+    public const int HashHead = 1024 * 1024;
+
     /// <summary>The cache key: SHA1 of the length prefix + the first 1 MiB, so a rename keeps its chart.</summary>
     public static string HashFile(string path)
     {
         long length = new FileInfo(path).Length;
-        var head = new byte[1024 * 1024];
+        var head = new byte[HashHead];
         int filled = 0;
         using (var file = File.OpenRead(path))
         {
@@ -106,13 +109,26 @@ public static class TrackDecoder
             while (filled < head.Length && (got = file.Read(head, filled, head.Length - filled)) > 0)
                 filled += got;
         }
+        return HashBytes(length, filled == head.Length ? head : head[..filled]);
+    }
+
+    /// <summary>
+    /// The same number as <see cref="HashFile"/> from a length and the head bytes on their own, for
+    /// the caller that has those without having the file: the cloud path asks the CDN for a length
+    /// and one megabyte so an authored or already charted track costs no download. Pass at most the
+    /// first <see cref="HashHead"/> bytes, and fewer when the file is shorter than that.
+    /// </summary>
+    public static string HashBytes(long length, byte[] head)
+    {
+        if (head == null) throw new ArgumentNullException(nameof(head));
+        int count = Math.Min(head.Length, HashHead);
 
         var prefix = BitConverter.GetBytes(length);
         if (!BitConverter.IsLittleEndian) Array.Reverse(prefix);
 
         using var sha = SHA1.Create();
         sha.TransformBlock(prefix, 0, prefix.Length, null, 0);
-        sha.TransformFinalBlock(head, 0, filled);
+        sha.TransformFinalBlock(head, 0, count);
         return Convert.ToHexString(sha.Hash ?? Array.Empty<byte>()).ToLowerInvariant();
     }
 


### PR DESCRIPTION
Lane D2b of Racing Thoughts x BambiCloud. Stacked on #911, which is stacked on #906. Merge bottom
up.

## Why

A length and the first megabyte is the whole cache key (CHART.md: SHA1 of the byte length as 8 bytes
little endian plus the first 1 MiB). There is no reason to pull an hour of audio down to find out we
already have its chart, or that a person wrote one.

## What is here

`TrackDecoder.HashBytes(length, head)` is that sum over bytes the caller already holds, and
`HashFile` is now a thin wrapper over it, so the two cannot drift apart.

On the cloud path the host now, in order:

1. derives the `cloudId` off the url and resolves the two authored doors with no request at all
2. asks for a `Content-Length` (a HEAD, or the total out of a one byte range's `Content-Range` for a
   CDN that will not answer HEAD) and a `Range: bytes=0-1048575`, and hashes those
3. resolves the authored folder, the shipped index and the chart cache off that hash

Only a track none of them knows is downloaded.

Nothing here is required. Ranges refused (a 200 instead of a 206), no length, a short read, any of
it: the probe answers nothing and the full download happens exactly as it did before this existed.
One retry, never more, the same bargain the download already makes. The probe is gated by
`RaceCloudWindow.IsSiteUri` like every other request the desktop makes on that path.

## Verified

- `dotnet build`: 0 errors.
- `HashBytes` equals `HashFile` on real files at 1 KiB, 1 MiB minus one byte, exactly 1 MiB, 1 MiB
  plus 4 KiB and 3 MiB, so the boundary where the head stops being the whole file is covered both
  sides.
- Independently: a Python implementation of the CHART.md recipe over a 3 MB mp3 gave
  `80760378dcdaa9d94a3ae293efe36e91c5602259`, which is the exact name of the file that mp3's chart
  was already sitting under in the cache. Three implementations agree on the number.

## Not verified

The ranged probe against the live CDN. Starting a track over there means clicking inside their page,
which the brief does not allow automating and which synthetic clicks cannot drive. Worth an owner
pass with `--race-cloud` on a public free playlist: the log should show the cloud hash line, the
door taken, and no download at all for a track already in the cache.

Rebased onto main after the web chain (#901-#914) on 2026-09-07; conflicts resolved: none (CHART.md appended below the desktop section, no overlap with main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

