### PR TITLE
feat(race): W5 word sync log, ?wsync=1 overlay, [ ] offset nudge, \ export

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/race/chart.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/chart.js
@@ -75,9 +75,11 @@ export function normalizeChart(json) {
     version: CHART_VERSION, binSec, energy: Object.freeze(energy),
     acts: normalizeActs(Array.isArray(json.acts) ? json.acts : [], durationSec),
     events: normalizeEvents(Array.isArray(json.events) ? json.events : [], durationSec),
-    source: Object.freeze({ name: str(src.name, 'track'), hash: str(src.hash, ''), durationSec, sampleRate: num(src.sampleRate, 16000) }),
+    // `cloudId` is the key race/wordSync.js files a track's pop log and offset under; `offsetSec` is the
+    // words offset this road already carries (race/cloudChart.js applies it, the sync overlay reads it)
+    source: Object.freeze({ name: str(src.name, 'track'), hash: str(src.hash, ''), durationSec, sampleRate: num(src.sampleRate, 16000), cloudId: str(src.cloudId, '').slice(0, 64) }),
     analysis: Object.freeze({
-      energy: str(an.energy, ''), words: str(an.words, 'none'), generatedAt: str(an.generatedAt, ''), partial: an.partial === true,
+      energy: str(an.energy, ''), words: str(an.words, 'none'), generatedAt: str(an.generatedAt, ''), partial: an.partial === true, offsetSec: num(an.offsetSec, 0),
       lexicon: Object.freeze((Array.isArray(an.lexicon) ? an.lexicon : []).filter((w) => typeof w === 'string')),
     }),
     // THE TRANSCRIPT (race/words.js, CHART.md `chart.words`). The lines the voice says, with

--- a/ConditioningControlPanel/Resources/web/dtrh/race/cloudChart.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/cloudChart.js
@@ -43,7 +43,8 @@ import { demoChart, normalizeChart } from './chart.js';
 import { generate } from '../chart/maker/generate.js';
 import { peaksInto, binsPer, binCount } from '../chart/editor/audio.js';
 import { cloudIdFrom, hashUrl, hashBytes, loadIndex, findAuthored, isAuthored } from './chartSource.js';
-import { loadWords } from './words.js';
+import { loadWords, loadWordsRow } from './words.js';
+import { shiftRoad, readNudge } from './wordSync.js';
 import { TRIGGER_SETS } from '../chart/editor/triggerSets.js';
 import { detect } from '../chart/maker/triggers.js';
 import { wordEventsFrom } from './wordBubbles.js';
@@ -456,6 +457,23 @@ export function createChartSource({ indexUrl, cache = null, onUpgrade = null, on
    */
   const named = (chart, title) => normalizeChart({ ...chart, source: { ...chart.source, name: title || (chart.source && chart.source.name) || 'track' } });
 
+  /**
+   * THE OFFSET (race/wordSync.js), applied ONCE, here, as a worded road leaves the source: the
+   * words/index.json row's `offsetSec` plus the `[` `]` nudge kept in localStorage for this track.
+   * Every word-derived second moves together (bubbles, rows, plates, band) and the cache holds the
+   * road at offset 0, so a nudge made after a road was cached still lands. `row` may be handed in
+   * by the generated door; the cached doors look it up (one index read, no transcript fetched).
+   */
+  async function tuned(chart, { cloudId, hash, row = null }) {
+    if (!chart.words || !chart.words.length) return chart;
+    let r = row;
+    if (!r) { try { r = await loadWordsRow({ cloudId, hash, fetch: get, log }); } catch (e) { r = null; } }
+    const key = (r && r.cloudId) || cloudId || hash || '';
+    const sec = (r ? r.offsetSec : 0) + readNudge(key);
+    if (!key) return chart;
+    return normalizeChart(shiftRoad(chart, sec, { trackId: key }));
+  }
+
   /** Fetch, decode, walk, lay a road. The only path that downloads the whole file. */
   async function generated({ id, url, title, durationSec, head, cloudId }) {
     stage(id, 'reading');
@@ -467,7 +485,7 @@ export function createChartSource({ indexUrl, cache = null, onUpgrade = null, on
     const hash = head && head.hash ? head.hash : await hashBytes(bytes, bytes.length);
     if (hash && cache) {
       const hit = await cache.get(hash, GENERATOR_ID);
-      if (hit) { say('cached (late hash) ' + hash.slice(0, 8)); return { chart: named(hit, title), door: 'cached' }; }
+      if (hit) { say('cached (late hash) ' + hash.slice(0, 8)); return { chart: await tuned(named(hit, title), { cloudId, hash }), door: 'cached' }; }
     }
     const buf = bytes.buffer;
     bytes = null;
@@ -483,8 +501,8 @@ export function createChartSource({ indexUrl, cache = null, onUpgrade = null, on
       ? wordedRoad({ peaks: walked.peaks, perSec: walked.perSec, durationSec: dur, name: title, hash, words })
       : roadFromPeaks({ peaks: walked.peaks, perSec: walked.perSec, durationSec: dur, name: title, hash });
     if (words && words.words.length) say(`${title}: ${road.words.length} words and ${road.analysis.lexicon.length} triggers on the road`);
-    if (hash && cache) await cache.put(hash, road, GENERATOR_ID);
-    return { chart: normalizeChart(road), door: 'generated' };
+    if (hash && cache) await cache.put(hash, road, GENERATOR_ID);   // at offset 0: tuned() shifts on the way out
+    return { chart: await tuned(normalizeChart(road), { cloudId, hash, row: words }), door: 'generated' };
   }
 
   /** The four doors, in order, for one track. Throws only when every one of them failed. */
@@ -509,7 +527,7 @@ export function createChartSource({ indexUrl, cache = null, onUpgrade = null, on
       if (byHash) return { chart: await authoredChart(byHash.row, title), door: 'authored by hash' };
       if (cache) {
         const hit = await cache.get(hash, GENERATOR_ID);
-        if (hit) return { chart: named(hit, title), door: 'cached' };
+        if (hit) return { chart: await tuned(named(hit, title), { cloudId, hash }), door: 'cached' };
       }
     }
     if (durationSec > MAX_DECODE_SEC) { shout(TOO_LONG_LINE); throw new Error(`${Math.round(durationSec / 60)} minutes is past the ${Math.round(MAX_DECODE_SEC / 60)} minute decode limit`); }

--- a/ConditioningControlPanel/Resources/web/dtrh/race/input.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/input.js
@@ -46,6 +46,8 @@ const ACTIONS = {
   Escape: 'brake',
   KeyP: 'pixel',
   KeyM: 'mute',   // race/audio.js listens
+  // the words offset (race/run.js, race/wordSync.js); the callback's second argument is whether shift was held
+  BracketLeft: 'nudgeDown', BracketRight: 'nudgeUp', Backslash: 'export',
 };
 const DEADZONE = 0.16;
 const PAD = { steer: 0, accelBtn: 7, brakeBtn: 6, drift: 0, jump: 1, start: 9 };
@@ -70,7 +72,7 @@ export function createInput({ target = window, root = null } = {}) {
   let jumpQ = false, jumpHeld = false, aidLeft = AID_JUMP;
   const padWas = { start: false, jump: false };
 
-  const fire = (name) => { for (const cb of acts) { try { cb(name); } catch (e) { /* a listener never breaks the wheel */ } } };
+  const fire = (name, shift = false) => { for (const cb of acts) { try { cb(name, shift); } catch (e) { /* a listener never breaks the wheel */ } } };
 
   /** The third source. null on a mouse desktop: not one node is built there. */
   const touch = createTouch({ root, fire: (name) => fire(name) });
@@ -89,7 +91,7 @@ export function createInput({ target = window, root = null } = {}) {
     }
     if (e.type === 'keydown') {
       if (e.repeat) { if (KEYS[code]) e.preventDefault(); return; }
-      if (ACTIONS[code]) { fire(ACTIONS[code]); return; }
+      if (ACTIONS[code]) { const t = e.target; if (t && t.tagName && /^(INPUT|TEXTAREA|SELECT)$/.test(t.tagName)) return; fire(ACTIONS[code], !!e.shiftKey); return; }   // a field being typed in keeps its letters
       if (!KEYS[code]) return;
       down.add(KEYS[code]);
       e.preventDefault();

--- a/ConditioningControlPanel/Resources/web/dtrh/race/race.css
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/race.css
@@ -335,6 +335,25 @@
 .race-hud .rt-pause { top: var(--rh-in-t); right: var(--rh-in-r); font-size: 1.05rem; letter-spacing: 0.16em; }
 .race-hud .rt-mute { top: var(--rh-in-t); right: calc(var(--rh-in-r) + 58px); font-size: 0.66rem; }
 
+/* ---- THE SYNC OVERLAY (race/wordSync.js, `?wsync=1`): how far from the word the pops land ----
+   Left edge, mid-height: under the toast rail (34%), above the mixer and the pickup chips, and
+   never on the band, the plate's rest spot or the speed box. Built only when asked for. Pink
+   numbers on the score plate's dark plate, HUD sans, tabular digits, no serif. */
+.race-hud .rw-sync {
+  position: fixed; z-index: 5; left: var(--rh-in-l); top: 50%; width: 178px; pointer-events: none;
+  color: #ffd6ea; font-family: var(--rh-font); font-size: 0.72rem; line-height: 1.35;
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.8);
+}
+.race-hud .rw-sync-title { font-size: 0.6rem; letter-spacing: 0.12em; opacity: 0.6; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.race-hud .rw-sync-row { display: flex; align-items: baseline; gap: 7px; white-space: nowrap; }
+.race-hud .rw-sync-row b { font-weight: 800; color: #ff69b4; }
+.race-hud .rw-sync-hist { display: block; width: 100%; height: 34px; margin: 4px 0 3px; }
+.race-hud .rw-sync-btn {
+  pointer-events: auto; margin-left: 2px; padding: 2px 8px; border-radius: 8px; font: 800 0.72rem var(--rh-font);
+  color: #ffd6ea; background: rgba(255, 105, 180, 0.22); border: 1px solid rgba(255, 105, 180, 0.6);
+}
+.race-hud .rw-sync-note { min-height: 1em; color: #fff; }
+
 /* ---- motion ---- */
 @keyframes rhThud { 0% { transform: scale(1); } 20% { transform: scale(1.32); } 60% { transform: scale(0.92); } 100% { transform: scale(1); } }
 @keyframes rhPulse { 0% { transform: scale(1); } 30% { transform: scale(1.4); } 100% { transform: scale(1); } }

--- a/ConditioningControlPanel/Resources/web/dtrh/race/run.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/run.js
@@ -50,12 +50,13 @@ import { createSpine } from './spine.js';
 import { roomById, rollRoomOrder, createRoomDresser } from './rooms.js';
 import { createWalls } from './walls.js';
 import { createCueSync, CUE_AHEAD_SEC } from './sync.js';
+import { createPopLog, createSyncOverlay, readNudge, writeNudge, shiftRoad, exportOf, trackIdOf, fmtSec, NUDGE_SEC, NUDGE_BIG_SEC, SHOW_MS } from './wordSync.js';
 import { createWallDomPosters } from './wallDom.js';
 import { KIND_BY_ID } from './bubbleKinds.js';
 import { createCocktail, CATEGORIES } from './cocktail.js';
 import { createBubbleField } from './bubbles.js';
 import { createTrackState } from './track.js';
-import { cueFor, resultTag } from './cues.js';
+import { cueFor, resultTag, LANE_X } from './cues.js';
 import { createKart } from './kart.js';
 import { createScore } from './score.js';
 import { createRaceHud } from './hud.js';
@@ -149,7 +150,70 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
   // track), `lineGot` how many of them the kart has taken this run, and the pop that finishes one
   // calls race/score.js chain(). A phrase left half-taken simply never pays.
   const lineN = new Map(), lineGot = new Map(), lineDone = new Set();
-  const fxProxy = { pulseFlash: (a) => { if (W) W.fx.pulseFlash(a); } };   // fx is rebuilt on "again"
+  // THE SYNC WIN (race/wordSync.js). Every word bubble and every trigger row popped or driven past
+  // writes how far from its second it landed into a ring in localStorage; `[` `]` move this track's
+  // offset; `\` copies the numbers. `rowOf` is the trigger rows still on the road (a row is not in
+  // wordOf: its pop is a rung and its word flies on the plate); `rowWatch` is the rows whose second
+  // has passed unpopped, so a missed row is logged at its pass time. Nothing here runs on a track
+  // without words, and the panel is only built for `?wsync=1` or the first nudge.
+  const popLog = createPopLog();
+  const rowOf = new Map(), rowWatch = [];
+  const WSYNC = flag('wsync') === '1';
+  const ROW_LATE_SEC = 0.6;
+  let syncHud = null;
+  const r3 = (v) => Math.round(v * 1000) / 1000;
+  const eventIndex = (id) => { const m = /(\d+)$/.exec(String(id)); return m ? +m[1] : String(id); };
+  const laneOf = (x) => { let b = 0; LANE_X.forEach((v, i) => { if (Math.abs(v - x) < Math.abs(LANE_X[b] - x)) b = i; }); return b; };
+  const trackKey = () => (TR.track && TR.lyrics ? trackIdOf(TR.track.chart) : '');
+  const offsetOf = () => (TR.track ? Number(TR.track.chart.analysis.offsetSec) || 0 : 0);
+  function refreshSync() { if (syncHud) syncHud.update({ rows: popLog.rows(trackKey()), offsetSec: offsetOf(), name: TR.track ? TR.track.name : '' }); }
+  function showSync(ms) {
+    if (!syncHud && hudRoot) syncHud = createSyncOverlay(hudRoot, { buttons: WSYNC, onNudge: nudge, onExport: exportSync });
+    if (!syncHud) return;
+    refreshSync(); syncHud.show(WSYNC ? 0 : ms);
+  }
+  /** The track second the kart's nose was level with depth `d`: a pop fires a frame early or late and
+   *  the miss is called MISS_BEHIND metres past the bubble, so the log reads the road, not the frame. */
+  function passTime(w, d) {
+    const t = TR.track ? TR.track.t : 0;
+    if (!w || d == null) return t;
+    const ks = w.kart.state, half = w.layout.totalDepth / 2;
+    return t + (w.layout.wrap(d - ks.d + half) - half) / Math.max(1, ks.speed);
+  }
+  function logWord(rec, popT, missed) {
+    const key = trackKey();
+    if (!key) return;
+    popLog.push({ trackId: key, i: rec.i, p: rec.p, w: rec.w, t: rec.t, popT: r3(popT), dt: r3(popT - rec.t), lane: rec.lane, missed: !!missed });
+    if (syncHud && !syncHud.el.hidden) refreshSync();
+  }
+  /** Move this track's offset by `deltaSec`: stored per track, and applied to the road NOW. The ids are
+   *  kept, so sched.replace adopts only the words not yet handed over; a bubble already on the road stays. */
+  function nudge(deltaSec) {
+    const key = trackKey();
+    if (!key || !deltaSec) return false;
+    writeNudge(key, readNudge(key) + deltaSec);
+    replaceTrack(shiftRoad(TR.track.chart, deltaSec));
+    showSync(SHOW_MS); syncHud.say('offset ' + fmtSec(offsetOf()));
+    return true;
+  }
+  function copyText(text) {
+    try { if (navigator.clipboard && navigator.clipboard.writeText) { navigator.clipboard.writeText(text).catch(() => copyFallback(text)); return; } } catch (e) { /* fall through */ }
+    copyFallback(text);
+  }
+  function copyFallback(text) {
+    try { const ta = document.createElement('textarea'); ta.value = text; ta.setAttribute('readonly', ''); ta.style.cssText = 'position:fixed;left:-9999px'; document.body.appendChild(ta); ta.select(); document.execCommand('copy'); ta.remove(); } catch (e) { /* no clipboard here */ }
+  }
+  /** The line words/index.json wants for this track, to the clipboard. Returns the JSON text, '' with no words. */
+  function exportSync() {
+    const key = trackKey();
+    if (!key) return '';
+    const text = JSON.stringify(exportOf({ cloudId: key, offsetSec: offsetOf(), rows: popLog.rows(key) }));
+    copyText(text);
+    hud.toast('offset copied', 'item');
+    showSync(SHOW_MS); syncHud.say('copied ' + fmtSec(offsetOf()));
+    return text;
+  }
+  const fxProxy ={ pulseFlash: (a) => { if (W) W.fx.pulseFlash(a); } };   // fx is rebuilt on "again"
   const payloadFx = createPayloadFx({ hud: sfHud, fx: fxProxy, media });
   // Q.leanSpirals (mobile): spiral pops draw from the two lightest bundled gifs, fetched while the intro plays
   // (warmFx) rather than 2-5 MB mid-lap; the desktop pool and the Loom's own spirals are untouched
@@ -280,11 +344,12 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
    * of word bubbles taken clean reads back as the sentence the voice said.
    * @param eventId the chart event that spawned the bubble, @param ghost true for a miss
    */
-  function spendWord(w, eventId, ghost) {
+  function spendWord(w, eventId, ghost, passT) {
     if (!eventId) return;
     const rec = wordOf.get(eventId);
     if (!rec) return;
     wordOf.delete(eventId);                       // one bubble, one flash: it is popped or it is past
+    logWord(rec, passT == null ? (TR.track ? TR.track.t : 0) : passT, ghost);
     if (captions && (!ghost || GHOST_MISSES)) captions.showWord(rec.w, { ink: rec.ink, accent: rec.accent, ghost: !!ghost });
     if (ghost || rec.p == null || lineDone.has(rec.p)) return;
     const n = lineN.get(rec.p) || 0, got = (lineGot.get(rec.p) || 0) + 1;
@@ -302,7 +367,12 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
   }
   function onPop(w, p) {
     const word = !!p.eventId && wordOf.has(p.eventId);   // a bubble off the transcript, not a chunk golden
-    if (p.eventId) { TR.taken(p.eventId); platePop(p.eventId); spendWord(w, p.eventId, false); }
+    if (p.eventId) {
+      const at = passTime(w, p.d);
+      TR.taken(p.eventId); platePop(p.eventId); spendWord(w, p.eventId, false, at);
+      const row = rowOf.get(p.eventId);   // a trigger row: one log line for the row, on its first pop
+      if (row) { rowOf.delete(p.eventId); logWord(row, at, false); }
+    }
     w.kart.pulseTarget(); w.kart.pose('grab', { side: (p.x == null ? w.kart.state.x : p.x) >= w.kart.state.x ? 1 : -1 });
     if (S.sweep) sfx('chain_pop', 0.5);          // the pump: every pop on the road sounds like the chain
     if (p.kind === 'treat') return treat(w, p, word);
@@ -389,7 +459,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
   }
   function onMiss(w, m) {
     const word = !!m.eventId && wordOf.has(m.eventId);
-    spendWord(w, m.eventId, true);   // the script is never hostage to the steering: the word still lands, grey
+    spendWord(w, m.eventId, true, passTime(w, m.d));   // the script is never hostage to the steering: the word still lands, grey
     // ALMOST: the treat slid past inside NEAR_MISS_M but outside the hit box; else the streak lets go
     let best = null, bestGap = Infinity;
     for (const s of trail) { if (!s.ok) continue; const g = Math.abs(w.layout.wrap(s.d - m.d + w.layout.totalDepth / 2) - w.layout.totalDepth / 2); if (g < bestGap) { bestGap = g; best = s; } }
@@ -463,7 +533,8 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     const t = TR.setTrack(chart);
     audio.setRoute(routeOf(t));
     S.trackHold = 0; S.statsAt = 0; S.quiet = false; S.quietAt = -9; sync.reset(); wordOf.clear();
-    lineN.clear(); lineGot.clear(); lineDone.clear();
+    lineN.clear(); lineGot.clear(); lineDone.clear(); rowOf.clear(); rowWatch.length = 0;
+    if (WSYNC && t && TR.lyrics) showSync(0); else refreshSync();
     for (const e of (t && t.chart && Array.isArray(t.chart.events) ? t.chart.events : [])) {
       if (e.kind === 'word' && e.p != null) lineN.set(e.p, (lineN.get(e.p) || 0) + 1);
     }
@@ -472,6 +543,13 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     audio.duck(!!t, 'track');   // the file is the soundtrack: the room OST sits under it until it is cleared
     if (bridge.log) bridge.log(t ? `race track: ${t.name}, ${Math.round(t.durationSec)}s, ${TR.stats().countable} to take` : 'race track: cleared');
     return t;
+  }
+  /** The words pass landing live, or a nudge: keep the clock, adopt only what is still ahead (track.js replace). */
+  function replaceTrack(chart) {
+    TR.replace(chart); audio.setRoute(routeOf(TR.track));
+    if (W) W.field.setSparse(TR.lyrics);
+    if (captions) captions.setTrack(TR.track ? TR.track.chart : null);
+    refreshSync();
   }
   /** The chart's fog knob rides the tunnel weather: fx.update writes scene.fog every frame, so the
    *  zone is the only fog dial the run may hold. 0 hands the organic roll back. */
@@ -513,7 +591,10 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
       // A trigger ROW is not one of these: its word flies at the camera on the plate instead.
       if (rowId && e.kind === 'word' && row[0].w) {
         if (wordOf.size >= WORD_MEM) wordOf.delete(wordOf.keys().next().value);
-        wordOf.set(e.id, { w: row[0].w, ink: row[0].ink || null, accent: !!row[0].big, p: e.p == null ? null : e.p });
+        wordOf.set(e.id, { w: row[0].w, ink: row[0].ink || null, accent: !!row[0].big, p: e.p == null ? null : e.p, t: e.t, i: eventIndex(e.id), lane: laneOf(row[0].x || 0) });
+      } else if (rowId && e.kind === 'trigger' && TR.lyrics) {   // the sync log's line for a row: w is the set's label
+        if (rowOf.size >= WORD_MEM) rowOf.delete(rowOf.keys().next().value);
+        rowOf.set(e.id, { w: e.label, p: null, t: e.t, i: eventIndex(e.id), lane: null });
       }
     }
     for (const sp of loose) {
@@ -560,7 +641,13 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     // the sync: rows nudged onto their word off the speed the kart has now, held cues fired on the second
     const held = sync.update(ts.t, ks.d, ks.speed);
     for (const m of held.move) w.field.moveRow(m.rowId, m.d);
-    for (const f of held.fire) spendCue(w, f.event, f.cue, f.plated);
+    for (const f of held.fire) { spendCue(w, f.event, f.cue, f.plated); if (rowOf.has(f.event.id)) rowWatch.push(f.event); }
+    // a row whose second went by unpopped is a miss, logged at the second the kart was on it
+    for (let k = rowWatch.length - 1; k >= 0; k--) {
+      const e = rowWatch[k];
+      if (!rowOf.has(e.id)) { rowWatch.splice(k, 1); continue; }
+      if (ts.t - e.t >= ROW_LATE_SEC || ts.t < e.t - 1) { const rec = rowOf.get(e.id); rowOf.delete(e.id); rowWatch.splice(k, 1); if (ts.t >= e.t) logWord(rec, e.t, true); }
+    }
     // THE QUIET. A stretch of file with no word due for longer than the streak's own patience holds
     // the ladder where it is: the voice stopped, the player did not. Re-read four times a second
     // rather than every frame (TR.nextEvent walks the file), and fed a step bigger than the frame so
@@ -771,7 +858,11 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
   bridge.on('pause', (m) => setPaused(!!(m && m.on)));
   bridge.on('payout-result', (m) => { if (payoutResolve) payoutResolve(m); });
   function cyclePixel() { pixel.cycle(); pixel.retexture(scene); hud.toast(pixel.label(), 'item'); }
-  input.onAction((a) => { if (a === 'brake') brake(); else if (a === 'pixel') cyclePixel(); });
+  input.onAction((a, shift) => {
+    if (a === 'brake') brake(); else if (a === 'pixel') cyclePixel();
+    else if (a === 'nudgeUp' || a === 'nudgeDown') nudge((a === 'nudgeUp' ? 1 : -1) * (shift ? NUDGE_BIG_SEC : NUDGE_SEC));
+    else if (a === 'export') exportSync();
+  });
   const onVis = () => { last = 0; };
   document.addEventListener('visibilitychange', onVis);
 
@@ -796,6 +887,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     if (raf) cancelAnimationFrame(raf);
     unbindResize();
     document.removeEventListener('visibilitychange', onVis);
+    if (syncHud) { syncHud.dispose(); syncHud = null; }
     if (payoutResolve) payoutResolve(null);
     teardown();
     audio.dispose();
@@ -852,7 +944,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
   return { start, prepare, setPaused, dispose, setCameraOverride, setStage, reseed, renderer, pixel, audio, hud, camera, perf,
     // track charts (CHART.md): setTrack before start(), replaceTrack for the words pass landing live,
     // trackClock for the host's 250 ms tick, trackEnded when the file runs out at the host's end
-    setTrack, replaceTrack: (chart) => { TR.replace(chart); audio.setRoute(routeOf(TR.track)); if (W) W.field.setSparse(TR.lyrics); if (captions) captions.setTrack(TR.track ? TR.track.chart : null); }, trackClock: (t, playing) => TR.clock(t, playing),
+    setTrack, replaceTrack, trackClock: (t, playing) => TR.clock(t, playing),
     trackEnded: () => { TR.end(); if (TR.track && S.running) endRun(); }, trackStats: () => TR.stats(), syncTrace: () => sync.trace(), debugPickup,
     /** What race/smoke/face-check.mjs reads: the word faces on the road this frame. */
     wordFaces: () => (W ? W.field.faceReport() : null),
@@ -860,6 +952,8 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     debugWord: (text, o) => (captions ? captions.showWord(text, o || {}) != null : false),
     /** Which half of race/captions.js is driving the band on this build: 'flash' or 'type'. */
     capMode: () => CAP_MODE,
+    /** THE SYNC WIN, for race/smoke/wsync-check.mjs: the log rows, the offset, a nudge, the export. */
+    wordSync: { rows: () => popLog.rows(trackKey()), size: () => popLog.size, offset: offsetOf, nudge, exportJson: exportSync, overlay: () => (syncHud ? syncHud.el : null) },
     get track() { return TR.track; } };
 }
 

--- a/ConditioningControlPanel/Resources/web/dtrh/race/smoke/wsync-check.mjs
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/smoke/wsync-check.mjs
@@ -1,0 +1,220 @@
+/* ============================================================================
+ * race/smoke/wsync-check.mjs - THE SYNC WIN: the pop log, the offset, the overlay.
+ *
+ *   node race/smoke/wsync-check.mjs      (from Resources/web/dtrh; 0 on pass, 1 with a count)
+ *   RACE_SHOTS=1 node race/smoke/wsync-check.mjs      (also writes shots/wsync.png, untracked)
+ *
+ * The node half holds race/wordSync.js on its own: the keys collide with nothing, the shift
+ * moves every word-derived second and keeps the ids, the index row's offsetSec is read, the
+ * ring never passes LOG_MAX. The browser half drives the Rapid Induction road on a 390x844
+ * phone: every pop logs inside 0.06 s of its word, a miss logs `missed: true`, three presses
+ * of `]` move the next un-spawned word by 0.15 s and the panel says so, `\` exports the row,
+ * and with `?wsync=1` the panel sits inside the glass and on nothing else. Counted, never
+ * printed: no word of the transcript is read out.
+ * ==========================================================================*/
+
+import { spawn } from 'node:child_process';
+import { createServer } from 'node:http';
+import { readFile } from 'node:fs/promises';
+import { readFileSync, writeFileSync, mkdirSync, mkdtempSync, rmSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, extname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { wordedRoad, PEAKS_PER_SEC } from '../cloudChart.js';
+import { normalizeChart } from '../chart.js';
+import { KART_X_MAX } from '../consts.js';
+import { loadWords, loadWordsRow, forgetWords } from '../words.js';
+import { shiftRoad, createPopLog, statsOf, exportOf, LOG_MAX, LOG_KEY, WORD_KINDS } from '../wordSync.js';
+
+let fails = 0;
+const ok = (cond, what) => { if (!cond) { console.error('FAIL ' + what); fails++; } else console.log('  ok  ' + what); };
+const eq = (got, want, what) => ok(got === want, what + ' (got ' + JSON.stringify(got) + ', want ' + JSON.stringify(want) + ')');
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const HERE = resolve(fileURLToPath(import.meta.url), '..');
+const RACE = resolve(HERE, '..');
+const WEB = resolve(RACE, '../..');
+const SHOTS = resolve(WEB, '../../../shots');
+const read = (rel) => JSON.parse(readFileSync(resolve(RACE, rel), 'utf8'));
+const src = (rel) => readFileSync(resolve(RACE, rel), 'utf8');
+
+/* ---- 1. the keys are free ---- */
+const KEYS = /BracketLeft|BracketRight|Backslash/g;
+eq((src('input.js').match(KEYS) || []).length, 3, '`[` `]` `\\` are wired once each in input.js ACTIONS');
+eq(((src('menu.js') + src('cards.js') + src('intro.js')).match(KEYS) || []).length, 0, 'and no menu, card or intro key reads them');
+
+/* ---- 2. the shift: every word-derived second moves, ids stay ---- */
+const rows = read('words/index.json').rows;
+const ROW = rows.find((r) => /rapid induction/i.test(String(r.title || ''))) || rows[0];
+const WORDS = read('words/' + ROW.file);
+function swell(durationSec, perSec = PEAKS_PER_SEC) {
+  const n = Math.ceil(durationSec * perSec), peaks = new Float32Array(n * 2);
+  for (let i = 0; i < n; i++) { const a = 0.22 + 0.5 * Math.max(0, Math.sin(((i / perSec) / 40) * Math.PI * 2)) ** 2; peaks[i * 2] = -a; peaks[i * 2 + 1] = a; }
+  return peaks;
+}
+const road = wordedRoad({ peaks: swell(WORDS.durationSec), durationSec: WORDS.durationSec, name: ROW.title, hash: ROW.hash, words: WORDS });
+road.source.cloudId = ROW.cloudId;
+const base = normalizeChart(road), moved = normalizeChart(shiftRoad(base, 0.15, { trackId: ROW.cloudId }));
+const byId = new Map(moved.events.map((e) => [e.id, e]));
+const off = (e) => Math.round((byId.get(e.id).t - e.t) * 1000) / 1000;
+const edge = (e) => byId.get(e.id).t === 0 || byId.get(e.id).t === base.source.durationSec;   // clamped at the file's ends
+ok(base.events.every((e) => byId.has(e.id)), 'every event keeps its id through the shift');
+ok(base.events.filter((e) => WORD_KINDS.includes(e.kind)).every((e) => off(e) === 0.15 || edge(e)), 'every word, row, count, drop and chant moved by +0.15 s');
+ok(base.events.filter((e) => !WORD_KINDS.includes(e.kind)).every((e) => off(e) === 0), 'and not one energy event did');
+ok(base.words.every((w, i) => Math.abs(moved.words[i].t - w.t - 0.15) < 1e-6), 'the caption track moved with them');
+eq(moved.analysis.offsetSec, 0.15, 'analysis.offsetSec says what was applied');
+eq(moved.source.cloudId, ROW.cloudId, 'and source.cloudId survives normalizeChart');
+const back = normalizeChart(shiftRoad(moved, -0.15));
+ok(base.events.every((e, i) => back.events[i].id === e.id && (edge(e) || Math.abs(back.events[i].t - e.t) < 1e-6)) && back.analysis.offsetSec === 0, 'shifting back lands on the original road');
+
+/* ---- 3. words.js reads offsetSec off the row ---- */
+const table = { version: 1, rows: [{ cloudId: 'aaaa', hash: 'h1', title: 'a', file: 'a.json', offsetSec: 0.12 }, { cloudId: 'bbbb', hash: 'h2', title: 'b', file: 'b.json' }] };
+const fakeFetch = async (url) => ({ ok: true, status: 200, json: async () => (/index\.json$/.test(url) ? table : { version: 1, hash: 'h', durationSec: 5, words: [{ t: 1, d: 0.3, w: 'ok' }] }) });
+const IX = 'http://x/words/index.json';
+forgetWords();
+eq((await loadWordsRow({ cloudId: 'AAAA', fetch: fakeFetch, indexUrl: IX })).offsetSec, 0.12, 'loadWordsRow hands back the row\'s offsetSec');
+eq((await loadWordsRow({ hash: 'h2', fetch: fakeFetch, indexUrl: IX })).offsetSec, 0, 'and 0 for a row without one');
+eq((await loadWords({ cloudId: 'aaaa', fetch: fakeFetch, indexUrl: IX })).offsetSec, 0.12, 'loadWords carries it too');
+eq(await loadWordsRow({ cloudId: 'zzzz', fetch: fakeFetch, indexUrl: IX }), null, 'and a track with no row is null');
+
+/* ---- 4. the ring, the stats, the export ---- */
+const mem = new Map(), storage = { getItem: (k) => (mem.has(k) ? mem.get(k) : null), setItem: (k, v) => mem.set(k, v), removeItem: (k) => mem.delete(k) };
+const log = createPopLog({ storage });
+for (let i = 0; i < 600; i++) log.push({ trackId: 't', i, dt: (i % 7) * 0.01 - 0.03, missed: i % 5 === 0 });
+eq(log.size, LOG_MAX, `600 pushes leave ${LOG_MAX} rows in the ring`);
+eq(JSON.parse(mem.get(LOG_KEY)).length, LOG_MAX, 'and localStorage holds exactly those');
+eq(JSON.parse(mem.get(LOG_KEY))[0].i, 600 - LOG_MAX, 'the oldest fell off, the newest stayed');
+const angry = createPopLog({ storage: { getItem: () => { throw new Error('no'); }, setItem: () => { throw new Error('no'); } } });
+angry.push({ dt: 0 });
+eq(angry.size, 1, 'a storage that throws is a ring in memory, never an exception');
+const st = statsOf([{ dt: 0.01 }, { dt: 0.03 }, { dt: -0.02 }, { dt: 0.9 }, { dt: 0.02, missed: true }, { dt: 2 }]);
+eq(st.n, 5, 'the stats count pops, never misses'); eq(st.median, 0.03, 'median'); eq(st.p90, 2, 'p90');
+eq(st.hist.length, 21, '21 bins'); eq(st.hist[10], 3, 'three of them on the word'); eq(st.hist[19], 1, 'and one out at +0.9 s');
+eq(Object.keys(exportOf({ cloudId: 'c', offsetSec: 0.05, rows: [] })).join(','), 'cloudId,offsetSec,n,medianDt,p90Dt', 'the export is the index row\'s shape');
+
+/* ---- the browser ---- */
+const CHROME = process.env.CHROME_PATH || 'C:/Program Files/Google/Chrome/Application/chrome.exe';
+const PORT = 8875, DEBUG_PORT = 9345;
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.mjs': 'text/javascript', '.css': 'text/css', '.json': 'application/json', '.glb': 'model/gltf-binary', '.png': 'image/png', '.webp': 'image/webp', '.jpg': 'image/jpeg', '.mp3': 'audio/mpeg', '.wav': 'audio/wav', '.svg': 'image/svg+xml', '.woff2': 'font/woff2' };
+const FIXTURE = JSON.stringify(road);
+if (!existsSync(CHROME)) { console.error('FAIL no chrome at ' + CHROME + ' (set CHROME_PATH)'); process.exit(1); }
+const server = createServer(async (req, res) => {
+  const path = decodeURIComponent(new URL(req.url, 'http://x').pathname);
+  if (path === '/fixture.json') { res.writeHead(200, { 'content-type': 'application/json' }); return res.end(FIXTURE); }
+  if (path.indexOf('..') >= 0) { res.writeHead(400); return res.end(); }
+  try { const body = await readFile(join(WEB, path)); res.writeHead(200, { 'content-type': MIME[extname(path).toLowerCase()] || 'application/octet-stream' }); res.end(req.method === 'HEAD' ? undefined : body); }
+  catch (e) { res.writeHead(404); res.end('no'); }
+});
+await new Promise((r) => server.listen(PORT, '127.0.0.1', r));
+const prof = mkdtempSync(join(tmpdir(), 'race-wsync-'));
+const chrome = spawn(CHROME, ['--headless=new', `--remote-debugging-port=${DEBUG_PORT}`, `--user-data-dir=${prof}`, '--no-first-run', '--no-default-browser-check', '--disable-gpu', '--mute-audio', '--enable-unsafe-swiftshader', '--autoplay-policy=no-user-gesture-required', '--window-size=390,844', 'about:blank'], { stdio: 'ignore' });
+async function done(code) {
+  try { chrome.kill(); } catch (e) { /* gone */ }
+  await new Promise((r) => server.close(r));
+  try { rmSync(prof, { recursive: true, force: true }); } catch (e) { /* windows holds the profile */ }
+  console.log(code ? `\nwsync-check: ${fails} failed` : '\nwsync-check: all good');
+  process.exit(code);
+}
+let page = null;
+for (let i = 0; i < 60 && !page; i++) { await sleep(250); try { page = (await (await fetch(`http://127.0.0.1:${DEBUG_PORT}/json/list`)).json()).find((t) => t.type === 'page'); } catch (e) { /* not up */ } }
+if (!page) { console.error('FAIL chrome never answered'); await done(1); }
+const ws = new WebSocket(page.webSocketDebuggerUrl);
+await new Promise((r) => { ws.onopen = r; });
+let msgId = 0;
+const waits = new Map(), errs = [];
+ws.onmessage = (e) => {
+  const m = JSON.parse(e.data);
+  if (m.id && waits.has(m.id)) { waits.get(m.id)(m); waits.delete(m.id); }
+  if (m.method === 'Runtime.exceptionThrown') errs.push('thrown: ' + (m.params.exceptionDetails?.exception?.description || m.params.exceptionDetails?.text || '?'));
+  if (m.method === 'Runtime.consoleAPICalled' && m.params.type === 'error') errs.push(m.params.args.map((a) => a.value ?? a.description ?? '?').join(' '));
+};
+const cdp = (method, params) => new Promise((res) => { const i = ++msgId; waits.set(i, res); ws.send(JSON.stringify({ id: i, method, params })); });
+const ev = async (x) => (await cdp('Runtime.evaluate', { expression: x, returnByValue: true, awaitPromise: true })).result?.result?.value;
+const json = async (x) => JSON.parse(await ev(`JSON.stringify(${x})`));
+await cdp('Runtime.enable'); await cdp('Page.enable');
+await cdp('Emulation.setDeviceMetricsOverride', { width: 390, height: 844, deviceScaleFactor: 2, mobile: true });
+const site = `http://127.0.0.1:${PORT}`;
+const firstWord = road.events.find((e) => e.kind === 'word').t;
+// THE DRIVE: the fixture lays each phrase in a lane of its own (random per build) and a phrase
+// steps one lane at a time. Take the first lane step with a word inside 2.5 s of it, and pin the
+// kart (`?x=`, race/kart.js's screenshot aid) one lane BEYOND the new lane: the new lane sits
+// 0.8 m off, inside the 1.15 m pop box, the old lane 1.6 m off, outside it. One drive logs both.
+const wordsOn = road.events.filter((e) => e.kind === 'word');
+const turn = wordsOn.findIndex((e, i) => i > 2 && e.x !== wordsOn[i - 1].x && e.t - wordsOn[i - 1].t < 2.5 && Math.abs(e.x + 0.8 * Math.sign(e.x - wordsOn[i - 1].x)) <= KART_X_MAX);
+const laneA = wordsOn[turn - 1].x, laneB = wordsOn[turn].x, pinX = laneB + 0.8 * Math.sign(laneB - laneA), seekT = wordsOn[turn].t - 6;
+const PIN = (pinX / KART_X_MAX).toFixed(3);
+const counted = (r) => r.t >= seekT + 3;   // a word inside the scheduler's lead at the seek had no run-up: not the sync's fault
+const URL0 = `${site}/dtrh/race.html?autostart=1&intro=0&cards=0&x=${PIN}&chart=${encodeURIComponent(`${site}/fixture.json`)}`;
+async function boot(url) {
+  await cdp('Page.navigate', { url });
+  for (let i = 0; i < 120; i++) { await sleep(250); if (await ev(`!!(window.__race && window.__race.race && window.__race.race.track && document.querySelector('.rc-layer'))`)) return true; }
+  return false;
+}
+const key = (code, shift = false) => ev(`window.dispatchEvent(new KeyboardEvent('keydown', { code: '${code}', shiftKey: ${shift}, bubbles: true })), 1`);
+const rect = `(el)=>{ if(!el) return null; const b=el.getBoundingClientRect(); return { x:b.left, y:b.top, w:b.width, h:b.height }; }`;
+const hits = (a, b) => !!a && !!b && a.x < b.x + b.w && b.x < a.x + a.w && a.y < b.y + b.h && b.y < a.y + a.h;
+
+/* ---- 5. the log, off a real road being driven; no panel without ?wsync ---- */
+ok(await boot(URL0), 'the page boots the Rapid Induction road');
+eq(await ev(`document.querySelectorAll('.rw-sync').length`), 0, 'without ?wsync=1 no overlay is built');
+await ev(`window.__race.race.trackClock(${seekT.toFixed(2)}, true)`);
+await sleep(12000);
+const got = await json(`({ rows: window.__race.race.wordSync.rows(), size: window.__race.race.wordSync.size(), stored: JSON.parse(localStorage.getItem('${LOG_KEY}')||'[]').length, t: window.__race.race.track.t })`);
+const pops = got.rows.filter((r) => !r.missed && counted(r)), misses = got.rows.filter((r) => r.missed && counted(r));
+
+ok(turn > 0 && got.t > seekT + 10, `the road rolled from ${seekT.toFixed(1)} s across the lane step at ${wordsOn[turn].t.toFixed(1)} s (x ${laneA} to ${laneB}, kart pinned on ${pinX.toFixed(1)}; to ${got.t.toFixed(1)} s)`);
+ok(pops.length > 0, `${pops.length} pops wrote a log row`);
+ok(pops.every((r) => Math.abs(r.dt) <= 0.06), `and every one landed inside 0.06 s of its word (worst ${Math.max(...pops.map((r) => Math.abs(r.dt))).toFixed(3)})`);
+ok(misses.length > 0 && misses.every((r) => r.missed === true), `${misses.length} words driven past wrote missed: true`);
+ok(got.rows.every((r) => r.trackId === ROW.cloudId && ['i', 'p', 'w', 't', 'popT', 'dt', 'lane', 'missed'].every((k) => k in r)), 'every row carries trackId, i, p, w, t, popT, dt, lane, missed');
+eq(got.stored, got.size, 'and the ring is written through to localStorage on every pop');
+ok(got.size <= LOG_MAX, `the ring is at ${got.size}, never over ${LOG_MAX}`);
+
+/* ---- 6. the nudge moves the next un-spawned word, and says so ---- */
+const next = await json(`(()=>{ const r=window.__race.race, t=r.track.t; const e=r.track.chart.events.find((e)=>e.kind==='word'&&e.t>t+4); return { id:e.id, t:e.t, n:r.track.chart.events.length }; })()`);
+await key('BracketRight'); await key('BracketRight'); await key('BracketRight');
+await sleep(150);
+const after = await json(`(()=>{ const r=window.__race.race, e=r.track.chart.events.find((e)=>e.id==='${next.id}'); const p=document.querySelector('.rw-sync');
+  return { t:e.t, n:r.track.chart.events.length, offset:r.wordSync.offset(), stored:localStorage.getItem('rt-word-offset:${ROW.cloudId}'), panel:!!p, shown:!!p&&!p.hidden, reads:p?p.querySelector('.rw-sync-off').textContent:'', btns:document.querySelectorAll('.rw-sync-btn').length }; })()`);
+ok(Math.abs(after.t - next.t - 0.15) < 1e-6, `three presses of ] moved the next un-spawned word by +0.15 s (${next.t} -> ${after.t})`);
+eq(after.n, next.n, 'with the same events on the road, none doubled and none lost');
+eq(after.offset, 0.15, 'the track reads its offset as +0.15');
+eq(after.stored, '0.15', 'and localStorage rt-word-offset:<cloudId> holds it');
+ok(after.panel && after.shown, 'the panel showed itself on the nudge');
+eq(after.reads, '+0.15 s', 'reading "+0.15 s"');
+eq(after.btns, 0, 'with no buttons on it: those are ?wsync=1 only');
+await sleep(2300);
+eq(await ev(`document.querySelector('.rw-sync').hidden`), true, 'and it put itself away after 2 s');
+await key('BracketLeft', true);
+eq(await ev(`window.__race.race.wordSync.offset()`), -0.1, 'shift+[ takes 0.25 s off');
+
+/* ---- 7. the export ---- */
+const exp = JSON.parse(await ev(`window.__race.race.wordSync.exportJson()`));
+eq(Object.keys(exp).join(','), 'cloudId,offsetSec,n,medianDt,p90Dt', 'the export is {cloudId, offsetSec, n, medianDt, p90Dt}');
+eq(exp.cloudId, ROW.cloudId, 'for this track'); eq(exp.offsetSec, -0.1, 'at the offset it has now');
+await key('Backslash'); await sleep(150);
+ok(await ev(`[...document.querySelectorAll('.rh-toast')].some((t)=>/copied/.test(t.textContent))`), 'and \\ says "offset copied" on the rail');
+
+/* ---- 8. ?wsync=1: the panel is on the glass and on nothing else ---- */
+ok(await boot(URL0 + '&wsync=1'), 'the page boots again with ?wsync=1');
+await ev(`window.__race.race.debugWord('ok'); window.__race.race.hud.toast('+10', 'pop')`);
+await sleep(250);
+const lay = await json(`(()=>{ const r=${rect}; const q=(s)=>r(document.querySelector(s)); const p=document.querySelector('.rw-sync');
+  return { panel:q('.rw-sync'), shown:!!p&&!p.hidden, btns:document.querySelectorAll('.rw-sync-btn').length, score:q('.rh-score-wrap'), cap:q('.rc-cap'), rail:q('.rh-toasts'), speed:q('.rh-speed'), chips:q('.rh-passive'),
+    plateY:parseFloat(getComputedStyle(document.querySelector('.rc-layer')).getPropertyValue('--rc-plate-y'))||0, serif:/serif/.test(getComputedStyle(p).fontFamily.replace(/sans-serif/g,'')), tnum:getComputedStyle(p.querySelector('.rw-sync-row')).fontVariantNumeric, vw:innerWidth, vh:innerHeight }; })()`);
+ok(lay.shown && lay.btns === 3, 'the panel is up from the start, with - + and export on it');
+ok(lay.panel.x >= 0 && lay.panel.y >= 0 && lay.panel.x + lay.panel.w <= lay.vw && lay.panel.y + lay.panel.h <= lay.vh, `inside the 390x844 glass (${Math.round(lay.panel.y)}..${Math.round(lay.panel.y + lay.panel.h)})`);
+ok(!hits(lay.panel, lay.score), 'clear of the score plate'); ok(!hits(lay.panel, lay.cap), 'clear of the band');
+ok(!hits(lay.panel, lay.rail), 'clear of the toast rail'); ok(!hits(lay.panel, lay.speed), 'clear of the speed box'); ok(!hits(lay.panel, lay.chips), 'clear of the pickup chips');
+ok(lay.plateY < lay.panel.y || lay.plateY > lay.panel.y + lay.panel.h, `and the plate's rest spot (y ${Math.round(lay.plateY)}) is not under it`);
+ok(!lay.serif && lay.tnum === 'tabular-nums', 'HUD sans, tabular digits, no serif');
+await ev(`document.querySelectorAll('.rw-sync-btn')[1].click()`);
+eq(await ev(`window.__race.race.wordSync.offset()`), 0.05, 'the + button is a 50 ms nudge');
+if (process.env.RACE_SHOTS) {
+  await ev(`window.__race.race.trackClock(${(firstWord - 2).toFixed(2)}, true)`);
+  await sleep(6000);
+  mkdirSync(SHOTS, { recursive: true });
+  const shot = await cdp('Page.captureScreenshot', { format: 'png' });
+  if (shot.result?.data) { writeFileSync(join(SHOTS, 'wsync.png'), Buffer.from(shot.result.data, 'base64')); console.log('  --  shot: ' + join(SHOTS, 'wsync.png')); }
+}
+eq(errs.length, 0, 'nothing on the console' + (errs.length ? ': ' + errs.slice(0, 4).join(' | ') : ''));
+await done(fails ? 1 : 0);

--- a/ConditioningControlPanel/Resources/web/dtrh/race/wordSync.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/wordSync.js
@@ -1,0 +1,157 @@
+/* ============================================================================
+ * race/wordSync.js - THE SYNC WIN: the log, the offset, the overlay.
+ *
+ *   createPopLog({ storage })        -> { push, rows, clear, size }
+ *   readNudge / writeNudge(trackId)  -> the per-track offset in localStorage
+ *   shiftRoad(chart, sec, { trackId }) -> the same road, every word-derived second moved
+ *   createSyncOverlay(root, opts)    -> the `?wsync=1` panel (built on demand only)
+ *
+ * WHY. A word bubble is poppable for 0.06 s at 22 m/s, so a transcript that is 80 ms
+ * late is a road nobody can drive clean, and nobody can tell late from early by ear.
+ * So every pop and every miss writes down how far from the word it landed (`dt`, in
+ * seconds of the file, positive = popped after the word) into a ring of LOG_MAX rows
+ * in localStorage, `[` and `]` move THIS track's offset by NUDGE_SEC (Shift: NUDGE_BIG_SEC)
+ * and `\` copies the numbers a words/index.json row wants. The offset is applied ONCE,
+ * in race/cloudChart.js, on the road as it leaves the source (file offset + local nudge),
+ * so bubbles, rows, plates and the band all move together and the cache never holds it.
+ *
+ * Everything but createSyncOverlay is node-clean: race/smoke/wsync-check.mjs runs it.
+ * ==========================================================================*/
+
+export const LOG_KEY = 'rt-word-sync';
+export const LOG_MAX = 512;
+export const OFFSET_PREFIX = 'rt-word-offset:';
+export const NUDGE_SEC = 0.05, NUDGE_BIG_SEC = 0.25;
+/** The overlay's window: median and p90 over this many pops, newest first. */
+export const STATS_N = 20;
+export const HIST_BINS = 21, HIST_SEC = 1;
+/** How long the panel shows itself after a nudge or an export on a page without ?wsync=1. */
+export const SHOW_MS = 2000, NOTE_MS = 1500;
+/** The event kinds laid off the words file. Energy kinds (build, peak, release) never move. */
+export const WORD_KINDS = Object.freeze(['word', 'trigger', 'count', 'drop', 'chant', 'silence']);
+
+const num = (v, d) => (typeof v === 'number' && isFinite(v) ? v : d);
+const r3 = (v) => Math.round(v * 1000) / 1000;
+const store = () => { try { return typeof localStorage !== 'undefined' ? localStorage : null; } catch (e) { return null; } };
+
+/** The key a track's log rows and offset are filed under: the cloud id first, the hash second. */
+export const trackIdOf = (chart) => (chart && chart.source && (chart.source.cloudId || chart.source.hash)) || '';
+/** '+0.15 s' */
+export const fmtSec = (v) => (v < 0 ? '-' : '+') + Math.abs(num(v, 0)).toFixed(2) + ' s';
+
+export function readNudge(trackId, storage = store()) {
+  if (!trackId || !storage) return 0;
+  try { return r3(num(parseFloat(storage.getItem(OFFSET_PREFIX + trackId)), 0)); } catch (e) { return 0; }
+}
+/** Store the offset (rounded to a millisecond; 0 removes the key). Returns what was stored. */
+export function writeNudge(trackId, sec, storage = store()) {
+  const v = r3(num(sec, 0));
+  if (!trackId || !storage) return v;
+  try { if (v) storage.setItem(OFFSET_PREFIX + trackId, String(v)); else storage.removeItem(OFFSET_PREFIX + trackId); } catch (e) { /* full, or private */ }
+  return v;
+}
+
+/**
+ * The road with every word-derived second moved by `sec`, as a plain object for
+ * normalizeChart. Ids are KEPT, so a mid-run replace (race/chart.js sched.replace)
+ * adopts only what is not yet handed over and never re-fires a bubble already down.
+ * `analysis.offsetSec` accumulates; `source.cloudId` is stamped when `trackId` is given.
+ */
+export function shiftRoad(chart, sec, { trackId = '' } = {}) {
+  const s = r3(num(sec, 0)), dur = num(chart.source && chart.source.durationSec, 0);
+  const mv = (t) => Math.max(0, Math.min(dur, r3(t + s)));
+  const events = (chart.events || []).map((e) => (WORD_KINDS.includes(e.kind) ? { ...e, t: mv(e.t) } : { ...e }));
+  const words = (chart.words || []).map((w) => ({ ...w, t: mv(w.t) }));
+  const source = { ...chart.source, ...(trackId ? { cloudId: trackId } : {}) };
+  const analysis = { ...(chart.analysis || {}), offsetSec: r3(num(chart.analysis && chart.analysis.offsetSec, 0) + s) };
+  return { ...chart, events, words, source, analysis };
+}
+
+/** The ring of pops and misses, written through to storage on every push, never throwing. */
+export function createPopLog({ storage = store(), max = LOG_MAX } = {}) {
+  let rows = [];
+  try { const got = storage ? JSON.parse(storage.getItem(LOG_KEY) || '[]') : []; if (Array.isArray(got)) rows = got.slice(-max); } catch (e) { rows = []; }
+  const save = () => { try { if (storage) storage.setItem(LOG_KEY, JSON.stringify(rows)); } catch (e) { /* full, or private */ } };
+  return {
+    push(row) { rows.push(row); if (rows.length > max) rows.splice(0, rows.length - max); save(); },
+    rows(trackId) { return trackId ? rows.filter((r) => r.trackId === trackId) : rows.slice(); },
+    clear() { rows = []; save(); },
+    get size() { return rows.length; },
+  };
+}
+
+/** Median and p90 of the newest `n` pops (misses excluded), and a histogram of every pop given. */
+export function statsOf(rows, n = STATS_N) {
+  const pops = rows.filter((r) => !r.missed && isFinite(num(r.dt, NaN)));
+  const last = pops.slice(-n).map((r) => r.dt).sort((a, b) => a - b);
+  const q = (p) => (last.length ? last[Math.min(last.length - 1, Math.max(0, Math.ceil(p * last.length) - 1))] : 0);
+  const hist = new Array(HIST_BINS).fill(0);
+  for (const r of pops) {
+    const b = Math.floor(((r.dt + HIST_SEC) / (2 * HIST_SEC)) * HIST_BINS);
+    if (b >= 0 && b < HIST_BINS) hist[b]++;
+  }
+  return { n: last.length, median: r3(q(0.5)), p90: r3(q(0.9)), hist };
+}
+
+/** The line a words/index.json row wants (W6 commits it). */
+export function exportOf({ cloudId = '', offsetSec = 0, rows = [] } = {}) {
+  const s = statsOf(rows, STATS_N);
+  return { cloudId, offsetSec: r3(num(offsetSec, 0)), n: s.n, medianDt: s.median, p90Dt: s.p90 };
+}
+
+/**
+ * The panel. Nothing is built until this is called, so a page without ?wsync=1 and
+ * without a nudge pays nothing. `buttons` puts the phone's [ - ] [ + ] and export on it.
+ */
+export function createSyncOverlay(root, { buttons = false, onNudge = null, onExport = null } = {}) {
+  const el = (tag, cls, parent, text) => { const d = document.createElement(tag); d.className = cls; if (text != null) d.textContent = text; parent.appendChild(d); return d; };
+  const box = el('div', 'rw-sync rh-plate', root);
+  const title = el('div', 'rw-sync-title', box, '');
+  const line = el('div', 'rw-sync-row rh-num', box);
+  const med = el('b', '', el('span', '', line, 'med '), '+0.00');
+  const p90 = el('b', '', el('span', '', line, 'p90 '), '+0.00');
+  const n = el('b', '', el('span', '', line, 'n '), '0');
+  const canvas = el('canvas', 'rw-sync-hist', box);
+  const offRow = el('div', 'rw-sync-row rh-num', box);
+  const off = el('b', 'rw-sync-off', el('span', '', offRow, 'offset '), '+0.00 s');
+  if (buttons) {
+    const btn = (label, fn) => { const b = el('button', 'rw-sync-btn', offRow, label); b.type = 'button'; b.addEventListener('click', (e) => { e.preventDefault(); fn(); }); return b; };
+    btn('-', () => { if (onNudge) onNudge(-NUDGE_SEC); });
+    btn('+', () => { if (onNudge) onNudge(NUDGE_SEC); });
+    btn('export', () => { if (onExport) onExport(); });
+  }
+  const note = el('div', 'rw-sync-note', box, '');
+  let hideT = 0, noteT = 0, lastHist = new Array(HIST_BINS).fill(0);
+  const later = (fn, ms) => setTimeout(fn, ms);
+  function paint(hist) {
+    const dpr = Math.min(2, num(window.devicePixelRatio, 1)), w = canvas.clientWidth || 160, h = canvas.clientHeight || 34;
+    if (canvas.width !== Math.round(w * dpr)) { canvas.width = Math.round(w * dpr); canvas.height = Math.round(h * dpr); }
+    const g = canvas.getContext('2d');
+    if (!g) return;
+    g.setTransform(dpr, 0, 0, dpr, 0, 0); g.clearRect(0, 0, w, h);
+    const top = Math.max(1, ...hist), bw = w / HIST_BINS;
+    g.fillStyle = 'rgba(255, 255, 255, 0.14)'; g.fillRect(Math.floor(w / 2), 0, 1, h);   // the word itself
+    g.fillStyle = '#ff69b4';
+    hist.forEach((v, i) => { if (v) { const bh = Math.max(1, (v / top) * (h - 2)); g.fillRect(i * bw + 1, h - bh, Math.max(1, bw - 2), bh); } });
+  }
+  return {
+    el: box,
+    /** Fresh numbers. `rows` are this track's log rows, `offsetSec` the total applied to it. */
+    update({ rows = [], offsetSec = 0, name = '' } = {}) {
+      const s = statsOf(rows);
+      title.textContent = name; med.textContent = fmtSec(s.median).slice(0, -2); p90.textContent = fmtSec(s.p90).slice(0, -2);
+      n.textContent = String(s.n); off.textContent = fmtSec(offsetSec); lastHist = s.hist;
+      if (!box.hidden) paint(s.hist);
+    },
+    /** Show it; for `ms` only when given (the auto-show on a nudge without ?wsync=1). */
+    show(ms = 0) {
+      if (box.hidden) { box.hidden = false; paint(lastHist); }
+      if (hideT) { clearTimeout(hideT); hideT = 0; }
+      if (ms > 0) hideT = later(() => { hideT = 0; box.hidden = true; }, ms);
+    },
+    say(text) { note.textContent = text; if (noteT) clearTimeout(noteT); noteT = later(() => { noteT = 0; note.textContent = ''; }, NOTE_MS); },
+    dispose() { if (hideT) clearTimeout(hideT); if (noteT) clearTimeout(noteT); if (box.parentNode) box.parentNode.removeChild(box); },
+  };
+}
+
+// self-check: node race/smoke/wsync-check.mjs (the log, the shift, the keys, and the panel on a phone).

--- a/ConditioningControlPanel/Resources/web/dtrh/race/words.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/words.js
@@ -85,14 +85,14 @@ export async function loadWords({ cloudId = '', hash = '', fetch: f = null, log 
   if (cache.has(key)) return cache.get(key);
   const work = (async () => {
     try {
-      if (!cache.has(indexUrl)) cache.set(indexUrl, readIndex(get, say, indexUrl));
-      const rows = await cache.get(indexUrl);
-      const row = (id && rows.find((r) => norm(r.cloudId) === id)) || (h && rows.find((r) => norm(r.hash) === h)) || null;
+      const row = await loadWordsRow({ cloudId, hash, fetch: get, log, indexUrl });
       if (!row) return null;
       const res = await get(new URL(row.file, indexUrl).href, { credentials: 'omit' });
       if (!res || !res.ok) throw new Error('the transcript answered ' + (res ? res.status : 'nothing'));
       const got = readFile(await res.json());
       say('words: ' + (got ? got.words.length + ' words for ' + (row.title || row.cloudId) : 'nothing readable in ' + row.file));
+      // the row's own key and offset ride along, so the road can be filed and shifted by them
+      if (got) { got.cloudId = row.cloudId; got.offsetSec = row.offsetSec; }
       return got;
     } catch (err) {
       say('words: ' + ((err && err.message) || err));
@@ -101,6 +101,27 @@ export async function loadWords({ cloudId = '', hash = '', fetch: f = null, log 
   })();
   cache.set(key, work);
   return work;
+}
+
+/**
+ * The index ROW for one track, or null: `{ cloudId, hash, title, file, offsetSec }`, with
+ * `offsetSec` (seconds added to every word of the file, default 0) read off the row so
+ * race/cloudChart.js can shift a CACHED road without fetching its transcript again.
+ * Same keys, same doors, never throws.
+ */
+export async function loadWordsRow({ cloudId = '', hash = '', fetch: f = null, log = null, indexUrl = INDEX_URL } = {}) {
+  const get = f || (typeof fetch !== 'undefined' ? fetch : null);
+  const say = (m) => { try { if (log) log(m); } catch (e) { /* no log */ } };
+  const id = norm(cloudId), h = norm(hash);
+  if (!get || (!id && !h)) return null;
+  try {
+    if (!cache.has(indexUrl)) cache.set(indexUrl, readIndex(get, say, indexUrl));
+    const rows = await cache.get(indexUrl);
+    const row = (id && rows.find((r) => norm(r.cloudId) === id)) || (h && rows.find((r) => norm(r.hash) === h)) || null;
+    if (!row) return null;
+    const off = Number(row.offsetSec);
+    return { cloudId: norm(row.cloudId), hash: norm(row.hash), title: String(row.title || ''), file: row.file, offsetSec: isFinite(off) ? off : 0 };
+  } catch (err) { say('words: ' + ((err && err.message) || err)); return null; }
 }
 
 /** The smoke starts over between sections; nothing in the game ever calls this. */


### PR DESCRIPTION
## W5 of the word-bubbles wave: the sync log, the `?wsync=1` overlay, the `[` `]` nudge and the `\` export

Base main (`b5ea3e80f`), one commit, 577 changed lines (555 added, 22 removed).

### What lands

**Pop log** (`race/wordSync.js`, wired in `race/run.js`)
- Every word bubble popped or missed appends `{trackId, i, p, w, t, popT, dt, lane, missed}` to a ring of 512 in localStorage `rt-word-sync`, written through on every row, every read and write guarded by try/catch (a storage that throws leaves a ring in memory).
- Trigger rows log too (`w` = the set label) on their first pop, or `missed: true` once the row is 0.6 s late and unpopped.
- `popT` is the distance-corrected track second the kart met the bubble (`track.t + ahead / speed`), so `dt` is not quantised to the frame.
- Nothing logs on a track without words (`trackKey()` is null there).

**Overlay** (`?wsync=1`)
- A small fixed `.rw-sync.rh-plate` panel: track title, median and p90 `dt` of the last 20 pops, `n`, a 21 bin histogram over -1..+1 s on a 34 px canvas, the current offset. HUD sans (`--rh-font`), `tabular-nums`, pink on the dark plate.
- Off by default: without the flag no DOM is built (the smoke asserts `.rw-sync` count 0).
- Sits at the left edge, 50% down (y 422..543 at 390x844): clear of the score plate, the band, the toast rail, the speed box, the pickup chips and the plate's rest spot.

**Nudge**
- `[` / `]` move this track's offset by 50 ms (Shift: 250 ms) into localStorage `rt-word-offset:<trackId>` (0 removes the key).
- Applied once in `race/cloudChart.js` (`tuned()`): the row's `offsetSec` from `words/index.json` plus the local nudge, on both cached doors and the generated door; the chart cache stays at offset 0.
- Mid-run: `replaceTrack(shiftRoad(chart, delta))` keeps event ids, so the scheduler adopts only the future and words still ahead move; words already handed to the road (inside the 2.5 s lead) keep their placement.
- The panel shows `offset +0.15 s` for 2 s (auto-shown without `?wsync`); phone `-` `+` buttons ride the panel with `?wsync=1` only.

**Export**
- `\` (and the panel's export button) copies `{"cloudId","offsetSec","n","medianDt","p90Dt"}` to the clipboard (`navigator.clipboard` with a textarea fallback), and says `offset copied` on the rail for 1.5 s.
- `race/words.js` gains `loadWordsRow()` and reads `offsetSec` off the index row (default 0). No `index.json` row changes here (W6).

**Desktop keys**: `BracketLeft`, `BracketRight`, `Backslash` in `race/input.js` ACTIONS; none are read by the menu, the cards or the intro. `onAction` callbacks now get `(name, shiftKey)`; ACTIONS are ignored when the key lands in an INPUT / TEXTAREA / SELECT.

**Smoke** `race/smoke/wsync-check.mjs` (node + headless Chrome, 390x844): the shift keeps ids and moves only word kinds, the row offset, the ring at 512, throwing storage, the stats, the export shape; then a drive of the Rapid Induction fixture: pops inside 0.06 s, misses flagged, three `]` presses move the next un-spawned word by +0.15 s with the panel reading `+0.15 s` and hiding after 2 s, `shift+[` takes 0.25 s, the export copies the right shape, the panel's rect is inside the glass and overlaps nothing, no panel without the flag, 0 console errors. `RACE_SHOTS=1` writes `shots/wsync.png` (untracked).

### Smokes
wsync-check, words-check, chart-check, cloud-chart-check, lyrics-road-check, rows-check, sync-check, captions-check, face-check, words-rate-check, pace-check, touch-check: all green, one browser at a time.

### Where the brief and the code disagree
- The speed box is bottom-right in `race.css`, not bottom-left; bottom-left holds the pickup chips and the mixer. The panel sits at the left edge, mid-height instead.
- "1.5 s toast on the band": the band is captions.js (untouched); the copy confirmation is the rail toast plus a 1.5 s note on the panel.
- `?chart=<url>` (what the smoke boots with) bypasses cloudChart.js, so the file-offset seam is covered in node and the runtime nudge in the browser.
- Words already inside the scheduler's lead when you nudge keep their placement; only the un-spawned tail moves.

Not touched: wordFace.js, bubbles.js's painter, pickups.js, wallDom.js, speed.js, the pace, the scheduler's timing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJ66hi5fRM1Dcjo38aSCa2
