### PR TITLE
feat(bark): telemetry for "I noticed" barks (pause/resume/refocus triggers + session ledger reads)

### DIFF
--- a/ConditioningControlPanel/Models/AppSettings.cs
+++ b/ConditioningControlPanel/Models/AppSettings.cs
@@ -871,6 +871,85 @@ namespace ConditioningControlPanel.Models
             set { _lastSeenUtc = value; OnPropertyChanged(); }
         }
 
+        // --- Session ledger: the companion's "I noticed" bark conditions --------------------
+        // Feeds sessions_7d / late_sessions_7d / sessions_today / same_mod_run in BarkService.
+        // Local settings only: never added to any server request, sync payload or telemetry.
+
+        private const int SessionLedgerCap = 60;
+
+        private List<DateTime> _recentSessionStartsUtc = new();
+        /// <summary>UTC start times of the most recent sessions (capped, oldest dropped).</summary>
+        public List<DateTime> RecentSessionStartsUtc
+        {
+            get => _recentSessionStartsUtc;
+            set { _recentSessionStartsUtc = value ?? new(); OnPropertyChanged(); }
+        }
+
+        private string _lastSessionModId = "";
+        /// <summary>Mod id active when the most recent session started.</summary>
+        public string LastSessionModId
+        {
+            get => _lastSessionModId;
+            set { _lastSessionModId = value ?? ""; OnPropertyChanged(); }
+        }
+
+        private int _sameModRun = 0;
+        /// <summary>How many consecutive sessions (including the latest) started under the same mod.</summary>
+        public int SameModRun
+        {
+            get => _sameModRun;
+            set { _sameModRun = Math.Max(0, value); OnPropertyChanged(); }
+        }
+
+        /// <summary>Append one session start to the ledger and advance the same-mod run.</summary>
+        public void RecordSessionStart(string? modId)
+        {
+            var list = new List<DateTime>(_recentSessionStartsUtc) { DateTime.UtcNow };
+            if (list.Count > SessionLedgerCap) list.RemoveRange(0, list.Count - SessionLedgerCap);
+            RecentSessionStartsUtc = list;
+
+            var id = modId ?? "";
+            SameModRun = string.Equals(id, _lastSessionModId, StringComparison.OrdinalIgnoreCase) && _sameModRun > 0
+                ? _sameModRun + 1
+                : 1;
+            LastSessionModId = id;
+        }
+
+        /// <summary>Sessions started within the last <paramref name="days"/> days.</summary>
+        public int SessionsWithinDays(int days)
+        {
+            var since = DateTime.UtcNow.AddDays(-days);
+            int n = 0;
+            foreach (var t in _recentSessionStartsUtc) if (t >= since) n++;
+            return n;
+        }
+
+        /// <summary>
+        /// Sessions started within the last <paramref name="days"/> days whose LOCAL start hour was
+        /// 23:00 or later, or before 04:00 (the "can't sleep" window).
+        /// </summary>
+        public int LateSessionsWithinDays(int days)
+        {
+            var since = DateTime.UtcNow.AddDays(-days);
+            int n = 0;
+            foreach (var t in _recentSessionStartsUtc)
+            {
+                if (t < since) continue;
+                int h = t.ToLocalTime().Hour;
+                if (h >= 23 || h < 4) n++;
+            }
+            return n;
+        }
+
+        /// <summary>Sessions started since local midnight today.</summary>
+        public int SessionsToday()
+        {
+            var today = DateTime.Today;
+            int n = 0;
+            foreach (var t in _recentSessionStartsUtc) if (t.ToLocalTime() >= today) n++;
+            return n;
+        }
+
         #endregion
 
         #region Flash Images

--- a/ConditioningControlPanel/Services/Bark/BarkState.cs
+++ b/ConditioningControlPanel/Services/Bark/BarkState.cs
@@ -142,6 +142,36 @@ namespace ConditioningControlPanel.Services.Bark
         public bool CurrentPhaseIsDeepener =>
             _currentPhaseName.IndexOf("deep", StringComparison.OrdinalIgnoreCase) >= 0;
 
+        // --- pause / planned length, live off the engine ---
+        public int PauseCount => _engine?.IsRunning == true ? _engine.PauseCount : 0;
+        public double SessionPlannedMinutes => _engine?.IsRunning == true ? (_engine.CurrentSession?.DurationMinutes ?? 0) : 0;
+
+        // --- refocus: main window lost focus during a session and got it back ---
+        // A "refocus" only counts when the window was gone for at least the threshold, so an
+        // accidental click on another monitor does not read as "you tabbed away".
+        private DateTime? _unfocusedSinceUtc;
+        private int _refocusCount;
+        public int RefocusCount => System.Threading.Volatile.Read(ref _refocusCount);
+
+        public void RegisterUnfocus()
+        {
+            lock (_lock) { _unfocusedSinceUtc ??= DateTime.UtcNow; }
+        }
+
+        /// <summary>Returns the seconds the window was away, or -1 when nothing counts as a refocus.</summary>
+        public double RegisterRefocus(double minAwaySeconds = 20)
+        {
+            lock (_lock)
+            {
+                if (!_unfocusedSinceUtc.HasValue) return -1;
+                var away = (DateTime.UtcNow - _unfocusedSinceUtc.Value).TotalSeconds;
+                _unfocusedSinceUtc = null;
+                if (away < minAwaySeconds) return -1;
+                _refocusCount++;
+                return away;
+            }
+        }
+
         /// <summary>Reset per-session state (called on session start).</summary>
         public void ResetSessionScoped()
         {
@@ -149,6 +179,8 @@ namespace ConditioningControlPanel.Services.Bark
             {
                 _crossedMarathon.Clear();
                 _faceLostSinceUtc = null;
+                _unfocusedSinceUtc = null;
+                _refocusCount = 0;
             }
             _currentPhaseName = "";
         }

--- a/ConditioningControlPanel/Services/Companion/BarkService.cs
+++ b/ConditioningControlPanel/Services/Companion/BarkService.cs
@@ -1477,6 +1477,7 @@ namespace ConditioningControlPanel.Services
                 case "pauses_this_session": return (double)_state.PauseCount;
                 case "refocus_this_session": return (double)_state.RefocusCount;
                 case "session_planned_min": return _state.SessionPlannedMinutes;
+                case "is_late_hour": { int h = DateTime.Now.Hour; return h >= 23 || h < 4; }
 
                 default:
                     return ctx.Values.TryGetValue(field, out var v) ? v : null;

--- a/ConditioningControlPanel/Services/Companion/BarkService.cs
+++ b/ConditioningControlPanel/Services/Companion/BarkService.cs
@@ -978,21 +978,72 @@ namespace ConditioningControlPanel.Services
                 EventHandler<SessionProgressEventArgs> progress = (_, __) =>
                     Raise("SessionProgress", c => c.Set("session_elapsed_sec", _state.SessionElapsedSeconds));
 
+                // Pause / resume: the "you stopped, and you came back" family. pause_n is the
+                // 1-based pause count this session; paused_sec is how long the resume waited.
+                EventHandler<int> paused = (_, n) =>
+                    Raise("SessionPaused", c => c.Set("pause_n", (double)n));
+                EventHandler<TimeSpan> resumed = (_, gap) =>
+                    Raise("SessionResumed", c => c
+                        .Set("pause_n", (double)_state.PauseCount)
+                        .Set("paused_sec", gap.TotalSeconds));
+
                 engine.SessionStarted += started;
                 engine.SessionStopped += stopped;
                 engine.SessionCompleted += completed;
                 engine.PhaseChanged += phase;
                 engine.ProgressUpdated += progress;
+                engine.SessionPaused += paused;
+                engine.SessionResumed += resumed;
 
                 _engineUnsubscribe.Add(() => engine.SessionStarted -= started);
                 _engineUnsubscribe.Add(() => engine.SessionStopped -= stopped);
                 _engineUnsubscribe.Add(() => engine.SessionCompleted -= completed);
                 _engineUnsubscribe.Add(() => engine.PhaseChanged -= phase);
                 _engineUnsubscribe.Add(() => engine.ProgressUpdated -= progress);
+                _engineUnsubscribe.Add(() => engine.SessionPaused -= paused);
+                _engineUnsubscribe.Add(() => engine.SessionResumed -= resumed);
+
+                AttachMainWindowFocus();
 
                 App.Logger?.Debug("BarkService: attached to SessionEngine");
             }
             catch (Exception ex) { App.Logger?.Warning(ex, "BarkService: AttachSessionEngine failed"); }
+        }
+
+        /// <summary>
+        /// Wire the main window's focus so a session that loses the window and gets it back
+        /// raises <c>SessionRefocused</c> (away_sec, refocus_n). The window exists by the time the
+        /// session engine is attached (it is MainWindow-owned), which is why this hangs off
+        /// <see cref="AttachSessionEngine"/> rather than <see cref="Start"/>. Unsubscribed with the
+        /// engine wiring, so a re-attach never double-subscribes.
+        /// </summary>
+        private void AttachMainWindowFocus()
+        {
+            try
+            {
+                var window = System.Windows.Application.Current?.MainWindow;
+                if (window == null) return;
+
+                EventHandler deactivated = (_, __) =>
+                {
+                    if (_state.SessionRunning) _state.RegisterUnfocus();
+                };
+                EventHandler activated = (_, __) =>
+                {
+                    if (!_state.SessionRunning) return;
+                    var away = _state.RegisterRefocus();
+                    if (away < 0) return;
+                    Raise("SessionRefocused", c => c
+                        .Set("away_sec", away)
+                        .Set("refocus_n", (double)_state.RefocusCount));
+                };
+
+                window.Deactivated += deactivated;
+                window.Activated += activated;
+                _engineUnsubscribe.Add(() => window.Deactivated -= deactivated);
+                _engineUnsubscribe.Add(() => window.Activated -= activated);
+            }
+            catch (Exception ex) { App.Logger?.Debug(ex, "BarkService: main window focus wiring skipped"); }
         }
 
         /// <summary>
@@ -1415,6 +1466,17 @@ namespace ConditioningControlPanel.Services
                 // --- session phase (for deepener conditions on non-phase events) ---
                 case "phase_name": return _state.CurrentPhaseName;
                 case "phase_is_deepener": return _state.CurrentPhaseIsDeepener;
+
+                // --- "I noticed" reads: the real-hit half of a cold read. Every one of these is a
+                // fact the app actually holds; a rule that needs one and finds it at 0 should simply
+                // not match, never guess. ---
+                case "sessions_7d": return (double)(App.Settings?.Current?.SessionsWithinDays(7) ?? 0);
+                case "late_sessions_7d": return (double)(App.Settings?.Current?.LateSessionsWithinDays(7) ?? 0);
+                case "sessions_today": return (double)(App.Settings?.Current?.SessionsToday() ?? 0);
+                case "same_mod_run": return (double)(App.Settings?.Current?.SameModRun ?? 0);
+                case "pauses_this_session": return (double)_state.PauseCount;
+                case "refocus_this_session": return (double)_state.RefocusCount;
+                case "session_planned_min": return _state.SessionPlannedMinutes;
 
                 default:
                     return ctx.Values.TryGetValue(field, out var v) ? v : null;

--- a/ConditioningControlPanel/Services/Session/SessionEngine.cs
+++ b/ConditioningControlPanel/Services/Session/SessionEngine.cs
@@ -25,7 +25,11 @@ namespace ConditioningControlPanel.Services
         public event EventHandler<SessionCompletedEventArgs>? SessionCompleted;
         public event EventHandler? SessionStarted;
         public event EventHandler? SessionStopped;
-        
+        /// <summary>Raised after a pause takes effect. Payload = the pause count this session (1-based).</summary>
+        public event EventHandler<int>? SessionPaused;
+        /// <summary>Raised after a resume takes effect. Payload = how long the pause lasted.</summary>
+        public event EventHandler<TimeSpan>? SessionResumed;
+
         // State
         private Session? _currentSession;
         private bool _isRunning;
@@ -239,6 +243,11 @@ namespace ConditioningControlPanel.Services
             _mainTimer.Tick += MainTimer_Tick;
             _mainTimer.Start();
             
+            // Local session ledger (recent start times + same-mod run) feeds the companion's
+            // "I noticed" bark conditions. Recorded BEFORE SessionStarted so the bark that fires
+            // on this very start already counts it. Local settings only, never sent anywhere.
+            try { App.Settings?.Current?.RecordSessionStart(App.Settings.Current.ActiveModId); } catch { }
+
             // Fire started event
             SessionStarted?.Invoke(this, EventArgs.Empty);
 
@@ -500,6 +509,7 @@ namespace ConditioningControlPanel.Services
             try { App.EmiDesk?.Fire("sessionPaused", new { n = _pauseCount }); } catch { }
             _pauseStartTime = DateTime.Now;
             _wallClockStopwatch.Stop();
+            try { SessionPaused?.Invoke(this, _pauseCount); } catch (Exception ex) { App.Logger?.Debug(ex, "SessionPaused handler threw"); }
 
             // Stop timers but keep session state
             _mainTimer?.Stop();
@@ -588,6 +598,10 @@ namespace ConditioningControlPanel.Services
             // EMI Desk (MOMENTS 4.B).
             try { App.EmiDesk?.Fire("sessionResumed", new { minutes = (int)Math.Round(RemainingTime.TotalMinutes) }); }
             catch { }
+
+            var pausedFor = DateTime.Now - _pauseStartTime;
+            if (pausedFor < TimeSpan.Zero) pausedFor = TimeSpan.Zero;
+            try { SessionResumed?.Invoke(this, pausedFor); } catch (Exception ex) { App.Logger?.Debug(ex, "SessionResumed handler threw"); }
         }
 
         private void MainTimer_Tick(object? sender, EventArgs e)


### PR DESCRIPTION
## What
Prep PR for the Barnum / cold-read bark wave. Adds the real-hit telemetry the new lines condition on. No lines in this PR.

**New triggers** (wired in `BarkService.AttachSessionEngine`):
- `SessionPaused` - `pause_n`
- `SessionResumed` - `pause_n`, `paused_sec`
- `SessionRefocused` - `away_sec`, `refocus_n` (main window lost focus for 20 s or more during a session, then came back)

**New live-read condition keys** (`ResolveField`): `sessions_7d`, `late_sessions_7d` (local 23:00 to 04:00 starts), `sessions_today`, `same_mod_run`, `pauses_this_session`, `refocus_this_session`, `session_planned_min`.

**Backing data**: a capped (60) local session-start ledger on `AppSettings` plus `LastSessionModId` / `SameModRun`, recorded in `SessionEngine.StartSessionAsync` right before `SessionStarted` fires so the bark on that very start already counts it. Local settings only, never sent anywhere.

`SessionEngine` gains `SessionPaused` / `SessionResumed` events (it previously had no pause seam, EMI Desk was fired inline).

## Size
4 files, +188 / -1. `dotnet build` green.

## Follow-ups (stacked)
- feat/barnum-barks: the companion lines across the 3 built-in mods
- EMI proposal doc (owner vets before wiring)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AQweaFVfv9BcfibpY5ooHD