### PR TITLE
feat(race): the popped word flashes on the caption band

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/race/captions.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/captions.js
@@ -11,15 +11,23 @@
  * Two layers, one file, because they are one idea: the road says the word, the
  * glass says the word, and the plate says it loudly.
  *
- *   THE CAPTION. `chart.words` (the caption track L2 puts on the road) is cut into
- *   phrases, one on screen at a time, low on the glass. Every word of the phrase is
- *   in the DOM from the moment the phrase opens but only INKED when the clock
- *   reaches its own timestamp, so the line types itself at the speed the voice
- *   actually spoke it and never reflows while it does. That is the typewriter: the
- *   voice is the timer, not a timer.
+ *   THE FLASH (`mode: 'flash'`, what a worded road runs). The words are on the ROAD
+ *   now, one to a bubble (race/wordBubbles.js), so the band is no longer where the
+ *   script is read: it is where a POP is answered. The word the kart just took hits
+ *   the band whole, holds FLASH_HOLD_MS, fades over FLASH_FADE_MS, and a pop inside
+ *   FLASH_JOIN_MS of the last one joins the same line, so a line driven clean reads
+ *   back as the sentence that was said. A word the kart drove past writes itself as
+ *   a GHOST, grey and faint: the script is never hostage to the steering.
+ *
+ *   THE CAPTION (`mode: 'type'`, behind `?cap=type`). The old typewriter: `chart.words`
+ *   cut into phrases, one on screen at a time, every word in the DOM from the moment
+ *   the phrase opens but only INKED when the clock reaches its own timestamp, so the
+ *   line types itself at the speed the voice actually spoke it and never reflows
+ *   while it does. The voice is the timer, not a timer.
  *
  *   THE PLATE. A sure trigger flies at the camera from the vanishing point, themed
  *   off race/triggerTheme.js, one at a time, a new one taking the old one's place.
+ *   It owns the glass while it flies: the plate clears the band under it.
  *
  * EVERYTHING IS A FUNCTION OF THE CLOCK. `update(t)` reads the track second and
  * nothing else: no elapsed frames, no timers of its own. A seek, a pause, a resume
@@ -46,6 +54,15 @@ export const CLEAR_SEC = 0.15;
 export const END_PUNCT = /[.?!]["')\]]?$/;
 /** The plate: the zoom, the hold, and the fade, in milliseconds (race.css runs the same numbers). */
 export const PLATE_MS = 1400;
+
+/** THE FLASH. A popped word stands on the band this long before it starts to go. */
+export const FLASH_HOLD_MS = 500;
+/** And it takes this long to go (race.css `.rc-cap.is-flash` runs the same number). */
+export const FLASH_FADE_MS = 300;
+/** A pop this soon after the last one JOINS its line, so a clean line reads back as the sentence. */
+export const FLASH_JOIN_MS = 300;
+/** A word the kart drove past: the ghost's own opacity (race.css `.rc-flash-word.is-ghost`). */
+export const GHOST_ALPHA = 0.35;
 
 /** Two lines and no more. A third is shrunk into the two, never cut off the glass. */
 export const MAX_LINES = 2;
@@ -157,9 +174,11 @@ function phraseAt(phrases, t) {
  *   --rc-plate-fs  how big the plate may be and still fit that air, whatever its theme adds
  * and `--rc-cap-b` on the hud root, which is where hud.js parks the act ribbon out of the way.
  */
-export function createCaptions(root) {
+export function createCaptions(root, opts = {}) {
   const doc = root && root.ownerDocument;
   if (!doc) return null;
+  /** 'flash' (the pops write the band) or 'type' (the old typewriter, behind `?cap=type`). */
+  const mode = (opts && opts.mode) === 'type' ? 'type' : 'flash';
   const reduced = !!(typeof matchMedia === 'function' && matchMedia('(prefers-reduced-motion: reduce)').matches);
   const el = (cls, parent) => { const d = doc.createElement('div'); d.className = cls; parent.appendChild(d); return d; };
 
@@ -256,6 +275,71 @@ export function createCaptions(root) {
     cap.hidden = true;
   }
 
+  // ---- THE FLASH: the word the kart just took, on the band ------------------
+  // Nothing here reads the track clock, and it must not: a pop is a thing the PLAYER did, at the
+  // wall's own second, and the band answers it at that second. (The typewriter above is the exact
+  // opposite and for the exact opposite reason: it says what the VOICE is doing, so it is a
+  // function of the file's clock and of nothing else.)
+  let flashN = 0, flashAt = 0, flashOut = false, holdTimer = 0, goneTimer = 0;
+  const nowMs = () => (win && win.performance && win.performance.now ? win.performance.now() : Date.now());
+
+  function clearFlash() {
+    if (holdTimer) { clearTimeout(holdTimer); holdTimer = 0; }
+    if (goneTimer) { clearTimeout(goneTimer); goneTimer = 0; }
+    flashN = 0; flashOut = false;
+    cap.classList.remove('is-flash');
+    cap.style.removeProperty('--rc-out');
+    clearPhrase();
+  }
+
+  /** The hold is up: let the line go over FLASH_FADE_MS, then take it off the glass. */
+  function fadeFlash() {
+    holdTimer = 0; flashOut = true;
+    cap.style.setProperty('--rc-out', '0');
+    goneTimer = setTimeout(() => { goneTimer = 0; clearFlash(); }, FLASH_FADE_MS + 40);
+  }
+
+  /**
+   * One word on the band, whole, now.
+   * @param text the word the bubble wore (a merged bubble's two words are one string)
+   * @param o { ghost, accent, ink }: a word the kart drove past is grey and faint; an accent word
+   *          is bigger, in the ink of the set the road says this second belongs to, and glows.
+   * @returns the span, or null when this build is not the one that flashes
+   */
+  function showWord(text, o = {}) {
+    if (mode !== 'flash') return null;
+    const said = String(text == null ? '' : text).trim();
+    if (!said) return null;
+    const at = nowMs();
+    // a fresh line: the first pop, one after the line began to go, or one the last line cannot hold
+    if (!flashN || flashOut || at - flashAt > FLASH_JOIN_MS) clearFlash();
+    if (goneTimer) { clearTimeout(goneTimer); goneTimer = 0; }
+    flashOut = false;
+    const s = doc.createElement('span');
+    s.className = 'rc-cap-word rc-flash-word is-said'
+      + (o.ghost ? ' is-ghost' : (o.accent ? ' is-accent' : ''))
+      + (reduced ? ' is-still' : '');
+    s.textContent = said;
+    if (o.ink && !o.ghost) s.style.setProperty('--rc-ink', o.ink);
+    const add = () => { line.appendChild(s); line.appendChild(doc.createTextNode(' ')); };
+    add();
+    spans.push(s); flashN++;
+    cap.hidden = false;
+    cap.classList.add('is-flash');
+    cap.style.setProperty('--rc-out', '1');
+    // MAX_LINES and not one more. A word that spilled the line into a third row does not get
+    // shrunk to fit (the sentence is already read; this is the answer to a pop): it starts again.
+    if (flashN > 1 && lineCount() > MAX_LINES) {
+      line.textContent = ''; spans = [s]; flashN = 1;
+      add();
+    }
+    flashAt = at;
+    if (holdTimer) clearTimeout(holdTimer);
+    holdTimer = setTimeout(fadeFlash, FLASH_HOLD_MS);
+    measure();      // the plate under the band goes wherever this left room
+    return s;
+  }
+
   function draw(i) {
     clearPhrase();
     const p = phrases[i];
@@ -280,6 +364,7 @@ export function createCaptions(root) {
    * needs no telling: the same second always draws the same line.
    */
   function update(t) {
+    if (mode !== 'type') return;   // the flash is answered by the pops, not typed by the second
     if (!phrases.length) { if (shown >= 0) clearPhrase(); return; }
     const sec = num(t, 0);
     const i = phraseAt(phrases, sec);
@@ -311,6 +396,7 @@ export function createCaptions(root) {
     const row = themeFor(event);
     const text = (event && typeof event.label === 'string' ? event.label : '').trim();
     if (!row || !text) return null;
+    clearFlash();   // the plate owns the glass: the band under it goes quiet for the flight
     measure();      // it lands in the air the band and the toast rail left, never on either
     if (plateTimer) { clearTimeout(plateTimer); plateTimer = 0; }
     if (plate) plate.remove();
@@ -342,7 +428,7 @@ export function createCaptions(root) {
     /** The loaded chart, or null to go quiet. Reads `words` and the trigger events, nothing else. */
     setTrack(chart) {
       phrases = chart ? paintTriggers(buildPhrases(chart.words), chart.events) : [];
-      clearPhrase();
+      clearFlash();
       // hud.js reads this: with words on the glass the act ribbon's old spot under the score
       // plate belongs to the caption band, so the ribbon takes the clear air lower down instead
       root.classList.toggle('has-rc-cap', phrases.length > 0);
@@ -351,9 +437,14 @@ export function createCaptions(root) {
     },
     update,
     showPlate,
+    showWord,
+    /** Which half of this file is driving the band: 'flash' (the pops) or 'type' (the clock). */
+    get mode() { return mode; },
+    /** How many words the flash line is holding right now. The smoke reads it; the game does not. */
+    get flashWords() { return mode === 'flash' ? flashN : 0; },
     /** The run is over or the file was cleared: nothing of the last one stays on the glass. */
     clear() {
-      clearPhrase();
+      clearFlash();
       if (plateTimer) { clearTimeout(plateTimer); plateTimer = 0; }
       if (plate) { plate.remove(); plate = null; }
       if (dimTimer) { clearTimeout(dimTimer); dimTimer = 0; }
@@ -373,4 +464,5 @@ export function createCaptions(root) {
   };
 }
 
-// self-check: node race/smoke/captions-check.mjs cuts the real caption track and drives the layer.
+// self-check: node race/smoke/captions-check.mjs cuts the real caption track, pops words at the
+// band and drives the typewriter behind ?cap=type.

--- a/ConditioningControlPanel/Resources/web/dtrh/race/race.css
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/race.css
@@ -534,6 +534,37 @@
 .race-hud .rc-cap-word.is-said { opacity: 0.82; }
 .race-hud .rc-cap-word.is-said.is-now { opacity: 1; text-shadow: 0 0 16px var(--rc-ink, rgba(255, 105, 180, 0.9)), 0 2px 5px rgba(0, 0, 0, 0.95); }
 
+/* ---- THE FLASH: the word you just popped, on the same band ----
+   The words live on the ROAD now, so the band is the ANSWER to a pop rather than the script:
+   the word lands whole, holds half a second, then lets go over 0.3s. A pop inside 0.3s of the
+   last one joins the line, so a line driven clean reads back as the sentence that was said. A
+   word the kart drove past writes itself grey and faint, and is still read. Same band, same
+   box, same two line cap: captions.js measures this one exactly as it measures the typed one. */
+.race-hud .rc-cap.is-flash { transition: opacity 300ms linear; }
+.race-hud .rc-cap-word.rc-flash-word {
+  display: inline-block; opacity: 1;
+  animation: rcFlashIn 160ms cubic-bezier(0.16, 0.9, 0.3, 1) both;
+}
+/* the ghost fades to its OWN alpha, so it needs its own keyframes: an `animation-fill-mode: both`
+   holds whatever the last keyframe said, and rcFlashIn's last word on opacity is 1. */
+.race-hud .rc-flash-word.is-ghost {
+  opacity: 0.35; color: #d6d0dd; text-shadow: 0 2px 5px rgba(0, 0, 0, 0.95);
+  animation: rcGhostIn 160ms ease-out both;
+}
+@keyframes rcGhostIn { from { opacity: 0; } to { opacity: 0.35; } }
+.race-hud .rc-flash-word.is-accent {
+  font-size: 1.3em; color: var(--rc-ink, #ff69b4);
+  animation: rcFlashIn 160ms cubic-bezier(0.16, 0.9, 0.3, 1) both, rcFlashGlow 160ms ease-out both;
+}
+/* reduced motion (captions.js hangs `is-still` on the word itself): it fades in place, never zooms */
+.race-hud .rc-flash-word.is-still { animation: none; }
+.race-hud .rc-flash-word.is-accent.is-still { text-shadow: 0 0 18px var(--rc-ink, rgba(255, 105, 180, 0.9)), 0 2px 5px rgba(0, 0, 0, 0.95); }
+@keyframes rcFlashIn { from { opacity: 0; transform: scale(1.14); } to { opacity: 1; transform: scale(1); } }
+@keyframes rcFlashGlow {
+  from { text-shadow: 0 0 30px var(--rc-ink, rgba(255, 105, 180, 0.95)), 0 2px 5px rgba(0, 0, 0, 0.95); }
+  to { text-shadow: 0 0 16px var(--rc-ink, rgba(255, 105, 180, 0.9)), 0 2px 5px rgba(0, 0, 0, 0.95); }
+}
+
 /* ---- the plate: out of the vanishing point, into your face ---- */
 .race-hud .rc-plates { position: absolute; inset: 0; perspective: 900px; }
 .race-hud .rc-plate {
@@ -669,5 +700,8 @@
     animation: rcHold 1400ms linear forwards; transform: translate(-50%, -50%) scale(1); filter: none;
   }
   .race-hud .rc-plate--pulse::before, .race-hud .rc-plate--gold .rc-plate-sparks { animation: none; opacity: 0; }
+  /* the flash fades in place too; the ghost keeps its own faintness, which is a reading and not a motion */
+  .race-hud .rc-cap-word.rc-flash-word, .race-hud .rc-flash-word.is-accent,
+  .race-hud .rc-flash-word.is-ghost { animation: none; }
   .race-hud .rc-dim.is-on { animation: none; }
 }

--- a/ConditioningControlPanel/Resources/web/dtrh/race/run.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/run.js
@@ -79,6 +79,13 @@ const SPAWN_T0 = 2.5, RAIN_T0 = 20, EARLY_SLOW = 1.5;   // the opening drips slo
 // track cues: an act only re-dresses the world when no gate is this many seconds of road away, and
 // the standalone page logs the scheduler this often (track time). CUE_AHEAD_SEC lives in race/sync.js.
 const ACT_GATE_SEC = 6, TRACK_STATS_SEC = 10;
+/** How many word bubbles may be in the air at once, at most. The word each one wears is kept by
+ *  the event that spawned it until the bubble is popped or driven past; the ring never grows. */
+const WORD_MEM = 256;
+/** One query flag, lowercased, never throwing (a page with no location is a smoke, not a player). */
+function flag(key) {
+  try { return (new URLSearchParams(location.search).get(key) || '').toLowerCase(); } catch (e) { return ''; }
+}
 const clamp = (v, a, b) => Math.max(a, Math.min(b, v));
 const hex = (n) => '#' + ((n >>> 0) & 0xffffff).toString(16).padStart(6, '0');
 
@@ -124,9 +131,18 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
 
   // ---- the parts that outlive a run ----
   const hud = createRaceHud(hudRoot);
-  // the voice on the glass: the caption line under the chrome and the trigger plate over it.
-  // It reads the track clock and nothing else, so a pause, a resume and a seek all land for free.
-  const captions = hudRoot ? createCaptions(hudRoot) : null;
+  // the voice on the glass: the band under the chrome and the trigger plate over it.
+  // The band ANSWERS THE POPS now (race/captions.js showWord): the words are on the road, so the
+  // word the kart just took is what lands, and the word it drove past lands as a ghost. The old
+  // word-timed typewriter is one release behind `?cap=type`; a track with no words file had no
+  // caption either way and is untouched.
+  const CAP_MODE = flag('cap') === 'type' ? 'type' : 'flash';
+  /** `?words=unread`: a word the kart drove past writes nothing. Ghost is the default. */
+  const GHOST_MISSES = flag('words') !== 'unread';
+  const captions = hudRoot ? createCaptions(hudRoot, { mode: CAP_MODE }) : null;
+  /** The word a word bubble wears, by the event that spawned it. race/bubbles.js is the layer that
+   *  DRAWS a bubble and it stays that: the pop and the ghost read the text off here instead. */
+  const wordOf = new Map();
   const fxProxy = { pulseFlash: (a) => { if (W) W.fx.pulseFlash(a); } };   // fx is rebuilt on "again"
   const payloadFx = createPayloadFx({ hud: sfHud, fx: fxProxy, media });
   // Q.leanSpirals (mobile): spiral pops draw from the two lightest bundled gifs, fetched while the intro plays
@@ -225,7 +241,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
       wasAirborne: false, airH: 0, effects: [], moodHeld: null, moodHold: 0, mood: 'calm', seed: runSeed,
       trackHold: 0, trackHoldFrom: 0, trackFog: 0, trackPaused: false, statsAt: 0, trackGap: 0 });
     trailClear();
-    mix.reset(); PACE.reset(); S.wobble = 0; clearMixChrome(); sync.reset();
+    mix.reset(); PACE.reset(); S.wobble = 0; clearMixChrome(); sync.reset(); wordOf.clear();
     hud.setScore(0); hud.setCombo(0, 1); hud.setBank(0); hud.setSpeed(0); hud.setFraught(0); hud.passiveClear(); TR.gild(0);
   }
 
@@ -252,8 +268,22 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
       sfx('golden_pop', 0.9); shake.shake(0.35, 240); poke('jackpot', 1.4); w.kart.pose('cheer');
     }
   }
+  /**
+   * THE FLASH. The word that bubble wore goes on the band: bright on a pop, a grey ghost on a
+   * word the kart drove past. Pops inside race/captions.js FLASH_JOIN_MS join one line, so a line
+   * of word bubbles taken clean reads back as the sentence the voice said.
+   * @param eventId the chart event that spawned the bubble, @param ghost true for a miss
+   */
+  function flashWord(eventId, ghost) {
+    if (!captions || !eventId) return;
+    const rec = wordOf.get(eventId);
+    if (!rec) return;
+    wordOf.delete(eventId);                       // one bubble, one flash: it is popped or it is past
+    if (ghost && !GHOST_MISSES) return;
+    captions.showWord(rec.w, { ink: rec.ink, accent: rec.accent, ghost: !!ghost });
+  }
   function onPop(w, p) {
-    if (p.eventId) TR.taken(p.eventId);
+    if (p.eventId) { TR.taken(p.eventId); flashWord(p.eventId, false); }
     w.kart.pulseTarget(); w.kart.pose('grab', { side: (p.x == null ? w.kart.state.x : p.x) >= w.kart.state.x ? 1 : -1 });
     if (S.sweep) sfx('chain_pop', 0.5);          // the pump: every pop on the road sounds like the chain
     if (p.kind === 'treat') return treat(w, p);
@@ -339,6 +369,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     }
   }
   function onMiss(w, m) {
+    flashWord(m.eventId, true);   // the script is never hostage to the steering: the word still lands, grey
     // ALMOST: the treat slid past inside NEAR_MISS_M but outside the hit box; else the streak lets go
     let best = null, bestGap = Infinity;
     for (const s of trail) { if (!s.ok) continue; const g = Math.abs(w.layout.wrap(s.d - m.d + w.layout.totalDepth / 2) - w.layout.totalDepth / 2); if (g < bestGap) { bestGap = g; best = s; } }
@@ -410,7 +441,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
   function setTrack(chart) {
     const t = TR.setTrack(chart);
     audio.setRoute(routeOf(t));
-    S.trackHold = 0; S.statsAt = 0; sync.reset();
+    S.trackHold = 0; S.statsAt = 0; sync.reset(); wordOf.clear();
     if (W) { W.field.setTracked(!!t); W.field.setSparse(TR.lyrics); W.field.setDensity(1); if (!t) applyFog(W, 0); }
     if (captions) captions.setTrack(t ? t.chart : null);
     audio.duck(!!t, 'track');   // the file is the soundtrack: the room OST sits under it until it is cleared
@@ -453,6 +484,12 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
       const rowId = w.field.spawnRow({ kindId: row[0].kindId, kindIds: row.map((sp) => sp.kindId), placement: row[0].placement, d, h: row[0].h, xs: row.map((sp) => sp.x), eventId: e.id,
         w: row[0].w || '', ink: row[0].ink || null, big: !!row[0].big });   // the tag, on the middle bubble alone
       if (rowId) sync.trackRow(rowId, e, at, d, t);
+      // the word this bubble wears, kept until it is popped or driven past (flashWord spends it).
+      // A trigger ROW is not one of these: its word flies at the camera on the plate instead.
+      if (rowId && e.kind === 'word' && row[0].w) {
+        if (wordOf.size >= WORD_MEM) wordOf.delete(wordOf.keys().next().value);
+        wordOf.set(e.id, { w: row[0].w, ink: row[0].ink || null, accent: !!row[0].big });
+      }
     }
     for (const sp of loose) {
       w.field.spawnAt({ kindId: sp.kindId, placement: sp.placement, d: sync.depthFor(t, ks.d, ks.speed, e.t + (sp.at || 0)), x: sp.x, h: sp.h, eventId: e.id });
@@ -781,6 +818,10 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     trackEnded: () => { TR.end(); if (TR.track && S.running) endRun(); }, trackStats: () => TR.stats(), syncTrace: () => sync.trace(), debugPickup,
     /** What race/smoke/face-check.mjs reads: the word faces on the road this frame. */
     wordFaces: () => (W ? W.field.faceReport() : null),
+    /** race/smoke/captions-check.mjs: one word at the band, the same call a pop makes. */
+    debugWord: (text, o) => (captions ? captions.showWord(text, o || {}) != null : false),
+    /** Which half of race/captions.js is driving the band on this build: 'flash' or 'type'. */
+    capMode: () => CAP_MODE,
     get track() { return TR.track; } };
 }
 

--- a/ConditioningControlPanel/Resources/web/dtrh/race/smoke/captions-check.mjs
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/smoke/captions-check.mjs
@@ -9,6 +9,14 @@
  * things this layer can get wrong that no unit test sees are "the caption sits on
  * the score plate" and "the plate never actually reached the DOM".
  *
+ * The browser half boots the same fixture TWICE, because the band has two halves of
+ * its own now. `?cap=type` is the old word-timed typewriter (sections 2, 3 and 7);
+ * the default build is THE FLASH (section 7b), where the words are on the road and
+ * the band answers a pop instead of typing the file. The flash section holds the
+ * whole rule: within 50 ms of a pop, joined inside 0.3 s, a fresh line after the
+ * fade, a ghost at 0.35 for a word driven past, two lines at most, no typewriter,
+ * and never a pixel on the score plate, the toast rail or the plate's rest spot.
+ *
  * The browser half builds one fixture chart off the real transcript, serves it to
  * `?chart=<url>`, then drives `race.trackClock(t, false)` straight at the seconds
  * it wants to look at. That is the host's own door, it is how a pause looks from
@@ -27,7 +35,8 @@ import { readFileSync, mkdtempSync, rmSync, existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, extname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { buildPhrases, paintTriggers, MAX_WORDS, GAP_SEC, HOLD_SEC, PLATE_MS } from '../captions.js';
+import { buildPhrases, paintTriggers, MAX_WORDS, GAP_SEC, HOLD_SEC, PLATE_MS,
+  FLASH_HOLD_MS, FLASH_FADE_MS, FLASH_JOIN_MS, GHOST_ALPHA } from '../captions.js';
 import { THEME_BY_PRESET, themeFor } from '../triggerTheme.js';
 import { wordedRoad, PEAKS_PER_SEC } from '../cloudChart.js';
 
@@ -154,12 +163,18 @@ await cdp('Runtime.enable'); await cdp('Page.enable');
 await cdp('Emulation.setDeviceMetricsOverride', { width: 390, height: 844, deviceScaleFactor: 2, mobile: true });
 
 const site = `http://127.0.0.1:${PORT}`;
-await cdp('Page.navigate', { url: `${site}/dtrh/race.html?autostart=1&intro=0&cards=0&chart=${encodeURIComponent(`${site}/fixture.json`)}` });
-let up = false;
-for (let i = 0; i < 120 && !up; i++) {
-  await sleep(250);
-  up = await ev(`!!(window.__race && window.__race.race && window.__race.race.track && document.querySelector('.rc-layer'))`);
+const FIXTURE_URL = `${site}/dtrh/race.html?autostart=1&intro=0&cards=0&chart=${encodeURIComponent(`${site}/fixture.json`)}`;
+/** Boot the fixture road and wait for the caption layer. Returns false if it never came up. */
+async function boot(url) {
+  await cdp('Page.navigate', { url });
+  for (let i = 0; i < 120; i++) {
+    await sleep(250);
+    if (await ev(`!!(window.__race && window.__race.race && window.__race.race.track && document.querySelector('.rc-layer'))`)) return true;
+  }
+  return false;
 }
+// sections 2, 3 and 7 are the TYPEWRITER, which is one release behind ?cap=type now
+const up = await boot(`${FIXTURE_URL}&cap=type`);
 ok(up, 'the page boots the fixture road and builds the caption layer');
 if (!up) {
   console.error('    boot: ' + await ev(`JSON.stringify({ race: !!window.__race, run: !!(window.__race&&window.__race.race), track: !!(window.__race&&window.__race.race&&window.__race.race.track), layer: !!document.querySelector('.rc-layer'), hud: !!document.querySelector('.race-hud'), body: document.body.className, url: location.href, title: document.title, html: document.documentElement.outerHTML.length })`));
@@ -336,6 +351,126 @@ eq(lines3, 0, `no phrase of the ${phrases.length} on this track draws a third li
 eq(clipped, 0, 'and none of them is cut off by its own box');
 ok(!!worst && worst.cap.y + worst.cap.h <= worst.vh, `the tallest band on the track is whole on the glass (${widest}px, bottom ${worst ? worst.cap.y + worst.cap.h : '?'} of ${shot.vh})`);
 ok(!!worst && !hits(worst.cap, worst.score), 'and even the tallest keeps off the score plate');
+
+/* ============================================================================
+ * 7b. THE FLASH: the band answers the pops, and nothing types
+ *
+ * The default build. The words are on the road (race/wordBubbles.js), so the band
+ * is where a POP is answered: the word lands whole, holds, joins the line if
+ * another pop is inside 0.3 s, and a word the kart drove past still lands as a
+ * grey ghost. `race.debugWord` is the same call race/run.js onPop makes, so the
+ * timings below are the layer's own and not a re-implementation of them.
+ *
+ * It never prints a word of the transcript: everything here is counted, measured
+ * or read off a class, and the one word it puts on the glass itself is 'ok'.
+ * ==========================================================================*/
+const upFlash = await boot(FIXTURE_URL);
+ok(upFlash, 'the default build boots the same road');
+if (!upFlash) await done(1);
+eq(await ev(`window.__race.race.capMode()`), 'flash', 'and the band is the flash, not the typewriter');
+
+/** What the band is holding right now: the words, their classes, and the boxes around them. */
+const band = () => json(`(()=>{ const cap=document.querySelector('.rc-cap');
+  const r=(el)=>{ if(!el) return null; const b=el.getBoundingClientRect(); return { x:Math.round(b.left), y:Math.round(b.top), w:Math.round(b.width), h:Math.round(b.height) }; };
+  const words=[...document.querySelectorAll('.rc-flash-word')];
+  const tops=new Set(); for(const w of words){ const b=w.getBoundingClientRect(); if(b.height>0) tops.add(Math.round(b.top)); }
+  const cs=(w)=>getComputedStyle(w);
+  return { n: words.length, typed: document.querySelectorAll('.rc-cap-word:not(.rc-flash-word)').length,
+    ghosts: words.filter(w=>w.classList.contains('is-ghost')).length,
+    accents: words.filter(w=>w.classList.contains('is-accent')).length,
+    alpha: words.map(w=>Math.round(+cs(w).opacity*100)/100), fs: words.map(w=>Math.round(parseFloat(cs(w).fontSize))),
+    lines: tops.size, hidden: !cap || cap.hidden, capOut: +getComputedStyle(cap).opacity,
+    cap: cap&&!cap.hidden?r(cap):null, score: r(document.querySelector('.rh-score-wrap')),
+    rail: r(document.querySelector('.rh-toasts')), plateY: parseFloat(getComputedStyle(document.querySelector('.rc-layer')).getPropertyValue('--rc-plate-y'))||0,
+    vw: innerWidth, vh: innerHeight };})()`);
+
+// Everything from here to the plate runs on the WORDLESS opening this file has (the road's own
+// first word is a minute and a half in), so no real bubble can land on the band mid-measurement.
+const quiet = await band();
+ok(quiet.hidden || quiet.n === 0, 'the band is off the glass until something pops: nothing types itself');
+
+// 1. a pop puts the whole word on the band, now
+const first = await json(`(()=>{ const t0=performance.now(); window.__race.race.debugWord('ok');
+  return { ms: Math.round(performance.now()-t0), n: document.querySelectorAll('.rc-flash-word').length,
+    len: (document.querySelector('.rc-flash-word')||{}).textContent?.length||0 };})()`);
+ok(first.ms <= 50, `the word is on the band ${first.ms}ms after the pop (50ms is the bar)`);
+eq(first.n, 1, 'and it is one whole word, not a letter of one');
+eq(first.len, 2, 'with the whole of it in the DOM at once: no typing');
+
+// 2. pops inside FLASH_JOIN_MS join the line; the sentence is what a clean line reads back as.
+// All three go in ONE evaluate: the join window is 0.3 s and a debug round trip is not free.
+await sleep(FLASH_HOLD_MS + FLASH_FADE_MS + 250);
+const joined = await json(`(()=>{ const r=window.__race.race; r.debugWord('ok'); r.debugWord('ok'); r.debugWord('ok');
+  const words=[...document.querySelectorAll('.rc-flash-word')], tops=new Set();
+  for (const w of words) { const b=w.getBoundingClientRect(); if (b.height>0) tops.add(Math.round(b.top)); }
+  return { n: words.length, lines: tops.size };})()`);
+eq(joined.n, 3, `three pops inside ${FLASH_JOIN_MS}ms are one line of three`);
+ok(joined.lines <= 2, `and the line is ${joined.lines} row(s), never more than 2`);
+
+// 3. a pop after the line has gone starts a fresh one
+await sleep(FLASH_HOLD_MS + FLASH_FADE_MS + 250);
+const gone = await band();
+ok(gone.hidden || gone.n === 0, `the line lets go ${FLASH_HOLD_MS}ms after the last pop and fades over ${FLASH_FADE_MS}ms`);
+await ev(`window.__race.race.debugWord('ok')`);
+const restarted = await band();
+eq(restarted.n, 1, 'and the next pop starts a fresh line rather than joining a dead one');
+
+// 4. the ghost: a word the kart drove past is still read, faint and grey
+await ev(`window.__race.race.debugWord('ok', { ghost: true })`);
+await sleep(220);        // past its 160ms fade in: an alpha read mid-animation is the animation's, not the rule's
+const ghosted = await band();
+eq(ghosted.ghosts, 1, 'a word the kart drove past still writes itself');
+ok(Math.abs(ghosted.alpha[ghosted.alpha.length - 1] - GHOST_ALPHA) < 0.02,
+  `and it sits at ${GHOST_ALPHA} where a popped word sits at 1 (got ${ghosted.alpha[ghosted.alpha.length - 1]})`);
+
+// 5. an accent word is bigger and wears the set's ink
+await sleep(FLASH_HOLD_MS + FLASH_FADE_MS + 250);
+await ev(`window.__race.race.debugWord('ok'); window.__race.race.debugWord('ok', { accent: true, ink: '#ff69b4' })`);
+const accented = await band();
+eq(accented.accents, 1, 'an accent word is marked as one');
+ok(accented.fs[1] > accented.fs[0], `and drawn bigger than the plain word beside it (${accented.fs[0]}px -> ${accented.fs[1]}px)`);
+
+// 6. a long chain never spills a third line, and never leaves the band's own box
+await sleep(FLASH_HOLD_MS + FLASH_FADE_MS + 250);
+await ev(`for (let i = 0; i < 12; i++) window.__race.race.debugWord('conditioning')`);
+const chain = await band();
+ok(chain.lines <= 2, `twelve long pops in a row still draw ${chain.lines} line(s), never a third`);
+ok(!!chain.cap && chain.cap.y >= 0 && chain.cap.y + chain.cap.h <= chain.vh, 'and the band is whole on the glass');
+const hitB = (a, b) => !!a && !!b && a.x < b.x + b.w && b.x < a.x + a.w && a.y < b.y + b.h && b.y < a.y + a.h;
+ok(!hitB(chain.cap, chain.score), `it never touches the score plate (band ${chain.cap.y}..${chain.cap.y + chain.cap.h}, plate ${chain.score.y}..${chain.score.y + chain.score.h})`);
+ok(!hitB(chain.cap, chain.rail), 'nor the toast rail');
+ok(chain.plateY > chain.cap.y + chain.cap.h, `and the plate's rest spot is still clear under it (band bottom ${chain.cap.y + chain.cap.h}, plate y ${chain.plateY})`);
+
+// 7. the typewriter really is behind ?cap=type: the clock inside a phrase writes nothing
+await sleep(FLASH_HOLD_MS + FLASH_FADE_MS + 250);
+await ev(`window.__race.race.trackClock(${target.words[1].t}, false)`);
+await sleep(300);
+eq((await band()).typed, 0, 'the clock inside a phrase types nothing: the typewriter only lives behind ?cap=type');
+
+// 8. the plate owns the glass: a trigger clears the band under it. The count is taken AT the frame
+// the plate reaches the DOM, because the kart is still driving and a real pop is 60ms away.
+await ev(`window.__race.race.debugWord('ok')`);
+ok((await band()).n >= 1, 'a word is on the band');
+await ev(`(()=>{ window.__atPlate = -1;
+  new MutationObserver((ms)=>{ for (const m of ms) for (const n of m.addedNodes) {
+    if (n.classList && n.classList.contains('rc-plate') && window.__atPlate < 0) window.__atPlate = document.querySelectorAll('.rc-flash-word').length;
+  } }).observe(document.querySelector('.rc-plates'), { childList: true });
+  window.__race.race.debugWord('ok'); window.__race.race.trackClock(${trig.t}, false); })()`);
+await sleep(500);
+eq(await ev(`window.__atPlate`), 0, 'and the trigger plate clears it: one thing at a time on the glass');
+eq(await json(`document.querySelectorAll('.rc-plate').length`), 1, 'with the plate itself flying');
+
+// 9. THE WIRING: real pops on the real road, counted as they land
+await ev(`(()=>{ window.__flash = 0; window.__ghost = 0;
+  const line = document.querySelector('.rc-cap-line');
+  new MutationObserver((ms)=>{ for (const m of ms) for (const n of m.addedNodes) {
+    if (!n.classList || !n.classList.contains('rc-flash-word')) continue;
+    window.__flash++; if (n.classList.contains('is-ghost')) window.__ghost++; } }).observe(line, { childList: true });
+  window.__race.race.trackClock(${Math.max(0, road.words[0].t - 0.7)}, true); })()`);
+await sleep(6000);
+const live = await json(`({ flash: window.__flash, ghost: window.__ghost, t: window.__race.race.track.t })`);
+ok(live.t > road.words[0].t, `the road rolled through the first spoken words (to ${live.t.toFixed(1)}s)`);
+ok(live.flash > 0, `and ${live.flash} of them reached the band off real pops and passes (${live.ghost} as ghosts)`);
 
 /* ============================================================================
  * 8. the demo road still runs, and nothing shouted


### PR DESCRIPTION
W3 of the word bubbles wave, on top of W1 (#938) and W2 (#939).

The words are on the road now, so the caption band stops being where the script is READ
and becomes where a pop is ANSWERED. The typewriter goes one release behind `?cap=type`.

## what lands

**The flash.** `race/captions.js` grows `showWord(text, { ghost, accent, ink })`. The word
lands on the band whole, no typing, holds `FLASH_HOLD_MS` 500, lets go over `FLASH_FADE_MS`
300. A pop inside `FLASH_JOIN_MS` 300 of the last one JOINS its line, so a line of word
bubbles taken clean reads back as the sentence that was said; a pop after the line began to
go starts a fresh one. Two lines and no more: a word that spills the line into a third row
starts the line again rather than shrinking to fit, because the sentence has already been
read and this is the answer to a pop, not the script. Accent words (the `ACCENT_WORDS` list
`cues.js` already stamps on the spawn) are 1.3x, wear the ink of the set the road says that
second belongs to, and glow for 160 ms. Reduced motion fades in place and never zooms.

**The ghost.** A word bubble the kart drove past still writes itself on the band, grey and
at `GHOST_ALPHA` 0.35, so the script is never hostage to the steering. `?words=unread` turns
the ghosts off, for the owner to feel both.

**The typewriter** is untouched behind `?cap=type`. A track with no words file never had a
caption and still does not.

**The plate** is exactly what it was, on all thirteen themes, fired by `sync.js` at
`event.t` as today. What is new is that it CLEARS the band under it: one thing at a time
on the glass.

**The wiring** lives in `run.js`, not in `bubbles.js`. The pop and miss callbacks carry an
`eventId` but not the word, so `run.js` keeps the word each word bubble wears by the event
that spawned it (a ring of `WORD_MEM` 256, cleared with the run and on a track swap) and
spends it on the pop or on the pass. `race/bubbles.js`, `race/wordTags.js` and
`race/wordFace.js` are not touched by this PR: they belong to the parallel word-face task.

## what the brief asked for and the code already had

The last item of W3 was "on worded tracks the random effect dressing appears only where no
word bubble is due for over 4 s". That is already true, and more strictly than asked:
`bubbles.js` `sparse` (set from `TR.lyrics`) makes `seedChunk` place ONE golden per chunk
and nothing else on a transcript road, `spawnAhead` and the rain bursts stand down whenever
a track is loaded, and `cues.js` halves a peak's rain and draws it from a fixed room kind
rather than `rollKind`. There is no random effect dressing left on a worded road to gate,
so nothing was built for it.

## smokes

`race/smoke/captions-check.mjs` boots the same fixture twice: `?cap=type` for the typewriter
sections it always had, and the default build for the flash. The flash section holds the
whole rule (the word on the band within 50 ms of a pop, joined inside 0.3 s, a fresh line
after the fade, the ghost at 0.35, the accent bigger, no typewriter, two lines at most under
twelve long pops, and never a pixel on the score plate, the toast rail or the plate's rest
spot at 390x844), watches the band at the exact frame a plate lands, then lets the real road
roll through its first spoken words and counts what reached the band off real pops and passes
(16 on this run). It still never prints a word of a transcript: everything is counted.

Green on this head: `captions-check` (all good, 0 console errors), plus `chart-check`,
`words-check`, `words-rate-check`, `levels-check`, `cloud-chart-check`, `lyrics-road-check`,
`track-run-check`, `rows-check`, `sync-check`, `fov-check`, `pickups-check`,
`spiral-pool-check`, `label-px-check`, `wall-dom-check`, `poses-smoke`, `gltf-smoke`,
`audio-check`, `ost-resident-check`, `cloud-check`, `remote-feed-check`, and `pace-check` /
`touch-check` run standalone.

346 changed lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJ66hi5fRM1Dcjo38aSCa2
