### PR TITLE
feat(race): a sure trigger cuts a row across the road

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/race/CHART.md
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/CHART.md
@@ -132,16 +132,24 @@ with a negative `dueIn` and the run may drop them.
 ### `race/cues.js` (PR c2 builds the plain mapping, PR c3 makes it sing)
 ```js
 export function cueFor(event, ctx) -> cue | null
-// ctx = { energy: 0..1, act, room, intensity, rng, triggerKinds: Map(label -> bubbleKindId) }
+// ctx = { energy: 0..1, act, room, intensity, rng, triggerKinds: Map(label -> bubbleKindId), lyrics: bool }
 // cue = {
-//   spawn: [ { kindId, placement: 'spawn' | 'air' | 'rain', x, h, at } ],   // at = seconds relative to event.t (0 = on the word)
+//   spawn: [ { kindId, placement: 'spawn' | 'air' | 'rain', x, h, at, row? } ],  // at = seconds relative to event.t (0 = on the word)
 //   jump: vh | 0, mix: bubbleKindId | null, mood: 'calm'|'streamed'|'fraught'|'smug'|'shock'|'jackpot' | null,
 //   pose: name | null, toast: { text, kind } | null, word: label | null, fog: 0..1 | null, boost: sec | 0, density: mult | null,
 //   holdSec: 0
 // }
 ```
-The plain mapping (c2): `trigger` -> one effect bubble of `triggerKinds.get(label)` or `flash`, lane
-placement, `word: label`; `word` -> a treat bubble; `count` -> a golden air bubble, `last` adds
+THE ROW (PR L4). A `trigger` the spotter is sure of is not one bubble, it is a LINE of them across
+the whole road: every spawn carries `row: true`, they share one kind, one depth and `at: 0`, and
+their x's run `-LANE_X_MAX` to `+LANE_X_MAX` with no gap wider than `2 * POP_HIT_X * 0.9`, so the
+pop box cannot be threaded between two of them wherever the kart sits. A trigger word is a thing
+that happens to you, not a thing you steer around. `ROW_X` and `ROW_MAX_GAP` are exported for the
+smoke; `race/smoke/rows-check.mjs` holds the geometry against `consts.js`. `ctx.lyrics` says the
+road came out of a transcript: it halves the `peak` rain and nothing else, because on a worded
+track the rows are the loud thing and a rain over them takes the reading away.
+
+The plain mapping (c2): `trigger` -> the row above, lane placement, `word: label`; `word` -> a treat bubble; `count` -> a golden air bubble, `last` adds
 `jump: 6`; `drop` -> `jump: 7`, `mix: 'spiral'`, `mood: 'streamed'`, three golden air bubbles at
 `at = 0.2, 0.5, 0.8`; `chant` -> `reps` treats in lane placement alternating `x = +-1.2` at
 `at = k * period`; `build` -> `boost: min(dur, 4)`, `density: 1.6`; `peak` -> 6 rain treats; `release`
@@ -168,9 +176,18 @@ A loaded track ducks the room OST to `TRACK_DUCK` (0.12) and the bed to silence 
 ### `race/bubbles.js` additions (PR c2)
 ```js
 field.spawnAt({ kindId, placement, d, x, h, eventId })   // an explicit placement; returns the slot id or -1 when the pool is full
+field.spawnRow({ kindId, placement, d, h, xs, eventId }) // a whole row at one depth (PR L4); returns how many went down, 0 for none
 field.setDensity(mult)                                  // already in CONTRACT.md; with a track this scales only the cue spawns
+field.setSparse(on)                                     // the loaded road came out of a transcript (PR L4): seedChunk stands down
 ```
 Pop events carry `eventId` when the bubble came from a cue; `onMiss` events do too.
+
+A row goes down whole or not at all: a row that would not fit the pool is not laid, the density
+gate is rolled ONCE for the line rather than per bubble, and `density > 1` never doubles it. It
+also SPENDS as one thing: the first of its bubbles to pop or to slip past settles the row, so five
+bubbles are one `taken` on the scheduler (`takenIds` is a set) and at worst one broken combo. With
+`setSparse(true)` `seedChunk` lays only the chunk's own golden and no lanes, ramp lines or item
+box pairs, so what the player drives through is the lyric. Too many bubbles is no bubbles.
 
 ### `race/run.js` + `raceBoot.js` (PR c2)
 ```js
@@ -180,8 +197,12 @@ race.track                          // { chart, sched, t, playing, name, duratio
 ```
 - With a track: `S.intensity` follows `sched.energyAt(t)` smoothed over 2 s (floor 0.05); the random
   `spawnAhead` / `rain` timers are off; `seedChunk` still dresses chunks with plain treats at
-  `density` so the road never looks empty; every cue spawn goes through `field.spawnAt` at
+  `density` so the road never looks empty (unless the road has words on it: see `setSparse`); every
+  cue spawn goes through `field.spawnAt`, or `field.spawnRow` for the row, at
   `d = kart.d + kart.speed * max(dueIn + at, 0.25)`.
+- `TR.lyrics` is true while the loaded chart has a caption track or an `analysis.words` other than
+  `none`. It drives `field.setSparse` and `ctx.lyrics`, and is re-read on `replaceTrack` so a words
+  pass landing on a partial chart thins the road the moment it arrives.
 - Acts: at a gate crossing use the current act's room instead of the feature's room; if the act
   changed and no gate is within 6 s of road, call `dresser.applyRoom` with a 2.5 s fade right away
   and show the MARQUEE with the act's `name`.

--- a/ConditioningControlPanel/Resources/web/dtrh/race/bubbles.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/bubbles.js
@@ -6,7 +6,10 @@
  * Every bubble is a pooled THREE.Sprite in track space (d, x, h), placed
  * through layout.toWorld only. Four placements: lane (rests on the road and
  * bobs), air (threads a ramp's air line), spawn (materialises ahead and
- * wobbles), rain (falls from the ceiling, rests, fizzles). Pops are pass-
+ * wobbles), rain (falls from the ceiling, rests, fizzles). A ROW (spawnRow) is a
+ * line of bubbles across the whole road at one depth: it goes down whole or not at
+ * all, and it spends as ONE thing (the first of them to pop or to slip past settles
+ * the row, so a row is one pop credit and at worst one broken combo, never five). Pops are pass-
  * through against the kart box; a pop is SILENT here (race/audio.js sounds it)
  * (engine/audioBus) and throws a few sparkle shards, the WPF BubbleService way.
  * Sprite textures come from the two locally mapped hosts (never remote media). Every sprite
@@ -90,7 +93,7 @@ export function createBubbleField({ scene, layout, media, getIntensity, getRoom,
     const sprite = new THREE.Sprite(mat);
     sprite.visible = false; sprite.layers.set(CRISP_LAYER);
     group.add(sprite);
-    pool.push({ sprite, mat, slot: i, eventId: null, alive: false, kindId: 'treat', placement: 'lane', d: 0, x: 0, h: LANE_H,
+    pool.push({ sprite, mat, slot: i, eventId: null, rowId: 0, alive: false, kindId: 'treat', placement: 'lane', d: 0, x: 0, h: LANE_H,
       x0: 0, baseH: LANE_H, phase: 0, age: 0, size: 1, scale: 1, popT: -1, missed: false });
   }
   const shards = [];
@@ -107,6 +110,11 @@ export function createBubbleField({ scene, layout, media, getIntensity, getRoom,
   // With a track loaded the density knob changes what it means: the seeded lanes must keep dressing
   // the road exactly as they do without one, so density gates the CUE spawns instead (CHART.md).
   let tracked = false;
+  // A track whose road came out of a transcript: seedChunk stops dressing the road at all, because
+  // the words are what the player is meant to read on it. The owner's law: too many bubbles is no
+  // bubbles, the fun is realising the bubbles are the lyric.
+  let sparse = false;
+  let rowSeq = 0;
   let reachX = POP_HIT_X, reachH = POP_HIT_H;   // the pop box, widened by the magnet item (setReach)
   const popCbs = [], missCbs = [];
   const emit = (cbs, ev) => { for (const cb of cbs) { try { cb(ev); } catch (e) { /* listener bug, not ours */ } } };
@@ -145,7 +153,7 @@ export function createBubbleField({ scene, layout, media, getIntensity, getRoom,
     s.kindId = k.id; s.placement = placement;
     s.d = layout.wrap(d); s.x = clamp(x, -LANE_X_MAX, LANE_X_MAX); s.x0 = s.x;
     s.h = h; s.baseH = h; s.phase = Math.random() * Math.PI * 2; s.age = 0;
-    s.size = sizeOf(k.id); s.scale = placement === 'spawn' ? 0 : 1; s.popT = -1; s.missed = false; s.eventId = null;
+    s.size = sizeOf(k.id); s.scale = placement === 'spawn' ? 0 : 1; s.popT = -1; s.missed = false; s.eventId = null; s.rowId = 0;
     s.mat.map = texOf[k.id]; s.mat.color.set(k.tint); s.mat.opacity = 1; s.mat.needsUpdate = true;
     s.sprite.scale.setScalar(s.size * s.scale);
     layout.toWorld(s.d, s.x, s.h, s.sprite.position);
@@ -177,6 +185,10 @@ export function createBubbleField({ scene, layout, media, getIntensity, getRoom,
     seeded.add(chunk.id);
     chunkRecs.push({ id: chunk.id, d0: chunk.d0, d1: chunk.d1 });
     const len = Math.max(0, chunk.d1 - chunk.d0);
+    if (sparse) {   // the file dresses this road, not us: one golden to say where the chunk ended, nothing else
+      if (chunk.kind !== 'gate' && len > 8) place('golden', 'lane', chunk.d1 - 2.5, 0, LANE_H);
+      return;
+    }
     if (chunk.id === 1 && chunk.room === 'teagarden' && chunk.kind === 'straight') seedStartStraight(chunk);
     else if (chunk.kind !== 'gate' && len > 8) {
       const lines = Math.max(1, Math.round((len / 26) * (tracked ? 1 : density)));
@@ -231,6 +243,32 @@ export function createBubbleField({ scene, layout, media, getIntensity, getRoom,
     }
     return s.slot;
   }
+  /** A ROW from a track cue: one bubble at every x the cue named, all at one depth, all carrying the
+   *  same eventId and one row id. All or nothing, three ways: a row that would not fit the pool is
+   *  not laid at all (a row with a hole in it is a row the kart drives through), the density gate is
+   *  rolled ONCE for the whole line rather than per bubble, and density over 1 never doubles it,
+   *  because a doubled row is just a thicker wall and the wall was already unavoidable.
+   *  Returns how many went down, 0 for a row that was gated out. */
+  function spawnRow({ kindId, placement = 'lane', d, h, xs, eventId = null } = {}) {
+    const list = Array.isArray(xs) ? xs.filter((x) => Number.isFinite(Number(x))) : [];
+    if (!list.length) return 0;
+    if (KIND_BY_ID[kindId] && KIND_BY_ID[kindId].spawn === false) return 0;   // a dark kind: no chart may place one
+    if (liveCount + list.length > CAP) return 0;
+    if (tracked) {
+      if (density <= 0) return 0;
+      if (density < 1 && Math.random() >= density) return 0;
+    }
+    const top = h == null ? (placement === 'rain' ? CEILING_H : placement === 'air' ? 2.6 : LANE_H) : h;
+    const id = ++rowSeq;
+    for (const x of list) { const s = place(kindId, placement, d, Number(x), top); s.eventId = eventId; s.rowId = id; }
+    return list.length;
+  }
+  /** The row has been settled by one of its own: nobody else in it may report a miss. `missed` is
+   *  only ever read by the miss gate, so marking the siblings is all it takes. */
+  function spendRow(id) {
+    if (!id) return;
+    for (const o of pool) if (o.alive && o.rowId === id) o.missed = true;
+  }
 
   // ---- pop -----------------------------------------------------------------
   const _r = new THREE.Vector3(), _u = new THREE.Vector3();
@@ -264,6 +302,7 @@ export function createBubbleField({ scene, layout, media, getIntensity, getRoom,
     if (s.popT >= 0) return;
     const k = KIND_BY_ID[s.kindId];
     s.popT = 0;
+    spendRow(s.rowId);              // one of the row is the row: the rest may not be missed behind it
     const golden = k.id === 'golden';
     burst(s, golden);
     const strength = k.strength > 0 ? clamp(k.strength + 0.35 * intensity() + Math.random() * 0.1, 0, 1) : 0;
@@ -311,6 +350,7 @@ export function createBubbleField({ scene, layout, media, getIntensity, getRoom,
         // behind the kart: a treat that slipped by is a miss, further back it is gone
         if (rel < -MISS_BEHIND && rel > -DROP_BEHIND - 40 && !s.missed) {
           s.missed = true;
+          spendRow(s.rowId);        // a whole row that slipped by is one miss, not one per bubble
           const k = KIND_BY_ID[s.kindId];
           if (k.kind === 'treat') emit(missCbs, { id: k.id, points: k.points, d: s.d, x: s.x, h: s.h, eventId: s.eventId });
         }
@@ -356,12 +396,14 @@ export function createBubbleField({ scene, layout, media, getIntensity, getRoom,
   }
 
   return {
-    seedChunk, spawnAhead, rain, spawnAt, update, dispose,
+    seedChunk, spawnAhead, rain, spawnAt, spawnRow, update, dispose,
     onPop(cb) { if (typeof cb === 'function') popCbs.push(cb); },
     onMiss(cb) { if (typeof cb === 'function') missCbs.push(cb); },
     setDensity(mult) { const v = Number(mult); density = clamp(isFinite(v) ? v : 1, tracked ? 0 : 0.25, 3); },
     /** A track is loaded: setDensity now gates the cue spawns, not the seeded lanes. */
     setTracked(on) { tracked = !!on; },
+    /** The loaded track has a transcript under it: seedChunk stands down to the chunk's golden. */
+    setSparse(on) { sparse = !!on; },
     /** Magnet: widen the pop box (X and H) by mult; 1 restores it. */
     setReach(mult) { const m = clamp(Number(mult) || 1, 0.5, 3); reachX = POP_HIT_X * m; reachH = POP_HIT_H * m; },
     get liveCount() { return liveCount; },

--- a/ConditioningControlPanel/Resources/web/dtrh/race/cues.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/cues.js
@@ -7,6 +7,10 @@
  * knows how to spend an event is worth (a bubble, a jump, a mood, a pose, a boost)
  * and never HOW: run.js owns every verb, this file only names them.
  *
+ * A spawn marked `row: true` is one bubble of a ROW: the whole set is placed together
+ * or not at all (bubbles.js spawnRow), because half a row is a row the kart can drive
+ * around, and the point of a row is that it cannot be driven around.
+ *
  * `at` on a spawn is seconds relative to the event's own second: 0 puts the bubble
  * on the spoken word, 0.5 half a second behind it. run.js turns that into a depth
  * at the kart's current speed, which is why the pop lands on the word whatever the
@@ -27,7 +31,7 @@
  *              peak; the count and the drop word go on the chrome.
  * ==========================================================================*/
 
-import { LANE_H, CEILING_H, LANE_X_MAX } from './consts.js';
+import { LANE_H, CEILING_H, LANE_X_MAX, POP_HIT_X } from './consts.js';
 
 /** A trigger phrase nobody has assigned a bubble to wears the room's own effect, else this. */
 const FALLBACK_TRIGGER = 'flash';
@@ -52,6 +56,16 @@ const WAKE_ACTS = new Set(['wake', 'free']);
 const FLOAT_WORDS = new Set(['float', 'floating', 'up', 'open', 'light', 'rise', 'lift']);
 /** The lanes a spoken word may land in. Narrower than the road: the kart has to steer, not lunge. */
 const LANE_X = [-1.6, -0.8, 0, 0.8, 1.6];
+/** THE ROW. A trigger the spotter is sure of is not a bubble in a lane, it is a line of them
+ *  across the whole road, because the owner's read of the game is that a trigger word is a thing
+ *  that HAPPENS to you: you do not get to steer around the word she just said.
+ *  The widest gap the line may leave is ten percent inside the pop box's own width, so the box
+ *  cannot be threaded between two of them wherever the kart sits. */
+export const ROW_MAX_GAP = 2 * POP_HIT_X * 0.9;
+/** How many that takes edge to edge, always odd so one bubble sits dead centre. */
+const ROW_N = (() => { const n = Math.ceil((LANE_X_MAX * 2) / ROW_MAX_GAP) + 1; return n % 2 ? n : n + 1; })();
+/** The row's own x's: -LANE_X_MAX to +LANE_X_MAX, evenly spaced. */
+export const ROW_X = Array.from({ length: ROW_N }, (_, i) => -LANE_X_MAX + (i * LANE_X_MAX * 2) / (ROW_N - 1));
 /** Height of an air bubble over the road, how much each of a drop's rings climbs, a floating word's hang. */
 const AIR_H = 2.6, AIR_RISE = 0.6, FLOAT_H = 1.9;
 /** A drop is golden rings through the air, one on the word and the rest behind it. */
@@ -60,6 +74,9 @@ const DROP_AT = [0.2, 0.5, 0.8], DROP_X = [-1.1, 0, 1.1];
 const DROP_SOFT = 0.6;
 /** A peak rains between these many, by intensity, this far apart. */
 const PEAK_MIN = 4, PEAK_MAX = 8, PEAK_GAP = 0.25;
+/** On a track whose road came out of a transcript the rain is halved: the rows are the loud thing
+ *  now, and a peak that buries them takes the reading away. Too many bubbles is no bubbles. */
+const PEAK_LYRIC_MULT = 0.5;
 /** The chant's two lanes, and the fallback beat when the analyzer sent no period. */
 const CHANT_X = 1.2, CHANT_PERIOD = 1.2, CHANT_MAX = 16;
 /** Every this-many chant treats, one is gold. */
@@ -89,7 +106,7 @@ function triggerKind(label, ctx) {
 
 /**
  * @param event a chart event (race/chart.js normalizeChart shape)
- * @param ctx { energy, act, room, intensity, rng, triggerKinds }
+ * @param ctx { energy, act, room, intensity, rng, triggerKinds, lyrics }
  * @returns the cue, or null for an event this build has nothing to say about (an unknown
  *          kind, or a word the feel pass decided the spotter only guessed at).
  */
@@ -104,9 +121,14 @@ export function cueFor(event, ctx = {}) {
     // the voice said a trigger phrase: its own effect bubble in a lane, the word on the chrome, and
     // she reaches for it. A phrase the spotter only half heard is a plain treat and stays off the chrome.
     case 'trigger': {
-      const sure = conf01(event) >= TRIGGER_SURE;
-      cue.spawn.push({ kindId: sure ? triggerKind(label, ctx) : 'treat', placement: 'lane', x: laneX(rng), h: LANE_H, at: 0 });
-      if (sure) { cue.word = label || null; cue.pose = 'grab'; }
+      if (conf01(event) < TRIGGER_SURE) {   // a phrase half heard: one plain treat, off the chrome, easy to miss
+        cue.spawn.push({ kindId: 'treat', placement: 'lane', x: laneX(rng), h: LANE_H, at: 0 });
+        break;
+      }
+      const kindId = triggerKind(label, ctx);
+      for (const x of ROW_X) cue.spawn.push({ kindId, placement: 'lane', x, h: LANE_H, at: 0, row: true });
+      cue.word = label || null;
+      cue.pose = 'grab';
       break;
     }
 
@@ -174,7 +196,8 @@ export function cueFor(event, ctx = {}) {
 
     // the top of the climb: the room's own bubbles out of the ceiling, more the louder the file is, and a cheer
     case 'peak': {
-      const n = Math.round(PEAK_MIN + (PEAK_MAX - PEAK_MIN) * intensity);
+      const lyric = ctx.lyrics ? PEAK_LYRIC_MULT : 1;
+      const n = Math.max(1, Math.round((PEAK_MIN + (PEAK_MAX - PEAK_MIN) * intensity) * lyric));
       const kindId = ROOM_RAIN[roomId(ctx)] || 'treat';
       for (let i = 0; i < n; i++) {
         cue.spawn.push({ kindId, placement: 'rain', x: spread(rng), h: CEILING_H, at: i * PEAK_GAP });
@@ -221,4 +244,5 @@ export function resultTag(taken, countable) {
   return 'you were not listening';
 }
 
-// self-check: node race/smoke/track-run-check.mjs walks every kind through this table.
+// self-check: node race/smoke/track-run-check.mjs walks every kind through this table, and
+// node race/smoke/rows-check.mjs holds the row's geometry against the pop box.

--- a/ConditioningControlPanel/Resources/web/dtrh/race/run.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/run.js
@@ -192,6 +192,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     score.onEvent((e) => onScore(w, e));
     items.onEvent((e) => onItem(w, e));
     field.setTracked(!!TR.track);
+    field.setSparse(TR.lyrics);
     pixel.retexture(scene);
     return w;
   }
@@ -384,7 +385,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     const t = TR.setTrack(chart);
     audio.setRoute(routeOf(t));
     S.trackHold = 0; S.statsAt = 0;
-    if (W) { W.field.setTracked(!!t); W.field.setDensity(1); if (!t) applyFog(W, 0); }
+    if (W) { W.field.setTracked(!!t); W.field.setSparse(TR.lyrics); W.field.setDensity(1); if (!t) applyFog(W, 0); }
     audio.duck(!!t, 'track');   // the file is the soundtrack: the room OST sits under it until it is cleared
     if (bridge.log) bridge.log(t ? `race track: ${t.name}, ${Math.round(t.durationSec)}s, ${TR.stats().countable} to take` : 'race track: cleared');
     return t;
@@ -409,9 +410,16 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
    *  have reached when the voice says it, so the pop lands on the word whatever the throttle did. */
   function applyCue(w, due) {
     const ks = w.kart.state;
-    const cue = cueFor(due.event, { energy: TR.intensity, act: TR.act, room: S.room, intensity: S.intensity, rng: w.rng, triggerKinds: TR.triggerKinds });
+    const cue = cueFor(due.event, { energy: TR.intensity, act: TR.act, room: S.room, intensity: S.intensity, rng: w.rng, triggerKinds: TR.triggerKinds, lyrics: TR.lyrics });
     if (!cue) { TR.skip(due.event.id); return; }   // a guess the feel pass threw out never counts against the player
-    for (const sp of cue.spawn) {
+    // A row goes in as one thing (bubbles.js spawnRow): the density gate is rolled once for the
+    // whole line, so the road never gets a row with a hole in it that the kart can steer through.
+    const row = cue.spawn.filter((sp) => sp.row), loose = cue.spawn.filter((sp) => !sp.row);
+    if (row.length) {
+      const d = ks.d + ks.speed * Math.max(due.dueIn + (row[0].at || 0), CUE_AHEAD_SEC);
+      w.field.spawnRow({ kindId: row[0].kindId, placement: row[0].placement, d, h: row[0].h, xs: row.map((sp) => sp.x), eventId: due.event.id });
+    }
+    for (const sp of loose) {
       const d = ks.d + ks.speed * Math.max(due.dueIn + (sp.at || 0), CUE_AHEAD_SEC);
       w.field.spawnAt({ kindId: sp.kindId, placement: sp.placement, d, x: sp.x, h: sp.h, eventId: due.event.id });
     }
@@ -711,7 +719,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
   return { start, prepare, setPaused, dispose, setCameraOverride, setStage, reseed, renderer, pixel, audio, hud, camera, perf,
     // track charts (CHART.md): setTrack before start(), replaceTrack for the words pass landing live,
     // trackClock for the host's 250 ms tick, trackEnded when the file runs out at the host's end
-    setTrack, replaceTrack: (chart) => { TR.replace(chart); audio.setRoute(routeOf(TR.track)); }, trackClock: (t, playing) => TR.clock(t, playing),
+    setTrack, replaceTrack: (chart) => { TR.replace(chart); audio.setRoute(routeOf(TR.track)); if (W) W.field.setSparse(TR.lyrics); }, trackClock: (t, playing) => TR.clock(t, playing),
     trackEnded: () => { TR.end(); if (TR.track && S.running) endRun(); }, trackStats: () => TR.stats(), debugItemBox,
     get track() { return TR.track; } };
 }

--- a/ConditioningControlPanel/Resources/web/dtrh/race/smoke/rows-check.mjs
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/smoke/rows-check.mjs
@@ -1,0 +1,128 @@
+/* ============================================================================
+ * race/smoke/rows-check.mjs - the row a sure trigger cuts across the road.
+ *
+ *   node race/smoke/rows-check.mjs     (from Resources/web/dtrh; 0 on pass, 1 with a count)
+ *
+ * Pure: no browser, no network, no audio. cues.js is the only place the row's
+ * geometry is written down and consts.js is the only place the pop box is, so the
+ * two can be held against each other here without a renderer.
+ *
+ * What it holds:
+ *   1. the row is a line across the WHOLE road, one kind, one depth, no gap the
+ *      pop box could be threaded through, and there is no x the kart may sit at
+ *      where the row misses it. That is the owner's ask: a trigger is not a thing
+ *      you steer around.
+ *   2. the row wears the preset's own bubble, and a treats or mark preset is a
+ *      row of treats rather than an effect
+ *   3. a trigger the spotter only half heard is the single treat it always was
+ *   4. one event is one credit however many of its bubbles were popped
+ *   5. a worded track halves the peak rain; nothing else on the road moves
+ *
+ * It never prints a line of a transcript. Everything below is counted.
+ * ==========================================================================*/
+
+import { cueFor, ROW_X, ROW_MAX_GAP } from '../cues.js';
+import { createScheduler, normalizeChart } from '../chart.js';
+import { KART_X_MAX, LANE_X_MAX, POP_HIT_X, LANE_H, makeRng } from '../consts.js';
+import { THEME_BY_PRESET, kindForPreset } from '../triggerTheme.js';
+import { KIND_BY_ID } from '../bubbleKinds.js';
+
+let fails = 0;
+const ok = (cond, what) => { if (!cond) { console.error('FAIL ' + what); fails++; } else console.log('  ok  ' + what); };
+const eq = (got, want, what) => ok(got === want, what + ' (got ' + JSON.stringify(got) + ', want ' + JSON.stringify(want) + ')');
+const near = (a, b, eps = 1e-9) => Math.abs(a - b) <= eps;
+
+/** A ctx the way run.js builds one, with the trigger map track.js would have dealt. */
+const ctxFor = (kinds, extra = {}) => ({
+  rng: makeRng(7), intensity: 0.5, act: { kind: 'triggers', room: 'toybox' }, room: { id: 'toybox' },
+  triggerKinds: new Map(Object.entries(kinds || {})), ...extra,
+});
+
+/* ---- 1. the geometry ----------------------------------------------------- */
+const sure = cueFor({ kind: 'trigger', t: 10, label: 'a phrase', conf: 1, cue: 'blackout' },
+  ctxFor({ 'a phrase': kindForPreset('blackout') }));
+ok(!!sure, 'a sure trigger is a cue');
+const row = sure.spawn.filter((s) => s.row);
+eq(row.length, sure.spawn.length, 'every spawn a sure trigger makes belongs to the row');
+eq(row.length, ROW_X.length, 'the row is the width cues.js worked out');
+ok(row.length >= 3, 'and a row is at least three bubbles wide (' + row.length + ')');
+ok(row.every((s) => s.at === 0), 'all of them land on the spoken word, not behind it');
+ok(row.every((s) => s.placement === 'lane'), 'all of them sit on the road');
+ok(row.every((s) => s.h === LANE_H), 'all of them at lane height, so none can be jumped over');
+eq(new Set(row.map((s) => s.kindId)).size, 1, 'the row is one kind of bubble, not a mixture');
+
+const xs = row.map((s) => s.x).sort((a, b) => a - b);
+ok(near(xs[0], -LANE_X_MAX), 'the row starts at the far left of the drivable width (' + xs[0].toFixed(3) + ')');
+ok(near(xs[xs.length - 1], LANE_X_MAX), 'and ends at the far right (' + xs[xs.length - 1].toFixed(3) + ')');
+let widest = 0;
+for (let i = 1; i < xs.length; i++) widest = Math.max(widest, xs[i] - xs[i - 1]);
+ok(widest <= 2 * POP_HIT_X, 'no gap in it is wider than the pop box (' + widest.toFixed(3) + ' m vs ' + (2 * POP_HIT_X).toFixed(3) + ' m)');
+ok(widest <= ROW_MAX_GAP, 'and it keeps the ten percent cues.js holds back (' + ROW_MAX_GAP.toFixed(3) + ' m)');
+// the real question: is there anywhere the kart may legally sit where none of them is in reach?
+let worst = 0, worstX = 0;
+for (let i = 0; i <= 2000; i++) {
+  const kx = -KART_X_MAX + (i * KART_X_MAX * 2) / 2000;
+  let d = Infinity;
+  for (const x of xs) d = Math.min(d, Math.abs(x - kx));
+  if (d > worst) { worst = d; worstX = kx; }
+}
+ok(worst < POP_HIT_X, 'there is no x the kart may steer to where the row misses it (worst ' + worst.toFixed(3)
+  + ' m at x ' + worstX.toFixed(2) + ', box ' + POP_HIT_X + ' m)');
+console.log('  --  the row: ' + ROW_X.length + ' bubbles, ' + ((LANE_X_MAX * 2) / (ROW_X.length - 1)).toFixed(3)
+  + ' m apart, across ' + (LANE_X_MAX * 2).toFixed(2) + ' m of road');
+
+/* ---- 2. the row wears the preset ---------------------------------------- */
+let dressed = true;
+for (const preset of Object.keys(THEME_BY_PRESET)) {
+  const kind = kindForPreset(preset);
+  const c = cueFor({ kind: 'trigger', t: 4, label: 'a phrase', conf: 0.9, cue: preset }, ctxFor({ 'a phrase': kind }));
+  const r = c.spawn.filter((s) => s.row);
+  if (r.length !== ROW_X.length || r.some((s) => s.kindId !== kind) || KIND_BY_ID[kind].spawn === false) {
+    ok(false, 'the ' + preset + ' row is a full row of the ' + kind + ' bubble');
+    dressed = false;
+    break;
+  }
+}
+if (dressed) ok(true, 'every preset in the table lays a full row of its own bubble, and none of them is darkened');
+for (const preset of ['treats', 'mark']) {
+  const c = cueFor({ kind: 'trigger', t: 4, label: 'a phrase', conf: 0.9, cue: preset }, ctxFor({ 'a phrase': kindForPreset(preset) }));
+  eq(c.spawn.filter((s) => s.row && s.kindId === 'treat').length, ROW_X.length, 'a ' + preset + ' trigger is a row of treats, not an effect');
+}
+
+/* ---- 3. the unsure trigger is what it always was ------------------------- */
+const unsure = cueFor({ kind: 'trigger', t: 10, label: 'a phrase', conf: 0.3, cue: 'blackout' },
+  ctxFor({ 'a phrase': 'braindrain' }));
+eq(unsure.spawn.length, 1, 'a trigger the spotter half heard is still one bubble');
+eq(unsure.spawn[0].kindId, 'treat', 'and still a plain treat');
+ok(!unsure.spawn[0].row, 'and not a row: a guess must never wall the road off');
+eq(unsure.word, null, 'and it stays off the chrome');
+
+/* ---- 4. one event, one credit ------------------------------------------- */
+const chart = normalizeChart({
+  version: 1, binSec: 0.5, energy: [0.4, 0.4, 0.4, 0.4],
+  acts: [{ kind: 'triggers', room: 'toybox', t0: 0, t1: 2, name: 'triggers' }],
+  events: [{ kind: 'trigger', t: 1, label: 'a phrase', conf: 1, setId: 'a-set', cue: 'blackout' }],
+  source: { name: 'rows', hash: 'rows', durationSec: 2, sampleRate: 16000 },
+  analysis: { energy: 'x', words: 'script-align-v1', lexicon: ['a phrase'], generatedAt: '', partial: false },
+});
+const sched = createScheduler(chart);
+const due = sched.update(1, 0, 22);
+eq(due.length, 1, 'the scheduler hands the trigger over once');
+const id = due[0].event.id;
+for (let i = 0; i < ROW_X.length; i++) sched.taken(id);   // the kart popped the whole row on its way through
+eq(sched.stats().taken, 1, 'popping every bubble of the row is ONE event taken, not ' + ROW_X.length);
+eq(sched.stats().countable, 1, 'and the row is one thing to take');
+
+/* ---- 5. the rain thins out on a worded track ---------------------------- */
+const peakOf = (lyrics) => cueFor({ kind: 'peak', t: 5 }, ctxFor(null, { intensity: 1, lyrics })).spawn.length;
+const plain = peakOf(false), worded = peakOf(true);
+ok(plain > 0 && worded > 0, 'a peak still rains either way (' + plain + ' -> ' + worded + ')');
+ok(worded <= Math.round(plain / 2), 'a worded track halves it, so the rows stay the loud thing');
+const other = (lyrics) => ['word', 'count', 'drop', 'chant', 'build', 'release', 'silence']
+  .map((k) => JSON.stringify(cueFor({ kind: k, t: 5, label: 'deeper', conf: 1, n: 1, of: 3, reps: 3, dur: 4, strength: 1, period: 1.2 },
+    ctxFor(null, { lyrics }))));
+const moved = other(true).filter((c, i) => c !== other(false)[i]).length;
+eq(moved, 0, 'and nothing else on the road changes with the transcript');
+
+console.log(fails ? '\nrows-check: ' + fails + ' failed' : '\nrows-check: all good');
+process.exit(fails ? 1 : 0);

--- a/ConditioningControlPanel/Resources/web/dtrh/race/smoke/track-run-check.mjs
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/smoke/track-run-check.mjs
@@ -42,6 +42,13 @@ function stubField() {
       live.push({ kindId, placement, d, x, h, eventId });
       return live.length - 1;
     },
+    /** A row goes down whole or not at all, and the density gate is rolled once for it. */
+    spawnRow({ kindId, placement, d, h, xs, eventId }) {
+      if (live.length + xs.length > CAP) return 0;
+      if (density <= 0) return 0;
+      for (const x of xs) live.push({ kindId, placement, d, x, h, eventId, row: true });
+      return xs.length;
+    },
     setDensity(m) { density = m; },
     get live() { return live; },
     get density() { return density; },
@@ -121,8 +128,10 @@ function chartEnergy(t) {
   ok(cueFor(null, ctx) === null && cueFor({ kind: 'nonsense' }, ctx) === null, 'a junk event is null, never a throw');
 
   const t = cueFor({ kind: 'trigger', label: 'good girl' }, ctx);
-  ok(t.spawn.length === 1 && KIND_BY_ID[t.spawn[0].kindId].kind === 'effect' && t.word === 'good girl', 'a trigger is one effect bubble and the word: ' + t.spawn[0].kindId);
-  ok(cueFor({ kind: 'trigger', label: 'never analysed' }, ctx).spawn[0].kindId === 'flash', 'an unmapped phrase falls back to flash');
+  // a sure trigger is a ROW across the road now (rows-check.mjs holds its geometry), all one kind
+  ok(t.spawn.length > 1 && t.spawn.every((sp) => sp.row) && KIND_BY_ID[t.spawn[0].kindId].kind === 'effect' && t.word === 'good girl',
+    'a trigger is a row of ' + t.spawn.length + ' effect bubbles and the word: ' + t.spawn[0].kindId);
+  ok(cueFor({ kind: 'trigger', label: 'never analysed' }, ctx).spawn.every((sp) => sp.kindId === 'flash'), 'an unmapped phrase falls back to flash');
   const w = cueFor({ kind: 'word', label: 'deeper' }, ctx);
   ok(w.spawn.length === 1 && w.spawn[0].kindId === 'treat' && w.spawn[0].h === LANE_H, 'a structure word is one lane treat');
   const c = cueFor({ kind: 'count', label: '1', n: 1, of: 10, last: true }, ctx);
@@ -180,7 +189,14 @@ function chartEnergy(t) {
     for (const due of st.due(d, SPEED)) {
       const cue = cueFor(due.event, { energy: s.intensity, act: s.act, room: null, intensity: s.intensity, rng, triggerKinds: st.triggerKinds });
       if (!cue) { st.skip(due.event.id); skips++; continue; }
+      const rowSp = cue.spawn.filter((sp) => sp.row);
+      if (rowSp.length) {
+        const at = d + SPEED * Math.max(due.dueIn + (rowSp[0].at || 0), CUE_AHEAD_SEC);
+        if (at <= d) behind++;
+        spawns += field.spawnRow({ kindId: rowSp[0].kindId, placement: rowSp[0].placement, d: at, h: rowSp[0].h, xs: rowSp.map((sp) => sp.x), eventId: due.event.id });
+      }
       for (const sp of cue.spawn) {
+        if (sp.row) continue;
         const at = d + SPEED * Math.max(due.dueIn + (sp.at || 0), CUE_AHEAD_SEC);
         if (at <= d) behind++;
         if (field.spawnAt({ kindId: sp.kindId, placement: sp.placement, d: at, x: sp.x, h: sp.h, eventId: due.event.id }) >= 0) spawns++;

--- a/ConditioningControlPanel/Resources/web/dtrh/race/track.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/track.js
@@ -41,6 +41,19 @@ const TRIGGER_KINDS = ['flash', 'subliminal', 'pink', 'spiral', 'glitch', 'freez
 const clamp01 = (v) => (v < 0 ? 0 : v > 1 ? 1 : v);
 
 /**
+ * Was this road built off a transcript? The run asks so the seeded dressing can stand down and the
+ * peak rains can halve: on a worded track the bubbles ARE the lyric, and anything else on the road
+ * is noise over it. Either half is enough on its own, because a partial chart can carry the
+ * analysis stamp a beat before the caption track lands on it.
+ */
+function hasWords(ch) {
+  if (!ch) return false;
+  if (Array.isArray(ch.words) && ch.words.length > 0) return true;
+  const w = ch.analysis && ch.analysis.words;
+  return typeof w === 'string' && w !== '' && w !== 'none';
+}
+
+/**
  * Every distinct trigger phrase in the chart gets its own bubble, the same one every time the file
  * is loaded: the lexicon and the spoken labels sorted, then dealt round robin. The player learns
  * "good girl is the pink one" over a track and that reading holds for the whole file.
@@ -73,14 +86,15 @@ export function createTrackState(opts = {}) {
   const now = typeof opts.now === 'function' ? opts.now
     : (typeof performance === 'object' && performance && performance.now) ? () => performance.now() : () => Date.now();
   let track = null, sched = null, triggerKinds = new Map();
-  let intensity = FLOOR, act = null, ended = false, mark = 0;
+  let intensity = FLOOR, act = null, ended = false, mark = 0, lyrics = false;
 
   /** Load a chart (or null to go back to the seeded run). Returns the new `track`. */
   function setTrack(chart) {
-    if (!chart) { track = null; sched = null; triggerKinds = new Map(); intensity = FLOOR; act = null; ended = false; return null; }
+    if (!chart) { track = null; sched = null; triggerKinds = new Map(); intensity = FLOOR; act = null; ended = false; lyrics = false; return null; }
     sched = createScheduler(chart, leadSec != null ? { leadSec } : {});
     const ch = sched.chart;
     triggerKinds = mapTriggers(ch);
+    lyrics = hasWords(ch);
     intensity = Math.max(FLOOR, sched.energyAt(0));
     act = sched.actAt(0);            // the opening act is where we already are, never a change
     ended = false; mark = 0;
@@ -96,6 +110,7 @@ export function createTrackState(opts = {}) {
     track.name = ch.source.name;
     track.durationSec = ch.source.durationSec;
     triggerKinds = mapTriggers(ch);
+    lyrics = hasWords(ch);
     return track;
   }
 
@@ -150,6 +165,8 @@ export function createTrackState(opts = {}) {
     get act() { return act; },
     get intensity() { return Math.max(FLOOR, clamp01(intensity)); },
     get triggerKinds() { return triggerKinds; },
+    /** True while the loaded road came out of a transcript (run.js thins the road for it). */
+    get lyrics() { return lyrics; },
     get ended() { return ended; },
   };
 }


### PR DESCRIPTION
Wave 2, chain B, PR L4. Stacked on #916 (`feat/race-lyrics-l2-road`), which builds the worded
road this one drives through. Review after that one; the base moves to main when it merges.

## Why

The owner, on the levels build:

> "Moreover we gotta drop onto the track in correspondence to the triggers a row of bubbles with
> one effect, in horizontal, cutting the road, so an user will trigger it for sure and cant avoid
> it - also seems like the bubbles are still placed randomly (there are a lot and they arent
> synched (too many bubbles = no bubbles, the fun comes in realizing that the bubbles remark the
> lyrics)"

Two asks in one paragraph: make the trigger unavoidable, and get everything else off the road so
the player can see that the bubbles are the words.

## The row

A `trigger` event the spotter is sure of used to be one effect bubble in a random lane. It is now a
line of them at one depth, all `at: 0` so they land on the spoken word, all lane placement so none
can be jumped over, all one kind, all carrying the event id.

The width comes off `consts.js` rather than a taste number. The widest gap the line may leave is
`2 * POP_HIT_X * 0.9`, ten percent inside the pop box's own width, so the box cannot be threaded
between two of them; the count is whatever that takes edge to edge, forced odd so one sits dead
centre. Today that is **5 bubbles, 1.290 m apart, across 5.16 m of road**, and the smoke sweeps
every x the kart may legally steer to: the worst case is 0.644 m from a bubble against a 1.15 m
box. There is nowhere to hide from the word she just said.

A `treats` or `mark` preset is the same geometry in plain treats, because a marked word is not an
effect. A trigger under `TRIGGER_SURE` is exactly what it was: one treat, off the chrome. A guess
must never wall the road off.

## A row is one thing

- **Whole or not at all.** A row that would not fit the pool is not laid; half a row is a row the
  kart drives around.
- **Gated once.** `field.spawnRow` rolls the density gate for the line, not per bubble, and
  `density > 1` never doubles it (a doubled wall is still one wall).
- **One credit.** The scheduler's `takenIds` is a set, so popping five bubbles of a row is one
  event taken out of "you took N of M". The extra pops score as ordinary pops, which is the point
  of driving into the middle of it.
- **One miss.** The first bubble of a row to pop or to slip past settles the row, so a treat row
  that goes by costs one broken combo rather than five.

## The road goes quiet

`TR.lyrics` is true while the loaded chart has a caption track or an `analysis.words` other than
`none` (re-read on `replaceTrack`, so a words pass landing on a partial chart thins the road the
moment it arrives). With it:

- `seedChunk` lays only the chunk's own golden. No lane lines, no ramp air lines, no item box
  pairs. The file dresses this road.
- the peak rain halves, so a swell cannot bury the rows.

A wordless track keeps every bit of today's behaviour, and the smoke holds every other cue kind
byte for byte identical with and without a transcript.

## Verified

- `node race/smoke/rows-check.mjs` (new): the geometry against `consts.js`, the kart sweep, every
  preset laying a full row of its own bubble with no darkened kind, the unsure trigger unchanged,
  one event one credit, the halved rain and nothing else moving. All green.
- `race/smoke/track-run-check.mjs` updated for the row (its stub field grew `spawnRow`) and green.
- Every other race and chart smoke green, unchanged: chart, levels, words, lyrics-road, fov, gltf,
  poses, spiral-pool, ost-resident, touch, audio, cloud, cloud-chart, remote-feed, generate,
  tokens, triggers.
- Headless `?autostart=1&chart=demo` on a 390x844 viewport: boots, rolls 30 s, zero console errors,
  4 to 6 bubbles on the road between events instead of a carpet, and the row going in on cue.

Nothing here touches `chart.js`, `cloudChart.js`, `words.js`, `triggerTheme.js` or `chart/*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
