### PR TITLE
feat(race): the voice on the glass

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/race/captions.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/captions.js
@@ -1,0 +1,263 @@
+/* ============================================================================
+ * race/captions.js - the voice on the glass: the caption line and the zoom plate.
+ *
+ * The owner's ask, on the levels build: "i want the text to be displayed live as
+ * captions when the words are being spoken, you can start the typewrite effect to
+ * the corresponding timestamp for that phrase on the script we got. this text
+ * should be visible but fleeting and the triggers should be shown with a zooming
+ * animation (like they come towards the pov) and more visible and big, themed
+ * animations for each trigger."
+ *
+ * Two layers, one file, because they are one idea: the road says the word, the
+ * glass says the word, and the plate says it loudly.
+ *
+ *   THE CAPTION. `chart.words` (the caption track L2 puts on the road) is cut into
+ *   phrases, one on screen at a time, low on the glass. Every word of the phrase is
+ *   in the DOM from the moment the phrase opens but only INKED when the clock
+ *   reaches its own timestamp, so the line types itself at the speed the voice
+ *   actually spoke it and never reflows while it does. That is the typewriter: the
+ *   voice is the timer, not a timer.
+ *
+ *   THE PLATE. A sure trigger flies at the camera from the vanishing point, themed
+ *   off race/triggerTheme.js, one at a time, a new one taking the old one's place.
+ *
+ * EVERYTHING IS A FUNCTION OF THE CLOCK. `update(t)` reads the track second and
+ * nothing else: no elapsed frames, no timers of its own. A seek, a pause, a resume
+ * and a chart swapped in under the run all land right for free, because there is no
+ * state to get out of step. The only thing with a timer is the plate, which is a
+ * one shot animation and belongs to no second in particular.
+ *
+ * `buildPhrases` is pure and node-clean; the layer wants a DOM.
+ * ==========================================================================*/
+
+import { themeFor } from './triggerTheme.js';
+
+/** A silence longer than this between two words ends the phrase. */
+export const GAP_SEC = 0.7;
+/** And so does the ninth word, whatever the voice was doing. */
+export const MAX_WORDS = 9;
+/** A phrase holds this long after its last word ends, then fades. */
+export const HOLD_SEC = 1.0;
+/** It opens this early, so a line is never half drawn when its first word lands. */
+export const LEAD_SEC = 0.12;
+/** And it is off the glass this long before the next one opens: one phrase at a time. */
+export const CLEAR_SEC = 0.15;
+/** A word that ends a sentence ends the phrase with it. */
+export const END_PUNCT = /[.?!]["')\]]?$/;
+/** The plate: the zoom, the hold, and the fade, in milliseconds (race.css runs the same numbers). */
+export const PLATE_MS = 1400;
+
+const num = (v, d = 0) => (Number.isFinite(Number(v)) ? Number(v) : d);
+
+/**
+ * Cut a caption track into phrases.
+ * @param words `chart.words`: [{ t, d, w }] sorted by t
+ * @returns [{ t0, t1, tStart, tEnd, words: [{ t, d, w }] }], no two windows overlapping
+ */
+export function buildPhrases(words) {
+  const list = (Array.isArray(words) ? words : [])
+    .filter((w) => w && typeof w.w === 'string' && w.w !== '' && Number.isFinite(Number(w.t)))
+    .map((w) => ({ t: Math.max(0, num(w.t)), d: Math.max(0, num(w.d)), w: w.w }))
+    .sort((a, b) => a.t - b.t);
+
+  const out = [];
+  let cur = [];
+  const flush = () => {
+    if (!cur.length) return;
+    const last = cur[cur.length - 1];
+    out.push({ t0: cur[0].t, t1: last.t + last.d, tStart: 0, tEnd: 0, words: cur });
+    cur = [];
+  };
+  for (const w of list) {
+    if (cur.length) {
+      const prev = cur[cur.length - 1];
+      if (w.t - (prev.t + prev.d) > GAP_SEC) flush();
+    }
+    cur.push(w);
+    if (cur.length >= MAX_WORDS || END_PUNCT.test(w.w)) flush();
+  }
+  flush();
+
+  // The windows. A phrase hangs on past its last word, but never into the next one's opening:
+  // one phrase at a time is the whole point, and a caption that crossfades with another is noise.
+  for (let i = 0; i < out.length; i++) {
+    const p = out[i], next = out[i + 1];
+    p.tEnd = next ? Math.max(p.t1, Math.min(p.t1 + HOLD_SEC, next.t0 - CLEAR_SEC)) : p.t1 + HOLD_SEC;
+  }
+  for (let i = 0; i < out.length; i++) {
+    const p = out[i];
+    p.tStart = Math.max(0, p.t0 - LEAD_SEC);
+    if (i > 0) p.tStart = Math.max(p.tStart, out[i - 1].tEnd);
+  }
+  return out;
+}
+
+/**
+ * The colour every caption word is inked in: a word inside a trigger event's span wears that
+ * trigger's own colour, so the phrase itself shows you which of its words is the one that counts.
+ * @param phrases from buildPhrases
+ * @param events the chart's events (only `trigger` ones are read)
+ */
+export function paintTriggers(phrases, events) {
+  const spans = [];
+  for (const e of Array.isArray(events) ? events : []) {
+    if (!e || e.kind !== 'trigger') continue;
+    const row = themeFor(e);
+    if (!row) continue;
+    spans.push({ t0: num(e.t), t1: num(e.t) + Math.max(0.25, num(e.dur, 0.6)), color: row.color });
+  }
+  if (!spans.length) return phrases;
+  for (const p of phrases) {
+    for (const w of p.words) {
+      const mid = w.t + w.d / 2;
+      const hit = spans.find((s) => mid >= s.t0 - 0.15 && mid <= s.t1 + 0.15);
+      if (hit) w.color = hit.color;
+    }
+  }
+  return phrases;
+}
+
+/** The last phrase whose window has opened at `t`, by bisection. -1 before the first one. */
+function phraseAt(phrases, t) {
+  let lo = 0, hi = phrases.length - 1, found = -1;
+  while (lo <= hi) {
+    const mid = (lo + hi) >> 1;
+    if (phrases[mid].tStart <= t) { found = mid; lo = mid + 1; } else hi = mid - 1;
+  }
+  if (found < 0) return -1;
+  return t < phrases[found].tEnd ? found : -1;
+}
+
+/**
+ * The layer. `root` is the `.race-hud` div; this sits above `.rh-chrome` so a caption is never
+ * under the score plate, and it is click-through like the rest of the chrome.
+ */
+export function createCaptions(root) {
+  const doc = root && root.ownerDocument;
+  if (!doc) return null;
+  const reduced = !!(typeof matchMedia === 'function' && matchMedia('(prefers-reduced-motion: reduce)').matches);
+  const el = (cls, parent) => { const d = doc.createElement('div'); d.className = cls; parent.appendChild(d); return d; };
+
+  const layer = el('rc-layer', root);
+  const dim = el('rc-dim', layer);                 // the ink theme's 300 ms screen dip
+  const plateWrap = el('rc-plates', layer);
+  const cap = el('rc-cap', layer);
+  const line = el('rc-line', cap);
+  cap.hidden = true;
+
+  let phrases = [];
+  let shown = -1;              // which phrase is in the DOM
+  let inked = -1;              // how many of its words have been inked
+  let spans = [];              // the word elements of the phrase in the DOM
+  let plate = null, plateTimer = 0, dimTimer = 0;
+
+  function clearPhrase() {
+    line.textContent = '';
+    spans = [];
+    shown = -1; inked = -1;
+    cap.hidden = true;
+  }
+
+  function draw(i) {
+    clearPhrase();
+    const p = phrases[i];
+    if (!p) return;
+    for (const w of p.words) {
+      const s = doc.createElement('span');
+      s.className = 'rc-word';
+      s.textContent = w.w;
+      if (w.color) s.style.setProperty('--rc-ink', w.color);
+      line.appendChild(s);
+      line.appendChild(doc.createTextNode(' '));
+      spans.push(s);
+    }
+    shown = i; inked = 0;
+    cap.hidden = false;
+  }
+
+  /**
+   * One frame, off the track clock. Everything below is derived from `t`, so a seek or a resume
+   * needs no telling: the same second always draws the same line.
+   */
+  function update(t) {
+    if (!phrases.length) { if (shown >= 0) clearPhrase(); return; }
+    const sec = num(t, 0);
+    const i = phraseAt(phrases, sec);
+    if (i !== shown) {
+      if (i < 0) { clearPhrase(); return; }
+      draw(i);
+    }
+    const p = phrases[shown];
+    if (!p) return;
+    // ink every word the voice has reached, and un-ink the ones a seek put back in the future
+    let n = 0;
+    while (n < p.words.length && p.words[n].t <= sec) n++;
+    if (n !== inked) {
+      for (let k = 0; k < spans.length; k++) spans[k].classList.toggle('is-said', k < n);
+      inked = n;
+    }
+    // the word being spoken right now carries the light
+    for (let k = 0; k < spans.length; k++) {
+      const w = p.words[k];
+      spans[k].classList.toggle('is-now', sec >= w.t && sec < w.t + Math.max(0.12, w.d));
+    }
+    // fleeting: the line lets go over its last second rather than blinking out
+    const left = p.tEnd - sec;
+    cap.style.setProperty('--rc-out', String(Math.max(0, Math.min(1, left / 0.45))));
+  }
+
+  /** A sure trigger, flying at the camera. One at a time: a new one takes the old one's place. */
+  function showPlate(event) {
+    const row = themeFor(event);
+    const text = (event && typeof event.label === 'string' ? event.label : '').trim();
+    if (!row || !text) return null;
+    if (plateTimer) { clearTimeout(plateTimer); plateTimer = 0; }
+    if (plate) plate.remove();
+    plate = doc.createElement('div');
+    plate.className = `rc-plate rc-plate--${row.theme}${reduced ? ' is-still' : ''}`;
+    plate.setAttribute('data-theme', row.theme);
+    plate.setAttribute('data-preset', row.preset);
+    plate.style.setProperty('--rc-glow', row.color);
+    plate.style.setProperty('--rc-ink', row.ink);
+    const word = doc.createElement('span');
+    word.className = 'rc-plate-word';
+    word.textContent = text;
+    plate.appendChild(word);
+    const sparks = doc.createElement('span');   // only the gold row makes anything of these
+    sparks.className = 'rc-plate-sparks';
+    plate.appendChild(sparks);
+    plateWrap.appendChild(plate);
+    plateTimer = setTimeout(() => { plateTimer = 0; if (plate) { plate.remove(); plate = null; } }, PLATE_MS + 120);
+    // the ink row takes the room away with it for a beat
+    if (row.theme === 'ink' && !reduced) {
+      if (dimTimer) clearTimeout(dimTimer);
+      dim.classList.remove('is-on'); void dim.offsetWidth; dim.classList.add('is-on');
+      dimTimer = setTimeout(() => { dim.classList.remove('is-on'); dimTimer = 0; }, 340);
+    }
+    return plate;
+  }
+
+  return {
+    /** The loaded chart, or null to go quiet. Reads `words` and the trigger events, nothing else. */
+    setTrack(chart) {
+      phrases = chart ? paintTriggers(buildPhrases(chart.words), chart.events) : [];
+      clearPhrase();
+      return phrases.length;
+    },
+    update,
+    showPlate,
+    /** The run is over or the file was cleared: nothing of the last one stays on the glass. */
+    clear() {
+      clearPhrase();
+      if (plateTimer) { clearTimeout(plateTimer); plateTimer = 0; }
+      if (plate) { plate.remove(); plate = null; }
+      if (dimTimer) { clearTimeout(dimTimer); dimTimer = 0; }
+      dim.classList.remove('is-on');
+    },
+    dispose() { this.clear(); phrases = []; layer.remove(); },
+    get phraseCount() { return phrases.length; },
+    get phrases() { return phrases; },
+  };
+}
+
+// self-check: node race/smoke/captions-check.mjs cuts the real caption track and drives the layer.

--- a/ConditioningControlPanel/Resources/web/dtrh/race/race.css
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/race.css
@@ -533,3 +533,172 @@
 @media (prefers-reduced-motion: reduce) {
   #race-root .rh-laned { animation: rhFade var(--rh-lane-dur, 2600ms) linear forwards !important; }
 }
+
+/* ============================================================================
+ * THE VOICE ON THE GLASS (race/captions.js): the caption line and the zoom plate.
+ *
+ * One layer above .rh-chrome, click-through like the rest of it. The caption is a
+ * lower third that clears the item slot, the mixer stack and the speed bar, so it
+ * can never sit on a plate; the score plate is top-left and is never in reach of
+ * it at any size. The plate flies out of the vanishing point in the middle of the
+ * glass, one at a time, wearing the theme race/triggerTheme.js named for its
+ * trigger's preset. THIRTEEN THEMES, one class each, listed in the table there.
+ * ==========================================================================*/
+.race-hud .rc-layer { position: fixed; inset: 0; z-index: 4; pointer-events: none; overflow: hidden; }
+.race-hud .rc-layer * { pointer-events: none; }
+.race-hud.is-lobby .rc-layer { display: none; }
+
+/* ---- the caption: low, fleeting, one phrase, typed by the voice ---- */
+.race-hud .rc-cap {
+  position: absolute; left: var(--rh-in-l); right: var(--rh-in-r);
+  /* above the item slot (bottom), the mixer column (bottom + 72px) and the speed bar */
+  bottom: calc(var(--rh-in-b) + 148px);
+  display: flex; justify-content: center;
+  opacity: var(--rc-out, 1); transition: opacity 0.18s linear;
+}
+.race-hud .rc-line {
+  max-width: min(94%, 900px); text-align: center; text-wrap: balance;
+  font-size: clamp(1.05rem, 4.4vw, 1.55rem); font-weight: 800; line-height: 1.28; letter-spacing: 0.02em;
+  /* two lines at most: a third would climb into the road */
+  max-height: 2.6em; overflow: hidden;
+  text-shadow: 0 0 14px rgba(0, 0, 0, 0.9), 0 2px 5px rgba(0, 0, 0, 0.95);
+}
+/* every word of the phrase is in the DOM from the start so the line never reflows as it types;
+   a word the voice has not reached holds its space and nothing else */
+.race-hud .rc-word { color: var(--rc-ink, #fff); opacity: 0; transition: opacity 0.16s linear, text-shadow 0.16s linear; }
+.race-hud .rc-word.is-said { opacity: 0.82; }
+.race-hud .rc-word.is-said.is-now { opacity: 1; text-shadow: 0 0 16px var(--rc-ink, rgba(255, 105, 180, 0.9)), 0 2px 5px rgba(0, 0, 0, 0.95); }
+
+/* ---- the plate: out of the vanishing point, into your face ---- */
+.race-hud .rc-plates { position: absolute; inset: 0; perspective: 900px; }
+.race-hud .rc-plate {
+  position: absolute; top: 42%; left: 50%; transform: translate(-50%, -50%) scale(0.15);
+  max-width: 92vw; text-align: center; white-space: nowrap;
+  font-size: 12vw; font-weight: 900; line-height: 1; letter-spacing: 0.06em; text-transform: lowercase;
+  color: var(--rc-glow, #fff);
+  text-shadow: 0 0 30px var(--rc-glow, #fff), 0 4px 10px rgba(0, 0, 0, 0.9);
+  animation: rcZoom 1400ms cubic-bezier(0.16, 0.9, 0.3, 1) forwards;
+  will-change: transform, opacity;
+}
+@media (min-width: 700px) { .race-hud .rc-plate { font-size: 7vw; } }
+.race-hud .rc-plate-sparks { display: none; }
+/* zoom 0.15 to 1.35 over 700 ms, hold 400 ms, then away */
+@keyframes rcZoom {
+  0%   { opacity: 0; transform: translate(-50%, -50%) scale(0.15); }
+  8%   { opacity: 1; }
+  50%  { opacity: 1; transform: translate(-50%, -50%) scale(1.35); }
+  78%  { opacity: 1; transform: translate(-50%, -50%) scale(1.35); }
+  100% { opacity: 0; transform: translate(-50%, -50%) scale(1.62); }
+}
+/* the ink theme takes the room away for 300 ms */
+.race-hud .rc-dim { position: absolute; inset: 0; background: #05050a; opacity: 0; }
+.race-hud .rc-dim.is-on { animation: rcDim 300ms ease-out forwards; }
+@keyframes rcDim { 0% { opacity: 0; } 30% { opacity: 0.62; } 100% { opacity: 0; } }
+
+/* ---- the thirteen themes (race/triggerTheme.js THEME_BY_PRESET) ---- */
+/* blackout: a near black card, white letters, and the room goes with it */
+.race-hud .rc-plate--ink {
+  color: var(--rc-ink, #f4f2ff); padding: 0.18em 0.5em; border-radius: 0.12em;
+  background: rgba(9, 9, 16, 0.94); border: 2px solid rgba(244, 242, 255, 0.22);
+  text-shadow: 0 2px 10px rgba(0, 0, 0, 0.95);
+}
+/* pink-blink: hot pink, twice */
+.race-hud .rc-plate--blink { animation: rcZoom 1400ms cubic-bezier(0.16, 0.9, 0.3, 1) forwards, rcBlink 1400ms steps(1) forwards; }
+@keyframes rcBlink { 0%, 44% { filter: none; } 48% { filter: brightness(0.2); } 52% { filter: brightness(1.7); } 60% { filter: brightness(0.2); } 64%, 100% { filter: none; } }
+/* pink-wall: the letters come in from both sides and close up */
+.race-hud .rc-plate--wall { animation: rcZoom 1400ms cubic-bezier(0.16, 0.9, 0.3, 1) forwards, rcWall 700ms cubic-bezier(0.16, 0.9, 0.3, 1) forwards; }
+@keyframes rcWall { 0% { letter-spacing: 0.9em; } 100% { letter-spacing: 0.06em; } }
+/* freeze-snap: ice, a crackle, and a hard stop with no overshoot */
+.race-hud .rc-plate--frost { animation: rcFrost 1400ms cubic-bezier(0.2, 0.9, 0.2, 1) forwards, rcCrackle 260ms steps(3) 480ms; }
+@keyframes rcFrost {
+  0% { opacity: 0; transform: translate(-50%, -50%) scale(0.15); }
+  8% { opacity: 1; }
+  46%, 78% { opacity: 1; transform: translate(-50%, -50%) scale(1); }
+  100% { opacity: 0; transform: translate(-50%, -50%) scale(1.04); }
+}
+@keyframes rcCrackle {
+  0% { text-shadow: 0 0 30px var(--rc-glow), 0 4px 10px rgba(0, 0, 0, 0.9); }
+  50% { text-shadow: 0 0 6px #fff, 2px -2px 0 var(--rc-glow), -2px 2px 0 #fff; }
+  100% { text-shadow: 0 0 30px var(--rc-glow), 0 4px 10px rgba(0, 0, 0, 0.9); }
+}
+/* snap-shake: one violent shake, white */
+.race-hud .rc-plate--snap { animation: rcZoom 1400ms cubic-bezier(0.16, 0.9, 0.3, 1) forwards, rcShake 130ms steps(2) 460ms 3; }
+@keyframes rcShake { 0% { margin-left: 0; } 25% { margin-left: -0.09em; } 50% { margin-left: 0.11em; } 75% { margin-left: -0.05em; } 100% { margin-left: 0; } }
+/* glitch-shake: yellow, split into its channels */
+.race-hud .rc-plate--split { animation: rcZoom 1400ms cubic-bezier(0.16, 0.9, 0.3, 1) forwards, rcSplit 900ms steps(4) 420ms forwards; }
+@keyframes rcSplit {
+  0% { text-shadow: 0 0 30px var(--rc-glow), 0 4px 10px rgba(0, 0, 0, 0.9); }
+  35% { text-shadow: 0.08em 0 0 rgba(255, 40, 90, 0.95), -0.08em 0 0 rgba(60, 230, 255, 0.95), 0 0 26px var(--rc-glow); }
+  70% { text-shadow: -0.06em 0 0 rgba(255, 40, 90, 0.95), 0.06em 0 0 rgba(60, 230, 255, 0.95), 0 0 26px var(--rc-glow); }
+  100% { text-shadow: 0 0 30px var(--rc-glow), 0 4px 10px rgba(0, 0, 0, 0.9); }
+}
+/* flash-pulse: three white flashes behind the word */
+.race-hud .rc-plate--pulse::before {
+  content: ''; position: absolute; inset: -18vh -30vw; z-index: -1;
+  background: radial-gradient(closest-side, rgba(255, 255, 255, 0.85), rgba(255, 255, 255, 0));
+  animation: rcPulse 300ms steps(1) 260ms 3;
+}
+@keyframes rcPulse { 0%, 40% { opacity: 0.9; } 41%, 100% { opacity: 0; } }
+/* golden-rain: gold, with shards coming off the letters */
+.race-hud .rc-plate--gold { color: #ffe27a; text-shadow: 0 0 34px rgba(255, 215, 0, 0.95), 0 4px 10px rgba(0, 0, 0, 0.9); }
+.race-hud .rc-plate--gold .rc-plate-sparks {
+  display: block; position: absolute; left: 50%; top: 62%; width: 6px; height: 6px; border-radius: 50%;
+  background: #ffe27a;
+  box-shadow: -3.2em 0 0 #ffd700, -1.4em 0.3em 0 #fff2b8, 1.2em -0.2em 0 #ffd700, 3.1em 0.4em 0 #fff2b8;
+  animation: rcShards 900ms ease-in 420ms forwards;
+}
+@keyframes rcShards { 0% { opacity: 0.95; transform: translateY(0) scale(1); } 100% { opacity: 0; transform: translateY(2.4em) scale(0.5); } }
+/* spiral-air: lilac, turning slowly the whole way in */
+.race-hud .rc-plate--spiral { animation: rcSpiral 1400ms cubic-bezier(0.16, 0.9, 0.3, 1) forwards; }
+@keyframes rcSpiral {
+  0% { opacity: 0; transform: translate(-50%, -50%) scale(0.15) rotate(-26deg); }
+  8% { opacity: 1; }
+  50% { opacity: 1; transform: translate(-50%, -50%) scale(1.35) rotate(-6deg); }
+  78% { opacity: 1; transform: translate(-50%, -50%) scale(1.35) rotate(0deg); }
+  100% { opacity: 0; transform: translate(-50%, -50%) scale(1.62) rotate(7deg); }
+}
+/* melt: deep blue, the letters sag and go soft on the way down */
+.race-hud .rc-plate--melt {
+  color: #cfe0ff; text-shadow: 0 0 30px #4060c0, 0 4px 10px rgba(0, 0, 0, 0.9);
+  animation: rcMelt 1400ms cubic-bezier(0.3, 0.6, 0.2, 1) forwards;
+}
+@keyframes rcMelt {
+  0% { opacity: 0; filter: blur(0); transform: translate(-50%, -50%) scale(0.15); }
+  8% { opacity: 1; }
+  50% { opacity: 1; filter: blur(0); transform: translate(-50%, -50%) scale(1.35) skewY(0deg); }
+  78% { opacity: 1; filter: blur(1px); transform: translate(-50%, -44%) scale(1.35) skewY(2.5deg); }
+  100% { opacity: 0; filter: blur(9px); transform: translate(-50%, -34%) scale(1.4) skewY(6deg); }
+}
+/* video: red, behind a set of scanlines */
+.race-hud .rc-plate--scan { color: #ffd9dd; text-shadow: 0 0 30px #ff5c6c, 0 4px 10px rgba(0, 0, 0, 0.9); }
+.race-hud .rc-plate--scan::after {
+  content: ''; position: absolute; inset: -0.2em -0.4em;
+  background: repeating-linear-gradient(180deg, rgba(0, 0, 0, 0.55) 0 2px, rgba(0, 0, 0, 0) 2px 5px);
+  mix-blend-mode: multiply;
+}
+/* treats: warm pink, and it lands on a bounce rather than a glide */
+.race-hud .rc-plate--bounce { animation: rcZoom 1400ms cubic-bezier(0.2, 1.7, 0.35, 1) forwards; }
+/* mark: a marked word, not a trigger moment. Small, and it does not come at you. */
+.race-hud .rc-plate--mark {
+  font-size: clamp(1.4rem, 5vw, 2.2rem); letter-spacing: 0.22em; color: #ece8ff;
+  text-shadow: 0 0 16px rgba(236, 232, 255, 0.7), 0 2px 6px rgba(0, 0, 0, 0.9);
+  animation: rcMark 1100ms ease-out forwards;
+}
+@keyframes rcMark {
+  0% { opacity: 0; transform: translate(-50%, -50%) scale(1); }
+  14%, 62% { opacity: 1; transform: translate(-50%, -50%) scale(1); }
+  100% { opacity: 0; transform: translate(-50%, -50%) scale(1); }
+}
+
+/* reduced motion (Law VI): nothing comes at you. The plate fades in place at full size, and the
+   caption still types itself, because that is the voice and not an animation. */
+@keyframes rcHold { 0% { opacity: 0; } 10%, 80% { opacity: 1; } 100% { opacity: 0; } }
+@media (prefers-reduced-motion: reduce) {
+  .race-hud .rc-plate, .race-hud .rc-plate--blink, .race-hud .rc-plate--wall, .race-hud .rc-plate--frost,
+  .race-hud .rc-plate--snap, .race-hud .rc-plate--split, .race-hud .rc-plate--spiral, .race-hud .rc-plate--melt,
+  .race-hud .rc-plate--bounce, .race-hud .rc-plate--mark {
+    animation: rcHold 1400ms linear forwards; transform: translate(-50%, -50%) scale(1); filter: none;
+  }
+  .race-hud .rc-plate--pulse::before, .race-hud .rc-plate--gold .rc-plate-sparks { animation: none; opacity: 0; }
+  .race-hud .rc-dim.is-on { animation: none; }
+}

--- a/ConditioningControlPanel/Resources/web/dtrh/race/run.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/run.js
@@ -55,6 +55,7 @@ import { cueFor, resultTag } from './cues.js';
 import { createKart } from './kart.js';
 import { createScore } from './score.js';
 import { createRaceHud } from './hud.js';
+import { createCaptions } from './captions.js';
 import { createMediaLane } from './mediaLane.js';
 import { createItems } from './items.js';
 import { createInput } from './input.js';
@@ -119,6 +120,9 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
 
   // ---- the parts that outlive a run ----
   const hud = createRaceHud(hudRoot);
+  // the voice on the glass: the caption line under the chrome and the trigger plate over it.
+  // It reads the track clock and nothing else, so a pause, a resume and a seek all land for free.
+  const captions = hudRoot ? createCaptions(hudRoot) : null;
   const fxProxy = { pulseFlash: (a) => { if (W) W.fx.pulseFlash(a); } };   // fx is rebuilt on "again"
   const payloadFx = createPayloadFx({ hud: sfHud, fx: fxProxy, media });
   // Q.leanSpirals (mobile): spiral pops draw from the two lightest bundled gifs, fetched while the intro plays
@@ -386,6 +390,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     audio.setRoute(routeOf(t));
     S.trackHold = 0; S.statsAt = 0;
     if (W) { W.field.setTracked(!!t); W.field.setSparse(TR.lyrics); W.field.setDensity(1); if (!t) applyFog(W, 0); }
+    if (captions) captions.setTrack(t ? t.chart : null);
     audio.duck(!!t, 'track');   // the file is the soundtrack: the room OST sits under it until it is cleared
     if (bridge.log) bridge.log(t ? `race track: ${t.name}, ${Math.round(t.durationSec)}s, ${TR.stats().countable} to take` : 'race track: cleared');
     return t;
@@ -428,7 +433,9 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     if (cue.mood) poke(cue.mood, Math.max(1.2, cue.holdSec));
     if (cue.pose) w.kart.pose(cue.pose);
     if (cue.toast) hud.toast(cue.toast.text, cue.toast.kind || 'effect');
-    if (cue.word) hud.toast(cue.word, 'effect');
+    // a sure trigger no longer whispers on the toast rail: it flies at the camera, themed off the
+    // preset its set carries (race/captions.js + race/triggerTheme.js). Everything else still toasts.
+    if (cue.word) { if (due.event.kind === 'trigger' && captions) captions.showPlate(due.event); else hud.toast(cue.word, 'effect'); }
     if (cue.fog != null) applyFog(w, cue.fog);
     if (cue.boost) w.kart.applyBoost(cue.boost);
     if (cue.density != null) w.field.setDensity(cue.density);
@@ -447,6 +454,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
   function trackFrame(w, ts) {
     const ks = w.kart.state;
     if (S.trackHold > 0) { S.trackHold -= ts.dt; if (S.trackHold <= 0) { applyFog(w, 0); w.field.setDensity(1); } }
+    if (captions) captions.update(ts.t);   // the phrase is a function of the second, never of the frame
     for (const due of TR.due(ks.d, ks.speed)) applyCue(w, due);
     if (ts.actChanged) actMoved(w, ts.act, ks);
     if (ts.dt > S.trackGap) S.trackGap = ts.dt;   // the worst frame the scheduler had to reach over
@@ -589,6 +597,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     const w = W;
     S.ended = true; S.running = false; S.paused = false;
     try { payloadFx.cancelHeavy(); } catch (e) { /* nothing heavy */ }
+    if (captions) captions.clear();   // nothing of the last phrase is left over the end card
     const st = w.score.state;
     const summary = { score: st.score, banked: st.banked, bestCombo: st.bestCombo, popped: st.popped, treats: st.treats, effects: st.effects,
       nearMisses: st.nearMisses, laps: w.kart.state.lap, durationSec: Math.round(S.elapsed), seed: S.seed,
@@ -664,7 +673,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     if (payoutResolve) payoutResolve(null);
     teardown();
     audio.dispose();
-    input.dispose(); hud.dispose(); shake.dispose(); payloadFx.dispose(); speedFx.dispose(); lane.dispose();
+    input.dispose(); hud.dispose(); if (captions) captions.dispose(); shake.dispose(); payloadFx.dispose(); speedFx.dispose(); lane.dispose();
     pixel.dispose();
     scene.clear(); renderer.dispose();
     setFlip(false);
@@ -719,7 +728,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
   return { start, prepare, setPaused, dispose, setCameraOverride, setStage, reseed, renderer, pixel, audio, hud, camera, perf,
     // track charts (CHART.md): setTrack before start(), replaceTrack for the words pass landing live,
     // trackClock for the host's 250 ms tick, trackEnded when the file runs out at the host's end
-    setTrack, replaceTrack: (chart) => { TR.replace(chart); audio.setRoute(routeOf(TR.track)); if (W) W.field.setSparse(TR.lyrics); }, trackClock: (t, playing) => TR.clock(t, playing),
+    setTrack, replaceTrack: (chart) => { TR.replace(chart); audio.setRoute(routeOf(TR.track)); if (W) W.field.setSparse(TR.lyrics); if (captions) captions.setTrack(TR.track ? TR.track.chart : null); }, trackClock: (t, playing) => TR.clock(t, playing),
     trackEnded: () => { TR.end(); if (TR.track && S.running) endRun(); }, trackStats: () => TR.stats(), debugItemBox,
     get track() { return TR.track; } };
 }


### PR DESCRIPTION
Chain B, PR 2 of 3. Base: `feat/race-lyrics-l4-rows` (#917), which sits on `feat/race-lyrics-l2-road` (#916).

The owner's ask: *"i want the text to be displayed live as captions when the words are being spoken, you can start the typewrite effect to the corresponding timestamp for that phrase on the script we got. this text should be visible but fleeting and the triggers should be shown with a zooming animation (like they come towards the pov) and more visible and big, themed animations for each trigger."*

### the caption
`race/captions.js` cuts `chart.words` (the caption track L2 puts on the road) into phrases: a silence over 0.7 s ends one, so does a full stop, so does the ninth word. One is on the glass at a time, and a phrase is off it before the next one opens.

Every word of the phrase is in the DOM from the moment it opens and only **inked** when the clock reaches its own timestamp. That is the typewriter: the line types itself at the speed the voice actually spoke it, and because nothing is inserted as it goes, it never reflows mid-phrase. The word being spoken right now carries the light. The line lets go over its last half second rather than blinking out.

On the real opening level: **152 caption words, 19 phrases**, longest 9 words. 34 of those words wear their own trigger's colour, so the phrase shows you which of its words is the one that counts.

### the plate
A sure trigger no longer whispers on the toast rail. It flies out of the vanishing point at the camera, big, one at a time, wearing the theme `race/triggerTheme.js` already named for its preset. Thirteen themes, a class each: `ink` (near black card, and the room dims with it for 300 ms), `blink`, `wall`, `frost`, `snap`, `split`, `pulse`, `gold`, `spiral`, `melt`, `scan`, `bounce`, `mark`. `prefers-reduced-motion` swaps every one of them for a fade in place.

### the clock is the only input
`update(t)` reads the track second and nothing else: no elapsed frames, no timer of its own. A pause, a resume, a seek and the words pass landing live under a running chart all come out right for free, because there is no state to get out of step.

### on a phone
On a 390x844 portrait viewport the caption sits at 76% of the height, above the item slot, the mixer column and the speed bar, and nowhere near the score plate at top-left (caption y 641..680, score y 16..162). Two lines at most: a third would climb into the road.

### checked
`race/smoke/captions-check.mjs` is in the follow-up PR, because this one plus its checks is 757 lines and the cap is 600. Everything below was run against **this** branch:

- `captions-check` (the new one): 19 phrases off the real transcript, no phrase over 9 words, none overlapping, every cut explained by a rule; headless at 390x844, the line types itself 1 -> 3 -> 8 of 8 inked, a seek back re-inks from the clock, the glass is clear between phrases, no overlap with any HUD plate, the plate flies with the right theme, one at a time, and race.css carries a class for all 13
- every existing race and chart check: chart, levels, track-run, words, lyrics-road, rows, fov, gltf, poses, spiral-pool, ost-resident, touch, audio, cloud, cloud-chart, remote-feed, generate, tokens, triggers. All green
- `real-audio-check` twice: once on the localhost stub, and **once against the real cdn** (one file, read-only guest, nothing else touched). 44 events, 152 words, and on real playback the caption opened as the voice reached it (9 words at 80.6 s, 1 inked), the trigger at 105.7 s flew its `blink` plate, and the plate was gone a second and a half later
- headless `?autostart=1&chart=demo` at 390x844: 30 s, 0 console errors

No transcript line is printed by any of it. Everything reported is counted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
