### PR TITLE
feat(race): the road opens slow and takes its speed from the act

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/race/consts.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/consts.js
@@ -20,6 +20,20 @@ export const KART_MAX_SPEED = 34;
 export const KART_MIN_SPEED = 8;
 export const GRAVITY = 18;
 
+// THE OPENING IS GENTLE. The owner, on the phone build: "the start feels too fast (122mph)". A
+// track opens at OPEN_PACE of the cruise with a boost that may only reach OPEN_BOOST_PACE of it,
+// and the full curve arrives over OPEN_RAMP_SEC after the first act (or after OPEN_SEC on a road
+// with no acts). race/pace.js is the only place these are read; kart.js takes the two numbers it
+// works out and nothing else in the run knows the difference. See race/pace.js.
+export const OPEN_PACE = 0.7;
+export const OPEN_BOOST_PACE = 1.15;
+export const OPEN_SEC = 45;
+export const OPEN_RAMP_SEC = 20;
+/** What an act's kind does to the pace once the opening is over, blended over ACT_BLEND_SEC. */
+export const ACT_PACE = { induction: 0.85, deepening: 0.85, triggers: 1, mantra: 1, build: 1.1, wake: 1.05, silence: 0.75, free: 1 };
+/** An act change is a lean, not a lurch: its pace arrives over these seconds from the act's own t0. */
+export const ACT_BLEND_SEC = 3;
+
 // Drift mini-turbo (kart.js): hold drift while steering; the charge crosses these seconds to reach
 // tier 1/2/3 (blue / orange / purple sparks) and releasing hands out that many seconds of boost.
 export const DRIFT_TIER_SEC = [0.8, 1.6, 2.6];

--- a/ConditioningControlPanel/Resources/web/dtrh/race/kart.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/kart.js
@@ -39,7 +39,7 @@ import * as THREE from 'three';
 import {
   KART_BASE_SPEED, KART_MAX_SPEED, KART_MIN_SPEED, GRAVITY, KART_X_MAX, SAUCER_R_ROAD,
   CAM_BACK, CAM_UP, CAM_LOOK_AHEAD, CAM_LOOK_SPEED, KART_SCALE,
-  POP_HIT_D, POP_HIT_X, POP_HIT_H, LANE_H, DRIFT_TIER_SEC, DRIFT_BOOST_SEC, WALL_SCRUB_SEC,
+  POP_HIT_D, POP_HIT_X, POP_HIT_H, LANE_H, DRIFT_TIER_SEC, DRIFT_BOOST_SEC, WALL_SCRUB_SEC, OPEN_PACE,
 } from './consts.js';
 import { createEmiRig } from './emi.js';
 
@@ -132,8 +132,14 @@ function makeTierSparks(scene, n) {
  */
 export function createKart({ scene, layout, reducedMotion = false, pixel = null }) {
   const state = {
-    d: 0, x: 0, h: 0, vh: 0, speed: KART_BASE_SPEED, steer: 0, drift: false, airborne: false,
+    // the flag drops at the opening cruise, not the full one: a run that opened at 79 km/h and
+    // eased down to 55 over its first second is exactly the start the owner called too fast.
+    // The pace (race/pace.js) holds the road there for its first act; this is only the first frame.
+    d: 0, x: 0, h: 0, vh: 0, speed: KART_BASE_SPEED * OPEN_PACE, steer: 0, drift: false, airborne: false,
     boostSec: 0, slowMult: 1, slowSec: 0, lap: 0,
+    // the pace the run is asking for, in metres per second: the cruise and the hard ceiling.
+    // run.js writes them every frame off race/pace.js; untouched they are the old constants.
+    paceBase: KART_BASE_SPEED, paceCap: KART_MAX_SPEED,
     driftSec: 0, driftTier: 0, scrub: false,
     inverted: false, roll: 0, trick: null, trickStreak: 0,
     lapSec: 0, lapsTimed: 0,
@@ -164,6 +170,12 @@ export function createKart({ scene, layout, reducedMotion = false, pixel = null 
   const emit = (ev) => { for (const cb of listeners) { try { cb(ev); } catch (e) { /* a listener never breaks the kart */ } } };
 
   function applyBoost(sec) { state.boostSec = Math.max(state.boostSec, +sec || 0); }
+  /** The run's pace for this frame, in m/s: the cruise it holds and the ceiling a boost may reach. */
+  function pace(base, cap) {
+    const b = +base, c = +cap;
+    state.paceBase = isFinite(b) && b > 0 ? Math.min(b, KART_MAX_SPEED) : KART_BASE_SPEED;
+    state.paceCap = isFinite(c) && c > 0 ? Math.min(Math.max(c, state.paceBase), KART_MAX_SPEED) : KART_MAX_SPEED;
+  }
   function applySlow(mult, sec) {
     state.slowMult = clamp(+mult || 1, 0.2, 1);
     state.slowSec = Math.max(state.slowSec, +sec || 0);
@@ -223,18 +235,22 @@ export function createKart({ scene, layout, reducedMotion = false, pixel = null 
   function stepSpeed(dt, input) {
     if (state.boostSec > 0) state.boostSec = Math.max(0, state.boostSec - dt);
     if (state.slowSec > 0) { state.slowSec = Math.max(0, state.slowSec - dt); if (state.slowSec === 0) state.slowMult = 1; }
-    const cap = state.boostSec > 0 ? KART_MAX_SPEED : KART_BASE_SPEED;
+    // the cruise and the ceiling are the run's to set (race/pace.js): a track's first act rolls
+    // slower than its last, and a boost early on is a lift rather than the full 122 km/h
+    const cruise = state.paceBase > 0 ? state.paceBase : KART_BASE_SPEED;
+    const ceiling = clamp(state.paceCap > 0 ? state.paceCap : KART_MAX_SPEED, cruise, KART_MAX_SPEED);
+    const cap = state.boostSec > 0 ? ceiling : cruise;
     // accel holds cruise, letting go coasts a touch under it, boost pins the cap
     let target = state.boostSec > 0 ? cap : cap * (0.88 + 0.12 * input.accel);
     if (state.drift) target *= 1.04;                                   // small speed keep while drifting
     target = target * (1 - input.brake) + KART_MIN_SPEED * input.brake;
     if (state.slowSec > 0) target *= state.slowMult;
     if (state.scrub) target *= WALL_SCRUB_MULT;                         // scrubbing the kerb costs a touch, never a stop
-    target = clamp(target, KART_MIN_SPEED, KART_MAX_SPEED);
+    target = clamp(target, KART_MIN_SPEED, ceiling);
     const rising = target > state.speed;
     const k = rising ? (state.boostSec > 0 ? 6 : 2.5) : (input.brake > 0 ? 3 : state.drift ? 0.8 : 1.5);
     state.speed += (target - state.speed) * ease(k, dt);
-    state.speed = clamp(state.speed, KART_MIN_SPEED, KART_MAX_SPEED);
+    state.speed = clamp(state.speed, KART_MIN_SPEED, ceiling);
   }
 
   /** Drift let go: the charge becomes boost by tier, and the cup straightens with a counter-steer snap. */
@@ -496,7 +512,7 @@ export function createKart({ scene, layout, reducedMotion = false, pixel = null 
     listeners.length = 0;
   }
 
-  return { state, update, applyBoost, applySlow, setMood: rig.setMood, setFraught: rig.setFraught, camera, group,
+  return { state, update, applyBoost, applySlow, pace, setMood: rig.setMood, setFraught: rig.setFraught, camera, group,
     pulseTarget, setReach, onEvent, dispose,
     emiModel: () => rig.model(), emiReady: (cb) => rig.onReady(cb),
     setFace: (i) => rig.setFace(i), pose: (name, opts) => rig.pose(name, opts) };

--- a/ConditioningControlPanel/Resources/web/dtrh/race/pace.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/pace.js
@@ -1,0 +1,117 @@
+/* ============================================================================
+ * race/pace.js - how fast the road is allowed to feel, second by second.
+ *
+ * THE OPENING IS GENTLE. The owner played two tracks on a phone and wrote: "the
+ * start feels too fast (122mph)". He was reading the speed plate off a combo
+ * boost in the first minute of an induction. Nothing about the kart's handling
+ * was wrong; what was wrong is that a hypno file opens by putting you under, and
+ * the road was already at full pelt while the voice was still saying hello.
+ *
+ * So the run asks this module for two numbers every frame and hands them to the
+ * kart (kart.js pace()): the CRUISE it holds with the accelerator down, and the
+ * CEILING a boost may reach. Both are honest metres per second - the speed plate
+ * reads the kart's own speed, so whatever this says, the number on the glass is
+ * the number the kart has (Law I).
+ *
+ *   THE ENVELOPE   a track's first act (or the first OPEN_SEC on a road with no
+ *                  acts) cruises at OPEN_PACE of the base and a boost may only
+ *                  reach OPEN_BOOST_PACE of that base: 15.4 m/s (55 km/h) with a
+ *                  lift to 25.3 (91), instead of 22 (79) with a lift to 34 (122).
+ *                  Over the OPEN_RAMP_SEC that follow, both walk in a straight
+ *                  line up to the full curve, and from there the kart is the kart
+ *                  it always was.
+ *   THE ACT        an act's kind colours the pace once it is running: an
+ *                  induction or a deepening is 0.85 of it, triggers and a mantra
+ *                  are the whole of it, a build 1.1, a wake 1.05, a silence 0.75
+ *                  (consts.js ACT_PACE). The change is a lean, not a lurch: it
+ *                  arrives over ACT_BLEND_SEC from the act's own t0, so the road
+ *                  is already leaning while the voice changes its mind.
+ *
+ * The envelope is a pure function of the second, which is what a seek needs: park
+ * the clock anywhere and the road paces itself the same way it would have if it
+ * had driven there. Only the act blend carries a memory (which pace it is coming
+ * FROM), because that is a thing the file cannot say for you.
+ *
+ * A NOTE FOR THE ROW PLACEMENT: run.js places a trigger's row at
+ * `kart.d + speed * dueIn`, which assumes the speed it reads at handover holds
+ * over the lookahead. It does not any more, so the placement is out by the area
+ * under the ramp: about 0.33 m/s^2 through the opening ramp, which over a 3 s
+ * lookahead is 1.5 m, under a tenth of a second of road. An act change is
+ * sharper (up to 1.8 m/s^2 across the blend) and that is the one to watch;
+ * race/smoke/pace-check.mjs measures both against the clock.
+ * ==========================================================================*/
+
+import {
+  KART_BASE_SPEED, KART_MAX_SPEED,
+  OPEN_PACE, OPEN_BOOST_PACE, OPEN_SEC, OPEN_RAMP_SEC, ACT_PACE, ACT_BLEND_SEC,
+} from './consts.js';
+
+const num = (v, d = 0) => (typeof v === 'number' && isFinite(v) ? v : d);
+const clamp01 = (v) => (v < 0 ? 0 : v > 1 ? 1 : v);
+/** The boost ceiling the opening allows, in m/s. */
+const OPEN_CAP = OPEN_BOOST_PACE * KART_BASE_SPEED;
+
+/**
+ * The opening envelope at a second, before the act has coloured it.
+ * `openEnd` is the end of the file's first act; 0 or nothing means OPEN_SEC.
+ * Returns the cruise as a fraction of KART_BASE_SPEED, the ceiling in m/s, and
+ * `k`, how far along the ramp to the full curve this second is (1 = arrived).
+ */
+export function envelopeAt(t, openEnd) {
+  const sec = Math.max(0, num(t));
+  const end = num(openEnd) > 0 ? num(openEnd) : OPEN_SEC;
+  const k = clamp01((sec - end) / OPEN_RAMP_SEC);
+  return {
+    pace: OPEN_PACE + (1 - OPEN_PACE) * k,
+    cap: OPEN_CAP + (KART_MAX_SPEED - OPEN_CAP) * k,
+    k,
+    openEnd: end,
+  };
+}
+
+/** What a kind is worth. An unknown kind (or none) is the road as written. */
+export function paceForKind(kind) {
+  const v = kind == null ? null : ACT_PACE[kind];
+  return typeof v === 'number' && isFinite(v) ? v : 1;
+}
+
+/** Where the first act ends, off a chart. Null chart, no acts, or a broken t1: OPEN_SEC. */
+export function openEndOf(chart) {
+  const acts = chart && Array.isArray(chart.acts) ? chart.acts : null;
+  const t1 = acts && acts.length ? num(acts[0].t1, 0) : 0;
+  return t1 > 0 ? t1 : OPEN_SEC;
+}
+
+/**
+ * The run's pace, frame by frame. `at(t, act, chart)` takes the track second (or
+ * the run's own elapsed seconds off a chart), track.js's current act and the
+ * chart it came from, and gives back the two numbers kart.js wants.
+ */
+export function createPace() {
+  let actId = null;      // the act the blend is running for
+  let from = 1;          // the pace it is leaning away from
+  let last = 1;          // and the one it reached on the last frame
+
+  return {
+    at(t, act, chart) {
+      const sec = Math.max(0, num(t));
+      const env = envelopeAt(sec, openEndOf(chart));
+      const want = paceForKind(act ? act.kind : null);
+      const id = act ? (act.id != null ? act.id : act.t0) : null;
+      if (id !== actId) { from = last; actId = id; }
+      const k = act && isFinite(act.t0) ? clamp01((sec - num(act.t0)) / ACT_BLEND_SEC) : 1;
+      const mult = from + (want - from) * k;
+      last = mult;
+      // while the opening is still running the envelope is a CEILING, not a suggestion: an act
+      // kind may only make those seconds gentler (a first act of build does not undo the point)
+      const open = env.k < 1;
+      const cruise = KART_BASE_SPEED * env.pace;
+      const base = Math.min(KART_MAX_SPEED, open ? Math.min(cruise, cruise * mult) : cruise * mult);
+      const ceil = open ? Math.min(env.cap, env.cap * mult) : env.cap * mult;
+      const cap = Math.min(KART_MAX_SPEED, Math.max(base, ceil));
+      return { base, cap, mult, kind: act ? act.kind || null : null, opening: env.k < 1, k: env.k, openEnd: env.openEnd };
+    },
+    /** A fresh run (or a seek that changed the file): forget which act we came from. */
+    reset() { actId = null; from = 1; last = 1; },
+  };
+}

--- a/ConditioningControlPanel/Resources/web/dtrh/race/run.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/run.js
@@ -44,6 +44,7 @@ import { createPayloadFx } from '../game/payloadFx.js';
 import { setBundledSpiralPool, prefetchSpirals, LEAN_SPIRALS } from '../engine/loomSpirals.js';
 import { createScreenShake } from '../game/screenShake.js';
 import { INTENSITY_RAMP_SEC, TREATS_ONLY_SEC, KART_BASE_SPEED, MULT_LADDER, makeRng } from './consts.js';
+import { createPace } from './pace.js';
 import { createSpine } from './spine.js';
 import { roomById, rollRoomOrder, createRoomDresser } from './rooms.js';
 import { createWalls } from './walls.js';
@@ -151,6 +152,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
   fovLive = true;   // S exists: resize() may shift S.fov from here on
   const mix = createCocktail({ now: () => S.elapsed });   // THE MIX: one live effect per category (cocktail.js); S.effects mirrors its live slots
   const TR = createTrackState();      // the loaded track chart: its clock, its energy, its acts (race/track.js)
+  const PACE = createPace();          // how fast the road is allowed to feel this second (race/pace.js)
   const hosted = bridge.isHosted !== false;   // the standalone page logs where the host would be told
   const sync = createCueSync({ aheadSec: CUE_AHEAD_SEC, trace: true });   // the visible half of a cue waits for the word (race/sync.js); the trace is 64 small rows the smokes read
   let W = null;                       // the world: everything that is rebuilt on "again"
@@ -214,7 +216,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
       wasAirborne: false, airH: 0, effects: [], moodHeld: null, moodHold: 0, mood: 'calm', seed: runSeed,
       trackHold: 0, trackHoldFrom: 0, trackFog: 0, trackPaused: false, statsAt: 0, trackGap: 0 });
     setFlip(false); trailClear();
-    mix.reset(); S.wobble = 0; clearMixChrome(); sync.reset();
+    mix.reset(); PACE.reset(); S.wobble = 0; clearMixChrome(); sync.reset();
     hud.setScore(0); hud.setCombo(0, 1); hud.setBank(0); hud.setSpeed(0); hud.setFraught(0); hud.pickupClear(); hud.item(null, 'no item yet');
   }
 
@@ -512,6 +514,11 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     const wdt = dt * S.timeScale;                     // the world clock (tea_time); the kart keeps real time
     S.t += wdt;
     const prevD = ks.d;
+    // THE OPENING IS GENTLE (race/pace.js): the first act cruises at 0.7 of the base with a boost
+    // that only lifts to 1.15 of it, then the full curve walks in over 20 s, and the act's kind
+    // colours the pace from there. Off a chart the clock is the run's own elapsed seconds.
+    S.pace = PACE.at(ts ? ts.t : S.elapsed, ts ? ts.act : null, TR.track ? TR.track.chart : null);
+    k.pace(S.pace.base, S.pace.cap);
     k.update(dt, input.read(), lay);
     w.score.tick(dt); w.items.update(dt);
     { const tr = trail[trailI]; tr.d = ks.d; tr.x = ks.x; tr.h = ks.h; tr.ok = true; trailI = (trailI + 1) % TRAIL_N; }
@@ -578,7 +585,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     if (mood !== S.mood) { S.mood = mood; k.setMood(mood); }
     const fraught = clamp(S.effects.length / 3, 0, 1);
     k.setFraught(fraught); hud.setFraught(fraught);
-    hud.setSpeed(ks.speed);
+    hud.setSpeed(ks.speed, ks.boostSec > 0);
     audio.update(dt, { world: w, run: S, kart: ks });
   }
 
@@ -741,6 +748,8 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
       geometries: mem.geometries == null ? -1 : mem.geometries, textures: mem.textures == null ? -1 : mem.textures, texMax,
       audio: audio._tracks ? audio._tracks.size : -1, dpr: renderer.getPixelRatio(), block: pixel.block,
       world: !!W, stage: !!stage, running: S.running, bubbles: W ? W.field.liveCount : 0,
+      // the pace envelope and what the kart actually did with it (race/pace.js, race/smoke/pace-check.mjs)
+      speed: W ? W.kart.state.speed : 0, boosting: W ? W.kart.state.boostSec > 0 : false, pace: S.pace ? { ...S.pace } : null,
     };
   }
   function setStage(s) { stage = s && typeof s.update === 'function' ? s : null; if (!stage) pixel.retexture(scene); }   // the menu may have changed the block

--- a/ConditioningControlPanel/Resources/web/dtrh/race/smoke/pace-check.mjs
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/smoke/pace-check.mjs
@@ -1,0 +1,295 @@
+/* ============================================================================
+ * race/smoke/pace-check.mjs - the gentle opening, and the rows that still land.
+ *
+ *   node race/smoke/pace-check.mjs     (from Resources/web/dtrh; 0 on pass, 1 with a count)
+ *
+ * The owner, on the phone build: "the start feels too fast (122mph)". race/pace.js
+ * answers that, and this holds it to the numbers.
+ *
+ * Two halves. The first is pure: the envelope and the act table are read straight
+ * out of pace.js and consts.js and checked second by second, in m/s and in the
+ * km/h the plate would show. The second drives a headless browser at a phone
+ * viewport through the first 75 seconds of a real worded road and watches what
+ * the kart actually did: it never passes the ceiling it was given, the speed
+ * plate says the number the kart has and nothing else, and a trigger's row is
+ * still under the kart when the word arrives even though the speed is moving
+ * under the placement.
+ *
+ * It never prints a line of a transcript. Everything below is counted.
+ *
+ * CHROME: `CHROME_PATH` if it is set, else the usual Windows install.
+ * ==========================================================================*/
+
+import { spawn } from 'node:child_process';
+import { createServer } from 'node:http';
+import { readFile } from 'node:fs/promises';
+import { readFileSync, mkdtempSync, rmSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, extname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { envelopeAt, paceForKind, openEndOf, createPace } from '../pace.js';
+import { KART_BASE_SPEED, KART_MAX_SPEED, OPEN_PACE, OPEN_BOOST_PACE, OPEN_SEC, OPEN_RAMP_SEC, ACT_PACE, ACT_BLEND_SEC } from '../consts.js';
+import { wordedRoad, PEAKS_PER_SEC } from '../cloudChart.js';
+
+let fails = 0;
+const ok = (cond, what) => { if (!cond) { console.error('FAIL ' + what); fails++; } else console.log('  ok  ' + what); };
+const eq = (got, want, what) => ok(got === want, what + ' (got ' + JSON.stringify(got) + ', want ' + JSON.stringify(want) + ')');
+const near = (a, b, eps) => Math.abs(a - b) <= eps;
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const kmh = (ms) => Math.round(ms * 3.6);
+
+const HERE = resolve(fileURLToPath(import.meta.url), '..');
+const RACE = resolve(HERE, '..');
+const WEB = resolve(RACE, '../..');                        // Resources/web
+const read = (rel) => JSON.parse(readFileSync(resolve(RACE, rel), 'utf8'));
+const ROW = read('words/index.json').rows[0];             // the opening level
+const WORDS = read('words/' + ROW.file);
+
+/** A curve shaped like a spoken track, the same swell the other road smokes use. */
+function swell(durationSec, perSec = PEAKS_PER_SEC) {
+  const n = Math.ceil(durationSec * perSec);
+  const peaks = new Float32Array(n * 2);
+  for (let i = 0; i < n; i++) {
+    const a = 0.22 + 0.5 * Math.max(0, Math.sin(((i / perSec) / 40) * Math.PI * 2)) ** 2;
+    peaks[i * 2] = -a; peaks[i * 2 + 1] = a;
+  }
+  return peaks;
+}
+const road = wordedRoad({ peaks: swell(WORDS.durationSec), durationSec: WORDS.durationSec, name: ROW.title, hash: ROW.hash, words: WORDS });
+
+/* ============================================================================
+ * 1. the envelope: 0.7 of the cruise, a lift instead of a boost, then the curve
+ * ==========================================================================*/
+const OPEN_CAP = OPEN_BOOST_PACE * KART_BASE_SPEED;
+ok(kmh(KART_BASE_SPEED) === 79 && kmh(KART_MAX_SPEED) === 122, `the road as written is ${kmh(KART_BASE_SPEED)} km/h with a boost to ${kmh(KART_MAX_SPEED)}`);
+const e0 = envelopeAt(0, 45);
+ok(near(e0.pace, OPEN_PACE, 1e-9), `at 0 s the cruise is ${OPEN_PACE} of the base (${(KART_BASE_SPEED * e0.pace).toFixed(1)} m/s, ${kmh(KART_BASE_SPEED * e0.pace)} km/h)`);
+ok(near(e0.cap, OPEN_CAP, 1e-9), `and a boost only lifts to ${OPEN_BOOST_PACE} of it (${OPEN_CAP.toFixed(1)} m/s, ${kmh(OPEN_CAP)} km/h, not ${kmh(KART_MAX_SPEED)})`);
+for (const t of [10, 30, 44.9]) {
+  const e = envelopeAt(t, 45);
+  ok(near(e.pace, OPEN_PACE, 1e-9) && near(e.cap, OPEN_CAP, 1e-9), `at ${t} s the first act is still the gentle one (${kmh(KART_BASE_SPEED * e.pace)} km/h, lift ${kmh(e.cap)})`);
+}
+const mid = envelopeAt(45 + OPEN_RAMP_SEC / 2, 45);
+ok(near(mid.pace, OPEN_PACE + (1 - OPEN_PACE) / 2, 1e-9), `half way up the ramp the cruise is half way back (${kmh(KART_BASE_SPEED * mid.pace)} km/h)`);
+ok(near(mid.cap, OPEN_CAP + (KART_MAX_SPEED - OPEN_CAP) / 2, 1e-9), 'and so is the ceiling');
+const arrived = envelopeAt(45 + OPEN_RAMP_SEC + 5, 45);
+ok(near(arrived.pace, 1, 1e-9) && near(arrived.cap, KART_MAX_SPEED, 1e-9), `${OPEN_RAMP_SEC} s after the first act the kart is the kart it always was (${kmh(KART_BASE_SPEED)} / ${kmh(KART_MAX_SPEED)} km/h)`);
+const noActs = envelopeAt(OPEN_SEC - 0.1, 0);
+ok(near(noActs.pace, OPEN_PACE, 1e-9) && noActs.openEnd === OPEN_SEC, `a road with no acts opens for ${OPEN_SEC} s on its own`);
+eq(openEndOf(null), OPEN_SEC, 'and a run with no chart at all is the same');
+ok(openEndOf(road) > 0 && openEndOf(road) === road.acts[0].t1, `the real track's first act ends at ${openEndOf(road).toFixed(1)} s, and that is where its ramp starts`);
+
+/* ============================================================================
+ * 2. the act kind colours the pace, and leans into it
+ * ==========================================================================*/
+const WANT_KIND = { induction: 0.85, deepening: 0.85, triggers: 1, mantra: 1, build: 1.1, wake: 1.05, silence: 0.75 };
+for (const kind of Object.keys(WANT_KIND)) {
+  eq(paceForKind(kind), WANT_KIND[kind], `an act of ${kind} runs at ${WANT_KIND[kind]} of the pace`);
+  eq(ACT_PACE[kind], WANT_KIND[kind], 'and consts.js is the only place that says so');
+}
+eq(paceForKind('free'), 1, 'free running is the road as written');
+eq(paceForKind(null), 1, 'and so is no act at all');
+
+const pace = createPace();
+const past = 200;                                    // well clear of the opening ramp
+const act = (kind, t0) => ({ id: kind + t0, kind, t0, t1: t0 + 60 });
+const a1 = act('triggers', past);
+pace.at(past + 10, a1, road);                        // settled in the triggers act
+const a2 = act('silence', past + 60);
+const atChange = pace.at(a2.t0 + 0.01, a2, road);
+const half = pace.at(a2.t0 + ACT_BLEND_SEC / 2, a2, road);
+const settled = pace.at(a2.t0 + ACT_BLEND_SEC + 1, a2, road);
+ok(near(atChange.mult, 1, 0.02), `an act change starts from the pace it is leaving (${atChange.mult.toFixed(3)})`);
+ok(near(half.mult, (1 + WANT_KIND.silence) / 2, 0.02), `it is half way there ${ACT_BLEND_SEC / 2} s in (${half.mult.toFixed(3)})`);
+ok(near(settled.mult, WANT_KIND.silence, 1e-9), `and arrives after ${ACT_BLEND_SEC} s (${settled.mult.toFixed(3)})`);
+ok(settled.base < KART_BASE_SPEED, `a silence really is slower road (${settled.base.toFixed(1)} m/s, ${kmh(settled.base)} km/h)`);
+const build = pace.at(past + 400, act('build', past + 300), road);
+ok(build.base > KART_BASE_SPEED && build.base <= KART_MAX_SPEED, `and a build really is faster (${build.base.toFixed(1)} m/s, ${kmh(build.base)} km/h)`);
+const opener = createPace();
+const loud = opener.at(1, act('build', 0), road);
+ok(loud.cap <= OPEN_CAP + 1e-9 && loud.base <= KART_BASE_SPEED * OPEN_PACE + 1e-9,
+  `nothing the act table says can lift the opening past its own ceiling (a first act of build still opens at ${kmh(loud.base)} km/h with a lift to ${kmh(loud.cap)})`);
+const quiet = opener.at(1.6, act('silence', 0), road);
+ok(quiet.base < KART_BASE_SPEED * OPEN_PACE, `but it can still make those seconds gentler (a silence opens at ${kmh(quiet.base)} km/h)`);
+ok(createPace().at(1e6, act('build', 0), road).cap <= KART_MAX_SPEED, 'and nothing can lift the kart past the one hard maximum');
+
+// the numbers the report wants, off the real track
+console.log('  --  the pace on the real track:');
+const p2 = createPace();
+for (const t of [0, 10, 30, 60]) {
+  const a = road.acts.find((x) => t >= x.t0 && t < x.t1) || null;
+  const s = p2.at(t, a, road);
+  console.log(`      t=${String(t).padStart(3)}s  act ${(a && a.kind) || 'none'}  cruise ${s.base.toFixed(1)} m/s (${kmh(s.base)} km/h)  ceiling ${s.cap.toFixed(1)} m/s (${kmh(s.cap)} km/h)`);
+}
+
+/* ============================================================================
+ * the browser: the web folder plus the fixture chart
+ * ==========================================================================*/
+const CHROME = process.env.CHROME_PATH || 'C:/Program Files/Google/Chrome/Application/chrome.exe';
+const PORT = 8873;
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.mjs': 'text/javascript', '.css': 'text/css', '.json': 'application/json', '.glb': 'model/gltf-binary', '.png': 'image/png', '.webp': 'image/webp', '.jpg': 'image/jpeg', '.mp3': 'audio/mpeg', '.wav': 'audio/wav', '.svg': 'image/svg+xml', '.woff2': 'font/woff2' };
+/* The real opening level puts its first trigger at 105 s, which is no use to a smoke that has to
+ * watch a row land inside the ramp. So the browser half drives a RAMP FIXTURE cut from the same
+ * road: the real chart, its first act shortened to 30 s so the ramp runs 30..50 s, a build after
+ * it (the sharpest blend the act table can ask for, 0.85 to 1.1), the real triggers re-timed one
+ * every 6 s across all of it, and no other events or words at all. That last part is the point:
+ * the only bubbles on this road are the trigger rows, so a pop can only be a row landing. */
+const RAMP_ACT_END = 30;
+const T = road.events.filter((e) => e.kind === 'trigger');
+const RAMP = {
+  ...road,
+  words: [],
+  acts: [
+    { ...road.acts[0], id: 'ramp-a0', kind: 'induction', t0: 0, t1: RAMP_ACT_END },
+    { ...(road.acts[1] || road.acts[0]), id: 'ramp-a1', kind: 'build', t0: RAMP_ACT_END, t1: Math.max(180, road.durationSec) },
+  ],
+  events: Array.from({ length: 11 }, (_, i) => ({ ...T[i % T.length], id: `ramp-t${i}`, t: 8 + i * 6 })),
+};
+const FIXTURE = JSON.stringify(RAMP);
+
+if (!existsSync(CHROME)) { console.error('FAIL no chrome at ' + CHROME + ' (set CHROME_PATH)'); process.exit(1); }
+const server = createServer(async (req, res) => {
+  const path = decodeURIComponent(new URL(req.url, 'http://x').pathname);
+  if (path === '/fixture.json') { res.writeHead(200, { 'content-type': 'application/json' }); return res.end(FIXTURE); }
+  if (path.indexOf('..') >= 0) { res.writeHead(400); return res.end(); }
+  try {
+    const body = await readFile(join(WEB, path));
+    res.writeHead(200, { 'content-type': MIME[extname(path).toLowerCase()] || 'application/octet-stream' });
+    res.end(req.method === 'HEAD' ? undefined : body);
+  } catch (e) { res.writeHead(404, { 'content-type': 'text/plain' }); res.end('no'); }
+});
+await new Promise((r) => server.listen(PORT, '127.0.0.1', r));
+
+const prof = mkdtempSync(join(tmpdir(), 'race-pace-'));
+const chrome = spawn(CHROME, [
+  '--headless=new', '--remote-debugging-port=9343', `--user-data-dir=${prof}`,
+  '--no-first-run', '--no-default-browser-check', '--disable-gpu', '--mute-audio',
+  '--enable-unsafe-swiftshader', '--autoplay-policy=no-user-gesture-required',
+  '--window-size=390,844', 'about:blank',
+], { stdio: 'ignore' });
+
+let page = null;
+for (let i = 0; i < 60 && !page; i++) {
+  await sleep(250);
+  try { page = (await (await fetch('http://127.0.0.1:9343/json/list')).json()).find((t) => t.type === 'page'); } catch (e) { /* not up */ }
+}
+if (!page) { console.error('FAIL chrome never answered on the debug port'); await finish(1); }
+
+const ws = new WebSocket(page.webSocketDebuggerUrl);
+await new Promise((r) => { ws.onopen = r; });
+let msgId = 0;
+const waits = new Map(), errs = [];
+ws.onmessage = (e) => {
+  const m = JSON.parse(e.data);
+  if (m.id && waits.has(m.id)) { waits.get(m.id)(m); waits.delete(m.id); }
+  if (m.method === 'Runtime.exceptionThrown') errs.push('thrown: ' + (m.params.exceptionDetails?.exception?.description || m.params.exceptionDetails?.text || '?'));
+  if (m.method === 'Runtime.consoleAPICalled' && m.params.type === 'error') errs.push(m.params.args.map((a) => a.value ?? a.description ?? '?').join(' '));
+};
+const cdp = (method, params) => new Promise((res) => { const i = ++msgId; waits.set(i, res); ws.send(JSON.stringify({ id: i, method, params })); });
+const ev = async (x) => (await cdp('Runtime.evaluate', { expression: x, returnByValue: true, awaitPromise: true })).result?.result?.value;
+const json = async (x) => JSON.parse(await ev(`JSON.stringify(${x})`));
+await cdp('Runtime.enable'); await cdp('Page.enable');
+await cdp('Emulation.setDeviceMetricsOverride', { width: 390, height: 844, deviceScaleFactor: 2, mobile: true });
+
+const site = `http://127.0.0.1:${PORT}`;
+await cdp('Page.navigate', { url: `${site}/dtrh/race.html?autostart=1&intro=0&cards=0&chart=${encodeURIComponent(`${site}/fixture.json`)}` });
+let up = false;
+for (let i = 0; i < 120 && !up; i++) {
+  await sleep(250);
+  up = await ev(`!!(window.__race && window.__race.race && window.__race.race.track && window.__race.race.perf().world)`);
+}
+ok(up, 'the page boots the fixture road at a phone viewport');
+if (!up) { if (errs.length) console.error('    said: ' + errs.slice(0, 6).join(' | ')); await finish(1); }
+
+/* ============================================================================
+ * 3. what the kart actually did, and what the plate said about it
+ * ==========================================================================*/
+// every toast the run makes, stamped with the track second it was made on: a row
+// under the kart is a pop, and a pop is the only honest witness to when it landed
+await ev(`(()=>{ const h=window.__race.race.hud; window.__pops=[]; const was=h.toast.bind(h);
+  h.toast=(text,kind)=>{ try{ window.__pops.push({ t: window.__race.race.track.t, kind: kind||'pop' }); }catch(e){}
+  return was(text,kind); }; return 1; })()`);
+
+const SAMPLE_MS = 500, RUN_SEC = 78;
+const samples = [];
+const grab = async () => samples.push(await json(`(()=>{const r=window.__race.race, p=r.perf();
+  const n=document.querySelector('.rh-speed-n');
+  return { t:+r.track.t.toFixed(3), speed:+(p.speed||0).toFixed(3), boosting:!!p.boosting,
+    base:p.pace?+p.pace.base.toFixed(3):null, cap:p.pace?+p.pace.cap.toFixed(3):null,
+    mult:p.pace?+p.pace.mult.toFixed(3):null, kind:p.pace?p.pace.kind:null,
+    plate:n?+n.textContent:null };})()`));
+await grab();
+const t0 = Date.now();
+while ((Date.now() - t0) / 1000 < RUN_SEC) { await sleep(SAMPLE_MS); await grab(); }
+const ran = samples.filter((s) => s.t > 0.2);
+ok(ran.length > 20 && ran[ran.length - 1].t > 60, `the run rolled ${ran.length ? ran[ran.length - 1].t.toFixed(1) : 0}s of the file on its own`);
+
+const fake = ran.filter((s) => s.plate !== Math.round(s.speed * 3.6));
+eq(fake.length, 0, 'the speed plate says the number the kart has, on every frame it was read');
+const overCap = ran.filter((s) => s.cap != null && s.speed > s.cap + 0.35);
+eq(overCap.length, 0, 'and the kart never passed the ceiling the pace gave it');
+
+const openEnd = openEndOf(RAMP);
+const early = ran.filter((s) => s.t > 2 && s.t < Math.min(openEnd, 40));
+const late = ran.filter((s) => s.t > openEnd + OPEN_RAMP_SEC + 1);
+const worstEarly = early.reduce((m, s) => Math.max(m, s.speed), 0);
+ok(early.length > 5, `${early.length} samples inside the opening act`);
+ok(worstEarly <= OPEN_CAP + 0.35, `nothing in the opening went past the lift (${worstEarly.toFixed(1)} m/s, ${kmh(worstEarly)} km/h, ceiling ${kmh(OPEN_CAP)})`);
+ok(worstEarly < KART_MAX_SPEED - 6, `and the plate never showed the ${kmh(KART_MAX_SPEED)} km/h the owner photographed (worst ${kmh(worstEarly)} km/h)`);
+if (late.length) {
+  const bestLate = late.reduce((m, s) => Math.max(m, s.speed), 0);
+  ok(bestLate > worstEarly, `the road gets its legs back after the ramp (${kmh(worstEarly)} -> ${kmh(bestLate)} km/h)`);
+} else {
+  ok(true, 'the run did not reach the far side of the ramp in the time given');
+}
+console.log('  --  the kart, second by second:');
+for (const want of [0, 10, 30, 60]) {
+  const s = ran.reduce((best, x) => (best && Math.abs(best.t - want) <= Math.abs(x.t - want) ? best : x), null);
+  if (s) console.log(`      t=${String(want).padStart(3)}s  act ${s.kind || 'none'}  ${s.speed.toFixed(1)} m/s  plate ${s.plate} km/h  cruise ${s.base} ceiling ${s.cap}`);
+}
+
+/* ============================================================================
+ * 4. the row still lands on the word while the speed is moving under it
+ * ==========================================================================*/
+const pops = await json('window.__pops');
+const lastT = ran.length ? ran[ran.length - 1].t : 0;
+const trig = RAMP.events.filter((e) => e.kind === 'trigger' && e.t > 3 && e.t < lastT - 2);
+const deltas = [];
+for (const e of trig) {
+  let best = null;
+  for (const p of pops) {
+    const d = p.t - e.t;
+    if (Math.abs(d) <= 1.2 && (best === null || Math.abs(d) < Math.abs(best))) best = d;
+  }
+  if (best !== null) deltas.push(best);
+}
+ok(deltas.length >= 3, `${deltas.length} of the ${trig.length} triggers inside the ramp had a row under the kart to time`);
+if (deltas.length) {
+  const abs = deltas.map((d) => Math.abs(d)).sort((a, b) => a - b);
+  const median = abs[Math.floor(abs.length / 2)];
+  const worst = abs[abs.length - 1];
+  console.log(`  --  row under the kart: median ${median.toFixed(3)}s, worst ${worst.toFixed(3)}s, over ${deltas.length} rows`);
+  // A ROW STILL LANDS ON ITS WORD WHILE THE SPEED IS MOVING UNDER IT. Two things could have
+  // gone wrong here and neither did. Measured on this same fixture with the pace neutralised
+  // (OPEN_PACE 1, every act 1, i.e. the road without this PR): median 0.224s, worst 1.096s.
+  // With the ramp in: median 0.062s, worst 0.148s, because race/sync.js (Task S1, in this
+  // branch base) re-places a row every frame off the speed the kart has now, so a road that
+  // changes pace mid-lookahead is exactly what that nudge was written for. If this ever fails,
+  // read it as "the pace and the sync disagree about where the kart will be", not as a slow road.
+  ok(median <= 0.15, `a row is under the kart within 0.15s of its word (median ${median.toFixed(3)}s)`);
+  ok(worst <= 0.5, `and the worst of them is still inside half a second (${worst.toFixed(3)}s)`);
+}
+ok(errs.length === 0, 'not one console error in the whole run' + (errs.length ? ':\n    ' + errs.slice(0, 5).join('\n    ') : ''));
+
+await finish(fails ? 1 : 0);
+
+async function finish(code) {
+  try { ws && ws.close(); } catch (e) { /* never opened */ }
+  try { chrome.kill(); } catch (e) { /* already gone */ }
+  await new Promise((r) => server.close(r));
+  await sleep(300);
+  try { rmSync(prof, { recursive: true, force: true }); } catch (e) { /* chrome still has a lock */ }
+  if (code) console.error(`\n${fails} failure${fails === 1 ? '' : 's'}`);
+  else console.log('\npace-check: all good');
+  process.exit(code);
+}


### PR DESCRIPTION
Second of two in the HUD polish chain. **Base: `feat/race-polish-p1-captions-top` (PR #921).** Review P1 first; this branch contains it.

## The complaint

The owner's photo of the first ten seconds has the speed plate at **122 km/h** while the voice is still saying "close your eyes". Every run started at the full cruise, so the fastest the road ever felt was the moment the player had the least idea what any of it meant. And the road ran at one speed whether the file was an induction or a wake-up.

## What changed

**`race/pace.js` (new)** owns two things and hands `run.js` a `{ base, cap }` per frame.

*The opening.* The first act, or the first 45 s when a file has no acts, runs at `0.7` of base with a boost that can only reach `1.15` of base. Then the road takes 20 s to walk linearly up to the curve it always had. While that opening is still running the envelope is a **ceiling**, not a suggestion: an act may make those seconds gentler, never faster. A file whose first act is a `build` still opens at 55 km/h.

*The act colour.* On top of the envelope, `induction`/`deepening` 0.85, `triggers`/`mantra` 1.0, `build` 1.1, `wake` 1.05, `silence` 0.75, `free` 1.0, each blended over 3 s from whatever the last act was, so nothing snaps at an act edge.

**`kart.js`** takes a paced cruise and ceiling (`kart.pace(base, cap)`) instead of reading the two constants directly. `stepSpeed` clamps to the paced ceiling in both the cruise and the boost branch. The flag also drops at the opening cruise, so a run opens at 55 km/h instead of showing 79 for a second and easing down.

**`run.js`** is 5 small hunks, **all confined to the speed/act code path**: the `createPace()` instance, its reset in `resetRunState`, one line in `step()` before `k.update` that feeds the kart, the `hud.setSpeed` call reading the kart's own speed, and a `pace` field on `perf()` so a smoke can see it. **It does not touch `applyCue` or the scheduler, which Task S owns.**

The speed plate shows the number the kart actually has, every frame. Nothing on the glass is decorative.

## Numbers

Real track (`consts` + a real chart), cruise and ceiling:

| t | act | cruise | ceiling |
|---|---|---|---|
| 0 s | induction | 15.4 m/s (55 km/h) | 25.3 m/s (91 km/h) |
| 10 s | induction | 13.1 m/s (47 km/h) | 21.5 m/s (77 km/h) |
| 30 s | induction | 13.1 m/s (47 km/h) | 21.5 m/s (77 km/h) |
| 60 s | induction | 13.1 m/s (47 km/h) | 21.5 m/s (77 km/h) |

Headless run at 390x844 on the ramp fixture, what the plate actually said:

| t | act | kart | plate |
|---|---|---|---|
| 0 s | induction | 15.3 m/s | 55 km/h |
| 10 s | induction | 21.5 m/s | 77 km/h (boosting, at the opening ceiling) |
| 30 s | build | 13.1 m/s | 47 km/h |
| 60 s | build | 24.2 m/s | 87 km/h |

By act kind at full base: silence 59 km/h, induction/deepening 67 km/h, triggers/mantra/free 79 km/h, wake 83 km/h, build 87 km/h. The worst the plate showed anywhere inside the opening was 77 km/h, against the 122 in the photo.

## Rows still land on the word

`rows-check` and `sync-check` green. Plus a headless run that wraps `hud.toast` to stamp the clock when a pop fires (a pop is the only honest witness that a row was under the kart) across 11 triggers inside the ramp:

| | median | worst |
|---|---|---|
| pace neutralised (the road without this PR) | 0.224 s | 1.096 s |
| with this PR, on the rebased base | **0.062-0.076 s** | **0.148-0.209 s** |

Both inside the 0.15 s / 0.5 s bar, which the smoke now asserts outright. S1's `race/sync.js` is what earns it: it re-places a row every frame off the speed the kart has now, so a road that changes pace mid-lookahead is exactly the case that nudge was written for. In `step()` the pace is read before `kart.update` and before `trackFrame`, so the sync always nudges off a speed the pace has already granted. If that assertion ever fails, read it as "the pace and the sync disagree about where the kart will be", not as a slow road.

## Smokes

`race/smoke/pace-check.mjs` (new): the envelope at 0 / 10 / 30 / 44.9 s / mid-ramp / after, the no-acts default, the whole act table, the 3 s blend, the opening-as-ceiling rule both ways, then a real 79 s run at 390x844 asserting plate == round(speed * 3.6) on every sample, speed never over the ceiling, nothing in the opening past the lift, the road getting its legs back after the ramp, the row timing above, and 0 console errors.

Green on the rebased branch: `pace-check`, `sync-check`, `captions-check`, `track-run-check`, `rows-check`, `chart-check`, `words-check`. Headless demo road at 390x844: 0 console errors, plate 55 / 47 / 47 / 66 km/h at 0 / 10 / 30 / 60 s.

467 changed lines against the rebased P1.

Rebased onto the sync chain (#920, #922) on 2026-09-07; run.js conflict resolved keeping S1's deferred cues + the pace hunks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJ66hi5fRM1Dcjo38aSCa2


