### PR TITLE
feat(race): the plate and the row land on the word, not 2.5 s before it (sync S1)

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/race/CHART.md
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/CHART.md
@@ -199,7 +199,19 @@ race.track                          // { chart, sched, t, playing, name, duratio
   `spawnAhead` / `rain` timers are off; `seedChunk` still dresses chunks with plain treats at
   `density` so the road never looks empty (unless the road has words on it: see `setSparse`); every
   cue spawn goes through `field.spawnAt`, or `field.spawnRow` for the row, at
-  `d = kart.d + kart.speed * max(dueIn + at, 0.25)`.
+  `d = kart.d + kart.speed * max(event.t + at - t, 0.25)` (`sync.depthFor`).
+- The sync (`race/sync.js`): the scheduler hands an event over `LEAD_SEC` early so the spawns can
+  go down the road; only the spawns are spent at that handover. The visible half of the cue (plate,
+  toast, mood, pose, jump, mix, fog, boost, density, hold) is held by `createCueSync` and fired from
+  `trackFrame` the frame the track clock reaches `event.t` (`sync.update`), so it lands on the word
+  and not 2.5 s before it. A held cue found more than `LATE_SEC` (1 s) past its second is dropped
+  (a seek forward); a seek back drops what the scheduler is about to hand over again; a pause drains
+  nothing because the second does not move. The row is re-placed every frame off the kart's current
+  speed (`field.moveRow`) until `CUE_AHEAD_SEC` is left, so a boost or a ramp inside the lookahead
+  still lands it under the kart on the word. A fog/density hold is a stretch of track seconds
+  (`S.trackHold` is the second it ends), never a count of frames. `race.syncTrace()` is the per-event
+  trace (handedAt, firedAt, rowPlacedAt, rowAt, dropped) the smokes read: `race/smoke/sync-check.mjs`
+  (demo, headless) and `real-audio-check.mjs` section 3c (a real voice, `RACE_TRACK_FILE`).
 - `TR.lyrics` is true while the loaded chart has a caption track or an `analysis.words` other than
   `none`. It drives `field.setSparse` and `ctx.lyrics`, and is re-read on `replaceTrack` so a words
   pass landing on a partial chart thins the road the moment it arrives.

--- a/ConditioningControlPanel/Resources/web/dtrh/race/bubbles.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/bubbles.js
@@ -261,7 +261,17 @@ export function createBubbleField({ scene, layout, media, getIntensity, getRoom,
     const top = h == null ? (placement === 'rain' ? CEILING_H : placement === 'air' ? 2.6 : LANE_H) : h;
     const id = ++rowSeq;
     for (const x of list) { const s = place(kindId, placement, d, Number(x), top); s.eventId = eventId; s.rowId = id; }
-    return list.length;
+    return id;   // the row's id: run.js hands it to race/sync.js, which moveRow()s it onto its word
+  }
+  /** A row goes to depth `d`: the kart's speed changed inside the lookahead, so the word will be said
+   *  somewhere else on the road (race/sync.js re-places it every frame until the kart is on it). A
+   *  bubble already popped or slipped stays where it is; the sprite follows `d` on the next update. */
+  function moveRow(id, d) {
+    if (!id || !Number.isFinite(Number(d))) return 0;
+    const dd = layout.wrap(Number(d));
+    let n = 0;
+    for (const s of pool) if (s.alive && s.rowId === id && s.popT < 0 && !s.missed) { s.d = dd; n++; }
+    return n;
   }
   /** The row has been settled by one of its own: nobody else in it may report a miss. `missed` is
    *  only ever read by the miss gate, so marking the siblings is all it takes. */
@@ -396,7 +406,7 @@ export function createBubbleField({ scene, layout, media, getIntensity, getRoom,
   }
 
   return {
-    seedChunk, spawnAhead, rain, spawnAt, spawnRow, update, dispose,
+    seedChunk, spawnAhead, rain, spawnAt, spawnRow, moveRow, update, dispose,
     onPop(cb) { if (typeof cb === 'function') popCbs.push(cb); },
     onMiss(cb) { if (typeof cb === 'function') missCbs.push(cb); },
     setDensity(mult) { const v = Number(mult); density = clamp(isFinite(v) ? v : 1, tracked ? 0 : 0.25, 3); },

--- a/ConditioningControlPanel/Resources/web/dtrh/race/run.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/run.js
@@ -47,6 +47,7 @@ import { INTENSITY_RAMP_SEC, TREATS_ONLY_SEC, KART_BASE_SPEED, MULT_LADDER, make
 import { createSpine } from './spine.js';
 import { roomById, rollRoomOrder, createRoomDresser } from './rooms.js';
 import { createWalls } from './walls.js';
+import { createCueSync, CUE_AHEAD_SEC } from './sync.js';
 import { KIND_BY_ID } from './bubbleKinds.js';
 import { createCocktail, CATEGORIES } from './cocktail.js';
 import { createBubbleField } from './bubbles.js';
@@ -72,9 +73,9 @@ const HEARTBEAT_MS = 2000, PAYOUT_WAIT_MS = 2000, NEAR_MISS_M = 1.15, FOV_BASE =
 const WOBBLE_SCALE = 0.82, WOBBLE_SEC = 0.3;
 const ladderMult = (combo) => { let m = 1; for (const [at, mult] of MULT_LADDER) if (combo >= at) m = mult; return m; };
 const SPAWN_T0 = 2.5, RAIN_T0 = 20, EARLY_SLOW = 1.5;   // the opening drips slower (TREATS_ONLY_SEC)
-// track cues: a bubble never lands nearer than this, an act only re-dresses the world when no gate is
-// this many seconds of road away, and the standalone page logs the scheduler this often (track time).
-const CUE_AHEAD_SEC = 0.25, ACT_GATE_SEC = 6, TRACK_STATS_SEC = 10;
+// track cues: an act only re-dresses the world when no gate is this many seconds of road away, and
+// the standalone page logs the scheduler this often (track time). CUE_AHEAD_SEC lives in race/sync.js.
+const ACT_GATE_SEC = 6, TRACK_STATS_SEC = 10;
 const clamp = (v, a, b) => Math.max(a, Math.min(b, v));
 const hex = (n) => '#' + ((n >>> 0) & 0xffffff).toString(16).padStart(6, '0');
 
@@ -145,12 +146,13 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     elapsed: 0, t: 0, intensity: intensityFloor, timeScale: 1, jackpotBias: 1, parasol: false, magnet: false,
     flip: false, spawnT: SPAWN_T0, rainT: RAIN_T0, tunnelTime: 0, rush: 0, fov: fovBase, fovBoost: 0, gates: 0, room: null,
     wasAirborne: false, airH: 0, effects: [], moodHeld: null, moodHold: 0, mood: 'calm', bestAtStart: 0, seed, wobble: 0,
-    trackHold: 0, trackFog: 0, trackPaused: false, statsAt: 0, trackGap: 0,
+    trackHold: 0, trackHoldFrom: 0, trackFog: 0, trackPaused: false, statsAt: 0, trackGap: 0,   // trackHold: the track second a fog/density hold ends, 0 for none
   };
   fovLive = true;   // S exists: resize() may shift S.fov from here on
   const mix = createCocktail({ now: () => S.elapsed });   // THE MIX: one live effect per category (cocktail.js); S.effects mirrors its live slots
   const TR = createTrackState();      // the loaded track chart: its clock, its energy, its acts (race/track.js)
   const hosted = bridge.isHosted !== false;   // the standalone page logs where the host would be told
+  const sync = createCueSync({ aheadSec: CUE_AHEAD_SEC, trace: true });   // the visible half of a cue waits for the word (race/sync.js); the trace is 64 small rows the smokes read
   let W = null;                       // the world: everything that is rebuilt on "again"
   let raf = 0, last = 0, lastBeat = 0, payoutResolve = null;
   let camOverride = null;                // fn(camera, dt, w, camOut) -> false when done (intro.js cameras)
@@ -210,9 +212,9 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     Object.assign(S, { running: false, paused: false, ended: false, elapsed: 0, t: 0, intensity: intensityFloor, timeScale: 1,
       jackpotBias: 1, parasol: false, magnet: false, spawnT: SPAWN_T0, rainT: RAIN_T0, rush: 0, fovBoost: 0, gates: 0, room: null,
       wasAirborne: false, airH: 0, effects: [], moodHeld: null, moodHold: 0, mood: 'calm', seed: runSeed,
-      trackHold: 0, trackFog: 0, trackPaused: false, statsAt: 0, trackGap: 0 });
+      trackHold: 0, trackHoldFrom: 0, trackFog: 0, trackPaused: false, statsAt: 0, trackGap: 0 });
     setFlip(false); trailClear();
-    mix.reset(); S.wobble = 0; clearMixChrome();
+    mix.reset(); S.wobble = 0; clearMixChrome(); sync.reset();
     hud.setScore(0); hud.setCombo(0, 1); hud.setBank(0); hud.setSpeed(0); hud.setFraught(0); hud.pickupClear(); hud.item(null, 'no item yet');
   }
 
@@ -388,7 +390,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
   function setTrack(chart) {
     const t = TR.setTrack(chart);
     audio.setRoute(routeOf(t));
-    S.trackHold = 0; S.statsAt = 0;
+    S.trackHold = 0; S.statsAt = 0; sync.reset();
     if (W) { W.field.setTracked(!!t); W.field.setSparse(TR.lyrics); W.field.setDensity(1); if (!t) applyFog(W, 0); }
     if (captions) captions.setTrack(t ? t.chart : null);
     audio.duck(!!t, 'track');   // the file is the soundtrack: the room OST sits under it until it is cleared
@@ -411,23 +413,34 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     pour(w, { id: k.id, payload: k.payload, overlayKind: k.overlayKind }, r, Math.round(clamp(k.strength, 0, 1) * 100), durationMult);
     if (r.recipe) serve(w, r.recipe);
   }
-  /** One event off the scheduler, spent on the world. Every spawn goes in at the depth the kart will
-   *  have reached when the voice says it, so the pop lands on the word whatever the throttle did. */
+  /** One event off the scheduler. The scheduler hands it over LEAD_SEC early on purpose, so the SPAWNS
+   *  can go down the road at the depth the kart will have reached when the voice says the word: they
+   *  go in now. Everything the player sees or hears is held by race/sync.js and fired from trackFrame
+   *  the frame the track clock reaches event.t; spent here it landed 2.5 s before the word (the
+   *  owner's "too soon by 2 sec or so", measured in race/smoke/sync-check.mjs). */
   function applyCue(w, due) {
-    const ks = w.kart.state;
-    const cue = cueFor(due.event, { energy: TR.intensity, act: TR.act, room: S.room, intensity: S.intensity, rng: w.rng, triggerKinds: TR.triggerKinds, lyrics: TR.lyrics });
-    if (!cue) { TR.skip(due.event.id); return; }   // a guess the feel pass threw out never counts against the player
+    const ks = w.kart.state, e = due.event, t = TR.track ? TR.track.t : 0;
+    const cue = cueFor(e, { energy: TR.intensity, act: TR.act, room: S.room, intensity: S.intensity, rng: w.rng, triggerKinds: TR.triggerKinds, lyrics: TR.lyrics });
+    if (!cue) { TR.skip(e.id); return; }   // a guess the feel pass threw out never counts against the player
     // A row goes in as one thing (bubbles.js spawnRow): the density gate is rolled once for the
     // whole line, so the road never gets a row with a hole in it that the kart can steer through.
+    // Its depth assumes the speed the kart has now; the sync re-places it every frame until the
+    // kart is on it, so a boost or a ramp inside the lookahead still lands the row on the word.
+    // A loose treat keeps its first depth: it is a guess at an unsure word, not a pop on a beat.
     const row = cue.spawn.filter((sp) => sp.row), loose = cue.spawn.filter((sp) => !sp.row);
     if (row.length) {
-      const d = ks.d + ks.speed * Math.max(due.dueIn + (row[0].at || 0), CUE_AHEAD_SEC);
-      w.field.spawnRow({ kindId: row[0].kindId, placement: row[0].placement, d, h: row[0].h, xs: row.map((sp) => sp.x), eventId: due.event.id });
+      const at = e.t + (row[0].at || 0), d = sync.depthFor(t, ks.d, ks.speed, at);
+      const rowId = w.field.spawnRow({ kindId: row[0].kindId, placement: row[0].placement, d, h: row[0].h, xs: row.map((sp) => sp.x), eventId: e.id });
+      if (rowId) sync.trackRow(rowId, e, at, d, t);
     }
     for (const sp of loose) {
-      const d = ks.d + ks.speed * Math.max(due.dueIn + (sp.at || 0), CUE_AHEAD_SEC);
-      w.field.spawnAt({ kindId: sp.kindId, placement: sp.placement, d, x: sp.x, h: sp.h, eventId: due.event.id });
+      w.field.spawnAt({ kindId: sp.kindId, placement: sp.placement, d: sync.depthFor(t, ks.d, ks.speed, e.t + (sp.at || 0)), x: sp.x, h: sp.h, eventId: e.id });
     }
+    sync.defer(e, cue, t);
+  }
+  /** The visible half of a cue, on the word: trackFrame fires it the frame the clock reaches event.t. */
+  function spendCue(w, event, cue) {
+    const ks = w.kart.state;
     if (cue.jump) { ks.vh = Math.max(ks.vh, cue.jump); ks.h = Math.max(ks.h, 0.06); ks.airborne = true; w.kart.pose('air'); }
     if (cue.mix) cueMix(w, cue.mix);
     if (cue.mood) poke(cue.mood, Math.max(1.2, cue.holdSec));
@@ -435,11 +448,13 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     if (cue.toast) hud.toast(cue.toast.text, cue.toast.kind || 'effect');
     // a sure trigger no longer whispers on the toast rail: it flies at the camera, themed off the
     // preset its set carries (race/captions.js + race/triggerTheme.js). Everything else still toasts.
-    if (cue.word) { if (due.event.kind === 'trigger' && captions) captions.showPlate(due.event); else hud.toast(cue.word, 'effect'); }
+    if (cue.word) { if (event.kind === 'trigger' && captions) captions.showPlate(event); else hud.toast(cue.word, 'effect'); }
     if (cue.fog != null) applyFog(w, cue.fog);
     if (cue.boost) w.kart.applyBoost(cue.boost);
     if (cue.density != null) w.field.setDensity(cue.density);
-    if (cue.holdSec > 0) S.trackHold = cue.holdSec;
+    // the hold is a stretch of the TRACK, not a count of frames: a seek past it must not carry the
+    // fog and the empty road along for the seconds it had left (a 20 s silence hold once did)
+    if (cue.holdSec > 0) { S.trackHoldFrom = event.t; S.trackHold = event.t + cue.holdSec; }
   }
   /** The act moved with no gate in reach: dress the new room where we stand and marquee its name. */
   function actMoved(w, act, ks) {
@@ -453,9 +468,13 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
   /** One frame of the track. Returns true when the file is over and the run has been ended. */
   function trackFrame(w, ts) {
     const ks = w.kart.state;
-    if (S.trackHold > 0) { S.trackHold -= ts.dt; if (S.trackHold <= 0) { applyFog(w, 0); w.field.setDensity(1); } }
+    if (S.trackHold > 0 && (ts.t >= S.trackHold || ts.t < S.trackHoldFrom)) { S.trackHold = 0; applyFog(w, 0); w.field.setDensity(1); }   // over, or a seek back to before it (the scheduler re-hands it)
     if (captions) captions.update(ts.t);   // the phrase is a function of the second, never of the frame
     for (const due of TR.due(ks.d, ks.speed)) applyCue(w, due);
+    // the sync: rows nudged onto their word off the speed the kart has now, held cues fired on the second
+    const held = sync.update(ts.t, ks.d, ks.speed);
+    for (const m of held.move) w.field.moveRow(m.rowId, m.d);
+    for (const f of held.fire) spendCue(w, f.event, f.cue);
     if (ts.actChanged) actMoved(w, ts.act, ks);
     if (ts.dt > S.trackGap) S.trackGap = ts.dt;   // the worst frame the scheduler had to reach over
     if (!hosted && ts.t - S.statsAt >= TRACK_STATS_SEC) {   // standalone dev aid: the scheduler on the console
@@ -729,7 +748,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     // track charts (CHART.md): setTrack before start(), replaceTrack for the words pass landing live,
     // trackClock for the host's 250 ms tick, trackEnded when the file runs out at the host's end
     setTrack, replaceTrack: (chart) => { TR.replace(chart); audio.setRoute(routeOf(TR.track)); if (W) W.field.setSparse(TR.lyrics); if (captions) captions.setTrack(TR.track ? TR.track.chart : null); }, trackClock: (t, playing) => TR.clock(t, playing),
-    trackEnded: () => { TR.end(); if (TR.track && S.running) endRun(); }, trackStats: () => TR.stats(), debugItemBox,
+    trackEnded: () => { TR.end(); if (TR.track && S.running) endRun(); }, trackStats: () => TR.stats(), syncTrace: () => sync.trace(), debugItemBox,
     get track() { return TR.track; } };
 }
 

--- a/ConditioningControlPanel/Resources/web/dtrh/race/smoke/real-audio-check.mjs
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/smoke/real-audio-check.mjs
@@ -44,7 +44,10 @@ const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
 const HERE = resolve(fileURLToPath(import.meta.url), '..');
 const WEB = resolve(HERE, '../../..');                     // Resources/web
-const TRACK_FILE = resolve(WEB, 'dtrh/assets/audio/drone1.mp3');
+// RACE_TRACK_FILE: a local copy of a track the words index knows (the hash is a length and the first
+// MiB, chartSource.js, so the stub serves the same bytes and the transcript lands by hash), which is
+// how section 3c measures the sync against a real voice with nothing leaving this machine.
+const TRACK_FILE = process.env.RACE_TRACK_FILE ? resolve(process.env.RACE_TRACK_FILE) : resolve(WEB, 'dtrh/assets/audio/drone1.mp3');
 const PORT = 8865;
 const REAL = process.env.RACE_REAL_URL || '';
 const CHROME = process.env.CHROME_PATH || 'C:/Program Files/Google/Chrome/Application/chrome.exe';
@@ -52,7 +55,7 @@ const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.mjs': 'text/jav
 
 if (!existsSync(TRACK_FILE)) { console.error('FAIL no mp3 at ' + TRACK_FILE); process.exit(1); }
 const TRACK = readFileSync(TRACK_FILE);
-console.log(`the file: ${TRACK_FILE.slice(WEB.length + 1)}, ${TRACK.length} bytes (${(TRACK.length / 1048576).toFixed(2)} MiB)`);
+console.log(`the file: ${TRACK_FILE.startsWith(WEB) ? TRACK_FILE.slice(WEB.length + 1) : 'RACE_TRACK_FILE'}, ${TRACK.length} bytes (${(TRACK.length / 1048576).toFixed(2)} MiB)`);
 
 /* ============================================================================
  * 0. the cdn's own headers, only when a real url was handed in
@@ -259,6 +262,68 @@ if (c.words && c.words !== 'none') {
   }
 } else {
   console.log('  --  3b skipped: this file has no transcript, so there is nothing to caption');
+}
+
+/* ============================================================================
+ * 3c. the sync, measured against the real voice
+ *
+ * The owner heard the plate land "too soon by 2 sec or so" on the phone. This
+ * seeks a few seconds ahead of the first sure triggers, lets the file PLAY, and
+ * watches: the track second each plate reached the DOM, and race/sync.js's own
+ * trace (the second the scheduler handed the event over, the second its visible
+ * half fired, the second the kart met its row). Everything is a delta from
+ * event.t; nothing here is a word of the transcript. The clock is the <audio>
+ * element through the host's 250 ms tick, so a quarter second of slack is real
+ * playback, not the sync. RACE_SYNC_REPORT=1 prints and does not judge.
+ * ==========================================================================*/
+if (c.words && c.words !== 'none') {
+  const trig = await json(`(()=>{const ch=window.__race.race.track.chart; return ch.events.filter(e=>e.kind==='trigger'&&(e.conf==null||e.conf>=0.55)).map(e=>({id:String(e.id),t:e.t}));})()`);
+  const WINDOW = 12, TOL = 0.3, REPORT = !!process.env.RACE_SYNC_REPORT;
+  if (trig.length) {
+    // the window: the WINDOW seconds with the most sure triggers in them, starting 3 s before the first
+    const count = (t0) => trig.filter((e) => e.t >= t0 && e.t <= t0 + WINDOW).length;
+    // (RACE_SYNC_T0 pins it: the number an isolated trigger gives is the one to quote)
+    const t0 = process.env.RACE_SYNC_T0 ? Number(process.env.RACE_SYNC_T0) : trig.map((e) => Math.max(0, e.t - 3)).reduce((best, v) => (count(v) > count(best) ? v : best), Math.max(0, trig[0].t - 3));
+    const watched = trig.filter((e) => e.t >= t0 && e.t <= t0 + WINDOW);
+    await ev(`(()=>{const S=window.__sync={plates:[]}; const R=window.__race.race;
+      new MutationObserver((ms)=>{for(const m of ms)for(const n of m.addedNodes){if(n.nodeType===1&&n.classList&&n.classList.contains('rc-plate'))S.plates.push({t:R.track?R.track.t:-1});}}).observe(document.body,{childList:true,subtree:true});
+      const a=window.__rcAudio; if(a){a.currentTime=${t0}; if(a.paused)a.play().catch(()=>{});} return 1;})()`);
+    let now = -1;
+    for (let i = 0; i < (WINDOW + 4) * 4 && now < t0 + WINDOW + 1; i++) { await sleep(250); now = await ev(`window.__race.race.track.t`); }
+    ok(now >= t0 + WINDOW, `the file played the ${WINDOW}s window on its own clock (${t0.toFixed(1)}s to ${now.toFixed(1)}s)`);
+    const plates = await json(`window.__sync.plates`);
+    const gates = await json(`(()=>{const ch=window.__race.race.track.chart; return ch.events.filter(e=>e.kind==='silence'||e.kind==='build'||e.kind==='release').map(e=>e.kind+'@'+e.t.toFixed(1)+(e.dur?'x'+Number(e.dur).toFixed(1):''));})()`);
+    console.log('  --  density gates on the road: ' + (gates.join(' ') || 'none') + `; ${await ev('window.__race.race.perf().bubbles')} bubbles live`);
+    const trace = await json(`window.__race.race.syncTrace ? window.__race.race.syncTrace() : []`);
+    const byId = new Map(trace.map((r) => [String(r.id), r]));
+    const f2 = (v) => (v == null ? '   -   ' : (v >= 0 ? '+' : '') + v.toFixed(2));
+    console.log(`  --  ${watched.length} sure triggers in the window, ${plates.length} plates seen, ${trace.length} trace lines`);
+    // every plate against the sure trigger nearest to it: the raw picture, whichever way the sync leans
+    const nearest = (t) => trig.reduce((b, e) => (Math.abs(e.t - t) < Math.abs(b.t - t) ? e : b), trig[0]);
+    console.log('  plates, each against the nearest sure trigger: ' + (plates.map((p) => f2(p.t - nearest(p.t).t)).join('  ') || 'none'));
+    console.log('  event.t   plate    handed   fired    placed   rowAt');
+    const plateOff = [], rowOff = [], used = new Set();
+    for (const e of watched) {
+      const r = byId.get(e.id) || {};
+      const pl = plates.find((p, i) => !used.has(i) && p.t >= e.t - 0.5 && p.t <= e.t + 1.5 && used.add(i));   // the plate on or just after the second, once
+      const dp = pl ? pl.t - e.t : null, dr = r.rowAt != null ? r.rowAt - e.t : null;
+      if (dp != null) plateOff.push(dp);
+      if (dr != null) rowOff.push(dr);
+      console.log(`  ${e.t.toFixed(2).padStart(7)}  ${f2(dp)}  ${f2(r.handedAt != null ? r.handedAt - e.t : null)}  ${f2(r.firedAt != null ? r.firedAt - e.t : null)}  ${f2(r.rowPlacedAt != null ? r.rowPlacedAt - e.t : null)}  ${f2(dr)}${r.dropped ? '  dropped' : ''}`);
+    }
+    const worst = (a) => a.reduce((m, v) => (Math.abs(v) > Math.abs(m) ? v : m), 0);
+    if (plateOff.length) console.log(`  --  plate - t: worst ${f2(worst(plateOff))}s over ${plateOff.length};  row - t: worst ${f2(worst(rowOff))}s over ${rowOff.length}`);
+    if (!REPORT) {
+      ok(plateOff.length === watched.length, `every sure trigger in the window flew a plate (${plateOff.length} of ${watched.length})`);
+      ok(plateOff.every((v) => v >= -0.05 && v <= TOL), `every plate reached the DOM on its word, never early, within ${TOL}s of real playback`);
+      ok(watched.every((e) => !(byId.get(e.id) || {}).dropped), 'and no cue in the window was dropped (a seek forward in 3b may drop what the voice already said)');
+      const laid = watched.filter((e) => (byId.get(e.id) || {}).rowPlacedAt != null);   // the density gate may keep a row off the road
+      ok(laid.length > 0, `at least one row went down in the window (${laid.length} of ${watched.length})`);
+      ok(laid.every((e) => { const r = byId.get(e.id); return r.rowAt != null && Math.abs(r.rowAt - e.t) <= TOL; }), `every row that went down was under the kart within ${TOL}s of its word`);
+    }
+  } else {
+    console.log('  --  3c skipped: this transcript has no sure trigger to measure against');
+  }
 }
 
 /* ============================================================================

--- a/ConditioningControlPanel/Resources/web/dtrh/race/smoke/rows-check.mjs
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/smoke/rows-check.mjs
@@ -17,6 +17,10 @@
  *   3. a trigger the spotter only half heard is the single treat it always was
  *   4. one event is one credit however many of its bubbles were popped
  *   5. a worded track halves the peak rain; nothing else on the road moves
+ *   6. the row lands ON the word: driven through race/sync.js with a simulated
+ *      kart whose speed changes inside the lookahead, the row is under the kart
+ *      within 0.15 s of event.t, and the visible half of the cue fires on the
+ *      second, never at the scheduler's 2.5 s early handover
  *
  * It never prints a line of a transcript. Everything below is counted.
  * ==========================================================================*/
@@ -26,6 +30,7 @@ import { createScheduler, normalizeChart } from '../chart.js';
 import { KART_X_MAX, LANE_X_MAX, POP_HIT_X, LANE_H, makeRng } from '../consts.js';
 import { THEME_BY_PRESET, kindForPreset } from '../triggerTheme.js';
 import { KIND_BY_ID } from '../bubbleKinds.js';
+import { createCueSync, CUE_AHEAD_SEC, LATE_SEC } from '../sync.js';
 
 let fails = 0;
 const ok = (cond, what) => { if (!cond) { console.error('FAIL ' + what); fails++; } else console.log('  ok  ' + what); };
@@ -123,6 +128,68 @@ const other = (lyrics) => ['word', 'count', 'drop', 'chant', 'build', 'release',
     ctxFor(null, { lyrics }))));
 const moved = other(true).filter((c, i) => c !== other(false)[i]).length;
 eq(moved, 0, 'and nothing else on the road changes with the transcript');
+
+/* ---- 6. the row lands on the word, whatever the throttle did --------------- */
+// A kart on a 60 Hz clock. The scheduler hands the event over LEAD_SEC (2.5 s) early; the row is
+// placed off the speed the kart has THEN and the sync re-places it each frame. `speedAt` is the
+// throttle: a boost or a ramp inside the lookahead is exactly what used to move the pop off the word.
+const ROW_TOL = 0.15, LEAD = 2.5, DT = 1 / 60;
+function drive(speedAt, { sync: withSync = true, eventT = 30, handAt = eventT - LEAD } = {}) {
+  const sync = createCueSync({ trace: true });
+  const event = { id: 'e1', kind: 'trigger', t: eventT, label: 'a phrase' };
+  let t = handAt - 1, d = 0, rowD = null, metAt = null, firedAt = null, handed = false;
+  for (let i = 0; i < 6 * 60 && metAt == null; i++) {
+    const speed = speedAt(t);
+    if (!handed && t >= handAt) {
+      handed = true;
+      rowD = sync.depthFor(t, d, speed, event.t);
+      sync.trackRow(7, event, event.t, rowD, t);
+      sync.defer(event, { toast: { text: 'x' } }, t);
+    }
+    const out = sync.update(t, d, speed);
+    if (withSync) for (const m of out.move) if (m.rowId === 7) rowD = m.d;
+    if (out.fire.length) firedAt = t;
+    if (rowD != null && d >= rowD) metAt = t;
+    d += speed * DT; t += DT;
+  }
+  return { metAt, firedAt, rowD, trace: sync.trace()[0] };
+}
+const steady = drive(() => 22);
+ok(steady.metAt != null && Math.abs(steady.metAt - 30) <= ROW_TOL, `at a steady 22 m/s the row is under the kart on the word (${(steady.metAt - 30).toFixed(3)}s)`);
+// a boost 1.5 s before the word: 22 -> 34 m/s (the demo's build), then back down
+const boost = (t) => (t >= 28.5 && t < 29.6 ? 34 : 22);
+const bare = drive(boost, { sync: false });
+ok(bare.metAt != null && bare.metAt - 30 < -0.3, `left where it was placed, a boost inside the lookahead brings the row early (${(bare.metAt - 30).toFixed(2)}s), which is the bug`);
+const kept = drive(boost);
+ok(kept.metAt != null && Math.abs(kept.metAt - 30) <= ROW_TOL, `re-placed each frame, the row is still under the kart on the word through the boost (${(kept.metAt - 30).toFixed(3)}s)`);
+// the opening ramp: a slow kart picking up speed across the whole lookahead
+const ramp = drive((t) => 8 + Math.max(0, Math.min(1, (t - 27) / 3)) * 20);
+ok(ramp.metAt != null && Math.abs(ramp.metAt - 30) <= ROW_TOL, `and through a ramp 8 -> 28 m/s (${(ramp.metAt - 30).toFixed(3)}s)`);
+// a slow: the row would have been late without the nudge
+const slow = drive((t) => (t >= 28 ? 12 : 26));
+ok(slow.metAt != null && Math.abs(slow.metAt - 30) <= ROW_TOL, `and through a slow 26 -> 12 m/s (${(slow.metAt - 30).toFixed(3)}s)`);
+ok(kept.trace && kept.trace.rowAt != null && kept.trace.handedAt != null && kept.trace.handedAt <= 30 - LEAD + DT, 'the trace has the handover and the meeting');
+// the visible half waits for the second
+ok(kept.firedAt != null && kept.firedAt >= 30 && kept.firedAt < 30 + DT + 1e-9, `the cue fired on the word, not at the handover (${(kept.firedAt - 30).toFixed(3)}s after event.t)`);
+ok(kept.trace.firedAt != null && kept.trace.firedAt - kept.trace.handedAt > 2, 'and the trace shows the 2.5 s it was held');
+{
+  const sync = createCueSync();
+  const ev2 = (id, t) => ({ id, kind: 'word', t, label: 'w' });
+  sync.defer(ev2('a', 10), { toast: { text: 'a' } }, 8);
+  sync.defer(ev2('b', 12), { toast: { text: 'b' } }, 9.5);
+  eq(sync.update(9.9, 0, 20).fire.length, 0, 'nothing fires before its second');
+  eq(sync.update(9.9, 0, 20).fire.length, 0, 'a paused clock (the same second again) drains nothing');
+  eq(sync.update(10.0, 0, 20).fire.length, 1, 'the second arrives, the cue goes');
+  eq(sync.pending, 1, 'the later one is still held');
+  sync.update(8, 0, 20);   // a seek back 2 s: the scheduler is about to hand b over again
+  eq(sync.pending, 0, 'a seek back drops what the scheduler will hand over again');
+  sync.defer(ev2('c', 20), { toast: { text: 'c' } }, 18);
+  const late = sync.update(20 + LATE_SEC + 0.5, 0, 20);
+  eq(late.fire.length, 0, 'a seek forward past LATE_SEC lets a held cue go unspent');
+  eq(sync.dropped, 1, 'and counts it');
+  const d0 = sync.depthFor(5, 100, 20, 5.1);
+  eq(d0, 100 + 20 * CUE_AHEAD_SEC, 'a spawn never lands nearer than CUE_AHEAD_SEC of road');
+}
 
 console.log(fails ? '\nrows-check: ' + fails + ' failed' : '\nrows-check: all good');
 process.exit(fails ? 1 : 0);

--- a/ConditioningControlPanel/Resources/web/dtrh/race/smoke/sync-check.mjs
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/smoke/sync-check.mjs
@@ -1,0 +1,187 @@
+/* ============================================================================
+ * race/smoke/sync-check.mjs - the plate and the row land on the spoken word.
+ *
+ *   node race/smoke/sync-check.mjs     (from Resources/web/dtrh; 0 on pass, 1 with a count)
+ *   RACE_SYNC_DUR=90 RACE_SYNC_REPORT=1 ...   a longer demo, and the numbers only
+ *
+ * Headless Chrome at a PHONE viewport (390x844) drives the demo track (`?chart=demo`,
+ * the wall is the clock) for one whole run and measures, off the page itself:
+ *
+ *   plate    the track second a `.rc-plate` node reached the DOM, by a MutationObserver
+ *   taken    the track second `trackStats().taken` went up, polled every frame, which
+ *            is the pop of the row's own bubble: the row was under the kart's nose
+ *   trace    `race.syncTrace()`, the standalone-only log race/sync.js keeps: when each
+ *            event was handed over by the scheduler, when its visible half fired,
+ *            when its row went down and when the kart reached it
+ *
+ * against `event.t` off the chart. The owner heard the effect ~2 s before the
+ * word; the scheduler's lookahead is 2.5 s. This is where that number is held down:
+ * the plate inside PLATE_TOL of the word, the row under the kart inside ROW_TOL,
+ * through a build (the boost ramps the speed mid-lookahead) and a drop (a jump).
+ *
+ * Nothing leaves this machine: the web folder is served off localhost and the demo
+ * road has no audio at all. It never prints a line of a transcript.
+ *
+ * CHROME: `CHROME_PATH` if it is set, else the usual Windows install.
+ * ==========================================================================*/
+
+import { spawn } from 'node:child_process';
+import { createServer } from 'node:http';
+import { readFile } from 'node:fs/promises';
+import { mkdtempSync, rmSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, extname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { demoChart } from '../chart.js';
+
+let fails = 0;
+const REPORT = process.env.RACE_SYNC_REPORT === '1';   // the numbers only: nothing fails (the "before" run)
+const ok = (cond, what) => { if (!cond && !REPORT) { console.error('FAIL ' + what); fails++; } else console.log((cond ? '  ok  ' : '  --  ') + what); };
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const f2 = (v) => (v == null ? '-' : (v >= 0 ? '+' : '') + v.toFixed(2));
+
+const HERE = resolve(fileURLToPath(import.meta.url), '..');
+const WEB = resolve(HERE, '../../..');                     // Resources/web
+const CHROME = process.env.CHROME_PATH || 'C:/Program Files/Google/Chrome/Application/chrome.exe';
+const PORT = 8871;
+const DUR = Math.max(40, Number(process.env.RACE_SYNC_DUR) || 60);
+/** The plate may be one frame late (it is fired from the frame loop) and never early. */
+const PLATE_TOL = 0.15;
+/** The row: the brief's own number. The pop box reads 1.4 m ahead, 0.06 s at base speed. */
+const ROW_TOL = 0.15;
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.mjs': 'text/javascript', '.css': 'text/css', '.json': 'application/json', '.glb': 'model/gltf-binary', '.png': 'image/png', '.webp': 'image/webp', '.jpg': 'image/jpeg', '.mp3': 'audio/mpeg', '.wav': 'audio/wav', '.svg': 'image/svg+xml', '.woff2': 'font/woff2' };
+
+const chart = demoChart({ durationSec: DUR });
+const triggers = chart.events.filter((e) => e.kind === 'trigger' && e.conf >= 0.55);
+const builds = chart.events.filter((e) => e.kind === 'build');
+console.log(`the demo: ${DUR}s, ${chart.events.length} events, ${triggers.length} sure triggers at ${triggers.map((e) => e.t.toFixed(1)).join(', ')}s, a build at ${builds.map((e) => e.t.toFixed(1)).join(', ')}s`);
+
+if (!existsSync(CHROME)) { console.error('FAIL no chrome at ' + CHROME + ' (set CHROME_PATH)'); process.exit(1); }
+const server = createServer(async (req, res) => {
+  const path = decodeURIComponent(new URL(req.url, 'http://x').pathname);
+  if (path.indexOf('..') >= 0) { res.writeHead(400); return res.end(); }
+  try {
+    const body = await readFile(join(WEB, path));
+    res.writeHead(200, { 'content-type': MIME[extname(path).toLowerCase()] || 'application/octet-stream' });
+    res.end(req.method === 'HEAD' ? undefined : body);
+  } catch (e) { res.writeHead(404, { 'content-type': 'text/plain' }); res.end('no'); }
+});
+await new Promise((r) => server.listen(PORT, '127.0.0.1', r));
+
+const prof = mkdtempSync(join(tmpdir(), 'race-sync-'));
+const chrome = spawn(CHROME, [
+  '--headless=new', '--remote-debugging-port=9341', `--user-data-dir=${prof}`,
+  '--no-first-run', '--no-default-browser-check', '--disable-gpu', '--mute-audio',
+  '--enable-unsafe-swiftshader', '--autoplay-policy=no-user-gesture-required',
+  '--window-size=390,844', 'about:blank',
+], { stdio: 'ignore' });
+
+let page = null;
+for (let i = 0; i < 60 && !page; i++) {
+  await sleep(250);
+  try { page = (await (await fetch('http://127.0.0.1:9341/json/list')).json()).find((t) => t.type === 'page'); } catch (e) { /* not up */ }
+}
+if (!page) { console.error('FAIL chrome never answered on the debug port'); await done(1); }
+
+const ws = new WebSocket(page.webSocketDebuggerUrl);
+await new Promise((r) => { ws.onopen = r; });
+let msgId = 0;
+const waits = new Map(), errs = [], logs = [];
+ws.onmessage = (e) => {
+  const m = JSON.parse(e.data);
+  if (m.id && waits.has(m.id)) { waits.get(m.id)(m); waits.delete(m.id); }
+  if (m.method === 'Runtime.exceptionThrown') errs.push('thrown: ' + (m.params.exceptionDetails?.exception?.description || m.params.exceptionDetails?.text || '?'));
+  if (m.method === 'Runtime.consoleAPICalled') {
+    const line = m.params.args.map((a) => a.value ?? a.description ?? '?').join(' ');
+    logs.push(line);
+    if (m.params.type === 'error') errs.push(line);
+  }
+};
+const cdp = (method, params) => new Promise((res) => { const i = ++msgId; waits.set(i, res); ws.send(JSON.stringify({ id: i, method, params })); });
+const ev = async (x) => (await cdp('Runtime.evaluate', { expression: x, returnByValue: true, awaitPromise: true })).result?.result?.value;
+const json = async (x) => JSON.parse(await ev(`JSON.stringify(${x})`));
+await cdp('Runtime.enable'); await cdp('Page.enable');
+await cdp('Emulation.setDeviceMetricsOverride', { width: 390, height: 844, deviceScaleFactor: 2, mobile: true });
+
+/* ============================================================================
+ * 1. the run rolls, with the probe on it
+ * ==========================================================================*/
+const site = `http://127.0.0.1:${PORT}`;
+await cdp('Page.navigate', { url: `${site}/dtrh/race.html?autostart=1&intro=0&cards=0&chart=demo&dur=${DUR}` });
+let up = false;
+for (let i = 0; i < 120 && !up; i++) {
+  await sleep(250);
+  up = await ev(`!!(window.__race && window.__race.race && window.__race.race.track && document.querySelector('.rc-layer'))`);
+}
+ok(up, 'the page boots the demo road at 390x844');
+if (!up) { if (errs.length) console.error('    said: ' + errs.slice(0, 6).join(' | ')); await done(1); }
+
+// THE PROBE. Two things the page cannot lie about: the frame a plate node entered the DOM and
+// the frame the scheduler's `taken` count went up (one credit per event, so one line per row).
+await ev(`(()=>{
+  const race = window.__race.race;
+  const S = window.__sync = { plates: [], taken: [] };
+  new MutationObserver((muts) => { for (const m of muts) for (const n of m.addedNodes) {
+    if (n && n.classList && n.classList.contains('rc-plate')) S.plates.push({ t: race.track.t, word: n.textContent.trim() });
+  } }).observe(document.body, { childList: true, subtree: true });
+  let last = race.trackStats().taken;
+  (function poll() { const s = race.trackStats(); if (s.taken > last) { last = s.taken; S.taken.push({ t: race.track.t, n: s.taken }); } requestAnimationFrame(poll); })();
+  return 1;
+})()`);
+
+let t = 0, ended = false;
+for (let i = 0; i < (DUR + 30) * 4 && !ended; i++) {
+  await sleep(250);
+  const st = await json(`(()=>{ const tr = window.__race.race.track; return { t: tr ? tr.t : -1, ended: !tr || tr.t >= ${DUR} - 0.3 }; })()`);
+  t = st.t; ended = st.ended;
+}
+ok(ended, `the run drove the whole demo (clock at ${t.toFixed(1)}s of ${DUR}s)`);
+
+/* ============================================================================
+ * 2. the numbers
+ * ==========================================================================*/
+const probe = await json('window.__sync');
+const trace = await json(`(window.__race.race.syncTrace ? window.__race.race.syncTrace() : [])`);
+const byId = new Map(trace.map((r) => [r.id, r]));
+console.log(`  --  ${probe.plates.length} plates seen, ${probe.taken.length} events taken, ${trace.length} trace lines`);
+
+const nearest = (list, t0, win) => { let best = null; for (const x of list) { const d = x.t - t0; if (Math.abs(d) <= win && (!best || Math.abs(d) < Math.abs(best.t - t0))) best = x; } return best; };
+console.log('  event         t      plate    row(pop)  handed   fired    rowAt');
+const plateDs = [], rowDs = [], handDs = [];
+for (const e of triggers) {
+  const p = nearest(probe.plates.filter((x) => x.word === e.label), e.t, 3.5);
+  const k = nearest(probe.taken, e.t, 3.5);
+  const tr = byId.get(e.id) || {};
+  const pd = p ? p.t - e.t : null, kd = k ? k.t - e.t : null;
+  if (pd != null) plateDs.push(pd);
+  if (kd != null) rowDs.push(kd);
+  if (tr.handedAt != null) handDs.push(tr.handedAt - e.t);
+  console.log(`  ${e.label.padEnd(12)} ${e.t.toFixed(2).padStart(6)}  ${f2(pd).padStart(7)}  ${f2(kd).padStart(8)}  ${f2(tr.handedAt == null ? null : tr.handedAt - e.t).padStart(7)}  ${f2(tr.firedAt == null ? null : tr.firedAt - e.t).padStart(7)}  ${f2(tr.rowAt == null ? null : tr.rowAt - e.t).padStart(7)}`);
+}
+const stat = (a) => (a.length ? `median ${f2(a.slice().sort((x, y) => x - y)[a.length >> 1])} worst ${f2(a.reduce((m, v) => (Math.abs(v) > Math.abs(m) ? v : m), 0))}` : 'none');
+console.log(`  --  plate - t: ${stat(plateDs)};  row pop - t: ${stat(rowDs)};  handover - t: ${stat(handDs)}`);
+
+ok(plateDs.length === triggers.length, `every sure trigger flew a plate (${plateDs.length} of ${triggers.length})`);
+ok(plateDs.every((d) => d >= -0.02 && d <= PLATE_TOL), `every plate reached the DOM ON its word, never early, at most a frame late (within ${PLATE_TOL}s)`);
+ok(rowDs.length === triggers.length, `every row was met by the kart (${rowDs.length} of ${triggers.length})`);
+ok(rowDs.every((d) => Math.abs(d) <= ROW_TOL), `every row was under the kart within ${ROW_TOL}s of its word, through the build's boost`);
+ok(trace.length > 0, 'the standalone sync trace is on (race.syncTrace)');
+ok(trace.filter((r) => r.kind === 'trigger').every((r) => r.firedAt != null && !r.dropped), 'and no trigger was dropped on the way');
+
+/* ============================================================================
+ * 3. nothing went wrong out loud
+ * ==========================================================================*/
+ok(errs.length === 0, 'not one console error in the whole run' + (errs.length ? ':\n    ' + errs.slice(0, 5).join('\n    ') : ''));
+
+await done(fails ? 1 : 0);
+
+async function done(code) {
+  try { ws && ws.close(); } catch (e) { /* never opened */ }
+  try { chrome.kill(); } catch (e) { /* already gone */ }
+  await new Promise((r) => server.close(r));
+  await sleep(300);
+  try { rmSync(prof, { recursive: true, force: true }); } catch (e) { /* chrome still has a lock */ }
+  if (code) console.error(`\n${fails} failure${fails === 1 ? '' : 's'}`);
+  else console.log('\nsync-check: all good');
+  process.exit(code);
+}

--- a/ConditioningControlPanel/Resources/web/dtrh/race/sync.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/sync.js
@@ -1,0 +1,143 @@
+/* ============================================================================
+ * race/sync.js - the visible half of a cue waits for the word.
+ *
+ *   createCueSync({ aheadSec, lateSec, trace }) -> { depthFor, defer, trackRow, update, reset, trace }
+ *
+ * WHY THIS EXISTS. The scheduler (race/chart.js createScheduler) hands an event
+ * over LEAD_SEC (2.5 s) before its second, on purpose: a bubble has to be placed
+ * down the road early enough that the kart reaches it exactly when the voice says
+ * the word. run.js used to spend the WHOLE cue at that handover, spawns and all,
+ * so the plate flew, the toast landed, EMI reached, the fog rolled in and the mix
+ * poured two and a half seconds before the word was said. That is the "too soon
+ * by 2 sec or so" the owner heard on the phone, measured at 2.3 to 2.5 s early in
+ * race/smoke/sync-check.mjs.
+ *
+ * So a cue is now two halves. The SPAWNS still go down at handover, at the depth
+ * the kart will have reached by the word. Everything the player sees or hears
+ * (plate, toast, mood, pose, jump, mix, fog, boost, density, hold) is held here
+ * and fired from the frame loop when the track clock reaches `event.t`. Nothing
+ * here reads a clock of its own: `update(t)` is handed the track second, so a
+ * pause drains nothing (the second stops), a resume needs no telling, and a seek
+ * rebuilds the queue (a jump back drops what the scheduler is about to hand over
+ * again; a jump forward drops what the voice already said past LATE_SEC).
+ *
+ * THE ROW. A row is placed at `d = kartD + speed * dueIn`, which assumes the kart
+ * holds its speed for the whole lookahead. It does not: a boost, a slow, the
+ * opening ramp all move the arrival. So a row is tracked here until the kart is
+ * on it and re-placed every frame off the CURRENT speed and the time still to go,
+ * until only AHEAD_SEC is left; over that last quarter second the kart cannot
+ * change speed enough to matter (under 0.05 s at the hardest boost). The row is
+ * under the kart's nose when the word lands, whatever the throttle did.
+ *
+ * Pure: no three, no DOM, no clock, so `node race/smoke/rows-check.mjs` drives it
+ * with a simulated kart whose speed ramps mid-lookahead.
+ * ==========================================================================*/
+
+/** A spawn never lands nearer than this many seconds of road ahead of the kart (run.js's own floor). */
+export const CUE_AHEAD_SEC = 0.25;
+/** A held cue found this far past its second is let go, not fired: the voice already said it. One
+ *  slow frame (track.js MAX_STEP_SEC) is inside this; a seek forward is not. */
+export const LATE_SEC = 1.0;
+/** A clock that jumps back further than this is a seek (chart.js SEEK_SEC, the same number). */
+export const SEEK_SEC = 1.0;
+/** The standalone trace keeps this many events; the smokes read it, the game never does. */
+export const TRACE_MAX = 64;
+
+const num = (v, d) => (typeof v === 'number' && isFinite(v) ? v : d);
+
+export function createCueSync({ aheadSec = CUE_AHEAD_SEC, lateSec = LATE_SEC, trace = false } = {}) {
+  const ahead = Math.max(0, num(aheadSec, CUE_AHEAD_SEC));
+  const late = Math.max(0, num(lateSec, LATE_SEC));
+  let queue = [];         // { at, event, cue }: the visible half, waiting for the second
+  let rows = [];          // { rowId, at, d }: a row being kept under its word
+  let lastT = 0, dropped = 0;
+  const log = trace ? new Map() : null;
+
+  /** One trace line per event id, capped; `firedAt` is the frame the visible half went out on. */
+  function rec(event, patch) {
+    if (!log || !event) return;
+    const id = String(event.id);
+    let row = log.get(id);
+    if (!row) {
+      if (log.size >= TRACE_MAX) log.delete(log.keys().next().value);
+      row = { id, kind: event.kind, t: event.t, handedAt: null, firedAt: null, dropped: false, rowPlacedAt: null, rowAt: null };
+      log.set(id, row);
+    }
+    Object.assign(row, patch);
+  }
+
+  /** The depth a spawn due at track second `at` belongs at, seen from the kart right now. */
+  function depthFor(t, kartD, speed, at) {
+    return num(kartD, 0) + Math.max(0, num(speed, 0)) * Math.max(num(at, t) - t, ahead);
+  }
+
+  return {
+    depthFor,
+
+    /** Hold the visible half of a cue until the clock reaches the event's second. `t` is now. */
+    defer(event, cue, t) {
+      if (!event || !cue) return;
+      const at = num(event.t, 0);
+      queue.push({ at, event, cue });
+      rec(event, { handedAt: num(t, null) });
+    },
+
+    /** A row went down at depth `d` for the word at `at`: keep it under the word until the kart is on it. */
+    trackRow(rowId, event, at, d, t) {
+      if (!rowId || !event) return;
+      rows.push({ rowId, event, at: num(at, num(event.t, 0)), d: num(d, 0) });
+      rec(event, { rowPlacedAt: num(t, null) });
+    },
+
+    /**
+     * One frame. `t` is the track second, `kartD` the kart's depth, `speed` metres a second.
+     * Returns everything to do this frame: `fire` in the order it was held, `move` per row.
+     */
+    update(t, kartD, speed) {
+      const now = num(t, 0);
+      if (now < lastT - SEEK_SEC) {           // a seek back: the scheduler re-hands the future, so let it go here
+        queue = queue.filter((q) => q.at <= now);
+        rows = rows.filter((r) => r.at <= now);
+      }
+      lastT = now;
+      const fire = [], move = [];
+      if (queue.length) {
+        const keep = [];
+        for (const q of queue) {
+          if (now < q.at) { keep.push(q); continue; }
+          if (now - q.at > late) { dropped++; rec(q.event, { dropped: true }); continue; }   // the voice already said it
+          fire.push({ event: q.event, cue: q.cue, late: now - q.at });
+          rec(q.event, { firedAt: now });
+        }
+        queue = keep;
+      }
+      if (rows.length) {
+        const keep = [];
+        for (const r of rows) {
+          const rem = r.at - now;
+          if (rem > ahead) {                    // still in the lookahead: re-place off the speed the kart has NOW
+            const d = depthFor(now, kartD, speed, r.at);
+            if (Math.abs(d - r.d) > 1e-3) { r.d = d; move.push({ rowId: r.rowId, d }); }
+            keep.push(r);
+          } else if (num(kartD, 0) >= r.d - 1e-6) {   // the kart is on it
+            rec(r.event, { rowAt: now });
+          } else if (rem < -late) {              // never met (a lap wrap, a seek): stop watching it
+            /* let it go */
+          } else keep.push(r);
+        }
+        rows = keep;
+      }
+      return { fire, move };
+    },
+
+    /** A new run: nothing held over from the last one. */
+    reset() { queue = []; rows = []; lastT = 0; dropped = 0; if (log) log.clear(); },
+    /** The standalone trace, oldest first. Empty unless the sync was built with `trace: true`. */
+    trace() { return log ? [...log.values()].map((r) => ({ ...r })) : []; },
+    get pending() { return queue.length; },
+    get tracked() { return rows.length; },
+    get dropped() { return dropped; },
+  };
+}
+
+// self-check: node race/smoke/rows-check.mjs section 6 drives a row through this under a speed ramp.


### PR DESCRIPTION
## Racing Thoughts polish, Task S1: the plate and the row land on the word

The owner heard the trigger plate land "too soon by 2 sec or so" on the phone. This PR measures it first, then fixes it.

### Diagnosis (measured, not guessed)

| suspect | verdict | numbers |
|---|---|---|
| (a) run.js spent the whole cue at the scheduler handover (`LEAD_SEC` 2.5 s early) | **confirmed, the cause** | demo (headless 390x844): plate 2.49 / 2.50 / 2.50 s early on the 3 sure triggers. Real voice (Rapid Induction, isolated trigger at 105.72 s, local copy through the stub): plate 2.49 s early |
| (b) words-file timings vs the cloud audio | cleared | 144 confident words of Rapid Induction against an onset detector on the decoded waveform: onset minus t median -0.24 s, p10 -0.46, p90 +0.08; the trigger phrases themselves -0.6 to +0.4 s. Nothing near 2 s |
| (c) iOS HTMLAudio latency | not measurable headless; literature says under 0.3 s | it cannot explain 2.5 s |

The row was already close at constant speed (0.04 s early) but slid 0.52 to 0.75 s early during the demo's boost, because it was placed once off the speed the kart had at handover.

### The fix

- `race/sync.js` (new, pure): a cue is two halves. The spawns still go down at handover; the visible half (plate, toast, mood, pose, jump, mix, fog, boost, density, hold) is held and fired from `trackFrame` the frame the track clock reaches `event.t`. No clock of its own: a pause drains nothing, a seek back drops what the scheduler re-hands, a seek forward past `LATE_SEC` (1 s) lets the held cue go.
- The row is re-placed every frame off the kart's current speed (`bubbles.js moveRow`, `spawnRow` now returns the row id) until `CUE_AHEAD_SEC` is left, so a boost or ramp inside the lookahead still lands it under the kart on the word.
- A fog/density hold is now a stretch of track seconds, not a count of frames: seeking past the 20 s opening silence used to carry density 0 and the fog along for the seconds it had left (found because it hid every row in the real-voice smoke).
- `race.syncTrace()` exposes the per-event trace (handedAt, firedAt, rowPlacedAt, rowAt, dropped) for the smokes.

### After

| run | plate minus event.t | row under the kart minus event.t |
|---|---|---|
| demo, 3 triggers, through the build's boost | +0.00 / +0.02 / +0.00 | -0.05 / -0.04 / -0.02 |
| real voice, local copy, 9 triggers in 12 s | +0.01 to +0.05 | -0.02 to +0.07 |
| real voice, the cdn file (one download) | +0.00 to +0.07 | +0.01 to +0.07 |

### Verified

- `node race/smoke/sync-check.mjs` (new; headless demo 390x844, plate within [-0.02, 0.15] s and row within 0.15 s of event.t, trace on, no drops, 0 console errors): all good
- `node race/smoke/rows-check.mjs` section 6 (new; pure sync.js under a 22 to 34 m/s boost, an 8 to 28 ramp, a 26 to 12 slow; the un-nudged row lands 0.52 s early, the nudged one within 0.017 s; deferred fire, pause, seek back, seek forward): all good
- `RACE_TRACK_FILE=<local copy> node race/smoke/real-audio-check.mjs` (new env + section 3c): all good, table above
- `RACE_REAL_URL=https://cdn.bambicloud.com/<id>.mp3 node race/smoke/real-audio-check.mjs`: all good (one HEAD, one ranged GET, one download, public file, read-only guest)
- every `race/smoke/*.mjs` (18) and `chart/smoke/*.mjs` (3): all green, run one browser at a time

### Notes for the wave

- run.js: this PR touches only `applyCue` / new `spendCue`, `trackFrame`'s due loop, the hold in `resetRunState` / `setTrack` and the return object. Task P's speed-ramp hunk in run.js should stay clear of those.
- The loose (unsure) treat keeps its constant-speed placement on purpose: it is a guess at a half-heard word, not a pop on a beat.
- 528 insertions / 25 deletions, of which 187 are the new smoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJ66hi5fRM1Dcjo38aSCa2
