### PR TITLE
feat(race): feed images on the tube walls, not placeholders

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/hostMedia.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/hostMedia.js
@@ -34,10 +34,21 @@
  * Every three.js consumer in this game is on one of those roads. So remote
  * entries live in a SECOND pool that draw()/drawKind()/favorite()/urlByName()
  * cannot see - those four feed the WebGL layer and stay local-only forever - and
- * are handed out only through drawDom(), whose one consumer is game/payloadFx.js
- * (plain <img>/<video>/CSS background-image, no canvas, no texture). The DTRH
- * tube therefore stays local-media-only by design; the payload FX are where a
- * user with no library of their own actually sees something.
+ * are handed out only through the two DOM-only draws below, whose consumers use
+ * plain <img>/<video>/CSS background-image and nothing else (no canvas, no
+ * createImageBitmap, no fetch, no THREE texture):
+ *
+ *   drawDom(kind)        - game/payloadFx.js, the flash / cascade / subliminal cards.
+ *                          Mixes the two pools by `remoteShare`.
+ *   drawRemoteDom(kind)  - race/wallDom.js, the online feed hung on the race's tube
+ *                          wall as CSS-transformed elements. REMOTE ONLY: local media
+ *                          already has a texture road of its own in
+ *                          engine/wallPosters.js, and this one exists precisely
+ *                          because a remote image can never take that road.
+ *
+ * The DTRH tube therefore stays local-media-only by design; the payload FX and the
+ * race's DOM wall are where a user with no library of their own actually sees
+ * something. If you add a THIRD consumer, read this header first.
  *
  * Remote-ness is decided by the URL's ORIGIN, never by the host's name marker: a
  * marker is a hint, an origin is a fact, and only a fact belongs on the road that
@@ -106,6 +117,20 @@ export function createHostMediaSource() {
     // Nothing to read or revoke - the URL streams straight off the virtual host.
     return { url: entry.url, release() {} };
   };
+
+  /** The REMOTE draw, hoisted for the same reason as drawLocal: it is both the tail of
+   *  drawDom() and, exposed as drawRemoteDom(), the whole of race/wallDom.js's supply.
+   *  Small pool, no deck: pick at random and refuse the last few urls outright, so the
+   *  two callers cannot hand out the same picture back to back. */
+  function drawRemote(kind) {
+    const pool = remote.filter((e) => (!kind || e.kind === kind) && !remoteRecent.includes(e.url));
+    const from = pool.length ? pool : remote.filter((e) => !kind || e.kind === kind);
+    const e = from[(Math.random() * from.length) | 0];
+    if (!e) return null;
+    remoteRecent.push(e.url);
+    if (remoteRecent.length > 4) remoteRecent.shift();
+    return { kind: e.kind, name: e.name, remote: true, acquire: makeAcquire(e) };
+  }
 
   /** The LOCAL deck draw, hoisted so drawDom() can reach it without a `this` binding
    *  (callers routinely hold `media.drawDom` on its own). */
@@ -217,15 +242,20 @@ export function createHostMediaSource() {
       const wantLocal = entries.some((e) => !kind || e.kind === kind);
       if (!wantRemote && !wantLocal) return null;
       const useRemote = wantRemote && (!wantLocal || Math.random() < remoteShare);
-      if (!useRemote) return drawLocal(kind);
-      // Small pool, no deck: pick at random and refuse the last few urls outright.
-      const pool = remote.filter((e) => (!kind || e.kind === kind) && !remoteRecent.includes(e.url));
-      const from = pool.length ? pool : remote.filter((e) => !kind || e.kind === kind);
-      const e = from[(Math.random() * from.length) | 0];
-      if (!e) return null;
-      remoteRecent.push(e.url);
-      if (remoteRecent.length > 4) remoteRecent.shift();
-      return { kind: e.kind, name: e.name, remote: true, acquire: makeAcquire(e) };
+      return useRemote ? drawRemote(kind) : drawLocal(kind);
     },
+
+    /**
+     * THE SECOND DOM-ONLY DRAW, and the only REMOTE-ONLY one. Same {kind,name,remote,acquire}
+     * shape as drawDom(), with the same hard rule about how the caller may render it, but it
+     * never falls back to the local pool. Its one consumer, race/wallDom.js, hangs the feed on
+     * the race's tube wall as elements because a remote image cannot become a texture (this
+     * file's header has the reason); the player's own media does not need it, since
+     * engine/wallPosters.js already puts local pictures on that wall as real geometry.
+     *
+     * Null when the remote pool holds nothing of this kind, and a null there means the caller
+     * builds no layer at all. Shares drawDom()'s remoteRecent echo guard.
+     */
+    drawRemoteDom(kind) { return drawRemote(kind); },
   };
 }

--- a/ConditioningControlPanel/Resources/web/dtrh/race/race.css
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/race.css
@@ -14,7 +14,8 @@
  * insets) so nothing is flush to an edge; the MARQUEE moved off top-centre to
  * a left ribbon; the numbers ride thin dark plates so they stay readable over
  * the big-pixel render. The tail of this file caps the payloadFx full-screen
- * overlays and styles the media lane (see race/mediaLane.js).
+ * overlays, styles the media lane (see race/mediaLane.js) and holds the DOM wall
+ * layer at z1 (see race/wallDom.js).
  * ==========================================================================*/
 
 .race-hud {
@@ -417,6 +418,26 @@
 }
 /* the ceiling strip is a shallower box, so a tall card reads as a banner */
 #race-root .rh-lane-ceiling { border-radius: 8px; }
+
+/* ---- THE DOM WALL (race/wallDom.js) ----
+   The online feed's pictures cannot be textures (that file's header says why), so
+   they ride here instead: elements transformed into the tube's own 3D space. The
+   layer sits at z1, ABOVE the canvas (z0, in flow) and BELOW the HUD chrome (z3),
+   the payload cards (z4 / z9), the menu (z25) and the splash (z30), and it never
+   takes a pointer: a thumb on a poster is a steer, exactly as it was.
+   NOT pixelated. The local-media posters already render on pixel.js's CRISP_LAYER
+   at full resolution, so a crisp feed poster is the look that is already there. */
+#race-root .rh-wall3d {
+  position: fixed; inset: 0; z-index: 1; overflow: hidden;
+  pointer-events: none; touch-action: none;
+}
+#race-root .rh-wall3d-cam { position: absolute; left: 0; top: 0; width: 100%; height: 100%; transform-style: preserve-3d; }
+#race-root .rh-wall3d-shot {
+  position: absolute; left: 0; top: 0; opacity: 0; visibility: hidden;
+  object-fit: cover; pointer-events: none; user-select: none;
+  border-radius: 3px; box-shadow: 0 0 0 2px rgba(20, 10, 26, 0.85), 0 6px 26px rgba(0, 0, 0, 0.55);
+  will-change: transform, opacity;
+}
 
 /* ---- the overlay cap ----
    The owner's second screenshot: a braindrain pop painted an opaque wash over

--- a/ConditioningControlPanel/Resources/web/dtrh/race/run.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/run.js
@@ -6,7 +6,8 @@
  *
  * Composes renderer + spine + tunnel + fx + rooms + bubbles + kart + score + hud
  * + pickups + payloadFx + screen shake and runs the frame loop. `root` holds the
- * <canvas>, the `.race-hud` div and the `.sf-hud` layer payloadFx draws into.
+ * <canvas>, the `.race-hud` div, the `.sf-hud` layer payloadFx draws into and, when
+ * the online feed is on, race/wallDom.js's `.rh-wall3d` layer over the canvas.
  * Nothing here subtracts: the run ends only from the Brake (Esc) or the host.
  *
  * Host traffic owned here: sends heartbeat, run-started, sfx, fire-payload
@@ -49,6 +50,7 @@ import { createSpine } from './spine.js';
 import { roomById, rollRoomOrder, createRoomDresser } from './rooms.js';
 import { createWalls } from './walls.js';
 import { createCueSync, CUE_AHEAD_SEC } from './sync.js';
+import { createWallDomPosters } from './wallDom.js';
 import { KIND_BY_ID } from './bubbleKinds.js';
 import { createCocktail, CATEGORIES } from './cocktail.js';
 import { createBubbleField } from './bubbles.js';
@@ -182,7 +184,11 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     scene.add(tunnel.mesh);
     const fx = createFx({ scene, layout, tunnelMat: tunnel.material, particleFog: false });
     const dresser = createRoomDresser({ scene, layout });
-    const walls = createWalls({ scene, layout, media, renderer, camera, rng });
+    // the online feed cannot be a texture, so it rides a DOM layer over the canvas instead
+    // (race/wallDom.js); the painted fill placards stand down as soon as its pictures are in
+    let wallDom = null;
+    const walls = createWalls({ scene, layout, media, renderer, camera, rng, hasDomPosters: () => !!wallDom && wallDom.ready() });
+    wallDom = createWallDomPosters({ root, layout, camera, media, rng });
     const kart = createKart({ scene, layout, reducedMotion, pixel });
     const score = createScore();
     const getRoom = () => {
@@ -192,7 +198,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     };
     const field = createBubbleField({ scene, layout, media, getIntensity: () => S.intensity, getRoom, getElapsed: () => S.elapsed, onTexture: pixel.filterTexture });
     const pickups = createPickups({ rng, spots: layout.chunks.flatMap((c) => c.features || []).filter((f) => f.type === 'pickup'), totalDepth: layout.totalDepth });
-    const w = { layout, tunnel, fx, dresser, walls, kart, score, field, pickups, rng };
+    const w = { layout, tunnel, fx, dresser, walls, wallDom, kart, score, field, pickups, rng };
     field.onPop((p) => onPop(w, p));
     field.onMiss((m) => onMiss(w, m));
     kart.onEvent((e) => onKart(w, e));
@@ -205,7 +211,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
   }
   function teardown() {
     if (!W) return;
-    try { W.field.dispose(); W.kart.dispose(); W.walls.dispose(); W.dresser.dispose(); W.fx.dispose(); } catch (e) { /* half-built world */ }
+    try { W.field.dispose(); W.kart.dispose(); W.wallDom.dispose(); W.walls.dispose(); W.dresser.dispose(); W.fx.dispose(); } catch (e) { /* half-built world */ }
     scene.remove(W.tunnel.mesh); W.tunnel.dispose();
     W = null;
   }
@@ -587,6 +593,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     if (Math.abs(fovT - S.fov) > 0.05) { S.fov += (fovT - S.fov) * Math.min(1, dt * 6); camera.fov = S.fov; camera.updateProjectionMatrix(); }
     cupLight.position.copy(k.group.position).addScaledVector(_v.copy(camOut.up), 1.6);
     speedFx.update(dt, ks, lay);
+    w.wallDom.update(ks.d);   // AFTER the camera: a DOM poster is transformed by THIS frame's lens
 
     // EMI: calm cruise, streamed on boost, fraught under a stack, pokes on top
     if (S.moodHold > 0) { S.moodHold -= dt; if (S.moodHold <= 0) S.moodHeld = null; }
@@ -605,6 +612,9 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     if (now - lastBeat > HEARTBEAT_MS) { lastBeat = now; send({ type: 'heartbeat', t: now }); }
     const dt = last ? clamp((now - last) / 1000, 0, 0.1) : 0;
     last = now;
+    // the DOM wall is over the canvas and nothing in the scene can hide it, so it goes away
+    // whenever the world is not the thing on screen: the menu, the intro, the Brake, the host's pause
+    if (W) W.wallDom.setHidden(!!stage || S.paused || S.hostPaused || S.ended || !S.running);
     if (stage) { try { stage.update(dt); stage.render(); } catch (e) { bridge.log && bridge.log('race stage: ' + (e && e.stack || e)); } return; }
     if (!W) return;
     if (S.running && !S.paused && !S.hostPaused) {

--- a/ConditioningControlPanel/Resources/web/dtrh/race/wallDom.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/wallDom.js
@@ -1,0 +1,254 @@
+/* ============================================================================
+ * race/wallDom.js - the ONLINE FEED on the tube wall, as DOM.
+ *
+ * createWallDomPosters({ root, layout, camera, media, rng })
+ *   -> { update(depth), setRoom(id), setHidden(bool), ready(), dispose() }
+ *
+ * No dt: the layer has no animation of its own, every poster is a pure function of the
+ * camera and the road, so one depth per frame is the whole input.
+ *
+ * WHY THIS IS NOT A TEXTURE, AND NEVER CAN BE
+ *
+ * race/walls.js plasters the upper wall out of engine/wallPosters.js, which
+ * decodes each picture into a three.js texture. That road is closed to the feed:
+ * the feed's media all comes off images.scrolller.com, which sends NO
+ * access-control-allow-origin header at all (its preflight 403s), so
+ *
+ *   - `fetch(url)` is refused outright. wallPosters.js's loader is a fetch, so a
+ *     remote entry can never enter its pool in the first place.
+ *   - an `<img crossOrigin="anonymous">` does not merely taint, it FAILS TO LOAD.
+ *   - a plain `<img>` loads and taints the canvas, and uploading a tainted image
+ *     to WebGL throws SecurityError.
+ *
+ * Proxying the bytes through a CC Labs server is not on the table either: the
+ * browser talks to the source or it does not talk. So a player with no library of
+ * their own used to get painted word placards on the wall while the feed showed
+ * only on the flash cards. The pixels have to reach the wall some other way, and
+ * the only other way is to draw them as ELEMENTS and transform those elements
+ * into the same 3D space the wall quads live in. That is this file. If you are
+ * here to "simplify" it into a texture: read the three bullets again.
+ *
+ * THE TRANSFORM. No CSS3DRenderer is vendored (adding one means a new file under
+ * vendor/three/addons), so the matrix is written out here, and it is short: the
+ * container carries a CSS `perspective` solved from the camera's live fov and the
+ * viewport height; the inner "camera" element carries translateZ(perspective) plus
+ * camera.matrixWorldInverse with its y ROW negated; each poster carries
+ * translate(-50%,-50%) plus its own world matrix with its y COLUMN negated. Both
+ * negations are the same fact twice: CSS's y axis points down.
+ *
+ * PLACED, NOT FETCHED. A fixed set of remote entries is drawn ONCE at creation and
+ * every one starts loading immediately; a slot is only ever pointed at a picture
+ * that has already finished loading, and a slot that falls behind the camera is
+ * re-pointed at another member of that same set. Nothing is drawn or loaded per
+ * slot mid-run, so the wall never stalls waiting on the CDN.
+ *
+ * OCCLUSION. A DOM layer sits over the WebGL canvas and cannot be hidden by
+ * geometry, so the discipline is all here: a forward-depth window, a facing test
+ * against the wall normal so nothing shows through a bend, a distance fade so a
+ * poster arrives instead of popping, the same upper-wall band walls.js uses so
+ * nothing lands over the road, and a hard hide under the menu, the Brake and
+ * setHidden(true).
+ * ==========================================================================*/
+
+import * as THREE from 'three';
+import { BAND_LO, BAND_HI, makeWallFrame } from './walls.js';
+import { roomById } from './rooms.js';
+
+/* The pre-drawn set. Ten, because the forward window below is ~58 m and a slot
+ * lands every ~7.5 m, so ten covers the whole visible band with a little slack:
+ * one picture per slot at the start, and enough spare that a recycled slot can
+ * re-point at something it was not already showing. Ten decodes of feed-sized
+ * jpegs is a one-time cost the HTTP cache absorbs, and it stays wide enough that
+ * hostMedia's four-deep echo guard keeps neighbours different. */
+const PRE_DRAW = 10;
+const SLOT_GAP = 7.5;        // metres of road between slots
+const FAR = 58, NEAR = 2.2;  // the forward window: nothing outside it is on the wall
+const FADE_FAR = 16, FADE_NEAR = 3.5;   // metres of fade at each end of the window
+const BEHIND = 9;            // metres behind the lens before a slot recycles ahead
+const FACE_MIN = 0.12;       // cos of the grazing angle at which a wall has turned away
+const PX_W = 300;            // the element's own pixel box; the world size is the scale
+const POSTER_W = 3.4;        // metres wide, before the per-slot jitter
+const ALPHA = 0.94;          // never quite solid: the wall paint reads through
+const NDC_PAD = 1.5;         // off-screen by more than half a screen, stop transforming it
+
+/** loud rooms plaster, soft rooms scatter, the Tea Garden keeps a bare wall (walls.js). */
+const density = (id) => { const r = roomById(id); return !r || id === 'teagarden' ? 0 : r.loud ? 1 : 0.6; };
+const clamp01 = (v) => (v < 0 ? 0 : v > 1 ? 1 : v);
+const e6 = (v) => (Math.abs(v) < 1e-6 ? 0 : Math.round(v * 1e5) / 1e5);
+/** camera.matrixWorldInverse as CSS: the y ROW flips, because CSS's y points down. */
+const camCss = (e) => 'matrix3d(' + [e[0], -e[1], e[2], e[3], e[4], -e[5], e[6], e[7], e[8], -e[9], e[10], e[11], e[12], -e[13], e[14], e[15]].map(e6) + ')';
+/** a world matrix as CSS: the y COLUMN flips, the same fact from the object's side. */
+const objCss = (e) => 'matrix3d(' + [e[0], e[1], e[2], e[3], -e[4], -e[5], -e[6], -e[7], e[8], e[9], e[10], e[11], e[12], e[13], e[14], e[15]].map(e6) + ')';
+
+const INERT = { update() {}, setRoom() {}, setHidden() {}, ready: () => false, dispose() {} };
+
+export function createWallDomPosters({ root, layout, camera, media, rng }) {
+  if (!root || !layout || !camera || !media || typeof media.drawRemoteDom !== 'function') return INERT;
+  if (typeof document === 'undefined' || typeof Image === 'undefined') return INERT;
+
+  // ---- the pre-draw: one pass at the pool, before anything is placed ----------------
+  const picks = [];
+  for (let i = 0; i < PRE_DRAW; i++) { const p = media.drawRemoteDom('image'); if (p) picks.push(p); }
+  if (!picks.length) return INERT;   // no feed, no consent: build nothing, cost nothing
+
+  let disposed = false;
+  const shots = [];            // { url, aspect } - ONLY once the picture has finished loading
+  const loading = new Set();   // the loader <img>s, so dispose can let go of them
+  for (const p of picks) {
+    Promise.resolve().then(() => p.acquire()).then((h) => {
+      if (disposed || !h || !h.url) return;
+      // no crossOrigin: the CDN sends no ACAO, and an anonymous request would not load at all
+      const img = new Image();
+      img.decoding = 'async';
+      loading.add(img);
+      img.onload = () => {
+        loading.delete(img);
+        if (!disposed && img.naturalWidth) shots.push({ url: h.url, aspect: img.naturalHeight / img.naturalWidth });
+      };
+      img.onerror = () => loading.delete(img);
+      img.src = h.url;
+    }).catch(() => { /* the pool handed back nothing: the slot simply stays empty */ });
+  }
+
+  // ---- the layer -------------------------------------------------------------------
+  const box = document.createElement('div');
+  box.className = 'rh-wall3d';
+  const camEl = document.createElement('div');
+  camEl.className = 'rh-wall3d-cam';
+  box.appendChild(camEl);
+  root.appendChild(box);
+
+  const slots = [];
+  for (let i = 0; i < PRE_DRAW; i++) {
+    const el = document.createElement('img');
+    el.className = 'rh-wall3d-shot';
+    el.alt = '';
+    el.decoding = 'async';
+    camEl.appendChild(el);
+    slots.push({ el, shot: null, depth: 0, angle: 0, roll: 0, w: POSTER_W, h: POSTER_W, on: false, shown: false });
+  }
+
+  const wallFrame = makeWallFrame(layout);
+  const total = layout.totalDepth;
+  const _m = new THREE.Matrix4(), _inv = new THREE.Matrix4();
+  const _pos = new THREE.Vector3(), _v = new THREE.Vector3(), _fwd = new THREE.Vector3(), _ndc = new THREE.Vector3();
+  const _bx = new THREE.Vector3(), _by = new THREE.Vector3(), _bz = new THREE.Vector3();
+  let odo = 0, lastW = null, head = 0, seeded = false;
+  let room = null, live = 0, hidden = false, wasHidden = null, side = rng() < 0.5 ? 1 : -1;
+
+  /** A picture out of the pre-drawn set that this slot is not already showing. */
+  function pickShot(cur) {
+    if (!shots.length) return null;
+    if (shots.length === 1) return shots[0];
+    for (let t = 0; t < 6; t++) { const s = shots[(rng() * shots.length) | 0]; if (s && s !== cur) return s; }
+    return shots[0];
+  }
+
+  /** Aim a slot at a depth. False while nothing has finished loading, and a slot that
+   *  cannot be aimed stays off: a poster is never placed before its picture is in. */
+  function aim(slot, depth) {
+    const s = pickShot(slot.shot);
+    if (!s) return false;
+    slot.shot = s; slot.depth = depth; slot.on = true;
+    side = -side;
+    slot.angle = side * (BAND_LO + rng() * (BAND_HI - BAND_LO));
+    slot.roll = (rng() - 0.5) * 0.3;
+    slot.w = POSTER_W * (0.85 + rng() * 0.4);
+    slot.h = slot.w * Math.max(0.6, Math.min(1.5, s.aspect));
+    if (slot.el.getAttribute('src') !== s.url) slot.el.src = s.url;
+    slot.el.style.width = PX_W + 'px';
+    slot.el.style.height = Math.round(PX_W * slot.h / slot.w) + 'px';
+    return true;
+  }
+
+  const off = (slot) => { if (slot.shown) { slot.shown = false; slot.el.style.opacity = '0'; slot.el.style.visibility = 'hidden'; } };
+
+  function setRoom(id) {
+    if (id === room) return;
+    room = id;
+    live = Math.round(slots.length * density(id));
+  }
+  /** Hides AT ONCE, not on the next update: the run's pause and the menu both stop calling
+   *  update(), so a lever that only took effect there would leave the layer standing. */
+  function setHidden(v) {
+    hidden = !!v;
+    if (hidden && wasHidden !== true) { wasHidden = true; box.style.display = 'none'; }
+  }
+  const ready = () => shots.length > 0;
+
+  function update(depth) {
+    if (disposed) return;
+    // unwrapped odometer, exactly walls.js's: the race laps a closed loop but a slot's
+    // depth has to keep counting up, and frameAtDepth wraps internally anyway
+    const w = layout.wrap(depth);
+    // the odometer STARTS at the first depth it is given, not at zero: the run's own first
+    // frame is at depth 0, but nothing may assume that, and a layer seeded at 0 while the
+    // camera stands at 288 hangs its whole band a lap away where no one can see it
+    if (lastW == null) { lastW = w; odo = w; }
+    let delta = w - lastW;
+    if (delta > total / 2) delta -= total; else if (delta < -total / 2) delta += total;
+    odo += delta; lastW = w;
+    setRoom(layout.roomAtDepth(w));
+
+    if (hidden || !live) {
+      if (wasHidden !== true) { wasHidden = true; box.style.display = 'none'; }
+      return;
+    }
+    if (wasHidden !== false) { wasHidden = false; box.style.display = ''; }
+
+    if (!seeded) { seeded = true; head = odo + 6; }
+    const vw = window.innerWidth || root.clientWidth || 1, vh = window.innerHeight || root.clientHeight || 1;
+    const persp = 0.5 * vh / Math.tan(camera.fov * Math.PI / 360);
+
+    camera.updateMatrixWorld();
+    _inv.copy(camera.matrixWorld).invert();
+    camera.matrixWorldInverse.copy(_inv);          // Vector3.project reads this
+    box.style.perspective = e6(persp) + 'px';
+    camEl.style.transform = 'translateZ(' + e6(persp) + 'px)' + camCss(_inv.elements) + 'translate(' + vw / 2 + 'px,' + vh / 2 + 'px)';
+    camera.matrixWorld.extractBasis(_bx, _by, _bz);
+    _fwd.copy(_bz).negate();                        // the lens looks down its own -Z
+
+    for (let i = 0; i < slots.length; i++) {
+      const slot = slots[i];
+      if (i >= live) { off(slot); continue; }
+      // recycle first, so a slot that fell behind is re-aimed ahead in the same frame
+      if (slot.on && slot.depth < odo - BEHIND) slot.on = false;
+      if (!slot.on) {
+        // the head only advances on a SUCCESSFUL aim: a slot that could not be filled
+        // (nothing loaded yet) must not push the next one out past the far window
+        const at = Math.max(head, odo + 6) + SLOT_GAP * (0.8 + rng() * 0.4);
+        if (!aim(slot, at)) { off(slot); continue; }
+        head = at;
+      }
+      const f = wallFrame(slot.depth, slot.angle, slot.roll);
+      _pos.copy(f.c);
+      _v.subVectors(_pos, camera.position);
+      const fwd = _v.dot(_fwd);
+      if (fwd <= NEAR || fwd >= FAR) { off(slot); continue; }
+      const dist = _v.length() || 1;
+      const face = -_v.dot(f.in) / dist;            // f.in is the poster's own front normal
+      if (face < FACE_MIN) { off(slot); continue; }
+      _ndc.copy(_pos).project(camera);
+      if (Math.abs(_ndc.x) > NDC_PAD || Math.abs(_ndc.y) > NDC_PAD) { off(slot); continue; }
+      const o = ALPHA * clamp01((FAR - fwd) / FADE_FAR) * clamp01((fwd - NEAR) / FADE_NEAR) * clamp01((face - FACE_MIN) / 0.25);
+      if (o <= 0.01) { off(slot); continue; }
+      const s = slot.w / PX_W;
+      _m.makeBasis(_bx.copy(f.rt).multiplyScalar(s), _by.copy(f.up).multiplyScalar(s), _bz.copy(f.in).multiplyScalar(s));
+      _m.setPosition(_pos);
+      slot.el.style.transform = 'translate(-50%,-50%)' + objCss(_m.elements);
+      slot.el.style.opacity = e6(o);
+      if (!slot.shown) { slot.shown = true; slot.el.style.visibility = 'visible'; }
+    }
+  }
+
+  function dispose() {
+    disposed = true;
+    for (const img of loading) { img.onload = null; img.onerror = null; img.src = ''; }
+    loading.clear();
+    for (const slot of slots) { slot.el.src = ''; slot.shot = null; }
+    slots.length = 0; shots.length = 0;
+    if (box.parentNode) box.parentNode.removeChild(box);
+  }
+
+  return { update, setRoom, setHidden, ready, dispose };
+}

--- a/ConditioningControlPanel/Resources/web/dtrh/race/walls.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/walls.js
@@ -18,12 +18,13 @@
  *
  * Signage: one merged quad mesh per room, textured from a single pixel canvas atlas
  * of room words in the room's colours. A sparse "base" set is always up (diegetic
- * placards); the "fill" set only draws while media.hasUserMedia() is false, via
+ * placards); the "fill" set only draws while media.hasUserMedia() is false AND the
+ * feed's DOM posters are not up (hasDomPosters, race/wallDom.js), via
  * geometry drawRange, so an empty library still gets a dressed wall. 8 meshes, only
  * the rooms in view visible (2..3 draw calls at a time). The media posters live on
  * pixel.js's CRISP_LAYER (full resolution); the painted signs stay in the pixel world.
  *
- * createWalls({ scene, layout, media, renderer, camera, rng }) -> { update(d, dt), setRoom(id), dispose }
+ * createWalls({ scene, layout, media, renderer, camera, rng, hasDomPosters }) -> { update(d, dt), setRoom(id), dispose }
  * ==========================================================================*/
 
 import * as THREE from 'three';
@@ -33,8 +34,11 @@ import { ROOMS, roomById } from './rooms.js';
 import { pixelTex } from './roomProps.js';
 import { CRISP_LAYER } from './pixel.js';
 
-const BAND_LO = 0.32, BAND_HI = 1.27;   // radians from the ceiling: the upper-wall poster band
-const SIGN_INSET = 0.16;                // signs sit just inside the wall, like the posters
+// radians from the ceiling: the upper-wall poster band. Exported with makeWallFrame below
+// because race/wallDom.js hangs the online feed's DOM posters in the very same band, with
+// the very same basis: one copy of the maths, two consumers.
+export const BAND_LO = 0.32, BAND_HI = 1.27;
+export const WALL_INSET = 0.16;         // signs and posters sit just inside the wall
 const SIGN_W = 3.2, SIGN_H = 2.4;
 const VIEW = 170;                       // metres: rooms farther than this hide their signs
 const CELL_W = 64, CELL_H = 48, ATLAS_COLS = 4;
@@ -49,6 +53,28 @@ const WORDS = {
 const SIGN_GAP = { loud: [40, 9], soft: [60, 15], teagarden: [70, 36] };
 
 function hex(c) { return '#' + c.toString(16).padStart(6, '0'); }
+
+/** Wall point + axes at (depth, angle from ceiling): the poster's own placement maths.
+ *  Hoisted out of createWalls so race/wallDom.js can put a DOM poster exactly where a
+ *  mesh would go. The returned function writes into its own four vectors and hands them
+ *  back on itself (`f.c` / `f.in` / `f.rt` / `f.up`), so a per-frame call allocates nothing. */
+export function makeWallFrame(layout) {
+  const c = new THREE.Vector3(), inward = new THREE.Vector3(), rt = new THREE.Vector3(), up = new THREE.Vector3();
+  function wallFrame(depth, angle, roll) {
+    const fr = layout.frameAtDepth(depth);
+    const ca = Math.cos(angle), sa = Math.sin(angle), R = RADIUS - WALL_INSET;
+    c.copy(fr.pos).addScaledVector(fr.normal, ca * R).addScaledVector(fr.binormal, sa * R);
+    inward.copy(fr.normal).multiplyScalar(-ca).addScaledVector(fr.binormal, -sa).normalize();
+    rt.copy(fr.tangent).normalize();
+    up.crossVectors(inward, rt).normalize();
+    rt.crossVectors(up, inward).normalize();
+    if (up.dot(fr.normal) < 0) { up.negate(); rt.negate(); }   // upright: words and faces read from the road
+    if (roll) { rt.applyAxisAngle(inward, roll); up.applyAxisAngle(inward, roll); }
+    return wallFrame;
+  }
+  wallFrame.c = c; wallFrame.in = inward; wallFrame.rt = rt; wallFrame.up = up;
+  return wallFrame;
+}
 
 /** The placard atlas: a 4x4 grid of 64x48 cells, two per room, drawn once. */
 function signAtlas() {
@@ -68,24 +94,12 @@ function signAtlas() {
   }, { clamp: true });
 }
 
-export function createWalls({ scene, layout, media, renderer, camera, rng }) {
+export function createWalls({ scene, layout, media, renderer, camera, rng, hasDomPosters }) {
   const total = layout.totalDepth;
   const wrapDist = (a, b) => { const w = layout.wrap(a - b); return Math.min(w, total - w); };
-  const _c = new THREE.Vector3(), _in = new THREE.Vector3(), _rt = new THREE.Vector3(), _up = new THREE.Vector3();
   const _m = new THREE.Matrix4();
-
-  /** Wall point + axes at (depth, angle from ceiling): the poster's own placement maths. */
-  function wallFrame(depth, angle, roll) {
-    const fr = layout.frameAtDepth(depth);
-    const ca = Math.cos(angle), sa = Math.sin(angle), R = RADIUS - SIGN_INSET;
-    _c.copy(fr.pos).addScaledVector(fr.normal, ca * R).addScaledVector(fr.binormal, sa * R);
-    _in.copy(fr.normal).multiplyScalar(-ca).addScaledVector(fr.binormal, -sa).normalize();
-    _rt.copy(fr.tangent).normalize();
-    _up.crossVectors(_in, _rt).normalize();
-    _rt.crossVectors(_up, _in).normalize();
-    if (_up.dot(fr.normal) < 0) { _up.negate(); _rt.negate(); }   // upright: words and faces read from the road
-    if (roll) { _rt.applyAxisAngle(_in, roll); _up.applyAxisAngle(_in, roll); }
-  }
+  const wallFrame = makeWallFrame(layout);
+  const _c = wallFrame.c, _in = wallFrame.in, _rt = wallFrame.rt, _up = wallFrame.up;
 
   // ---- the posters (engine/wallPosters.js, adapted) --------------------------------------
   const posters = createWallPosters({ scene, layout, media, renderer, camera });
@@ -108,7 +122,7 @@ export function createWalls({ scene, layout, media, renderer, camera, rng }) {
       slot.angle = side * (BAND_LO + rng() * (BAND_HI - BAND_LO));
       slot.roll = (rng() - 0.5) * 0.3;
       wallFrame(slot.depth, slot.angle, 0);
-      mesh.position.copy(_c).addScaledVector(_in, RADIUS - SIGN_INSET - slot.wallR); // keep the slot's own wall radius
+      mesh.position.copy(_c).addScaledVector(_in, RADIUS - WALL_INSET - slot.wallR); // keep the slot's own wall radius
       mesh.quaternion.setFromRotationMatrix(_m.makeBasis(_rt, _up, _in));
       mesh.rotateZ(slot.roll);
     }
@@ -179,7 +193,10 @@ export function createWalls({ scene, layout, media, renderer, camera, rng }) {
     setRoom(layout.roomAtDepth(w));
     posters.update(camera, odometer, dt);
     aimNewSlots();
-    const fill = !(media && typeof media.hasUserMedia === 'function' && media.hasUserMedia());
+    // the fill set is the EMPTY-WALL dressing: it stands down for the player's own media and
+    // equally for the feed's DOM posters (race/wallDom.js), so words never compete with images
+    const fill = !(media && typeof media.hasUserMedia === 'function' && media.hasUserMedia())
+      && !(typeof hasDomPosters === 'function' && hasDomPosters());
     for (const s of signs) {
       s.mesh.visible = wrapDist(w, s.d0) < VIEW || wrapDist(w, s.d1) < VIEW || (w >= s.d0 && w <= s.d1);
       s.mesh.geometry.setDrawRange(0, fill ? s.all : s.baseCount);


### PR DESCRIPTION
Task W of the Racing Thoughts polish wave, PR 1 of 2 (stack). This is the parked branch `feat/race-wall-dom-posters` (one commit, never PR'd) rebased onto main and read critically. PR 2 (`feat/race-walls-w2-first-metre`) is the actual fix for the owner's note and stacks on this one; merge this first.

## What it does

The online feed's pictures reach the tube wall as DOM posters instead of painted word placards.

`images.scrolller.com` sends no `access-control-allow-origin` at all (its preflight 403s), so a feed image can NEVER become a three.js texture: `fetch` is refused outright (and `engine/wallPosters.js`'s loader is a fetch), an `<img crossOrigin="anonymous">` does not merely taint but fails to load, and uploading a plain tainted `<img>` to WebGL throws SecurityError. Proxying the bytes through a CC Labs server is off the table by the bright line. So the pixels reach the wall as elements transformed into the same 3D space the wall quads live in.

- `dtrh/hostMedia.js` gains `drawRemoteDom()`, the second DOM-only draw beside `drawDom()` (the payload cards). The two-pool split by URL origin is unchanged: remote urls never reach a texture.
- `race/wallDom.js` (new) is the layer. No CSS3DRenderer is vendored, so the matrix is written out: the container carries a CSS `perspective` solved from the camera's live fov, the inner element carries `translateZ(perspective)` plus `camera.matrixWorldInverse` with its y row negated, each poster carries its own world matrix with its y column negated. A forward-depth window, a facing test, a distance fade, the same upper-wall band `walls.js` uses, and a hard hide under the menu, the Brake and `setHidden(true)` are the whole occlusion discipline, because a DOM layer over the canvas cannot be hidden by geometry.
- `race/walls.js` stands its painted fill placards down for a room as soon as the DOM layer has pictures in it (`hasDomPosters`).

## Other tasks' files

- `race/run.js`: wall/media hunks only (the import, the layer's creation and teardown, one `update()` call after the camera, one `setHidden()`). Task S owns `applyCue` / the scheduler / `sync.js` and Task P owns the pace; none of those lines are touched. The rebase onto main conflicted twice in run.js (the file header, and the `w` object where `items` became `pickups`): main's hunks were kept both times and the two wall lines re-applied on top.
- `race/race.css`: one new block (`.rh-wall3d`, `.rh-wall3d-cam`, `.rh-wall3d-shot`) at z-index 1, under the HUD. Task P owns the rest of that file; nothing existing is edited.

## Smokes

All 21 `race/smoke/*.mjs` green on this commit alone (`3d31c6180`), so the stack is safe to merge bottom-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJ66hi5fRM1Dcjo38aSCa2
