### PR TITLE
refactor(race): retire the sugar cube, keep its spots and its flash

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/race/AUDIO.md
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/AUDIO.md
@@ -5,8 +5,8 @@ on the dive's shared context (`engine/audioBus.js`, so the DtRH master colour ap
 fanfares the host already ships (`Resources/sounds/chaos/*.mp3`) go out as `sfx` bridge messages.
 `run.js` only calls `audio.sfx(name, scale)`, `audio.update(dt, { world, run, kart })` once per
 step, `audio.duck(on, why)` on brake / host pause / end, and `audio.dispose()`. Everything else
-audio.js reads off the live world it is handed: it subscribes to `field.onPop`, `score.onEvent`
-and `items.onEvent` itself (re-subscribing when "again" builds a new world) and watches
+audio.js reads off the live world it is handed: it subscribes to `field.onPop` and `score.onEvent`
+itself (re-subscribing when "again" builds a new world) and watches
 per-frame edges (airborne, boost, drift, the Big Wheel span, the room).
 
 `bubbles.js` plays its own kind-blind pop through `makeSfxPlayer`; that player honours
@@ -77,7 +77,7 @@ door's three. race/menu.js calls them; race/cards.js calls `ui`.
 | beat | source | in-page (WebAudio) | host leg (`sfx` name) |
 |------|--------|--------------------|-----------------------|
 | treat pop | `field.onPop` treat | Pop / Pop2 / Pop3 round-robin, combo pitch, panned, 0.34 | - |
-| lucky pop | `field.onPop` lucky | Pop2 + chime1 at +5 (item incoming) | - |
+| lucky pop | `field.onPop` lucky | Pop2 + chime1 at +5 (the 25 point treat) | - |
 | prism pop | `field.onPop` prism | Pop2 at +3 + chime1 at +5 (its chained pops sound themselves) | - |
 | golden pop | `field.onPop` golden | Pop3 at +2, chime3 at +7 (50 ms), chime3 at +12 (140 ms) | swallowed (`golden_pop` 0.9) |
 | jackpot | `score` jackpot | chime1-2-3 arpeggio 80 ms (minor 0.7), major adds chime3 at +12 (300 ms) | - |
@@ -85,14 +85,10 @@ door's three. race/menu.js calls them; race/cards.js calls `ui`.
 | near miss | `score` almost | Pop2 at -4, 0.10 (the whisper) | - |
 | rung up | `score` mult (to > from) | chime ladder (above) | swallowed (`streak_milestone` 0.6) |
 | bank | `score` bank | thud (120>38 Hz sine + click) + chime1-2-3 arpeggio 90 ms | `streak_milestone` 0.9 or `pb_fanfare` 0.9 |
-| boost (pad or sugar_rush) | `kart.boostSec` rising edge | noise whoosh, bandpass 300>3200 Hz, 0.7 s | `tunnel_powerup_collect` 0.8 |
+| boost (pad) | `kart.boostSec` rising edge | noise whoosh, bandpass 300>3200 Hz, 0.7 s | `tunnel_powerup_collect` 0.8 |
 | ramp launch | `kart.airborne` rising | sine rise 220>700 Hz, 0.36 s, soft | - |
 | ramp land | `kart.airborne` falling | thump 110>42 Hz + click | - |
 | Big Wheel | `layout.featuresBetween` loop | two noise sweeps up then down, 1.3 s + 1.0 s | - |
-| item roll | `items` itemRoll | 6 Pop3 ticks over 0.85 s, pitch rising | swallowed (`ui_click` 0.5) |
-| item arm | `items` itemArm | chime1 at +4 | swallowed (`ui_click` 0.4) |
-| item use | `items` itemUse | Pop2 at -3 + noise puff | `tunnel_powerup_collect` 0.7 |
-| tea time in / out | run.js | lowpass 1.4 kHz on the music while timeScale < 1 | `time_slow_in` / `time_slow_out` |
 | gate (room change) | `run.room.id` edge | chime2 at -3 + the crossfade | `depth_change` 0.7 |
 | brake open / close | `duck('brake')` | Pop at -7 / Pop2 at +3 | `ui_click` 0.5 (open) |
 | end card | `sfx('surface')` | chime arpeggio 130 ms + chime3 at +5 | `surface` 0.8 |

--- a/ConditioningControlPanel/Resources/web/dtrh/race/CHART.md
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/CHART.md
@@ -186,8 +186,8 @@ A row goes down whole or not at all: a row that would not fit the pool is not la
 gate is rolled ONCE for the line rather than per bubble, and `density > 1` never doubles it. It
 also SPENDS as one thing: the first of its bubbles to pop or to slip past settles the row, so five
 bubbles are one `taken` on the scheduler (`takenIds` is a set) and at worst one broken combo. With
-`setSparse(true)` `seedChunk` lays only the chunk's own golden and no lanes, ramp lines or item
-box pairs, so what the player drives through is the lyric. Too many bubbles is no bubbles.
+`setSparse(true)` `seedChunk` lays only the chunk's own golden and no lanes or ramp lines,
+so what the player drives through is the lyric. Too many bubbles is no bubbles.
 
 ### `race/run.js` + `raceBoot.js` (PR c2)
 ```js

--- a/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
@@ -96,7 +96,7 @@ Returns a `layout` object that is ALSO a valid argument to `engine/tunnel.js cre
   - `{ type:'boost', d, x }` - boost pad centre
   - `{ type:'loop', d0, d1 }` - the Big Wheel occupies `d0..d1`
   - `{ type:'gate', d, room }` - room boundary; MARQUEE fires here
-  - `{ type:'itembox', d, x }` - sugar cube (item roll)
+  - `{ type:'pickup', d, x }` - a pickup spot (race/pickups.js lights one at a time)
 - `featuresBetween(d0, d1)` -> features whose `d` (or `d0`) falls in the wrapped range.
 - `roomAtDepth(d)` -> room id.
 - `rampAt(d)` -> the ramp feature whose air line covers `d`, else `null`.
@@ -107,7 +107,7 @@ thing closes back onto the start (closed curve, `spine.closed = true`). The loop
 laterally by more than `2*RADIUS` so the tube never self-intersects (see the demo in the pitch).
 Each room's FIRST chunk is its `gate` chunk (the gate feature sits mid-chunk); the Tea Garden gate
 is `chunks[0]` at `d = 0`, so THE BANK fires on every lap crossing, and the start straight follows.
-Every room also carries at least one `itembox`, and a `boost` pad sits on the run-up to the loop.
+Every room also carries at least one `pickup` spot, and a `boost` pad sits on the run-up to the loop.
 
 ### `race/rooms.js` (PR 1)
 ```js
@@ -134,7 +134,8 @@ hemisphere (the pink sky the props and the cup are painted for; a directional in
 purple and flat) and EMI's cupLight are that tier's whole bill. Desktop is untouched.
 A crossed cube hides, throws its splits and puts a BILLBOARD flash on its spot: never a solid mesh,
 which used to read as a second, empty white box standing beside the shards.
-Road furniture (item box and its twelve splits, boost pad, ramp lip, air marker) takes its geometry
+Road furniture (boost pad, ramp lip, air marker; the pack's `item_cube` and its twelve splits are
+retired, see assets/PROPS.md) takes its geometry
 from `props.glb` through `race/propPack.js` once the pack resolves; before that, and forever if the
 pack or a node is missing, the hand-built voxel primitives stay. Placement, physics and animation
 are untouched by the swap: only geometry and material change. `roadMatrix` builds a LEFT handed
@@ -145,7 +146,7 @@ the right way round.
 ```js
 export const BUBBLE_KINDS;   // see table below
 export function createBubbleField({ scene, layout, media, getIntensity, getRoom }) -> field
-field.seedChunk(chunk)                  // place lane/air/itembox-adjacent bubbles for a chunk (idempotent per chunk id)
+field.seedChunk(chunk)                  // place lane/air bubbles for a chunk (idempotent per chunk id)
 field.spawnAhead(kartD, n)              // 'spawn' placement: appear 35..60 m ahead on the road
 field.rain(kartD, n)                    // 'rain' placement: fall from the ceiling ahead of the kart
 field.update(dt, t, kart)               // kart = { d, x, h, speed }; runs motion + collision

--- a/ConditioningControlPanel/Resources/web/dtrh/race/assets/PROPS.md
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/assets/PROPS.md
@@ -28,8 +28,8 @@ Source of truth for the geometry: `ConditioningControlPanel/tools/blender/props/
 |---|---:|---:|---|---|
 | `kart_cup` | 1720 | 3000 | 1.35 x 0.69 x 1.11 | JS lathe profile; rim = pink glaze band in the wall; handle roots start inside the wall with a boss each. Sit it 0.09 above the saucer like the JS rig. Handle on +x. |
 | `kart_saucer` | 488 | 600 | 1.90 x 0.12 x 1.90 | pink glaze rim band + mark at +x |
-| `item_cube` | 448 | 600 | 1.25 x 1.25 x 1.25 | 1.2 cube, gold "?" raised 0.025 on all six faces |
-| `item_shard_00..11` | 24 each | 40 | 0.52 or 0.68 x 0.34/0.40/0.46 x 0.72/0.48 | 2 x 2 x 3 uneven split; each node's `translation` is its centroid in cube space, so the twelve reassemble the cube exactly (checked: -0.6..0.6, 0..1.2, -0.6..0.6). 01, 06, 10 are gold. |
+| `item_cube` | 448 | 600 | 1.25 x 1.25 x 1.25 | 1.2 cube, gold "?" raised 0.025 on all six faces RETIRED with the passive pickups (race/pickups.js): still in the file, never drawn, no Blender regen. |
+| `item_shard_00..11` | 24 each | 40 | 0.52 or 0.68 x 0.34/0.40/0.46 x 0.72/0.48 | 2 x 2 x 3 uneven split; each node's `translation` is its centroid in cube space, so the twelve reassemble the cube exactly (checked: -0.6..0.6, 0..1.2, -0.6..0.6). 01, 06, 10 are gold. RETIRED with the passive pickups (race/pickups.js): still in the file, never drawn, no Blender regen. |
 | `boost_pad` | 280 | 600 | 5.75 x 0.11 x 3.00 | dark plate, edge strips, three chevron rib pairs pointing +z, ribs and strips in `boost_strip` |
 | `ramp_lip` | 160 | 600 | 7.10 x 0.31 x 0.34 | cream kerb block + pink roll |
 | `air_marker` | 88 | 600 | 0.35 x 0.35 x 0.35 | gold sugar lump |

--- a/ConditioningControlPanel/Resources/web/dtrh/race/bubbles.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/bubbles.js
@@ -179,7 +179,7 @@ export function createBubbleField({ scene, layout, media, getIntensity, getRoom,
     place('golden', 'lane', chunk.d1 - 2.5, 0, LANE_H);
   }
 
-  /** Lane lines the kart can thread, ramp air lines, and a pair flanking each sugar cube. */
+  /** Lane lines the kart can thread and ramp air lines. */
   function seedChunk(chunk) {
     if (!chunk || seeded.has(chunk.id)) return;
     seeded.add(chunk.id);
@@ -210,9 +210,6 @@ export function createBubbleField({ scene, layout, media, getIntensity, getRoom,
           const u = (i + 0.5) / n;
           place(roll('air'), 'air', f.d + f.airLen * u, x, 2 + 3 * (4 * u * (1 - u)));
         }
-      } else if (f.type === 'itembox') {
-        place(roll('lane'), 'lane', f.d, f.x - 1.5, LANE_H);
-        place(roll('lane'), 'lane', f.d, f.x + 1.5, LANE_H);
       }
     }
   }

--- a/ConditioningControlPanel/Resources/web/dtrh/race/rooms.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/rooms.js
@@ -7,13 +7,13 @@
  * everything that sits on or around the road: the pixel-tiled road ribbon with its
  * chequered kerbs and centre dash (one draw call, room-tinted through an alpha mask),
  * tiled ramp wedges with a pink lip and gold air-line cubes, lane-wide boost pads
- * with running chevrons, bobbing sugar-cube item boxes, and the diegetic props from
+ * with running chevrons, and the diegetic props from
  * race/roomProps.js. The furniture is drawn from the Blender pack (race/assets/props.glb,
  * race/propPack.js) as soon as it loads; the primitives below are the shape of every mesh
  * until then and the fallback forever if the pack is missing. update(d) culls rooms out of sight and animates what is near
  * the kart; applyRoom(fx, roomId, fadeSec) hands the room's biome style to
- * fx.applyRegionGrade; breakItemBox(feature) smashes a crossed sugar cube (pooled
- * shards, a white flash, regrowth after RESPAWN_SEC); dispose() tears it all down.
+ * fx.applyRegionGrade; dispose() tears it all down. The sugar cube and its shards are retired
+ * (the white take flash stays, for race/pickups.js).
  *
  * Every position goes through layout.toWorld(d, x, h) and every orientation through
  * layout.frameAtDepth(d). Draw calls: 6 for the furniture + 21 for the props (27).
@@ -236,11 +236,10 @@ export function createRoomDresser({ scene, layout, rooms = ROOMS }) {
     return mesh;
   })();
 
-  // ---- ramps: tiled wedge + pink lip + gold air cubes; boost pads; sugar cubes ---------
+  // ---- ramps: tiled wedge + pink lip + gold air cubes; boost pads; the take flash ---------
   const feats = layout.chunks.flatMap((c) => c.features);
   const ramps = feats.filter((f) => f.type === 'ramp');
   const pads = feats.filter((f) => f.type === 'boost');
-  const cubes = feats.filter((f) => f.type === 'itembox');
   const wedgeTex = pixelTex(32, 32, (c, w, h) => {
     c.fillStyle = '#d8d8d8'; c.fillRect(0, 0, w, h);
     for (let y = 0; y < h; y += 8) for (let x = 0; x < w; x += 8) { c.fillStyle = (((x + y) / 8) & 1) ? '#e8e8e8' : '#cfcfcf'; c.fillRect(x, y, 8, 8); }
@@ -288,32 +287,10 @@ export function createRoomDresser({ scene, layout, rooms = ROOMS }) {
   const padMesh = new THREE.InstancedMesh(padGeo, padMat, Math.max(1, pads.length));
   pads.forEach((p, i) => padMesh.setMatrixAt(i, roadMatrix(p.d, p.x, 0.03, 0, 1, _m)));
   padMesh.count = pads.length;
-  // sugar cube: 1.2 m, pixel "?" on every face, bobbing + turning, gold glow
-  const cubeTex = pixelTex(16, 16, (c, w, h) => {
-    c.fillStyle = '#fff6ea'; c.fillRect(0, 0, w, h);
-    c.fillStyle = '#e9d9c4'; c.fillRect(0, 0, w, 1); c.fillRect(0, 0, 1, h); c.fillRect(0, h - 1, w, 1); c.fillRect(w - 1, 0, 1, h);
-    c.fillStyle = '#e23c9c';
-    const Q = ['.####.', '##..##', '....##', '...##.', '..##..', '......', '..##..', '..##..'];
-    Q.forEach((row, y) => [...row].forEach((ch, x) => { if (ch === '#') c.fillRect(5 + x, 3 + y, 1, 1); }));
-  });
-  if (cubeTex) texes.push(cubeTex);
-  const cubeMat = mat(new THREE.MeshLambertMaterial({ map: cubeTex, color: 0xffffff, emissive: 0xf2c14e, emissiveIntensity: 0.25 }));
-  const CUBE = 1.2;
-  const cubeMesh = new THREE.InstancedMesh(track(new THREE.BoxGeometry(CUBE, CUBE, CUBE)), cubeMat, Math.max(1, cubes.length));
-  cubes.forEach((c, i) => cubeMesh.setMatrixAt(i, roadMatrix(c.d, c.x, CUBE * 0.75, 0, 1, _m)));
-  cubeMesh.count = cubes.length;
-  // a crossed cube BREAKS: it hides, throws SHARDS_PER pieces of itself (pooled, world space,
-  // gravity along the local up) with a white flash on its spot, and grows back after RESPAWN_SEC.
-  const cubeIndex = new Map(cubes.map((c, i) => [c, i]));
-  const cubeBrokenAt = new Float64Array(Math.max(1, cubes.length)).fill(-1);   // -1 = intact
-  const RESPAWN_SEC = 8, REGROW_SEC = 0.5, SHARD_TTL = 0.65, SHARDS_PER = 8, SHARD_N = 48, FLASH_N = 4, FLASH_SEC = 0.22;
-  const shards = new THREE.InstancedMesh(track(new THREE.BoxGeometry(CUBE * 0.24, CUBE * 0.24, CUBE * 0.24)), cubeMat, SHARD_N);
-  const shard = []; for (let i = 0; i < SHARD_N; i++) shard.push({ life: 0, age: 0, spin: 0, p: new THREE.Vector3(), v: new THREE.Vector3(), g: new THREE.Vector3(), axis: new THREE.Vector3(0, 1, 0) });
-  let shardCursor = 0, shardsLive = 0;
-  // The break flash used to be a full-size CUBE of opaque white: it swelled past the box for a
-  // fifth of a second and read as a SECOND, empty white box standing beside the shards. A flash is
-  // light, not furniture, so it is now a billboard that always faces the seat, additive over the
-  // road and fading as it swells. It can never draw an edge, so it can never read as a box.
+  const FLASH_N = 4, FLASH_SEC = 0.22, FLASH_SIZE = 1.2;
+  // The take flash (race/pickups.js) is light, not furniture: a billboard that always faces the seat,
+  // additive over the road and fading as it swells. It can never draw an edge, so it can never read
+  // as a box. flashAt(d, x, h) lights one on that spot.
   const flashTex = pixelTex(24, 24, (c, w, h) => {
     c.fillStyle = '#000'; c.fillRect(0, 0, w, h);
     const mid = (w - 1) / 2;
@@ -332,65 +309,20 @@ export function createRoomDresser({ scene, layout, rooms = ROOMS }) {
   for (let i = 0; i < FLASH_N; i++) {
     const fm = mat(new THREE.SpriteMaterial({ map: flashTex, color: 0xffffff, transparent: true, opacity: 0, depthWrite: false, blending: THREE.AdditiveBlending }));
     const sprite = new THREE.Sprite(fm);
-    sprite.name = 'race-cube-flash'; sprite.visible = false; sprite.frustumCulled = false;
+    sprite.name = 'race-take-flash'; sprite.visible = false; sprite.frustumCulled = false;
     group.add(sprite);
     flash.push({ life: 0, sprite, fm });
   }
   let flashCursor = 0, flashesLive = 0;
-  const _q = new THREE.Quaternion(), _up = new THREE.Vector3(), _hide = new THREE.Vector3(0, -999, 0);
-  const hideAll = (mesh, n) => { for (let i = 0; i < n; i++) mesh.setMatrixAt(i, _m.compose(_hide, _q.identity(), _s.setScalar(0.0001))); };
-  hideAll(shards, SHARD_N);
   let lastT = -1;
-  /** Break the cube for feature f (or its index). Returns true when it was intact, false when
-   *  it was already broken (the run brain hands out an item only on true). */
-  function breakItemBox(f) {
-    const i = typeof f === 'number' ? f : cubeIndex.get(f);
-    if (i == null || cubeBrokenAt[i] >= 0) return false;
-    const c = cubes[i];
-    cubeBrokenAt[i] = now() - t0;
-    cubeMesh.setMatrixAt(i, roadMatrix(c.d, c.x, CUBE * 0.75, 0, 0.0001, _m)); cubeMesh.instanceMatrix.needsUpdate = true;
-    const fr = layout.frameAtDepth(c.d); _up.copy(fr.up);
-    layout.toWorld(c.d, c.x, CUBE * 0.75, _p);
-    // with the pack in, a break throws the cube's OWN twelve splits from where they were
-    // authored, so the box comes apart instead of shedding generic crumbs
-    const per = shardKinds ? shardKinds.length : SHARDS_PER;
-    if (shardKinds) shardSet = (shardSet + 1) % SHARD_SETS;
-    for (let k = 0; k < per; k++) {
-      const kind = shardKinds ? shardKinds[k] : null;
-      const j = kind ? shardSet * shardKinds.length + k : shardCursor;
-      if (!kind) shardCursor = (shardCursor + 1) % SHARD_N;
-      const s = shard[j];
-      if (s.life <= 0) shardsLive++;
-      s.life = SHARD_TTL; s.age = 0;
-      const ox = kind ? kind.off.x : (rng() - 0.5) * CUBE * 0.6, oy = kind ? kind.off.y : (rng() - 0.5) * CUBE * 0.6, oz = kind ? kind.off.z : (rng() - 0.5) * CUBE * 0.6;
-      s.p.copy(_p).addScaledVector(fr.right, ox).addScaledVector(_up, oy).addScaledVector(fr.tangent, oz);
-      if (kind) s.v.copy(fr.right).multiplyScalar(ox * 7 + (rng() - 0.5) * 2).addScaledVector(_up, 2.5 + oy * 4 + rng() * 2).addScaledVector(fr.tangent, oz * 7 + 1 + rng() * 3);
-      else s.v.copy(fr.right).multiplyScalar((rng() - 0.5) * 7).addScaledVector(_up, 2.5 + rng() * 4).addScaledVector(fr.tangent, 1 + rng() * 5);
-      s.g.copy(_up).multiplyScalar(-14);
-      s.axis.set(rng() - 0.5, rng() - 0.5, rng() - 0.5).normalize(); s.spin = (rng() - 0.5) * 24;
-    }
+  function flashAt(d, x, h) {
+    layout.toWorld(d, x, h, _p);
     const fl = flash[flashCursor]; flashCursor = (flashCursor + 1) % FLASH_N;
     if (fl.life <= 0) flashesLive++;
     fl.life = FLASH_SEC; fl.sprite.position.copy(_p); fl.sprite.visible = true;
-    return true;
   }
-  function updateBreaks(t) {
+  function updateFlashes(t) {
     const dt = lastT < 0 ? 0 : Math.min(0.05, t - lastT); lastT = t;
-    if (shardsLive > 0) {                   // shards fly, spin and shrink out
-      let live = 0;
-      for (let i = 0; i < SHARD_N; i++) {
-        const s = shard[i];
-        if (s.life <= 0) continue;
-        s.life -= dt; s.age += dt;
-        if (s.life <= 0) { setShard(i, _m.compose(_hide, _q.identity(), _s.setScalar(0.0001))); continue; }
-        live++;
-        s.v.addScaledVector(s.g, dt); s.p.addScaledVector(s.v, dt);
-        setShard(i, _m.compose(s.p, _q.setFromAxisAngle(s.axis, s.spin * s.age), _s.setScalar(0.4 + 0.6 * (s.life / SHARD_TTL))));
-      }
-      shardsLive = live;
-      if (shardKinds) for (const k of shardKinds) { k.mesh.visible = live > 0; k.mesh.instanceMatrix.needsUpdate = true; }
-      else shards.instanceMatrix.needsUpdate = true;
-    }
     if (flashesLive > 0) {                  // the flash: a burst of light on the spot that swells and fades out
       let live = 0;
       for (let i = 0; i < FLASH_N; i++) {
@@ -401,17 +333,17 @@ export function createRoomDresser({ scene, layout, rooms = ROOMS }) {
         live++;
         const u = fl.life / FLASH_SEC;       // 1 on the break, 0 as it goes
         fl.fm.opacity = 0.9 * u;
-        fl.sprite.scale.setScalar(CUBE * (1.7 + 2.0 * (1 - u)));
+        fl.sprite.scale.setScalar(FLASH_SIZE * (1.7 + 2.0 * (1 - u)));
       }
       flashesLive = live;
     }
   }
-  for (const m of [wedges, lips, airDots, padMesh, cubeMesh, shards]) { m.frustumCulled = false; m.instanceMatrix.needsUpdate = true; group.add(m); }
+  for (const m of [wedges, lips, airDots, padMesh]) { m.frustumCulled = false; m.instanceMatrix.needsUpdate = true; group.add(m); }
   if (wedges.instanceColor) wedges.instanceColor.needsUpdate = true;
 
   // ---- the Blender pack takes the furniture over (race/assets/props.glb) -----------------
-  // Geometry and material only: every instance matrix written above stays valid, so the bob,
-  // the turn, the break, the regrow and the air-line fade all carry across untouched. The pack
+  // Geometry and material only: every instance matrix written above stays valid, so the pad
+  // pulse and the air-line fade carry across untouched. The pack
   // is authored base-centre on the ground, so each geometry is nudged to sit where the
   // primitive's origin was. No pack, a slow pack or a broken node: the primitives stay.
   // roadMatrix builds its basis from (right, up, tangent), which is LEFT handed, so every road
@@ -419,18 +351,12 @@ export function createRoomDresser({ scene, layout, rooms = ROOMS }) {
   // from the instance one, so an authored prop would rasterise inside out: its faces cull away and
   // the inverted hull shows as a solid dark block. Mirroring the geometry on x cancels that: the
   // pair of flips is a plain rotation, the prop reads the right way round and the hull is a
-  // silhouette again. The shards compose their own matrices, so they stay as authored.
+  // silhouette again.
   const ROAD_MIRROR = -1;
-  const SHARD_KINDS = 12, SHARD_SETS = Math.max(1, Math.floor(SHARD_N / SHARD_KINDS));
   const packGeos = [], packMeshes = [];
-  let itemMat = cubeMat, lipMat = pinkGlow, padPulse = null, shardKinds = null, shardSet = -1, dead = false;
-  const setShard = (i, m) => {
-    if (shardKinds) shardKinds[i % SHARD_KINDS].mesh.setMatrixAt((i / SHARD_KINDS) | 0, m);
-    else shards.setMatrixAt(i, m);
-  };
+  let lipMat = pinkGlow, padPulse = null, dead = false;
   const litMat = (emissive, intensity) => mat(new THREE.MeshLambertMaterial({ vertexColors: true, emissive, emissiveIntensity: intensity }));
   const swapMesh = (mesh, geo, material) => { packGeos.push(geo); mesh.geometry = geo; if (material) mesh.material = material; };
-  const hideMatrix = () => _m.compose(_hide, _q.identity(), _s.setScalar(0.0001));
 
   /** The colour of the material named `name` anywhere under pack node `node`, or null. */
   function packColor(pack, node, name) {
@@ -472,28 +398,6 @@ ${sh.fragmentShader}`.replace('#include <emissivemap_fragment>', `#include <emis
     return m;
   }
 
-  /** One InstancedMesh per authored split, SHARD_SETS deep, hidden while nothing is flying: the
-   *  steady-state draw count matches the single pooled shard mesh these replace. */
-  function packShards(pack, cy) {
-    const out = [];
-    for (let k = 0; k < SHARD_KINDS; k++) {
-      const name = `item_shard_${String(k).padStart(2, '0')}`;
-      const node = pack.byName(name), geo = packGeo(pack, name);
-      if (!node || !geo) {
-        for (const it of out) { group.remove(it.mesh); it.mesh.dispose(); it.geo.dispose(); }
-        if (geo) geo.dispose();
-        return null;
-      }
-      const mesh = new THREE.InstancedMesh(geo, itemMat, SHARD_SETS);
-      mesh.frustumCulled = false; mesh.visible = false; mesh.name = `race-shard-${k}`;
-      for (let j = 0; j < SHARD_SETS; j++) mesh.setMatrixAt(j, hideMatrix());
-      group.add(mesh); packMeshes.push(mesh);
-      out.push({ mesh, geo, off: new THREE.Vector3(node.position.x, node.position.y - cy, node.position.z) });
-    }
-    shards.visible = false;
-    return out;
-  }
-
   function dressFurniture(pack) {
     const lip = packGeo(pack, 'ramp_lip', [0, -0.07, 0], ROAD_MIRROR);       // base lands on the wedge crest
     if (lip) { lipMat = litMat(0xff69b4, 0.7); swapMesh(lips, lip, lipMat); }
@@ -506,15 +410,6 @@ ${sh.fragmentShader}`.replace('#include <emissivemap_fragment>', `#include <emis
       pad.boundingBox = null; pad.computeBoundingSphere();
       padPulse = { value: 0 };
       swapMesh(padMesh, pad, stripMaterial(pack, pad, padPulse));
-    }
-    const cube = packGeo(pack, 'item_cube', null, ROAD_MIRROR);
-    if (cube) {
-      const cy = geoSize(cube).cy;                                          // the shards are authored in cube space
-      cube.translate(0, -cy, 0); cube.boundingBox = null;
-      itemMat = litMat(0xf2c14e, 0.25);
-      swapMesh(cubeMesh, cube, itemMat);
-      shardKinds = packShards(pack, cy);
-      if (shardKinds) { for (const s of shard) s.life = 0; shardsLive = 0; }
     }
   }
   propPack().then((pack) => { if (pack && !dead) dressFurniture(pack); });
@@ -536,21 +431,7 @@ ${sh.fragmentShader}`.replace('#include <emissivemap_fragment>', `#include <emis
   function update(d) {
     const t = now() - t0;
     props.update(d, t);
-    let dirty = false;
-    for (let i = 0; i < cubes.length; i++) {
-      const c = cubes[i], since = cubeBrokenAt[i] >= 0 ? t - cubeBrokenAt[i] : -1;
-      if (since >= 0 && since < RESPAWN_SEC) continue;                       // hidden, matrix already written
-      let scale = 1;
-      if (since >= 0) {                                                       // growing back
-        const u = Math.min(1, (since - RESPAWN_SEC) / REGROW_SEC);
-        scale = u < 1 ? Math.max(0.0001, 1.12 * Math.sin(u * Math.PI * 0.5)) : 1;
-        if (u >= 1) cubeBrokenAt[i] = -1;
-      } else if (wrapDist(c.d, d) > ANIM) continue;
-      cubeMesh.setMatrixAt(i, roadMatrix(c.d, c.x, CUBE * 0.75 + 0.18 * Math.sin(t * 2 + i), t * 1.1 + i, scale, _m));
-      dirty = true;
-    }
-    if (dirty) cubeMesh.instanceMatrix.needsUpdate = true;
-    updateBreaks(t);
+    updateFlashes(t);
     // air-line dots: gone while they would sit between the seat and the cup, back over DOT_NEAR..DOT_FAR
     let adirty = false;
     for (let i = 0; i < airD.length; i++) {
@@ -563,7 +444,6 @@ ${sh.fragmentShader}`.replace('#include <emissivemap_fragment>', `#include <emis
       adirty = true;
     }
     if (adirty) airDots.instanceMatrix.needsUpdate = true;
-    itemMat.emissiveIntensity = 0.25 + 0.2 * (0.5 + 0.5 * Math.sin(t * 3));
     if (padPulse) padPulse.value = t * 7;                 // the pack's ribs glow and the glow runs
     else {
       if (padTex) padTex.offset.y = (t * 1.6) % 1;        // the chevrons run forward
@@ -590,8 +470,8 @@ ${sh.fragmentShader}`.replace('#include <emissivemap_fragment>', `#include <emis
     for (const t of texes) t.dispose();
     props.dispose();
     for (const fl of flash) group.remove(fl.sprite);
-    for (const m of [wedges, lips, airDots, padMesh, cubeMesh, shards]) m.dispose();
+    for (const m of [wedges, lips, airDots, padMesh]) m.dispose();
   }
 
-  return { update, applyRoom, breakItemBox, dispose, group, spans, rooms: specs };
+  return { update, applyRoom, dispose, group, spans, rooms: specs };
 }

--- a/ConditioningControlPanel/Resources/web/dtrh/race/run.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/run.js
@@ -512,7 +512,6 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     // track features crossed this frame
     for (const f of lay.featuresBetween(prevD, ks.d)) {
       if (f.type === 'boost' && !ks.airborne && Math.abs(f.x - ks.x) <= 1.2) { k.applyBoost(1.6); sfx('tunnel_powerup_collect', 0.8); shake.shake(0.25, 200); poke('streamed', 1.2); k.pose('boost'); }
-      else if (f.type === 'itembox' && Math.abs(f.x - ks.x) <= 1.2 && w.dresser.breakItemBox(f)) shake.shake(0.2, 120);
       else if (f.type === 'gate') enterRoom(w, ts && ts.act ? ts.act.room : f.room, ts && ts.act ? ts.act.name : null);
     }
     if (ks.airborne) S.airH = Math.max(S.airH, ks.h);
@@ -669,26 +668,6 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     scene.clear(); renderer.dispose();
   }
 
-  /** Screenshot aid (`?itembox=<ms>` on the standalone page): break the nearest sugar cube ahead the
-   *  way a crossing does, so a headless shot catches the break without anyone steering. A cube too
-   *  far to read is pulled into view first (the kart's depth jumps): a dev-only warp, and the reason
-   *  this is never reachable from the host. Returns false when there is no cube to break. */
-  function debugItemBox() {
-    if (!W || !S.running || S.paused) return false;
-    const ks = W.kart.state, lay = W.layout, half = lay.totalDepth / 2;
-    let best = null, bestRel = Infinity;
-    for (const c of lay.chunks) for (const f of c.features || []) {
-      if (f.type !== 'itembox') continue;
-      const rel = lay.wrap(f.d - ks.d + half) - half;
-      if (rel > 5 && rel < bestRel) { bestRel = rel; best = f; }
-    }
-    if (!best) return false;
-    if (bestRel > 16) { ks.d = lay.wrap(best.d - 16); trailClear(); }
-    if (!W.dresser.breakItemBox(best)) return false;
-    shake.shake(0.2, 120);
-    return true;
-  }
-
   resetRunState(seed);          // the world waits for prepare() / start(): frame() draws the stage until then
   raf = requestAnimationFrame(frame);
   function setCameraOverride(fn) { camOverride = typeof fn === 'function' ? fn : null; }
@@ -720,7 +699,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     // track charts (CHART.md): setTrack before start(), replaceTrack for the words pass landing live,
     // trackClock for the host's 250 ms tick, trackEnded when the file runs out at the host's end
     setTrack, replaceTrack: (chart) => { TR.replace(chart); audio.setRoute(routeOf(TR.track)); if (W) W.field.setSparse(TR.lyrics); if (captions) captions.setTrack(TR.track ? TR.track.chart : null); }, trackClock: (t, playing) => TR.clock(t, playing),
-    trackEnded: () => { TR.end(); if (TR.track && S.running) endRun(); }, trackStats: () => TR.stats(), syncTrace: () => sync.trace(), debugItemBox,
+    trackEnded: () => { TR.end(); if (TR.track && S.running) endRun(); }, trackStats: () => TR.stats(), syncTrace: () => sync.trace(),
     get track() { return TR.track; } };
 }
 

--- a/ConditioningControlPanel/Resources/web/dtrh/race/spine.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/spine.js
@@ -183,11 +183,11 @@ export function createSpine({ seed = 1, roomOrder } = {}) {
       features.push({ type: 'ramp', d: d0 + 14, airLen: range(rng, [22, 30]), height: range(rng, [3, 4]) });
     } else {
       if (rng() < boostOdds) features.push({ type: 'boost', d: d0 + len * 0.5, x: range(rng, [-1.2, 1.2]) });
-      if (rng() < 0.5) features.push({ type: 'itembox', d: d0 + len * (rng() < 0.5 ? 0.28 : 0.76), x: range(rng, [-1.8, 1.8]) });
+      if (rng() < 0.5) features.push({ type: 'pickup', d: d0 + len * (rng() < 0.5 ? 0.28 : 0.76), x: range(rng, [-1.8, 1.8]) });
     }
     return { id: i, kind: c.kind, d0, d1, room: c.room, features };
   });
-  // a boost pad on the run-up to the wheel, and one sugar cube per room at least
+  // a boost pad on the run-up to the wheel, and one pickup spot per room at least (race/pickups.js)
   chunks.forEach((ch, i) => {
     if (ch.kind !== 'loop' || i === 0) return;
     const prev = chunks[i - 1];
@@ -195,9 +195,9 @@ export function createSpine({ seed = 1, roomOrder } = {}) {
   });
   for (const room of new Set(chunks.map((c) => c.room))) {
     const mine = chunks.filter((c) => c.room === room);
-    if (mine.some((c) => c.features.some((f) => f.type === 'itembox'))) continue;
+    if (mine.some((c) => c.features.some((f) => f.type === 'pickup'))) continue;
     const host = mine.find((c) => c.kind !== 'gate' && c.kind !== 'loop' && c.kind !== 'ramp') || mine[1] || mine[0];
-    host.features.push({ type: 'itembox', d: host.d0 + (host.d1 - host.d0) * 0.6, x: 0 });
+    host.features.push({ type: 'pickup', d: host.d0 + (host.d1 - host.d0) * 0.6, x: 0 });
   }
   chunks.forEach((c) => c.features.sort((a, b) => (a.d ?? a.d0) - (b.d ?? b.d0)));
   const allFeatures = chunks.flatMap((c) => c.features);

--- a/ConditioningControlPanel/Resources/web/dtrh/raceBoot.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/raceBoot.js
@@ -45,8 +45,7 @@
  * either they show once, gated on localStorage `race.cards`), and `?card=N`
  * opens them on card N (1..4, a screenshot aid the way `?hold=` is one);
  * `?pixel=N` (0 = off) beats `race.options` which beats `settings.pixel` from
- * the host init; `?itembox=ms` breaks the next sugar cube that comes into
- * reading range after that time and is a screenshot aid for the break;
+ * the host init;
  * `?panel=howto` opens the menu on the key card (race/menu.js).
  *
  * `?back=<same-origin path>` is WHERE THE MENU'S `surface` VERB GOES when there
@@ -302,7 +301,7 @@ async function boot() {
     host.log(`race booted: seed ${seed} (${opts.seed}), tier ${Q.tier}${tierParam ? ' (?tier)' : ''}, hosted ${hosted}, manifest ${haveManifest}`);
     if (params.get('perf') === '1') perfLog();
     await standaloneTrack();
-    if (params.get('autostart') === '1') { startRun(false); debugItemBox(); return; }
+    if (params.get('autostart') === '1') { startRun(false); return; }
     if (hudRoot) hudRoot.classList.add('is-lobby');   // the run's chrome stays out of the menu and the intro
     levels = await makeLevels();
     menu = createMenu({ root, renderer: race.renderer, pixel: race.pixel, audio: race.audio, settings, log: host.log, send: host.send, levels });
@@ -529,18 +528,6 @@ function perfLog() {
   };
   setInterval(tick, PERF_LOG_MS);
 }
-/** `?itembox=<ms>`: the screenshot aid. Waits for the run, then retries until a cube is in range. */
-function debugItemBox() {
-  const at = Number(params.get('itembox'));
-  if (!(at > 0) || !race || !race.debugItemBox) return;
-  setTimeout(function tick() {
-    let hit = false;
-    try { hit = race.debugItemBox(); } catch (e) { host.log('itembox: ' + e); return; }
-    if (hit) host.log('itembox: broken at ' + Math.round(performance.now()) + ' ms');
-    else if (!exiting) setTimeout(tick, 90);
-  }, at);
-}
-
 function hideSplash() {
   splash.classList.add('is-off');
   setTimeout(() => { splash.hidden = true; }, 600);


### PR DESCRIPTION
## Stack

Racing Thoughts passive pickups, PR 2 of 4. Base `feat/race-pickups-r0a-retire-items`, next `r1-passive`. Site PR CodeBambi/cclabs-web#183 must merge before the app-side `sync:race` runs after r1.

## What

Retires the sugar cube item box mesh and its pickup-and-roll flow in `rooms.js` (141 lines out), the run.js hook that fed it, the raceBoot.js debug aid for it, and the last bubbles.js/spine.js references. The spots stay: spine.js still rolls one `pickup` feature per chunk at `rng() < 0.5`, x in [-1.8, 1.8], plus one per room at x 0, and the white take flash stays for r1 to reuse. Docs (AUDIO.md item row, CHART.md, CONTRACT.md, assets/PROPS.md) updated to match. 244 changed lines, 42+ / 202-.

## Checks

Same set as r0a, all green: node-only 11/11, headless captions/cloud-chart/cloud/levels/pace/real-audio/rows/sync/track-run, demo run at 390x844 with 0 console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJ66hi5fRM1Dcjo38aSCa2
