### PR TITLE
feat(race): the script written on the road, W1 - one word a bubble, in a line down a lane

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/race/chart.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/chart.js
@@ -15,7 +15,7 @@
  * after its second is dropped and counted as missed, never spawned behind the kart.
  * ==========================================================================*/
 
-import { ROOM_IDS, KART_BASE_SPEED, makeRng } from './consts.js';
+import { ROOM_IDS, KART_BASE_SPEED, LANE_X_MAX, makeRng } from './consts.js';
 
 export const CHART_VERSION = 1;
 
@@ -141,6 +141,14 @@ function normalizeEvents(raw, durationSec) {
         dur: clamp(num(e.dur, 0), 0, durationSec - t), weight: clamp01(num(e.weight, 1)) };
       if (e.kind === 'count') { ev.n = num(e.n, 0); ev.of = num(e.of, 0); ev.last = e.last === true; }
       if (e.kind === 'drop') ev.strength = clamp01(num(e.strength, 1));
+      // A WORD BUBBLE off the transcript (race/wordBubbles.js): the word this bubble wears and the
+      // lane its phrase put it in. Kept for the same reason `cue` below is kept - this pass
+      // validates a chart, it does not rewrite one - and without the pair the road loses the lyric
+      // it was laid on and every word falls back into a random lane.
+      if (e.kind === 'word' && typeof e.w === 'string' && e.w) {
+        ev.w = e.w.slice(0, 40);
+        ev.x = clamp(num(e.x, 0), -LANE_X_MAX, LANE_X_MAX);
+      }
       if (e.kind === 'chant') { ev.reps = Math.max(1, Math.round(num(e.reps, 3))); ev.period = Math.max(0, num(e.period, 0)); }
       // An author marks the events they placed by hand inside a road, names the cue they
       // want on one, and leaves a note for the next author. Kept, for the same reason `hand`

--- a/ConditioningControlPanel/Resources/web/dtrh/race/cloudChart.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/cloudChart.js
@@ -46,6 +46,7 @@ import { cloudIdFrom, hashUrl, hashBytes, loadIndex, findAuthored, isAuthored } 
 import { loadWords } from './words.js';
 import { TRIGGER_SETS } from '../chart/editor/triggerSets.js';
 import { detect } from '../chart/maker/triggers.js';
+import { wordEventsFrom } from './wordBubbles.js';
 
 /**
  * THE GENERATOR ID. It is the cache key's second half: change any knob below and
@@ -57,8 +58,11 @@ import { detect } from '../chart/maker/triggers.js';
  * v3 (the sync wave): the trigger seconds come off the fingerprinted `hits` in the
  * words file (tools/racechart/fingerprint.py) when it has them, so a v2 road, laid
  * on the aligner's guess, must regenerate too.
+ * v4 (the word bubbles): the whole script is on the road now, one word a bubble in
+ * its phrase's lane (race/wordBubbles.js), so a v3 road carries a few dozen loose
+ * treats where the new one carries the lyric and cannot be served in its place.
  */
-export const GENERATOR_ID = 'web-road-v3';
+export const GENERATOR_ID = 'web-road-v4';
 
 /* ---- the knobs, and why each one is what it is --------------------------- */
 /**
@@ -330,13 +334,22 @@ export function wordedRoad({ peaks, perSec = PEAKS_PER_SEC, durationSec, name = 
   const hits = triggerHits(words, durationSec);
   const g = generate({ peaks, perSec, durationSec, words, hits, setById: SET_BY_ID, binSec: WORD_BIN_SEC, now });
   const energy = g.energy.map(clamp01);
-  const events = triggersFromHits(g.events, hits, SET_BY_ID)
+  const caps = captionWords(words);
+  const road = triggersFromHits(g.events, hits, SET_BY_ID);
+  const triggers = road.filter((e) => e.kind === 'trigger');
+  // THE SCRIPT IS THE ROAD. generate.js spends a handful of STRUCTURE words as loose treats in
+  // random lanes, which was the right answer while the road had no transcript on it and is the
+  // wrong one now: the transcript has every word the voice says, so those few are dropped and
+  // race/wordBubbles.js lays the whole script instead - one word a bubble, a phrase a lane, and
+  // never within HIT_GUARD_SEC of a trigger, because those seconds belong to the row.
+  const events = road.filter((e) => e.kind !== 'word')
+    .concat(wordEventsFrom(caps, triggers))
     .sort((a, b) => a.t - b.t)
     .map((e, i) => ({ ...e, id: 'g' + i }));
   const lexicon = [...new Set(events.filter((e) => e.kind === 'trigger').map((e) => e.label))].sort();
   return {
     version: 1, binSec: WORD_BIN_SEC, energy, events, acts: g.acts,
-    words: captionWords(words),
+    words: caps,
     source: { name, hash, durationSec, sampleRate: DECODE_RATE },
     analysis: { energy: 'web-rms-v1', words: 'script-align-v1', lexicon, generatedAt: g.generatedAt, partial: false },
   };

--- a/ConditioningControlPanel/Resources/web/dtrh/race/cues.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/cues.js
@@ -54,8 +54,10 @@ const WAKE_WORDS = new Set(['wake', 'awake', 'waking', 'up', 'open']);
 const WAKE_ACTS = new Set(['wake', 'free']);
 /** Words that lift: their treat hangs in the air; every other structure word sits in a lane. */
 const FLOAT_WORDS = new Set(['float', 'floating', 'up', 'open', 'light', 'rise', 'lift']);
-/** The lanes a spoken word may land in. Narrower than the road: the kart has to steer, not lunge. */
-const LANE_X = [-1.6, -0.8, 0, 0.8, 1.6];
+/** The lanes a spoken word may land in. Narrower than the road: the kart has to steer, not lunge.
+ *  Exported because race/wordBubbles.js walks a line of word bubbles across these same five lanes
+ *  and a second copy of them would be a second road. */
+export const LANE_X = [-1.6, -0.8, 0, 0.8, 1.6];
 /** THE ROW. A trigger the spotter is sure of is not a bubble in a lane, it is a line of them
  *  across the whole road, because the owner's read of the game is that a trigger word is a thing
  *  that HAPPENS to you: you do not get to steer around the word she just said.
@@ -137,6 +139,19 @@ export function cueFor(event, ctx = {}) {
     // a structure word (drop, deeper, breathe): a treat to drive through; a lifting word hangs in the air.
     // A lone number, a wake word before the way up, or a guess is nothing at all.
     case 'word': {
+      // A WORD BUBBLE off the transcript (race/wordBubbles.js): one word, one bubble, sitting in
+      // the lane its PHRASE was given, so the line of them spells the sentence down one lane and
+      // the player steers in the silence between two lines. `row: true` is not a row of five here,
+      // it is what buys the bubble its tracking: run.js hands a row to race/sync.js, which re-places
+      // it every frame off the speed the kart has NOW, so the kart meets the word when the voice
+      // says it whatever the throttle did. A row of one is still a row of one.
+      // It carries nothing on the chrome: six hundred words on the toast rail is exactly the noise
+      // the owner asked us to take off this road, and the word is read off the bubble's own tag.
+      if (typeof event.w === 'string' && event.w) {
+        const x = Number.isFinite(Number(event.x)) ? clamp(Number(event.x), -LANE_X_MAX, LANE_X_MAX) : 0;
+        cue.spawn.push({ kindId: 'treat', placement: 'lane', x, h: LANE_H, at: 0, row: true, w: event.w });
+        break;
+      }
       if (conf01(event) < WORD_SURE) return null;
       if (NUMBER_WORD.test(label)) return null;
       if (WAKE_WORDS.has(label) && !(ctx.act && WAKE_ACTS.has(ctx.act.kind))) return null;

--- a/ConditioningControlPanel/Resources/web/dtrh/race/smoke/lyrics-road-check.mjs
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/smoke/lyrics-road-check.mjs
@@ -142,7 +142,7 @@ eq(plain.analysis.words, 'none', 'a track with no transcript still gets the road
 eq(plain.binSec, BIN_SEC, 'at the quarter second bin it was tuned to');
 ok(!plain.events.some((e) => e.kind === 'trigger'), 'and it has no triggers on it, because nobody heard one');
 eq(normalizeChart(plain).words.length, 0, 'and no caption track');
-eq(GENERATOR_ID, 'web-road-v3', 'the cache key moved again, so a v2 road (laid on the aligner\'s seconds) can never be served');
+eq(GENERATOR_ID, 'web-road-v4', 'the cache key moved again, so a v3 road (a handful of loose treats where the new one carries the whole script) can never be served');
 
 console.log(fails ? '\nlyrics-road-check: ' + fails + ' failed' : '\nlyrics-road-check: all good');
 process.exit(fails ? 1 : 0);

--- a/ConditioningControlPanel/Resources/web/dtrh/race/smoke/rows-check.mjs
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/smoke/rows-check.mjs
@@ -17,6 +17,9 @@
  *   3. a trigger the spotter only half heard is the single treat it always was
  *   4. one event is one credit however many of its bubbles were popped
  *   5. a worded track halves the peak rain; nothing else on the road moves
+ *   7. and a WORD BUBBLE (a row of one, race/cues.js `case 'word'`) lands on its
+ *      own word the same way, driven off the real opening transcript through the
+ *      opening ramp and a boost: worst inside 0.15 s, median inside 0.08 s
  *   6. the row lands ON the word: driven through race/sync.js with a simulated
  *      kart whose speed changes inside the lookahead, the row is under the kart
  *      within 0.15 s of event.t, and the visible half of the cue fires on the
@@ -31,6 +34,13 @@ import { KART_X_MAX, LANE_X_MAX, POP_HIT_X, LANE_H, makeRng } from '../consts.js
 import { THEME_BY_PRESET, kindForPreset } from '../triggerTheme.js';
 import { KIND_BY_ID } from '../bubbleKinds.js';
 import { createCueSync, CUE_AHEAD_SEC, LATE_SEC } from '../sync.js';
+import { wordEventsFrom } from '../wordBubbles.js';
+import { triggerHits, triggersFromHits, captionWords, SET_BY_ID } from '../cloudChart.js';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
 
 let fails = 0;
 const ok = (cond, what) => { if (!cond) { console.error('FAIL ' + what); fails++; } else console.log('  ok  ' + what); };
@@ -189,6 +199,63 @@ ok(kept.trace.firedAt != null && kept.trace.firedAt - kept.trace.handedAt > 2, '
   eq(sync.dropped, 1, 'and counts it');
   const d0 = sync.depthFor(5, 100, 20, 5.1);
   eq(d0, 100 + 20 * CUE_AHEAD_SEC, 'a spawn never lands nearer than CUE_AHEAD_SEC of road');
+}
+
+/* ---- 7. a WORD BUBBLE lands on its own word too --------------------------- */
+// The row used to be the only thing race/sync.js tracked. A word bubble is a row of ONE (cues.js
+// `case 'word'` marks its single spawn `row: true` for exactly this reason), so the same
+// re-placement holds it on the second the voice says it, through the opening ramp and through a
+// boost. Driven off the REAL opening transcript rather than a made-up one, because the thing being
+// measured is whether the road holds three words a second, not whether the arithmetic closes.
+{
+  const file = JSON.parse(readFileSync(resolve(HERE, '../words/a15c22e0-d347-4d92-9f78-0fb37099e549.json'), 'utf8'));
+  const triggers = triggersFromHits([], triggerHits(file, file.durationSec), SET_BY_ID);
+  const events = wordEventsFrom(captionWords(file), triggers, { rng: makeRng(7) })
+    .sort((a, b) => a.t - b.t)
+    .map((e, i) => ({ ...e, id: 'w' + i }));
+  ok(events.length > 50, 'the opening transcript lays ' + events.length + ' word bubbles');
+
+  const wctx = { rng: makeRng(11), intensity: 0.5, act: { kind: 'induction', room: 'teagarden' },
+    room: { id: 'teagarden' }, triggerKinds: new Map(), lyrics: true };
+  /** The throttle a real lap has over this stretch: the opening ramp, a cruise, then a boost. */
+  const speedAt = (t) => (t < 84 ? 15 + Math.max(0, t - 78) * 1.2 : (t > 100 && t < 108) ? 30 : 22);
+
+  /** One 60 Hz run over the worded stretch. `track` off is what a loose spawn does. */
+  function driveWords(track) {
+    const sy = createCueSync();
+    const placed = new Map();        // rowId -> { d, at }
+    const err = [];
+    let t = events[0].t - LEAD - 1, d = 0, cursor = 0, seq = 0, laid = 0;
+    for (let i = 0; i < 200 * 60 && (cursor < events.length || placed.size); i++) {
+      const speed = speedAt(t);
+      while (cursor < events.length && events[cursor].t - LEAD <= t) {     // the scheduler's handover
+        const e = events[cursor++];
+        const cue = cueFor(e, wctx);
+        const sp = cue && cue.spawn[0];
+        if (!sp || !sp.row) continue;
+        const at = e.t + (sp.at || 0), dd = sy.depthFor(t, d, speed, at);
+        const rowId = ++seq;
+        placed.set(rowId, { d: dd, at });
+        if (track) sy.trackRow(rowId, e, at, dd, t);
+        laid++;
+      }
+      for (const m of sy.update(t, d, speed).move) { const r = placed.get(m.rowId); if (r) r.d = m.d; }
+      for (const [id, r] of placed) if (d >= r.d) { err.push(t - r.at); placed.delete(id); }
+      d += speed * DT; t += DT;
+    }
+    const abs = err.map((x) => Math.abs(x)).sort((a, b) => a - b);
+    return { laid, met: abs.length, median: abs.length ? abs[abs.length >> 1] : 99, worst: abs.length ? abs[abs.length - 1] : 99 };
+  }
+
+  const kept = driveWords(true);
+  ok(kept.laid > 50, 'and the run lays every one of them (' + kept.laid + ')');
+  eq(kept.met, kept.laid, 'the kart meets each of them exactly once');
+  ok(kept.worst <= ROW_TOL, `every word bubble is under the kart within ${ROW_TOL} s of its word (worst ${kept.worst.toFixed(3)}s)`);
+  ok(kept.median <= 0.08, `and the median is inside 0.08 s (${kept.median.toFixed(3)}s over ${kept.met} bubbles)`);
+  const loose = driveWords(false);
+  ok(loose.worst > kept.worst, `left where it was placed a bubble is ${loose.worst.toFixed(2)}s off its word at worst, which is what the tracking is for`);
+  console.log('  --  ' + kept.laid + ' word bubbles, median ' + kept.median.toFixed(3) + 's, worst '
+    + kept.worst.toFixed(3) + 's tracked, ' + loose.worst.toFixed(2) + 's loose');
 }
 
 console.log(fails ? '\nrows-check: ' + fails + ' failed' : '\nrows-check: all good');

--- a/ConditioningControlPanel/Resources/web/dtrh/race/smoke/words-rate-check.mjs
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/smoke/words-rate-check.mjs
@@ -1,0 +1,168 @@
+/* ============================================================================
+ * race/smoke/words-rate-check.mjs - the script on the road is drivable.
+ *
+ *   node race/smoke/words-rate-check.mjs   (from Resources/web/dtrh; 0 on pass, 1 with a count)
+ *
+ * Pure: no browser, no network, no audio. race/wordBubbles.js is the only place the
+ * lane rule is written down and race/cues.js holds the lanes themselves, so the two
+ * can be held against every transcript on the shelf without a renderer.
+ *
+ * What it holds, over ALL of race/words/:
+ *   1. the rule table is the rule table (the numbers the owner picked)
+ *   2. no five second window of any track asks for more than MAX_CHANGES lane
+ *      changes: a lane step is 0.12 s of steering plus its easing, and a road that
+ *      asks for more than one a second is a road nobody can read
+ *   3. two consecutive bubbles are never closer than MERGE_SEC, because at 22 m/s
+ *      the pop box is only poppable for 0.06 s and two bubbles that close are one
+ *      pop the player cannot take twice
+ *   4. no word bubble lands within HIT_GUARD_SEC of a trigger event: those seconds
+ *      belong to the row of five (race/cues.js `case 'trigger'`)
+ *   5. no phrase straddles a row, so a line is never cut in half by one
+ *   6. one word a bubble, two at the most, never three
+ *   7. every phrase sits in ONE lane, one of the five in cues.js LANE_X, and the
+ *      lane never steps more than LANE_STEP_MAX between phrases
+ *   8. the events the road is built from carry the word and the lane through
+ *      chart.js normalizeEvents, and cues.js lays a tracked bubble of one on them
+ *
+ * It never prints a line of a transcript. Everything below is counted.
+ * ==========================================================================*/
+
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { phrasesFrom, wordEventsFrom, rateOf, WORD_RULE, LANE_MID } from '../wordBubbles.js';
+import { triggerHits, triggersFromHits, captionWords, SET_BY_ID, TRIGGER_GAP } from '../cloudChart.js';
+import { cueFor, LANE_X } from '../cues.js';
+import { normalizeChart } from '../chart.js';
+import { LANE_X_MAX, LANE_H, makeRng } from '../consts.js';
+
+let fails = 0;
+const ok = (cond, what) => { if (!cond) { console.error('FAIL ' + what); fails++; } else console.log('  ok  ' + what); };
+const eq = (got, want, what) => ok(got === want, what + ' (got ' + JSON.stringify(got) + ', want ' + JSON.stringify(want) + ')');
+
+/** The most lane changes a five second window of road may ask a thumb for. */
+const MAX_CHANGES = 6;
+const WIN_SEC = 5;
+const HERE = dirname(fileURLToPath(import.meta.url));
+const WORDS = resolve(HERE, '../words');
+
+/* ---- 1. the rule is what the owner picked -------------------------------- */
+eq(WORD_RULE.MERGE_SEC, 0.12, 'two words closer than 0.12 s share one bubble');
+eq(WORD_RULE.PHRASE_GAP_SEC, 0.3, 'a silence over 0.3 s ends the phrase');
+eq(WORD_RULE.PHRASE_MAX_WORDS, 4, 'and so does a fourth bubble');
+eq(WORD_RULE.HIT_GUARD_SEC, 0.4, 'no word bubble within 0.4 s of a trigger');
+eq(WORD_RULE.LANE_STEP_MAX, 1, 'a phrase may step one lane, never two');
+eq(LANE_X.length, 5, 'and there are five lanes to step between');
+eq(LANE_MID, 2, 'a track opens in the middle one');
+
+/* ---- the shelf ----------------------------------------------------------- */
+const index = JSON.parse(readFileSync(resolve(WORDS, 'index.json'), 'utf8'));
+const rows = Array.isArray(index.rows) ? index.rows : [];
+ok(rows.length === 11, 'the shelf has all eleven transcripts on it (' + rows.length + ')');
+
+const table = [];
+let worstChangeWindow = 0, worstChangeTrack = '', tightest = Infinity, guardBreaks = 0, straddles = 0,
+  laneJumps = 0, offLane = 0, tripled = 0, collisions = 0;
+
+for (const row of rows) {
+  const file = JSON.parse(readFileSync(resolve(WORDS, row.file), 'utf8'));
+  const durationSec = Number(file.durationSec) || 0;
+  // the trigger events the road will actually carry: the fingerprinted hits, thinned against each
+  // other by TRIGGER_GAP exactly the way cloudChart.js lays them (no events, so only the triggers
+  // come back). Those are the seconds the rows own.
+  const triggers = triggersFromHits([], triggerHits(file, durationSec), SET_BY_ID);
+  const caps = captionWords(file);
+  const phrases = phrasesFrom(caps, triggers, { rng: makeRng(7) });
+  const m = rateOf(phrases, WIN_SEC);
+  collisions += phrases.collided || 0;
+
+  if (m.worstChanges > worstChangeWindow) { worstChangeWindow = m.worstChanges; worstChangeTrack = row.title; }
+  tightest = Math.min(tightest, m.minGap);
+
+  // 4 + 5: the row owns its seconds, and no line is cut in half by one
+  for (const p of phrases) {
+    if (p.lane < 0 || p.lane >= LANE_X.length || p.x !== LANE_X[p.lane]) offLane++;
+    for (const b of p.words) {
+      if (b.w.trim().split(/\s+/).length > 2) tripled++;
+      for (const h of triggers) {
+        const t1 = h.t + Math.max(0, Number(h.dur) || 0);
+        if (b.t > h.t - WORD_RULE.HIT_GUARD_SEC && b.t < t1 + WORD_RULE.HIT_GUARD_SEC) guardBreaks++;
+      }
+    }
+    for (const h of triggers) if (p.t < h.t && p.words[p.words.length - 1].t > h.t) straddles++;
+  }
+  // 7: one step at a time
+  for (let i = 1; i < phrases.length; i++) {
+    if (Math.abs(phrases[i].lane - phrases[i - 1].lane) > WORD_RULE.LANE_STEP_MAX) laneJumps++;
+  }
+  table.push({ title: String(row.title || row.cloudId).slice(0, 24), durationSec, triggers: triggers.length,
+    bubbles: m.bubbles, phrases: m.phrases, perPhrase: m.perPhrase, minGap: m.minGap,
+    changes: m.changes, worstBubbles: m.worstBubbles, worstChanges: m.worstChanges, worstAt: m.worstAt });
+}
+
+console.log('\n  track                    |  dur | trig | bubbles | phrases | w/phr | min gap | lane chg | worst 5 s');
+console.log('  -------------------------+------+------+---------+---------+-------+---------+----------+-----------');
+for (const r of table) {
+  console.log('  ' + r.title.padEnd(24) + ' | ' + String(Math.round(r.durationSec)).padStart(4)
+    + ' | ' + String(r.triggers).padStart(4) + ' | ' + String(r.bubbles).padStart(7)
+    + ' | ' + String(r.phrases).padStart(7) + ' | ' + r.perPhrase.toFixed(2).padStart(5)
+    + ' | ' + r.minGap.toFixed(3).padStart(7) + ' | ' + String(r.changes).padStart(8)
+    + ' | ' + String(r.worstBubbles).padStart(2) + ' bub, ' + r.worstChanges + ' chg @ ' + Math.round(r.worstAt) + 's');
+}
+console.log('');
+
+ok(worstChangeWindow <= MAX_CHANGES, `no five second window on the shelf asks for more than ${MAX_CHANGES} lane changes (worst ${worstChangeWindow}, on ${worstChangeTrack})`);
+ok(tightest >= WORD_RULE.MERGE_SEC - 1e-9, `two bubbles are never closer than ${WORD_RULE.MERGE_SEC} s (tightest ${tightest.toFixed(3)} s)`);
+eq(guardBreaks, 0, 'not one word bubble lands inside a trigger row\'s seconds');
+eq(straddles, 0, 'and not one phrase straddles a row');
+eq(tripled, 0, 'no bubble carries three words');
+eq(offLane, 0, 'every phrase sits in one of the five lanes');
+eq(laneJumps, 0, 'and no phrase steps more than one lane from the last');
+console.log('  --  ' + collisions + ' transcript collisions dropped across the shelf (three or more words on one second)');
+
+/* ---- 8. the events survive the chart and cues.js lays them ---------------- */
+const sample = JSON.parse(readFileSync(resolve(WORDS, rows[0].file), 'utf8'));
+const sampleTriggers = triggersFromHits([], triggerHits(sample, sample.durationSec), SET_BY_ID);
+const events = wordEventsFrom(captionWords(sample), sampleTriggers, { rng: makeRng(7) });
+ok(events.length > 50, 'the opening track turns into ' + events.length + ' word events');
+ok(events.every((e) => e.kind === 'word' && typeof e.w === 'string' && e.w && Number.isFinite(e.x)), 'each one carries its word and its lane');
+const chart = normalizeChart({
+  version: 1, binSec: 0.5, energy: [0.4, 0.4],
+  acts: [{ kind: 'triggers', room: 'toybox', t0: 0, t1: sample.durationSec, name: 'triggers' }],
+  events: events.concat(sampleTriggers),
+  source: { name: 'rate', hash: 'rate', durationSec: sample.durationSec, sampleRate: 16000 },
+  analysis: { energy: 'x', words: 'script-align-v1', lexicon: [], generatedAt: '', partial: false },
+});
+const kept = chart.events.filter((e) => e.kind === 'word');
+eq(kept.length, events.length, 'chart.js keeps every word event');
+ok(kept.every((e) => typeof e.w === 'string' && e.w), 'and the word on each of them');
+ok(kept.every((e) => Number.isFinite(e.x) && Math.abs(e.x) <= LANE_X_MAX), 'and the lane, inside the drivable width');
+const lanes = new Set(kept.map((e) => e.x));
+ok([...lanes].every((x) => LANE_X.includes(x)), 'and it is one of the five lanes, not a rounded one');
+
+const ctx = { rng: makeRng(3), intensity: 0.5, act: { kind: 'triggers', room: 'toybox' }, room: { id: 'toybox' }, triggerKinds: new Map(), lyrics: true };
+let spawned = 0, tracked = 0, chromed = 0, wrongLane = 0;
+for (const e of kept) {
+  const cue = cueFor(e, ctx);
+  if (!cue) continue;
+  spawned++;
+  if (cue.spawn.length !== 1) { wrongLane++; continue; }
+  const sp = cue.spawn[0];
+  if (sp.row) tracked++;
+  if (sp.x !== e.x || sp.h !== LANE_H || sp.at !== 0 || sp.kindId !== 'treat' || sp.w !== e.w) wrongLane++;
+  if (cue.word) chromed++;
+}
+eq(spawned, kept.length, 'cues.js has a bubble for every word event, and throws none of them out');
+eq(tracked, kept.length, 'every one of them is tracked onto its own second (a row of one)');
+eq(wrongLane, 0, 'every one is a plain treat, at lane height, on the word, in its phrase\'s lane, wearing its word');
+eq(chromed, 0, 'and not one of them goes on the toast rail: the word is read off the bubble');
+
+// the OLD word event, the structure-word treat generate.js lays on a road with no transcript, is
+// untouched: it has no `w`, so it falls through to the branch it always had.
+const plain = cueFor({ id: 'p', kind: 'word', t: 5, label: 'deeper', conf: 1 }, ctx);
+ok(plain && plain.spawn.length === 1 && !plain.spawn[0].row && !plain.spawn[0].w, 'a structure word with no transcript behind it is the loose treat it always was');
+ok(cueFor({ id: 'q', kind: 'word', t: 5, label: 'deeper', conf: 0.2 }, ctx) === null, 'and an unsure one is still nothing at all');
+ok(TRIGGER_GAP > 0, 'the trigger thinning is still the one cloudChart.js owns (' + TRIGGER_GAP + ' s)');
+
+console.log(fails ? '\nwords-rate-check: ' + fails + ' failed' : '\nwords-rate-check: all good');
+process.exit(fails ? 1 : 0);

--- a/ConditioningControlPanel/Resources/web/dtrh/race/wordBubbles.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/wordBubbles.js
@@ -1,0 +1,222 @@
+/* ============================================================================
+ * race/wordBubbles.js - THE SCRIPT WRITTEN ON THE ROAD.
+ *
+ *   phrasesFrom(words, hits, opts) -> [{ t, t1, lane, x, words: [{ t, d, w }] }]
+ *
+ * One word, one bubble. The owner's picture, and the only picture: a bubble does
+ * not carry a sentence, it carries a word, and the sentence is what a LINE of them
+ * spells out down one lane of the road.
+ *
+ * THE LANE RULE, which is the whole of this file. Words abut: eleven of every
+ * fifteen gaps in these transcripts are under half a second, and a lane change is
+ * 0.12 s of steering plus the easing either side of it. So a line of word bubbles
+ * scattered one lane per word would be a road nobody can read and nobody can pop.
+ * Instead the words are grouped into PHRASES - a run of speech with no gap in it
+ * longer than PHRASE_GAP_SEC, cut on punctuation and at PHRASE_MAX_WORDS - and
+ * every bubble of one phrase sits in ONE lane, in a line, on its own second. The
+ * lane may only step BETWEEN phrases, one lane at a time, and only when the
+ * silence between them is long enough to steer through. The player reads the line,
+ * drives the line, and steers in the gap where the voice stopped.
+ *
+ * A phrase of five words or more is cut at four and simply CONTINUES the line: the
+ * gap inside a sentence is far under the steering gap, so the next four words
+ * inherit the lane they were already in. The cut is there so a tag never has to
+ * hold a whole sentence, not to move the road.
+ *
+ * WHAT THE ROW OWNS. A fingerprinted trigger keeps its row of five across the whole
+ * road (race/cues.js `case 'trigger'`). A word bubble never lands on top of one, so
+ * every word inside HIT_GUARD_SEC of a trigger event is left to the row, and the
+ * phrase is cut there rather than straddling it.
+ *
+ * THE MERGE. Two words closer together than MERGE_SEC share one bubble, because at
+ * 22 m/s the pop box is only poppable for 0.06 s and two bubbles that close are one
+ * bubble the player can only take once. Never three: a third word that close is a
+ * transcript collision (one file has eight words sharing a single second) and is
+ * dropped, which is also what keeps the spacing between bubbles at MERGE_SEC or more.
+ *
+ * SPEED DOES NOT LIVE HERE. Every number below is in SECONDS of the file. The kart's
+ * speed decides how far apart the bubbles are laid on the road, never how many there
+ * are: run.js places each one at the depth the kart will have reached by its word
+ * (race/sync.js depthFor) and keeps it there. A faster lap is a longer road, not a
+ * busier one.
+ *
+ * Pure: no three, no DOM, no clock, no fetch. `node race/smoke/words-rate-check.mjs`
+ * runs it over all eleven transcripts.
+ * ==========================================================================*/
+
+import { LANE_X } from './cues.js';
+
+/**
+ * The rule, in one table. Every one of these is in seconds of the file except the
+ * two counts. Change one and re-run race/smoke/words-rate-check.mjs: it holds the
+ * whole shelf of transcripts against them.
+ */
+export const WORD_RULE = Object.freeze({
+  /** Two words closer than this share one bubble. A third that close is dropped. */
+  MERGE_SEC: 0.12,
+  /** Silence longer than this between two words ends the phrase. */
+  PHRASE_GAP_SEC: 0.3,
+  /** And so does a fourth bubble, so a tag never has to hold a sentence. */
+  PHRASE_MAX_WORDS: 4,
+  /** No word bubble this near a trigger event: those words belong to the row. */
+  HIT_GUARD_SEC: 0.4,
+  /** The silence a line needs before the next one may sit in another lane. */
+  LANE_MOVE_SEC: 0.3,
+  /** And how many lanes it may move when it does. One. */
+  LANE_STEP_MAX: 1,
+});
+
+/** A word that ends a clause ends the phrase, whatever the timing says. */
+export const CUT_PUNCT = /[,.;:!?…]["')\]]?$/;
+
+const num = (v, d) => (typeof v === 'number' && isFinite(v) ? v : d);
+/** The centre lane, where every track's first line starts. */
+export const LANE_MID = LANE_X.length >> 1;
+
+/** Only what a bubble can be made of: a word with a second, sorted, nothing else. */
+function readWords(raw) {
+  return (Array.isArray(raw) ? raw : [])
+    .filter((w) => w && typeof w === 'object' && typeof w.w === 'string' && w.w && isFinite(num(w.t, NaN)))
+    .map((w) => ({ t: num(w.t, 0), d: Math.max(0, num(w.d, 0)), w: w.w }))
+    .sort((a, b) => a.t - b.t);
+}
+
+/**
+ * The seconds a trigger row owns: its own second, its length, and HIT_GUARD_SEC of
+ * quiet either side. `hits` may be the chart's trigger EVENTS or the raw hits off
+ * the words file; both carry `t` and both may carry `dur`.
+ */
+export function guardWindows(hits, guardSec = WORD_RULE.HIT_GUARD_SEC) {
+  const g = Math.max(0, num(guardSec, WORD_RULE.HIT_GUARD_SEC));
+  return (Array.isArray(hits) ? hits : [])
+    .filter((h) => h && isFinite(num(h.t, NaN)))
+    .map((h) => ({ t0: num(h.t, 0) - g, t1: num(h.t, 0) + Math.max(0, num(h.dur, 0)) + g }))
+    .sort((a, b) => a.t0 - b.t0);
+}
+
+/** Is this second inside a row's window? The list is sorted, so a walking cursor does it. */
+function inGuard(windows, i, t) {
+  let k = i;
+  while (k < windows.length && windows[k].t1 < t) k++;
+  return { i: k, hit: k < windows.length && t >= windows[k].t0 };
+}
+
+/**
+ * The road's script.
+ *
+ * @param words  the caption track: [{ t, d, w }], the shape `chart.words` is in
+ *               (race/cloudChart.js captionWords, already cut at CAPTION_CONF)
+ * @param hits   the trigger events (or the words file's own hits): [{ t, dur }]
+ * @param opts   { rng, rule } - rng seeds the lane walk, rule overrides WORD_RULE
+ * @returns phrases, in order: `{ t, t1, lane, x, words }` where `words` are the
+ *          BUBBLES of the line (one word each, two when they merged), `lane` is an
+ *          index into cues.js LANE_X and `x` is that lane in metres.
+ */
+export function phrasesFrom(words, hits = [], opts = {}) {
+  const R = { ...WORD_RULE, ...(opts.rule || {}) };
+  const rng = typeof opts.rng === 'function' ? opts.rng : Math.random;
+  const list = readWords(words);
+  const windows = guardWindows(hits, R.HIT_GUARD_SEC);
+
+  // ---- 1. the bubbles: guarded words dropped, close words merged ------------
+  // `cut` on a bubble means "the phrase ends here": a row took the words that
+  // followed, or the word itself closed a clause.
+  const bubbles = [];
+  let gi = 0, guarded = false, collided = 0;
+  for (const w of list) {
+    const g = inGuard(windows, gi, w.t);
+    gi = g.i;
+    if (g.hit) { guarded = true; continue; }        // the row says this word; the phrase stops here
+    const last = bubbles[bubbles.length - 1];
+    if (last && !last.cut && !guarded && w.t - last.t < R.MERGE_SEC) {
+      if (last.n >= 2) { collided++; continue; }    // three words on one second: a transcript collision
+      last.w += ' ' + w.w;
+      last.n = 2;
+      last.d = Math.max(last.d, w.t + w.d - last.t);
+      last.cut = CUT_PUNCT.test(w.w);
+      continue;
+    }
+    bubbles.push({ t: w.t, d: w.d, w: w.w, n: 1, cut: CUT_PUNCT.test(w.w), guarded });
+    guarded = false;
+  }
+
+  // ---- 2. the phrases: a run of speech with no steerable gap in it ----------
+  const phrases = [];
+  let cur = null;
+  for (const b of bubbles) {
+    const gap = cur ? b.t - (cur.t1) : Infinity;
+    const full = cur && cur.words.length >= R.PHRASE_MAX_WORDS;
+    if (!cur || b.guarded || gap > R.PHRASE_GAP_SEC || cur.closed || full) {
+      cur = { t: b.t, t1: b.t + b.d, gap: cur ? gap : Infinity, closed: false, words: [] };
+      phrases.push(cur);
+    }
+    cur.words.push({ t: b.t, d: b.d, w: b.w });
+    cur.t1 = Math.max(cur.t1, b.t + b.d);
+    cur.closed = b.cut;
+  }
+
+  // ---- 3. the lane walk: one step per phrase, and only through a real gap ---
+  // Start in the middle. A phrase that follows another too closely to steer through
+  // keeps the lane it is in (this is the "a phrase of five words continues the
+  // line" case, and every four-word cut inside a sentence). A phrase with room in
+  // front of it ALWAYS moves, because a line that could have moved and did not
+  // reads as one long line rather than as a new thing being said.
+  const step = Math.max(1, Math.round(num(R.LANE_STEP_MAX, 1)));
+  const top = LANE_X.length - 1;
+  let lane = LANE_MID;
+  for (const p of phrases) {
+    if (p.gap >= R.LANE_MOVE_SEC) {
+      const dir = lane <= 0 ? 1 : lane >= top ? -1 : (rng() < 0.5 ? -1 : 1);
+      lane = Math.max(0, Math.min(top, lane + dir * step));
+    }
+    p.lane = lane;
+    p.x = LANE_X[lane];
+    delete p.closed;
+  }
+  phrases.collided = collided;
+  return phrases;
+}
+
+/**
+ * The phrases flattened back into the chart events run.js spends: one `word` event
+ * per bubble, carrying the text it wears and the lane its phrase put it in.
+ * race/chart.js normalizeEvents keeps both fields; race/cues.js `case 'word'` reads
+ * them and lays a tracked bubble of one on that second.
+ */
+export function wordEventsFrom(words, hits = [], opts = {}) {
+  const out = [];
+  for (const p of phrasesFrom(words, hits, opts)) {
+    for (const b of p.words) out.push({ kind: 'word', t: b.t, dur: b.d, label: '', conf: 1, weight: 1, w: b.w, x: p.x });
+  }
+  return out;
+}
+
+/**
+ * What the smoke counts: bubbles, phrases, the worst five second window, the
+ * tightest spacing, the lane changes. Pure arithmetic over the phrases above, kept
+ * here so the rule and its own measure never drift apart.
+ */
+export function rateOf(phrases, winSec = 5) {
+  const flat = [];
+  for (const p of phrases) for (const b of p.words) flat.push({ t: b.t, lane: p.lane });
+  let minGap = Infinity, changes = 0, worstBubbles = 0, worstChanges = 0, worstAt = 0;
+  for (let i = 1; i < flat.length; i++) minGap = Math.min(minGap, flat[i].t - flat[i - 1].t);
+  const changeT = [];
+  for (let i = 1; i < phrases.length; i++) {
+    if (phrases[i].lane !== phrases[i - 1].lane) { changes++; changeT.push(phrases[i].t); }
+  }
+  for (let i = 0, j = 0; i < flat.length; i++) {          // bubbles in any winSec window
+    while (flat[j].t < flat[i].t - winSec) j++;
+    if (i - j + 1 > worstBubbles) worstBubbles = i - j + 1;
+  }
+  for (let i = 0, j = 0; i < changeT.length; i++) {       // lane changes in any winSec window
+    while (changeT[j] < changeT[i] - winSec) j++;
+    if (i - j + 1 > worstChanges) { worstChanges = i - j + 1; worstAt = changeT[i]; }
+  }
+  return { bubbles: flat.length, phrases: phrases.length, minGap, changes, worstBubbles, worstChanges, worstAt,
+    perPhrase: phrases.length ? flat.length / phrases.length : 0 };
+}
+
+export default phrasesFrom;
+
+// self-check: node race/smoke/words-rate-check.mjs holds all eleven transcripts against WORD_RULE.


### PR DESCRIPTION
## the script written on the road, W1: one word a bubble, in a line down a lane

The bubbles on a worded road had nothing to do with the voice. This lays the whole
transcript on the road instead: **one word, one bubble**, and the sentence is what a
LINE of them spells out down one lane.

### the rule (`race/wordBubbles.js`, pure, node-testable)

Everything is in seconds of the file. Nothing here knows the kart's speed: speed
decides how far apart the bubbles are laid, never how many there are, so a faster lap
is a longer road and not a busier one.

| knob | value | why |
|---|---|---|
| `MERGE_SEC` | 0.12 s | two words closer than this share one bubble; at 22 m/s the pop box is poppable for 0.06 s, so two bubbles that close are one pop the player cannot take twice. Never three: a third that close is a transcript collision and is dropped, which is also what floors the spacing. |
| `PHRASE_GAP_SEC` | 0.3 s | a silence longer than this ends the phrase |
| `PHRASE_MAX_WORDS` | 4 | and so does a fourth bubble, or a comma or a full stop |
| `HIT_GUARD_SEC` | 0.4 s | no word bubble within this of a trigger event: those seconds belong to the row of five |
| `LANE_STEP_MAX` | 1 | a phrase steps one lane, never two |
| `LANE_MOVE_SEC` | 0.3 s | and only through a silence long enough to steer in |

**THE LANE RULE.** All the bubbles of one phrase sit in ONE lane, in a line, each on
its own second. The lane may only step between phrases, one lane at a time, and only
when there is a gap in front of the line to steer through. So a sentence cut at four
words simply CONTINUES the line it was already in, and the player steers where the
voice stopped. The walk starts in the centre lane and is seeded off the run rng.

**THE ROW STILL OWNS ITS SECONDS.** A fingerprinted trigger keeps its row of five
(`cues.js case 'trigger'`, unchanged). Word bubbles never land on one, and a phrase is
cut at a row rather than straddling it.

### the sync bet

A word bubble is a **row of one**: its single spawn is marked `row: true`, which is what
buys it `race/sync.js`'s per-frame re-placement off the speed the kart has NOW. Without
that, the opening ramp and a boost alone put a bubble most of a second off its word.

Driven off the real opening transcript through the opening ramp and a boost
(`rows-check` section 7):

```
107 word bubbles, median 0.010s, worst 0.050s tracked, 0.64s loose
```

### the rest

- `cloudChart.js` drops the handful of loose structure-word treats `generate.js` used to
  lay (the transcript has every word now) and builds the word events where it builds the
  trigger events, so a desktop local track with a words file gets them too. Cache key
  moves to `web-road-v4`.
- `chart.js normalizeEvents` keeps `w` and `x` on a `word` event, for the same reason it
  keeps `cue`: it validates a chart, it does not rewrite one.
- `cues.js` exports `LANE_X` (the pitch said it lived in `consts.js`; it does not) and
  gains a word-bubble branch. A structure word with no transcript behind it is the loose
  treat it always was, and a wordless road does not move by a line.
- A word bubble puts **nothing** on the toast rail. Six hundred words on the chrome is
  exactly the noise this lane is meant to take off the road; the word is read off the
  bubble's own tag, which is W2.

### what is NOT here

The "random dressing only in wordless gaps over 4 s" rule. `seedChunk` is driven by
DEPTH (chunk boundaries on a looping road) and the words are driven by the track CLOCK,
and the run holds no mapping between the two, so the gate cannot be written where the
brief assumed it could. On a worded track `setSparse` already reduces the dressing to one
golden per chunk and `spawnAhead`/rain already stand down, so what is left is small. Left
for W3 with a real design.

### smokes

- **new** `race/smoke/words-rate-check.mjs`: all eleven transcripts against the rule.
  No five second window asks for more than 6 lane changes (worst on the shelf is **4**),
  spacing never under 0.12 s, nothing inside a row's seconds, no phrase straddles one,
  no bubble carries three words, every phrase in one of the five lanes, no two-lane step.
- **extended** `race/smoke/rows-check.mjs` section 7: the sync numbers above.
- `lyrics-road-check.mjs` follows the cache key to v4.

Green on this head: chart, cloud-chart, cloud, fov, levels, lyrics-road, words, track-run,
captions, pickups, audio, spiral-pool, ost-resident, remote-feed, sync, pace, wall-dom,
touch, gltf, poses, and the new rate check. `real-audio-check` not run (it fetches a
third-party file and needs `RACE_REAL_URL`).

507 changed lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJ66hi5fRM1Dcjo38aSCa2
