### PR TITLE
feat(race-web): the levels panel, so a phone opens the race and taps a track

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/race/cloud.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/cloud.js
@@ -149,7 +149,7 @@ export function createCloud({ settings = {}, hooks = {}, log = null, ui = null, 
   let list = [], at = -1, el = null, timer = 0, tries = 0, retry = 0, gen = 0;
   let played = false;                 // a run has actually played this element, so `pause` means something
   let rolled = false;                 // this element has already handed the lap on
-  let view = 'paste', busy = false, disposed = false;
+  let view = 'paste', busy = false, disposed = false, inner = false;
   let input = null, countEl = null, nextEl = null, rows = [], els = [], slotEl = null;
   let onPickRow = null, onClose = null, onRefresh = null;
 
@@ -221,7 +221,7 @@ export function createCloud({ settings = {}, hooks = {}, log = null, ui = null, 
     try { dur = await metadata(a); } catch (err) { return bail(i, err, mine); }
     if (disposed || mine !== gen) return false;
     let chart = null;
-    try { chart = await call('chart', { id: e.id, url: e.url, title: e.title, durationSec: dur, el: a }); }
+    try { chart = await call('chart', { id: e.id, url: e.url, title: e.title, durationSec: dur, bytes: e.bytes || 0, el: a }); }
     catch (err) { return bail(i, err, mine); }
     if (disposed || mine !== gen) return false;
     if (!chart) return bail(i, new Error('no chart'), mine);
@@ -244,7 +244,7 @@ export function createCloud({ settings = {}, hooks = {}, log = null, ui = null, 
   function armPrefetch() {
     const nx = nextPlayable(at + 1);
     const e = nx >= 0 ? list[nx] : null;
-    call('prefetch', e ? { id: e.id, url: e.url, title: e.title } : null);
+    call('prefetch', e ? { id: e.id, url: e.url, title: e.title, bytes: e.bytes || 0 } : null);
   }
 
   /** One retry, then stop. Nothing here ever schedules a second one. */
@@ -345,13 +345,22 @@ export function createCloud({ settings = {}, hooks = {}, log = null, ui = null, 
     for (const e of Array.isArray(entries) ? entries : []) {
       if (!e || !e.id || have.has(e.id)) continue;
       have.add(e.id);
-      list.push({ id: String(e.id), url: e.url ? String(e.url) : null, title: String(e.title || 'track').slice(0, 60), locked: !e.url || e.locked === true, failed: false });
+      list.push({ id: String(e.id), url: e.url ? String(e.url) : null, title: String(e.title || 'track').slice(0, 60), bytes: Number(e.bytes) || 0, locked: !e.url || e.locked === true, failed: false });
     }
     if (list.some((e) => e.locked)) say(`${list.filter((e) => e.locked).length} locked, skipped`);
     view = list.length ? 'list' : 'paste';
     paint();
     if (at < 0) { const nx = nextPlayable(0); if (nx >= 0) load(nx); }
     else armPrefetch();                 // a link pasted mid run may be the next lap
+  }
+
+  /**
+   * Play exactly these and nothing else: forget whatever was in hand, take the new list
+   * and start its first playable track. This is what a level row is: one tap, one run.
+   */
+  function setTracks(entries) {
+    forget();
+    addTracks(entries);
   }
 
   function forget() {
@@ -369,7 +378,7 @@ export function createCloud({ settings = {}, hooks = {}, log = null, ui = null, 
     list.forEach((e, i) => out.push({ id: 'trk-' + i, label: e.title, press: () => { if (e.locked || e.failed) { call('toast', e.locked ? LOCKED_WORD : FAIL_LINE); return; } load(i); } }));
     if (el && played) out.push({ id: 'pause', label: paused() ? 'resume' : 'pause', press: () => call('pause', !paused()) });
     if (list.length) out.push({ id: 'forget', label: 'forget them', press: forget });
-    out.push({ id: 'back', label: 'back', press: () => { if (onClose) onClose(); } });
+    if (!inner) out.push({ id: 'back', label: 'back', press: () => { if (onClose) onClose(); } });
     return out;
   }
 
@@ -413,12 +422,13 @@ export function createCloud({ settings = {}, hooks = {}, log = null, ui = null, 
    * finger, an arrow and the pad all land on the same line; `close` is the menu's way back to the
    * verbs; `refresh` repaints the menu's focus after the list has changed shape under it.
    */
-  function buildPanel({ slot, pick, close, refresh }) {
+  function buildPanel({ slot, pick, close, refresh, nested = false }) {
     slotEl = slot;
+    inner = !!nested;
     onPickRow = typeof pick === 'function' ? pick : null;
     onClose = typeof close === 'function' ? close : null;
     onRefresh = typeof refresh === 'function' ? refresh : null;
-    elm('h3', 'rm-h', slot, VERB_LABEL);
+    if (!inner) elm('h3', 'rm-h', slot, VERB_LABEL);
     elm('div', 'rm-hint rm-cloud-line', slot, CONSENT_LINE);
     input = elm('input', 'rm-seed rm-cloud-in', slot);
     input.type = 'text'; input.placeholder = PASTE_LABEL; input.setAttribute('aria-label', PASTE_LABEL);
@@ -436,6 +446,7 @@ export function createCloud({ settings = {}, hooks = {}, log = null, ui = null, 
     els: () => els,
     hostFrame,
     addTracks,
+    setTracks,
     paint,
     /** For the smoke and for anything that wants to know what is loaded. */
     get state() { return { view, at, busy, played, t: el ? Number(el.currentTime) || 0 : 0, playing: !!(el && !el.paused), list: list.map((e) => ({ ...e })) }; },

--- a/ConditioningControlPanel/Resources/web/dtrh/race/levels.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/levels.js
@@ -1,0 +1,322 @@
+/* ============================================================================
+ * race/levels.js - the LEVELS panel: the first thing a player sees.
+ *
+ *   levelsEnabled(settings) -> boolean       the verb's whole visibility rule
+ *   mmss(seconds) -> '2:42'                  pure
+ *   parseSets(json) -> set[]                 pure, no network, no DOM
+ *   loadLevels(url, { fetch }) -> Promise<set[]>
+ *   createLevels({ ... }) -> panel
+ *
+ * WHAT IT IS. race/levels.json is a static list of the tracks in a public set,
+ * shipped with the game. The panel paints one big tappable row per track, and a
+ * tap plays it. No pasting, no login, no search box: open the race, see the
+ * levels, tap one, drive.
+ *
+ * THE FILE IS STATIC AND IT IS OURS. levels.json holds a title, a file id, a
+ * length and a byte count per track and NOTHING ELSE. It is read from our own
+ * origin, it is never refreshed off the site, and a set that is not in it simply
+ * is not on the list. `bytes` is the whole point of carrying it: the CHART.md
+ * hash is a length plus the first megabyte, so a length written down here is a
+ * length the page does not have to ask a cdn for (race/CLOUD.md, "levels").
+ *
+ * TWO HOSTS, ONE PANEL.
+ *   web      the row hands the track to race/cloud.js, which owns the <audio>
+ *            element, and the run follows that element the way lane W1 built it.
+ *   desktop  (`settings.trackPick`) the desktop owns playback, so the row posts
+ *            `cloud-open { url }` and says to press play over there. This page
+ *            never loads a byte of audio in that mode.
+ *
+ * THE MARK ON A ROW. `hand-tuned` when race/charts/index.json has a row for that
+ * track, `road` when it does not, `again` on the last one played. Deciding it
+ * costs NO NETWORK: the index is same-origin and already fetched, and the key is
+ * the cloudId off the url.
+ *
+ * THE PASTE BOX IS STILL THERE. `or paste a link` opens lane W1's panel under
+ * the list, unchanged, so a track that is not one of the levels is still one
+ * paste away.
+ * ==========================================================================*/
+
+import { cloudIdFrom, findAuthored } from './chartSource.js';
+
+/** The panel key. Kept as `cloud` so the menu, `?panel=cloud` and the smokes all still name it. */
+export const VERB_ID = 'cloud';
+/** The verb. Lower case like every other one, and it sits right under `race`. */
+export const VERB_LABEL = 'levels';
+/** Where the list lives, relative to race/. `?levels=` overrides it, same origin only. */
+export const LEVELS_FILE = 'levels.json';
+/** The last level played, so the panel can say `again` on it. One id, nothing else. */
+export const LAST_KEY = 'race.level';
+/** The page a desktop host is asked to open for a track. A PAGE, never a file. */
+export const FILE_PAGE = 'https://bambicloud.com/file/';
+
+export const SET_LABEL = 'play the set';
+export const PASTE_LABEL = 'or paste a link';
+export const PASTE_OPEN_LABEL = 'hide the link box';
+export const BACK_LABEL = 'back';
+export const HAND_MARK = 'hand-tuned';
+export const ROAD_MARK = 'road';
+export const AGAIN_MARK = 'again';
+export const OVER_THERE_LINE = 'press play over there';
+export const EMPTY_LINE = 'no levels on this build, paste a link instead';
+
+/** The verb's whole visibility rule: a build that carries the levels, host or no host. */
+export function levelsEnabled(settings) {
+  return !!settings && settings.cloud === true;
+}
+
+/** 162 -> '2:42'. A length nobody can read is an empty string, not a lie. */
+export function mmss(seconds) {
+  const s = Math.round(Number(seconds));
+  if (!(s >= 0) || !isFinite(s)) return '';
+  const m = Math.floor(s / 60);
+  return m + ':' + String(s % 60).padStart(2, '0');
+}
+
+/**
+ * levels.json -> sets. PURE. Anything malformed is dropped rather than repaired:
+ * a level with no url cannot be played and a set with no levels is not a set.
+ */
+export function parseSets(json) {
+  const sets = Array.isArray(json && json.sets) ? json.sets : [];
+  const out = [];
+  for (const s of sets) {
+    if (!s || typeof s !== 'object') continue;
+    const levels = [];
+    for (const l of Array.isArray(s.levels) ? s.levels : []) {
+      if (!l || !l.id || !l.url) continue;
+      levels.push({
+        n: Number(l.n) || levels.length + 1,
+        id: String(l.id),
+        title: String(l.title || 'track').slice(0, 60),
+        url: String(l.url),
+        durationSec: Number(l.durationSec) || 0,
+        bytes: Number(l.bytes) || 0,
+        hash: String(l.hash || ''),
+      });
+    }
+    if (!levels.length) continue;
+    out.push({ id: String(s.id || 'set'), title: String(s.title || 'a set').slice(0, 60), playlistUrl: String(s.playlistUrl || ''), levels });
+  }
+  return out;
+}
+
+/**
+ * race/levels.json, off our own origin. A list that will not load is an EMPTY
+ * list and one log line: the paste box is still there and the race still runs.
+ */
+export async function loadLevels(url, { fetch: f = null, log = null } = {}) {
+  const get = f || (typeof fetch !== 'undefined' ? fetch : null);
+  const say = (m) => { try { if (log) log('levels: ' + m); } catch (e) { /* no log */ } };
+  if (!get || !url) return [];
+  try {
+    const res = await get(String(url), { credentials: 'omit' });
+    if (!res || !res.ok) { say('none (' + (res ? res.status : 'no answer') + ')'); return []; }
+    const sets = parseSets(await res.json());
+    say(sets.length ? sets.map((s) => `${s.title} (${s.levels.length})`).join(', ') : 'the file is empty');
+    return sets;
+  } catch (e) { say('unreadable: ' + ((e && e.message) || e)); return []; }
+}
+
+const elm = (tag, cls, parent, text) => {
+  const d = document.createElement(tag);
+  d.className = cls;
+  if (text != null) d.textContent = text;
+  parent.appendChild(d);
+  return d;
+};
+
+/**
+ * @param {object}   o
+ * @param {object}   o.settings   the host's `init.settings`
+ * @param {object[]} o.sets       parseSets output. An empty list is a panel that says so.
+ * @param {object}   [o.cloud]    race/cloud.js, or null on a desktop host
+ * @param {object}   [o.index]    race/charts/index.json, for the `hand-tuned` mark
+ * @param {object}   o.hooks      play(entries), open(url), toast(line)
+ * @param {function} [o.log]
+ * @param {object}   [o.store]    localStorage, or null. The smoke's seam.
+ */
+export function createLevels({ settings = {}, sets = [], cloud = null, index = null, hooks = {}, log = null, store = undefined }) {
+  const say = (m) => { try { if (log) log('levels: ' + m); } catch (e) { /* no log */ } };
+  const call = (n, ...a) => { try { return typeof hooks[n] === 'function' ? hooks[n](...a) : undefined; } catch (e) { say(n + ': ' + e); return undefined; } };
+  // A desktop host owns playback outright: this panel only ever points it at a page.
+  const desktop = settings.trackPick === true || !cloud;
+  const set = sets[0] || null;
+  const levels = set ? set.levels : [];
+  const mem = store !== undefined ? store : (typeof localStorage !== 'undefined' ? localStorage : null);
+
+  let slotEl = null, listEl = null, pasteEl = null, cloudUi = null;
+  let levelEls = [], tailEls = [], backEl = null;
+  let levelRows = [], tailRows = [], backRow = null;
+  let pasteOpen = false, disposed = false;
+  let stageId = '', stageWord = '';
+  let last = '';
+  let onPick = null, onClose = null, onRefresh = null;
+
+  try { last = String((mem && mem.getItem(LAST_KEY)) || ''); } catch (e) { last = ''; }
+  const remember = (id) => {
+    last = String(id || '');
+    try { if (mem) mem.setItem(LAST_KEY, last); } catch (e) { /* a private window, and nothing is lost */ }
+  };
+
+  /** The `hand-tuned` mark, decided with no network at all: the index is same origin. */
+  const authored = (lv) => !!findAuthored(index, { cloudId: cloudIdFrom(lv.url), hash: lv.hash });
+  /** What race/cloud.js is handed for a level. `bytes` saves it a HEAD the cdn will not answer. */
+  const entry = (lv) => ({ id: lv.id, url: lv.url, title: lv.title, bytes: lv.bytes, locked: false });
+
+  /** Where a level sits in the player right now, or ''. Read at paint time: the list is live. */
+  function playerState(lv) {
+    if (desktop || !cloud) return '';
+    let st = null;
+    try { st = cloud.state; } catch (e) { return ''; }
+    if (!st || st.at < 0) return '';
+    const cur = st.list[st.at];
+    if (!cur || cur.id !== lv.id) return '';
+    if (st.busy) return stageId === lv.id && stageWord ? stageWord : 'loading';
+    if (!st.played) return 'loaded';
+    return st.playing ? 'playing' : 'paused';
+  }
+
+  /** The small mark on the right of a row. State first, then memory, then the road it will get. */
+  function markOf(lv) {
+    const live = playerState(lv);
+    if (live) return live;
+    if (lv.id === last) return AGAIN_MARK;
+    return authored(lv) ? HAND_MARK : ROAD_MARK;
+  }
+
+  /* ---- the presses ------------------------------------------------------- */
+  /** A tap on a level. One track, one run. On a desktop it is a door, not a download. */
+  function tap(lv) {
+    remember(lv.id);
+    if (desktop) {
+      call('open', FILE_PAGE + lv.id, lv.title);
+      call('toast', OVER_THERE_LINE);
+      say(lv.title + ': handed to the desktop');
+      paint();
+      return;
+    }
+    say('level ' + lv.n + ': ' + lv.title);
+    call('play', [entry(lv)]);
+    paint();
+  }
+
+  /** The whole set, in order. The rollover between them is lane W1's, unchanged. */
+  function playSet() {
+    if (!levels.length) return;
+    remember(levels[0].id);
+    say(set.title + ': all ' + levels.length);
+    call('play', levels.map(entry));
+    paint();
+  }
+
+  function togglePaste() {
+    pasteOpen = !pasteOpen;
+    if (pasteEl) pasteEl.hidden = !pasteOpen;
+    paint();
+  }
+
+  /* ---- the rows the menu walks ------------------------------------------- */
+  /** How many rows sit above the nested paste panel, so a click in it maps to the right index. */
+  const head = () => levelRows.length + tailRows.length;
+  function rows() {
+    const out = levelRows.concat(tailRows);
+    if (pasteOpen && cloudUi) out.push(...cloud.rows());
+    if (backRow) out.push(backRow);
+    return out;
+  }
+  function els() {
+    const out = levelEls.concat(tailEls);
+    if (pasteOpen && cloudUi) out.push(...cloud.els());
+    if (backEl) out.push(backEl);
+    return out;
+  }
+
+  function paint() {
+    if (!slotEl || disposed) return;
+    for (let i = 0; i < levels.length; i++) {
+      const b = levelEls[i]; if (!b) continue;
+      const lv = levels[i], mark = markOf(lv), m = b.querySelector('.rm-level-mark');
+      if (m && m.textContent !== mark) m.textContent = mark;
+      b.classList.toggle('is-on', !!playerState(lv));
+      b.classList.toggle('is-hand', authored(lv));
+    }
+    const pasteBtn = tailEls[tailEls.length - 1];
+    if (pasteBtn && cloudUi) {
+      const want = pasteOpen ? PASTE_OPEN_LABEL : PASTE_LABEL;
+      if (pasteBtn.textContent !== want) pasteBtn.textContent = want;
+    }
+    if (onRefresh) onRefresh();
+  }
+
+  /**
+   * Build the panel into the menu's slot. `pick(i)` is the menu's own press for row i,
+   * `close` is the way back to the verbs, `refresh` repaints the menu's focus after the
+   * rows changed shape (the paste drawer opening is exactly that).
+   */
+  function buildPanel({ slot, pick, close, refresh }) {
+    slotEl = slot;
+    onPick = typeof pick === 'function' ? pick : null;
+    onClose = typeof close === 'function' ? close : null;
+    onRefresh = typeof refresh === 'function' ? refresh : null;
+    elm('h3', 'rm-h', slot, VERB_LABEL);
+    elm('div', 'rm-hint rm-levels-set', slot, set ? set.title : EMPTY_LINE);
+    listEl = elm('div', 'rm-levels', slot);
+
+    levelRows = []; levelEls = [];
+    levels.forEach((lv, i) => {
+      const b = elm('button', 'rm-btn rm-level-btn', listEl);
+      b.type = 'button'; b.dataset.id = 'lv-' + lv.n; b.setAttribute('role', 'menuitem');
+      elm('span', 'rm-level-n', b, String(lv.n).padStart(2, '0'));
+      elm('span', 'rm-level-title', b, lv.title);
+      elm('span', 'rm-level-len', b, mmss(lv.durationSec));
+      elm('span', 'rm-level-mark', b, '');
+      b.addEventListener('click', (ev) => { ev.stopPropagation(); if (onPick) onPick(i); });
+      levelEls.push(b);
+      levelRows.push({ id: 'lv-' + lv.n, label: lv.title, press: () => tap(lv) });
+    });
+
+    const tail = elm('div', 'rm-levels-tail', slot);
+    tailRows = []; tailEls = [];
+    const tailBtn = (id, label, press) => {
+      const b = elm('button', 'rm-btn rm-media-btn rm-levels-btn', tail, label);
+      b.type = 'button'; b.dataset.id = id; b.setAttribute('role', 'menuitem');
+      const at = levelRows.length + tailRows.length;
+      b.addEventListener('click', (ev) => { ev.stopPropagation(); if (onPick) onPick(at); });
+      tailEls.push(b); tailRows.push({ id, label, press });
+    };
+    if (levels.length && !desktop) tailBtn('set', SET_LABEL, playSet);
+    if (cloud) tailBtn('paste', PASTE_LABEL, togglePaste);
+
+    // The paste drawer: lane W1's panel, whole and unchanged, nested under the list.
+    pasteEl = elm('div', 'rm-cloud-paste', slot); pasteEl.hidden = true;
+    if (cloud) {
+      cloudUi = cloud.buildPanel({
+        slot: pasteEl, nested: true,
+        pick: (i) => { if (onPick) onPick(head() + i); },
+        close: () => { if (onClose) onClose(); },
+        refresh: () => paint(),
+      });
+    }
+    const foot = elm('div', 'rm-levels-foot', slot);
+    backEl = elm('button', 'rm-btn rm-media-btn rm-levels-btn', foot, BACK_LABEL);
+    backEl.type = 'button'; backEl.dataset.id = 'back'; backEl.setAttribute('role', 'menuitem');
+    backEl.addEventListener('click', (ev) => { ev.stopPropagation(); if (onPick) onPick(rows().length - 1); });
+    backRow = { id: 'back', label: BACK_LABEL, press: () => { if (onClose) onClose(); } };
+
+    paint();
+    return { rows, els };
+  }
+
+  return {
+    buildPanel,
+    rows,
+    els,
+    paint,
+    /** Lane W2's progress, landing on the row it belongs to. '' takes the stage word off again. */
+    setStage(id, word) { stageId = String(id || ''); stageWord = String(word || ''); paint(); },
+    get state() { return { desktop, sets: sets.length, levels: levels.length, pasteOpen, last, stage: stageWord }; },
+    dispose() { disposed = true; try { if (cloud) cloud.dispose(); } catch (e) { /* already gone */ } },
+  };
+}
+
+export default createLevels;

--- a/ConditioningControlPanel/Resources/web/dtrh/race/levels.json
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/levels.json
@@ -1,0 +1,113 @@
+{
+  "version": 1,
+  "sets": [
+    {
+      "id": "bambi-bimbodoll-conditioning",
+      "title": "Bambi Bimbodoll Conditioning",
+      "source": "bambicloud",
+      "playlistId": "e5dd01c7-960a-4ccd-8a7f-e6b60c56ed42",
+      "playlistUrl": "https://bambicloud.com/playlist/e5dd01c7-960a-4ccd-8a7f-e6b60c56ed42",
+      "levels": [
+        {
+          "n": 1,
+          "id": "a15c22e0-d347-4d92-9f78-0fb37099e549",
+          "title": "Rapid Induction",
+          "url": "https://cdn.bambicloud.com/a15c22e0-d347-4d92-9f78-0fb37099e549.mp3",
+          "durationSec": 162.0,
+          "bytes": 3581627,
+          "trackNum": 0
+        },
+        {
+          "n": 2,
+          "id": "97a86947-7a16-499d-b0e2-804d743ef45f",
+          "title": "Bubble Induction",
+          "url": "https://cdn.bambicloud.com/97a86947-7a16-499d-b0e2-804d743ef45f.mp3",
+          "durationSec": 1049.0,
+          "bytes": 25960832,
+          "trackNum": 1
+        },
+        {
+          "n": 3,
+          "id": "396cd1de-d462-45cf-aa9d-ba51501429cd",
+          "title": "Bubble Acceptance",
+          "url": "https://cdn.bambicloud.com/396cd1de-d462-45cf-aa9d-ba51501429cd.mp3",
+          "durationSec": 1734.0,
+          "bytes": 63191652,
+          "trackNum": 2
+        },
+        {
+          "n": 4,
+          "id": "86b98576-c8e9-4776-ad3d-873cc36cd596",
+          "title": "Bambi Named and Drained",
+          "url": "https://cdn.bambicloud.com/86b98576-c8e9-4776-ad3d-873cc36cd596.mp3",
+          "durationSec": 949.0,
+          "bytes": 25805817,
+          "trackNum": 3
+        },
+        {
+          "n": 5,
+          "id": "6c909be2-7a5b-495b-9f09-fabe1e3d5c16",
+          "title": "Bambi IQ Lock",
+          "url": "https://cdn.bambicloud.com/6c909be2-7a5b-495b-9f09-fabe1e3d5c16.mp3",
+          "durationSec": 726.0,
+          "bytes": 26603754,
+          "trackNum": 4
+        },
+        {
+          "n": 6,
+          "id": "b97ad669-f0f1-487c-9587-2dc57012c912",
+          "title": "Bambi Body Lock",
+          "url": "https://cdn.bambicloud.com/b97ad669-f0f1-487c-9587-2dc57012c912.mp3",
+          "durationSec": 908.0,
+          "bytes": 24182388,
+          "trackNum": 5
+        },
+        {
+          "n": 7,
+          "id": "37896de1-538e-4bd7-b338-25716f6e42e6",
+          "title": "Bambi Attitude Lock",
+          "url": "https://cdn.bambicloud.com/37896de1-538e-4bd7-b338-25716f6e42e6.mp3",
+          "durationSec": 839.0,
+          "bytes": 22537753,
+          "trackNum": 6
+        },
+        {
+          "n": 8,
+          "id": "6431b388-1068-4d2b-af5f-2292dbdbaab3",
+          "title": "Bambi Uniformed",
+          "url": "https://cdn.bambicloud.com/6431b388-1068-4d2b-af5f-2292dbdbaab3.mp3",
+          "durationSec": 815.0,
+          "bytes": 22748353,
+          "trackNum": 7
+        },
+        {
+          "n": 9,
+          "id": "36786265-e45d-4cf8-9e42-fc387b1d01cc",
+          "title": "Bambi Takeover",
+          "url": "https://cdn.bambicloud.com/36786265-e45d-4cf8-9e42-fc387b1d01cc.mp3",
+          "durationSec": 625.0,
+          "bytes": 17515202,
+          "trackNum": 8
+        },
+        {
+          "n": 10,
+          "id": "aa5c82d0-9766-4d27-ba08-9851fa744371",
+          "title": "Bambi Cockslut",
+          "url": "https://cdn.bambicloud.com/aa5c82d0-9766-4d27-ba08-9851fa744371.mp3",
+          "durationSec": 1081.0,
+          "bytes": 30071942,
+          "trackNum": 9
+        },
+        {
+          "n": 11,
+          "id": "e422c9a9-d24e-4318-bc35-a966b0a24f95",
+          "title": "Bambi Awakens",
+          "url": "https://cdn.bambicloud.com/e422c9a9-d24e-4318-bc35-a966b0a24f95.mp3",
+          "durationSec": 591.0,
+          "bytes": 16243432,
+          "trackNum": 10
+        }
+      ]
+    }
+  ]
+}

--- a/ConditioningControlPanel/Resources/web/dtrh/race/menu.css
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/menu.css
@@ -131,7 +131,30 @@
    consent is a real thing to want and it costs no network. */
 #race-root .rm-feed-btn.is-off .rm-feed-label, #race-root .rm-feed-btn.is-off .rm-feed-val { opacity: 0.5; }
 
-/* ---- play from bambicloud: the paste box and the pasted list (race/cloud.js) ---- */
+/* ---- the levels list (race/levels.js): the first thing a player sees ---- */
+/* One row per track, full width, and never under 48 px anywhere: this is the whole happy path on
+   a phone and a thumb has to be able to hit it without aiming. */
+#race-root .rm-levels { display: flex; flex-direction: column; gap: 4px; }
+#race-root .rm-levels-set { margin-top: 0; margin-bottom: 6px; color: #ffd6ea; letter-spacing: 0.08em; text-transform: uppercase; }
+#race-root .rm-level-btn {
+  display: grid; grid-template-columns: 2.4em 1fr auto; grid-template-areas: 'n title len' 'n mark mark';
+  gap: 0 10px; align-items: center; width: 100%; min-height: 48px; text-align: left;
+  padding: 7px 14px 7px 28px; font-size: 16px;
+}
+#race-root .rm-level-n { grid-area: n; color: rgba(255, 214, 234, 0.6); font-weight: 800; font-variant-numeric: tabular-nums; }
+#race-root .rm-level-title { grid-area: title; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+#race-root .rm-level-len { grid-area: len; color: rgba(255, 214, 234, 0.75); font-variant-numeric: tabular-nums; }
+#race-root .rm-level-mark { grid-area: mark; font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: rgba(255, 214, 234, 0.55); }
+/* a hand-made road is the one thing on this list worth pointing at, so it is the one thing lit */
+#race-root .rm-level-btn.is-hand .rm-level-mark { color: var(--pink, #ff69b4); }
+#race-root .rm-level-btn.is-on .rm-level-title { color: #fff; }
+#race-root .rm-level-btn.is-on .rm-level-mark { color: #ffd6ea; }
+#race-root .rm-levels-tail, #race-root .rm-levels-foot { display: flex; flex-direction: column; gap: 4px; margin-top: 6px; }
+#race-root .rm-levels-btn { align-self: flex-start; }
+#race-root .rm-cloud-paste { margin-top: 8px; padding-top: 8px; border-top: 1px solid rgba(255, 105, 180, 0.22); }
+#race-root .rm-cloud-paste[hidden] { display: none; }
+
+/* ---- the paste box and the pasted list (race/cloud.js), nested under the levels ---- */
 #race-root .rm-cloud-line { margin-top: 0; margin-bottom: 6px; max-width: 42ch; line-height: 1.45; }
 #race-root .rm-cloud-in { width: 100%; max-width: 42ch; margin: 0 0 6px; }
 #race-root .rm-cloud-next { margin: 2px 0 6px 2px; color: rgba(255, 214, 234, 0.75); }
@@ -304,6 +327,9 @@
   #race-root .rm-feed-sub { margin-top: 5px; }
   #race-root .rm-cloud-line { line-height: 1.35; }
   #race-root .rm-cloud-in { margin-bottom: 4px; }
+  /* the rows keep their 48 px: a short screen scrolls the column, it does not shrink the target */
+  #race-root .rm-level-btn { font-size: 15px; padding: 5px 14px 5px 28px; }
+  #race-root .rm-level-mark { font-size: 10px; }
   #race-root .rm-h { margin-bottom: 2px; font-size: 16px; }
   #race-root .rm-row { padding: 5px 12px; font-size: 15px; }
   #race-root .rm-row-hint, #race-root .rm-hint { font-size: 10px; margin-top: 2px; }

--- a/ConditioningControlPanel/Resources/web/dtrh/race/menu.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/menu.js
@@ -86,7 +86,7 @@ import { PIXEL_STEPS, PIXEL_DEFAULT, normalizeBlock } from './pixel.js';
 import { createMenuFlashes } from './menuFlashes.js';
 import { vFovForAspect, bindViewportResize } from './viewport.js';
 import { createFeedGroup } from './feedGroup.js';
-import { cloudEnabled, VERB_ID as CLOUD_VERB, VERB_LABEL as CLOUD_LABEL } from './cloud.js';
+import { levelsEnabled, VERB_ID as CLOUD_VERB, VERB_LABEL as CLOUD_LABEL } from './levels.js';
 
 export const OPTIONS_KEY = 'race.options';
 export const PROPS_URL = '/dtrh/race/assets/props.glb';
@@ -478,7 +478,7 @@ export function createStage({ renderer, pixel, reducedMotion = false, log = null
 }
 
 // ---- the menu ------------------------------------------------------------------------------------
-export function createMenu({ root, renderer, pixel, audio, settings = {}, log = null, send = null, cloud = null }) {
+export function createMenu({ root, renderer, pixel, audio, settings = {}, log = null, send = null, levels = null }) {
   const options = loadOptions();
   const systemReduced = !!(typeof matchMedia === 'function' && matchMedia('(prefers-reduced-motion: reduce)').matches);
   const reduced = () => wantsReducedMotion(options, settings.reducedMotion != null ? settings.reducedMotion : systemReduced);
@@ -499,8 +499,8 @@ export function createMenu({ root, renderer, pixel, audio, settings = {}, log = 
   const optPanel = el('div', 'rm-panel rm-options', col); optPanel.hidden = true;
   const mediaPanel = el('div', 'rm-panel rm-media', col); mediaPanel.hidden = true;
   const howPanel = el('div', 'rm-panel rm-how', col); howPanel.hidden = true;
-  // The BambiCloud mini-player's panel (race/cloud.js). The node is always built - one empty
-  // div costs nothing - and stays empty on any host that does not carry the `cloud` flag.
+  // The levels panel (race/levels.js, with race/cloud.js's paste box nested inside it). The node
+  // is always built - one empty div costs nothing - and stays empty on a build without the levels.
   const cloudPanel = el('div', 'rm-panel rm-cloud', col); cloudPanel.hidden = true;
   // ---- the track plate: what the host is doing with the file, then what it found ----
   const trackEl = el('div', 'rm-track', col); trackEl.hidden = true; trackEl.setAttribute('aria-live', 'polite');
@@ -645,11 +645,11 @@ export function createMenu({ root, renderer, pixel, audio, settings = {}, log = 
 
   // ---- the verbs. `track` only under a host (the file dialog is its), `clear` only once a file is in ----
   const canTrack = !!settings.trackPick;
-  // `cloud` is web only and its rule lives in race/cloud.js, so this file and the smoke read one
-  // predicate rather than two copies of it. A desktop host resolves it false and the verb never
-  // reaches the list.
-  const canCloud = cloudEnabled(settings) && !!cloud;
-  const VERBS = [['race', 'race'], ['track', 'load a track'], [CLOUD_VERB, CLOUD_LABEL], ['clear', 'just the road'], ['options', 'options'], ['media', 'your media'], ['how', 'how to drive'], ['story', 'the story'], ['surface', 'surface']];
+  // `levels` rides on the build's own `cloud` flag and its rule lives in race/levels.js, so this
+  // file and the smoke read one predicate rather than two copies of it. It sits directly under
+  // `race` because on a phone it is the whole happy path: open, see the levels, tap one.
+  const canCloud = levelsEnabled(settings) && !!levels;
+  const VERBS = [['race', 'race'], [CLOUD_VERB, CLOUD_LABEL], ['track', 'load a track'], ['clear', 'just the road'], ['options', 'options'], ['media', 'your media'], ['how', 'how to drive'], ['story', 'the story'], ['surface', 'surface']];
   const verbEls = VERBS.map(([id, label], i) => {
     const b = el('button', 'rm-btn', list, label); b.type = 'button'; b.dataset.id = id; b.setAttribute('role', 'menuitem');
     b.addEventListener('click', (e) => { e.stopPropagation(); idx.main = i; act('press'); });
@@ -705,7 +705,7 @@ export function createMenu({ root, renderer, pixel, audio, settings = {}, log = 
   let panel = 'main', shown = false, disposed = false, viewHeld = false;
   const idx = { main: 0, options: 0, media: 0, cloud: 0 };
   if (canCloud) {
-    cloudUi = cloud.buildPanel({
+    cloudUi = levels.buildPanel({
       slot: cloudPanel,
       pick: (i) => { idx.cloud = i; act('press'); },
       close: () => open('main'),

--- a/ConditioningControlPanel/Resources/web/dtrh/race/smoke/cloud-chart-check.mjs
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/smoke/cloud-chart-check.mjs
@@ -259,7 +259,13 @@ async function play(links, wantName) {
   return false;
 }
 const site = `http://127.0.0.1:${PORT}`;
-const openPanel = async () => { await click('.rm-list .rm-btn[data-id=cloud]'); await sleep(400); };
+// Lane W4 put the levels list on top and folded lane W1's paste box into a drawer under it.
+// Everything below walks the drawer, so opening the panel means opening that too: while it is
+// collapsed its rows are not part of the panel's walk and a press cannot land on one.
+const openPanel = async () => {
+  await click('.rm-list .rm-btn[data-id=cloud]'); await sleep(400);
+  await click('.rm-levels-tail .rm-btn[data-id=paste]'); await sleep(300);
+};
 
 await cdp('Runtime.enable'); await cdp('Page.enable'); await cdp('Network.enable');
 

--- a/ConditioningControlPanel/Resources/web/dtrh/race/smoke/cloud-check.mjs
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/smoke/cloud-check.mjs
@@ -141,15 +141,21 @@ await cdp('Runtime.enable'); await cdp('Page.enable'); await cdp('Network.enable
 
 /* ---- 1. the gate -------------------------------------------------------- */
 ok(await bootAt(`${site}/dtrh/race.html?cloud=1&intro=0&cards=0`), 'the page boots to the menu with ?cloud=1');
-ok((await verbs()).includes('cloud'), 'the `play from bambicloud` verb is on the list');
-ok(await ev(`document.querySelector('.rm-list .rm-btn[data-id=cloud]').textContent`) === 'play from bambicloud', 'and it is labelled in the menu\'s own lower case');
+ok((await verbs()).includes('cloud'), 'the `levels` verb is on the list');
+ok(await ev(`document.querySelector('.rm-list .rm-btn[data-id=cloud]').textContent`) === 'levels', 'and it is labelled in the menu\'s own lower case');
 
 /* ---- 2. the panel ------------------------------------------------------- */
 await click('.rm-list .rm-btn[data-id=cloud]');
 await sleep(400);
 ok(await ev(`!document.querySelector('.rm-cloud').hidden`), 'pressing the verb opens the panel');
+// Lane W4 put the levels list on top and folded this panel into a drawer under it. The drawer is
+// the whole of lane W1 and it is what the rest of this file walks, so open it first.
+ok(await ev(`document.querySelector('.rm-cloud-paste').hidden === true`), 'the paste box starts collapsed under the levels');
+await click('.rm-levels-btn[data-id=paste]');
+await sleep(300);
+ok(await ev(`!document.querySelector('.rm-cloud-paste').hidden`), '`or paste a link` opens it');
 ok(await ev(`!!document.querySelector('.rm-cloud-in')`), 'the panel carries the paste box');
-ok((await rowIds()).map((r) => r.split('=')[0]).join(',') === 'add,back', 'an empty panel is the add row and back, nothing else');
+ok((await rowIds()).map((r) => r.split('=')[0]).join(',') === 'add', 'an empty drawer is the add row and nothing else, the way back belongs to the panel around it');
 
 /* ---- 3. a link that will not load: loud, and once ------------------------ */
 await ev(`(()=>{const i=document.querySelector('.rm-cloud-in'); i.value='${site}/stub/missing.wav'; return 1;})()`);
@@ -192,7 +198,7 @@ await sleep(3000);
 }
 
 /* ---- 6. the run's clock follows the file --------------------------------- */
-await click('.rm-cloud .rm-cloud-btn[data-id=back]');
+await click('.rm-levels-foot .rm-btn[data-id=back]');
 await click('.rm-list .rm-btn[data-id=race]');
 await sleep(2000);
 {

--- a/ConditioningControlPanel/Resources/web/dtrh/race/smoke/real-audio-check.mjs
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/smoke/real-audio-check.mjs
@@ -163,6 +163,9 @@ for (let i = 0; i < 80 && !up; i++) {
 ok(up, 'the page boots to the menu with ?cloud=1');
 await click('.rm-list .rm-btn[data-id=cloud]');
 await sleep(400);
+// lane W4: the paste box lives in a drawer under the levels list
+await click('.rm-levels-btn[data-id=paste]');
+await sleep(300);
 await click('.rm-cloud .rm-cloud-btn[data-id=forget]');
 await sleep(300);
 await ev(`(()=>{const i=document.querySelector('.rm-cloud-in'); i.value=${JSON.stringify(URL_UNDER_TEST)}; return 1;})()`);
@@ -204,7 +207,7 @@ if (!REAL) {
  * ==========================================================================*/
 {
   // The chart loading is not the lap starting: leave the panel and drive.
-  await click('.rm-cloud .rm-cloud-btn[data-id=back]');
+  await click('.rm-levels-foot .rm-btn[data-id=back]');
   await click('.rm-list .rm-btn[data-id=race]');
   await sleep(2000);
   const a = await json(`({ t: window.__race.race.track.t, playing: window.__race.race.track.playing })`);

--- a/ConditioningControlPanel/Resources/web/dtrh/raceBoot.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/raceBoot.js
@@ -144,6 +144,7 @@ const settingEchoes = [];           // `setting` echoes that landed before there
 let settings = {}, seed = 0;
 let trackProgress = null, trackReady = null, errorTimer = 0, startTrackClock = null, trackTimer = 0, trackAudio = null;
 let cloud = null;                   // race/cloud.js, when the host says this build has it
+let levels = null;                  // race/levels.js, the panel the mini-player hangs under
 let cloudSource = null;             // race/cloudChart.js, the thing that answers hooks.chart
 let cloudWhere = '';                // ' · 3 of 9', kept so an upgraded chart repaints the same plate
 
@@ -229,6 +230,7 @@ function surface() {
   exiting = true;
   stopTrackClock();
   if (errorTimer) clearTimeout(errorTimer);
+  try { if (levels) levels.dispose(); } catch (e) { host.log('levels dispose: ' + e); }
   try { if (cloud) cloud.dispose(); } catch (e) { host.log('cloud dispose: ' + e); }
   try { if (cloudSource) cloudSource.dispose(); } catch (e) { host.log('cloud source dispose: ' + e); }
   try { if (menu) menu.dispose(); } catch (e) { host.log('menu dispose: ' + e); }
@@ -270,9 +272,13 @@ async function boot() {
     // hosted in every way the bridge can see and has no file dialog to open, and a verb that answers
     // nothing is worse than no verb at all.
     settings.trackPick = hosted && settings.trackPick !== false;
+    // `?trackpick=1` is a CHECK AID, nothing else: it makes an unhosted page claim the desktop
+    // host's track door so race/smoke/levels-check.mjs can walk that branch of the levels panel.
+    if (params.get('trackpick') === '1') settings.trackPick = true;
     // `cloud` is the browser host's capability flag; `?cloud=1` is the same switch for a page with
-    // no host under it, and it can never turn on where a desktop host already owns track loading.
-    settings.cloud = settings.cloud === true || (!settings.trackPick && params.get('cloud') === '1');
+    // no host under it. A desktop host that carries it gets the LEVELS panel (which hands a track
+    // to the desktop) and never the mini-player: race/cloud.js's own rule still refuses that.
+    settings.cloud = settings.cloud === true || params.get('cloud') === '1';
     cloud = await makeCloud();
     // run.js posts the track frames only when it believes something is hosting the file. With the
     // mini-player on, something is: this page. audio.js reads the same flag to decide where the
@@ -289,7 +295,8 @@ async function boot() {
     await standaloneTrack();
     if (params.get('autostart') === '1') { startRun(false); debugItemBox(); return; }
     if (hudRoot) hudRoot.classList.add('is-lobby');   // the run's chrome stays out of the menu and the intro
-    menu = createMenu({ root, renderer: race.renderer, pixel: race.pixel, audio: race.audio, settings, log: host.log, send: host.send, cloud });
+    levels = await makeLevels();
+    menu = createMenu({ root, renderer: race.renderer, pixel: race.pixel, audio: race.audio, settings, log: host.log, send: host.send, levels });
     if (localMedia) { try { menu.setLocalMedia(localMedia); } catch (e) { host.log('local-media: ' + e); } }
     while (settingEchoes.length) { try { menu.settingEcho(settingEchoes.shift()); } catch (e) { host.log('setting: ' + e); } }
     // Nowhere to surface to: no host and no `?back=`, or a host that says outright it cannot take
@@ -441,6 +448,54 @@ async function makeCloud() {
   });
 }
 
+/**
+ * THE LEVELS PANEL (race/levels.js). The first thing a player sees: the tracks of the set that
+ * ships in race/levels.json, one big row each, and a tap plays one.
+ *
+ * Both files it reads are OURS and SAME ORIGIN - the level list and the authored-chart index -
+ * so the list, the lengths and the `hand-tuned` marks are all decided before anything touches a
+ * cdn. `?levels=` swaps the list for the check's own, same origin only, so a query string can
+ * never point the panel at somebody else's file.
+ *
+ *   play  the web path: race/cloud.js takes exactly these tracks and starts the first one.
+ *   open  the desktop path: the host is asked to open the track's PAGE and the player presses
+ *         play over there. This page loads no audio at all in that mode.
+ */
+async function makeLevels() {
+  if (!settings.cloud) return null;
+  let mod = null, src = null;
+  try {
+    mod = await import('./race/levels.js');
+    src = await import('./race/chartSource.js');
+  } catch (err) { host.log('levels: ' + ((err && err.message) || err)); return null; }
+  let listUrl = new URL('race/levels.json', import.meta.url).href;
+  const want = params.get('levels');
+  if (want) {
+    try { const u = new URL(want, location.href); if (u.origin === location.origin) listUrl = u.href; else host.log('levels: ?levels is off origin, ignored'); }
+    catch (e) { host.log('levels: ?levels is not a url, ignored'); }
+  }
+  const indexUrl = new URL('race/charts/index.json', import.meta.url).href;
+  const [sets, index] = await Promise.all([
+    mod.loadLevels(listUrl, { log: host.log }),
+    src.loadIndex(indexUrl, { log: host.log }),
+  ]);
+  const toast = (line) => {
+    const msg = String(line || '').slice(0, 80).toLowerCase();
+    host.log('levels toast: ' + msg);
+    try { if (race && race.hud) race.hud.toast(msg.slice(0, 60), 'effect'); } catch (e) { /* no hud yet */ }
+  };
+  return mod.createLevels({
+    settings, sets, index, cloud, log: host.log,
+    hooks: {
+      play: (entries) => { if (cloud) cloud.setTracks(entries); },
+      // D1's cloud-open, with the track's own page on it. A host that only knows the bare
+      // message opens its window and ignores the url until it learns to read one.
+      open: (url) => host.send({ type: 'cloud-open', url }),
+      toast,
+    },
+  });
+}
+
 function stopTrackClock() {
   if (trackTimer) { clearInterval(trackTimer); trackTimer = 0; }
   if (trackAudio) { try { trackAudio.pause(); } catch (e) { /* already gone */ } }
@@ -544,7 +599,7 @@ async function startRun(withIntro) {
 // Gated on `hosted`: under a real host this is never defined and nothing can reach in.
 if (!hosted) {
   try {
-    window.__race = { get race() { return race; }, get cloud() { return cloud; }, get menu() { return menu; }, get settings() { return settings; } };
+    window.__race = { get race() { return race; }, get cloud() { return cloud; }, get levels() { return levels; }, get menu() { return menu; }, get settings() { return settings; } };
   } catch (e) { /* no window */ }
 }
 


### PR DESCRIPTION
Lane W4a of Racing Thoughts x BambiCloud. Stacked on `feat/race-cloud-w3-link`.

## The happy path

Before this, playing anything from the cloud meant leaving the game, finding a track,
copying a url and pasting it back. Now: open the race, see the levels, tap one, drive.

The verb is `levels` and it sits directly under `race`, because on a phone that is the
whole path.

## What is in it

**`race/levels.json`** ships the eleven tracks of the public Bambi Bimbodoll Conditioning
set. A title, a file id, a length and a byte count each, and nothing else. Static, read
off our own origin, never refreshed off the site. `bytes` is carried on purpose: the
CHART.md hash is a length plus the first megabyte, so a length written down here is a
length the page never has to ask a cdn for (lane W4b uses it).

**`race/levels.js`** is the panel. The set title, then one row per track: number, name,
length as `m:ss`, and one small mark. `hand-tuned` when the authored index has a row for
it, `road` when it does not, `again` on the last level played (kept in `localStorage`
under `race.level`, an id and nothing else), and the live word while it is being worked
on. Deciding the mark costs no network at all: both files it reads are same origin. Rows
are 48 px minimum and full width, per race/CONTRACT.md.

**Two hosts, one panel.** On the web a tap hands that one track to `race/cloud.js`, which
owns the element and the clock exactly as lane W1 built it, and `play the set` hands it
all eleven with W1's own rollover between them. On a desktop host the desktop owns
playback, so a tap posts `cloud-open` with the track's PAGE url and toasts "press play
over there"; this page loads no audio at all in that mode, and `play the set` is not
offered because the playlist is not this page's to hold.

> The C# `cloud-open` handler on the D lanes takes no `url` today: it opens its window and
> ignores the field. The message carries it anyway so the host can learn to read it without
> the page changing. No C# was touched here.

**Lane W1 is whole.** Its paste box is folded into a drawer under the list behind
`or paste a link`, unchanged. `race/cloud.js` grew three small things for that: a `nested`
build that skips its own heading and its own way back, `setTracks` for "play exactly
these", and `bytes` carried through to the chart hook.

## Verified

- `node race/smoke/cloud-check.mjs` all good (33 assertions, W1 behaviour intact)
- `node race/smoke/cloud-chart-check.mjs` all good (W2)
- `node race/smoke/track-run-check.mjs`, `chart-check`, `audio-check`, `touch-check`,
  `fov-check`, `gltf-smoke`, `poses-smoke`, `remote-feed-check`, `spiral-pool-check`,
  `ost-resident-check` all good
- the panel's own check lands in W4b

The two W1/W2 smokes that walk the paste box now open the drawer first: while it is
collapsed its rows are not part of the panel's walk, so a press cannot land on one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
