### PR TITLE
feat(race): the lyrics are the road (lyrics L2)

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/race/chart.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/chart.js
@@ -80,6 +80,10 @@ export function normalizeChart(json) {
       energy: str(an.energy, ''), words: str(an.words, 'none'), generatedAt: str(an.generatedAt, ''), partial: an.partial === true,
       lexicon: Object.freeze((Array.isArray(an.lexicon) ? an.lexicon : []).filter((w) => typeof w === 'string')),
     }),
+    // THE TRANSCRIPT (race/words.js, CHART.md `chart.words`). The lines the voice says, with
+    // the second each word lands on: it is what the captions layer reads and what tells the
+    // player the bubbles are the lyrics. Optional, and a road built without one carries [].
+    words: normalizeWords(json.words, durationSec),
     // AUTHORED CHARTS (race/charts/README.md). A chart a person wrote carries `hand: true`
     // and may carry a `rules` object. Normalizing is a validation pass, not an edit, so both
     // come back untouched: strip them and an authored chart stops being one the moment it
@@ -87,6 +91,22 @@ export function normalizeChart(json) {
     hand: json.hand === true,
     rules: Object.freeze((json.rules && typeof json.rules === 'object') ? { ...json.rules } : null),
   });
+}
+
+/**
+ * `chart.words`: `[{ t, d, w }]`, sorted, and nothing else. `w` is kept exactly as the
+ * transcript spelt it, case and punctuation and all, because a caption is read and not
+ * matched: the matching was done before this, against the normalised form. Anything that
+ * is not a word with a time is dropped, so a malformed field is an empty caption track
+ * rather than a broken chart.
+ */
+function normalizeWords(raw, durationSec) {
+  const out = (Array.isArray(raw) ? raw : [])
+    .filter((w) => w && typeof w === 'object' && typeof w.w === 'string' && w.w && isFinite(num(w.t, NaN)))
+    .map((w) => ({ t: clamp(num(w.t, 0), 0, durationSec), d: Math.max(0, num(w.d, 0)), w: w.w }))
+    .sort((a, b) => a.t - b.t)
+    .map((w) => Object.freeze(w));
+  return Object.freeze(out);
 }
 
 function normalizeActs(raw, durationSec) {
@@ -127,6 +147,10 @@ function normalizeEvents(raw, durationSec) {
       // is kept above: this pass validates a chart, it does not rewrite one.
       if (e.hand === true) ev.hand = true;
       if (typeof e.cue === 'string' && e.cue) ev.cue = e.cue;
+      // The trigger catalogue set this event came out of (chart/editor/triggerSets.js). It is
+      // what race/triggerTheme.js looks the plate and the bubble up by, so a trigger that lost
+      // it falls back to matching on its label, which two sets may share.
+      if (typeof e.setId === 'string' && e.setId) ev.setId = e.setId.slice(0, 40);
       if (typeof e.note === 'string' && e.note) ev.note = e.note.slice(0, 200);
       return Object.freeze(ev);
     });

--- a/ConditioningControlPanel/Resources/web/dtrh/race/cloudChart.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/cloudChart.js
@@ -43,13 +43,19 @@ import { demoChart, normalizeChart } from './chart.js';
 import { generate } from '../chart/maker/generate.js';
 import { peaksInto, binsPer, binCount } from '../chart/editor/audio.js';
 import { cloudIdFrom, hashUrl, hashBytes, loadIndex, findAuthored, isAuthored } from './chartSource.js';
+import { loadWords } from './words.js';
+import { TRIGGER_SETS } from '../chart/editor/triggerSets.js';
+import { detect } from '../chart/maker/triggers.js';
 
 /**
  * THE GENERATOR ID. It is the cache key's second half: change any knob below and
  * change this, and every chart the old road wrote is dropped on sight instead of
  * being played back at a player who is owed the new one.
+ *
+ * v2 (the lyrics wave): a road built on a transcript has words on it and a v1 road
+ * has none, so every v1 entry in the cache must regenerate rather than be served.
  */
-export const GENERATOR_ID = 'web-road-v1';
+export const GENERATOR_ID = 'web-road-v2';
 
 /* ---- the knobs, and why each one is what it is --------------------------- */
 /**
@@ -62,6 +68,22 @@ export const GENERATOR_ID = 'web-road-v1';
  * whichever of six rises happened to be loudest.
  */
 export const BIN_SEC = 0.25;
+/**
+ * And the bin the WORDED road uses, which is generate.js's own default. With a
+ * transcript the road is mostly words and the curve only has to carry the mood, so
+ * the reason BIN_SEC was halved does not apply: at 0.5 the build lands on the swell
+ * the way the maker's own roads have it, and the events the player meets are the
+ * ones the voice said.
+ */
+export const WORD_BIN_SEC = 0.5;
+/** A word this unsure is not a caption: the transcript guessed and the plate would lie. */
+export const CAPTION_CONF = 0.35;
+/**
+ * No two triggers land closer together than this: generate.js's own WORD_GAP, so a
+ * phrase said six times in ten seconds is a moment on the road and not a wall of them.
+ * The owner's law for this whole lane: too many bubbles is no bubbles.
+ */
+export const TRIGGER_GAP = 2.2;
 /** Peaks per second off the waveform. `energyFromPeaks` bins these down; this is the walk's own rate. */
 export const PEAKS_PER_SEC = 50;
 /** The rate everything is decoded at. Charts are timestamps: nothing here needs music bandwidth. */
@@ -190,6 +212,112 @@ export function roadFromPeaks({ peaks, perSec = PEAKS_PER_SEC, durationSec, name
   };
 }
 
+/* ---- the worded road ----------------------------------------------------- */
+
+/** The catalogue, by id, the way generate.js wants it for the labels on its events. */
+export const SET_BY_ID = new Map(TRIGGER_SETS.map((s) => [s.id, s]));
+
+/**
+ * Every trigger the transcript says, over the whole catalogue: the maker's own
+ * scan (chart/maker/words.js `scan`), in the shape generate.js reads, so a hit here
+ * means what a hit means on the Track Maker page.
+ *
+ * @returns [{ id, t, dur, setId, n }] sorted by t
+ */
+export function scanTriggers(words, durationSec) {
+  const list = (words && Array.isArray(words.words)) ? words.words : [];
+  // The phrase is only as sure as the least sure word in it: cues.js reads `conf` and
+  // spends anything under TRIGGER_SURE as a plain treat with no word on the chrome,
+  // which is the right answer for a phrase the transcript was guessing at.
+  const conf = (i0, i1) => {
+    let low = 1;
+    for (let i = i0; i <= i1 && i < list.length; i++) {
+      const c = list[i] && typeof list[i].conf === 'number' ? list[i].conf : 1;
+      if (c < low) low = c;
+    }
+    return Math.round(clamp01(low) * 100) / 100;
+  };
+  const out = [];
+  for (const set of TRIGGER_SETS) {
+    const ms = detect(words, set, [], { durationSec });
+    ms.forEach((m, n) => out.push({ id: 'h:' + set.id + ':' + n, t: m.t, dur: r3(Number(m.dur) || 0),
+      setId: set.id, n, conf: conf(m.i0, m.i1) }));
+  }
+  return out.sort((a, b) => a.t - b.t || a.setId.localeCompare(b.setId));
+}
+
+/**
+ * THE TRIGGERS OWN THEIR SECOND.
+ *
+ * generate.js spends a hit as a `word` event, because on the maker page the trigger
+ * itself is a hand-placed recipe sitting on top and the road underneath is only the
+ * road. Here there is no recipe: the trigger IS the road, and it is the whole point of
+ * this lane, so it is placed first and everything else gives way to it.
+ *
+ * That matters more than it sounds. `wordEvents` will not put a word inside 1.2 s of a
+ * count, a drop or a chant, and a trigger phrase is very often exactly where a drop is
+ * (the phrase contains a drop word, which is why it is a trigger at all), so the road
+ * generated straight out of generate.js loses most of them. Measured on the opening
+ * track: nineteen hits, four of them the phrase this whole road is built on, and not
+ * one of the four survived to be a trigger event.
+ *
+ * So: the hits are thinned against each other by TRIGGER_GAP, first one wins, and then
+ * every `word` event generate laid inside TRIGGER_GAP of one is dropped, because it was
+ * only ever filler standing where a trigger could not. Counts, drops and chants stay:
+ * a jump and a trigger on the same second is the file doing both, and cues.js spends
+ * them differently.
+ */
+export function triggersFromHits(events, hits, setById) {
+  const kept = [];
+  for (const h of hits) {
+    const set = setById.get(h.setId);
+    if (!set) continue;
+    const prev = kept[kept.length - 1];
+    if (prev && h.t - prev.t < TRIGGER_GAP) continue;
+    kept.push({ h, set });
+  }
+  const triggers = kept.map(({ h, set }) => ({
+    kind: 'trigger', t: r3(h.t), dur: r3(h.dur || 0), label: String(set.name).toLowerCase(),
+    conf: typeof h.conf === 'number' ? h.conf : 1, weight: 1, setId: set.id, cue: set.preset,
+  }));
+  const near = (t) => triggers.some((x) => Math.abs(x.t - t) < TRIGGER_GAP);
+  return events.filter((e) => !(e.kind === 'word' && near(e.t))).concat(triggers);
+}
+
+/** The caption track: what the voice says and when, and nothing the plate cannot show. */
+export function captionWords(words) {
+  const raw = (words && Array.isArray(words.words)) ? words.words : [];
+  return raw
+    .filter((w) => w && typeof w.w === 'string' && w.w && typeof w.t === 'number' && (typeof w.conf !== 'number' || w.conf >= CAPTION_CONF))
+    .map((w) => ({ t: r3(w.t), d: r3(Number(w.d) || 0), w: w.w }));
+}
+
+/**
+ * The road for a file we have the transcript of. generate.js does the whole of it -
+ * counts, drops, chants, the words themselves, the build/peak/release off the curve,
+ * the silences in the gaps between words and the acts off what is being said - because
+ * every one of those passes has the words it was written for. The two replacements the
+ * WORDLESS road needs are exactly the two that only exist because it has none.
+ *
+ * Then the trigger events, the caption track, and the lexicon the plate and the bubble
+ * mapping both read. Pure, so the smoke runs it in node.
+ */
+export function wordedRoad({ peaks, perSec = PEAKS_PER_SEC, durationSec, name = 'track', hash = '', words, now = new Date() }) {
+  const hits = scanTriggers(words, durationSec);
+  const g = generate({ peaks, perSec, durationSec, words, hits, setById: SET_BY_ID, binSec: WORD_BIN_SEC, now });
+  const energy = g.energy.map(clamp01);
+  const events = triggersFromHits(g.events, hits, SET_BY_ID)
+    .sort((a, b) => a.t - b.t)
+    .map((e, i) => ({ ...e, id: 'g' + i }));
+  const lexicon = [...new Set(events.filter((e) => e.kind === 'trigger').map((e) => e.label))].sort();
+  return {
+    version: 1, binSec: WORD_BIN_SEC, energy, events, acts: g.acts,
+    words: captionWords(words),
+    source: { name, hash, durationSec, sampleRate: DECODE_RATE },
+    analysis: { energy: 'web-rms-v1', words: 'script-align-v1', lexicon, generatedAt: g.generatedAt, partial: false },
+  };
+}
+
 /* ---- the decode ---------------------------------------------------------- */
 
 /**
@@ -270,7 +398,7 @@ export function createChartSource({ indexUrl, cache = null, onUpgrade = null, on
   const named = (chart, title) => normalizeChart({ ...chart, source: { ...chart.source, name: title || (chart.source && chart.source.name) || 'track' } });
 
   /** Fetch, decode, walk, lay a road. The only path that downloads the whole file. */
-  async function generated({ id, url, title, durationSec, head }) {
+  async function generated({ id, url, title, durationSec, head, cloudId }) {
     stage(id, 'reading');
     const res = await get(url, { mode: 'cors', credentials: 'omit' });
     if (!res || !res.ok) throw new Error('the file answered ' + (res ? res.status : 'nothing'));
@@ -289,7 +417,13 @@ export function createChartSource({ indexUrl, cache = null, onUpgrade = null, on
     stage(id, 'charting');
     const dur = durationSec > 0 ? durationSec : walked.durationSec;
     if (Math.abs(walked.durationSec - dur) > 1) say(`the element says ${Math.round(dur)}s and the file decodes to ${Math.round(walked.durationSec)}s; the element is the clock`);
-    const road = roadFromPeaks({ peaks: walked.peaks, perSec: walked.perSec, durationSec: dur, name: title, hash });
+    // The transcript, if this track has one. Same origin, small, and never fatal: a track
+    // with no words gets exactly the road it got before this lane landed.
+    const words = await loadWords({ cloudId, hash, fetch: get, log });
+    const road = (words && words.words.length)
+      ? wordedRoad({ peaks: walked.peaks, perSec: walked.perSec, durationSec: dur, name: title, hash, words })
+      : roadFromPeaks({ peaks: walked.peaks, perSec: walked.perSec, durationSec: dur, name: title, hash });
+    if (words && words.words.length) say(`${title}: ${road.words.length} words and ${road.analysis.lexicon.length} triggers on the road`);
     if (hash && cache) await cache.put(hash, road, GENERATOR_ID);
     return { chart: normalizeChart(road), door: 'generated' };
   }
@@ -320,7 +454,7 @@ export function createChartSource({ indexUrl, cache = null, onUpgrade = null, on
       }
     }
     if (durationSec > MAX_DECODE_SEC) { shout(TOO_LONG_LINE); throw new Error(`${Math.round(durationSec / 60)} minutes is past the ${Math.round(MAX_DECODE_SEC / 60)} minute decode limit`); }
-    return generated({ id: info.id, url, title, durationSec, head });
+    return generated({ id: info.id, url, title, durationSec, head, cloudId });
   }
 
   /** Resolve, log the door, and fall back to the demo road rather than to a dead run. */

--- a/ConditioningControlPanel/Resources/web/dtrh/race/smoke/lyrics-road-check.mjs
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/smoke/lyrics-road-check.mjs
@@ -1,0 +1,127 @@
+/* ============================================================================
+ * race/smoke/lyrics-road-check.mjs - the road a track with a transcript gets.
+ *
+ *   node race/smoke/lyrics-road-check.mjs     (from Resources/web/dtrh; 0 on pass, 1 with a count)
+ *
+ * Pure: no browser, no network, no audio. The words are the real transcript this
+ * branch ships for the opening track; the curve under them is a synthetic swell
+ * this file writes, because the road's WORDS are what is under test here and
+ * cloud-chart-check.mjs already charts real audio.
+ *
+ * What it holds:
+ *   1. the theme table: a row per preset the catalogue uses, every kind a real
+ *      bubble, no darkened kind ever named
+ *   2. the detector over the real transcript, and the hits it hands generate.js
+ *   3. the worded road: trigger events with a setId and a cue, a caption track,
+ *      analysis.words, and acts that are more than one room
+ *   4. what normalizeChart keeps of it: `words`, `setId`, `cue`
+ *   5. the wordless road is untouched, and a v1 cached road cannot be served
+ *
+ * It never prints a line of a transcript. Everything below is counted, never quoted.
+ * ==========================================================================*/
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { BUBBLE_KINDS, KIND_BY_ID } from '../bubbleKinds.js';
+import { normalizeChart } from '../chart.js';
+import { THEME_BY_PRESET, PRESETS_IN_USE, kindForPreset, themeFor, FALLBACK_KIND } from '../triggerTheme.js';
+import { GENERATOR_ID, WORD_BIN_SEC, BIN_SEC, CAPTION_CONF, captionWords, scanTriggers, wordedRoad, roadFromPeaks, PEAKS_PER_SEC } from '../cloudChart.js';
+
+let fails = 0;
+const ok = (cond, what) => { if (!cond) { console.error('FAIL ' + what); fails++; } else console.log('  ok  ' + what); };
+const eq = (got, want, what) => ok(got === want, what + ' (got ' + JSON.stringify(got) + ', want ' + JSON.stringify(want) + ')');
+
+const RACE = resolve(fileURLToPath(import.meta.url), '../..');
+const read = (rel) => JSON.parse(readFileSync(resolve(RACE, rel), 'utf8'));
+const index = read('words/index.json');
+const ROW = index.rows[0];                                  // the opening track: short, and it says the phrase
+const WORDS = read('words/' + ROW.file);
+const DUR = WORDS.durationSec;
+
+/** A curve shaped like a spoken track: a speaking level throughout, swelling every 40 s. */
+function swell(durationSec, perSec = PEAKS_PER_SEC) {
+  const n = Math.ceil(durationSec * perSec);
+  const peaks = new Float32Array(n * 2);
+  for (let i = 0; i < n; i++) {
+    const t = i / perSec;
+    const a = 0.22 + 0.5 * Math.max(0, Math.sin((t / 40) * Math.PI * 2)) ** 2;
+    peaks[i * 2] = -a; peaks[i * 2 + 1] = a;
+  }
+  return peaks;
+}
+
+/* ---- 1. the theme table --------------------------------------------------- */
+const rows = Object.entries(THEME_BY_PRESET);
+ok(rows.length >= 13, 'the table has a row for every preset the brief named (' + rows.length + ')');
+ok(PRESETS_IN_USE.every((p) => !!THEME_BY_PRESET[p]), 'every preset the catalogue uses has a row');
+ok(rows.every(([, r]) => !!KIND_BY_ID[r.kind]), 'every row names a real bubble kind');
+ok(rows.every(([, r]) => r.theme && r.color && r.ink && r.note), 'every row has a theme, two colours and a note');
+eq(new Set(rows.map(([, r]) => r.theme)).size, rows.length, 'no two rows share a plate theme');
+const dark = BUBBLE_KINDS.filter((k) => k.spawn === false).map((k) => k.id);
+ok(dark.length > 0 && rows.some(([, r]) => dark.includes(r.kind)), 'the table does point a row at a darkened kind (' + dark.join(', ') + ')');
+ok(rows.every(([p]) => !dark.includes(kindForPreset(p))), 'and kindForPreset never hands one out');
+eq(kindForPreset('video'), FALLBACK_KIND, 'the darkened row falls back to the flash bubble');
+eq(kindForPreset('not-a-preset'), null, 'a preset nobody wrote a row for is null, not a guess');
+eq(themeFor({ kind: 'trigger', label: 'bambi sleep', setId: 'bambi-sleep', cue: 'blackout' }).theme, 'ink', 'themeFor reads the cue');
+eq(themeFor({ kind: 'trigger', label: 'good girl', setId: 'good-girl' }).theme, 'blink', 'and falls back to the set when the cue is gone');
+eq(themeFor({ kind: 'trigger', label: 'nothing anyone said', cue: 'nope' }).theme, 'mark', 'and to the mark row when it knows neither');
+eq(themeFor(null), null, 'themeFor of nothing is null');
+
+/* ---- 2. the detector over the real transcript ----------------------------- */
+const hits = scanTriggers(WORDS, DUR);
+ok(hits.length > 0, ROW.title + ': the catalogue lands ' + hits.length + ' hits on the transcript');
+ok(hits.every((h, i) => i === 0 || h.t >= hits[i - 1].t), 'the hits come out sorted by time');
+ok(hits.every((h) => h.setId && h.id && h.t >= 0 && h.t <= DUR), 'every hit names its set and sits inside the file');
+ok(hits.some((h) => h.setId === 'bambi-sleep'), 'and the opening track really does say the phrase the road is built on');
+
+/* ---- 3. the worded road --------------------------------------------------- */
+const road = wordedRoad({ peaks: swell(DUR), durationSec: DUR, name: ROW.title, hash: ROW.hash, words: WORDS });
+const kinds = {};
+for (const e of road.events) kinds[e.kind] = (kinds[e.kind] || 0) + 1;
+console.log('\n  road: ' + JSON.stringify({ n: road.events.length, kinds, acts: road.acts.map((a) => a.kind), words: road.words.length }) + '\n');
+
+eq(road.binSec, WORD_BIN_SEC, 'the worded road bins at the maker default, not at the wordless quarter second');
+eq(road.analysis.words, 'script-align-v1', 'the road says it was built on a transcript');
+ok(road.words.length > 100, 'the caption track is the file talking (' + road.words.length + ' words)');
+ok(road.words.every((w) => Object.keys(w).length === 3 && typeof w.w === 'string'), 'and it is t, d and w, and nothing else');
+ok(road.words.every((w, i) => i === 0 || w.t >= road.words[i - 1].t), 'the caption track is sorted');
+eq(captionWords({ words: [{ t: 1, d: 0.2, w: 'x', conf: CAPTION_CONF - 0.01 }] }).length, 0, 'a word the transcript only guessed at is not a caption');
+eq(captionWords(null).length, 0, 'and no transcript is an empty caption track, not a throw');
+
+const triggers = road.events.filter((e) => e.kind === 'trigger');
+ok(triggers.length > 0, 'the road has trigger events on it (' + triggers.length + '), which the wordless one never had');
+ok(triggers.every((e) => e.setId && e.cue && e.weight === 1), 'every trigger carries its setId and its cue');
+ok(triggers.every((e) => !!THEME_BY_PRESET[e.cue]), 'every cue is a row in the theme table');
+const sleeps = triggers.filter((e) => e.setId === 'bambi-sleep');
+ok(sleeps.length >= 1, "'bambi sleep' is on the road " + sleeps.length + ' times');
+ok(sleeps.every((e) => e.cue === 'blackout'), 'and it carries the blackout cue');
+ok(road.analysis.lexicon.length > 0 && road.analysis.lexicon.every((w) => triggers.some((e) => e.label === w)),
+  'the lexicon is the phrases actually heard (' + road.analysis.lexicon.length + ')');
+ok(road.acts.length > 1, 'the file is more than one room (' + road.acts.map((a) => a.kind).join(' -> ') + ')');
+ok(road.events.some((e) => e.kind === 'peak'), 'the curve is still read: the road has its build, peak and release');
+ok(road.events.every((e, i) => i === 0 || e.t >= road.events[i - 1].t), 'and the whole road is sorted');
+eq(new Set(road.events.map((e) => e.id)).size, road.events.length, 'every event has its own id');
+
+/* ---- 4. what the chart keeps of it ---------------------------------------- */
+const chart = normalizeChart(road);
+eq(chart.words.length, road.words.length, 'normalizeChart keeps the caption track');
+ok(Object.isFrozen(chart.words), 'and freezes it, so a run cannot scribble on it');
+const kept = chart.events.filter((e) => e.kind === 'trigger');
+eq(kept.length, triggers.length, 'it keeps every trigger event');
+ok(kept.every((e) => e.setId && e.cue), 'with the setId and the cue still on them');
+eq(normalizeChart({ ...road, words: 'not an array' }).words.length, 0, 'a malformed caption track is an empty one, not a throw');
+eq(normalizeChart({ ...road, words: undefined }).words.length, 0, 'and no caption track at all is the same');
+const long = normalizeChart({ ...road, events: [{ kind: 'trigger', t: 1, label: 'x', setId: 'y'.repeat(80) }] });
+eq(long.events[0].setId.length, 40, 'a setId is cut to forty characters');
+
+/* ---- 5. the wordless road, and the cache --------------------------------- */
+const plain = roadFromPeaks({ peaks: swell(DUR), durationSec: DUR, name: ROW.title, hash: ROW.hash });
+eq(plain.analysis.words, 'none', 'a track with no transcript still gets the road it always got');
+eq(plain.binSec, BIN_SEC, 'at the quarter second bin it was tuned to');
+ok(!plain.events.some((e) => e.kind === 'trigger'), 'and it has no triggers on it, because nobody heard one');
+eq(normalizeChart(plain).words.length, 0, 'and no caption track');
+eq(GENERATOR_ID, 'web-road-v2', 'the cache key moved, so a v1 road (which has no words) can never be served');
+
+console.log(fails ? '\nlyrics-road-check: ' + fails + ' failed' : '\nlyrics-road-check: all good');
+process.exit(fails ? 1 : 0);

--- a/ConditioningControlPanel/Resources/web/dtrh/race/track.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/track.js
@@ -24,6 +24,7 @@
 
 import { createScheduler } from './chart.js';
 import { BUBBLE_KINDS } from './bubbleKinds.js';
+import { kindForPreset } from './triggerTheme.js';
 
 /** Intensity never quite reaches zero: even a silent stretch keeps the tube alive. */
 const FLOOR = 0.05;
@@ -43,6 +44,11 @@ const clamp01 = (v) => (v < 0 ? 0 : v > 1 ? 1 : v);
  * Every distinct trigger phrase in the chart gets its own bubble, the same one every time the file
  * is loaded: the lexicon and the spoken labels sorted, then dealt round robin. The player learns
  * "good girl is the pink one" over a track and that reading holds for the whole file.
+ *
+ * A trigger that names its own `cue` is not dealt at all: the trigger catalogue already said what
+ * that phrase looks like, and race/triggerTheme.js is the one table that reads it. So the freeze
+ * trigger is the freeze bubble on every track that says it, rather than whichever kind the round
+ * robin happened to land on in this file. The round robin still dresses everything else.
  */
 function mapTriggers(chart) {
   const m = new Map();
@@ -50,6 +56,11 @@ function mapTriggers(chart) {
   for (const w of chart.analysis.lexicon || []) if (w) words.add(String(w).toLowerCase());
   for (const e of chart.events) if (e.kind === 'trigger' && e.label) words.add(e.label);
   [...words].sort().forEach((w, i) => m.set(w, TRIGGER_KINDS[i % TRIGGER_KINDS.length]));
+  for (const e of chart.events) {
+    if (e.kind !== 'trigger' || !e.label || !e.cue) continue;
+    const kind = kindForPreset(e.cue);
+    if (kind) m.set(e.label, kind);
+  }
   return m;
 }
 

--- a/ConditioningControlPanel/Resources/web/dtrh/race/triggerTheme.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/triggerTheme.js
@@ -1,0 +1,95 @@
+/* ============================================================================
+ * race/triggerTheme.js - one table: preset -> bubble kind -> plate theme.
+ *
+ * A trigger event carries `cue`, which is the preset the trigger catalogue gave
+ * its set (`chart/editor/triggerSets.js`). This file is the only place that says
+ * what a preset LOOKS like, so the bubble the player drives into and the plate
+ * that flies at their face are picked off one row and can never drift apart.
+ *
+ *   kindForPreset(preset) -> a bubbleKinds.js id
+ *   themeFor(event)       -> { preset, kind, theme, color, ink, note } or null
+ *
+ * WHO READS WHICH HALF. `race/track.js` takes the kind, so a trigger phrase wears
+ * the same bubble every time the file is loaded rather than whatever the round
+ * robin dealt it. The captions layer takes `theme` and writes one CSS class per
+ * row; the animations the rows describe are its business, not this file's.
+ *
+ * DARK KINDS. `bubbleKinds.js` may darken a row (`spawn: false`) and a chart is
+ * never allowed to place one, so a preset that points at a dark kind falls back
+ * to `flash`. That check is made here, against the live table, so darkening one
+ * more row never needs an edit in this file.
+ *
+ * Node-clean: no DOM, no window.
+ * ==========================================================================*/
+
+import { KIND_BY_ID } from './bubbleKinds.js';
+import { TRIGGER_SETS } from '../chart/editor/triggerSets.js';
+
+/** What a preset that points at a darkened kind wears instead. */
+export const FALLBACK_KIND = 'flash';
+/** And what an event with no preset at all, or one nobody wrote a row for, wears. */
+export const FALLBACK_THEME = 'mark';
+
+/**
+ * The table. `kind` is the bubble; `theme` is the plate's CSS class; `color` and
+ * `ink` are the plate's own two colours where the row fixes them, and `note` is
+ * what the plate is supposed to DO, in one line, for whoever writes that class.
+ */
+export const THEME_BY_PRESET = {
+  'blackout':     { kind: 'braindrain', theme: 'ink',    color: '#0f0f16', ink: '#f4f2ff', note: 'near black card, white text, the screen dims for 300 ms' },
+  'pink-blink':   { kind: 'pink',       theme: 'blink',  color: '#ff3da5', ink: '#0f0f1c', note: 'hot pink, double blink' },
+  'pink-wall':    { kind: 'pink',       theme: 'wall',   color: '#ff69b4', ink: '#0f0f1c', note: 'pink, wide letter spacing, slides in from both sides' },
+  'freeze-snap':  { kind: 'freeze',     theme: 'frost',  color: '#8ae6ff', ink: '#0f0f1c', note: 'ice blue, frost crackle, hard stop at scale 1' },
+  'snap-shake':   { kind: 'glitch',     theme: 'snap',   color: '#f4f2ff', ink: '#0f0f1c', note: 'white, one violent shake' },
+  'glitch-shake': { kind: 'glitch',     theme: 'split',  color: '#ffd166', ink: '#0f0f1c', note: 'yellow, chromatic split' },
+  'flash-pulse':  { kind: 'flash',      theme: 'pulse',  color: '#ffffff', ink: '#0f0f1c', note: 'white flash behind, three pulses' },
+  'golden-rain':  { kind: 'golden',     theme: 'gold',   color: '#ffd700', ink: '#0f0f1c', note: 'gold, sparkle shards fall off the letters' },
+  'spiral-air':   { kind: 'spiral',     theme: 'spiral', color: '#c8a8ff', ink: '#0f0f1c', note: 'lilac, slow rotate while it zooms' },
+  'melt':         { kind: 'braindrain', theme: 'melt',   color: '#4060c0', ink: '#f4f2ff', note: 'deep blue, letters sag and blur downward' },
+  'video':        { kind: 'video',      theme: 'scan',   color: '#ff5c6c', ink: '#f4f2ff', note: 'red, scanlines' },
+  // A row of treats is not an effect: the road is what happens, and the plate is warm rather than loud.
+  'treats':       { kind: 'treat',      theme: 'bounce', color: '#ffb3d9', ink: '#0f0f1c', note: 'warm pink, bouncy letters' },
+  // A marked word, not a trigger moment: small, no zoom.
+  'mark':         { kind: 'treat',      theme: 'mark',   color: '#ece8ff', ink: '#0f0f1c', note: 'soft white, small, no zoom' },
+};
+
+const spawnable = (id) => { const k = KIND_BY_ID[id]; return !!k && k.spawn !== false; };
+const SET_BY_ID = new Map(TRIGGER_SETS.map((s) => [s.id, s]));
+const SET_BY_NAME = new Map(TRIGGER_SETS.map((s) => [String(s.name).toLowerCase(), s]));
+
+/** The bubble a preset wears, with a darkened kind swapped for the fallback. */
+export function kindForPreset(preset) {
+  const row = THEME_BY_PRESET[String(preset || '')];
+  if (!row) return null;
+  return spawnable(row.kind) ? row.kind : FALLBACK_KIND;
+}
+
+/**
+ * The whole row for one trigger event: `cue` first, then the event's `setId`, then
+ * its label read back off the catalogue, so an event that lost its preset on the
+ * way through still lands on the theme its phrase belongs to.
+ *
+ * `color` is the row's own where the row fixes one and the SET's colour where it
+ * does not, which is the plate glow for anything the table never named.
+ */
+export function themeFor(event) {
+  if (!event || typeof event !== 'object') return null;
+  const set = SET_BY_ID.get(String(event.setId || '')) || SET_BY_NAME.get(String(event.label || '').toLowerCase()) || null;
+  const want = String(event.cue || (set && set.preset) || '');
+  const preset = THEME_BY_PRESET[want] ? want : FALLBACK_THEME;
+  const row = THEME_BY_PRESET[preset];
+  return {
+    preset,
+    kind: spawnable(row.kind) ? row.kind : FALLBACK_KIND,
+    theme: row.theme,
+    // The row's own colour, and the set's when this event fell through to the fallback row.
+    color: (preset === want ? row.color : (set && set.color)) || row.color,
+    ink: row.ink,
+    note: row.note,
+  };
+}
+
+/** Every preset the catalogue uses. The smoke holds the two lists level. */
+export const PRESETS_IN_USE = [...new Set(TRIGGER_SETS.map((s) => s.preset))].sort();
+
+// self-check: node race/smoke/lyrics-road-check.mjs walks every row of the table.


### PR DESCRIPTION
**Stacked on #915.** Base is `feat/race-lyrics-l1-words`, so review that one first
and merge it first.

The web road was energy and nothing else. `cloudChart.js` called `generate()` with
`words: { words: [] }` and `hits: []`, so every bubble the player saw was seeded
chunk dressing or a peak rain, and none of it had anything to do with what the voice
was saying. With L1's transcripts on the shelf it can read the file.

## the worded road (`race/cloudChart.js`)

When `loadWords` finds a transcript, the trigger catalogue is run over it
(`scanTriggers`, the maker's own `scan` in the shape `generate.js` reads), the hits go
to `generate()` along with the words and the maker's own 0.5 s bin, and the road comes
back with the counts, drops, chants, silences and acts those passes were written for.
The two replacements the WORDLESS road needs are exactly the two that only exist
because it has none, so they are not used here.

**The wordless path is untouched**, knob for knob, for a track with no transcript.
`roadFromPeaks` is the same function it was.

### the triggers own their second

This is the part that is not in the brief, and it is the reason the lane works at all.

`generate()` spends a hit as a plain `word` event, and `wordEvents` will not place one
inside 1.2 s of a count, a drop or a chant. A trigger phrase is very often exactly
where a drop is, because the phrase CONTAINS the drop word, which is half of why it is
a trigger. So the road straight out of `generate()` loses most of them. Measured on
the opening track: **19 hits, 4 of them the phrase this whole road is built on, and
not one of the four survived to be a trigger event.**

So the triggers are placed first: thinned against each other by `TRIGGER_GAP` (2.2 s,
`generate.js`'s own `WORD_GAP`, so a phrase said six times in ten seconds is a moment
and not a wall), then every `word` event `generate` laid inside that gap of one is
dropped, because it was only filler standing where a trigger could not. Counts, drops
and chants stay: a jump and a trigger on the same second is the file doing both, and
`cues.js` spends them differently.

A trigger's `conf` is the LEAST sure word the phrase spans, so a phrase the transcript
was guessing at comes in under `cues.js`'s `TRIGGER_SURE` and is spent as a plain
treat with no word on the chrome, which is the right answer for a guess.

`GENERATOR_ID` is `web-road-v2`: a v1 road has no words and must never be served.

## the chart contract (`race/chart.js`)

Two additions, and nothing else in the file changes:

- `chart.words`: `[{ t, d, w }]`, sorted, frozen, `w` exactly as the transcript spelt
  it (a caption is read, not matched). Absent or malformed is `[]`, never a throw.
- `setId` is kept on an event, capped at 40 characters.

Both for the same reason it already keeps `hand` and `cue`: this pass validates a
chart, it does not rewrite one.

## one table (`race/triggerTheme.js`)

`THEME_BY_PRESET`, `kindForPreset(preset)`, `themeFor(event)`. The bubble the player
drives into and the plate that flies at their face come off one row, so they cannot
drift apart. A preset pointing at a `spawn: false` kind falls back to `flash`, and
that check is made against the live `bubbleKinds.js` table, so darkening one more row
never needs an edit here. L3 reads `theme`, `color`, `ink` and `note` and writes one
CSS class per row; L4 reads `kind`.

## the round robin (`race/track.js`)

`mapTriggers`: a trigger that names its own `cue` wears that kind on every track that
says it, instead of whatever the round robin happened to deal it in this file. The
round robin still dresses everything without one.

## verified

| check | result |
|---|---|
| `node race/smoke/lyrics-road-check.mjs` | all good (48 assertions, new) |
| `node race/smoke/cloud-chart-check.mjs` | all good (headless) |
| `node race/smoke/cloud-check.mjs` | all good (headless) |
| `node race/smoke/levels-check.mjs` | all good (headless) |
| `node race/smoke/words-check.mjs` | all good |
| `node race/smoke/chart-check.mjs` | all good |
| `node race/smoke/track-run-check.mjs` | all good |
| `node chart/smoke/generate-check.mjs` / `triggers-check` / `tokens-check` | all good |

### the real file, once

```
RACE_REAL_URL=https://cdn.bambicloud.com/a15c22e0-...mp3 node race/smoke/real-audio-check.mjs
```
all good. One cross origin HEAD (200, `content-length: 3581627`) and one ranged GET
(206, `access-control-allow-origin: *`, `content-range: bytes 0-1048575/3581627`), then
the file, decoded and charted in the browser in 2.7 s. Read-only guest, nothing else
touched.

The road it came out with, on the real audio:

```
44 events: trigger 19, word 15, build 2, peak 2, release 2, drop 2, chant 1, silence 1
324 bins of 0.5s, 162s, rooms: induction -> triggers
hash 98c540802f64db35ca0458fb7e678ccc8b283baa, analysis.words script-align-v1
```

Triggers by set: `w-sleep` 5, `bambi-sleep` 4, `w-obey` 3, `good-girl` 2, `deeper` 2,
`w-relax` 1, `sleep-now` 1, `w-blank` 1. The four `bambi-sleep` events carry
`cue: 'blackout'`, which is the ink plate and the braindrain bubble. 152 caption words.

The run rolled on it and the clock stayed the file's clock to within 0.01 s. Not one
console error.

## what this does NOT do

No bubble row, no caption layer, no zoom plate: that is L4 and L3, and `cues.js`,
`bubbles.js` and `run.js` are untouched here. A player on this branch alone gets
trigger bubbles that land on the spoken phrase instead of energy guesses, which is
the half the other two are built on.

399 changed lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
