### PR TITLE
feat(race): the pickup family, pocket watch to riptide

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
@@ -258,7 +258,7 @@ while the glb is mounted (the primitive EMI has no limbs to pose).
 
 ### `race/pickups.js` (the passive pickups)
 ```js
-export const TUNE;      // the one table of knobs: FIRST_SEC, GAP_SEC, AHEAD_M, TAKE_X, POINTS, DROP_M
+export const TUNE;      // the one table of knobs: FIRST_SEC, GAP_SEC, AHEAD_M, TAKE_X, POINTS, DROP_M, CLEAR_SEC, GOLD_LEAD_SEC
 export const PICKUPS;   // rows { id, name, family, pool, sec, sprite, ...the effect's own numbers }; PICKUP_BY_ID by id
 export function weightFor(pickup, mult) / rollPickup(mult, rand, exclude)
 export function createPickups({ rng, spots, totalDepth }) -> { update(dt, frame), take(), light(id, spot), chips(), reset(), onEvent(cb), byId(id), live, active, spots }
@@ -275,8 +275,18 @@ The module never touches three or the DOM; effects are events the run brain appl
 `applyPickup` in run.js) off the row's numbers: `{type:'pickupSpawn', id, d, x}`, `{type:'pickupTake',
 id, p, refresh}`, `{type:'pickupEnd', id}`, `{type:'pickupDrop', id}`. The rows: `poppers` (the cup grows
 to `scale`, the pop box to `reach` and the seat slides back: `kart.setScale`, `field.setReach`,
-`kart.setReach`), `the_pump` (`field.setSweep(on)` pops the whole road for `sec` on a
-`kart.applyBoost(sec)`). `lucky` is a plain 25 point treat.
+`kart.setReach`), `pocket_watch` (`kart.setSway(swing, period)` swings the cup like the pendulum,
+`score.freezeCombo(sec)` holds the combo), `the_wand` (`field.setReach(reach, true)`: a magnet for
+treats alone, effect bubbles keep the plain box), `rabbit_foot` (`S.jackpotBias = bias` on a seeded
+road; on a worded one `track.gild(rows)` and cues.js puts a `golden` in the centre of the next `rows`
+trigger rows through `ctx.gold()`), `golden_touch` (`score.boostMult(mult, sec)`), `the_pump`
+(`field.setSweep(on)` pops the whole road for `sec` on a `kart.applyBoost(sec)`) and `riptide`
+(`field.setPull(on)` slides everything within 40 m ahead into the lane over 0.5 s; the cruise runs
+`speed` times faster through `S.tide` on the pace path, under the pace's own ceiling). `lucky` is a
+plain 25 point treat. On a track the frame carries `t` and `nextEventT` (track.js `nextEvent`, the
+one door into the file): a take lands `CLEAR_SEC` clear of every chart event at the kart's speed,
+never in the first act, and `golden_touch` is not rolled but lit when the next trigger is
+`GOLD_LEAD_SEC` past the take.
 
 ### `race/hud.js` + `race/race.css` (PR 4)
 ```js
@@ -372,8 +382,9 @@ As built (PR 5 reality notes):
   and the host refuses the message, so this path is dark at both ends.
 - The first Tea Garden gate sits at d = 9 (mid gate chunk), so it crosses ~0.4 s after start: that crossing
   shows the opening MARQUEE and never banks. Later Tea Garden gates bank only when the road score is > 0.
-- The pickups (race/pickups.js) widen the pop box through `field.setReach(mult)` + `kart.setReach(mult)`
-  (poppers, the wand) and open it to the whole road through `field.setSweep(on)` (the pump).
+- The pickups (race/pickups.js) widen the pop box through `field.setReach(mult, treatsOnly)` + `kart.setReach(mult)`
+  (poppers, the wand), open it to the whole road through `field.setSweep(on)` (the pump) and pull the
+  road into the lane through `field.setPull(on)` (riptide).
 - Nothing flips the canvas: screen shake owns the root's `style.transform` alone.
 - `again` on the end screen rebuilds the world in place (spine, tunnel, fx, dresser, field, kart, score,
   pickups) with a fresh seed; renderer, HUD, input, payloadFx and shake persist for the page's life.

--- a/ConditioningControlPanel/Resources/web/dtrh/race/bubbles.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/bubbles.js
@@ -84,6 +84,8 @@ export function createBubbleField({ scene, layout, media, getIntensity, getRoom,
 
   // ---- pools ---------------------------------------------------------------
   const CAP = Q.bubbleCap || 160, SHARD_CAP = Q.bubbleShards || 64, VIEW_AHEAD = Q.bubbleViewAhead || 110;
+  /** riptide (race/pickups.js): bubbles this far ahead slide into the kart's lane over this long. */
+  const PULL_M = 40, PULL_SEC = 0.5;
   const group = new THREE.Group();
   group.name = 'race-bubbles';
   scene.add(group);
@@ -117,6 +119,8 @@ export function createBubbleField({ scene, layout, media, getIntensity, getRoom,
   let rowSeq = 0;
   let reachX = POP_HIT_X, reachH = POP_HIT_H;   // the pop box (setReach: poppers, the wand)
   let sweep = false;                            // the pump: the whole road pops (setSweep)
+  let reachAll = true;                          // false: the wider box is for treats alone (the wand)
+  let pull = false;                             // riptide: the road ahead slides into the lane (setPull)
   const popCbs = [], missCbs = [];
   const emit = (cbs, ev) => { for (const cb of cbs) { try { cb(ev); } catch (e) { /* listener bug, not ours */ } } };
 
@@ -247,7 +251,7 @@ export function createBubbleField({ scene, layout, media, getIntensity, getRoom,
    *  rolled ONCE for the whole line rather than per bubble, and density over 1 never doubles it,
    *  because a doubled row is just a thicker wall and the wall was already unavoidable.
    *  Returns how many went down, 0 for a row that was gated out. */
-  function spawnRow({ kindId, placement = 'lane', d, h, xs, eventId = null } = {}) {
+  function spawnRow({ kindId, kindIds = null, placement = 'lane', d, h, xs, eventId = null } = {}) {
     const list = Array.isArray(xs) ? xs.filter((x) => Number.isFinite(Number(x))) : [];
     if (!list.length) return 0;
     if (KIND_BY_ID[kindId] && KIND_BY_ID[kindId].spawn === false) return 0;   // a dark kind: no chart may place one
@@ -258,7 +262,8 @@ export function createBubbleField({ scene, layout, media, getIntensity, getRoom,
     }
     const top = h == null ? (placement === 'rain' ? CEILING_H : placement === 'air' ? 2.6 : LANE_H) : h;
     const id = ++rowSeq;
-    for (const x of list) { const s = place(kindId, placement, d, Number(x), top); s.eventId = eventId; s.rowId = id; }
+    // kindIds: one kind per x for a row that is not all one thing (the rabbit foot's golden centre)
+    list.forEach((x, i) => { const s = place((kindIds && kindIds[i]) || kindId, placement, d, Number(x), top); s.eventId = eventId; s.rowId = id; });
     return id;   // the row's id: run.js hands it to race/sync.js, which moveRow()s it onto its word
   }
   /** A row goes to depth `d`: the kart's speed changed inside the lookahead, so the word will be said
@@ -339,6 +344,8 @@ export function createBubbleField({ scene, layout, media, getIntensity, getRoom,
         if (f >= 1) { freeSlot(s); continue; }
       } else {
         const bob = 0.12 * Math.sin(t * 2.2 + s.phase);
+        // riptide: x slides to the kart (x0 too, so a spawn's wobble rides along with it)
+        if (pull && rel > 0 && rel <= PULL_M) { const k = Math.min(1, dt / PULL_SEC); s.x += (kart.x - s.x) * k; s.x0 += (kart.x - s.x0) * k; }
         if (s.placement === 'lane') { s.h = s.baseH + bob; }
         else if (s.placement === 'air') { s.h = s.baseH + 0.08 * Math.sin(t * 2.6 + s.phase); }
         else if (s.placement === 'spawn') {
@@ -363,7 +370,8 @@ export function createBubbleField({ scene, layout, media, getIntensity, getRoom,
           if (k.kind === 'treat') emit(missCbs, { id: k.id, points: k.points, d: s.d, x: s.x, h: s.h, eventId: s.eventId });
         }
         if (rel < -DROP_BEHIND && rel > -DROP_BEHIND - 40) { freeSlot(s); continue; }
-        if (Math.abs(rel) < POP_HIT_D && (sweep || (Math.abs(s.x - kart.x) < reachX && Math.abs(s.h - kart.h) < reachH))) pop(s);
+        const wide = reachAll || KIND_BY_ID[s.kindId].kind === 'treat';   // the wand reaches for treats alone
+        if (Math.abs(rel) < POP_HIT_D && (sweep || (Math.abs(s.x - kart.x) < (wide ? reachX : POP_HIT_X) && Math.abs(s.h - kart.h) < (wide ? reachH : POP_HIT_H)))) pop(s);
       }
       s.sprite.visible = rel > -DROP_BEHIND && rel < VIEW_AHEAD;
       if (s.sprite.visible) {
@@ -412,10 +420,13 @@ export function createBubbleField({ scene, layout, media, getIntensity, getRoom,
     setTracked(on) { tracked = !!on; },
     /** The loaded track has a transcript under it: seedChunk stands down to the chunk's golden. */
     setSparse(on) { sparse = !!on; },
-    /** Poppers / the wand: widen the pop box (X and H) by mult; 1 restores it. */
-    setReach(mult) { const m = clamp(Number(mult) || 1, 0.5, 3); reachX = POP_HIT_X * m; reachH = POP_HIT_H * m; },
+    /** Poppers / the wand: widen the pop box (X and H) by mult; 1 restores it. treatsOnly keeps an
+     *  effect bubble at the plain box, so the wand is a magnet for treats and never a shortcut into a payload. */
+    setReach(mult, treatsOnly = false) { const m = clamp(Number(mult) || 1, 0.5, 3); reachX = POP_HIT_X * m; reachH = POP_HIT_H * m; reachAll = !treatsOnly; },
     /** The pump: while on, every bubble the kart's depth crosses pops, the whole road wide and high. */
     setSweep(on) { sweep = !!on; },
+    /** riptide: while on, everything inside PULL_M ahead slides into the kart's lane. */
+    setPull(on) { pull = !!on; },
     get liveCount() { return liveCount; },
   };
 }

--- a/ConditioningControlPanel/Resources/web/dtrh/race/cues.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/cues.js
@@ -106,7 +106,8 @@ function triggerKind(label, ctx) {
 
 /**
  * @param event a chart event (race/chart.js normalizeChart shape)
- * @param ctx { energy, act, room, intensity, rng, triggerKinds, lyrics }
+ * @param ctx { energy, act, room, intensity, rng, triggerKinds, lyrics, gold }
+ *            gold() answers true while a trigger row is owed a golden centre (rabbit foot, track.js takeGold)
  * @returns the cue, or null for an event this build has nothing to say about (an unknown
  *          kind, or a word the feel pass decided the spotter only guessed at).
  */
@@ -126,7 +127,8 @@ export function cueFor(event, ctx = {}) {
         break;
       }
       const kindId = triggerKind(label, ctx);
-      for (const x of ROW_X) cue.spawn.push({ kindId, placement: 'lane', x, h: LANE_H, at: 0, row: true });
+      const gold = typeof ctx.gold === 'function' && ctx.gold() === true;   // rabbit foot: a golden in the middle
+      for (const x of ROW_X) cue.spawn.push({ kindId: gold && Math.abs(x) < 1e-6 ? 'golden' : kindId, placement: 'lane', x, h: LANE_H, at: 0, row: true });
       cue.word = label || null;
       cue.pose = 'grab';
       break;

--- a/ConditioningControlPanel/Resources/web/dtrh/race/kart.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/kart.js
@@ -93,6 +93,8 @@ const ease = (k, dt) => 1 - Math.exp(-k * dt);
 /** setScale (poppers): the tween rate, and how far the seat slides back / up per unit of
  *  (scale / KART_SCALE - 1), so poppers' 1.8 (a third bigger) is 1.2 m back and 0.4 m up. */
 const SIZE_EASE = 8, SIZE_CAM_BACK = 3.6, SIZE_CAM_UP = 1.2;
+/** Pocket watch: the swing's amplitude eases in and out (~0.5 s) so the cup never jumps at either end. */
+const SWAY_EASE = 4;
 const smooth = (u) => u <= 0 ? 0 : u >= 1 ? 1 : u * u * (3 - 2 * u);
 const tierFor = (sec) => { let t = 0; for (const at of DRIFT_TIER_SEC) if (sec >= at) t++; return t; };
 
@@ -162,6 +164,7 @@ export function createKart({ scene, layout, reducedMotion = false, pixel = null 
   scene.add(ring);
   let pulse = 0, reach = 1;
   let size = KART_SCALE, sizeTarget = KART_SCALE;   // the rig's scale: poppers grows it (setScale)
+  let sway = 0, swayTarget = 0, swayPeriod = 2, swayX = 0;   // pocket watch: the pendulum (setSway)
 
   let vx = 0, lean = 0, pitch = 0, elapsed = 0, lastRampD = -1, driftSide = 1, camReady = false, camX = 0, camH = 0;
   let camBoost = 0, steerS = 0, hopT = 0, scrubSec = 0, sparkAcc = 0, driftWas = false;
@@ -299,6 +302,10 @@ export function createKart({ scene, layout, reducedMotion = false, pixel = null 
     if (edge < WALL_SOFT && outward) vTarget *= clamp(edge / WALL_SOFT, 0, 1);
     vx += (vTarget - vx) * ease(state.drift ? 9 : 6, dt);
     state.x += vx * dt;
+    // pocket watch: the pendulum. Added as a delta so the clamp and the soft wall below still hold,
+    // with the amplitude eased so the cup settles back where the player left it when the watch stops.
+    if (sway !== swayTarget) { sway += (swayTarget - sway) * ease(SWAY_EASE, dt); if (Math.abs(sway - swayTarget) < 0.002) sway = swayTarget; }
+    if (sway > 0 || swayX !== 0) { const sx = sway * Math.sin((Math.PI * 2 * elapsed) / swayPeriod); state.x += sx - swayX; swayX = sx; }
     if (Math.abs(state.x) > xMax) {
       state.x = Math.sign(state.x) * xMax;
       if (Math.sign(vx) === Math.sign(state.x)) vx *= 0.25;
@@ -515,6 +522,8 @@ export function createKart({ scene, layout, reducedMotion = false, pixel = null 
   function setReach(mult) { reach = clamp(+mult || 1, 0.5, 3); }
   /** Poppers: tween the rig to this scale (0 = back to KART_SCALE); the seat and the road clamp follow. */
   function setScale(s) { sizeTarget = s > 0 ? clamp(+s, KART_SCALE * 0.5, KART_SCALE * 2) : KART_SCALE; }
+  /** Pocket watch: swing the cup `amp` metres either side every `period` seconds (amp 0 stops it). */
+  function setSway(amp, period) { swayTarget = clamp(+amp || 0, 0, KART_X_MAX); if (period > 0) swayPeriod = +period; }
   function onEvent(cb) { if (typeof cb === 'function') listeners.push(cb); return () => { const i = listeners.indexOf(cb); if (i >= 0) listeners.splice(i, 1); }; }
 
   function dispose() {
@@ -526,7 +535,7 @@ export function createKart({ scene, layout, reducedMotion = false, pixel = null 
   }
 
   return { state, update, applyBoost, applySlow, pace, setMood: rig.setMood, setFraught: rig.setFraught, camera, group,
-    pulseTarget, setReach, setScale, onEvent, dispose,
+    pulseTarget, setReach, setScale, setSway, onEvent, dispose,
     emiModel: () => rig.model(), emiReady: (cb) => rig.onReady(cb),
     setFace: (i) => rig.setFace(i), pose: (name, opts) => rig.pose(name, opts) };
 }

--- a/ConditioningControlPanel/Resources/web/dtrh/race/pickups.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/pickups.js
@@ -39,6 +39,8 @@ export const TUNE = Object.freeze({
   TAKE_X: 1.2,              // the cube's own crossing test: |x - ks.x| <= TAKE_X
   POINTS: 10,               // a take pays like a plain treat and keeps the combo warm
   DROP_M: 8,                // this far behind the kart an untaken pickup goes away
+  CLEAR_SEC: 2,             // on a track the take lands this clear of every chart event (pickFor)
+  GOLD_LEAD_SEC: [6, 9],    // golden touch lights when the next trigger is this far past the take
 });
 
 /**
@@ -48,9 +50,16 @@ export const TUNE = Object.freeze({
 export const PICKUPS = [
   // group one: the passive bonuses (family bonus)
   { id: 'poppers',      name: 'poppers',      family: 'bonus', pool: 'mid',   sec: 8,  scale: 1.8, reach: 1.35, sprite: SPRITE_BASE + 'poppers.png' },
+  { id: 'pocket_watch', name: 'pocket watch', family: 'bonus', pool: 'catch', sec: 10, swing: 0.8, period: 2, sprite: SPRITE_BASE + 'pocket_watch.png' },
+  { id: 'the_wand',     name: 'the wand',     family: 'bonus', pool: 'catch', sec: 7,  reach: 2.2, sprite: SPRITE_BASE + 'the_wand.png' },
+  { id: 'rabbit_foot',  name: 'rabbit foot',  family: 'bonus', pool: 'mid',   sec: 12, bias: 2, rows: 2, sprite: SPRITE_BASE + 'rabbit_foot.png' },
+  { id: 'golden_touch', name: 'golden touch', family: 'bonus', pool: 'risk',  sec: 8,  mult: 2, sprite: SPRITE_BASE + 'golden_touch.png' },
   // group two: the pop-everything family (family sweep)
   { id: 'the_pump',     name: 'the pump',     family: 'sweep', pool: 'mid',   sec: 5,  sprite: SPRITE_BASE + 'the_pump.png' },
+  { id: 'riptide',      name: 'riptide',      family: 'sweep', pool: 'catch', sec: 6,  pull: 40, pullSec: 0.5, speed: 1.15, sprite: SPRITE_BASE + 'riptide.png' },
 ];
+/** On a track golden touch is never rolled: pickFor lights it on the lead rule alone. */
+const GOLD = new Set(['golden_touch']);
 export const PICKUP_BY_ID = Object.fromEntries(PICKUPS.map((p) => [p.id, p]));
 
 /** Pool weights by multiplier: x1 is generous with catch-up, x8 leans into risk / reward. */
@@ -105,6 +114,25 @@ export function createPickups({ rng, spots = [], totalDepth = 1e9 } = {}) {
     }
     return best;
   }
+  /**
+   * THE LYRIC PLACEMENT RULE. Off a track (f.t null) the roll is the pool. On one, f.t is the track
+   * second and f.nextEventT the one door into the file (track.js nextEvent): the take must land
+   * CLEAR_SEC clear of every chart event at the speed the kart has now, so a pickup never sits on a
+   * word's row; a spot that would is skipped this frame and the gap keeps waiting. golden touch is
+   * not rolled there at all: it lights when the next trigger is GOLD_LEAD_SEC past the take, where
+   * its double is worth the most, and only then.
+   */
+  function pickFor(spot, d, f) {
+    const next = typeof f.nextEventT === 'function' ? f.nextEventT : null;
+    if (f.t == null || !next) return rollPickup(f.mult, rand);
+    const arrive = Number(f.t) + relD(spot.d, d) / Math.max(1, Number(f.speed) || 0);
+    const near = next(arrive - TUNE.CLEAR_SEC);
+    if (near != null && near < arrive + TUNE.CLEAR_SEC) return null;
+    const trig = next(arrive, 'trigger');
+    const lead = trig == null ? -1 : trig - arrive;
+    if (lead >= TUNE.GOLD_LEAD_SEC[0] && lead <= TUNE.GOLD_LEAD_SEC[1]) return PICKUP_BY_ID.golden_touch;
+    return rollPickup(f.mult, rand, GOLD);
+  }
   function start(p) {
     const was = [...active.values()].find((a) => a.p.family === p.family);
     const refresh = !!was && was.p.id === p.id;
@@ -116,8 +144,9 @@ export function createPickups({ rng, spots = [], totalDepth = 1e9 } = {}) {
   const api = {
     /**
      * One frame. `f` is the kart and the run this second:
-     *   { d, x, speed, elapsed, opening, mult }
-     * elapsed is seconds of driving, opening true while the gentle start holds (race/pace.js).
+     *   { d, x, speed, elapsed, opening, mult, t, nextEventT }
+     * elapsed is seconds of driving, opening true while the gentle start holds (race/pace.js),
+     * t the track second (null off a track) and nextEventT(t, kind) track.js's getter (pickFor).
      */
     update(dt, f) {
       if (!(dt > 0) || !f) return;
@@ -140,7 +169,8 @@ export function createPickups({ rng, spots = [], totalDepth = 1e9 } = {}) {
         gapLeft -= dt;
         if (gapLeft <= 0) {
           const spot = spotAhead(d);
-          if (spot) { light(rollPickup(f.mult, rand), spot); gapLeft = rollGap(); }
+          const p = spot ? pickFor(spot, d, f) : null;
+          if (p) { light(p, spot); gapLeft = rollGap(); }
         }
       }
       prevD = d;

--- a/ConditioningControlPanel/Resources/web/dtrh/race/run.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/run.js
@@ -144,7 +144,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
   // ---- run state ----
   const S = {
     started: false, running: false, paused: false, hostPaused: false, ended: false, disposed: false,
-    elapsed: 0, t: 0, intensity: intensityFloor, timeScale: 1, jackpotBias: 1, sweep: false,
+    elapsed: 0, t: 0, intensity: intensityFloor, timeScale: 1, jackpotBias: 1, sweep: false, tide: 1,
     spawnT: SPAWN_T0, rainT: RAIN_T0, tunnelTime: 0, rush: 0, fov: fovBase, fovBoost: 0, gates: 0, room: null,
     wasAirborne: false, airH: 0, effects: [], moodHeld: null, moodHold: 0, mood: 'calm', bestAtStart: 0, seed, wobble: 0,
     trackHold: 0, trackHoldFrom: 0, trackFog: 0, trackPaused: false, statsAt: 0, trackGap: 0,   // trackHold: the track second a fog/density hold ends, 0 for none
@@ -211,12 +211,12 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
   }
   function resetRunState(runSeed) {
     Object.assign(S, { running: false, paused: false, ended: false, elapsed: 0, t: 0, intensity: intensityFloor, timeScale: 1,
-      jackpotBias: 1, sweep: false, spawnT: SPAWN_T0, rainT: RAIN_T0, rush: 0, fovBoost: 0, gates: 0, room: null,
+      jackpotBias: 1, sweep: false, tide: 1, spawnT: SPAWN_T0, rainT: RAIN_T0, rush: 0, fovBoost: 0, gates: 0, room: null,
       wasAirborne: false, airH: 0, effects: [], moodHeld: null, moodHold: 0, mood: 'calm', seed: runSeed,
       trackHold: 0, trackHoldFrom: 0, trackFog: 0, trackPaused: false, statsAt: 0, trackGap: 0 });
     trailClear();
     mix.reset(); PACE.reset(); S.wobble = 0; clearMixChrome(); sync.reset();
-    hud.setScore(0); hud.setCombo(0, 1); hud.setBank(0); hud.setSpeed(0); hud.setFraught(0); hud.passiveClear();
+    hud.setScore(0); hud.setCombo(0, 1); hud.setBank(0); hud.setSpeed(0); hud.setFraught(0); hud.passiveClear(); TR.gild(0);
   }
 
   // ---- rooms ----
@@ -362,6 +362,8 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
       case 'pickupEnd': applyPickup(w, w.pickups.byId(e.id), false); hud.passive(e.id, null); break;
     }
   }
+  /** The one door pickups.js has into the file: the next chart event's second (track.js nextEvent). */
+  const nextEventT = (t, kind) => { const e = TR.nextEvent(t, kind); return e ? e.t : null; };
   /** What each pickup DOES, on and off. Every number comes off its PICKUPS row. */
   function applyPickup(w, p, on) {
     if (!p) return;
@@ -370,6 +372,16 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
       case 'poppers': w.kart.setScale(on ? p.scale : 0); w.field.setReach(on ? p.reach : 1); w.kart.setReach(on ? p.reach : 1); break;
       // the pump: the whole road is the pop box, and the kart rides a boost for the length of it
       case 'the_pump': S.sweep = on; w.field.setSweep(on); if (on) w.kart.applyBoost(p.sec); break;
+      // pocket watch: the cup swings like the pendulum and the combo clock stops for the length of it
+      case 'pocket_watch': w.kart.setSway(on ? p.swing : 0, p.period); if (on) w.score.freezeCombo(p.sec); break;
+      // the wand: the pop box reaches for treats alone (an effect bubble still has to be driven into)
+      case 'the_wand': w.field.setReach(on ? p.reach : 1, on); w.kart.setReach(on ? p.reach : 1); break;
+      // rabbit foot: the seeded lanes lean golden; on a worded road the next rows carry one instead (cues.js)
+      case 'rabbit_foot': S.jackpotBias = on ? p.bias : 1; TR.gild(on && TR.lyrics ? p.rows : 0); break;
+      // golden touch: every pop pays double for sec (score.js boostMult; off resets it)
+      case 'golden_touch': w.score.boostMult(on ? p.mult : 1, on ? p.sec : 0); break;
+      // riptide: the road ahead slides into the lane and the cruise runs faster through the pace
+      case 'riptide': S.tide = on ? p.speed : 1; w.field.setPull(on); break;
     }
   }
 
@@ -418,7 +430,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
    *  owner's "too soon by 2 sec or so", measured in race/smoke/sync-check.mjs). */
   function applyCue(w, due) {
     const ks = w.kart.state, e = due.event, t = TR.track ? TR.track.t : 0;
-    const cue = cueFor(e, { energy: TR.intensity, act: TR.act, room: S.room, intensity: S.intensity, rng: w.rng, triggerKinds: TR.triggerKinds, lyrics: TR.lyrics });
+    const cue = cueFor(e, { energy: TR.intensity, act: TR.act, room: S.room, intensity: S.intensity, rng: w.rng, triggerKinds: TR.triggerKinds, lyrics: TR.lyrics, gold: () => TR.takeGold() });
     if (!cue) { TR.skip(e.id); return; }   // a guess the feel pass threw out never counts against the player
     // A row goes in as one thing (bubbles.js spawnRow): the density gate is rolled once for the
     // whole line, so the road never gets a row with a hole in it that the kart can steer through.
@@ -428,7 +440,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     const row = cue.spawn.filter((sp) => sp.row), loose = cue.spawn.filter((sp) => !sp.row);
     if (row.length) {
       const at = e.t + (row[0].at || 0), d = sync.depthFor(t, ks.d, ks.speed, at);
-      const rowId = w.field.spawnRow({ kindId: row[0].kindId, placement: row[0].placement, d, h: row[0].h, xs: row.map((sp) => sp.x), eventId: e.id });
+      const rowId = w.field.spawnRow({ kindId: row[0].kindId, kindIds: row.map((sp) => sp.kindId), placement: row[0].placement, d, h: row[0].h, xs: row.map((sp) => sp.x), eventId: e.id });
       if (rowId) sync.trackRow(rowId, e, at, d, t);
     }
     for (const sp of loose) {
@@ -514,10 +526,11 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     // that only lifts to 1.15 of it, then the full curve walks in over 20 s, and the act's kind
     // colours the pace from there. Off a chart the clock is the run's own elapsed seconds.
     S.pace = PACE.at(ts ? ts.t : S.elapsed, ts ? ts.act : null, TR.track ? TR.track.chart : null);
-    k.pace(S.pace.base, S.pace.cap);
+    k.pace(Math.min(S.pace.base * S.tide, S.pace.cap), S.pace.cap);   // riptide runs the cruise faster, under the same ceiling
     k.update(dt, input.read(), lay);
     w.score.tick(dt);
-    w.pickups.update(dt, { d: ks.d, x: ks.x, speed: ks.speed, elapsed: S.elapsed, opening: !!(S.pace && S.pace.opening), mult: w.score.state.mult });
+    w.pickups.update(dt, { d: ks.d, x: ks.x, speed: ks.speed, elapsed: S.elapsed, opening: !!(S.pace && S.pace.opening), mult: w.score.state.mult,
+      t: TR.track ? TR.track.t : null, nextEventT });
     for (const c of w.pickups.chips()) hud.passive(c.id, c);
     { const tr = trail[trailI]; tr.d = ks.d; tr.x = ks.x; tr.h = ks.h; tr.ok = true; trailI = (trailI + 1) % TRAIL_N; }
     for (const e of mix.tick(dt)) onMix(w, e);

--- a/ConditioningControlPanel/Resources/web/dtrh/race/smoke/pickups-check.mjs
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/smoke/pickups-check.mjs
@@ -1,0 +1,265 @@
+/* ============================================================================
+ * race/smoke/pickups-check.mjs - THE PASSIVE PICKUPS (race/pickups.js).
+ *
+ *   node race/smoke/pickups-check.mjs            (from Resources/web/dtrh)
+ *   CHROME_PATH=... to point at a Chrome that is not in the default place
+ *
+ * Under node: the table (the seven rows, their pictures on disk, the pool weights at x1 and x8),
+ * a whole seeded run of the brain (the gentle start, one on the road at a time, the gap, a take,
+ * a drop), the families (two chips stack, the same one again refreshes, another of the family
+ * replaces), track.js's one door into the file (nextEvent, gild / takeGold, the golden centre a
+ * trigger row gets), and THE LYRIC PLACEMENT RULE on the opening level's real transcript: never in
+ * the first act, never within CLEAR_SEC of a chart event, golden touch only on the lead.
+ *
+ * Then one headless Chrome at a phone viewport lights each of the seven with the ?pickup= aid on
+ * the demo road: it is taken, its chip comes up, riptide runs the cruise faster and the pump rides
+ * a boost, and not one console error or missing file across all seven.
+ * ==========================================================================*/
+
+import { spawn } from 'node:child_process';
+import { createServer } from 'node:http';
+import { readFile } from 'node:fs/promises';
+import { readFileSync, mkdtempSync, rmSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, extname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { TUNE, PICKUPS, PICKUP_BY_ID, weightFor, rollPickup, createPickups } from '../pickups.js';
+import { createTrackState } from '../track.js';
+import { cueFor, ROW_X } from '../cues.js';
+import { demoChart } from '../chart.js';
+import { makeRng } from '../consts.js';
+import { wordedRoad, PEAKS_PER_SEC } from '../cloudChart.js';
+
+let fails = 0;
+const ok = (c, m) => { console.log(`  ${c ? 'ok ' : 'FAIL'} ${m}`); if (!c) fails++; };
+const eq = (a, b, m) => ok(a === b, `${m} (${JSON.stringify(a)}${a === b ? '' : ' != ' + JSON.stringify(b)})`);
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const HERE = resolve(fileURLToPath(import.meta.url), '..');
+const RACE = resolve(HERE, '..');
+const WEB = resolve(RACE, '../..');
+const SPEED = 22, DT = 1 / 60;
+
+/* ============================================================================
+ * 1. the table
+ * ==========================================================================*/
+console.log('the table');
+const WANT = { poppers: 8, pocket_watch: 10, the_wand: 7, rabbit_foot: 12, golden_touch: 8, the_pump: 5, riptide: 6 };
+eq(PICKUPS.map((p) => p.id).sort().join(','), Object.keys(WANT).sort().join(','), 'the seven rows, and only those');
+ok(PICKUPS.every((p) => p.sec === WANT[p.id]), 'every effect runs the seconds the owner picked');
+ok(PICKUPS.every((p) => p.name === p.id.replace(/_/g, ' ') && p.name === p.name.toLowerCase()), 'every name is the house name, lowercase');
+ok(PICKUPS.every((p) => (p.family === 'bonus' || p.family === 'sweep') && ['catch', 'mid', 'risk'].includes(p.pool)), 'every row has a family and a pool');
+eq(PICKUPS.filter((p) => p.family === 'sweep').map((p) => p.id).join(','), 'the_pump,riptide', 'the pump and riptide are the sweep family');
+ok(PICKUPS.every((p) => existsSync(resolve(WEB, '.' + p.sprite))), 'every picture is on disk under assets/items');
+ok(['FIRST_SEC', 'GAP_SEC', 'AHEAD_M', 'TAKE_X', 'POINTS', 'DROP_M', 'CLEAR_SEC', 'GOLD_LEAD_SEC'].every((k) => k in TUNE), 'every knob is in the one table');
+const w1 = (pool) => weightFor({ pool }, 1), w8 = (pool) => weightFor({ pool }, 8);
+ok(w1('catch') > w1('mid') && w1('mid') > w1('risk'), `at x1 catch-up leads (${w1('catch')} > ${w1('mid')} > ${w1('risk')})`);
+ok(w8('risk') > w8('mid') && w8('mid') > w8('catch'), `at x8 risk leads (${w8('risk')} > ${w8('mid')} > ${w8('catch').toFixed(2)})`);
+{
+  const rng = makeRng(7), n = {};
+  for (let i = 0; i < 3000; i++) { const p = rollPickup(1, rng); n[p.pool] = (n[p.pool] || 0) + 1; }
+  ok(n.catch > n.mid && n.mid > n.risk, `3000 rolls at x1 land that way (catch ${n.catch}, mid ${n.mid}, risk ${n.risk})`);
+  let gold = 0;
+  for (let i = 0; i < 500; i++) if (rollPickup(8, rng, new Set(['golden_touch'])).id === 'golden_touch') gold++;
+  eq(gold, 0, 'an excluded id is never rolled, even at x8');
+}
+
+/* ============================================================================
+ * 2. a seeded run of the brain: the gentle start, one at a time, the gap, a take, a drop
+ * ==========================================================================*/
+console.log('a seeded run');
+{
+  const LAP = 1200, spots = [];
+  for (let d = 30; d < LAP; d += 50) spots.push({ d, x: 0 });
+  const pk = createPickups({ rng: makeRng(3), spots, totalDepth: LAP });
+  const ev = []; pk.onEvent((e) => ev.push({ ...e, at: elapsed, kd: kartD }));
+  let elapsed = 0, kartD = 0, liveMax = 0, kartX = 0;
+  const OPEN = 20;
+  while (elapsed < 420) {
+    kartD = (kartD + SPEED * DT) % LAP; elapsed += DT;
+    kartX = ev.filter((e) => e.type === 'pickupSpawn').length === 3 ? 1.5 : 0;   // the third one is let go by
+    pk.update(DT, { d: kartD, x: kartX, speed: SPEED, elapsed, opening: elapsed < OPEN, mult: 1 });
+    liveMax = Math.max(liveMax, (pk.live ? 1 : 0));
+  }
+  const spawns = ev.filter((e) => e.type === 'pickupSpawn'), takes = ev.filter((e) => e.type === 'pickupTake'), drops = ev.filter((e) => e.type === 'pickupDrop');
+  ok(spawns.length >= 5, `${spawns.length} pickups lit over 420 s of driving`);
+  ok(spawns[0] && spawns[0].at >= TUNE.FIRST_SEC, `nothing lit before ${TUNE.FIRST_SEC} s (first at ${spawns[0] ? spawns[0].at.toFixed(1) : '-'} s)`);
+  const rel = (s) => { let r = (s.d - s.kd) % LAP; if (r > LAP / 2) r -= LAP; return r; };
+  ok(spawns.every((s) => rel(s) >= TUNE.AHEAD_M[0] && rel(s) <= TUNE.AHEAD_M[1]), 'every one lit inside the AHEAD_M window');
+  eq(liveMax, 1, 'never more than one on the road');
+  eq(takes.length, spawns.length - 1, 'every one crossed at the kart\'s x was taken');
+  eq(drops.length, 1, 'the one the kart steered past was dropped');
+  ok(takes.every((t) => t.refresh === false || t.refresh === true), 'a take says whether it was a refresh');
+  const ends = [...takes, ...drops].sort((a, b) => a.at - b.at), gaps = [];
+  for (let i = 1; i < spawns.length; i++) gaps.push(spawns[i].at - ends.find((e) => e.at > spawns[i - 1].at).at);
+  ok(gaps.every((g) => g >= TUNE.GAP_SEC[0] - 0.5), `the next waits at least ${TUNE.GAP_SEC[0]} s of driving (gaps ${gaps.map((g) => g.toFixed(0)).join(' ')})`);
+}
+
+/* ============================================================================
+ * 3. the families: two chips stack, the same again refreshes, another of the family replaces
+ * ==========================================================================*/
+console.log('the families');
+{
+  const pk = createPickups({ rng: makeRng(1), spots: [{ d: 10, x: 0 }], totalDepth: 100 });
+  const ev = []; pk.onEvent((e) => ev.push(e));
+  const grab = (id) => { pk.light(id, { d: 10, x: 0 }); return pk.take(); };
+  grab('poppers'); eq(pk.chips().length, 1, 'poppers: one chip');
+  grab('the_pump'); eq(pk.chips().map((c) => c.id).join('+'), 'poppers+the_pump', 'the pump on top: two chips, one per family');
+  pk.update(3, { d: 0, x: 0, speed: 0, elapsed: 0, opening: true, mult: 1 });
+  ok(pk.chips().find((c) => c.id === 'poppers').frac < 0.7, 'three seconds in, the poppers bar has drained');
+  grab('poppers');
+  ok(ev.at(-1).type === 'pickupTake' && ev.at(-1).refresh === true, 'poppers again is a refresh');
+  ok(pk.chips().length === 2 && pk.chips().find((c) => c.id === 'poppers').frac === 1, 'still two chips, its bar full again');
+  grab('the_wand');
+  const ended = ev.filter((e) => e.type === 'pickupEnd').map((e) => e.id);
+  eq(ended.join(','), 'poppers', 'the wand replaces poppers: its end fires');
+  eq(pk.chips().map((c) => c.id).sort().join('+'), 'the_pump+the_wand', 'and there are still two chips, never three');
+  pk.update(2.5, { d: 0, x: 0, speed: 0, elapsed: 0, opening: true, mult: 1 });
+  eq(pk.chips().map((c) => c.id).join('+'), 'the_wand', 'the pump runs out on its own clock (5 s) and its chip goes');
+  pk.reset(); eq(pk.chips().length, 0, 'a reset clears every chip');
+}
+
+/* ============================================================================
+ * 4. track.js: the one door into the file, and the golden centre of a trigger row
+ * ==========================================================================*/
+console.log('track.js');
+{
+  const TR = createTrackState();
+  ok(TR.nextEvent(0) === null, 'no track: nextEvent is null');
+  TR.setTrack(demoChart({ durationSec: 240 }));
+  const ch = TR.track.chart, mid = TR.track.durationSec / 2;
+  eq(TR.nextEvent(0).id, ch.events[0].id, 'nextEvent(0) is the first event');
+  const e = TR.nextEvent(mid);
+  ok(e && e.t >= mid && ch.events.every((x) => x.t < mid || x.t >= e.t), 'nextEvent(t) is the first at or after t');
+  const tr = TR.nextEvent(mid, 'trigger');
+  ok(tr && tr.kind === 'trigger' && tr.t >= mid, 'and asks for one kind');
+  ok(TR.nextEvent(1e9) === null, 'nothing after the end');
+  TR.gild(2);
+  eq([TR.takeGold(), TR.takeGold(), TR.takeGold()].join(','), 'true,true,false', 'gild(2) hands out two goldens and no more');
+  TR.gild(2); TR.setTrack(null); eq(TR.takeGold(), false, 'a new track forgets the gold owed');
+  const trig = ch.events.find((x) => x.kind === 'trigger') || { kind: 'trigger', label: 'sleep', t: 10, conf: 1 };
+  const ctx = (gold) => ({ rng: makeRng(2), triggerKinds: new Map(), gold: () => gold });
+  const plain = cueFor({ ...trig, conf: 1 }, ctx(false)).spawn, gilded = cueFor({ ...trig, conf: 1 }, ctx(true)).spawn;
+  eq(plain.filter((s) => s.kindId === 'golden').length, 0, 'a plain trigger row has no golden in it');
+  const centre = gilded.filter((s) => Math.abs(s.x) < 1e-6);
+  ok(centre.length === 1 && centre[0].kindId === 'golden' && centre[0].row === true, 'with gold owed its centre is a golden, still part of the row');
+  eq(gilded.filter((s) => s.kindId === 'golden').length, 1, 'and only the centre');
+  eq(gilded.length, ROW_X.length, 'the row is still the full row');
+}
+
+/* ============================================================================
+ * 5. THE LYRIC PLACEMENT RULE on the opening level's transcript
+ * ==========================================================================*/
+console.log('the lyric placement rule');
+{
+  const read = (rel) => JSON.parse(readFileSync(resolve(RACE, rel), 'utf8'));
+  const ROW = read('words/index.json').rows[0], WORDS = read('words/' + ROW.file);
+  const n = Math.ceil(WORDS.durationSec * PEAKS_PER_SEC), peaks = new Float32Array(n * 2);
+  for (let i = 0; i < n; i++) { const a = 0.22 + 0.5 * Math.max(0, Math.sin(((i / PEAKS_PER_SEC) / 40) * Math.PI * 2)) ** 2; peaks[i * 2] = -a; peaks[i * 2 + 1] = a; }
+  const road = wordedRoad({ peaks, durationSec: WORDS.durationSec, name: ROW.title, hash: ROW.hash, words: WORDS });
+  /** Drive the brain down a whole track at cruise, x 0, and hold every spawn to the rule. */
+  function drive(chart, label, want) {
+    const TR = createTrackState();
+    TR.setTrack(chart);
+    const ch = TR.track.chart, dur = TR.track.durationSec, openEnd = ch.acts[0].t1;
+    const nextEventT = (t, kind) => { const x = TR.nextEvent(t, kind); return x ? x.t : null; };
+    const LAP = 3000, spots = [];
+    for (let d = 20; d < LAP; d += 30) spots.push({ d, x: 0 });
+    const pk = createPickups({ rng: makeRng(5), spots, totalDepth: LAP });
+    const spawns = []; pk.onEvent((e) => { if (e.type === 'pickupSpawn') spawns.push({ ...e, t, kd: kartD }); });
+    let t = 0, kartD = 0;
+    while (t < dur) {
+      kartD = (kartD + SPEED * DT) % LAP; t += DT;
+      pk.update(DT, { d: kartD, x: 0, speed: SPEED, elapsed: t, opening: t < openEnd, mult: 1, t, nextEventT });
+    }
+    const arrive = (s) => s.t + (s.d - s.kd) / SPEED;
+    ok(spawns.length >= want, `${spawns.length} pickups lit over ${dur.toFixed(0)} s of ${label} (${ch.events.length} events)`);
+    ok(spawns.every((s) => s.t >= openEnd), `none in the first act (it ends at ${openEnd.toFixed(0)} s)`);
+    const tooClose = spawns.filter((s) => ch.events.some((e) => Math.abs(e.t - arrive(s)) < TUNE.CLEAR_SEC));
+    eq(tooClose.length, 0, `every take lands ${TUNE.CLEAR_SEC} s clear of every event`);
+    const lead = (s) => { const x = nextEventT(arrive(s), 'trigger'); return x == null ? -1 : x - arrive(s); };
+    const inLead = (s) => lead(s) >= TUNE.GOLD_LEAD_SEC[0] && lead(s) <= TUNE.GOLD_LEAD_SEC[1];
+    ok(spawns.every((s) => (s.id === 'golden_touch') === inLead(s)), 'golden touch exactly when the next trigger is 6 to 9 s past the take, never otherwise');
+    console.log('      ' + spawns.map((s) => `${s.id}@${s.t.toFixed(0)}s`).join(' '));
+  }
+  // the real transcript is dense (an event every second or two past the first act): the rule leaves
+  // it very few clear takes, and that is the rule doing its job, not a starved brain
+  drive(road, ROW.title, 1);
+  drive(demoChart({ durationSec: 300 }), 'the demo road', 3);
+}
+
+/* ============================================================================
+ * 6. the browser: each of the seven, lit, taken, its chip up, on the demo road
+ * ==========================================================================*/
+console.log('the browser');
+const CHROME = process.env.CHROME_PATH || 'C:/Program Files/Google/Chrome/Application/chrome.exe';
+const PORT = 8875, DBG = 9345;
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.mjs': 'text/javascript', '.css': 'text/css', '.json': 'application/json', '.png': 'image/png', '.jpg': 'image/jpeg',
+  '.webp': 'image/webp', '.svg': 'image/svg+xml', '.glb': 'model/gltf-binary', '.gltf': 'model/gltf+json', '.mp3': 'audio/mpeg', '.ogg': 'audio/ogg', '.wav': 'audio/wav', '.woff2': 'font/woff2', '.txt': 'text/plain' };
+if (!existsSync(CHROME)) { console.error('FAIL no chrome at ' + CHROME + ' (set CHROME_PATH)'); process.exit(1); }
+const server = createServer(async (req, res) => {
+  const path = decodeURIComponent(new URL(req.url, 'http://x').pathname);
+  if (path.indexOf('..') >= 0) { res.writeHead(400); return res.end(); }
+  try {
+    const body = await readFile(join(WEB, path));
+    res.writeHead(200, { 'content-type': MIME[extname(path).toLowerCase()] || 'application/octet-stream' });
+    res.end(req.method === 'HEAD' ? undefined : body);
+  } catch (e) { res.writeHead(404, { 'content-type': 'text/plain' }); res.end('no'); }
+});
+await new Promise((r) => server.listen(PORT, '127.0.0.1', r));
+const prof = mkdtempSync(join(tmpdir(), 'race-pickups-'));
+const chrome = spawn(CHROME, ['--headless=new', `--remote-debugging-port=${DBG}`, `--user-data-dir=${prof}`, '--no-first-run', '--no-default-browser-check',
+  '--disable-gpu', '--mute-audio', '--enable-unsafe-swiftshader', '--autoplay-policy=no-user-gesture-required', '--window-size=390,844', 'about:blank'], { stdio: 'ignore' });
+let page = null;
+for (let i = 0; i < 60 && !page; i++) {
+  await sleep(250);
+  try { page = (await (await fetch(`http://127.0.0.1:${DBG}/json/list`)).json()).find((t) => t.type === 'page'); } catch (e) { /* not up */ }
+}
+if (!page) { console.error('FAIL chrome never answered on the debug port'); await finish(1); }
+const ws = new WebSocket(page.webSocketDebuggerUrl);
+await new Promise((r) => { ws.onopen = r; });
+let msgId = 0, errs = [], logs = [], missing = [];
+const waits = new Map();
+ws.onmessage = (e) => {
+  const m = JSON.parse(e.data);
+  if (m.id && waits.has(m.id)) { waits.get(m.id)(m); waits.delete(m.id); }
+  if (m.method === 'Runtime.exceptionThrown') errs.push('thrown: ' + (m.params.exceptionDetails?.exception?.description || m.params.exceptionDetails?.text || '?'));
+  if (m.method === 'Runtime.consoleAPICalled') { const line = m.params.args.map((a) => a.value ?? a.description ?? '?').join(' '); (m.params.type === 'error' ? errs : logs).push(line); }
+  if (m.method === 'Network.responseReceived' && m.params.response.status >= 400 && !m.params.response.url.endsWith('favicon.ico')) missing.push(m.params.response.url);
+};
+const cdp = (method, params) => new Promise((res) => { const i = ++msgId; waits.set(i, res); ws.send(JSON.stringify({ id: i, method, params })); });
+const ev = async (x) => (await cdp('Runtime.evaluate', { expression: x, returnByValue: true, awaitPromise: true })).result?.result?.value;
+const perf = async () => JSON.parse(await ev('JSON.stringify(window.__race.race.perf())'));
+await cdp('Runtime.enable'); await cdp('Page.enable'); await cdp('Network.enable');
+await cdp('Emulation.setDeviceMetricsOverride', { width: 390, height: 844, deviceScaleFactor: 2, mobile: true });
+const site = `http://127.0.0.1:${PORT}`;
+for (const p of PICKUPS) {
+  errs = []; logs = []; missing = [];
+  await cdp('Page.navigate', { url: `${site}/dtrh/race.html?autostart=1&intro=0&cards=0&chart=demo&dur=240&pickup=${p.id}` });
+  let up = false;
+  for (let i = 0; i < 120 && !up; i++) { await sleep(250); up = await ev('!!(window.__race && window.__race.race && window.__race.race.track && window.__race.race.perf().world)'); }
+  let lit = false;
+  for (let i = 0; i < 200 && up && !lit; i++) { await sleep(50); lit = logs.some((l) => l.includes(`pickup: ${p.id} lit`)); }
+  let chip = 0;
+  for (let i = 0; i < 100 && lit && !chip; i++) { await sleep(50); chip = await ev('document.querySelectorAll(\'.rh-pchip\').length'); }
+  const name = await ev('(document.querySelector(\'.rh-pchip-name\') || {}).textContent');
+  ok(up && lit && chip === 1 && name === p.name, `${p.name}: lit on a spot ahead, taken, its chip up${chip === 1 ? '' : ` (chips ${chip}, lit ${lit})`}`);
+  if (p.id === 'riptide' && chip) {
+    await sleep(2500);
+    const s = await perf();
+    ok(s.speed >= s.pace.base * 1.08, `riptide runs the cruise faster (${s.speed.toFixed(1)} m/s over a base of ${s.pace.base.toFixed(1)})`);
+  }
+  if (p.id === 'the_pump' && chip) { await sleep(300); ok((await perf()).boosting, 'the pump rides a boost'); }
+  ok(errs.length === 0 && missing.length === 0, `no console error and nothing missing for ${p.name}` + (errs.length || missing.length ? ':\n    ' + [...errs, ...missing].slice(0, 4).join('\n    ') : ''));
+}
+await finish(fails ? 1 : 0);
+
+async function finish(code) {
+  try { ws && ws.close(); } catch (e) { /* never opened */ }
+  try { chrome.kill(); } catch (e) { /* already gone */ }
+  await new Promise((r) => server.close(r));
+  await sleep(300);
+  try { rmSync(prof, { recursive: true, force: true }); } catch (e) { /* chrome still has a lock */ }
+  if (code) console.error(`\n${fails} failure${fails === 1 ? '' : 's'}`);
+  else console.log('\npickups-check: all good');
+  process.exit(code);
+}

--- a/ConditioningControlPanel/Resources/web/dtrh/race/track.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/track.js
@@ -87,9 +87,11 @@ export function createTrackState(opts = {}) {
     : (typeof performance === 'object' && performance && performance.now) ? () => performance.now() : () => Date.now();
   let track = null, sched = null, triggerKinds = new Map();
   let intensity = FLOOR, act = null, ended = false, mark = 0, lyrics = false;
+  let gold = 0;   // rabbit foot (race/pickups.js): trigger rows still owed a golden centre (gild / takeGold)
 
   /** Load a chart (or null to go back to the seeded run). Returns the new `track`. */
   function setTrack(chart) {
+    gold = 0;
     if (!chart) { track = null; sched = null; triggerKinds = new Map(); intensity = FLOOR; act = null; ended = false; lyrics = false; return null; }
     sched = createScheduler(chart, leadSec != null ? { leadSec } : {});
     const ch = sched.chart;
@@ -161,6 +163,17 @@ export function createTrackState(opts = {}) {
     },
     /** The host said the file is over, wherever our clock had got to. */
     end() { ended = true; },
+    /** The first chart event at or after track second `t` (of one `kind` when given), or null. The
+     *  one door race/pickups.js has into the file: the scheduler is never read past this. */
+    nextEvent(t, kind) {
+      if (!track) return null;
+      const at = Number(t) || 0;
+      for (const e of track.chart.events) if (e.t >= at && (!kind || e.kind === kind)) return e;
+      return null;
+    },
+    /** rabbit foot on a worded road: the next `n` trigger rows carry a golden at their centre (cues.js takes one per row). */
+    gild(n) { gold = Math.max(0, Math.floor(Number(n) || 0)); },
+    takeGold() { if (gold <= 0) return false; gold--; return true; },
     get track() { return track; },
     get act() { return act; },
     get intensity() { return Math.max(FLOOR, clamp01(intensity)); },


### PR DESCRIPTION
## Stack

Racing Thoughts passive pickups, PR 4 of 4. Base `feat/race-pickups-r1-passive`. Site PR CodeBambi/cclabs-web#183 first, see r1.

## What

The other five pickups on the r1 system plus the lyric placement rule and the new `pickups-check.mjs` smoke. 400 changed lines (377+ / 23-).

| pickup | family / pool | effect |
|---|---|---|
| pocket watch | bonus / catch, 10 s | kart pendulum x +-0.8 m, 2 s period (`kart.setSway`), combo frozen (`score.freezeCombo`) |
| the wand | bonus / catch, 7 s | treats-only magnet, `field.setReach(2.2, true)` + `kart.setReach(2.2)` |
| rabbit foot | bonus / mid, 12 s | `S.jackpotBias = 2` on a wordless road; on a lyric track the centre of the next 2 trigger rows turns golden (`track.gild` -> `ctx.gold` in cues.js) |
| golden touch | bonus / risk, 8 s | `score.boostMult(2, 8)`; seeded only when the next trigger event lands 6 to 9 s after the kart would arrive, read through ONE new `track.nextEvent(t, kind)` getter, the scheduler is not edited |
| riptide | sweep / catch, 6 s | bubbles within 40 m ahead tween to the kart's x over 0.5 s (`field.setPull`), speed +15 percent through the pace path (`S.tide`), not the cap |

Two chips can stack, a third of the same family refreshes its bar. Lucky stays a pure 25 point treat. Lyric placement: a pickup never lights within 2 s of any event t at the kart's expected speed (`TUNE.CLEAR_SEC`), never in the first act.

## Smoke: `race/smoke/pickups-check.mjs` (headless, one Chrome)

1. the table: seven rows, lowercase names, families and pools, sprites on disk, weights at x1 / x8 over 3000 rolls
2. seeded run: first pickup after 45 s, one live at a time, 30 to 45 s gaps
3. families: stack, refresh, replace, the pump expiry, reset
4. track.js: `nextEvent`, `gild` / `takeGold`, `cueFor` golden centre
5. placement rule on the Rapid Induction words road (at least 1) and the 300 s demo chart (at least 3)
6. browser: each id lit, taken, chip named; riptide speed at least 1.08x base; the pump boosting; no console errors, no 404s

All sections pass. Full set also green: node-only 11/11, headless captions/cloud-chart/cloud/levels/pace/real-audio/rows/sync/track-run, demo road at 390x844 with 0 console errors (100.8 s). pace-check failed once on a single frame ("speed plate says the number") and passed on two reruns; noting it as a flake.

## Things the pitch got wrong against main

- audio.js also listened on `world.items.onEvent` (retired in r0a).
- main's items.js auto-used items after 1.5 s and drew the seeded rng, so pace-check's fixture timing depended on it (fixed in r0a).
- The 2 s clear rule leaves exactly one pickup on Rapid Induction (162 s, 50 events, first act ends at 120 s). Dense lyric tracks are pickup-poor by design; loosen `CLEAR_SEC` if that reads as empty.
- golden touch never met the 6 to 9 s lead on the demo road fixture in a seeded run; it is exercised through the aid and the unit section instead.

Does not touch the DtRH side, applyCue, the scheduler or sync.js internals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJ66hi5fRM1Dcjo38aSCa2
