### PR TITLE
feat(race): the word on a tag over the bubble, with a floor you can read on a phone

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/race/bubbles.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/bubbles.js
@@ -96,7 +96,8 @@ export function createBubbleField({ scene, layout, media, getIntensity, getRoom,
     sprite.visible = false; sprite.layers.set(CRISP_LAYER);
     group.add(sprite);
     pool.push({ sprite, mat, slot: i, eventId: null, rowId: 0, alive: false, kindId: 'treat', placement: 'lane', d: 0, x: 0, h: LANE_H,
-      x0: 0, baseH: LANE_H, phase: 0, age: 0, size: 1, scale: 1, popT: -1, missed: false });
+      x0: 0, baseH: LANE_H, phase: 0, age: 0, size: 1, scale: 1, popT: -1, missed: false,
+      w: '', ink: null, big: false, rowN: 0 });   // the word this bubble wears, for race/wordTags.js
   }
   const shards = [];
   for (let i = 0; i < SHARD_CAP; i++) {
@@ -159,6 +160,7 @@ export function createBubbleField({ scene, layout, media, getIntensity, getRoom,
     s.d = layout.wrap(d); s.x = clamp(x, -LANE_X_MAX, LANE_X_MAX); s.x0 = s.x;
     s.h = h; s.baseH = h; s.phase = Math.random() * Math.PI * 2; s.age = 0;
     s.size = sizeOf(k.id); s.scale = placement === 'spawn' ? 0 : 1; s.popT = -1; s.missed = false; s.eventId = null; s.rowId = 0;
+    s.w = ''; s.ink = null; s.big = false; s.rowN = 0;
     s.mat.map = texOf[k.id]; s.mat.color.set(k.tint); s.mat.opacity = 1; s.mat.needsUpdate = true;
     s.sprite.scale.setScalar(s.size * s.scale);
     layout.toWorld(s.d, s.x, s.h, s.sprite.position);
@@ -230,7 +232,7 @@ export function createBubbleField({ scene, layout, media, getIntensity, getRoom,
    *  the pool is full (a cue never steals a live bubble), when the kind is dark (bubbleKinds.js
    *  spawn:false), or when density has gated this one out.
    *  Over 1, density is the chance of a second bubble beside the first. */
-  function spawnAt({ kindId, placement = 'lane', d, x = 0, h, eventId = null } = {}) {
+  function spawnAt({ kindId, placement = 'lane', d, x = 0, h, eventId = null, w = '', ink = null, big = false } = {}) {
     if (liveCount >= CAP) return -1;
     if (KIND_BY_ID[kindId] && KIND_BY_ID[kindId].spawn === false) return -1;   // a dark kind: no chart may place one
     if (tracked) {
@@ -240,6 +242,7 @@ export function createBubbleField({ scene, layout, media, getIntensity, getRoom,
     const top = h == null ? (placement === 'rain' ? CEILING_H : placement === 'air' ? 2.6 : LANE_H) : h;
     const s = place(kindId, placement, d, x, top);
     s.eventId = eventId;
+    if (w) { s.w = String(w); s.ink = ink || null; s.big = !!big; }
     if (tracked && density > 1 && liveCount < CAP && Math.random() < density - 1) {
       place(kindId, placement, d + 2.4, x + (x > 0 ? -1.1 : 1.1), top).eventId = eventId;
     }
@@ -251,7 +254,7 @@ export function createBubbleField({ scene, layout, media, getIntensity, getRoom,
    *  rolled ONCE for the whole line rather than per bubble, and density over 1 never doubles it,
    *  because a doubled row is just a thicker wall and the wall was already unavoidable.
    *  Returns how many went down, 0 for a row that was gated out. */
-  function spawnRow({ kindId, kindIds = null, placement = 'lane', d, h, xs, eventId = null } = {}) {
+  function spawnRow({ kindId, kindIds = null, placement = 'lane', d, h, xs, eventId = null, w = '', ink = null, big = false } = {}) {
     const list = Array.isArray(xs) ? xs.filter((x) => Number.isFinite(Number(x))) : [];
     if (!list.length) return 0;
     if (KIND_BY_ID[kindId] && KIND_BY_ID[kindId].spawn === false) return 0;   // a dark kind: no chart may place one
@@ -263,7 +266,14 @@ export function createBubbleField({ scene, layout, media, getIntensity, getRoom,
     const top = h == null ? (placement === 'rain' ? CEILING_H : placement === 'air' ? 2.6 : LANE_H) : h;
     const id = ++rowSeq;
     // kindIds: one kind per x for a row that is not all one thing (the rabbit foot's golden centre)
-    list.forEach((x, i) => { const s = place((kindIds && kindIds[i]) || kindId, placement, d, Number(x), top); s.eventId = eventId; s.rowId = id; });
+    // the word goes on the CENTRE bubble alone: five copies of it is a wall of text where a wall
+    // of bubbles was the point. A row of one (a word bubble, cues.js `case 'word'`) is its own centre.
+    const mid = list.length >> 1;
+    list.forEach((x, i) => {
+      const s = place((kindIds && kindIds[i]) || kindId, placement, d, Number(x), top);
+      s.eventId = eventId; s.rowId = id;
+      if (w && i === mid) { s.w = String(w); s.ink = ink || null; s.big = !!big; s.rowN = list.length; }
+    });
     return id;   // the row's id: run.js hands it to race/sync.js, which moveRow()s it onto its word
   }
   /** A row goes to depth `d`: the kart's speed changed inside the lookahead, so the word will be said
@@ -284,6 +294,13 @@ export function createBubbleField({ scene, layout, media, getIntensity, getRoom,
   }
 
   // ---- pop -----------------------------------------------------------------
+  // ---- the word tags' scan (race/wordTags.js) -------------------------------
+  // A bubble wearing a word hands its world position out once a frame. The entries are reused and
+  // refilled in update(), sorted nearest-camera first: nothing here allocates or searches.
+  const TAG_SCAN = 24, TAG_AHEAD_M = 34;
+  const tagScratch = [], tagOut = [];
+  for (let i = 0; i < TAG_SCAN; i++) tagScratch.push({ key: '', w: '', ink: null, big: false, rowN: 0, pos: new THREE.Vector3(), alpha: 1, ahead: 0 });
+
   const _r = new THREE.Vector3(), _u = new THREE.Vector3();
   // burst frames come from a fixed ring (no per-pop allocation): one right/up pair per burst,
   // shared by its shards; 16 pairs outlive any shard (life <= 0.6 s, 64 shards, 7..12 per burst)
@@ -333,6 +350,7 @@ export function createBubbleField({ scene, layout, media, getIntensity, getRoom,
   // ---- per frame -----------------------------------------------------------
   function update(dt, t, kart) {
     lastKartD = kart.d;
+    tagOut.length = 0;
     for (const s of pool) {
       if (!s.alive) continue;
       s.age += dt;
@@ -374,6 +392,11 @@ export function createBubbleField({ scene, layout, media, getIntensity, getRoom,
         if (Math.abs(rel) < POP_HIT_D && (sweep || (Math.abs(s.x - kart.x) < (wide ? reachX : POP_HIT_X) && Math.abs(s.h - kart.h) < (wide ? reachH : POP_HIT_H)))) pop(s);
       }
       s.sprite.visible = rel > -DROP_BEHIND && rel < VIEW_AHEAD;
+      if (s.sprite.visible && s.w && s.popT < 0 && rel < TAG_AHEAD_M && tagOut.length < TAG_SCAN) {
+        const e = tagScratch[tagOut.length];
+        e.key = 'b' + s.slot; e.w = s.w; e.ink = s.ink; e.big = s.big; e.rowN = s.rowN; e.ahead = rel;
+        tagOut.push(e);   // pos + alpha are filled below, once this frame has moved the sprite
+      }
       if (s.sprite.visible) {
         layout.toWorld(s.d, s.x, s.h, s.sprite.position);
         // a bubble that slipped past the pop box fades and shrinks before it can balloon into the
@@ -381,6 +404,8 @@ export function createBubbleField({ scene, layout, media, getIntensity, getRoom,
         const gone = s.popT < 0 && rel < -POP_HIT_D ? clamp(1 + (rel + POP_HIT_D) / PASS_FADE_M, 0, 1) : 1;
         if (gone < 1) s.mat.opacity = Math.min(s.mat.opacity, gone);
         s.sprite.scale.setScalar(s.size * s.scale * (0.6 + 0.4 * gone));
+        const e = tagOut.length && tagOut[tagOut.length - 1];
+        if (e && e.key === 'b' + s.slot) { e.pos.copy(s.sprite.position); e.alpha = s.mat.opacity; }
       }
     }
     for (const sh of shards) {
@@ -427,6 +452,8 @@ export function createBubbleField({ scene, layout, media, getIntensity, getRoom,
     setSweep(on) { sweep = !!on; },
     /** riptide: while on, everything inside PULL_M ahead slides into the kart's lane. */
     setPull(on) { pull = !!on; },
+    /** The bubbles wearing a word this frame, nearest the camera first (race/wordTags.js). */
+    wordTagList() { tagOut.sort((a, b) => a.ahead - b.ahead); return tagOut; },
     get liveCount() { return liveCount; },
   };
 }

--- a/ConditioningControlPanel/Resources/web/dtrh/race/cloudChart.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/cloudChart.js
@@ -47,6 +47,7 @@ import { loadWords } from './words.js';
 import { TRIGGER_SETS } from '../chart/editor/triggerSets.js';
 import { detect } from '../chart/maker/triggers.js';
 import { wordEventsFrom } from './wordBubbles.js';
+import { themeFor } from './triggerTheme.js';
 
 /**
  * THE GENERATOR ID. It is the cache key's second half: change any knob below and
@@ -343,7 +344,7 @@ export function wordedRoad({ peaks, perSec = PEAKS_PER_SEC, durationSec, name = 
   // race/wordBubbles.js lays the whole script instead - one word a bubble, a phrase a lane, and
   // never within HIT_GUARD_SEC of a trigger, because those seconds belong to the row.
   const events = road.filter((e) => e.kind !== 'word')
-    .concat(wordEventsFrom(caps, triggers))
+    .concat(inkWords(wordEventsFrom(caps, triggers), triggers))
     .sort((a, b) => a.t - b.t)
     .map((e, i) => ({ ...e, id: 'g' + i }));
   const lexicon = [...new Set(events.filter((e) => e.kind === 'trigger').map((e) => e.label))].sort();
@@ -353,6 +354,27 @@ export function wordedRoad({ peaks, perSec = PEAKS_PER_SEC, durationSec, name = 
     source: { name, hash, durationSec, sampleRate: DECODE_RATE },
     analysis: { energy: 'web-rms-v1', words: 'script-align-v1', lexicon, generatedAt: g.generatedAt, partial: false },
   };
+}
+
+/** How near a trigger a word has to be to be part of what that trigger is doing. */
+export const WORD_INK_SEC = 6;
+/**
+ * The colour a word bubble's tag is written in (race/cues.js reads it back through
+ * race/triggerTheme.js). A word inside WORD_INK_SEC of a trigger belongs to that set and wears its
+ * theme; everything else stays pink. The field is `cue`, which race/chart.js already carries for
+ * every kind, so it survives the round trip without a new one. Both lists are in time order.
+ */
+export function inkWords(words, triggers) {
+  const list = Array.isArray(triggers) ? triggers : [];
+  if (!list.length) return words;
+  let j = 0;
+  for (const e of words) {
+    while (j + 1 < list.length && Math.abs(list[j + 1].t - e.t) <= Math.abs(list[j].t - e.t)) j++;
+    if (Math.abs(list[j].t - e.t) > WORD_INK_SEC) continue;
+    const row = themeFor(list[j]);
+    if (row && row.preset) e.cue = row.preset;
+  }
+  return words;
 }
 
 /* ---- the decode ---------------------------------------------------------- */

--- a/ConditioningControlPanel/Resources/web/dtrh/race/cues.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/cues.js
@@ -32,6 +32,28 @@
  * ==========================================================================*/
 
 import { LANE_H, CEILING_H, LANE_X_MAX, POP_HIT_X } from './consts.js';
+import { themeFor } from './triggerTheme.js';
+
+/**
+ * The words a tag is drawn BIG for (race/wordTags.js): the ones the file is actually about. Every
+ * other word wears the same plate at the same size, so these read as the beat of the line rather
+ * than as sixteen shouts. A phrase that landed in one bubble counts if either half is on the list.
+ */
+export const ACCENT_WORDS = new Set(['drop', 'sink', 'deeper', 'down', 'relax', 'now', 'empty',
+  'blank', 'bump', 'obey', 'pink', 'good', 'girl', 'bambi', 'sleep', 'bimbo']);
+/** What is stripped off a transcript word before it is held against that list. */
+const ACCENT_TRIM = /^["'(\[]+|[,.;:!?…"')\]]+$/g;
+
+/** Is this bubble's word one of them, and what colour does it want? */
+function accentOf(text) {
+  return String(text || '').toLowerCase().split(/\s+/).some((part) => ACCENT_WORDS.has(part.replace(ACCENT_TRIM, '')));
+}
+/** The theme colour of the set this word sits inside, when the road put one on the event. */
+function tagInk(event) {
+  if (!event || typeof event.cue !== 'string' || !event.cue) return null;
+  const row = themeFor(event);
+  return row && row.preset === event.cue ? row.color : null;
+}
 
 /** A trigger phrase nobody has assigned a bubble to wears the room's own effect, else this. */
 const FALLBACK_TRIGGER = 'flash';
@@ -130,7 +152,10 @@ export function cueFor(event, ctx = {}) {
       }
       const kindId = triggerKind(label, ctx);
       const gold = typeof ctx.gold === 'function' && ctx.gold() === true;   // rabbit foot: a golden in the middle
-      for (const x of ROW_X) cue.spawn.push({ kindId: gold && Math.abs(x) < 1e-6 ? 'golden' : kindId, placement: 'lane', x, h: LANE_H, at: 0, row: true });
+      // the row wears ONE tag, on its middle bubble (bubbles.js spawnRow), at 1.3x, inked in the
+      // set's own theme colour: five copies of one word is a wall of text.
+      const ink = (themeFor(event) || {}).color || null;
+      for (const x of ROW_X) cue.spawn.push({ kindId: gold && Math.abs(x) < 1e-6 ? 'golden' : kindId, placement: 'lane', x, h: LANE_H, at: 0, row: true, w: label || '', ink, big: true });
       cue.word = label || null;
       cue.pose = 'grab';
       break;
@@ -149,7 +174,11 @@ export function cueFor(event, ctx = {}) {
       // the owner asked us to take off this road, and the word is read off the bubble's own tag.
       if (typeof event.w === 'string' && event.w) {
         const x = Number.isFinite(Number(event.x)) ? clamp(Number(event.x), -LANE_X_MAX, LANE_X_MAX) : 0;
-        cue.spawn.push({ kindId: 'treat', placement: 'lane', x, h: LANE_H, at: 0, row: true, w: event.w });
+        // the tag: every word gets one, an accent word gets it bigger and in the colour of the set
+        // the road says this second belongs to (race/cloudChart.js stamps `cue` on it), else pink.
+        const accent = accentOf(event.w);
+        cue.spawn.push({ kindId: 'treat', placement: 'lane', x, h: LANE_H, at: 0, row: true, w: event.w,
+          big: accent, ink: accent ? tagInk(event) : null });
         break;
       }
       if (conf01(event) < WORD_SURE) return null;

--- a/ConditioningControlPanel/Resources/web/dtrh/race/run.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/run.js
@@ -54,6 +54,7 @@ import { createWallDomPosters } from './wallDom.js';
 import { KIND_BY_ID } from './bubbleKinds.js';
 import { createCocktail, CATEGORIES } from './cocktail.js';
 import { createBubbleField } from './bubbles.js';
+import { createWordTags } from './wordTags.js';
 import { createTrackState } from './track.js';
 import { cueFor, resultTag } from './cues.js';
 import { createKart } from './kart.js';
@@ -202,7 +203,10 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     };
     const field = createBubbleField({ scene, layout, media, getIntensity: () => S.intensity, getRoom, getElapsed: () => S.elapsed, onTexture: pixel.filterTexture });
     const pickups = createPickups({ rng, spots: layout.chunks.flatMap((c) => c.features || []).filter((f) => f.type === 'pickup'), totalDepth: layout.totalDepth });
-    const w = { layout, tunnel, fx, dresser, walls, wallDom, kart, score, field, pickups, rng };
+    // the words get a readable tag over the bubble (race/wordTags.js): the sprite itself is 20 px
+    // tall at 20 m on a phone, which is no size at all to read four letters in
+    const wordTags = createWordTags({ scene, camera, viewport: () => ({ w: root.clientWidth || window.innerWidth, h: root.clientHeight || window.innerHeight }) });
+    const w = { layout, tunnel, fx, dresser, walls, wallDom, kart, score, field, pickups, wordTags, rng };
     field.onPop((p) => onPop(w, p));
     field.onMiss((m) => onMiss(w, m));
     kart.onEvent((e) => onKart(w, e));
@@ -215,7 +219,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
   }
   function teardown() {
     if (!W) return;
-    try { W.field.dispose(); W.kart.dispose(); W.wallDom.dispose(); W.walls.dispose(); W.dresser.dispose(); W.fx.dispose(); } catch (e) { /* half-built world */ }
+    try { W.wordTags.dispose(); W.field.dispose(); W.kart.dispose(); W.wallDom.dispose(); W.walls.dispose(); W.dresser.dispose(); W.fx.dispose(); } catch (e) { /* half-built world */ }
     scene.remove(W.tunnel.mesh); W.tunnel.dispose();
     W = null;
   }
@@ -450,7 +454,8 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     const row = cue.spawn.filter((sp) => sp.row), loose = cue.spawn.filter((sp) => !sp.row);
     if (row.length) {
       const at = e.t + (row[0].at || 0), d = sync.depthFor(t, ks.d, ks.speed, at);
-      const rowId = w.field.spawnRow({ kindId: row[0].kindId, kindIds: row.map((sp) => sp.kindId), placement: row[0].placement, d, h: row[0].h, xs: row.map((sp) => sp.x), eventId: e.id });
+      const rowId = w.field.spawnRow({ kindId: row[0].kindId, kindIds: row.map((sp) => sp.kindId), placement: row[0].placement, d, h: row[0].h, xs: row.map((sp) => sp.x), eventId: e.id,
+        w: row[0].w || '', ink: row[0].ink || null, big: !!row[0].big });   // the tag, on the middle bubble alone
       if (rowId) sync.trackRow(rowId, e, at, d, t);
     }
     for (const sp of loose) {
@@ -598,6 +603,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     cupLight.position.copy(k.group.position).addScaledVector(_v.copy(camOut.up), 1.6);
     speedFx.update(dt, ks, lay);
     w.wallDom.update(ks.d);   // AFTER the camera: a DOM poster is transformed by THIS frame's lens
+    w.wordTags.update(w.field.wordTagList());   // and so is a tag: it is placed in camera space
 
     // EMI: calm cruise, streamed on boost, fraught under a stack, pokes on top
     if (S.moodHold > 0) { S.moodHold -= dt; if (S.moodHold <= 0) S.moodHeld = null; }
@@ -778,6 +784,8 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     // trackClock for the host's 250 ms tick, trackEnded when the file runs out at the host's end
     setTrack, replaceTrack: (chart) => { TR.replace(chart); audio.setRoute(routeOf(TR.track)); if (W) W.field.setSparse(TR.lyrics); if (captions) captions.setTrack(TR.track ? TR.track.chart : null); }, trackClock: (t, playing) => TR.clock(t, playing),
     trackEnded: () => { TR.end(); if (TR.track && S.running) endRun(); }, trackStats: () => TR.stats(), syncTrace: () => sync.trace(), debugPickup,
+    /** What race/smoke/label-px-check.mjs measures: every word tag on the glass this frame. */
+    wordTags: () => (W ? W.wordTags.measure() : null),
     get track() { return TR.track; } };
 }
 

--- a/ConditioningControlPanel/Resources/web/dtrh/race/smoke/label-px-check.mjs
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/smoke/label-px-check.mjs
@@ -1,0 +1,253 @@
+/* ============================================================================
+ * race/smoke/label-px-check.mjs - the word on the road is big enough to read.
+ *
+ *   node race/smoke/label-px-check.mjs      (from Resources/web/dtrh; 0 on pass, 1 with a count)
+ *   RACE_SHOTS=1 node race/smoke/label-px-check.mjs      (also writes shots/, untracked)
+ *
+ * THE THING THIS FILE EXISTS FOR. A bubble is 1.15 m across and the phone's own field of
+ * view (race/viewport.js: FOV_BASE is a HORIZONTAL 72 wearing a vertical number) draws
+ * that at about 20 px at 20 m. Four letters inside 20 px is not a word, it is a texture.
+ * race/wordTags.js therefore gives the word its own sprite with its own screen-size floor,
+ * and a floor is exactly the kind of promise that holds on the machine it was written on
+ * and quietly breaks on a phone. So it is measured here, on a phone (390x844 at device
+ * scale 2, the narrowest window the web build supports and the worst case for every number
+ * below), on a real transcript, in a run that is driving itself.
+ *
+ * `?chart=<url>` hands race.html a whole road built here off the Bubble Induction
+ * transcript, the same door race/smoke/captions-check.mjs uses. No audio is fetched or
+ * played and no third party is touched.
+ *
+ * What it holds, over every frame it samples:
+ *   1. the floor is in the file (a source guard: wordTags.js cannot be imported in node)
+ *   2. a worded road actually puts tags on the glass, in LINES of four and more
+ *   3. every visible tag's measured cap height is at least MIN_CAP_PX, from the far end
+ *      of the fade all the way down to the pop point
+ *   4. no two tags on one frame overlap, which is the whole reason the lift exists
+ *   5. no tag is drawn off the glass
+ *   6. a trigger row wears ONE tag, not five
+ *   7. nothing on the console
+ *
+ * It never prints a line of a transcript: everything below is counted.
+ *
+ * CHROME: `CHROME_PATH` if it is set, else the usual Windows install.
+ * ==========================================================================*/
+
+import { spawn } from 'node:child_process';
+import { createServer } from 'node:http';
+import { readFile } from 'node:fs/promises';
+import { readFileSync, writeFileSync, mkdirSync, mkdtempSync, rmSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, extname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { wordedRoad, PEAKS_PER_SEC } from '../cloudChart.js';
+
+let fails = 0;
+const ok = (cond, what) => { if (!cond) { console.error('FAIL ' + what); fails++; } else console.log('  ok  ' + what); };
+const eq = (got, want, what) => ok(got === want, what + ' (got ' + JSON.stringify(got) + ', want ' + JSON.stringify(want) + ')');
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const HERE = resolve(fileURLToPath(import.meta.url), '..');
+const RACE = resolve(HERE, '..');
+const WEB = resolve(RACE, '../..');                        // Resources/web
+const SHOTS = resolve(WEB, '../../../shots');           // C:/wt-race-words/shots, untracked
+const read = (rel) => JSON.parse(readFileSync(resolve(RACE, rel), 'utf8'));
+
+/* ============================================================================
+ * 1. the floor is written down (wordTags.js imports three and the DOM: source guard)
+ * ==========================================================================*/
+const src = readFileSync(resolve(RACE, 'wordTags.js'), 'utf8');
+const constOf = (name) => Number((src.match(new RegExp(name + ' = ([0-9.]+)')) || [])[1]);
+const MIN_CAP_PX = constOf('MIN_CAP_PX');
+eq(MIN_CAP_PX, 18, 'the cap height floor is 18 px');
+eq(constOf('REF_W_PX'), 390, 'and it is written for a 390 px wide phone');
+eq(constOf('POOL'), 16, 'the tag pool is 16 sprites');
+eq(constOf('TAG_WEAR'), 10, 'and the nearest 10 bubbles wear one');
+eq(constOf('TEX_W'), 256, 'each on a 256 px canvas');
+eq(constOf('TEX_H'), 64, 'by 64');
+ok(/CRISP_LAYER/.test(src), 'the tags draw on the crisp full-res layer, not the blocky pass');
+ok(/--rh-font/.test(src) && /800 /.test(src), 'and are set in the HUD sans at weight 800');
+ok(!/serif/.test(src.replace(/sans-serif/g, 'sans')), 'with no serif anywhere near them');
+
+/* ============================================================================
+ * the road: the Bubble Induction transcript, charted here, served to ?chart=
+ * ==========================================================================*/
+const rows = read('words/index.json').rows;
+const ROW = rows.find((r) => /bubble induction/i.test(String(r.title || ''))) || rows[0];
+const WORDS = read('words/' + ROW.file);
+/** A curve shaped like a spoken track, the same swell the other road checks use. */
+function swell(durationSec, perSec = PEAKS_PER_SEC) {
+  const n = Math.ceil(durationSec * perSec);
+  const peaks = new Float32Array(n * 2);
+  for (let i = 0; i < n; i++) {
+    const a = 0.22 + 0.5 * Math.max(0, Math.sin(((i / perSec) / 40) * Math.PI * 2)) ** 2;
+    peaks[i * 2] = -a; peaks[i * 2 + 1] = a;
+  }
+  return peaks;
+}
+const road = wordedRoad({ peaks: swell(WORDS.durationSec), durationSec: WORDS.durationSec, name: ROW.title, hash: ROW.hash, words: WORDS });
+const wordEvents = road.events.filter((e) => e.kind === 'word' && e.w);
+const rowEvents = road.events.filter((e) => e.kind === 'trigger');
+console.log(`the road: ${wordEvents.length} word bubbles, ${rowEvents.length} trigger rows, ${Math.round(road.source.durationSec)}s`);
+ok(wordEvents.length > 200, 'the fixture road carries the whole script');
+
+/* ============================================================================
+ * the browser
+ * ==========================================================================*/
+const CHROME = process.env.CHROME_PATH || 'C:/Program Files/Google/Chrome/Application/chrome.exe';
+const PORT = 8873, DEBUG_PORT = 9343;
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.mjs': 'text/javascript', '.css': 'text/css', '.json': 'application/json', '.glb': 'model/gltf-binary', '.png': 'image/png', '.webp': 'image/webp', '.jpg': 'image/jpeg', '.mp3': 'audio/mpeg', '.wav': 'audio/wav', '.svg': 'image/svg+xml', '.woff2': 'font/woff2' };
+const FIXTURE = JSON.stringify(road);
+
+if (!existsSync(CHROME)) { console.error('FAIL no chrome at ' + CHROME + ' (set CHROME_PATH)'); process.exit(1); }
+const server = createServer(async (req, res) => {
+  const path = decodeURIComponent(new URL(req.url, 'http://x').pathname);
+  if (path === '/fixture.json') { res.writeHead(200, { 'content-type': 'application/json' }); return res.end(FIXTURE); }
+  if (path.indexOf('..') >= 0) { res.writeHead(400); return res.end(); }
+  try {
+    const body = await readFile(join(WEB, path));
+    res.writeHead(200, { 'content-type': MIME[extname(path).toLowerCase()] || 'application/octet-stream' });
+    res.end(req.method === 'HEAD' ? undefined : body);
+  } catch (e) { res.writeHead(404, { 'content-type': 'text/plain' }); res.end('no'); }
+});
+await new Promise((r) => server.listen(PORT, '127.0.0.1', r));
+
+const prof = mkdtempSync(join(tmpdir(), 'race-tags-'));
+const chrome = spawn(CHROME, [
+  '--headless=new', `--remote-debugging-port=${DEBUG_PORT}`, `--user-data-dir=${prof}`,
+  '--no-first-run', '--no-default-browser-check', '--disable-gpu', '--mute-audio',
+  '--enable-unsafe-swiftshader', '--autoplay-policy=no-user-gesture-required',
+  '--window-size=390,844', 'about:blank',
+], { stdio: 'ignore' });
+
+async function done(code) {
+  try { chrome.kill(); } catch (e) { /* already gone */ }
+  await new Promise((r) => server.close(r));
+  try { rmSync(prof, { recursive: true, force: true }); } catch (e) { /* windows holds the profile */ }
+  process.exit(code);
+}
+
+let page = null;
+for (let i = 0; i < 60 && !page; i++) {
+  await sleep(250);
+  try { page = (await (await fetch(`http://127.0.0.1:${DEBUG_PORT}/json/list`)).json()).find((t) => t.type === 'page'); } catch (e) { /* not up */ }
+}
+if (!page) { console.error('FAIL chrome never answered on the debug port'); await done(1); }
+
+const ws = new WebSocket(page.webSocketDebuggerUrl);
+await new Promise((r) => { ws.onopen = r; });
+let msgId = 0;
+const waits = new Map(), errs = [];
+ws.onmessage = (e) => {
+  const m = JSON.parse(e.data);
+  if (m.id && waits.has(m.id)) { waits.get(m.id)(m); waits.delete(m.id); }
+  if (m.method === 'Runtime.exceptionThrown') errs.push('thrown: ' + (m.params.exceptionDetails?.exception?.description || m.params.exceptionDetails?.text || '?'));
+  if (m.method === 'Runtime.consoleAPICalled' && m.params.type === 'error') errs.push(m.params.args.map((a) => a.value ?? a.description ?? '?').join(' '));
+};
+const cdp = (method, params) => new Promise((res) => { const i = ++msgId; waits.set(i, res); ws.send(JSON.stringify({ id: i, method, params })); });
+const ev = async (x) => (await cdp('Runtime.evaluate', { expression: x, returnByValue: true, awaitPromise: true })).result?.result?.value;
+const json = async (x) => JSON.parse(await ev(`JSON.stringify(${x})`));
+await cdp('Runtime.enable'); await cdp('Page.enable');
+await cdp('Emulation.setDeviceMetricsOverride', { width: 390, height: 844, deviceScaleFactor: 2, mobile: true });
+
+const site = `http://127.0.0.1:${PORT}`;
+await cdp('Page.navigate', { url: `${site}/dtrh/race.html?autostart=1&intro=0&cards=0&chart=${encodeURIComponent(`${site}/fixture.json`)}` });
+let up = false;
+for (let i = 0; i < 120 && !up; i++) {
+  await sleep(250);
+  up = await ev(`!!(window.__race && window.__race.race && window.__race.race.track && window.__race.race.wordTags())`);
+}
+ok(up, 'the page boots the worded road and builds the tag layer');
+if (!up) {
+  console.error('    boot: ' + await ev(`JSON.stringify({ race: !!window.__race, run: !!(window.__race&&window.__race.race), track: !!(window.__race&&window.__race.race&&window.__race.race.track), tags: !!(window.__race&&window.__race.race&&window.__race.race.wordTags) })`));
+  if (errs.length) console.error('    said: ' + errs.slice(0, 6).join(' | '));
+  await done(1);
+}
+
+/* ---- the sampling ---------------------------------------------------------
+ * Every sample is one frame of the live run. race/track.js starts a chart PAUSED (the
+ * host's 250 ms tick is the only thing that ever sets the second), so the clock is started
+ * once, at the file's first word, and then left to walk on its own off the wall: what is
+ * measured below is a road being driven, not a road being posed. */
+const START = Math.max(0, (wordEvents[0] ? wordEvents[0].t : 0) - 3);
+await ev(`window.__race.race.trackClock(${START.toFixed(2)}, true)`);
+await sleep(400);
+ok(await ev(`window.__race.race.track.playing === true`), `the clock is running, from ${START.toFixed(1)}s (the file's first word)`);
+const SAMPLES = 150, EVERY_MS = 120;
+const samples = [];
+for (let i = 0; i < SAMPLES; i++) {
+  const s = await json(`(()=>{ const r=window.__race.race, m=r.wordTags();
+    return { t: r.track ? r.track.t : 0, vw: m.vw, vh: m.vh, floorPx: m.floorPx, tags: m.tags }; })()`);
+  if (s) samples.push(s);
+  await sleep(EVERY_MS);
+}
+ok(samples.length > 100, `sampled ${samples.length} frames of the run`);
+
+let seen = 0, withTags = 0, lines4 = 0, lines6 = 0, thin = 0, overlaps = 0, offGlass = 0, rowTags = 0, bigTags = 0;
+let minCap = Infinity, maxCap = 0, minDist = Infinity, maxDist = 0, mostTags = 0, best = null, bestRow = null;
+const cover = (a, b) => !(a.right <= b.left || a.left >= b.right || a.bottom <= b.top || a.top >= b.bottom);
+for (const s of samples) {
+  const tags = s.tags || [];
+  seen += tags.length;
+  if (tags.length) withTags++;
+  if (tags.length >= 4) lines4++;
+  if (tags.length >= 6) lines6++;
+  if (tags.length > mostTags) { mostTags = tags.length; best = s; }
+  for (let i = 0; i < tags.length; i++) {
+    const a = tags[i];
+    if (a.capPx < minCap) minCap = a.capPx;
+    if (a.capPx > maxCap) maxCap = a.capPx;
+    if (a.dist < minDist) minDist = a.dist;
+    if (a.dist > maxDist) maxDist = a.dist;
+    if (a.capPx < MIN_CAP_PX - 0.01) thin++;
+    if (a.top < 0 || a.bottom > s.vh || a.left < 0 || a.right > s.vw) offGlass++;
+    if (a.big) bigTags++;
+    if (a.rowN > 1) { rowTags++; if (!bestRow || tags.length > (bestRow.tags || []).length) bestRow = s; }
+    for (let j = i + 1; j < tags.length; j++) if (cover(a, tags[j])) overlaps++;
+  }
+}
+eq(samples.filter((s) => s.vw === 390 && s.vh === 844).length, samples.length, 'every sample was taken on a 390x844 phone');
+ok(withTags > samples.length * 0.5, `the road wears its script: ${withTags} of ${samples.length} frames had a tag on the glass, ${seen} tags in all`);
+ok(lines4 > 0, `and ${lines4} of them carried a LINE of four or more (the most at once was ${mostTags})`);
+eq(thin, 0, `not one tag was drawn under the ${MIN_CAP_PX} px floor (smallest ${minCap === Infinity ? 0 : minCap.toFixed(1)} px, largest ${maxCap.toFixed(1)} px)`);
+eq(overlaps, 0, 'and no two tags on one frame overlapped, however deep the line ran');
+eq(offGlass, 0, 'every tag drawn was fully on the glass');
+ok(maxDist > 20, `they were measured from ${maxDist.toFixed(1)} m out down to ${minDist.toFixed(1)} m, which is the pop point`);
+ok(bigTags > 0, `${bigTags} of them were the 1.3x tag an accent word or a trigger row wears`);
+ok(rowTags > 0, `and ${rowTags} were a trigger row's shared tag`);
+const doubled = samples.reduce((n, s) => { const r = (s.tags || []).filter((t) => t.rowN > 1);
+  return n + (r.length !== new Set(r.map((t) => t.w + '@' + Math.round(t.dist))).size ? 1 : 0); }, 0);
+eq(doubled, 0, 'a row of five wears ONE tag, never five copies of it');
+eq(errs.length, 0, 'with nothing on the console' + (errs.length ? ': ' + errs.slice(0, 4).join(' | ') : ''));
+console.log(`  --  ${seen} tags over ${samples.length} frames, ${lines4} frames with a line of 4+, ${lines6} with 6+, cap ${minCap === Infinity ? 0 : minCap.toFixed(1)}..${maxCap.toFixed(1)} px`);
+
+/* ---- the pictures the owner decides on ------------------------------------
+ * Only with RACE_SHOTS=1: the check itself must not write into the worktree on a
+ * plain run, and shots/ is never committed. One browser, so they are taken here
+ * rather than in a second headless run. */
+if (process.env.RACE_SHOTS) {
+  mkdirSync(SHOTS, { recursive: true });
+  const shoot = async (name) => {
+    const r = await cdp('Page.captureScreenshot', { format: 'png', captureBeyondViewport: false });
+    const data = r.result?.data;
+    if (!data) return null;
+    const file = join(SHOTS, name);
+    writeFileSync(file, Buffer.from(data, 'base64'));
+    return file;
+  };
+  async function shotWhen(name, want, tries = 400) {   // wait for the frame the picture wants
+    for (let i = 0; i < tries; i++) {
+      const m = await json(`window.__race.race.wordTags()`);
+      if (m && want(m.tags || [])) { const f = await shoot(name); return { file: f, tags: m.tags.length }; }
+      await sleep(90);
+    }
+    return { file: null, tags: 0 };
+  }
+  const line = await shotWhen('words-line.png', (t) => t.length >= 4);
+  ok(!!line.file, `shot: a line of ${line.tags} word tags -> ${line.file}`);
+  // near enough to read: a row's tag at 30 m is a true picture of nothing much
+  const row = await shotWhen('words-row.png', (t) => t.some((x) => x.rowN > 1 && x.dist < 20));
+  ok(!!row.file, `shot: a trigger row's shared tag -> ${row.file}`);
+}
+
+console.log(fails ? `\nlabel-px-check: ${fails} failed` : '\nlabel-px-check: all good');
+await done(fails ? 1 : 0);

--- a/ConditioningControlPanel/Resources/web/dtrh/race/wordTags.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/wordTags.js
@@ -39,9 +39,9 @@ export const TEX_W = 256, TEX_H = 64;
 /** The floor, in CSS pixels of cap height, and how it grows on a window wider than a phone. */
 export const MIN_CAP_PX = 18, CAP_VW = 0.048, MAX_CAP_PX = 30, REF_W_PX = 390;
 /** Nearer than this (camera distance) the tag stops holding the floor and grows with the bubble. */
-export const TAG_HOLD_M = 12;
-/** And the most it may grow to, so a tag at the pop point is not the whole windscreen. */
-export const MAX_GROW = 2.2;
+export const TAG_HOLD_M = 9;
+/** And the most it may grow to: the owner's call, so a near plate never covers the cup or EMI. */
+export const MAX_GROW = 1.5;
 /** The tag hangs this far over its bubble before anything is stacked on top of it. */
 export const LIFT_BASE_PX = 26;
 /** Clear air between two tags of one line, and the highest a tag may be pushed before it is dropped. */

--- a/ConditioningControlPanel/Resources/web/dtrh/race/wordTags.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/wordTags.js
@@ -1,0 +1,241 @@
+/* ============================================================================
+ * race/wordTags.js - the word on a tag over the bubble, big enough to read.
+ *
+ *   createWordTags({ scene, camera, viewport }) -> { update(list), measure(), dispose() }
+ *
+ * THE BUBBLE'S OWN FACE CANNOT HOLD A WORD. run.js's FOV_BASE 72 re-solves on a 390x844
+ * phone to viewport.js MAX_VFOV, and a 1.15 m sprite then draws about 20 px tall at 20 m.
+ * So the word gets its OWN sprite with its OWN screen-size floor, hung over the bubble on
+ * the crisp full-res layer the bubbles already draw on (pixel.js CRISP_LAYER).
+ *
+ * THE FLOOR. A tag's cap height never drops under MIN_CAP_PX on a phone (the caption band
+ * in race.css measures 17.9 px there, which is the size the owner already reads at). Past
+ * TAG_HOLD_M the tag holds that size on the glass however far off it is; inside it the tag
+ * is a fixed size in the world and grows with the bubble, up to MAX_GROW. The sum is done
+ * in camera space each frame off the live vertical fov, so it holds at every window shape.
+ *
+ * THE STACK, which is the part the geometry forces. A line of word bubbles runs down ONE
+ * lane toward the vanishing point, so their tags land almost on top of each other: on a
+ * phone the whole 5 m to 30 m of road is about 14 px of screen height. A tag is therefore
+ * LIFTED, near one first, until its box clears the box of the tag in front of it by
+ * GAP_PX. The lift is worked out in pixels and spent in metres, so the line reads as a
+ * rising stack of words in the order they are said, each still over its own lane. A tag
+ * that would have to climb past LIFT_MAX_PX is not drawn: past that it is nearer the sky
+ * than the road and belongs to no bubble the eye can follow.
+ *
+ * COST. A pool of POOL sprites, each with its own 256x64 canvas, redrawn only when the word
+ * on it changes. No new render pass. The caller hands in the nearest few, already sorted.
+ * ==========================================================================*/
+
+import * as THREE from 'three';
+import { CRISP_LAYER } from './pixel.js';
+
+/** How many tags exist. The caller never hands in more than this many. */
+export const POOL = 16;
+/** And how many bubbles actually wear one: the nearest few, so the road ahead stays road. */
+export const TAG_WEAR = 10;
+/** The tag canvas. 4:1, one word wide, and small enough that a redraw is not felt. */
+export const TEX_W = 256, TEX_H = 64;
+/** The floor, in CSS pixels of cap height, and how it grows on a window wider than a phone. */
+export const MIN_CAP_PX = 18, CAP_VW = 0.048, MAX_CAP_PX = 30, REF_W_PX = 390;
+/** Nearer than this (camera distance) the tag stops holding the floor and grows with the bubble. */
+export const TAG_HOLD_M = 12;
+/** And the most it may grow to, so a tag at the pop point is not the whole windscreen. */
+export const MAX_GROW = 2.2;
+/** The tag hangs this far over its bubble before anything is stacked on top of it. */
+export const LIFT_BASE_PX = 26;
+/** Clear air between two tags of one line, and the highest a tag may be pushed before it is dropped. */
+export const GAP_PX = 4, LIFT_MAX_PX = 240;
+/** Metres of road ahead over which a tag fades in. */
+export const FADE_IN_M = 30, FADE_M = 8;
+/** An accent word, and a trigger row's shared tag, are drawn this much bigger. */
+export const BIG = 1.3;
+
+/** The plate: dark card, one pixel of light on its edge, so the word reads on the tube and on the sky. */
+const PLATE = 'rgba(16,13,28,0.82)', EDGE = 'rgba(255,255,255,0.34)', INK = '#ff8fd0';
+const PAD_X = 14, RADIUS = 16;
+/** The type. The HUD's own sans (styles.css --rh-font), heavy, lowercase, never a book face. */
+const FALLBACK_FONT = "'Poppins', system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif";
+const FONT_PX = 40, FONT_MIN_PX = 22;
+
+const clamp = (v, a, b) => (v < a ? a : v > b ? b : v);
+
+/** The HUD's font stack, read once off the document, so a tag is set in the same face as the chrome. */
+function hudFont() {
+  try {
+    const v = getComputedStyle(document.documentElement).getPropertyValue('--rh-font');
+    return (v && v.trim()) || FALLBACK_FONT;
+  } catch (e) { return FALLBACK_FONT; }
+}
+
+export function createWordTags({ scene, camera, viewport = null } = {}) {
+  const group = new THREE.Group();
+  group.name = 'race-word-tags';
+  group.renderOrder = 3;
+  if (scene) scene.add(group);
+  const family = hudFont();
+  const pool = [];
+  for (let i = 0; i < POOL; i++) {
+    const canvas = document.createElement('canvas');
+    canvas.width = TEX_W; canvas.height = TEX_H;
+    const ctx = canvas.getContext('2d');
+    const tex = new THREE.CanvasTexture(canvas);
+    tex.colorSpace = THREE.SRGBColorSpace;
+    const mat = new THREE.SpriteMaterial({ map: tex, transparent: true, depthWrite: false, depthTest: false, opacity: 0 });
+    const sprite = new THREE.Sprite(mat);
+    sprite.visible = false;
+    sprite.layers.set(CRISP_LAYER);
+    sprite.renderOrder = 3;
+    group.add(sprite);
+    // capFrac: how much of the 64 px texture the cap height actually is, measured at draw time,
+    // because the type shrinks to fit a long word and the floor is about the LETTERS, not the plate.
+    pool.push({ sprite, mat, ctx, tex, key: '', text: '', ink: '', capFrac: 0.5, seen: 0 });
+  }
+
+  /** One redraw. Only ever called when the word or its ink changed. */
+  function draw(slot, text, ink) {
+    const c = slot.ctx;
+    c.clearRect(0, 0, TEX_W, TEX_H);
+    let size = FONT_PX;
+    c.font = `800 ${size}px ${family}`;
+    let w = c.measureText(text).width;
+    const room = TEX_W - PAD_X * 2 - 6;
+    if (w > room) {                                   // a long word shrinks rather than spilling off the plate
+      size = Math.max(FONT_MIN_PX, Math.floor(size * (room / w)));
+      c.font = `800 ${size}px ${family}`;
+      w = c.measureText(text).width;
+    }
+    const m = c.measureText('h');
+    const cap = (m && m.actualBoundingBoxAscent) ? m.actualBoundingBoxAscent : size * 0.72;
+    const plateW = Math.min(TEX_W - 2, w + PAD_X * 2), x0 = (TEX_W - plateW) / 2;
+    c.beginPath();
+    if (c.roundRect) c.roundRect(x0, 4, plateW, TEX_H - 8, RADIUS);
+    else c.rect(x0, 4, plateW, TEX_H - 8);
+    c.fillStyle = PLATE; c.fill();
+    c.lineWidth = 1; c.strokeStyle = EDGE; c.stroke();
+    c.font = `800 ${size}px ${family}`;
+    c.textAlign = 'center'; c.textBaseline = 'middle';
+    c.fillStyle = ink || INK;
+    c.shadowColor = 'rgba(0,0,0,0.85)'; c.shadowBlur = 4;
+    c.fillText(text, TEX_W / 2, TEX_H / 2 + 1);
+    c.shadowBlur = 0;
+    slot.tex.needsUpdate = true;
+    slot.text = text; slot.ink = ink || INK;
+    slot.capFrac = clamp(cap / TEX_H, 0.2, 0.95);
+    // the widest the plate is, as a fraction of the sprite, so the overlap pass boxes the PLATE
+    slot.wideFrac = plateW / TEX_W;
+  }
+
+  /** The slot already wearing this word, else the least recently seen one. */
+  let stamp = 0;
+  function claim(key, text, ink) {
+    let free = null, oldest = pool[0];
+    for (const s of pool) {
+      if (s.key === key) { s.seen = ++stamp; if (s.text !== text || s.ink !== ink) draw(s, text, ink); return s; }
+      if (!free && !s.key) free = s;
+      if (s.seen < oldest.seen) oldest = s;
+    }
+    const s = free || oldest;
+    s.key = key; s.seen = ++stamp;
+    draw(s, text, ink);
+    return s;
+  }
+
+  const _p = new THREE.Vector3();
+  const boxes = [];                    // { top, bottom, left, right } of the tags already placed
+  const shown = [];                    // what measure() reports, rebuilt each update
+  let vpW = 0, vpH = 0, kPx = 0;
+
+  /** Viewport in CSS pixels and the pixels-per-world-unit-at-one-metre the camera works out to. */
+  function readViewport() {
+    let w = 0, h = 0;
+    if (viewport) { const v = viewport(); if (v) { w = v.w; h = v.h; } }
+    if (!w || !h) { w = (typeof innerWidth === 'number' ? innerWidth : REF_W_PX); h = (typeof innerHeight === 'number' ? innerHeight : 844); }
+    vpW = Math.max(1, w); vpH = Math.max(1, h);
+    const vFov = (camera && camera.fov ? camera.fov : 72) * Math.PI / 180;
+    kPx = vpH / (2 * Math.tan(vFov / 2));
+  }
+
+  /** The cap height a tag may never draw under on THIS window. */
+  const floorPx = () => clamp(vpW * CAP_VW, MIN_CAP_PX, MAX_CAP_PX);
+
+  /**
+   * One frame.
+   * @param list the nearest bubbles that want a tag, NEAREST FIRST, each
+   *        `{ key, pos: Vector3 (world), w: string, ink?: string, big?: boolean, alpha: number, ahead: number }`
+   *        `ahead` is metres of road in front of the kart (the fade rides on it).
+   */
+  function update(list) {
+    readViewport();
+    // the tags are placed in CAMERA space, so this frame's lens has to be settled first. Cheap:
+    // three.js skips the work when nothing moved, and pixel.render() calls it again anyway.
+    camera.updateMatrixWorld();
+    const floor = floorPx();
+    boxes.length = 0; shown.length = 0;
+    const live = new Set();
+    for (const item of (list || [])) {
+      if (!item || !item.w) continue;
+      if (shown.length >= TAG_WEAR) break;
+      const slot = claim(item.key, String(item.w).toLowerCase(), item.ink || INK);
+      live.add(slot);
+      _p.copy(item.pos).applyMatrix4(camera.matrixWorldInverse);
+      const dist = -_p.z;
+      if (!(dist > 0.2)) { slot.sprite.visible = false; continue; }
+      // THE FLOOR. Past TAG_HOLD_M, grow is 1: the world size rises with the distance, the two
+      // cancel, and the tag holds `capPx` on the glass. Inside it the tag swells with its bubble,
+      // up to MAX_GROW. The measured cap is therefore never under the floor.
+      const big = item.big ? BIG : 1;
+      const capPx = floor * big;
+      const grow = clamp(TAG_HOLD_M / dist, 1, MAX_GROW);
+      const worldH = (capPx * grow * dist) / (kPx * slot.capFrac);
+      const halfH = worldH / 2, halfW = (worldH * (TEX_W / TEX_H) * (slot.wideFrac || 1)) / 2;
+      // the stack: lift until this tag's box clears the one in front of it
+      // LIFT_BASE_PX is clear air between the bubble's middle and the bottom edge of its own tag
+      let lift = (LIFT_BASE_PX * dist) / kPx + halfH;
+      const px = (v) => (v * kPx) / dist;
+      let top = 0, bottom = 0, left = 0, right = 0, tries = 0;
+      for (;;) {
+        const cy = vpH / 2 - px(_p.y + lift), cx = vpW / 2 + px(_p.x);
+        const hp = px(halfH), wp = px(halfW);
+        top = cy - hp; bottom = cy + hp; left = cx - wp; right = cx + wp;
+        let hitBottom = null;
+        for (const b of boxes) {
+          if (right < b.left - GAP_PX || left > b.right + GAP_PX) continue;
+          if (bottom < b.top - GAP_PX || top > b.bottom + GAP_PX) continue;
+          if (hitBottom == null || b.top < hitBottom) hitBottom = b.top;
+        }
+        if (hitBottom == null || ++tries > POOL) break;
+        lift += ((bottom - hitBottom) + GAP_PX) * dist / kPx;   // clear the box in front, in metres
+        if (px(lift) > LIFT_MAX_PX) break;
+      }
+      const liftPx = px(lift);
+      const fade = clamp((FADE_IN_M - (item.ahead || 0)) / FADE_M, 0, 1);
+      const alpha = clamp((item.alpha == null ? 1 : item.alpha) * fade, 0, 1);
+      // off the glass in any direction, too high to belong to a bubble, or faded out: not drawn.
+      if (liftPx > LIFT_MAX_PX || alpha <= 0.02 || top < 0 || bottom > vpH || left < 0 || right > vpW) { slot.sprite.visible = false; continue; }
+      _p.y += lift;
+      slot.sprite.position.copy(_p).applyMatrix4(camera.matrixWorld);
+      slot.sprite.scale.set(worldH * (TEX_W / TEX_H), worldH, 1);
+      slot.mat.opacity = alpha;
+      slot.sprite.visible = true;
+      boxes.push({ top, bottom, left, right });
+      shown.push({ w: slot.text, capPx: capPx * grow, floorPx: capPx, top, bottom, left, right, dist,
+        ahead: item.ahead || 0, alpha, big: !!item.big, rowN: item.rowN || 1, lift: liftPx });
+    }
+    for (const s of pool) if (!live.has(s)) { s.sprite.visible = false; s.key = ''; }
+  }
+
+  return {
+    update,
+    /** What is on the glass this frame, for race/smoke/label-px-check.mjs. Never read by the game. */
+    measure() { return { vw: vpW, vh: vpH, floorPx: floorPx(), tags: shown.map((t) => ({ ...t })) }; },
+    dispose() {
+      if (scene) scene.remove(group);
+      for (const s of pool) { s.mat.dispose(); s.tex.dispose(); }
+      pool.length = 0; boxes.length = 0; shown.length = 0;
+    },
+  };
+}
+
+// self-check: node race/smoke/label-px-check.mjs drives a phone viewport over a worded road and
+// measures every tag on the glass from 30 m down to the pop point.


### PR DESCRIPTION
## The word on a tag over the bubble

W1 put the whole script on the road, one word a bubble, in its phrase's lane. This is the half that makes it readable.

A bubble is 1.15 m across. On a 390x844 phone `race/viewport.js` re-solves FOV_BASE 72 (a horizontal fov wearing a vertical number) to MAX_VFOV, and the sprite then draws about **20 px tall at 20 m**. Four letters inside 20 px is a texture, not a word. So the word gets its own sprite with its own screen-size floor.

**`race/wordTags.js`** (new): a pool of 16 256x64 CanvasTexture plates on `CRISP_LAYER`, the full-res layer the bubbles already draw on, never the blocky pass. Redrawn only when the word on one changes. The nearest 10 bubbles wear one, fading in at 30 m and out with the bubble's own pass fade. Pink on a dark plate with a 1 px light edge, set in the HUD sans (`--rh-font`) at weight 800, lowercase.

**The floor.** A tag's cap height never drops under 18 px on a phone (the caption band in race.css measures 17.9 px there, which is the size the owner already reads at). Past `TAG_HOLD_M` 12 m the tag holds that size on the glass however far off it is; inside 12 m it is a fixed size in the world and swells with its bubble, capped at 2.2x. The whole sum is done in camera space each frame off the live vertical fov, so it holds at every window shape rather than only on the machine it was written on.

**The stack, which is what the geometry forces.** A line of word bubbles runs down ONE lane toward the vanishing point, so on a phone the whole 5 m to 30 m of road is about 14 px of screen height: a plain billboard tag "hung 0.9 m above the bubble" puts five words inside 14 px of each other. Each tag is therefore lifted, near one first, until its box clears the box of the tag in front of it. The lift is worked out in pixels and spent in metres, so the line reads as a rising stack of words in the order they are said, each still over its own lane. A tag that would have to climb past 240 px is not drawn at all.

**Trigger rows** wear ONE tag, on the middle bubble, at 1.3x, inked in the set's own theme colour (`race/triggerTheme.js`), carrying the label that was already going out on `cue.word`. Five copies of one word is a wall of text where a wall of bubbles was the point.

**Accent words** (drop, sink, deeper, down, relax, now, empty, blank, bump, obey, pink, good, girl, bambi, sleep, bimbo) are 1.3x too, in the theme colour of the set the road says that second belongs to, else pink. `cloudChart.js inkWords` stamps that on `cue`, the field `chart.js` already carries for every kind, so it survives the chart round trip with no new field and no new normalizer branch.

## The smoke

`race/smoke/label-px-check.mjs`: headless Chrome over CDP at 390x844, device scale 2, on a road built here from the Bubble Induction transcript and served to `?chart=<url>`. No audio is fetched or played, nothing third party is touched, and no line of a transcript is ever printed.

```
the road: 1927 word bubbles, 80 trigger rows, 1049s
  ok  the page boots the worded road and builds the tag layer
  ok  the clock is running, from 36.8s (the file's first word)
  ok  sampled 150 frames of the run
  ok  every sample was taken on a 390x844 phone
  ok  the road wears its script: 147 of 150 frames had a tag on the glass, 469 tags in all
  ok  and 67 of them carried a LINE of four or more (the most at once was 5)
  ok  not one tag was drawn under the 18 px floor (smallest 18.7 px, largest 24.3 px)
  ok  and no two tags on one frame overlapped, however deep the line ran
  ok  every tag drawn was fully on the glass
  ok  they were measured from 36.4 m out down to 7.5 m, which is the pop point
  ok  12 of them were the 1.3x tag an accent word or a trigger row wears
  ok  and 6 were a trigger row's shared tag
  ok  a row of five wears ONE tag, never five copies of it
  ok  with nothing on the console
```

Every other `race/smoke` check is green on this head: chart, cloud-chart, cloud, fov, levels, lyrics-road, words, words-rate, track-run, captions, pickups, audio, spiral-pool, ost-resident, remote-feed, sync, rows, pace, wall-dom, touch, gltf, poses. (`real-audio-check` is not run: it fetches a third party file and needs `RACE_REAL_URL`.)

`RACE_SHOTS=1 node race/smoke/label-px-check.mjs` also writes the two phone captures to `shots/`, which is untracked and not in this PR.

**Tuned down at the owner's request** after the first screenshots: `TAG_HOLD_M` 12 -> 9 and `MAX_GROW` 2.2 -> 1.5, so a tag holds the 18 px floor further in and the biggest one now draws about 24 px instead of 34. The near plates no longer cover the cup or EMI, the nearest tag clears the kart sprite, and the floor itself is unchanged.

## Notes for review

- **Two knobs decide how loud this is**: `TAG_HOLD_M` (now 9) and `MAX_GROW` (now 1.5). Together they say a tag is 18 px from 9 m out and grows to about 24 px at the pop point. Turning either further down makes the script quieter and smaller; it is one line each.
- Nothing in `race/captions.js`, `race/pickups.js`, `race/wallDom.js` or `race/speed.js` is touched, applyCue's visible-cue branches are untouched, and the scheduler's timing is untouched. `bubbles.js` gains three fields on a slot and one accessor; `run.js` builds the layer, plumbs the tag through the existing `spawnRow` call and updates it after the camera, beside the DOM wall.
- The tag layer allocates nothing per frame: fixed scratch entries in `bubbles.js`, a fixed sprite pool here, and a redraw only when a slot changes word.

Base is #938 (W1). Merge that first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJ66hi5fRM1Dcjo38aSCa2


