### PR TITLE
fix(race): pictures on the wall from the first metre

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/race/run.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/run.js
@@ -188,7 +188,11 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     // (race/wallDom.js); the painted fill placards stand down as soon as its pictures are in
     let wallDom = null;
     const walls = createWalls({ scene, layout, media, renderer, camera, rng, hasDomPosters: () => !!wallDom && wallDom.ready() });
-    wallDom = createWallDomPosters({ root, layout, camera, media, rng });
+    // its OWN stream, not the world's. The layer draws or does not draw depending on whether a
+    // feed answered, and a draw off the shared rng would shift every roll after it: measured on
+    // race/smoke/pace-check.mjs, one extra draw here moved the worst "row under the kart" from
+    // 0.12 s to 0.67 s. The road a player gets must not depend on whether their pictures arrived.
+    wallDom = createWallDomPosters({ root, layout, camera, media, rng: makeRng(runSeed ^ 0x7f4a7c15) });
     const kart = createKart({ scene, layout, reducedMotion, pixel });
     const score = createScore();
     const getRoom = () => {

--- a/ConditioningControlPanel/Resources/web/dtrh/race/smoke/wall-dom-check.mjs
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/smoke/wall-dom-check.mjs
@@ -1,0 +1,288 @@
+/* ============================================================================
+ * race/smoke/wall-dom-check.mjs - pictures on the tube wall from the first metre.
+ *
+ *   node race/smoke/wall-dom-check.mjs   (from Resources/web/dtrh; 0 on pass, 1 with a count)
+ *
+ * THE BUG THIS FILE EXISTS FOR. rooms.js rollRoomOrder puts the Tea Garden first in
+ * every single run, and the Tea Garden used to be the one room with no wall pictures
+ * at all: walls.js handed it wallPosters' Region I, which that file keeps deliberately
+ * BARE (REGION_MAX[1] === 0), and wallDom.js gave it density 0. The room runs 222..560 m,
+ * which is 10..25 s at KART_BASE_SPEED, so every run opened on a bare wall no matter what
+ * media the player had. A property nobody wrote down is a property somebody puts back.
+ *
+ * Two halves.
+ *
+ * PURE. race/wallWarm.js is the reason a run can OPEN on pictures instead of loading
+ * them once the flag has dropped, so its contract is held here with a stubbed Image:
+ * it tops up to what was asked, holds only what finished, is idempotent, and lets the
+ * set go when the pool empties (a feed switched off). Plus a source guard on walls.js,
+ * because that file imports three and cannot be loaded in node.
+ *
+ * BROWSER. A phone viewport (390x844) with a STUB FEED - pngs this file makes and
+ * serves itself, so nothing is ever fetched from a third party - and the transport
+ * double the web host installs. Two runs: the manifest landing with `ready` (the wall
+ * must carry >= 6 loaded posters inside the first 5 s) and the manifest landing AFTER
+ * the world was built (the layer used to be inert for the rest of that run).
+ *
+ * REMOTE URLS ARE NEVER TEXTURES. Every stub row here is an absolute url, which is what
+ * hostMedia.js splits on, so the pool it lands in is the DOM-only one by construction.
+ *
+ * CHROME: `CHROME_PATH` if it is set, else the usual Windows install.
+ * ==========================================================================*/
+
+import { spawn } from 'node:child_process';
+import { createServer } from 'node:http';
+import { readFile, readFile as read } from 'node:fs/promises';
+import { readFileSync, mkdtempSync, rmSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, extname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { deflateSync } from 'node:zlib';
+
+let fails = 0;
+const ok = (cond, what) => { if (!cond) { console.error('FAIL ' + what); fails++; } else console.log('  ok  ' + what); };
+const eq = (got, want, what) => ok(got === want, what + ' (got ' + JSON.stringify(got) + ', want ' + JSON.stringify(want) + ')');
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const HERE = resolve(fileURLToPath(import.meta.url), '..');
+const RACE = resolve(HERE, '..');
+const WEB = resolve(RACE, '../..');                        // Resources/web
+void read;
+
+/* ============================================================================
+ * 1. race/wallWarm.js: the pictures a run opens on
+ * ==========================================================================*/
+/** A stubbed Image: a src lands one turn later, exactly the way a cached decode does. */
+let imgsMade = 0;
+globalThis.Image = class {
+  constructor() { this.decoding = ''; this.naturalWidth = 0; this.naturalHeight = 0; this.onload = null; this.onerror = null; this._src = ''; imgsMade++; }
+  get src() { return this._src; }
+  set src(v) {
+    this._src = v;
+    if (!v) return;
+    setTimeout(() => {
+      if (String(v).indexOf('broken') >= 0) { if (this.onerror) this.onerror(); return; }
+      this.naturalWidth = 120; this.naturalHeight = 180;
+      if (this.onload) this.onload();
+    }, 0);
+  }
+};
+
+const { warmWallPosters, warmShots, clearWarmPosters, WARM_MAX } = await import('../wallWarm.js');
+
+/** hostMedia's drawRemoteDom, in miniature: a pool of remote rows handed out one at a time. */
+function fakeMedia(n, prefix = 'https://cdn.example/pic') {
+  let left = n;
+  return { drawRemoteDom: () => (left-- > 0 ? { kind: 'image', name: 'p', remote: true, acquire: async () => ({ url: `${prefix}${left}.jpg`, release() {} }) } : null) };
+}
+
+eq(warmShots().length, 0, 'the warm set starts empty');
+warmWallPosters(fakeMedia(20), 12);
+await sleep(30);
+eq(warmShots().length, 12, 'a manifest with a feed in it warms the number of pictures the wall wants');
+ok(warmShots().every((s) => s.url && s.aspect > 0 && s.img), 'and every warmed picture carries its url, its aspect and its own decoded element');
+
+const madeAfterFirst = imgsMade;
+warmWallPosters(fakeMedia(20), 12);
+await sleep(30);
+eq(warmShots().length, 12, 'a second manifest with the set already full warms nothing again');
+eq(imgsMade, madeAfterFirst, 'and asks the pool for no further pictures');
+
+warmWallPosters(fakeMedia(200), 999);
+await sleep(30);
+ok(warmShots().length <= WARM_MAX, `the set is capped at ${WARM_MAX} however many the caller asks for (got ${warmShots().length})`);
+
+clearWarmPosters();
+eq(warmShots().length, 0, 'clearing lets the whole set go');
+warmWallPosters({ drawRemoteDom: () => null }, 12);
+await sleep(30);
+eq(warmShots().length, 0, 'a pool with no feed in it (the desktop, or consent off) warms nothing and costs nothing');
+warmWallPosters({}, 12);
+eq(warmShots().length, 0, 'and a media source with no drawRemoteDom at all is simply ignored');
+
+/* ============================================================================
+ * 2. the source guard walls.js cannot have as a unit test (it imports three)
+ * ==========================================================================*/
+const wallsSrc = readFileSync(resolve(RACE, 'walls.js'), 'utf8');
+const setRegionLine = (wallsSrc.match(/posters\.setRegion\([^;]*\);/) || [''])[0];
+ok(setRegionLine.length > 0, 'walls.js still sets a poster region per room');
+ok(!/teagarden['"]\s*\?\s*1\b/.test(setRegionLine),
+  'and the Tea Garden is no longer pinned to Region I, which wallPosters keeps bare - it is the first room of every run');
+const domSrc = readFileSync(resolve(RACE, 'wallDom.js'), 'utf8');
+const densityLine = (domSrc.match(/const density = [^;]*;/) || [''])[0];
+ok(densityLine.length > 0 && !/teagarden['"]\s*\?\s*0\b/.test(densityLine) && !/teagarden['"]\s*\)\s*\?\s*0\b/.test(densityLine),
+  'and the DOM wall gives the Tea Garden a density above zero for the same reason');
+
+/* ============================================================================
+ * 3. the browser: a phone, a stub feed, and a wall that has pictures on it
+ * ==========================================================================*/
+const CHROME = process.env.CHROME_PATH || 'C:/Program Files/Google/Chrome/Application/chrome.exe';
+const PORT = 8871;
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.mjs': 'text/javascript', '.css': 'text/css', '.json': 'application/json', '.glb': 'model/gltf-binary', '.png': 'image/png', '.webp': 'image/webp', '.jpg': 'image/jpeg', '.mp3': 'audio/mpeg', '.wav': 'audio/wav', '.svg': 'image/svg+xml', '.woff2': 'font/woff2' };
+
+/** A solid png, built here. NOTHING in this file is fetched from a third party. */
+const CRC = (() => { const t = []; for (let n = 0; n < 256; n++) { let c = n; for (let k = 0; k < 8; k++) c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1; t[n] = c >>> 0; } return t; })();
+const crc32 = (buf) => { let c = 0xffffffff; for (const b of buf) c = CRC[(c ^ b) & 0xff] ^ (c >>> 8); return (c ^ 0xffffffff) >>> 0; };
+function chunk(type, data) {
+  const len = Buffer.alloc(4); len.writeUInt32BE(data.length);
+  const td = Buffer.concat([Buffer.from(type, 'ascii'), data]);
+  const crc = Buffer.alloc(4); crc.writeUInt32BE(crc32(td));
+  return Buffer.concat([len, td, crc]);
+}
+function png(w, h, seed) {
+  const ihdr = Buffer.alloc(13);
+  ihdr.writeUInt32BE(w, 0); ihdr.writeUInt32BE(h, 4); ihdr[8] = 8; ihdr[9] = 2;
+  const raw = Buffer.alloc(h * (1 + w * 3));
+  for (let y = 0; y < h; y++) {
+    const off = y * (1 + w * 3);
+    for (let x = 0; x < w; x++) { raw[off + 1 + x * 3] = (seed * 7 + x) & 255; raw[off + 2 + x * 3] = (seed * 13 + y) & 255; raw[off + 3 + x * 3] = 200; }
+  }
+  return Buffer.concat([Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]), chunk('IHDR', ihdr), chunk('IDAT', deflateSync(raw)), chunk('IEND', Buffer.alloc(0))]);
+}
+const STUBS = new Map();
+for (let i = 0; i < 24; i++) STUBS.set(`${i}.png`, png(120 + (i % 3) * 30, 170 + (i % 4) * 20, i + 1));
+
+/** The transport double the web host installs (cclabs-web scripts/race-web-ext/race-web-ext.js),
+ *  cut down to what this check needs: init, favorites, the pile's own empty manifest, then the
+ *  feed's manifest `?feedDelay` ms later. `?feedDelay=0` is the ordinary case. */
+const STUB_HOST = `(function () {
+  var Q = new URLSearchParams(location.search);
+  var delay = Number(Q.get('feedDelay') || 0) || 0, handlers = [];
+  function deliver(f) { handlers.slice().forEach(function (h) { try { h({ data: f }); } catch (e) { console.error(e); } }); }
+  window.chrome = window.chrome || {};
+  window.chrome.webview = {
+    addEventListener: function (t, fn) { if (t === 'message' && typeof fn === 'function') handlers.push(fn); },
+    removeEventListener: function (t, fn) { handlers = handlers.filter(function (h) { return h !== fn; }); },
+    postMessage: function (m) {
+      if (!m || m.type !== 'ready') { if (m && m.type === 'ping') deliver({ type: 'pong', t: m.t }); return; }
+      deliver({ type: 'init', protocol: 1, modId: null, modContent: null, settings: {
+        masterVolume: 0, reducedMotion: false, trackPick: false, hostSfx: false, canSurface: false,
+        cloud: true, mediaControls: true, remoteConsent: true, remoteMediaRatio: 1,
+        remoteCatalog: [{ id: 'a', label: 'a' }], niches: ['a'],
+        localMedia: { images: 0, videos: 0, skipped: 0, active: false, folder: false } } });
+      deliver({ type: 'favorites', names: [] });
+      deliver({ type: 'manifest', images: [], videos: [], skipped: 0, truncated: false });
+      setTimeout(function () {
+        var images = [];
+        for (var i = 0; i < 24; i++) images.push({ name: 'online100:s' + i + '.png', url: location.origin + '/_stub/' + (i % 24) + '.png' });
+        deliver({ type: 'manifest', images: images, videos: [], skipped: 0, truncated: false });
+      }, delay);
+    },
+  };
+  window.__raceWebExt = { version: 1, deliver: deliver, sources: { register: function () { return function () {}; } }, refreshManifest: function () {} };
+})();`;
+
+if (!existsSync(CHROME)) { console.error('FAIL no chrome at ' + CHROME + ' (set CHROME_PATH)'); process.exit(1); }
+const server = createServer(async (req, res) => {
+  const path = decodeURIComponent(new URL(req.url, 'http://x').pathname);
+  if (path.indexOf('..') >= 0) { res.writeHead(400); return res.end(); }
+  if (path === '/_stub/host.js') { res.writeHead(200, { 'content-type': 'text/javascript' }); return res.end(STUB_HOST); }
+  if (path.startsWith('/_stub/')) {
+    const b = STUBS.get(path.slice(7));
+    if (!b) { res.writeHead(404); return res.end(); }
+    res.writeHead(200, { 'content-type': 'image/png' }); return res.end(b);
+  }
+  try {
+    let body = await readFile(join(WEB, path));
+    // the double has to be a CLASSIC script above raceBoot's module tag or bridge.js latches
+    // isHosted false; that is the whole reason race-web-ext.js is injected the same way
+    if (extname(path).toLowerCase() === '.html') {
+      body = Buffer.from(String(body).replace('<script type="module" src="./raceBoot.js">', '<script src="/_stub/host.js"></script>\n    <script type="module" src="./raceBoot.js">'), 'utf8');
+    }
+    res.writeHead(200, { 'content-type': MIME[extname(path).toLowerCase()] || 'application/octet-stream' });
+    res.end(req.method === 'HEAD' ? undefined : body);
+  } catch (e) { res.writeHead(404, { 'content-type': 'text/plain' }); res.end('no'); }
+});
+await new Promise((r) => server.listen(PORT, '127.0.0.1', r));
+
+const prof = mkdtempSync(join(tmpdir(), 'race-wall-'));
+const chrome = spawn(CHROME, [
+  '--headless=new', '--remote-debugging-port=9341', `--user-data-dir=${prof}`,
+  '--no-first-run', '--no-default-browser-check', '--disable-gpu', '--mute-audio',
+  '--enable-unsafe-swiftshader', '--autoplay-policy=no-user-gesture-required',
+  '--window-size=390,844', 'about:blank',
+], { stdio: 'ignore' });
+
+async function done(code) {
+  try { chrome.kill(); } catch (e) { /* already gone */ }
+  await new Promise((r) => server.close(r));
+  try { rmSync(prof, { recursive: true, force: true }); } catch (e) { /* windows holds the profile */ }
+  process.exit(code);
+}
+
+let page = null;
+for (let i = 0; i < 60 && !page; i++) {
+  await sleep(250);
+  try { page = (await (await fetch('http://127.0.0.1:9341/json/list')).json()).find((t) => t.type === 'page'); } catch (e) { /* not up */ }
+}
+if (!page) { console.error('FAIL chrome never answered on the debug port'); await done(1); }
+
+const ws = new WebSocket(page.webSocketDebuggerUrl);
+await new Promise((r) => { ws.onopen = r; });
+let msgId = 0;
+const waits = new Map();
+let errs = [];
+ws.onmessage = (e) => {
+  const m = JSON.parse(e.data);
+  if (m.id && waits.has(m.id)) { waits.get(m.id)(m); waits.delete(m.id); }
+  if (m.method === 'Runtime.exceptionThrown') errs.push('thrown: ' + (m.params.exceptionDetails?.exception?.description || m.params.exceptionDetails?.text || '?'));
+  if (m.method === 'Runtime.consoleAPICalled' && m.params.type === 'error') errs.push(m.params.args.map((a) => a.value ?? a.description ?? '?').join(' '));
+};
+const cdp = (method, params) => new Promise((res) => { const i = ++msgId; waits.set(i, res); ws.send(JSON.stringify({ id: i, method, params })); });
+const ev = async (x) => (await cdp('Runtime.evaluate', { expression: x, returnByValue: true, awaitPromise: true })).result?.result?.value;
+const json = async (x) => JSON.parse(await ev(`JSON.stringify(${x})`));
+await cdp('Runtime.enable'); await cdp('Page.enable');
+await cdp('Emulation.setDeviceMetricsOverride', { width: 390, height: 844, deviceScaleFactor: 2, mobile: true });
+
+const site = `http://127.0.0.1:${PORT}`;
+/** What the wall is carrying: elements up, pictures decoded, and how many are actually painted.
+ *  It reports the PAGE's own clock with them, so every second below is counted from the
+ *  navigation. The layer is built on the first frame that has a picture to hang, so a clock
+ *  started when `.rh-wall3d` appears would measure nothing at all. */
+const WALL = `(()=>{ const els=[...document.querySelectorAll('.rh-wall3d-shot')];
+  const loaded=els.filter((e)=>e.complete&&e.naturalWidth>0);
+  const shown=loaded.filter((e)=>{const s=getComputedStyle(e);return s.visibility!=='hidden'&&Number(s.opacity)>0.01&&e.offsetParent!==null;});
+  const box=document.querySelector('.rh-wall3d');
+  return { t: performance.now()/1000, layer: !!box, slots: els.length, loaded: loaded.length, shown: shown.length,
+    over: shown.filter((e)=>{const b=e.getBoundingClientRect();return b.bottom>innerHeight*0.98||b.width<=0;}).length }; })()`;
+
+/** Poll the wall until the page's own clock passes `sec`, and report the first moment it
+ *  carried `want` painted posters, measured from the navigation. */
+async function watch(want, sec) {
+  let best = { t: 0, shown: 0, loaded: 0, slots: 0, layer: false, over: 0 }, at = null, layer = false;
+  for (;;) {
+    let w = null;
+    try { w = await json(WALL); } catch (e) { w = null; }   // still navigating
+    if (w) {
+      layer = layer || w.layer;
+      if (w.shown > best.shown) best = w;
+      if (at == null && w.shown >= want) { at = Math.round(w.t * 1000) / 1000; break; }
+      if (w.t >= sec) break;
+    }
+    await sleep(120);
+  }
+  return { best, at, layer };
+}
+
+// ---- run one: the manifest lands with `ready`, the way the web host posts it ----------
+errs = [];
+await cdp('Page.navigate', { url: `${site}/dtrh/race.html?autostart=1&intro=0&cards=0&feedDelay=0` });
+const first = await watch(6, 5);
+ok(first.layer, 'the run builds the DOM wall layer');
+ok(first.at != null, `>= 6 posters with a loaded picture are on the wall inside the first 5 s of the page (${first.best.shown} up, ${first.best.loaded} of ${first.best.slots} decoded, first six at ${first.at}s)`);
+eq(first.best.over, 0, 'and not one of them hangs off the bottom of the glass');
+eq(errs.length, 0, 'with nothing on the console' + (errs.length ? ': ' + errs.slice(0, 4).join(' | ') : ''));
+
+// ---- run two: the manifest lands AFTER the world was built ----------------------------
+// The feed's own build asks its source twice and waits on the network, so on a phone the
+// merged manifest routinely lands seconds after the page did. The layer used to draw its
+// whole set once, at world build, and a layer built before that frame stayed dead all run.
+errs = [];
+await cdp('Page.navigate', { url: `${site}/dtrh/race.html?autostart=1&intro=0&cards=0&feedDelay=3500` });
+const late = await watch(6, 12);
+ok(late.at != null && late.at > 3, `the feed only answered at 3.5 s, so nothing was on the wall before it (first six at ${late.at}s)`);
+ok(late.at != null && late.at < 9, `and it still reached the wall mid-run, without a rebuild (${late.best.shown} posters, ${late.best.loaded} of ${late.best.slots} decoded)`);
+eq(errs.length, 0, 'with nothing on the console' + (errs.length ? ': ' + errs.slice(0, 4).join(' | ') : ''));
+
+console.log(fails ? `\n${fails} FAILED` : '\nall good');
+await done(fails ? 1 : 0);

--- a/ConditioningControlPanel/Resources/web/dtrh/race/wallDom.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/wallDom.js
@@ -36,11 +36,16 @@
  * translate(-50%,-50%) plus its own world matrix with its y COLUMN negated. Both
  * negations are the same fact twice: CSS's y axis points down.
  *
- * PLACED, NOT FETCHED. A fixed set of remote entries is drawn ONCE at creation and
- * every one starts loading immediately; a slot is only ever pointed at a picture
- * that has already finished loading, and a slot that falls behind the camera is
- * re-pointed at another member of that same set. Nothing is drawn or loaded per
- * slot mid-run, so the wall never stalls waiting on the CDN.
+ * PLACED, NOT FETCHED, AND WARM BEFORE THE FLAG. A slot is only ever pointed at a
+ * picture that has already finished loading, so the loading cannot start when the
+ * world does or the run opens on a bare wall while the CDN answers. race/wallWarm.js
+ * starts it as soon as a manifest carrying feed rows lands - before the menu, let
+ * alone the countdown - and this layer opens on that set. It tops itself up from the
+ * pool afterwards, once a second while it is short, which is also how a feed switched
+ * on late (or a manifest that landed after the world was built) still reaches the wall
+ * instead of leaving the layer dead for the whole run. A slot that falls behind the
+ * camera is re-pointed at another member of the set it already holds; nothing is
+ * fetched per slot mid-run, so the wall never stalls waiting on the CDN.
  *
  * OCCLUSION. A DOM layer sits over the WebGL canvas and cannot be hidden by
  * geometry, so the discipline is all here: a forward-depth window, a facing test
@@ -53,15 +58,17 @@
 import * as THREE from 'three';
 import { BAND_LO, BAND_HI, makeWallFrame } from './walls.js';
 import { roomById } from './rooms.js';
+import { warmShots, warmWallPosters } from './wallWarm.js';
 
-/* The pre-drawn set. Ten, because the forward window below is ~58 m and a slot
- * lands every ~7.5 m, so ten covers the whole visible band with a little slack:
- * one picture per slot at the start, and enough spare that a recycled slot can
- * re-point at something it was not already showing. Ten decodes of feed-sized
- * jpegs is a one-time cost the HTTP cache absorbs, and it stays wide enough that
- * hostMedia's four-deep echo guard keeps neighbours different. */
-const PRE_DRAW = 10;
-const SLOT_GAP = 7.5;        // metres of road between slots
+/* The drawn set. Twelve, because the forward window below is ~56 m and a slot lands
+ * every ~6.5 m, so twelve covers the whole visible band with a little slack: one
+ * picture per slot at the start, and enough spare that a recycled slot can re-point
+ * at something it was not already showing. Twelve decodes of feed-sized jpegs is a
+ * one-time cost the HTTP cache absorbs, and it stays wide enough that hostMedia's
+ * four-deep echo guard keeps neighbours different. */
+const PRE_DRAW = 12;
+const REFILL_MS = 900;       // how often a layer that is short of pictures asks the pool again
+const SLOT_GAP = 6.5;        // metres of road between slots
 const FAR = 58, NEAR = 2.2;  // the forward window: nothing outside it is on the wall
 const FADE_FAR = 16, FADE_NEAR = 3.5;   // metres of fade at each end of the window
 const BEHIND = 9;            // metres behind the lens before a slot recycles ahead
@@ -71,8 +78,12 @@ const POSTER_W = 3.4;        // metres wide, before the per-slot jitter
 const ALPHA = 0.94;          // never quite solid: the wall paint reads through
 const NDC_PAD = 1.5;         // off-screen by more than half a screen, stop transforming it
 
-/** loud rooms plaster, soft rooms scatter, the Tea Garden keeps a bare wall (walls.js). */
-const density = (id) => { const r = roomById(id); return !r || id === 'teagarden' ? 0 : r.loud ? 1 : 0.6; };
+/** loud rooms plaster, soft rooms scatter, and the TEA GARDEN carries pictures too.
+ *  rooms.js rollRoomOrder puts the Tea Garden first in every run and it runs 222..560 m
+ *  (10..25 s at KART_BASE_SPEED), so a bare opening room is a bare opening minute - which
+ *  is exactly what a player saw. It opens generously and the rest of the run reads off it.
+ *  race/walls.js's own per-room density carries the same fix for the player's own media. */
+const density = (id) => { const r = roomById(id); return !r ? 0 : id === 'teagarden' ? 0.8 : r.loud ? 1 : 0.6; };
 const clamp01 = (v) => (v < 0 ? 0 : v > 1 ? 1 : v);
 const e6 = (v) => (Math.abs(v) < 1e-6 ? 0 : Math.round(v * 1e5) / 1e5);
 /** camera.matrixWorldInverse as CSS: the y ROW flips, because CSS's y points down. */
@@ -86,46 +97,76 @@ export function createWallDomPosters({ root, layout, camera, media, rng }) {
   if (!root || !layout || !camera || !media || typeof media.drawRemoteDom !== 'function') return INERT;
   if (typeof document === 'undefined' || typeof Image === 'undefined') return INERT;
 
-  // ---- the pre-draw: one pass at the pool, before anything is placed ----------------
-  const picks = [];
-  for (let i = 0; i < PRE_DRAW; i++) { const p = media.drawRemoteDom('image'); if (p) picks.push(p); }
-  if (!picks.length) return INERT;   // no feed, no consent: build nothing, cost nothing
-
+  // ---- the picture set -------------------------------------------------------------
+  // Whatever race/wallWarm.js already decoded IS the opening set: those pictures are in hand
+  // before the world is built, so the first slots can be aimed on the run's very first frame.
   let disposed = false;
-  const shots = [];            // { url, aspect } - ONLY once the picture has finished loading
-  const loading = new Set();   // the loader <img>s, so dispose can let go of them
-  for (const p of picks) {
+  const shots = warmShots().slice();   // { url, aspect } - ONLY pictures that have finished loading
+  const loading = new Set();           // the loader <img>s, so dispose can let go of them
+  let pending = 0;                     // draws in flight, so a refill does not re-ask for them
+  let lastRefill = 0;
+
+  function pull(p) {
+    pending++;
     Promise.resolve().then(() => p.acquire()).then((h) => {
-      if (disposed || !h || !h.url) return;
+      if (disposed || !h || !h.url) { pending--; return; }
       // no crossOrigin: the CDN sends no ACAO, and an anonymous request would not load at all
       const img = new Image();
       img.decoding = 'async';
       loading.add(img);
       img.onload = () => {
+        pending--;
         loading.delete(img);
-        if (!disposed && img.naturalWidth) shots.push({ url: h.url, aspect: img.naturalHeight / img.naturalWidth });
+        // the element is kept on the shot: its decode stays resident, so a slot pointed at this
+        // url paints in the same frame instead of asking the cache for the picture again
+        if (!disposed && img.naturalWidth) shots.push({ url: h.url, aspect: img.naturalHeight / img.naturalWidth, img });
       };
-      img.onerror = () => loading.delete(img);
+      img.onerror = () => { pending--; loading.delete(img); };
       img.src = h.url;
-    }).catch(() => { /* the pool handed back nothing: the slot simply stays empty */ });
+    }).catch(() => { pending--; /* the pool handed back nothing: the slot simply stays empty */ });
   }
 
-  // ---- the layer -------------------------------------------------------------------
-  const box = document.createElement('div');
-  box.className = 'rh-wall3d';
-  const camEl = document.createElement('div');
-  camEl.className = 'rh-wall3d-cam';
-  box.appendChild(camEl);
-  root.appendChild(box);
+  /** Top the set up from the pool. Called at creation and then, at most once a REFILL_MS,
+   *  while the layer is short: a manifest that lands after the world was built (the feed's
+   *  own build takes seconds on a phone) is the ordinary case, not the exception, and a
+   *  layer that only ever asked once would stay dead for the whole of that run. */
+  function refill() {
+    if (disposed || shots.length + pending >= PRE_DRAW) return;
+    for (let i = shots.length + pending; i < PRE_DRAW; i++) {
+      const p = media.drawRemoteDom('image');
+      if (!p) return;   // nothing in the pool yet: ask again on the next tick
+      pull(p);
+    }
+  }
+  warmWallPosters(media, PRE_DRAW);   // whatever the warm set is short of, start it now
+  refill();
 
+  // ---- the layer, built only when there is a picture for it -------------------------
+  // NOT eager. A full-screen 3D container with a dozen posters in it standing over the
+  // canvas is not free even with nothing in it and display:none on top: measured on
+  // race/smoke/pace-check.mjs, building it in a run that has no feed at all pushed the
+  // worst "row under the kart" from 0.10 s to 0.70 s and failed that check. A player with
+  // no feed (no consent, the desktop build, a manifest that carries no remote rows) must
+  // pay nothing for a layer that can never show anything, so the elements are made on the
+  // first frame that actually has a picture to hang, and a feed that arrives late still
+  // builds them then.
+  let box = null, camEl = null;
   const slots = [];
-  for (let i = 0; i < PRE_DRAW; i++) {
-    const el = document.createElement('img');
-    el.className = 'rh-wall3d-shot';
-    el.alt = '';
-    el.decoding = 'async';
-    camEl.appendChild(el);
-    slots.push({ el, shot: null, depth: 0, angle: 0, roll: 0, w: POSTER_W, h: POSTER_W, on: false, shown: false });
+  function build() {
+    box = document.createElement('div');
+    box.className = 'rh-wall3d';
+    camEl = document.createElement('div');
+    camEl.className = 'rh-wall3d-cam';
+    box.appendChild(camEl);
+    root.appendChild(box);
+    for (let i = 0; i < PRE_DRAW; i++) {
+      const el = document.createElement('img');
+      el.className = 'rh-wall3d-shot';
+      el.alt = '';
+      el.decoding = 'async';
+      camEl.appendChild(el);
+      slots.push({ el, shot: null, depth: 0, angle: 0, roll: 0, w: POSTER_W, h: POSTER_W, on: false, shown: false });
+    }
   }
 
   const wallFrame = makeWallFrame(layout);
@@ -166,13 +207,13 @@ export function createWallDomPosters({ root, layout, camera, media, rng }) {
   function setRoom(id) {
     if (id === room) return;
     room = id;
-    live = Math.round(slots.length * density(id));
+    live = Math.round(PRE_DRAW * density(id));
   }
   /** Hides AT ONCE, not on the next update: the run's pause and the menu both stop calling
    *  update(), so a lever that only took effect there would leave the layer standing. */
   function setHidden(v) {
     hidden = !!v;
-    if (hidden && wasHidden !== true) { wasHidden = true; box.style.display = 'none'; }
+    if (hidden && wasHidden !== true) { wasHidden = true; if (box) box.style.display = 'none'; }
   }
   const ready = () => shots.length > 0;
 
@@ -190,10 +231,20 @@ export function createWallDomPosters({ root, layout, camera, media, rng }) {
     odo += delta; lastW = w;
     setRoom(layout.roomAtDepth(w));
 
-    if (hidden || !live) {
-      if (wasHidden !== true) { wasHidden = true; box.style.display = 'none'; }
+    // ahead of the hidden check: a layer standing in a room that wants nothing still gathers
+    // the pictures the room after it will want
+    if (shots.length < PRE_DRAW) {
+      const now = Date.now();
+      if (now - lastRefill > REFILL_MS) { lastRefill = now; refill(); }
+    }
+
+    // Nothing decoded yet: no elements are made and none of the camera work below runs.
+    // This is the whole of the no-feed cost, and it is a room lookup and a compare.
+    if (hidden || !live || !shots.length) {
+      if (box && wasHidden !== true) { wasHidden = true; box.style.display = 'none'; }
       return;
     }
+    if (!box) build();
     if (wasHidden !== false) { wasHidden = false; box.style.display = ''; }
 
     if (!seeded) { seeded = true; head = odo + 6; }
@@ -246,8 +297,13 @@ export function createWallDomPosters({ root, layout, camera, media, rng }) {
     for (const img of loading) { img.onload = null; img.onerror = null; img.src = ''; }
     loading.clear();
     for (const slot of slots) { slot.el.src = ''; slot.shot = null; }
-    slots.length = 0; shots.length = 0;
-    if (box.parentNode) box.parentNode.removeChild(box);
+    slots.length = 0;
+    live = 0;
+    // the warm set's own elements are NOT released here: race/wallWarm.js owns those and the
+    // next run opens on them. Only this layer's own loaders are let go.
+    shots.length = 0;
+    if (box && box.parentNode) box.parentNode.removeChild(box);
+    box = null; camEl = null;
   }
 
   return { update, setRoom, setHidden, ready, dispose };

--- a/ConditioningControlPanel/Resources/web/dtrh/race/wallWarm.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/wallWarm.js
@@ -1,0 +1,82 @@
+/* ============================================================================
+ * race/wallWarm.js - the feed pictures a run OPENS on.
+ *
+ *   warmWallPosters(media, n)  draw n feed pictures and start loading them NOW
+ *   warmShots()                the ones that have finished, [{ url, aspect }]
+ *
+ * WHY IT EXISTS. race/wallDom.js only ever hangs a picture that has already
+ * finished loading, which is the right rule and the reason a run used to open on
+ * a bare wall: the loading started when the world was built, and a phone on a
+ * CDN needs a second or two per picture. So the loading has to start EARLIER
+ * than the world. raceBoot calls this the moment a `manifest` carrying feed rows
+ * lands - before the menu, let alone the countdown - and whatever has decoded by
+ * the time a run is built is on the wall from the first metre.
+ *
+ * THE ELEMENTS ARE KEPT. Holding each loader <img> keeps its decode resident, so
+ * pointing a wall slot at the same url paints in the same frame instead of
+ * re-decoding. Sixteen feed-sized pictures is the cap and the whole cost.
+ *
+ * NO THREE, NO DOM LAYOUT, NOTHING TO TEAR DOWN. This module is imported by
+ * raceBoot, which must not pull the 3D graph in on the boot path, so it imports
+ * nothing at all. race/wallDom.js reads the set; nobody else should.
+ *
+ * REMOTE ONLY, DOM ONLY. Every url here comes from hostMedia's drawRemoteDom(),
+ * so it is a third-party CDN url and it may only ever be an <img> src. It is
+ * never fetched, never drawn to a canvas and never uploaded to a texture
+ * (dtrh/hostMedia.js's header has the reason).
+ * ==========================================================================*/
+
+/** Pictures held at once. Twelve is what a wall wants (race/wallDom.js PRE_DRAW); the
+ *  few spare let a recycled slot re-point at something it was not already showing. */
+export const WARM_MAX = 16;
+
+const warm = [];      // { url, aspect, img } - only ever pushed once the picture is in
+let pending = 0;      // draws in flight, so a second call does not re-ask for the same slots
+
+/** The decoded set, for race/wallDom.js. Live array: it grows as pictures land. */
+export function warmShots() { return warm; }
+
+/** Let the set go (a feed switched off, a manifest with nothing remote in it). */
+export function clearWarmPosters() {
+  for (const s of warm) { if (s.img) { s.img.onload = null; s.img.onerror = null; s.img.src = ''; } }
+  warm.length = 0;
+}
+
+function pull(pick) {
+  pending++;
+  Promise.resolve().then(() => pick.acquire()).then((h) => {
+    if (!h || !h.url) { pending--; return; }
+    // no crossOrigin: the feed's CDN sends no ACAO and an anonymous request would not load at all
+    const img = new Image();
+    img.decoding = 'async';
+    img.onload = () => {
+      pending--;
+      if (img.naturalWidth && warm.length < WARM_MAX) warm.push({ url: h.url, aspect: img.naturalHeight / img.naturalWidth, img });
+    };
+    img.onerror = () => { pending--; };
+    img.src = h.url;
+  }).catch(() => { pending--; });
+}
+
+/**
+ * Top the set up to `n` pictures from the feed pool. Cheap and idempotent: a full set asks for
+ * nothing, and a pool with no feed in it (the desktop, or consent off) drops the set and returns 0.
+ *
+ * @param {object} media  dtrh/hostMedia.js's source; anything without drawRemoteDom is ignored
+ * @param {number} [n]    how many to hold, capped at WARM_MAX
+ * @returns {number} how many pictures are in hand right now
+ */
+export function warmWallPosters(media, n = 12) {
+  if (!media || typeof media.drawRemoteDom !== 'function') return warm.length;
+  if (typeof Image === 'undefined') return warm.length;
+  const want = Math.max(1, Math.min(WARM_MAX, n | 0));
+  for (let i = warm.length + pending; i < want; i++) {
+    const pick = media.drawRemoteDom('image');
+    // Nothing in the pool: if nothing has landed either, the feed is gone and so is the set.
+    if (!pick) { if (!warm.length && !pending) clearWarmPosters(); break; }
+    pull(pick);
+  }
+  return warm.length;
+}
+
+export default warmWallPosters;

--- a/ConditioningControlPanel/Resources/web/dtrh/race/walls.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/walls.js
@@ -180,7 +180,12 @@ export function createWalls({ scene, layout, media, renderer, camera, rng, hasDo
     if (id === room) return;
     room = id;
     const spec = roomById(id);
-    posters.setRegion(!spec || id === 'teagarden' ? 1 : spec.loud ? 3 : 2);
+    // The Tea Garden used to take Region I, which wallPosters.js keeps deliberately BARE. It is
+    // also always the first room of a run (rooms.js rollRoomOrder) and runs 222..560 m, so that
+    // one line was the whole of "no pictures on the wall from the start": the opening 10..25 s
+    // had a hard ceiling of zero posters no matter what media the player had. It scatters now,
+    // like the other calm rooms; the loud rooms still plaster.
+    posters.setRegion(!spec ? 2 : spec.loud ? 3 : 2);
   }
 
   // ---- runtime ----------------------------------------------------------------------------

--- a/ConditioningControlPanel/Resources/web/dtrh/raceBoot.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/raceBoot.js
@@ -89,6 +89,9 @@ import * as bridge from './bridge.js';
 import { detectMode } from './shared/capability.js';
 import { setQuality, Q } from './shared/quality.js';
 import { createHostMediaSource } from './hostMedia.js';
+// The feed's pictures start loading the moment a manifest carrying them lands, so a run built
+// later opens with pictures already on the wall. Imports nothing itself: this is the boot path.
+import { warmWallPosters } from './race/wallWarm.js';
 
 const INIT_TIMEOUT_MS = 4000, SPLASH_MS = 1000, TRACK_TICK_MS = 250, PERF_LOG_MS = 2000;
 const params = new URLSearchParams(location.search);
@@ -186,7 +189,7 @@ if (mode.hardBlock || !mode.canTry3d) {
 
 // ---- host wiring ----
 bridge.on('init', (m) => { initMsg = m; maybeBoot(); });
-bridge.on('manifest', (m) => { try { media.setManifest(m); } catch (e) { host.log('manifest: ' + e); } haveManifest = true; maybeBoot(); });
+bridge.on('manifest', (m) => { try { media.setManifest(m); warmWallPosters(media); } catch (e) { host.log('manifest: ' + e); } haveManifest = true; maybeBoot(); });
 bridge.on('favorites', (m) => { try { media.setFavorites(m && m.names || []); } catch (e) { host.log('favorites: ' + e); } });
 // The media panel's two frames (race/menu.js "YOUR MEDIA"). Both can land before the menu exists -
 // the pickers are only reachable from the menu, but the host pushes the pile it already holds on


### PR DESCRIPTION
Task W of the Racing Thoughts polish wave, PR 2 of 2. Stacked on #936; merge that one first. The owner's note was "we still dont see the images plastered on the wall from the start".

## The cause, with evidence

It was four faults stacked on the same stretch of road, not one.

**1. The first room of every run had a hard ceiling of ZERO posters.** `race/rooms.js rollRoomOrder()` opens with `const out = ['teagarden'];`, so the Tea Garden is room 0 of every run (measured over 200 seeds: 200/200 opened there). `race/walls.js setRoom()` handed that room `posters.setRegion(1)`, and `engine/wallPosters.js` has `REGION_MAX = [0, 0, 6, 16, 30]` on mobile: **Region I is deliberately bare**. Measured in-page over 200 seeds, the Tea Garden spans 222 to 560 m (p50 355 m), which at `KART_BASE_SPEED` is **10.1 to 25.5 s** (p50 16.1 s). So the opening of every run could not carry a poster no matter what media the player had. This is not web-only: the desktop build had the same bare opening.

**2. The DOM layer was bare there too.** `race/wallDom.js`'s own density table returned 0 for `teagarden`, which set `live = 0`, hid the box and returned early. Same room, same stretch, so the feed's pictures could not fill in for the missing textures either.

**3. The DOM layer drew its whole set ONCE, at world build.** With an empty remote pool it returned `INERT` and stayed dead for the entire run. On the web that is the ordinary case, not the exception: the host posts a LOCAL-ONLY manifest on `ready` and the feed's merged manifest only after two `assets-request` round trips (`ASK_MS` 11 s, the provider's own backstop 9 s), so a world built before that landed could never show a picture.

**4. Nothing started loading before the world did.** Even once a manifest landed, the first slot could only be aimed after a fetch and a decode, so the opening seconds were bare again.

A fifth cause lives in the site repo (an empty feed answer was cached for the whole session) and is fixed separately in cclabs-web.

**Baseline reproduction**, headless 390x844, `?autostart=1&cards=0`, stub feed, 14 s: `layerShown: false`, `loaded: 0`, `visible: 0` at every one of 14 samples.

## The fix

- `race/walls.js`: the Tea Garden scatters like the other calm rooms (Region II) instead of being pinned to the bare Region I. Loud rooms still plaster.
- `race/wallDom.js`: the Tea Garden gets a density of 0.8, so the opening room is the generous one and the rest of the run reads off it.
- `race/wallWarm.js` (new): starts the feed's pictures decoding the moment a manifest carrying them lands, before the menu, let alone the countdown. It imports nothing, because `raceBoot.js` imports it and that path must not pull three.js in.
- `race/wallDom.js` opens on the warm set and then tops itself up from the pool once a second while it is short, so a manifest that lands after the world was built still reaches the wall instead of leaving the layer dead all run.
- The layer is now built LAZILY, on the first frame that has a picture to hang, and it draws from **its own rng stream** rather than the world's.

## Two findings worth reading, both caught by `pace-check`

- **A DOM layer that has nothing to show still costs.** Building the full-screen 3D container and its posters in a run with no feed at all (no consent, the desktop build, a manifest with no remote rows) pushed `pace-check`'s worst "row under the kart" from 0.10 s to 0.70 s. Hence the lazy build: with no picture in hand, no elements are made and none of the camera work runs.
- **One rng draw shifted the whole world.** The layer took `side = rng() < 0.5` off the run's shared stream at creation. In the parked branch that draw only happened when the feed had answered, so **the road a player got depended on whether their pictures had arrived**. It also moved `pace-check`'s worst row from 0.12 s to 0.67 s. `run.js` now hands the layer `makeRng(runSeed ^ 0x7f4a7c15)`, its own stream, so the road is the same either way. This is a one-line wall/media hunk in run.js; Task S's `applyCue` / scheduler / `sync.js` and Task P's pace are untouched.

## Proof

New `race/smoke/wall-dom-check.mjs` (system Chrome over CDP, 390x844 DSF 2, a stub host that speaks the web host's transport, 24 locally generated PNGs, **no third-party fetch of any kind**). Every time it reports is measured from the navigation, not from the moment the layer appears.

- run one, manifest with `ready`: **6 posters painted with a decoded picture at 1.297 s**, 10 of 12 slots decoded, 0 hanging off the bottom of the glass, **0 console errors**.
- run two, `?feedDelay=3500` (the manifest lands after the world was built): nothing before 3.5 s, then **first six at 4.162 s**, 10 of 12 decoded, no rebuild, **0 console errors**.
- the node half also covers `wallWarm.js` topping up, holding only what finished, staying idempotent, capping at `WARM_MAX`, and ignoring a media source with no `drawRemoteDom` at all.

All **22** `race/smoke/*.mjs` green on this branch (21 pre-existing plus the new one), and all 21 green on #936 alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJ66hi5fRM1Dcjo38aSCa2
