### PR TITLE
feat(race): the plate flies on the pop, and the ladder counts lines

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/race/chart.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/chart.js
@@ -148,6 +148,9 @@ function normalizeEvents(raw, durationSec) {
       if (e.kind === 'word' && typeof e.w === 'string' && e.w) {
         ev.w = e.w.slice(0, 40);
         ev.x = clamp(num(e.x, 0), -LANE_X_MAX, LANE_X_MAX);
+        // and the LINE it belongs to (race/wordBubbles.js wordEventsFrom). A phrase is what the
+        // ladder and the end card count in, so losing this turns a sentence back into loose words.
+        if (isFinite(num(e.p, NaN))) ev.p = Math.max(0, Math.round(num(e.p, 0)));
       }
       if (e.kind === 'chant') { ev.reps = Math.max(1, Math.round(num(e.reps, 3))); ev.period = Math.max(0, num(e.period, 0)); }
       // An author marks the events they placed by hand inside a road, names the cue they
@@ -318,10 +321,29 @@ export function createScheduler(chart, opts = {}) {
     taken(id) { if (id) takenIds.add(id); },
     /** cues.js had nothing to put on the road for this one (a word the spotter only guessed at): it leaves the count. */
     skip(id) { if (id) skipped.add(id); },
+    /**
+     * The end card's "you took N of M". A PHRASE of word bubbles is ONE thing to take, not one per
+     * word: a road built off a transcript lays three bubbles a second and "you took 412 of 987" is
+     * a number nobody drove for. So every word event carrying a phrase index (`p`) folds into its
+     * line, and the line counts as taken only when every one of its bubbles was. Everything else
+     * (a trigger row, a count, a drop) is one thing to take, exactly as before, and so is a word
+     * event with no phrase index on it (the demo chart, a hand-written one).
+     */
     stats() {
-      let countable = 0;
-      for (const e of ch.events) if (COUNTABLE.has(e.kind) && !skipped.has(e.id)) countable++;
-      return { total: ch.events.length, fired: fired.size, countable, taken: takenIds.size, missed };
+      let countable = 0, taken = 0;
+      const lines = new Map();
+      for (const e of ch.events) {
+        if (!COUNTABLE.has(e.kind) || skipped.has(e.id)) continue;
+        if (e.kind === 'word' && e.p != null) {
+          let r = lines.get(e.p);
+          if (!r) { r = { n: 0, got: 0 }; lines.set(e.p, r); }
+          r.n++; if (takenIds.has(e.id)) r.got++;
+          continue;
+        }
+        countable++; if (takenIds.has(e.id)) taken++;
+      }
+      for (const r of lines.values()) { countable++; if (r.got >= r.n) taken++; }
+      return { total: ch.events.length, fired: fired.size, countable, taken, phrases: lines.size, missed };
     },
     reset() { fired.clear(); takenIds.clear(); skipped.clear(); cursor = 0; lastT = 0; missed = 0; },
     get chart() { return ch; },

--- a/ConditioningControlPanel/Resources/web/dtrh/race/run.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/run.js
@@ -44,7 +44,7 @@ import { createFx } from '../engine/fx.js';
 import { createPayloadFx } from '../game/payloadFx.js';
 import { setBundledSpiralPool, prefetchSpirals, LEAN_SPIRALS } from '../engine/loomSpirals.js';
 import { createScreenShake } from '../game/screenShake.js';
-import { INTENSITY_RAMP_SEC, TREATS_ONLY_SEC, KART_BASE_SPEED, MULT_LADDER, makeRng } from './consts.js';
+import { INTENSITY_RAMP_SEC, TREATS_ONLY_SEC, KART_BASE_SPEED, MULT_LADDER, COMBO_HOLD_SEC, makeRng } from './consts.js';
 import { createPace } from './pace.js';
 import { createSpine } from './spine.js';
 import { roomById, rollRoomOrder, createRoomDresser } from './rooms.js';
@@ -143,6 +143,12 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
   /** The word a word bubble wears, by the event that spawned it. race/bubbles.js is the layer that
    *  DRAWS a bubble and it stays that: the pop and the ghost read the text off here instead. */
   const wordOf = new Map();
+  // THE LINE LEDGER. A road built off a transcript lays three word bubbles a second, so a ladder
+  // that stepped on every one of them would hand out an 8x for twenty seconds of a chant. The rung
+  // is a LINE instead: `lineN` is how many bubbles each phrase of the file has (built with the
+  // track), `lineGot` how many of them the kart has taken this run, and the pop that finishes one
+  // calls race/score.js chain(). A phrase left half-taken simply never pays.
+  const lineN = new Map(), lineGot = new Map(), lineDone = new Set();
   const fxProxy = { pulseFlash: (a) => { if (W) W.fx.pulseFlash(a); } };   // fx is rebuilt on "again"
   const payloadFx = createPayloadFx({ hud: sfHud, fx: fxProxy, media });
   // Q.leanSpirals (mobile): spiral pops draw from the two lightest bundled gifs, fetched while the intro plays
@@ -165,7 +171,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     elapsed: 0, t: 0, intensity: intensityFloor, timeScale: 1, jackpotBias: 1, sweep: false, tide: 1,
     spawnT: SPAWN_T0, rainT: RAIN_T0, tunnelTime: 0, rush: 0, fov: fovBase, fovBoost: 0, gates: 0, room: null,
     wasAirborne: false, airH: 0, effects: [], moodHeld: null, moodHold: 0, mood: 'calm', bestAtStart: 0, seed, wobble: 0,
-    trackHold: 0, trackHoldFrom: 0, trackFog: 0, trackPaused: false, statsAt: 0, trackGap: 0,   // trackHold: the track second a fog/density hold ends, 0 for none
+    trackHold: 0, trackHoldFrom: 0, trackFog: 0, trackPaused: false, statsAt: 0, trackGap: 0, quiet: false, quietAt: -9,   // trackHold: the track second a fog/density hold ends, 0 for none
   };
   fovLive = true;   // S exists: resize() may shift S.fov from here on
   const mix = createCocktail({ now: () => S.elapsed });   // THE MIX: one live effect per category (cocktail.js); S.effects mirrors its live slots
@@ -239,9 +245,9 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     Object.assign(S, { running: false, paused: false, ended: false, elapsed: 0, t: 0, intensity: intensityFloor, timeScale: 1,
       jackpotBias: 1, sweep: false, tide: 1, spawnT: SPAWN_T0, rainT: RAIN_T0, rush: 0, fovBoost: 0, gates: 0, room: null,
       wasAirborne: false, airH: 0, effects: [], moodHeld: null, moodHold: 0, mood: 'calm', seed: runSeed,
-      trackHold: 0, trackHoldFrom: 0, trackFog: 0, trackPaused: false, statsAt: 0, trackGap: 0 });
+      trackHold: 0, trackHoldFrom: 0, trackFog: 0, trackPaused: false, statsAt: 0, trackGap: 0, quiet: false, quietAt: -9 });
     trailClear();
-    mix.reset(); PACE.reset(); S.wobble = 0; clearMixChrome(); sync.reset(); wordOf.clear();
+    mix.reset(); PACE.reset(); S.wobble = 0; clearMixChrome(); sync.reset(); wordOf.clear(); lineGot.clear(); lineDone.clear();
     hud.setScore(0); hud.setCombo(0, 1); hud.setBank(0); hud.setSpeed(0); hud.setFraught(0); hud.passiveClear(); TR.gild(0);
   }
 
@@ -261,8 +267,8 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
   }
 
   // ---- pops ----
-  function treat(w, p) {
-    w.score.pop(p.points, p.id);
+  function treat(w, p, word) {
+    w.score.pop(p.points, p.id, word ? { combo: false } : undefined);   // a word is worth its treat and no rung
     if (p.id === 'golden') {
       w.score.jackpot(S.jackpotBias > 1 ? 'major' : 'minor');
       sfx('golden_pop', 0.9); shake.shake(0.35, 240); poke('jackpot', 1.4); w.kart.pose('cheer');
@@ -274,19 +280,32 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
    * of word bubbles taken clean reads back as the sentence the voice said.
    * @param eventId the chart event that spawned the bubble, @param ghost true for a miss
    */
-  function flashWord(eventId, ghost) {
-    if (!captions || !eventId) return;
+  function spendWord(w, eventId, ghost) {
+    if (!eventId) return;
     const rec = wordOf.get(eventId);
     if (!rec) return;
     wordOf.delete(eventId);                       // one bubble, one flash: it is popped or it is past
-    if (ghost && !GHOST_MISSES) return;
-    captions.showWord(rec.w, { ink: rec.ink, accent: rec.accent, ghost: !!ghost });
+    if (captions && (!ghost || GHOST_MISSES)) captions.showWord(rec.w, { ink: rec.ink, accent: rec.accent, ghost: !!ghost });
+    if (ghost || rec.p == null || lineDone.has(rec.p)) return;
+    const n = lineN.get(rec.p) || 0, got = (lineGot.get(rec.p) || 0) + 1;
+    lineGot.set(rec.p, got);
+    if (n > 0 && got >= n) { lineDone.add(rec.p); w.score.chain(); }   // the whole line, read clean: one rung
+  }
+  /** THE PLATE, ON THE POP. The player took the row before the voice reached it, so the word flies
+   *  at the camera NOW rather than on a second they already beat. race/sync.js claim() marks the
+   *  held cue, so the frame that reaches event.t still fires the mix, the mood and the fog and just
+   *  leaves the plate alone. A row nobody takes plates on its second exactly as it always did. */
+  function platePop(eventId) {
+    if (!captions) return;
+    const early = sync.claim(eventId);
+    if (early && early.event.kind === 'trigger' && early.cue.word) captions.showPlate(early.event);
   }
   function onPop(w, p) {
-    if (p.eventId) { TR.taken(p.eventId); flashWord(p.eventId, false); }
+    const word = !!p.eventId && wordOf.has(p.eventId);   // a bubble off the transcript, not a chunk golden
+    if (p.eventId) { TR.taken(p.eventId); platePop(p.eventId); spendWord(w, p.eventId, false); }
     w.kart.pulseTarget(); w.kart.pose('grab', { side: (p.x == null ? w.kart.state.x : p.x) >= w.kart.state.x ? 1 : -1 });
     if (S.sweep) sfx('chain_pop', 0.5);          // the pump: every pop on the road sounds like the chain
-    if (p.kind === 'treat') return treat(w, p);
+    if (p.kind === 'treat') return treat(w, p, word);
     // THE MIX: one live effect per category, each with its own re-pop rule (cocktail.js); 'held' scores as a treat
     const durationMult = 0.5 + 0.5 * S.intensity;
     const r = mix.add(p.id, { durationMult });
@@ -369,17 +388,19 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     }
   }
   function onMiss(w, m) {
-    flashWord(m.eventId, true);   // the script is never hostage to the steering: the word still lands, grey
+    const word = !!m.eventId && wordOf.has(m.eventId);
+    spendWord(w, m.eventId, true);   // the script is never hostage to the steering: the word still lands, grey
     // ALMOST: the treat slid past inside NEAR_MISS_M but outside the hit box; else the streak lets go
     let best = null, bestGap = Infinity;
     for (const s of trail) { if (!s.ok) continue; const g = Math.abs(w.layout.wrap(s.d - m.d + w.layout.totalDepth / 2) - w.layout.totalDepth / 2); if (g < bestGap) { bestGap = g; best = s; } }
     const near = best && m.x != null && Math.abs(m.x - best.x) < NEAR_MISS_M && Math.abs((m.h || 0) - best.h) < NEAR_MISS_M;
-    if (near) w.score.nearMiss(); else w.score.miss();
+    // a word driven past is a word unread, never a broken streak: only a missed ROW lets the ladder go
+    if (near) w.score.nearMiss(); else if (!word) w.score.miss();
   }
   function onScore(w, e) {
     switch (e.type) {
       case 'pop': hud.setScore(e.score); hud.setCombo(e.combo, e.mult); hud.toast(`+${e.gain}`, 'pop'); break;
-      case 'combo': if (!e.combo) hud.setCombo(0, w.score.state.mult); break;
+      case 'combo': hud.setCombo(e.combo, e.mult != null ? e.mult : w.score.state.mult); break;   // a rung off a whole line moves it too
       case 'mult': hud.setCombo(w.score.state.combo, e.to); if (e.to > e.from) { hud.toast(`x${e.to}`, 'pop'); sfx('streak_milestone', 0.6); poke('smug', 1.0); } break;
       case 'miss': hud.setCombo(0, e.mult); break;
       case 'almost': hud.setScore(e.score); hud.toast(`almost +${e.gain}`, 'almost'); break;
@@ -441,7 +462,11 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
   function setTrack(chart) {
     const t = TR.setTrack(chart);
     audio.setRoute(routeOf(t));
-    S.trackHold = 0; S.statsAt = 0; sync.reset(); wordOf.clear();
+    S.trackHold = 0; S.statsAt = 0; S.quiet = false; S.quietAt = -9; sync.reset(); wordOf.clear();
+    lineN.clear(); lineGot.clear(); lineDone.clear();
+    for (const e of (t && t.chart && Array.isArray(t.chart.events) ? t.chart.events : [])) {
+      if (e.kind === 'word' && e.p != null) lineN.set(e.p, (lineN.get(e.p) || 0) + 1);
+    }
     if (W) { W.field.setTracked(!!t); W.field.setSparse(TR.lyrics); W.field.setDensity(1); if (!t) applyFog(W, 0); }
     if (captions) captions.setTrack(t ? t.chart : null);
     audio.duck(!!t, 'track');   // the file is the soundtrack: the room OST sits under it until it is cleared
@@ -488,7 +513,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
       // A trigger ROW is not one of these: its word flies at the camera on the plate instead.
       if (rowId && e.kind === 'word' && row[0].w) {
         if (wordOf.size >= WORD_MEM) wordOf.delete(wordOf.keys().next().value);
-        wordOf.set(e.id, { w: row[0].w, ink: row[0].ink || null, accent: !!row[0].big });
+        wordOf.set(e.id, { w: row[0].w, ink: row[0].ink || null, accent: !!row[0].big, p: e.p == null ? null : e.p });
       }
     }
     for (const sp of loose) {
@@ -497,7 +522,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     sync.defer(e, cue, t);
   }
   /** The visible half of a cue, on the word: trackFrame fires it the frame the clock reaches event.t. */
-  function spendCue(w, event, cue) {
+  function spendCue(w, event, cue, plated) {
     const ks = w.kart.state;
     if (cue.jump) { ks.vh = Math.max(ks.vh, cue.jump); ks.h = Math.max(ks.h, 0.06); ks.airborne = true; w.kart.pose('air'); }
     if (cue.mix) cueMix(w, cue.mix);
@@ -506,7 +531,10 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     if (cue.toast) hud.toast(cue.toast.text, cue.toast.kind || 'effect');
     // a sure trigger no longer whispers on the toast rail: it flies at the camera, themed off the
     // preset its set carries (race/captions.js + race/triggerTheme.js). Everything else still toasts.
-    if (cue.word) { if (event.kind === 'trigger' && captions) captions.showPlate(event); else hud.toast(cue.word, 'effect'); }
+    if (cue.word) {
+      if (event.kind === 'trigger' && captions) { if (!plated) captions.showPlate(event); }   // an early pop already flew it
+      else hud.toast(cue.word, 'effect');
+    }
     if (cue.fog != null) applyFog(w, cue.fog);
     if (cue.boost) w.kart.applyBoost(cue.boost);
     if (cue.density != null) w.field.setDensity(cue.density);
@@ -532,7 +560,17 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     // the sync: rows nudged onto their word off the speed the kart has now, held cues fired on the second
     const held = sync.update(ts.t, ks.d, ks.speed);
     for (const m of held.move) w.field.moveRow(m.rowId, m.d);
-    for (const f of held.fire) spendCue(w, f.event, f.cue);
+    for (const f of held.fire) spendCue(w, f.event, f.cue, f.plated);
+    // THE QUIET. A stretch of file with no word due for longer than the streak's own patience holds
+    // the ladder where it is: the voice stopped, the player did not. Re-read four times a second
+    // rather than every frame (TR.nextEvent walks the file), and fed a step bigger than the frame so
+    // race/score.js tick() stands the hold timer still exactly while the quiet lasts.
+    if (TR.lyrics && Math.abs(ts.t - S.quietAt) >= 0.25) {
+      S.quietAt = ts.t;
+      const nx = TR.nextEvent(ts.t, 'word');
+      S.quiet = !nx || nx.t - ts.t > COMBO_HOLD_SEC;
+    }
+    if (S.quiet) w.score.freezeCombo(ts.dt * 2);
     if (ts.actChanged) actMoved(w, ts.act, ks);
     if (ts.dt > S.trackGap) S.trackGap = ts.dt;   // the worst frame the scheduler had to reach over
     if (!hosted && ts.t - S.statsAt >= TRACK_STATS_SEC) {   // standalone dev aid: the scheduler on the console

--- a/ConditioningControlPanel/Resources/web/dtrh/race/score.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/score.js
@@ -77,12 +77,22 @@ export function createScore() {
     return lost;
   }
 
+  /**
+   * A pop in the ledger. `opts.combo === false` pays for it and steps NOTHING: that is a WORD
+   * BUBBLE, which is worth its treat but must not walk the ladder, because a transcript road lays
+   * three of them a second and an 8x arriving in twenty seconds of a chant is a multiplier nobody
+   * drove for. The ladder counts LINES on those roads instead, through `chain()` below.
+   */
   function pop(points, kindId, opts) {
     const k = KIND_BY_ID[kindId];
     const inverted = opts && 'inverted' in opts ? !!opts.inverted : state.inverted;
-    state.combo++; hold = COMBO_HOLD_SEC;
-    if (state.combo > state.bestCombo) state.bestCombo = state.combo;
-    const step = setMult() || ladderStep(state.combo);
+    const steps = !(opts && opts.combo === false);
+    hold = COMBO_HOLD_SEC;   // a word pop still keeps the streak breathing; only the RUNG is a phrase
+    if (steps) {
+      state.combo++;
+      if (state.combo > state.bestCombo) state.bestCombo = state.combo;
+    }
+    const step = steps ? (setMult() || ladderStep(state.combo)) : false;
     const gain = Math.round((Number(points) || 0) * state.mult);
     const bonus = inverted ? gain : 0;                     // upside down: the pop counts twice
     state.score += gain + bonus; state.popped++;
@@ -95,9 +105,24 @@ export function createScore() {
       note(`hot lap +${hot}`, 'jackpot', 'smug', 'streak_milestone');
     }
     emit({ type: 'pop', kindId, points, gain, bonus, inverted, combo: state.combo, mult: state.mult, score: state.score });
+    // a word bubble stepped nothing, so it says nothing about the ladder: the `pop` above already
+    // carried the combo and the mult the HUD draws, and the hold ring reads holdLeft() per frame.
+    if (steps) emit({ type: 'combo', combo: state.combo, step, mult: state.mult, hold });
+    if (steps && JACKPOT_COMBOS.includes(state.combo)) jackpot('major');
+    return gain + bonus;
+  }
+  /**
+   * A LINE of word bubbles taken whole: one rung of the ladder and no points of its own. run.js
+   * keeps the ledger of which bubbles belong to which phrase (race/wordBubbles.js hands every word
+   * event its phrase index) and calls this on the pop that finishes one.
+   */
+  function chain() {
+    state.combo++; hold = COMBO_HOLD_SEC;
+    if (state.combo > state.bestCombo) state.bestCombo = state.combo;
+    const step = setMult() || ladderStep(state.combo);
     emit({ type: 'combo', combo: state.combo, step, mult: state.mult, hold });
     if (JACKPOT_COMBOS.includes(state.combo)) jackpot('major');
-    return gain + bonus;
+    return state.combo;
   }
   /** kart.js says the road rolled past 120 degrees (on) or back (off). Off pays the full circle. */
   function setInverted(on) {
@@ -177,7 +202,7 @@ export function createScore() {
   }
 
   return {
-    state, pop, miss, nearMiss, bank, jackpot, tick, reset, setInverted, trick, lap, pace,
+    state, pop, chain, miss, nearMiss, bank, jackpot, tick, reset, setInverted, trick, lap, pace,
     onEvent(cb) { if (typeof cb === 'function') cbs.push(cb); },
     /** Pending HUD notes (upside down, full circle, ...), oldest first; the queue empties. */
     drainNotes() { return notes.splice(0, notes.length); },

--- a/ConditioningControlPanel/Resources/web/dtrh/race/smoke/rows-check.mjs
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/smoke/rows-check.mjs
@@ -24,13 +24,18 @@
  *      kart whose speed changes inside the lookahead, the row is under the kart
  *      within 0.15 s of event.t, and the visible half of the cue fires on the
  *      second, never at the scheduler's 2.5 s early handover
+ *   8. the plate flies on the POP or on the second, whichever the player reaches
+ *      first, and only ever once
+ *   9. the ladder counts LINES: a rung per phrase taken whole, no rung for a
+ *      single word, no release for a word driven past, and the quiet holds it
  *
  * It never prints a line of a transcript. Everything below is counted.
  * ==========================================================================*/
 
 import { cueFor, ROW_X, ROW_MAX_GAP } from '../cues.js';
 import { createScheduler, normalizeChart } from '../chart.js';
-import { KART_X_MAX, LANE_X_MAX, POP_HIT_X, LANE_H, makeRng } from '../consts.js';
+import { KART_X_MAX, LANE_X_MAX, POP_HIT_X, LANE_H, COMBO_HOLD_SEC, makeRng } from '../consts.js';
+import { createScore } from '../score.js';
 import { THEME_BY_PRESET, kindForPreset } from '../triggerTheme.js';
 import { KIND_BY_ID } from '../bubbleKinds.js';
 import { createCueSync, CUE_AHEAD_SEC, LATE_SEC } from '../sync.js';
@@ -256,6 +261,113 @@ ok(kept.trace.firedAt != null && kept.trace.firedAt - kept.trace.handedAt > 2, '
   ok(loose.worst > kept.worst, `left where it was placed a bubble is ${loose.worst.toFixed(2)}s off its word at worst, which is what the tracking is for`);
   console.log('  --  ' + kept.laid + ' word bubbles, median ' + kept.median.toFixed(3) + 's, worst '
     + kept.worst.toFixed(3) + 's tracked, ' + loose.worst.toFixed(2) + 's loose');
+}
+
+/* ---- 8. the plate flies once: on the pop, or on the second ---------------- */
+// A row used to plate only when the clock reached event.t, so a player who took it a beat early
+// watched the word arrive after they had already popped it. The plate now travels with whichever
+// came first. Nothing else in the cue moves: the mix, the mood and the fog still land on the word,
+// because those are the file talking and the plate is the player being answered.
+{
+  const sy = createCueSync();
+  const trig = (id, t) => ({ id, kind: 'trigger', t, label: 'a phrase' });
+  const cue = { word: 'a phrase', mix: 'blackout' };
+
+  sy.defer(trig('a', 30), cue, 27.5);
+  const early = sy.claim('a');
+  ok(!!early && early.event.id === 'a' && early.cue.word === 'a phrase', 'a row popped early hands its held cue back to be plated');
+  eq(sy.claim('a'), null, 'and the next bubble of the same row claims nothing: one plate, one row');
+  const fired = sy.update(30, 0, 22).fire;
+  eq(fired.length, 1, 'the rest of that cue still fires on the word, never at the pop');
+  eq(fired[0].plated, true, 'and carries word that the plate already flew');
+
+  sy.defer(trig('b', 40), cue, 37.5);
+  const onTime = sy.update(40, 0, 22).fire;
+  eq(onTime.length, 1, 'a row nobody took still fires on its second');
+  eq(onTime[0].plated, false, 'with its plate unspent: a row driven past is still read out');
+  eq(sy.claim('b'), null, 'and once a cue has fired there is nothing left to claim');
+  eq(sy.claim('never-deferred'), null, 'an id that was never held claims nothing');
+}
+
+/* ---- 9. the ladder counts LINES, not words ------------------------------- */
+// Driven off the REAL opening transcript, because the number that matters is how long an x8 takes
+// on a road that lays three bubbles a second, and no made-up chart has that shape.
+{
+  const file = JSON.parse(readFileSync(resolve(HERE, '../words/a15c22e0-d347-4d92-9f78-0fb37099e549.json'), 'utf8'));
+  const triggers = triggersFromHits([], triggerHits(file, file.durationSec), SET_BY_ID);
+  const events = wordEventsFrom(captionWords(file), triggers, { rng: makeRng(7) }).sort((a, b) => a.t - b.t);
+  const lines = new Map();
+  for (const e of events) lines.set(e.p, (lines.get(e.p) || 0) + 1);
+  ok(events.every((e) => e.p != null), 'every word bubble knows the line it belongs to');
+  ok(lines.size > 20 && events.length / lines.size > 1.4,
+    events.length + ' word bubbles across ' + lines.size + ' lines (' + (events.length / lines.size).toFixed(1) + ' a line)');
+
+  /** One run over the file. `missEvery` drives past every nth bubble; the quiet holds the ladder. */
+  function drive(missEvery, perBubble) {
+    const score = createScore();
+    let released = 0;
+    score.onEvent((e) => { if (e.type === 'combo' && e.lost > 0) released++; });
+    const got = new Map(), done = new Set();
+    const at = {};
+    let i = 0, last = events[0].t;
+    for (const e of events) {
+      const gap = Math.max(0, e.t - last); last = e.t;
+      if (gap > COMBO_HOLD_SEC) score.freezeCombo(gap * 2);   // run.js trackFrame: the quiet holds it
+      score.tick(gap);
+      if (missEvery && ++i % missEvery === 0) continue;       // driven past
+      if (perBubble) score.pop(10, 'treat');                  // the OLD rule, kept here to be measured
+      else {
+        score.pop(10, 'treat', { combo: false });
+        const g = (got.get(e.p) || 0) + 1;
+        got.set(e.p, g);
+        if (g >= (lines.get(e.p) || 0) && !done.has(e.p)) { done.add(e.p); score.chain(); }
+      }
+      for (const m of [4, 8]) if (at[m] == null && score.state.mult >= m) at[m] = e.t - events[0].t;
+    }
+    return { at, released, mult: score.state.mult, lines: done.size, score: score.state.score };
+  }
+
+  const was = drive(0, true), now = drive(0, false);
+  ok(was.at[8] != null && was.at[8] < 30, 'a rung per bubble reached x8 in ' + (was.at[8] || 0).toFixed(1) + ' s of the file, which is the thing being fixed');
+  ok(now.at[4] != null && was.at[4] != null && now.at[4] > was.at[4] * 2,
+    'a rung per line takes ' + now.at[4].toFixed(1) + ' s to reach x4 where a rung per bubble took ' + was.at[4].toFixed(1) + ' s');
+  ok(now.at[8] == null, 'and x8 is not something this opening hands out for reading along: the rows and the goldens on the road are the rest of it');
+  eq(now.mult, 6, 'a clean read of every line in the file is worth x' + now.mult);
+  ok(now.score >= events.length * 10, 'every word still pays its treat (' + now.score + ' points over ' + events.length + ' bubbles)');
+
+  const sloppy = drive(3, false);
+  eq(sloppy.released, 0, 'a word bubble driven past never lets the ladder go');
+  ok(sloppy.lines < now.lines, 'it just costs the line it was in (' + sloppy.lines + ' lines of ' + now.lines + ')');
+
+  const solo = createScore();
+  solo.pop(10, 'treat', { combo: false });
+  eq(solo.state.combo, 0, 'one word on its own is no rung at all');
+  eq(solo.state.score, 10, 'and is still worth its treat');
+
+  // the wordless opening: this file says nothing for over a minute, and a streak carried into it has
+  // to survive the drive rather than time out on an empty road
+  ok(events[0].t > COMBO_HOLD_SEC * 4, 'the file opens with ' + events[0].t.toFixed(0) + ' s of road before the first word');
+  const held = createScore(), letGo = createScore();
+  held.chain(); held.chain(); letGo.chain(); letGo.chain();
+  for (let t = 0; t < events[0].t; t += 1 / 60) { held.freezeCombo(2 / 60); held.tick(1 / 60); letGo.tick(1 / 60); }
+  eq(held.state.combo, 2, 'and the ladder is where the player left it when the first word lands');
+  eq(letGo.state.combo, 0, 'unheld it would have let go long before');
+
+  // and the end card counts the same way the ladder does
+  const two = normalizeChart({
+    version: 1, binSec: 0.5, energy: [0.4, 0.4, 0.4, 0.4],
+    acts: [{ kind: 'induction', room: 'teagarden', t0: 0, t1: 5, name: 'induction' }],
+    events: [{ kind: 'word', t: 1, w: 'aa', x: 0, p: 0 }, { kind: 'word', t: 1.2, w: 'bb', x: 0, p: 0 },
+      { kind: 'word', t: 3, w: 'cc', x: 0, p: 1 }, { kind: 'word', t: 3.2, w: 'dd', x: 0, p: 1 }],
+    source: { name: 'lines', hash: 'lines', durationSec: 5, sampleRate: 16000 },
+    analysis: { energy: 'x', words: 'script-align-v1', lexicon: [], generatedAt: '', partial: false },
+  });
+  const sc = createScheduler(two);
+  eq(sc.stats().countable, 2, 'four word bubbles in two lines is TWO things to take on the end card');
+  sc.taken(two.events[0].id);
+  eq(sc.stats().taken, 0, 'half a line read is nothing taken');
+  sc.taken(two.events[1].id);
+  eq(sc.stats().taken, 1, 'and the whole of it is one');
 }
 
 console.log(fails ? '\nrows-check: ' + fails + ' failed' : '\nrows-check: all good');

--- a/ConditioningControlPanel/Resources/web/dtrh/race/smoke/sync-check.mjs
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/smoke/sync-check.mjs
@@ -16,7 +16,8 @@
  *
  * against `event.t` off the chart. The owner heard the effect ~2 s before the
  * word; the scheduler's lookahead is 2.5 s. This is where that number is held down:
- * the plate inside PLATE_TOL of the word, the row under the kart inside ROW_TOL,
+ * the plate inside PLATE_TOL of the word (or on the pop, if the kart reached the row
+ * first: the plate travels with whichever came first), the row under the kart inside ROW_TOL,
  * through a build (the boost ramps the speed mid-lookahead) and a drop (a jump).
  *
  * Nothing leaves this machine: the web folder is served off localhost and the demo
@@ -147,13 +148,13 @@ console.log(`  --  ${probe.plates.length} plates seen, ${probe.taken.length} eve
 
 const nearest = (list, t0, win) => { let best = null; for (const x of list) { const d = x.t - t0; if (Math.abs(d) <= win && (!best || Math.abs(d) < Math.abs(best.t - t0))) best = x; } return best; };
 console.log('  event         t      plate    row(pop)  handed   fired    rowAt');
-const plateDs = [], rowDs = [], handDs = [];
+const plateDs = [], rowDs = [], handDs = [], pairs = [];
 for (const e of triggers) {
   const p = nearest(probe.plates.filter((x) => x.word === e.label), e.t, 3.5);
   const k = nearest(probe.taken, e.t, 3.5);
   const tr = byId.get(e.id) || {};
   const pd = p ? p.t - e.t : null, kd = k ? k.t - e.t : null;
-  if (pd != null) plateDs.push(pd);
+  if (pd != null) { plateDs.push(pd); pairs.push({ pd, kd }); }
   if (kd != null) rowDs.push(kd);
   if (tr.handedAt != null) handDs.push(tr.handedAt - e.t);
   console.log(`  ${e.label.padEnd(12)} ${e.t.toFixed(2).padStart(6)}  ${f2(pd).padStart(7)}  ${f2(kd).padStart(8)}  ${f2(tr.handedAt == null ? null : tr.handedAt - e.t).padStart(7)}  ${f2(tr.firedAt == null ? null : tr.firedAt - e.t).padStart(7)}  ${f2(tr.rowAt == null ? null : tr.rowAt - e.t).padStart(7)}`);
@@ -162,7 +163,11 @@ const stat = (a) => (a.length ? `median ${f2(a.slice().sort((x, y) => x - y)[a.l
 console.log(`  --  plate - t: ${stat(plateDs)};  row pop - t: ${stat(rowDs)};  handover - t: ${stat(handDs)}`);
 
 ok(plateDs.length === triggers.length, `every sure trigger flew a plate (${plateDs.length} of ${triggers.length})`);
-ok(plateDs.every((d) => d >= -0.02 && d <= PLATE_TOL), `every plate reached the DOM ON its word, never early, at most a frame late (within ${PLATE_TOL}s)`);
+ok(plateDs.every((d) => d <= PLATE_TOL), `no plate reached the DOM later than a frame after its word (within ${PLATE_TOL}s)`);
+// The plate travels with whichever came first, the pop or the word, so a row taken a frame early
+// plates a frame early. What it may never do is arrive before the player has done anything at all.
+ok(pairs.every(({ pd, kd }) => pd >= Math.min(0, kd == null ? 0 : kd) - 0.05),
+  'and none of them before the pop that bought it: the plate flies on the row or on the word, whichever the player reaches first');
 ok(rowDs.length === triggers.length, `every row was met by the kart (${rowDs.length} of ${triggers.length})`);
 ok(rowDs.every((d) => Math.abs(d) <= ROW_TOL), `every row was under the kart within ${ROW_TOL}s of its word, through the build's boost`);
 ok(trace.length > 0, 'the standalone sync trace is on (race.syncTrace)');

--- a/ConditioningControlPanel/Resources/web/dtrh/race/sync.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/sync.js
@@ -1,7 +1,7 @@
 /* ============================================================================
  * race/sync.js - the visible half of a cue waits for the word.
  *
- *   createCueSync({ aheadSec, lateSec, trace }) -> { depthFor, defer, trackRow, update, reset, trace }
+ *   createCueSync({ aheadSec, lateSec, trace }) -> { depthFor, defer, claim, trackRow, update, reset, trace }
  *
  * WHY THIS EXISTS. The scheduler (race/chart.js createScheduler) hands an event
  * over LEAD_SEC (2.5 s) before its second, on purpose: a bubble has to be placed
@@ -82,6 +82,25 @@ export function createCueSync({ aheadSec = CUE_AHEAD_SEC, lateSec = LATE_SEC, tr
       rec(event, { handedAt: num(t, null) });
     },
 
+    /**
+     * THE PLATE, ON THE POP. A row taken EARLY: the deferred cue is marked plated and handed back,
+     * so run.js can fly the word at the camera the moment the player takes it rather than making
+     * them wait for a second they already beat. Everything else in that cue (the mix, the mood, the
+     * fog, the boost) still fires at `event.t` and nothing here moves it: only the plate travels.
+     * Returns the held `{ event, cue }` the FIRST time an id is claimed and null every time after,
+     * so a row of five popped bubbles plates once and a row nobody takes still plates on its second.
+     */
+    claim(eventId) {
+      if (!eventId) return null;
+      for (const q of queue) {
+        if (q.event.id !== eventId) continue;
+        if (q.plated) return null;
+        q.plated = true;
+        return { event: q.event, cue: q.cue };
+      }
+      return null;
+    },
+
     /** A row went down at depth `d` for the word at `at`: keep it under the word until the kart is on it. */
     trackRow(rowId, event, at, d, t) {
       if (!rowId || !event) return;
@@ -106,7 +125,7 @@ export function createCueSync({ aheadSec = CUE_AHEAD_SEC, lateSec = LATE_SEC, tr
         for (const q of queue) {
           if (now < q.at) { keep.push(q); continue; }
           if (now - q.at > late) { dropped++; rec(q.event, { dropped: true }); continue; }   // the voice already said it
-          fire.push({ event: q.event, cue: q.cue, late: now - q.at });
+          fire.push({ event: q.event, cue: q.cue, late: now - q.at, plated: !!q.plated });
           rec(q.event, { firedAt: now });
         }
         queue = keep;

--- a/ConditioningControlPanel/Resources/web/dtrh/race/wordBubbles.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/wordBubbles.js
@@ -185,8 +185,14 @@ export function phrasesFrom(words, hits = [], opts = {}) {
  */
 export function wordEventsFrom(words, hits = [], opts = {}) {
   const out = [];
+  let n = 0;
   for (const p of phrasesFrom(words, hits, opts)) {
-    for (const b of p.words) out.push({ kind: 'word', t: b.t, dur: b.d, label: '', conf: 1, weight: 1, w: b.w, x: p.x });
+    // `p` is the index of the LINE this bubble belongs to, and it is the only thing that tells the
+    // rest of the game where one thing said ends and the next begins: race/score.js steps the combo
+    // ladder once per phrase taken whole (forty word pops is twenty seconds of a chant and an 8x
+    // nobody drove for) and race/chart.js stats() counts a phrase as one thing to take.
+    for (const b of p.words) out.push({ kind: 'word', t: b.t, dur: b.d, label: '', conf: 1, weight: 1, w: b.w, x: p.x, p: n });
+    n++;
   }
   return out;
 }


### PR DESCRIPTION
Stacked on #941 (`feat/race-words-w3-flash`). Merge that one first.

Two things a road built off a transcript got wrong.

## The plate flies on the pop

A sure trigger's word flew at the camera when the track clock reached `event.t`. That is right when nobody touched the row, and wrong when somebody did: take the row a beat early and you popped a word that arrived afterwards, answering a question you had already answered.

`race/sync.js` grows one call, `claim(eventId)`. The first bubble of a row popped claims the held cue, so run.js flies the plate then and there; the frame that reaches `event.t` fires everything else in that cue with `plated: true` and leaves the plate alone. A second bubble of the same row claims nothing. A row nobody takes plates on its second exactly as it always did.

The effect timing does not move. The mix, the mood, the fog and the boost are the file talking, and they still land on the word.

## The ladder counts lines

A transcript road lays three word bubbles a second, so a rung per bubble handed out an x8 in twenty seconds of a chant: a multiplier nobody drove for. Measured on the real opening file, a rung per bubble reaches x8 in 22 s.

The rung is a LINE now.

- `race/wordBubbles.js` writes the phrase index it already grouped by onto every word event (`p`); `race/chart.js` keeps it through normalize, the same way it keeps `w` and `x`.
- `run.js` holds the ledger: how many bubbles each line of the file has, how many of them the kart took, and the pop that finishes one calls the new `score.chain()`.
- A word pays its treat (10) and steps nothing: `score.pop(points, kind, { combo: false })`.
- A word driven past costs the line it was in and never lets the streak go. A word unread is not a broken streak. A missed trigger row still releases it, as before.
- A stretch with no word due for longer than the streak's own patience holds the ladder still, the way the pocket watch does. This file opens with eighty seconds of road before anybody says anything.

The end card counts the same way: `stats()` folds a line's bubbles into one thing to take, and a line counts as taken only when every bubble of it was, so "you took N of M" is lines and rows rather than bubbles. A word event with no phrase index on it (the demo chart, a hand-written one) still counts one for one.

## Smokes

`rows-check` gains two sections: the plate-once rule (claimed early, nothing left to claim after, a row nobody took still fires with its plate unspent) and the ladder over the real opening transcript.

```
  ok  a row popped early hands its held cue back to be plated
  ok  and the next bubble of the same row claims nothing: one plate, one row
  ok  the rest of that cue still fires on the word, never at the pop
  ok  107 word bubbles across 32 lines (3.3 a line)
  ok  a rung per bubble reached x8 in 22.0 s of the file, which is the thing being fixed
  ok  a rung per line takes 27.9 s to reach x4 where a rung per bubble took 10.4 s
  ok  a word bubble driven past never lets the ladder go
  ok  the file opens with 80 s of road before the first word
  ok  and the ladder is where the player left it when the first word lands
  ok  four word bubbles in two lines is TWO things to take on the end card
```

`sync-check`'s plate rule now allows the plate to arrive with the pop and holds it to never being earlier than that. Every other race smoke green on this head: chart, words, words-rate, levels, cloud-chart, lyrics-road, track-run, captions, sync, face, rows, pace, touch, pickups, fov, spiral-pool, wall-dom, poses, gltf, audio, ost-resident, cloud, remote-feed. Zero console errors.

## Notes for the reviewer

- This touches `race/chart.js`, which wave 1 asked chain B to leave alone. That was a chain rule for two agents editing the same file at once, not a rule about the file: the phrase index has to survive normalize or the road loses the only thing that says where one line ends.
- `stats().taken` used to be `takenIds.size`, which counted a popped bubble of any kind, so a run could end "you took 40 of 30". It now counts only countable events, which is what the end card was always trying to say.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJ66hi5fRM1Dcjo38aSCa2
