### PR TITLE
feat(race-web): a level's length is written down, so its hash costs one ranged GET

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/race/CLOUD.md
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/CLOUD.md
@@ -3,8 +3,10 @@
 What the web build of Racing Thoughts does with audio hosted on bambicloud.com,
 what it was allowed to find out, and where lane W2 plugs in.
 
-Code: `race/cloud.js` (the player and the panel), `race/menu.js` (the verb),
-`raceBoot.js` (the hooks and the outbound tap), `race/smoke/cloud-check.mjs`.
+Code: `race/levels.js` + `race/levels.json` (the levels panel and its list),
+`race/cloud.js` (the player and the paste box), `race/menu.js` (the verb),
+`raceBoot.js` (the hooks and the outbound tap), `race/smoke/levels-check.mjs`
+and `race/smoke/cloud-check.mjs`.
 
 ## The shape that shipped
 
@@ -18,7 +20,84 @@ loaded and charted, so the next track is the next lap.
 **There is no playlist browser.** See "what discovery found" below: the response
 shape of the site's public playlist collection was never confirmed, and a
 browser built against an unconfirmed shape is a screen of guesses that breaks in
-front of the player. The paste box is the whole door in this lane.
+front of the player. What shipped instead is a STATIC list, written down once and
+carried in the repo: see "the levels" below. The paste box is still there, folded
+under it, for a track that is not on the list.
+
+## The levels
+
+The verb is `levels` and it sits directly under `race`, because on a phone this is
+the whole happy path: open the race, see the tracks, tap one, drive. No pasting, no
+login, no search box.
+
+`race/levels.json` is where the list lives. It ships with the game, it is read off
+our own origin, and it is NEVER refreshed off the site: a set that is not written
+down is not on the screen.
+
+```json
+{ "version": 1, "sets": [ { "id": "...", "title": "...", "source": "bambicloud",
+  "playlistId": "...", "playlistUrl": "https://bambicloud.com/playlist/<id>",
+  "levels": [ { "n": 1, "id": "<file uuid>", "title": "...",
+                "url": "https://cdn.bambicloud.com/<uuid>.mp3",
+                "durationSec": 162, "bytes": 3581627, "trackNum": 0 } ] } ] }
+```
+
+| field | what it is |
+| --- | --- |
+| `n` | the number on the row, 1 up. The order the set is played in. |
+| `id` | the file's own id. It is the entry id the player keys on, and it is what a desktop host is asked to open (`https://bambicloud.com/file/<id>`, a PAGE, never a file). |
+| `title` | what the row and the plate say. |
+| `url` | the audio file on the cdn. The only url this page ever hands to an `<audio>` element or a `fetch`. |
+| `durationSec` | the length, for the `m:ss` on the row. The element is still the clock. |
+| `bytes` | the file's `Content-Length`. **Carried on purpose:** see below. |
+
+**Adding a set** is editing that file and nothing else. Append an object to `sets`
+with its own `levels`, keep `n` contiguous from 1, and give every level a real
+`bytes`. The panel shows the FIRST set; a second one is a list the panel can be
+taught to switch between later, and it costs no code to write it down now.
+
+**Why `bytes` is written down.** The `CHART.md` hash is the byte length plus the
+first 1 MiB, and the two lookups that can answer without downloading the file (the
+authored index by hash, and the generated-chart cache) both need that hash. A
+length already in hand is a `HEAD` request never sent, and on this cdn that matters
+(the facts are below). `hashUrl(url, { byteLength })` skips the HEAD outright when
+it is given one.
+
+**What a row says.** Its number, its title, its length as `m:ss`, and one small
+mark: `hand-tuned` when `race/charts/index.json` has a row for that track,
+`road` when it does not, `again` on the last level played (kept in `localStorage`
+under `race.level`, an id and nothing else), and the live word while it is being
+worked on (`naming`, `reading`, `decoding`, `charting`, then `playing` / `paused`).
+Deciding `hand-tuned` costs NO NETWORK: the index is same origin and already
+fetched, and the key is the `cloudId` off the url.
+
+**Two hosts, one panel.** On the web a tap hands that one track to `race/cloud.js`
+and the run follows the element. On a desktop host (`trackPick: true`) the desktop
+owns playback, so a tap posts `cloud-open { url }` with the track's PAGE url and
+toasts "press play over there"; this page loads no audio at all in that mode, and
+`play the set` is not offered because the playlist is not this page's to hold.
+
+> As of this lane the C# host's `cloud-open` handler takes no `url`: it opens its
+> window and ignores the field. The message carries it anyway so the host can learn
+> to read it without the page changing.
+
+**The cdn facts this is built on** (checked 2026-09-07 with `Origin:
+https://app.cclabs.app`):
+
+- `HEAD` answers 200 with `Accept-Ranges: bytes` and a `Content-Length`, but with
+  **no** `Access-Control-Allow-Origin`, so a cross origin HEAD from a browser
+  fails. That failure is one log line and an unknown length, never a thrown error.
+- `GET` with `Range: bytes=0-1048575` answers 206 with
+  `Access-Control-Allow-Origin: *`, so it works from the browser (a simple `Range`
+  value is a CORS-safelisted request header and needs no preflight). But there is
+  no `Access-Control-Expose-Headers`, so `Content-Range` and the total length are
+  **not** readable from JS, and the 206's `Content-Length` reads as the part size.
+- `OPTIONS` answers 403, so anything that would trigger a preflight fails.
+
+Which is exactly why the length is written down: for a level the hash is
+`SHA1(8-byte LE bytes + first 1 MiB)` off ONE ranged GET and no HEAD at all. A
+pasted link with no known length falls back to lane W2's other road: the length off
+`Content-Range` if the server exposes it, else off the full body.
 
 ## The rules this holds
 
@@ -232,17 +311,42 @@ track a new lap.
 ## Switches
 
 - `cloud: true` in the host's `init.settings` turns the verb on. The browser
-  host (cclabs-web `scripts/race-web-ext/host/index.js`) sets it; a desktop host
-  does not, and `trackPick: true` (a host that can open a file dialog) turns it
-  off outright - `cloudEnabled()` in `race/cloud.js` is the whole rule, exported
-  so the menu and the smoke read one predicate.
+  host (cclabs-web `scripts/race-web-ext/host/index.js`) sets it, and a desktop
+  host that carries it gets the levels panel in its desktop shape.
+  `levelsEnabled()` in `race/levels.js` is the whole rule for the verb, exported
+  so the menu and the smoke read one predicate; `cloudEnabled()` in
+  `race/cloud.js` is the narrower one for the mini-player, and `trackPick: true`
+  still turns THAT off outright, so a desktop host never streams audio here.
 - `?cloud=1` is the same switch for a page with no host under it. Dev and the
-  smoke use it; it can never turn on where a desktop host owns track loading.
+  smokes use it.
+- `?levels=<url>` swaps the level list for another one, **same origin only**, so a
+  query string can never point the panel at somebody else's file. It exists for
+  `race/smoke/levels-check.mjs`, which serves its own two-level list.
+- `?trackpick=1` makes an unhosted page claim the desktop host's track door, so
+  the check can walk the `cloud-open` branch. A check aid, nothing else.
 - `?panel=cloud` opens the menu on the panel, the way `?panel=howto` does.
-- `window.__race` is a standalone-only handle on `{ race, cloud, menu, settings }`
-  so a headless check can read the run's state. It is never defined under a host.
+- `window.__race` is a standalone-only handle on
+  `{ race, cloud, levels, menu, settings }` so a headless check can read the run's
+  state. It is never defined under a host.
 
 ## The check
+
+```
+node race/smoke/levels-check.mjs
+```
+
+The levels half. Serves `Resources/web` itself plus its OWN two-level list, its own
+authored index and its two WAV tracks (all in memory, so no binary and no test row
+is committed), and drives headless Chrome at 390x844, a phone, because that is who
+this panel is for. It holds: the verb is `levels` and sits under `race`; the panel
+lists the set title and one row per level with number, name and `m:ss`, every row
+at least 48 px tall and full width; `hand-tuned` and `road` land on the right rows
+and cost no request; a tap is a ONE TRACK run whose clock is the file's clock;
+`again` lands on the last level played and survives a reload; `play the set` is the
+whole list in order, the first one coming through the authored door, and the end of
+a file rolls the lap on; `or paste a link` opens lane W1's box unchanged; on a
+desktop host the row posts `cloud-open` with the page url and no byte of audio is
+asked for; and nothing left localhost.
 
 ```
 node race/smoke/cloud-check.mjs

--- a/ConditioningControlPanel/Resources/web/dtrh/race/chartSource.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/chartSource.js
@@ -99,8 +99,14 @@ function totalFromRange(v) {
 /**
  * The file's hash without downloading the file.
  *
- *   1. HEAD for `content-length` (a CORS safelisted response header, so it reads
- *      cross origin whenever the HEAD itself is allowed).
+ *   0. `byteLength`, when the caller already knows it. race/levels.json writes the
+ *      length of every level down, and a length in hand is a HEAD not sent: the
+ *      real cdn answers a HEAD with no `Access-Control-Allow-Origin` on it, so a
+ *      cross origin HEAD from a browser fails there no matter what we ask.
+ *   1. Otherwise HEAD for `content-length` (a CORS safelisted response header, so
+ *      it reads cross origin whenever the HEAD itself is allowed). A HEAD that is
+ *      refused is ONE log line and an unknown length, never a thrown error: step 2
+ *      still has a `Content-Range` to try and the 200 case still works.
  *   2. GET with `Range: bytes=0-<1 MiB - 1>`. A 206 gives the head bytes, and its
  *      `Content-Range` gives the total length when step 1 could not.
  *   3. If the server ignored the range and sent 200, that body IS the file: its
@@ -111,15 +117,18 @@ function totalFromRange(v) {
  * Answers `{ hash, bytes, total, ranged }` or null when it could not be worked
  * out at all. Never throws: every failure is a null and a log line.
  */
-export async function hashUrl(url, { fetch: f = null, log = null, signal = null } = {}) {
+export async function hashUrl(url, { fetch: f = null, log = null, signal = null, byteLength = 0 } = {}) {
   const get = f || (typeof fetch !== 'undefined' ? fetch : null);
   const say = (m) => { try { if (log) log('hash: ' + m); } catch (e) { /* no log */ } };
   if (!get || !url) return null;
-  let total = null;
-  try {
-    const h = await get(url, { method: 'HEAD', mode: 'cors', credentials: 'omit', signal });
-    if (h && h.ok) { const n = Number(h.headers.get('content-length')); if (n > 0) total = n; }
-  } catch (e) { say('no HEAD (' + ((e && e.message) || e) + ')'); }
+  let total = Number(byteLength) > 0 ? Number(byteLength) : null;
+  if (total) say('length in hand (' + total + '), no HEAD needed');
+  else {
+    try {
+      const h = await get(url, { method: 'HEAD', mode: 'cors', credentials: 'omit', signal });
+      if (h && h.ok) { const n = Number(h.headers.get('content-length')); if (n > 0) total = n; }
+    } catch (e) { say('no HEAD (' + ((e && e.message) || e) + '), reading the length off the range instead'); }
+  }
   let res = null;
   try {
     res = await get(url, { method: 'GET', mode: 'cors', credentials: 'omit', signal, headers: { Range: `bytes=0-${HASH_HEAD - 1}` } });

--- a/ConditioningControlPanel/Resources/web/dtrh/race/cloudChart.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/cloudChart.js
@@ -233,15 +233,18 @@ function plainRoad(name, durationSec) {
  * @param {string}   o.indexUrl        where race/charts/index.json lives
  * @param {object}   [o.cache]         race/chartCache.js, or null for none
  * @param {function} [o.onUpgrade]     (chart) -> void, the real road landing on a partial one
+ * @param {function} [o.onStage]       (id, word) -> void, which of the four steps this track is on
  * @param {function} [o.toast]         (line) -> void
  * @param {function} [o.log]
  * @param {function} [o.fetch]         the smoke's seam
  * @param {number}   [o.partialMs]
  */
-export function createChartSource({ indexUrl, cache = null, onUpgrade = null, toast = null, log = null, fetch: f = null, partialMs = PARTIAL_MS } = {}) {
+export function createChartSource({ indexUrl, cache = null, onUpgrade = null, onStage = null, toast = null, log = null, fetch: f = null, partialMs = PARTIAL_MS } = {}) {
   const get = f || (typeof fetch !== 'undefined' ? fetch : null);
   const say = (m) => { try { if (log) log('chart: ' + m); } catch (e) { /* no log */ } };
   const shout = (m) => { try { if (toast) toast(m); } catch (e) { /* no toast */ } };
+  /** Which step a track is on, for whatever is drawing its row. '' takes the word back off. */
+  const stage = (id, word) => { try { if (onStage) onStage(id, word); } catch (e) { /* nobody listening */ } };
   // README: a row's `chart` is written relative to `race/`, not to the index beside it, so
   // `charts/x.chart.json` is one readable path in the file instead of `./x.chart.json`.
   const chartUrl = (rel) => new URL(String(rel), new URL('../', indexUrl)).href;
@@ -267,7 +270,8 @@ export function createChartSource({ indexUrl, cache = null, onUpgrade = null, to
   const named = (chart, title) => normalizeChart({ ...chart, source: { ...chart.source, name: title || (chart.source && chart.source.name) || 'track' } });
 
   /** Fetch, decode, walk, lay a road. The only path that downloads the whole file. */
-  async function generated({ url, title, durationSec, head }) {
+  async function generated({ id, url, title, durationSec, head }) {
+    stage(id, 'reading');
     const res = await get(url, { mode: 'cors', credentials: 'omit' });
     if (!res || !res.ok) throw new Error('the file answered ' + (res ? res.status : 'nothing'));
     let bytes = new Uint8Array(await res.arrayBuffer());
@@ -280,7 +284,9 @@ export function createChartSource({ indexUrl, cache = null, onUpgrade = null, to
     }
     const buf = bytes.buffer;
     bytes = null;
+    stage(id, 'decoding');
     const walked = await peaksFromBytes(buf);
+    stage(id, 'charting');
     const dur = durationSec > 0 ? durationSec : walked.durationSec;
     if (Math.abs(walked.durationSec - dur) > 1) say(`the element says ${Math.round(dur)}s and the file decodes to ${Math.round(walked.durationSec)}s; the element is the clock`);
     const road = roadFromPeaks({ peaks: walked.peaks, perSec: walked.perSec, durationSec: dur, name: title, hash });
@@ -293,6 +299,7 @@ export function createChartSource({ indexUrl, cache = null, onUpgrade = null, to
     const { url, title } = info;
     const durationSec = Number(info.durationSec) || 0;
     const cloudId = cloudIdFrom(url);
+    stage(info.id, 'naming');
     const index = await loadIndex(indexUrl, { fetch: get, log });
 
     const byId = findAuthored(index, { cloudId });
@@ -301,7 +308,8 @@ export function createChartSource({ indexUrl, cache = null, onUpgrade = null, to
     // The hash is a length and the first megabyte, so both remaining lookups that can
     // answer without the file get their chance BEFORE anything is downloaded.
     let head = null;
-    try { head = await hashUrl(url, { fetch: get, log }); } catch (e) { say('hash: ' + ((e && e.message) || e)); }
+    // race/levels.json wrote this file's length down, so the hash is ONE ranged GET and no HEAD.
+    try { head = await hashUrl(url, { fetch: get, log, byteLength: Number(info.bytes) || 0 }); } catch (e) { say('hash: ' + ((e && e.message) || e)); }
     const hash = head && head.hash ? head.hash : '';
     if (hash) {
       const byHash = findAuthored(index, { hash });
@@ -312,7 +320,7 @@ export function createChartSource({ indexUrl, cache = null, onUpgrade = null, to
       }
     }
     if (durationSec > MAX_DECODE_SEC) { shout(TOO_LONG_LINE); throw new Error(`${Math.round(durationSec / 60)} minutes is past the ${Math.round(MAX_DECODE_SEC / 60)} minute decode limit`); }
-    return generated({ url, title, durationSec, head });
+    return generated({ id: info.id, url, title, durationSec, head });
   }
 
   /** Resolve, log the door, and fall back to the demo road rather than to a dead run. */
@@ -321,10 +329,12 @@ export function createChartSource({ indexUrl, cache = null, onUpgrade = null, to
     try {
       const { chart, door } = await resolve(info);
       say(`${info.title}: ${door} in ${((Date.now() - t0) / 1000).toFixed(1)}s`);
+      stage(info.id, '');
       return chart;
     } catch (err) {
       say(`${info.title}: ${(err && err.message) || err}`);
       shout(FALLBACK_LINE);
+      stage(info.id, '');
       const dur = Number(info.durationSec) > 0 ? Number(info.durationSec) : 240;
       const demo = demoChart({ durationSec: dur });
       return normalizeChart({ ...demo, source: { ...demo.source, name: info.title || demo.source.name, hash: '' } });

--- a/ConditioningControlPanel/Resources/web/dtrh/race/smoke/levels-check.mjs
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/smoke/levels-check.mjs
@@ -1,0 +1,323 @@
+/* ============================================================================
+ * race/smoke/levels-check.mjs - headless self-check for race/levels.js, the
+ * LEVELS panel, driven through the REAL page.
+ *
+ *   node race/smoke/levels-check.mjs      (exits 0 on pass, 1 with a count)
+ *
+ * THE SHIPPED LIST IS NEVER USED HERE. race/levels.json names files on a public
+ * cdn, and a check that reached them would be a check that phones a third party
+ * every time anybody runs it. So this file serves its OWN two-level list at
+ * /stub/levels.json and the page is pointed at it with `?levels=`, which
+ * raceBoot only honours for a same-origin url. The two tracks are WAV files
+ * this file writes in memory. Section 9 records every request the page made and
+ * fails if a single one left localhost.
+ *
+ * The authored index is stubbed the same way: /dtrh/race/charts/index.json is
+ * answered with one row for the FIRST stub track, so `hand-tuned` and `road`
+ * are both on the screen at once and neither of them is a row that shipped.
+ *
+ * What it holds:
+ *   1. the verb is `levels` and it sits directly under `race`
+ *   2. the panel opens on the set title and one row per level, each with its
+ *      number, its name and its length as m:ss
+ *   3. the marks: `hand-tuned` where the index has a row, `road` where it does
+ *      not, and neither of them cost a request
+ *   4. a tap is a ONE TRACK run: that track and nothing else, and the run's
+ *      clock is the file's clock
+ *   5. `again` lands on the last level played, and it survives a reload
+ *   6. `play the set` is the whole list in order, the first one is the authored
+ *      chart, and the end of a file rolls the lap on to the next level
+ *   7. `or paste a link` opens lane W1's box under the list, unchanged
+ *   8. on a desktop host nothing is loaded here: the row posts `cloud-open`
+ *      with the track's page url and says to press play over there
+ *   9. not one request left localhost
+ *
+ * CHROME: `CHROME_PATH` if it is set, else the usual Windows install. Nothing is
+ * installed by this file and the profile it makes is deleted on the way out.
+ * ==========================================================================*/
+
+import { spawn } from 'node:child_process';
+import { createServer } from 'node:http';
+import { readFile } from 'node:fs/promises';
+import { mkdtempSync, rmSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, extname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+let fails = 0;
+const ok = (cond, what) => { if (!cond) { console.error('FAIL ' + what); fails++; } else console.log('  ok  ' + what); };
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const HERE = resolve(fileURLToPath(import.meta.url), '..');
+const WEB = resolve(HERE, '../../..');          // Resources/web
+const PORT = 8866;
+const CHROME = process.env.CHROME_PATH || 'C:/Program Files/Google/Chrome/Application/chrome.exe';
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.mjs': 'text/javascript', '.css': 'text/css', '.json': 'application/json', '.glb': 'model/gltf-binary', '.png': 'image/png', '.webp': 'image/webp', '.jpg': 'image/jpeg', '.mp3': 'audio/mpeg', '.wav': 'audio/wav', '.svg': 'image/svg+xml', '.woff2': 'font/woff2' };
+
+/** A real, decodable mono WAV. Written here so no binary is committed for a smoke. */
+function wav(seconds = 4, rate = 8000) {
+  const n = seconds * rate, body = Buffer.alloc(n * 2);
+  for (let i = 0; i < n; i++) body.writeInt16LE(Math.round(3000 * Math.sin((2 * Math.PI * 220 * i) / rate)), i * 2);
+  const head = Buffer.alloc(44);
+  head.write('RIFF', 0); head.writeUInt32LE(36 + body.length, 4); head.write('WAVEfmt ', 8);
+  head.writeUInt32LE(16, 16); head.writeUInt16LE(1, 20); head.writeUInt16LE(1, 22);
+  head.writeUInt32LE(rate, 24); head.writeUInt32LE(rate * 2, 28); head.writeUInt16LE(2, 32); head.writeUInt16LE(16, 34);
+  head.write('data', 36); head.writeUInt32LE(body.length, 40);
+  return Buffer.concat([head, body]);
+}
+const TRACK = wav();
+
+/**
+ * The stub list. Two levels, both on this origin, both with their byte length written
+ * down the way the shipped file writes it: that length is what lets the hash skip the
+ * HEAD, which is the one thing the real cdn will not answer cross origin.
+ */
+const LEVELS = {
+  version: 1,
+  sets: [{
+    id: 'stub-set', title: 'A Stub Set', source: 'stub', playlistId: 'stub', playlistUrl: 'https://bambicloud.com/playlist/stub',
+    levels: [
+      { n: 1, id: 'stub-one', title: 'The First One', url: `http://127.0.0.1:${PORT}/stub/one.wav`, durationSec: 4, bytes: TRACK.length, trackNum: 0 },
+      { n: 2, id: 'stub-two', title: 'The Second One', url: `http://127.0.0.1:${PORT}/stub/two.wav`, durationSec: 4, bytes: TRACK.length, trackNum: 1 },
+    ],
+  }],
+};
+// cloudIdFrom('/stub/one.wav') is 'one': no path part is a uuid or 20 id characters, so the rule
+// falls through to the last part with its extension taken off. That is the key the index needs.
+const INDEX = { version: 1, tracks: [{ cloudId: 'one', title: 'The First One', durationSec: 4, chart: 'charts/stub.chart.json' }] };
+const AUTHORED = {
+  version: 1, hand: true, binSec: 0.5, energy: [0.2, 0.4, 0.6, 0.4],
+  acts: [{ t0: 0, t1: 4, kind: 'induction', name: 'the stub' }],
+  events: [{ id: 'a0', kind: 'peak', t: 2, dur: 0.5, label: 'by hand', conf: 1, weight: 1 }],
+  source: { name: 'The First One', hash: '', durationSec: 4, sampleRate: 16000 },
+  analysis: { energy: 'by-hand', words: 'none', partial: false },
+};
+
+const hits = new Map();                          // path -> how many times the page asked for it
+const bump = (p) => hits.set(p, (hits.get(p) || 0) + 1);
+const jsonRes = (res, o) => { const b = Buffer.from(JSON.stringify(o)); res.writeHead(200, { 'content-type': 'application/json', 'content-length': b.length }); res.end(b); };
+
+const server = createServer(async (req, res) => {
+  const path = decodeURIComponent(new URL(req.url, 'http://x').pathname);
+  bump(path);
+  if (path === '/stub/levels.json') return jsonRes(res, LEVELS);
+  // The stub index and its one chart stand in for the shipped pair, so no test row ever ships.
+  if (path === '/dtrh/race/charts/index.json') return jsonRes(res, INDEX);
+  if (path === '/dtrh/race/charts/stub.chart.json') return jsonRes(res, AUTHORED);
+  if (path === '/stub/one.wav' || path === '/stub/two.wav') {
+    const m = /^bytes=(\d+)-(\d*)$/.exec(req.headers.range || '');
+    if (m) {
+      const a = Number(m[1]), b = Math.min(TRACK.length - 1, m[2] ? Number(m[2]) : TRACK.length - 1);
+      const cut = TRACK.subarray(a, b + 1);
+      res.writeHead(206, { 'content-type': 'audio/wav', 'content-length': cut.length, 'content-range': `bytes ${a}-${b}/${TRACK.length}`, 'accept-ranges': 'bytes' });
+      return res.end(cut);
+    }
+    res.writeHead(200, { 'content-type': 'audio/wav', 'content-length': TRACK.length, 'accept-ranges': 'bytes' });
+    return res.end(TRACK);
+  }
+  if (path.indexOf('..') >= 0) { res.writeHead(400); return res.end(); }
+  try {
+    const body = await readFile(join(WEB, path));
+    res.writeHead(200, { 'content-type': MIME[extname(path).toLowerCase()] || 'application/octet-stream' });
+    res.end(body);
+  } catch (e) { res.writeHead(404, { 'content-type': 'text/plain' }); res.end('no'); }
+});
+
+if (!existsSync(CHROME)) {
+  console.error('FAIL no chrome at ' + CHROME + ' (set CHROME_PATH)');
+  process.exit(1);
+}
+await new Promise((r) => server.listen(PORT, '127.0.0.1', r));
+
+const prof = mkdtempSync(join(tmpdir(), 'race-levels-'));
+const chrome = spawn(CHROME, [
+  '--headless=new', '--remote-debugging-port=9338', `--user-data-dir=${prof}`,
+  '--no-first-run', '--no-default-browser-check', '--disable-gpu', '--mute-audio',
+  '--enable-unsafe-swiftshader', '--autoplay-policy=no-user-gesture-required',
+  '--window-size=390,844', 'about:blank',                       // a phone, because that is who this panel is for
+], { stdio: 'ignore' });
+
+let page = null;
+for (let i = 0; i < 60 && !page; i++) {
+  await sleep(250);
+  try { page = (await (await fetch('http://127.0.0.1:9338/json/list')).json()).find((t) => t.type === 'page'); } catch (e) { /* not up */ }
+}
+if (!page) { console.error('FAIL chrome never answered on the debug port'); await done(1); }
+
+const ws = new WebSocket(page.webSocketDebuggerUrl);
+await new Promise((r) => { ws.onopen = r; });
+let msgId = 0;
+const waits = new Map(), logs = [], asked = [];
+ws.onmessage = (e) => {
+  const m = JSON.parse(e.data);
+  if (m.id && waits.has(m.id)) { waits.get(m.id)(m); waits.delete(m.id); }
+  if (m.method === 'Network.requestWillBeSent') asked.push(m.params.request.url);
+  if (m.method === 'Runtime.consoleAPICalled') logs.push(m.params.args.map((a) => a.value ?? a.description ?? '?').join(' '));
+};
+const cdp = (method, params) => new Promise((res) => { const i = ++msgId; waits.set(i, res); ws.send(JSON.stringify({ id: i, method, params })); });
+const ev = async (x) => (await cdp('Runtime.evaluate', { expression: x, returnByValue: true, awaitPromise: true })).result?.result?.value;
+const json = async (x) => JSON.parse(await ev(`JSON.stringify(${x})`));
+const click = (sel) => ev(`(()=>{const b=document.querySelector(${JSON.stringify(sel)}); if(!b) return 0; b.click(); return 1;})()`);
+const verbs = () => json(`[...document.querySelectorAll('.rm-list .rm-btn')].filter(b=>!b.hidden).map(b=>b.dataset.id)`);
+/** Every level row as the screen reads it: number, title, length, mark, and whether it is lit. */
+const levelRows = () => json(`[...document.querySelectorAll('.rm-levels .rm-level-btn')].map(b=>({
+  id: b.dataset.id,
+  n: b.querySelector('.rm-level-n').textContent,
+  title: b.querySelector('.rm-level-title').textContent,
+  len: b.querySelector('.rm-level-len').textContent,
+  mark: b.querySelector('.rm-level-mark').textContent,
+  hand: b.classList.contains('is-hand'),
+  tall: Math.round(b.getBoundingClientRect().height),
+  wide: Math.round(b.getBoundingClientRect().width),
+}))`);
+
+const site = `http://127.0.0.1:${PORT}`;
+const LIST = `levels=${encodeURIComponent('/stub/levels.json')}`;
+
+async function bootAt(url) {
+  await cdp('Page.navigate', { url });
+  for (let i = 0; i < 80; i++) {
+    await sleep(250);
+    const up = await ev(`!!(window.__race && window.__race.menu) && !!document.querySelector('.rm-root') && !document.querySelector('.rm-root').hidden`);
+    if (up) { await sleep(300); return true; }
+  }
+  return false;
+}
+
+await cdp('Runtime.enable'); await cdp('Page.enable'); await cdp('Network.enable');
+
+/* ---- 1. the verb -------------------------------------------------------- */
+ok(await bootAt(`${site}/dtrh/race.html?cloud=1&intro=0&cards=0&${LIST}`), 'the page boots to the menu with ?cloud=1');
+{
+  const v = await verbs();
+  ok(v.includes('cloud'), 'the levels verb is on the list');
+  ok(v[0] === 'race' && v[1] === 'cloud', 'and it sits directly under `race`: ' + v.slice(0, 3).join(', '));
+  ok(await ev(`document.querySelector('.rm-list .rm-btn[data-id=cloud]').textContent`) === 'levels', 'labelled `levels`, in the menu\'s own lower case');
+}
+
+/* ---- 2. the panel ------------------------------------------------------- */
+await click('.rm-list .rm-btn[data-id=cloud]');
+await sleep(500);
+ok(await ev(`!document.querySelector('.rm-cloud').hidden`), 'pressing the verb opens the panel');
+ok(await ev(`document.querySelector('.rm-levels-set').textContent`) === 'A Stub Set', 'the set is named at the top');
+{
+  const r = await levelRows();
+  ok(r.length === 2, `one row per level (${r.length})`);
+  ok(r[0].n === '01' && r[0].title === 'The First One' && r[0].len === '0:04', 'a row is its number, its name and its length: ' + JSON.stringify([r[0].n, r[0].title, r[0].len]));
+  ok(r[1].n === '02' && r[1].title === 'The Second One' && r[1].len === '0:04', 'and so is the next one');
+  ok(r.every((x) => x.tall >= 48), `every row is at least 48 px tall for a thumb (${r.map((x) => x.tall).join(', ')})`);
+  ok(r.every((x) => x.wide > 200), `and full width (${r.map((x) => x.wide).join(', ')})`);
+}
+
+/* ---- 3. the marks, decided with no network ------------------------------ */
+{
+  const r = await levelRows();
+  ok(r[0].mark === 'hand-tuned' && r[0].hand === true, 'the level the authored index has a row for is marked hand-tuned');
+  ok(r[1].mark === 'road' && r[1].hand === false, 'and the one it does not is marked road');
+  ok(!hits.has('/stub/one.wav') && !hits.has('/stub/two.wav'), 'neither mark cost a single request for a file');
+}
+
+/* ---- 4. a tap is a one track run ---------------------------------------- */
+await click('.rm-levels .rm-level-btn[data-id=lv-2]');
+await sleep(3000);
+{
+  const st = await json(`window.__race.cloud.state`);
+  ok(st.list.length === 1 && st.list[0].id === 'stub-two', 'a tap plays that level and NOTHING else: ' + JSON.stringify(st.list.map((e) => e.id)));
+  ok(st.at === 0 && st.busy === false, 'and it is the track in hand');
+  ok(await ev(`document.querySelector('.rm-track-name').textContent`) === 'The Second One', 'the plate names it');
+}
+await click('.rm-levels-foot .rm-btn[data-id=back]');
+await click('.rm-list .rm-btn[data-id=race]');
+await sleep(2000);
+{
+  const s = await json(`({ el: window.__race.cloud.state.t, run: window.__race.race.track.t, playing: window.__race.race.track.playing })`);
+  ok(s.playing === true, 'the run reads the track as playing once the lap starts');
+  ok(s.el > 0.5, `the file is running (${s.el.toFixed(2)}s)`);
+  ok(Math.abs(s.el - s.run) < 0.5, `and the run's clock is the file's clock (${s.run.toFixed(2)}s vs ${s.el.toFixed(2)}s)`);
+}
+
+/* ---- 5. `again`, and it survives a reload -------------------------------- */
+ok(await ev(`localStorage.getItem('race.level')`) === 'stub-two', 'the level just played is remembered under race.level');
+ok(await bootAt(`${site}/dtrh/race.html?cloud=1&intro=0&cards=0&${LIST}`), 'the page boots again');
+await click('.rm-list .rm-btn[data-id=cloud]');
+await sleep(500);
+{
+  const r = await levelRows();
+  ok(r[1].mark === 'again', 'and the level played last carries the `again` hint');
+  ok(r[0].mark === 'hand-tuned', 'while the others still read as they did');
+}
+
+/* ---- 6. play the set ----------------------------------------------------- */
+await click('.rm-levels-tail .rm-btn[data-id=set]');
+await sleep(3000);
+{
+  const st = await json(`window.__race.cloud.state`);
+  ok(st.list.length === 2, `the whole set is in hand (${st.list.length})`);
+  ok(st.at === 0 && st.list[0].id === 'stub-one', 'starting at the first level');
+  const held = await json(`(()=>{const t=window.__race.race.track; return { name: t ? t.name : null, hand: t ? t.chart.hand : null };})()`);
+  ok(held.hand === true, 'and the authored chart won for it, off the index alone: ' + JSON.stringify(held));
+}
+await click('.rm-levels-foot .rm-btn[data-id=back]');
+await click('.rm-list .rm-btn[data-id=race]');
+for (let i = 0; i < 60; i++) {
+  const st = await json(`window.__race.cloud.state`);
+  if (st.at === 1 && st.busy === false) break;
+  await sleep(250);
+}
+{
+  const st = await json(`window.__race.cloud.state`);
+  ok(st.at === 1, 'the end of the first level rolls the lap on to the second');
+  const held = await json(`window.__race.race.track.name`);
+  ok(held === 'The Second One', 'and the run holds the next one: ' + JSON.stringify(held));
+}
+
+/* ---- 7. the paste box is still under there ------------------------------- */
+ok(await bootAt(`${site}/dtrh/race.html?cloud=1&intro=0&cards=0&${LIST}`), 'the page boots a third time');
+await click('.rm-list .rm-btn[data-id=cloud]');
+await sleep(500);
+ok(await ev(`document.querySelector('.rm-cloud-paste').hidden === true`), 'lane W1\'s paste box starts collapsed');
+await click('.rm-levels-tail .rm-btn[data-id=paste]');
+await sleep(300);
+ok(await ev(`!document.querySelector('.rm-cloud-paste').hidden`), '`or paste a link` opens it under the list');
+ok(await ev(`!!document.querySelector('.rm-cloud-paste .rm-cloud-in')`), 'and the box itself is the one lane W1 built');
+
+/* ---- 8. the desktop host: a door, not a download -------------------------- */
+ok(await bootAt(`${site}/dtrh/race.html?cloud=1&trackpick=1&intro=0&cards=0&${LIST}`), 'the page boots claiming a desktop host');
+ok(await ev(`window.__race.cloud === null`), 'the mini-player is never built there, so this page can load no audio at all');
+await click('.rm-list .rm-btn[data-id=cloud]');
+await sleep(500);
+{
+  const r = await levelRows();
+  ok(r.length === 2, 'the same two rows are on the screen');
+  ok(await ev(`!document.querySelector('.rm-levels-tail .rm-btn[data-id=set]')`), 'with no `play the set`: the desktop owns the playlist');
+}
+const before = asked.length;
+await click('.rm-levels .rm-level-btn[data-id=lv-1]');
+await sleep(700);
+{
+  const sent = logs.filter((l) => l.indexOf('cloud-open') >= 0).pop() || '';
+  ok(sent.indexOf('"url":"https://bambicloud.com/file/stub-one"') >= 0, 'a tap posts cloud-open with the track\'s PAGE url: ' + sent.slice(0, 120));
+  ok(logs.some((l) => l.indexOf('press play over there') >= 0), 'and the player is told to press play over there');
+  const after = asked.slice(before).filter((u) => /\.wav|\.mp3/.test(u));
+  ok(after.length === 0, 'and not one byte of audio was asked for on this page' + (after.length ? ': ' + after.join(', ') : ''));
+}
+
+/* ---- 9. nothing left this machine ---------------------------------------- */
+{
+  const away = asked.filter((u) => u.indexOf('http') === 0 && u.indexOf('127.0.0.1') < 0 && u.indexOf('localhost') < 0);
+  ok(away.length === 0, 'not one request left localhost in the whole run' + (away.length ? ': ' + away.slice(0, 3).join(', ') : ''));
+  ok(!hits.has('/dtrh/race/levels.json'), 'and the shipped level list was never read: this whole check ran on its own');
+}
+
+await done(fails ? 1 : 0);
+
+async function done(code) {
+  try { ws && ws.close(); } catch (e) { /* never opened */ }
+  try { chrome.kill(); } catch (e) { /* already gone */ }
+  await new Promise((r) => server.close(r));
+  await sleep(300);
+  try { rmSync(prof, { recursive: true, force: true }); } catch (e) { /* chrome still has a lock */ }
+  if (code) console.error(`\n${fails} failure${fails === 1 ? '' : 's'}`);
+  else console.log('\nlevels-check: all good');
+  process.exit(code);
+}

--- a/ConditioningControlPanel/Resources/web/dtrh/raceBoot.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/raceBoot.js
@@ -416,6 +416,9 @@ async function makeCloud() {
   cloudSource = chartMod.createChartSource({
     indexUrl: new URL('race/charts/index.json', import.meta.url).href,
     cache, log: host.log, toast,
+    // Which of the four steps a track is on, landing on that track's own row in the levels
+    // panel. The panel is built after this one, so it is read at call time and not captured.
+    onStage: (id, word) => { try { if (levels) levels.setStage(id, word); } catch (e) { /* no panel yet */ } },
     // The road landing on a plain one: `replaceTrack` while a lap is live keeps everything
     // already fired and adopts only the future, which is CHART.md's partial rule.
     onUpgrade(chart) {


### PR DESCRIPTION
Lane W4b of Racing Thoughts x BambiCloud. Stacked on `feat/race-cloud-w4-levels` (#913).

## What the cdn actually does

Measured 2026-09-07 with `Origin: https://app.cclabs.app`:

| request | answer |
| --- | --- |
| `HEAD` | 200, `Accept-Ranges: bytes`, `Content-Length`, **no** `Access-Control-Allow-Origin` |
| `GET Range: bytes=0-1048575` | 206, `Access-Control-Allow-Origin: *`, `Content-Range` present |
| `OPTIONS` | 403 |

So a cross origin HEAD from a browser fails. The ranged GET works (a simple `Range` value
is a CORS-safelisted request header and needs no preflight), but with no
`Access-Control-Expose-Headers` the `Content-Range` and the total length are not readable
from JS, and the 206's `Content-Length` reads as the part size. Anything that would
trigger a preflight fails as well.

Which leaves the byte length nowhere to come from in a browser, unless it is written down.

## What changed

`hashUrl` learned an optional `byteLength` and skips the HEAD outright when it has one.
`race/levels.json` (W4a) writes a length down for every level, and `cloudChart` passes it
through. Without one, the HEAD is still tried and a refusal is ONE log line and an unknown
length, never a thrown error: the `Content-Range` road and the full-body road are both
still behind it.

`createChartSource` also reports which of its four steps a track is on (`naming`,
`reading`, `decoding`, `charting`) so a levels row can say what is happening to it instead
of sitting on "loading" for a minute.

## The check

`race/smoke/levels-check.mjs`, 42 assertions, headless Chrome at 390x844 because a phone
is who this panel is for. It serves its OWN two-level list (pointed at with `?levels=`,
which raceBoot honours for a same-origin url only), its own authored index and its own two
WAV tracks: no binary and no test row is committed, and the shipped list is never read. It
holds the verb and its place under `race`, the rows and their lengths and their 48 px, the
`hand-tuned` / `road` marks and that neither cost a request, a tap being a ONE TRACK run
whose clock is the file's clock, `again` surviving a reload, `play the set` in order with
the first one coming through the authored door and the lap rolling on at the end of a
file, the paste drawer, the desktop `cloud-open` branch loading no audio at all, and that
not one request left localhost.

`race/CLOUD.md` gained a "the levels" section: where levels.json comes from, how to add a
set, why `bytes` is in it, and the cdn table above.

## Verified

- `node race/smoke/levels-check.mjs` all good, 42 assertions
- `node race/smoke/cloud-check.mjs` / `cloud-chart-check.mjs` / `real-audio-check.mjs` all good
- the one network run, `RACE_REAL_URL=https://cdn.bambicloud.com/a15c22e0-...-0fb37099e549.mp3
  node race/smoke/real-audio-check.mjs`: all good, the cdn headers are the table above, the
  chart is 648 bins / 13 events / 3 acts over the real 162 s, no console errors
- and the same level through the LEVELS panel against the real cdn:
  `hash: length in hand (3581627), no HEAD needed`, exactly one `Range: bytes=0-1048575`
  GET, chart hash `98c540802f64db35ca0458fb7e678ccc8b283baa` (the same number the pasted
  link produces the long way round), the row plays and the run's clock follows the file to
  within 0.03 s

🤖 Generated with [Claude Code](https://claude.com/claude-code)
