### PR TITLE
feat(race): captions to the top of the glass, the zoom plate off the toasts, the toasts down to chatter

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/race/captions.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/captions.js
@@ -47,6 +47,21 @@ export const END_PUNCT = /[.?!]["')\]]?$/;
 /** The plate: the zoom, the hold, and the fade, in milliseconds (race.css runs the same numbers). */
 export const PLATE_MS = 1400;
 
+/** Two lines and no more. A third is shrunk into the two, never cut off the glass. */
+export const MAX_LINES = 2;
+/** The band sits this far under the chrome above it (the score plate, the sound / pause buttons). */
+export const CAP_GAP = 8;
+/** And the plate keeps this much air off the band above it and the toast rail below it. */
+export const PLATE_GAP = 8;
+/** The plate's peak scale: race.css rcZoom holds it here. */
+export const PLATE_PEAK = 1.35;
+/** What the roomiest theme's box costs over its own font size (the ink card's padding). */
+const PLATE_ROOM = PLATE_PEAK * 1.08;
+/** The steps the caption may take down to fit a phrase that wanted a third line into two. */
+const FIT_STEPS = [1, 0.89, 0.78, 0.67, 0.58];
+/** The plate never shrinks past this, whatever the air says: below it there is no point. */
+const PLATE_MIN_PX = 26;
+
 const num = (v, d = 0) => (Number.isFinite(Number(v)) ? Number(v) : d);
 
 /**
@@ -131,6 +146,16 @@ function phraseAt(phrases, t) {
 /**
  * The layer. `root` is the `.race-hud` div; this sits above `.rh-chrome` so a caption is never
  * under the score plate, and it is click-through like the rest of the chrome.
+ *
+ * NOTHING BELOW GUESSES AT A BOX. The owner's phone cut the caption's second line in half and
+ * dropped the zoom plate straight onto a jackpot toast, and both were the same mistake: three
+ * layers guessing at each other's heights in CSS, on a phone that quietly inflates small text so
+ * that an `em` height holds fewer lines than it reads. So the layer measures the chrome it has to
+ * live between, and publishes what it found for the stylesheet to place things by:
+ *   --rc-cap-t     the top of the caption band, under the score plate and the top buttons
+ *   --rc-plate-y   the plate's resting centre, in the air between that band and the toast rail
+ *   --rc-plate-fs  how big the plate may be and still fit that air, whatever its theme adds
+ * and `--rc-cap-b` on the hud root, which is where hud.js parks the act ribbon out of the way.
  */
 export function createCaptions(root) {
   const doc = root && root.ownerDocument;
@@ -142,7 +167,7 @@ export function createCaptions(root) {
   const dim = el('rc-dim', layer);                 // the ink theme's 300 ms screen dip
   const plateWrap = el('rc-plates', layer);
   const cap = el('rc-cap', layer);
-  const line = el('rc-line', cap);
+  const line = el('rc-cap-line', cap);
   cap.hidden = true;
 
   let phrases = [];
@@ -150,6 +175,79 @@ export function createCaptions(root) {
   let inked = -1;              // how many of its words have been inked
   let spans = [];              // the word elements of the phrase in the DOM
   let plate = null, plateTimer = 0, dimTimer = 0;
+
+  // ---- the measured layout: see the header of this function ----
+  const win = doc.defaultView || (typeof window === 'object' ? window : null);
+  let capT = -1, plateY = -1, plateFs = -1, bandBot = 0;
+
+  /** The lowest edge of the chrome the band has to clear: the score plate, and the top buttons. */
+  function chromeBottom() {
+    let y = 0;
+    for (const sel of ['.rh-score-wrap', '.rt-mute', '.rt-pause']) {
+      const n = root.querySelector(sel);
+      if (!n) continue;
+      const r = n.getBoundingClientRect();
+      if (r.height > 0) y = Math.max(y, r.bottom);
+    }
+    return y;
+  }
+
+  /**
+   * How many lines the phrase is actually drawing, counted off the word boxes themselves: one
+   * distinct top per line, whatever the font or the phone's own idea of small text. (A Range's
+   * rects are not the answer: the spaces between the words draw their own shorter boxes at their
+   * own tops, so a two line phrase counts as four.)
+   */
+  function lineCount() {
+    const tops = new Set();
+    for (const s of spans) {
+      const b = s.getBoundingClientRect ? s.getBoundingClientRect() : null;
+      if (b && b.height > 0) tops.add(Math.round(b.top));
+    }
+    return tops.size || 1;          // a stub DOM with no layout: the CSS size stands
+  }
+
+  /**
+   * Two lines and no more, and never half of one. A phrase that wants a third line steps its own
+   * size down until it does not, and the steps are judged off the RENDERED line boxes rather than
+   * off the font size, because a phone inflates small text and an `em` height does not know it.
+   */
+  function fit() {
+    for (let i = 0; i < FIT_STEPS.length; i++) {
+      line.style.setProperty('--rc-fs', String(FIT_STEPS[i]));
+      if (lineCount() <= MAX_LINES) return FIT_STEPS[i];
+    }
+    return FIT_STEPS[FIT_STEPS.length - 1];
+  }
+
+  /** Where the band sits, where the plate rests, and how big the plate may be. Cheap, idempotent. */
+  function measure() {
+    const vw = (win && win.innerWidth) || 390, vh = (win && win.innerHeight) || 844;
+    const t = Math.round((chromeBottom() || vh * 0.02) + CAP_GAP);
+    if (t !== capT) { capT = t; layer.style.setProperty('--rc-cap-t', `${t}px`); }
+    // the band is always two lines tall whether or not a phrase is up, so the plate under it
+    // never hops about between a spoken line and a silence
+    let lh = 0;
+    try { lh = parseFloat(win ? win.getComputedStyle(line).lineHeight : '') || 0; } catch (e) { lh = 0; }
+    if (lh <= 0) lh = 23;
+    if (spans.length) {                       // never smaller than what the phrase really drew
+      const n = lineCount(), box = line.getBoundingClientRect();
+      if (n > 0 && box.height > 0) lh = Math.max(lh, box.height / n);
+    }
+    bandBot = t + Math.round(lh * MAX_LINES);
+    root.style.setProperty('--rc-cap-b', `${bandBot}px`);
+    const rail = root.querySelector('.rh-toasts');
+    const railTop = rail ? rail.getBoundingClientRect().top : vh * 0.34;
+    const a0 = bandBot + PLATE_GAP, a1 = Math.max(a0 + 32, railTop - PLATE_GAP);
+    const y = Math.round((a0 + a1) / 2);
+    if (y !== plateY) { plateY = y; layer.style.setProperty('--rc-plate-y', `${y}px`); }
+    const f = Math.round(Math.max(PLATE_MIN_PX, Math.min(vw * (vw >= 700 ? 0.07 : 0.12), (a1 - a0) / PLATE_ROOM)));
+    if (f !== plateFs) { plateFs = f; layer.style.setProperty('--rc-plate-fs', `${f}px`); }
+  }
+
+  const onResize = () => { capT = -1; plateY = -1; plateFs = -1; measure(); };
+  if (win && win.addEventListener) win.addEventListener('resize', onResize, { passive: true });
+  measure();
 
   function clearPhrase() {
     line.textContent = '';
@@ -164,7 +262,7 @@ export function createCaptions(root) {
     if (!p) return;
     for (const w of p.words) {
       const s = doc.createElement('span');
-      s.className = 'rc-word';
+      s.className = 'rc-cap-word';
       s.textContent = w.w;
       if (w.color) s.style.setProperty('--rc-ink', w.color);
       line.appendChild(s);
@@ -173,6 +271,8 @@ export function createCaptions(root) {
     }
     shown = i; inked = 0;
     cap.hidden = false;
+    fit();          // two lines, measured off what the phrase actually drew
+    measure();      // and the plate under it goes wherever that left room
   }
 
   /**
@@ -211,6 +311,7 @@ export function createCaptions(root) {
     const row = themeFor(event);
     const text = (event && typeof event.label === 'string' ? event.label : '').trim();
     if (!row || !text) return null;
+    measure();      // it lands in the air the band and the toast rail left, never on either
     if (plateTimer) { clearTimeout(plateTimer); plateTimer = 0; }
     if (plate) plate.remove();
     plate = doc.createElement('div');
@@ -242,6 +343,10 @@ export function createCaptions(root) {
     setTrack(chart) {
       phrases = chart ? paintTriggers(buildPhrases(chart.words), chart.events) : [];
       clearPhrase();
+      // hud.js reads this: with words on the glass the act ribbon's old spot under the score
+      // plate belongs to the caption band, so the ribbon takes the clear air lower down instead
+      root.classList.toggle('has-rc-cap', phrases.length > 0);
+      measure();
       return phrases.length;
     },
     update,
@@ -254,9 +359,17 @@ export function createCaptions(root) {
       if (dimTimer) { clearTimeout(dimTimer); dimTimer = 0; }
       dim.classList.remove('is-on');
     },
-    dispose() { this.clear(); phrases = []; layer.remove(); },
+    dispose() {
+      this.clear(); phrases = []; layer.remove();
+      root.classList.remove('has-rc-cap');
+      if (win && win.removeEventListener) win.removeEventListener('resize', onResize);
+    },
+    /** Re-read the chrome: the run calls nothing, the layer does it itself on a resize and a draw. */
+    measure,
     get phraseCount() { return phrases.length; },
     get phrases() { return phrases; },
+    /** What the last measure() found, so a check can hold the boxes against it. */
+    get band() { return { top: capT, bottom: bandBot, plateY, plateFs }; },
   };
 }
 

--- a/ConditioningControlPanel/Resources/web/dtrh/race/hud.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/hud.js
@@ -39,13 +39,25 @@ import { wantsTouch } from './touch.js';
 const TOUCH = wantsTouch();
 
 const FLICK_MS = 450;
-const TOAST_HOLD = { pop: 1100, almost: 1300, jackpot: 1800, bank: 1600, item: 1400, effect: 1400, recipe: 1700 };
+/**
+ * How long each kind of toast stays up, in milliseconds. CHATTER, NOT HEADLINES: the owner, on
+ * the phone build, "the items notification and the jackpot as well as the streak ones are noisy,
+ * make them last less and be kinda faded so they dont clash". Every hold is 60 percent of the one
+ * it replaced, and the two chatter kinds (a pop, an almost) are capped at CHATTER_MAX_MS however
+ * loud the run gets, because those are the ones that arrive ten to the second. race.css takes the
+ * rail down to 0.85 of its size at 70 percent to finish the job. The score plate keeps the number
+ * honestly (Law I); a toast is only the noise it makes on the way there.
+ */
+const CHATTER_MAX_MS = 700;
+const TOAST_HOLD = { pop: 660, almost: CHATTER_MAX_MS, jackpot: 1080, bank: 960, item: 840, effect: 840, recipe: 1020 };
 /** Two "+N" pops inside this window merge into one counting toast ("+30 x3"). */
 const POP_MERGE_MS = 600;
 /** Two "almost +N" inside this window merge the same way ("almost +50 x2"). */
 const ALMOST_MERGE_MS = 900;
 /** Chatter kinds (pop, almost) may not open a NEW toast more often than this. */
 const CHATTER_GAP_MS = 180;
+/** Where the act ribbon parks when a caption band owns the air under the score plate. */
+const BANNER_LOW = 0.58;
 
 /** The second-pass rung ladder. consts.js MULT_LADDER is the source of truth;
  * this is the documented fallback for when the import is missing or malformed. */
@@ -358,10 +370,17 @@ export function createRaceHud(root) {
       bannerTag.textContent = (tagline || '').toLowerCase();
       banner.classList.remove('is-on');
       // sit the ribbon under the MEASURED score block, so it never rides up
-      // into the bank line on a short window or down into the media lane
+      // into the bank line on a short window or down into the media lane.
+      // WITH WORDS ON THE GLASS that spot is the caption band's (race/captions.js sets the class
+      // and --rc-cap-b on this root), so the ribbon takes the clear air below the toast rail
+      // instead: an act name and a spoken line never sit on top of each other.
       try {
-        const b = scoreWrap.getBoundingClientRect();
-        if (b && b.bottom > 0) banner.style.top = `${Math.round(b.bottom + 12)}px`;
+        const vh = typeof window === 'object' ? (window.innerHeight || 0) : 0;
+        if (root.classList.contains('has-rc-cap') && vh > 0) banner.style.top = `${Math.round(vh * BANNER_LOW)}px`;
+        else {
+          const b = scoreWrap.getBoundingClientRect();
+          if (b && b.bottom > 0) banner.style.top = `${Math.round(b.bottom + 12)}px`;
+        }
       } catch (e) { /* no layout yet: the CSS fallback top stands */ }
       later(() => banner.classList.add('is-on'), 40);
       later(() => banner.classList.remove('is-on'), 2600);

--- a/ConditioningControlPanel/Resources/web/dtrh/race/race.css
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/race.css
@@ -222,27 +222,38 @@
 .race-hud .rh-speed.is-boost .rh-speed-fill { background: linear-gradient(90deg, #d8fbff, #7fe7f0 55%, #fff); box-shadow: 0 0 14px rgba(127, 231, 240, 0.95); }
 .race-hud .rh-speed.is-boost .rh-speed-tag { opacity: 1; animation: rhBoostTag 0.42s steps(2) infinite; }
 
-/* ---- toasts: one word at a time, mid-screen, each kind with its own motion ---- */
+/* ---- toasts: one word at a time, mid-screen, each kind with its own motion ----
+   CHATTER, NOT HEADLINES. The owner, on the phone build: "the items notification and the jackpot
+   as well as the streak ones are noisy, make them last less and be kinda faded so they dont
+   clash". So the whole rail is 0.85 of the size it was, at 70 percent, every hold is 40 percent
+   shorter (hud.js TOAST_HOLD) and the glows are roughly half. It reads under the caption band
+   now instead of over it. The score plate, the combo and the speed plate are untouched: those
+   are the honest numbers (Law I) and they stay loud. The rail's TOP does not move: the zoom
+   plate is what got out of its way (race/captions.js measures this rail to find its own air). */
 .race-hud .rh-toasts {
   position: absolute; top: 34%; left: 26vw; right: 26vw;
   display: flex; flex-direction: column; align-items: center; gap: 6px;
+  transform: scale(0.85); transform-origin: top center; opacity: 0.7;
 }
 .race-hud .rh-toast {
   font-weight: 900; letter-spacing: 0.1em; text-align: center; will-change: transform, opacity;
-  text-shadow: 0 0 18px rgba(255, 105, 180, 0.8), 0 2px 4px rgba(0, 0, 0, 0.85);
+  /* a toast grows DOWN out of its own top: the jackpot's reveal opens at 2.1 of its size, and
+     from the middle that would have swelled up into the air the zoom plate rests in */
+  transform-origin: top center;
+  text-shadow: 0 0 10px rgba(255, 105, 180, 0.45), 0 2px 4px rgba(0, 0, 0, 0.85);
   animation: rhToastPop var(--rh-hold, 1.2s) ease-out forwards;
 }
 .race-hud .rh-toast--pop { font-size: 1.1rem; color: #ffd6ea; }
 /* a merged run of pops ("+30 x3"): one toast, one spot, and it grows with the run */
-.race-hud .rh-toast--pop.is-run { font-size: 1.4rem; color: #fff0b8; text-shadow: 0 0 20px rgba(255, 212, 94, 0.9), 0 2px 4px rgba(0, 0, 0, 0.85); }
-.race-hud .rh-toast--almost { font-size: 1.5rem; color: #bfe9ff; animation: rhShiver 0.34s linear, rhToastPop 1.3s ease-out forwards; text-shadow: 0 0 18px rgba(150, 210, 255, 0.9), 0 2px 4px rgba(0, 0, 0, 0.85); }
+.race-hud .rh-toast--pop.is-run { font-size: 1.4rem; color: #fff0b8; text-shadow: 0 0 11px rgba(255, 212, 94, 0.5), 0 2px 4px rgba(0, 0, 0, 0.85); }
+.race-hud .rh-toast--almost { font-size: 1.5rem; color: #bfe9ff; animation: rhShiver 0.34s linear, rhToastPop 1.3s ease-out forwards; text-shadow: 0 0 10px rgba(150, 210, 255, 0.5), 0 2px 4px rgba(0, 0, 0, 0.85); }
 .race-hud .rh-toast--almost.is-run { font-size: 1.8rem; color: #e2f5ff; }
-.race-hud .rh-toast--jackpot { font-size: 2.4rem; color: #fff0b8; text-shadow: 0 0 26px rgba(242, 193, 78, 1), 0 2px 4px rgba(0, 0, 0, 0.85); animation: rhReveal 1.8s cubic-bezier(0.2, 1.4, 0.4, 1) forwards; }
-.race-hud .rh-toast--bank { font-size: 1.3rem; color: #ffe082; text-shadow: 0 0 18px rgba(255, 200, 60, 0.9), 0 2px 4px rgba(0, 0, 0, 0.85); animation: rhToastPop 1.6s ease-out forwards; }
+.race-hud .rh-toast--jackpot { font-size: 2.4rem; color: #fff0b8; text-shadow: 0 0 14px rgba(242, 193, 78, 0.55), 0 2px 4px rgba(0, 0, 0, 0.85); animation: rhReveal 1.8s cubic-bezier(0.2, 1.4, 0.4, 1) forwards; }
+.race-hud .rh-toast--bank { font-size: 1.3rem; color: #ffe082; text-shadow: 0 0 10px rgba(255, 200, 60, 0.5), 0 2px 4px rgba(0, 0, 0, 0.85); animation: rhToastPop 1.6s ease-out forwards; }
 .race-hud .rh-toast--item { font-size: 1.6rem; color: #ffd6ea; animation: rhBounce 0.36s cubic-bezier(0.2, 1.6, 0.4, 1), rhToastPop 1.4s ease-out forwards; }
-.race-hud .rh-toast--effect { font-size: 1.2rem; color: #e9c8ff; text-shadow: 0 0 18px rgba(180, 120, 255, 0.9), 0 2px 4px rgba(0, 0, 0, 0.85); animation: rhLean 1.4s ease-out forwards; }
+.race-hud .rh-toast--effect { font-size: 1.2rem; color: #e9c8ff; text-shadow: 0 0 10px rgba(180, 120, 255, 0.5), 0 2px 4px rgba(0, 0, 0, 0.85); animation: rhLean 1.4s ease-out forwards; }
 /* a served recipe: the name lands big and pink, a REVEAL like the jackpot but softer */
-.race-hud .rh-toast--recipe { font-size: 1.8rem; color: #ffb6d9; letter-spacing: 0.14em; text-shadow: 0 0 24px rgba(255, 61, 165, 0.95), 0 2px 4px rgba(0, 0, 0, 0.85); animation: rhReveal 1.7s cubic-bezier(0.2, 1.4, 0.4, 1) forwards; }
+.race-hud .rh-toast--recipe { font-size: 1.8rem; color: #ffb6d9; letter-spacing: 0.14em; text-shadow: 0 0 13px rgba(255, 61, 165, 0.55), 0 2px 4px rgba(0, 0, 0, 0.85); animation: rhReveal 1.7s cubic-bezier(0.2, 1.4, 0.4, 1) forwards; }
 .race-hud .rh-gold { position: absolute; inset: 0; background: radial-gradient(60% 60% at 50% 50%, rgba(255, 230, 140, 0.55), rgba(242, 193, 78, 0.18)); opacity: 0; }
 .race-hud .rh-gold.is-on { animation: rhGold 0.7s ease-out forwards; }
 .race-hud .rh-token {
@@ -537,50 +548,72 @@
 /* ============================================================================
  * THE VOICE ON THE GLASS (race/captions.js): the caption line and the zoom plate.
  *
- * One layer above .rh-chrome, click-through like the rest of it. The caption is a
- * lower third that clears the item slot, the mixer stack and the speed bar, so it
- * can never sit on a plate; the score plate is top-left and is never in reach of
- * it at any size. The plate flies out of the vanishing point in the middle of the
- * glass, one at a time, wearing the theme race/triggerTheme.js named for its
- * trigger's preset. THIRTEEN THEMES, one class each, listed in the table there.
+ * One layer above .rh-chrome, click-through like the rest of it.
+ *
+ * THE BAND IS AT THE TOP, AND IT IS MEASURED, NOT GUESSED. The owner's phone cut
+ * the caption's second line in half and dropped the zoom plate onto a jackpot
+ * toast. The cut was an `em` max-height on a phone that inflates small text: the
+ * box held 1.7 of its own rendered line boxes, so the second line lost its bottom
+ * half. Nothing here caps a height in `em` any more. captions.js measures the
+ * score plate, the top buttons and the toast rail and hands this file three
+ * numbers:
+ *   --rc-cap-t     the top of the caption band, clear of the chrome above it
+ *   --rc-plate-y   the plate's resting centre, in the air under that band
+ *   --rc-plate-fs  the plate's size, cut down only when that air is thin
+ * and it steps a long phrase's own size down until it draws in two lines, which
+ * is the only cap that cannot slice a letter in half. The plate flies out of the
+ * vanishing point into that air, one at a time, wearing the theme
+ * race/triggerTheme.js named for its trigger's preset. THIRTEEN THEMES, one class
+ * each, listed in the table there.
  * ==========================================================================*/
-.race-hud .rc-layer { position: fixed; inset: 0; z-index: 4; pointer-events: none; overflow: hidden; }
+.race-hud .rc-layer {
+  position: fixed; inset: 0; z-index: 4; pointer-events: none; overflow: hidden;
+  /* a phone that inflates the text inside a measured box makes the measuring a lie */
+  -webkit-text-size-adjust: 100%; text-size-adjust: 100%;
+}
 .race-hud .rc-layer * { pointer-events: none; }
 .race-hud.is-lobby .rc-layer { display: none; }
 
-/* ---- the caption: low, fleeting, one phrase, typed by the voice ---- */
+/* ---- the caption: top of the glass, fleeting, one phrase, typed by the voice ---- */
 .race-hud .rc-cap {
   position: absolute; left: var(--rh-in-l); right: var(--rh-in-r);
-  /* above the item slot (bottom), the mixer column (bottom + 72px) and the speed bar */
-  bottom: calc(var(--rh-in-b) + 148px);
+  /* under the score plate row; the value here is only the pre-measure fallback */
+  top: var(--rc-cap-t, calc(var(--rh-in-t) + 154px));
   display: flex; justify-content: center;
   opacity: var(--rc-out, 1); transition: opacity 0.18s linear;
 }
-.race-hud .rc-line {
+.race-hud .rc-cap-line {
   max-width: min(94%, 900px); text-align: center; text-wrap: balance;
-  font-size: clamp(1.05rem, 4.4vw, 1.55rem); font-weight: 800; line-height: 1.28; letter-spacing: 0.02em;
-  /* two lines at most: a third would climb into the road */
-  max-height: 2.6em; overflow: hidden;
+  /* --rc-fs is captions.js stepping a three line phrase down into two */
+  font-size: calc(var(--rc-fs, 1) * clamp(1rem, 4.6vw, 1.5rem));
+  font-weight: 800; line-height: 1.3; letter-spacing: 0.02em;
   text-shadow: 0 0 14px rgba(0, 0, 0, 0.9), 0 2px 5px rgba(0, 0, 0, 0.95);
 }
-/* every word of the phrase is in the DOM from the start so the line never reflows as it types;
-   a word the voice has not reached holds its space and nothing else */
-.race-hud .rc-word { color: var(--rc-ink, #fff); opacity: 0; transition: opacity 0.16s linear, text-shadow 0.16s linear; }
-.race-hud .rc-word.is-said { opacity: 0.82; }
-.race-hud .rc-word.is-said.is-now { opacity: 1; text-shadow: 0 0 16px var(--rc-ink, rgba(255, 105, 180, 0.9)), 0 2px 5px rgba(0, 0, 0, 0.95); }
+/* THE NAMES ARE THE CAPTION'S OWN. menu.css styles the intro cards under #race-root with
+   .rc-word and .rc-line, and an id beats any class, so a caption word used to be drawn at the
+   card wordmark's 30px inside a band built for 18px: that is what cut the owner's second line.
+   Nothing in this layer answers to a card's name any more.
+   Every word of the phrase is in the DOM from the start so the line never reflows as it types;
+   a word the voice has not reached holds its space and nothing else. */
+.race-hud .rc-cap-word { color: var(--rc-ink, #fff); opacity: 0; transition: opacity 0.16s linear, text-shadow 0.16s linear; }
+.race-hud .rc-cap-word.is-said { opacity: 0.82; }
+.race-hud .rc-cap-word.is-said.is-now { opacity: 1; text-shadow: 0 0 16px var(--rc-ink, rgba(255, 105, 180, 0.9)), 0 2px 5px rgba(0, 0, 0, 0.95); }
 
 /* ---- the plate: out of the vanishing point, into your face ---- */
 .race-hud .rc-plates { position: absolute; inset: 0; perspective: 900px; }
 .race-hud .rc-plate {
-  position: absolute; top: 42%; left: 50%; transform: translate(-50%, -50%) scale(0.15);
+  /* --rc-plate-y is the measured air between the caption band and the toast rail, so a trigger
+     and a jackpot can no longer land on each other; the percentage is the pre-measure fallback */
+  position: absolute; top: var(--rc-plate-y, 30%); left: 50%; transform: translate(-50%, -50%) scale(0.15);
   max-width: 92vw; text-align: center; white-space: nowrap;
-  font-size: 12vw; font-weight: 900; line-height: 1; letter-spacing: 0.06em; text-transform: lowercase;
+  font-size: var(--rc-plate-fs, 12vw);
+  font-weight: 900; line-height: 1; letter-spacing: 0.06em; text-transform: lowercase;
   color: var(--rc-glow, #fff);
   text-shadow: 0 0 30px var(--rc-glow, #fff), 0 4px 10px rgba(0, 0, 0, 0.9);
   animation: rcZoom 1400ms cubic-bezier(0.16, 0.9, 0.3, 1) forwards;
   will-change: transform, opacity;
 }
-@media (min-width: 700px) { .race-hud .rc-plate { font-size: 7vw; } }
+@media (min-width: 700px) { .race-hud .rc-plate { font-size: var(--rc-plate-fs, 7vw); } }
 .race-hud .rc-plate-sparks { display: none; }
 /* zoom 0.15 to 1.35 over 700 ms, hold 400 ms, then away */
 @keyframes rcZoom {
@@ -598,7 +631,8 @@
 /* ---- the thirteen themes (race/triggerTheme.js THEME_BY_PRESET) ---- */
 /* blackout: a near black card, white letters, and the room goes with it */
 .race-hud .rc-plate--ink {
-  color: var(--rc-ink, #f4f2ff); padding: 0.18em 0.5em; border-radius: 0.12em;
+  /* the card is wide, not tall: vertical padding here is height the measured air has to hold */
+  color: var(--rc-ink, #f4f2ff); padding: 0.05em 0.5em; border-radius: 0.12em;
   background: rgba(9, 9, 16, 0.94); border: 2px solid rgba(244, 242, 255, 0.22);
   text-shadow: 0 2px 10px rgba(0, 0, 0, 0.95);
 }
@@ -634,7 +668,7 @@
 }
 /* flash-pulse: three white flashes behind the word */
 .race-hud .rc-plate--pulse::before {
-  content: ''; position: absolute; inset: -18vh -30vw; z-index: -1;
+  content: ''; position: absolute; inset: -10vh -30vw; z-index: -1;
   background: radial-gradient(closest-side, rgba(255, 255, 255, 0.85), rgba(255, 255, 255, 0));
   animation: rcPulse 300ms steps(1) 260ms 3;
 }

--- a/ConditioningControlPanel/Resources/web/dtrh/race/smoke/captions-check.mjs
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/smoke/captions-check.mjs
@@ -27,7 +27,7 @@ import { readFileSync, mkdtempSync, rmSync, existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, extname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { buildPhrases, paintTriggers, MAX_WORDS, GAP_SEC, HOLD_SEC } from '../captions.js';
+import { buildPhrases, paintTriggers, MAX_WORDS, GAP_SEC, HOLD_SEC, PLATE_MS } from '../captions.js';
 import { THEME_BY_PRESET, themeFor } from '../triggerTheme.js';
 import { wordedRoad, PEAKS_PER_SEC } from '../cloudChart.js';
 
@@ -173,11 +173,15 @@ const at = async (t) => {
   await sleep(220);
   return json(`(()=>{ const cap=document.querySelector('.rc-cap'), plate=document.querySelector('.rc-plate');
     const r=(el)=>{ if(!el) return null; const b=el.getBoundingClientRect(); return { x:Math.round(b.left), y:Math.round(b.top), w:Math.round(b.width), h:Math.round(b.height) }; };
-    return { t: window.__race.race.track.t, hidden: !cap || cap.hidden, words: cap?cap.querySelectorAll('.rc-word').length:0,
-      said: cap?cap.querySelectorAll('.rc-word.is-said').length:0, now: cap?cap.querySelectorAll('.rc-word.is-now').length:0,
+    const line=document.querySelector('.rc-cap-line');
+    const tops=new Set(); for(const w of document.querySelectorAll('.rc-cap-word')){ const b=w.getBoundingClientRect(); if(b.height>0) tops.add(Math.round(b.top)); }
+    return { t: window.__race.race.track.t, hidden: !cap || cap.hidden, words: cap?cap.querySelectorAll('.rc-cap-word').length:0,
+      said: cap?cap.querySelectorAll('.rc-cap-word.is-said').length:0, now: cap?cap.querySelectorAll('.rc-cap-word.is-now').length:0,
       theme: plate?plate.getAttribute('data-theme'):null, plateLen: plate?plate.textContent.length:0,
       cap: cap&&!cap.hidden?r(cap):null, score: r(document.querySelector('.rh-score-wrap')), item: r(document.querySelector('.rh-item')),
-      speed: r(document.querySelector('.rh-speed')), vw: innerWidth, vh: innerHeight };})()`);
+      speed: r(document.querySelector('.rh-speed')), mute: r(document.querySelector('.rt-mute')), pause: r(document.querySelector('.rt-pause')),
+      lines: tops.size, hidWords: line ? Math.max(0, line.scrollHeight - line.clientHeight) : 0,
+      vw: innerWidth, vh: innerHeight };})()`);
 };
 
 /* ============================================================================
@@ -209,7 +213,16 @@ if (gapAt >= 0) {
 }
 
 /* ============================================================================
- * 3. the caption keeps off the chrome, on a 390x844 phone
+ * 3. the caption keeps off the chrome, at the TOP, on a 390x844 phone
+ *
+ * The owner's phone cut the second line in half and the band sat under the road.
+ * So: the band opens UNDER the score plate row, it is two lines at most, and
+ * every line of it is whole and on the glass. The cut had two causes and both
+ * are asserted here, not described: an `em` max-height on a box whose rendered
+ * lines were taller than its own font said (nothing is capped in `em` any more,
+ * so `hidWords` is 0), and menu.css owning `.rc-word` under #race-root at the
+ * intro card's 30px, which an id-carrying selector won over anything this layer
+ * could say (the caption's classes are its own now: .rc-cap-line, .rc-cap-word).
  * ==========================================================================*/
 const shot = await at(target.words[1].t);
 eq(shot.vw + 'x' + shot.vh, '390x844', 'the page really is a phone portrait viewport');
@@ -219,8 +232,16 @@ ok(!hits(shot.cap, shot.score), `it never touches the score plate (caption y ${s
 ok(!hits(shot.cap, shot.item), 'nor the item slot');
 ok(!hits(shot.cap, shot.speed), 'nor the speed bar');
 ok(shot.cap.y >= 0 && shot.cap.y + shot.cap.h <= shot.vh, 'and it is fully on the glass, not clipped off an edge');
-ok(shot.cap.y > shot.vh * 0.55, `it is a lower third (its top sits at ${Math.round((shot.cap.y / shot.vh) * 100)}% of the height)`);
-ok(shot.cap.h <= 100, `and it is two lines at most (${shot.cap.h}px tall)`);
+ok(shot.cap.y < shot.vh * 0.45, `it is a TOP band (its top sits at ${Math.round((shot.cap.y / shot.vh) * 100)}% of the height)`);
+ok(shot.cap.y >= shot.score.y + shot.score.h, `and it opens under the score plate row (band top ${shot.cap.y}, plate bottom ${shot.score.y + shot.score.h})`);
+if (shot.mute || shot.pause) {
+  ok(!hits(shot.cap, shot.mute) && !hits(shot.cap, shot.pause), 'nor under the sound and pause buttons');
+} else {
+  ok(true, 'the sound and pause buttons are a touch build; this run has none to clear');
+}
+ok(shot.lines <= 2, `it draws two lines at most (${shot.lines})`);
+ok(shot.hidWords === 0, `and not a pixel of it is hidden by its own box (${shot.hidWords}px over)`);
+
 
 /* ============================================================================
  * 4. the plate flies on a sure trigger
@@ -240,7 +261,84 @@ const themed = await json(`(()=>{ const s=[...document.styleSheets].flatMap(x=>{
 eq(themed, Object.keys(THEME_BY_PRESET).length, 'and race.css carries a class for every theme in the table');
 
 /* ============================================================================
- * 5. the demo road still runs, and nothing shouted
+ * 5. the plate rests in its own air: never on the band, never on a toast
+ *
+ * The owner's screenshot has the zoom plate sitting on top of "jackpot +200" and
+ * "+130 x3" in the same spot. captions.js measures the score plate, the band and
+ * the toast rail and parks the plate in what is left, so this holds a plate at
+ * the peak of its zoom against a jackpot and a pop fired the same second.
+ * ==========================================================================*/
+await at(trig.t);
+await ev(`window.__race.race.hud.toast('jackpot +200', 'jackpot')`);
+await sleep(200);
+await ev(`window.__race.race.hud.toast('+130 x3', 'pop')`);
+await sleep(480);                    // the zoom is at its peak by now, the toasts are up
+const air = await json(`(()=>{ const r=(el)=>{ if(!el) return null; const b=el.getBoundingClientRect();
+    return { x:Math.round(b.left), y:Math.round(b.top), w:Math.round(b.width), h:Math.round(b.height) }; };
+  return { plate:r(document.querySelector('.rc-plate')), cap:r(document.querySelector('.rc-cap')),
+    score:r(document.querySelector('.rh-score-wrap')), rail:r(document.querySelector('.rh-toasts')),
+    // only the toasts a player can SEE: one on its way out is a transparent box, not a clash
+    toasts:[...document.querySelectorAll('.rh-toast')].filter(t=>+getComputedStyle(t).opacity>0.05).map(r),
+    vh: innerHeight };})()`);
+ok(!!air.plate, 'a plate is on the glass with the toasts');
+ok(air.toasts.length >= 1, `and the rail is carrying ${air.toasts.length}`);
+ok(!hits(air.plate, air.cap), `the plate rests under the caption band (band ${air.cap ? air.cap.y + air.cap.h : '?'}, plate top ${air.plate.y})`);
+ok(!hits(air.plate, air.score), 'and clear of the score plate');
+const onToast = air.toasts.filter((t) => hits(air.plate, t));
+eq(onToast.length, 0, `and not one toast is under it (plate ${air.plate.y}..${air.plate.y + air.plate.h}, rail ${air.rail.y}..${air.rail.y + air.rail.h})`);
+ok(air.plate.y + air.plate.h <= air.rail.y, 'the plate is finished before the rail begins');
+ok(air.plate.y > air.vh * 0.15 && air.plate.y + air.plate.h < air.vh * 0.55, 'and it lands in the upper middle of the glass, where nothing else lives');
+
+/* ============================================================================
+ * 6. the toasts read as chatter: shorter, smaller, quieter
+ *
+ * The owner: "the items notification and the jackpot as well as the streak ones
+ * are noisy, make them last less and be kinda faded so they dont clash". Every
+ * hold is 60 percent of the wave 2 one, the two chatter kinds are capped, and
+ * the rail is 0.85 of its size at 70 percent. The score plate, the combo and the
+ * speed plate are not in this table and are not touched.
+ * ==========================================================================*/
+const WANT_HOLD = { pop: 660, almost: 700, jackpot: 1080, bank: 960, item: 840, effect: 840, recipe: 1020 };
+const WAS_HOLD = { pop: 1100, almost: 1300, jackpot: 1800, bank: 1600, item: 1400, effect: 1400, recipe: 1700 };
+for (const kind of Object.keys(WANT_HOLD)) {
+  await ev(`window.__race.race.hud.toast(${JSON.stringify(kind === 'bank' ? 'kept 40' : '+10')}, '${kind}')`);
+  await sleep(260);                  // longer than the chatter gap, so every kind gets its turn
+  const hold = await ev(`(()=>{const t=[...document.querySelectorAll('.rh-toast--${kind}')].pop();
+    return t ? t.style.getPropertyValue('--rh-hold') : null;})()`);
+  eq(hold, `${WANT_HOLD[kind]}ms`, `a ${kind === 'bank' ? 'kept' : kind} toast holds ${WANT_HOLD[kind]}ms`);
+  ok(WANT_HOLD[kind] <= Math.round(WAS_HOLD[kind] * 0.6), `and that is 40 percent off the wave 2 hold (${WAS_HOLD[kind]}ms)`);
+}
+ok(WANT_HOLD.pop <= 700 && WANT_HOLD.almost <= 700, 'the two chatter kinds are capped at 0.7s however loud the run gets');
+const railStyle = await json(`(()=>{const n=document.querySelector('.rh-toasts'); const cs=getComputedStyle(n);
+  const sc=document.querySelector('.rh-score-wrap'), sp=document.querySelector('.rh-speed');
+  return { t: cs.transform, o: +cs.opacity, scoreO: +getComputedStyle(sc).opacity, speedO: +getComputedStyle(sp).opacity };})()`);
+ok(/matrix\(0\.85,/.test(railStyle.t), `the rail is 0.85 of its old size (${railStyle.t})`);
+ok(Math.abs(railStyle.o - 0.7) < 0.01, `and sits at 70 percent (${railStyle.o})`);
+ok(railStyle.scoreO === 1 && railStyle.speedO === 1, 'while the score plate and the speed plate stay at full strength: those are the honest numbers');
+
+/* ============================================================================
+ * 7. EVERY phrase of the track, not the lucky one
+ *
+ * The cut the owner photographed was a long phrase's second line, so walk the
+ * whole caption track and hold each phrase to the same two rules: two lines at
+ * most, and not a pixel of it hidden by its own box. (Last, because it drives
+ * the clock past every trigger on the road.)
+ * ==========================================================================*/
+let widest = 0, worst = null, lines3 = 0, clipped = 0;
+for (const p of phrases.filter((x) => x.t0 > 3)) {
+  const s = await at(p.words[Math.min(1, p.words.length - 1)].t + 0.02);
+  if (s.hidden || !s.cap) continue;
+  if (s.lines > 2) lines3++;
+  if (s.hidWords > 0) clipped++;
+  if (s.cap.h > widest) { widest = s.cap.h; worst = s; }
+}
+eq(lines3, 0, `no phrase of the ${phrases.length} on this track draws a third line`);
+eq(clipped, 0, 'and none of them is cut off by its own box');
+ok(!!worst && worst.cap.y + worst.cap.h <= worst.vh, `the tallest band on the track is whole on the glass (${widest}px, bottom ${worst ? worst.cap.y + worst.cap.h : '?'} of ${shot.vh})`);
+ok(!!worst && !hits(worst.cap, worst.score), 'and even the tallest keeps off the score plate');
+
+/* ============================================================================
+ * 8. the demo road still runs, and nothing shouted
  * ==========================================================================*/
 await cdp('Page.navigate', { url: `${site}/dtrh/race.html?autostart=1&intro=0&cards=0&chart=demo&dur=240` });
 let demo = false;

--- a/ConditioningControlPanel/Resources/web/dtrh/race/smoke/real-audio-check.mjs
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/smoke/real-audio-check.mjs
@@ -239,8 +239,8 @@ if (c.words && c.words !== 'none') {
     await ev(`(()=>{const a=window.__rcAudio; if(a) a.currentTime=${Math.max(0, t)}; return 1;})()`);
     await sleep(wait);
     return json(`(()=>{const cap=document.querySelector('.rc-cap'), pl=document.querySelector('.rc-plate');
-      return { t: window.__race.race.track.t, hidden: !cap || cap.hidden, said: cap?cap.querySelectorAll('.rc-word.is-said').length:0,
-        words: cap?cap.querySelectorAll('.rc-word').length:0, theme: pl?pl.getAttribute('data-theme'):null };})()`);
+      return { t: window.__race.race.track.t, hidden: !cap || cap.hidden, said: cap?cap.querySelectorAll('.rc-cap-word.is-said').length:0,
+        words: cap?cap.querySelectorAll('.rc-cap-word').length:0, theme: pl?pl.getAttribute('data-theme'):null };})()`);
   };
   const w = await json(`(()=>{const ch=window.__race.race.track.chart, tr=ch.events.filter(e=>e.kind==='trigger');
     return { n: ch.words.length, t0: ch.words.length?ch.words[0].t:-1, trig: tr.length, at: tr.length?tr[0].t:-1 };})()`);


### PR DESCRIPTION
## the owner's phone, three faults, all geometry

The owner played Rapid Induction and Bubble Induction on a 390x844 phone and sent
three screenshots: the caption's second line cut in half at the bottom of the glass,
the zoom plate sitting on top of "jackpot +200" and "+130 x3", and a rail of toasts
loud enough to read as headlines. This is P1 of a two PR chain (P2 is the slow start).

## the cut: two causes, both gone

1. **A name collision that an id won.** `menu.css` styles the intro cards under
   `#race-root` with `.rc-word { font-size: clamp(30px, 4.6vw, 62px) }` and
   `.rc-line`. The caption layer used the same two names inside the same subtree, and
   an id-carrying selector beats any class, so **every caption word was drawn at the
   card wordmark's 30px inside a band built for 18px**. Measured on `main` at 390x844:
   the words rendered at 30px in line boxes 32px apart, and a two line phrase was 65px
   tall in a box allowed 39. The caption's classes are its own now: `.rc-cap-line`,
   `.rc-cap-word`.
2. **A max-height in `em`.** `.rc-line` capped itself at `2.6em` of a font-size that
   was not the size being drawn, so the box held 1.7 of its own rendered lines and the
   second line lost its bottom half. Nothing in this layer caps a height in `em` any
   more; a phrase that wants a third line steps its own size down until it does not,
   judged off the rendered word boxes (a Range's rects are not the answer: the spaces
   draw their own shorter boxes, so a two line phrase counted as four).

## the band, the plate, the toasts

- **The band is at the top**, under the score plate row. `captions.js` measures the
  score plate and the sound and pause buttons and hands `race.css` `--rc-cap-t`, so it
  clears whatever is actually up there instead of a number someone typed. Two lines
  at most, full width minus the safe area. The act ribbon parks lower while a caption
  band is live, so it cannot land on the band.
- **The plate rests in the air that is left**, between the band and the toast rail
  (`--rc-plate-y`, `--rc-plate-fs`, both measured, the size floored so the plate can
  never shrink into nothing). A trigger and a jackpot in the same second no longer
  land on each other.
- **The toasts read as chatter**: every hold is 60 percent of the wave 2 one, the two
  chatter kinds are capped at 0.7s, the rail is 0.85 of its size at 70 percent, the
  glows are roughly halved, and a toast grows DOWN out of its own top so the jackpot's
  reveal (which opens at 2.1 of its size) cannot swell up into the plate's air.

| kind | was | now |
|---|---|---|
| pop | 1100ms | **660ms** |
| almost | 1300ms | **700ms** (chatter cap) |
| jackpot | 1800ms | **1080ms** |
| kept | 1600ms | **960ms** |
| item | 1400ms | **840ms** |
| effect | 1400ms | **840ms** |
| recipe | 1700ms | **1020ms** |

The score plate, the combo and the speed plate are untouched: those are the honest
numbers and they stay loud.

## measured, 390x844, touch chrome up

| box | y | note |
|---|---|---|
| score plate | 16..162 | unchanged |
| sound / pause | 16..64 | unchanged |
| **caption band** | **170..216.6** | 2 lines, 0px hidden, x 16..374 |
| **plate at rest** | **227.1..276.9** | `--rc-plate-y: 252px`, `--rc-plate-fs: 37px` |
| toast rail | 287..398.3 | top unmoved; jackpot 286.9..374.1, pop run 370.9..390.5 |
| item slot / speed plate | 776..828 / 749..828 | untouched |

Gaps: 10.5px band to plate, 10.1px plate to rail. Nothing intersects anything.

## smokes

`captions-check.mjs` gained: the band is a TOP band under the score plate row; it
draws two lines at most with nothing hidden by its own box; **every phrase of the
opening track** is walked and held to the same two rules; a plate at the peak of its
zoom is held against a jackpot and a pop fired the same second (bounding boxes, and
only toasts a player can actually see); the hold of every toast kind, read off the
DOM, against the table above; and the rail's 0.85 / 70 percent while the score and
speed plates stay at full strength.

```
captions-check: all good   (74 checks, 0 console errors in either run)
chart-check / cloud-chart-check / levels-check / lyrics-road-check / rows-check /
words-check / track-run-check / touch-check / fov-check / spiral-pool-check /
audio-check / ost-resident-check: all good
```
Not run here: `cloud-check` and `remote-feed-check` (network), and `real-audio-check`
(Task S is driving it against the real audio right now; one headless browser at a
time). Its two `.rc-word` selectors are renamed with the rest, nothing else in it is
touched.

## files

`race/captions.js`, `race/hud.js`, `race/race.css`, `race/smoke/captions-check.mjs`,
and two selector lines in `race/smoke/real-audio-check.mjs`. **No `run.js`**, so
nothing here touches Task S's applyCue or the scheduler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJ66hi5fRM1Dcjo38aSCa2


Rebased onto the sync chain (#920, #922) on 2026-09-07; run.js conflict resolved keeping S1's deferred cues + the pace hunks.
