### PR TITLE
port: lower dialogs and URL validation with focused Windows CI

### DIFF
--- a/.github/scripts/url-dialog-original.patch
+++ b/.github/scripts/url-dialog-original.patch
@@ -1,0 +1,10 @@
+diff --git a/CCP.Avalonia/Views/Dialogs/UrlPromptDialog.axaml.cs b/CCP.Avalonia/Views/Dialogs/UrlPromptDialog.axaml.cs
+index a908d910..27210f53 100644
+--- a/CCP.Avalonia/Views/Dialogs/UrlPromptDialog.axaml.cs
++++ b/CCP.Avalonia/Views/Dialogs/UrlPromptDialog.axaml.cs
+@@ -1 +0,0 @@
+-using System;
+@@ -36,2 +35 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
+-            if (!Uri.TryCreate(text, UriKind.Absolute, out var uri)
+-                || (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
++            if (string.IsNullOrWhiteSpace(text))

--- a/.github/scripts/url-dialog-pair.ps1
+++ b/.github/scripts/url-dialog-pair.ps1
@@ -126,7 +126,8 @@ try {
         $tree = Require-Success (Invoke-Owned $git @('-C', $repo, 'rev-parse', "HEAD:$($entry[0])") $repo "tree-$($entry[0])")
         if ($tree -ne $entry[1]) { throw "Unreviewed source tree: $($entry[0])" }
     }
-    Require-Success (Invoke-Owned $git @('-C', $repo, 'archive', '--format=zip', "--output=$root/source.zip", 'HEAD', 'CCP.Avalonia', 'CCP.Core') $repo 'archive') | Out-Null
+    # Export committed LF bytes independently of the host's Git line-ending settings.
+    Require-Success (Invoke-Owned $git @('-C', $repo, '-c', 'core.autocrlf=false', '-c', 'core.eol=lf', 'archive', '--format=zip', "--output=$root/source.zip", 'HEAD', 'CCP.Avalonia', 'CCP.Core') $repo 'archive') | Out-Null
     $patch = Join-Path $root 'url-dialog-original.patch'
     [IO.File]::WriteAllText($patch, [IO.File]::ReadAllText("$PSScriptRoot/url-dialog-original.patch").Replace("`r`n", "`n"))
     if ((Get-FileHash $patch).Hash -ne '234a5a02dd46cdc09ec6a78af76366d44aee5af71b9f4ad1caaffe79d2610807') { throw 'Inverse patch changed' }
@@ -139,8 +140,8 @@ try {
         $source = Join-Path $pair 'source'
         Expand-Archive "$root/source.zip" $source
         if ($mode -eq 'red') {
-            Require-Success (Invoke-Owned $git @('-C', $source, 'apply', '--unidiff-zero', '--check', $patch) $source 'inverse-check') | Out-Null
-            Require-Success (Invoke-Owned $git @('-C', $source, 'apply', '--unidiff-zero', $patch) $source 'inverse-apply') | Out-Null
+            Require-Success (Invoke-Owned $git @('-C', $source, '-c', 'core.autocrlf=false', '-c', 'core.eol=lf', 'apply', '--unidiff-zero', '--check', $patch) $source 'inverse-check') | Out-Null
+            Require-Success (Invoke-Owned $git @('-C', $source, '-c', 'core.autocrlf=false', '-c', 'core.eol=lf', 'apply', '--unidiff-zero', $patch) $source 'inverse-apply') | Out-Null
         }
         $testHash = (Get-FileHash "$source/$tests" -Algorithm SHA256).Hash
         if ($testHash -ne '097b76f6434ab5b164fb06b1c13ede6a39dd19aacb831f21f6d7c7e1e558cd34') { throw 'Test bytes changed' }

--- a/.github/scripts/url-dialog-pair.ps1
+++ b/.github/scripts/url-dialog-pair.ps1
@@ -1,0 +1,196 @@
+param([switch]$SelfCheck)
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+# Classify only completed real smoke runs, never a build/bootstrap exception as RED.
+function Test-SmokeResult($Mode, $Code, [string]$Output, [string]$Errors) {
+    $passes = @([regex]::Matches($Output, '(?m)^  \[PASS\] ')).Count
+    $fails = @([regex]::Matches($Output, '(?m)^  \[FAIL\] (.*)\r?$') | ForEach-Object { $_.Groups[1].Value.TrimEnd("`r") })
+    if ($Errors.Trim() -or $Output -notmatch '(?m)^  \[PASS\] URL prompt bootstrap has no desktop lifetime\r?$') { return $false }
+    if ($Mode -eq 'green') {
+        return $Code -eq 0 -and $passes -eq 87 -and $fails.Count -eq 0 -and
+            $Output.TrimEnd().EndsWith('Linux head can produce every value it renders.')
+    }
+    $expected = @(
+        foreach ($route in 'Load', 'Enter') {
+            foreach ($inputText in 'not a URL', 'relative/path', 'https://', 'file:///tmp/example.mp4',
+                'ftp://example.invalid/a', 'data:text/plain,x', 'javascript:void(0)') {
+                "URL prompt $route '$inputText': rejects without completing  (Result=$inputText, visible=False, completed=True, errorVisible=False, error=)"
+            }
+            "URL prompt $route before correction: rejects without completing  (Result=not a URL, visible=False, completed=True, errorVisible=False, error=)"
+        }
+        foreach ($dismiss in 'Cancel', 'Escape') {
+            "URL prompt $dismiss (invalid first: True): rejects without completing  (Result=not a URL, visible=False, completed=True, errorVisible=False, error=)"
+        }
+    )
+    return $Code -eq 1 -and $passes -eq 63 -and $fails.Count -eq 18 -and
+        ($fails -join "`n") -ceq ($expected -join "`n") -and $Output.TrimEnd().EndsWith('18 assertion(s) failed.')
+}
+
+if ($SelfCheck) {
+    $ok = "  [PASS] URL prompt bootstrap has no desktop lifetime`n" + ("  [PASS] fixture`n" * 86) + 'Linux head can produce every value it renders.'
+    if (!(Test-SmokeResult green 0 $ok '') -or (Test-SmokeResult red 1 $ok '') -or
+        (Test-SmokeResult green 0 $ok 'startup error') -or (Test-SmokeResult green 1 $ok '') -or
+        (Test-SmokeResult green 0 ($ok.Replace('no desktop lifetime', 'desktop lifetime')) '') -or
+        (Test-SmokeResult green 0 ($ok.Replace("  [PASS] fixture`n", '')) '')) { throw 'Classifier self-check failed' }
+    'Managed classifier self-check passed (no application/process launch).'
+    return
+}
+
+$root = Join-Path $env:RUNNER_TEMP 'url-dialog-pair'
+if (Test-Path $root) { throw "Evidence directory already exists: $root" }
+New-Item -ItemType Directory $root | Out-Null
+function Save-Json($Path, $Value) { $Value | ConvertTo-Json -Depth 12 | Set-Content $Path -Encoding utf8 }
+
+# One bounded child at a time; stdout/stderr and exit/argv survive nonzero exits and timeouts.
+function Invoke-Owned($Exe, [string[]]$Arguments, $Cwd, $Label, $Seconds = 60, $Environment = $null) {
+    $prefix = Join-Path $root $Label
+    $receipt = [ordered]@{ exe = $Exe; argv = $Arguments; cwd = $Cwd; timeoutSeconds = $Seconds; environment = $Environment; exit = $null; timedOut = $false }
+    Save-Json "$prefix.command.json" $receipt
+    $info = [Diagnostics.ProcessStartInfo]::new($Exe)
+    $info.WorkingDirectory = $Cwd
+    $info.UseShellExecute = $false
+    $info.RedirectStandardOutput = $true
+    $info.RedirectStandardError = $true
+    foreach ($arg in $Arguments) { $info.ArgumentList.Add($arg) }
+    if ($null -ne $Environment) {
+        $info.Environment.Clear() # No parent env mutation/restoration, credentials or startup hooks.
+        foreach ($key in $Environment.Keys) { $info.Environment[$key] = $Environment[$key] }
+    }
+    $process = [Diagnostics.Process]::new()
+    $process.StartInfo = $info
+    $outFile = [IO.File]::Create("$prefix.stdout.log")
+    $errFile = [IO.File]::Create("$prefix.stderr.log")
+    try {
+        if (!$process.Start()) { throw "Could not start $Label" }
+        $stdout = $process.StandardOutput.BaseStream.CopyToAsync($outFile)
+        $stderr = $process.StandardError.BaseStream.CopyToAsync($errFile)
+        $finished = $process.WaitForExit($Seconds * 1000)
+        if (!$finished) {
+            $receipt.timedOut = $true
+            $process.Kill($true)
+            if (!$process.WaitForExit(10000)) { throw "$Label did not terminate after kill" }
+        }
+        $receipt.exit = $process.ExitCode
+        if (![Threading.Tasks.Task]::WaitAll([Threading.Tasks.Task[]]@($stdout, $stderr), 10000)) { throw "$Label log drain timed out" }
+        $outFile.Dispose()
+        $errFile.Dispose()
+        if (!$finished) { throw "$Label timed out" }
+        return [pscustomobject]@{ Code = $process.ExitCode; Output = [IO.File]::ReadAllText("$prefix.stdout.log"); Errors = [IO.File]::ReadAllText("$prefix.stderr.log") }
+    } finally {
+        $outFile.Dispose()
+        $errFile.Dispose()
+        Save-Json "$prefix.command.json" $receipt
+        $process.Dispose()
+    }
+}
+function Require-Success($Result) {
+    if ($Result.Code -ne 0) { throw "Required invocation exited $($Result.Code); see raw logs" }
+    return $Result.Output.Trim()
+}
+function New-Profile($Path) {
+    $map = @{}
+    foreach ($key in 'SystemRoot', 'WINDIR', 'SystemDrive', 'ComSpec', 'PATH', 'PATHEXT',
+        'PROCESSOR_ARCHITECTURE', 'NUMBER_OF_PROCESSORS', 'ProgramFiles', 'ProgramFiles(x86)', 'ProgramW6432') {
+        $value = [Environment]::GetEnvironmentVariable($key)
+        if ($null -ne $value) { $map[$key] = $value }
+    }
+    foreach ($key in 'HOME', 'USERPROFILE', 'APPDATA', 'LOCALAPPDATA', 'XDG_CONFIG_HOME', 'XDG_DATA_HOME',
+        'XDG_CACHE_HOME', 'CCP_USERDATA_DIR', 'DOTNET_CLI_HOME', 'TEMP', 'TMP') {
+        $map[$key] = Join-Path $Path $key
+        New-Item -ItemType Directory $map[$key] | Out-Null
+    }
+    $map.DOTNET_ROOT = Split-Path $dotnet
+    $map.DOTNET_CLI_TELEMETRY_OPTOUT = '1'
+    $map.DOTNET_NOLOGO = '1'
+    $map.DOTNET_SKIP_FIRST_TIME_EXPERIENCE = '1'
+    $map.NUGET_PACKAGES = Join-Path $root 'packages'
+    return $map
+}
+function Manifest($Path) {
+    Get-ChildItem $Path -File -Recurse | Sort-Object FullName | ForEach-Object {
+        [ordered]@{ path = [IO.Path]::GetRelativePath($Path, $_.FullName); sha256 = (Get-FileHash $_.FullName -Algorithm SHA256).Hash }
+    }
+}
+
+try {
+    if (!$IsWindows) { throw 'This pair requires Windows; use -SelfCheck for managed-only local validation' }
+    $repo = (Resolve-Path "$PSScriptRoot/../..").Path
+    $dotnet = (Get-Command dotnet -CommandType Application | Select-Object -First 1).Source
+    $git = (Get-Command git -CommandType Application | Select-Object -First 1).Source
+    $identity = Require-Success (Invoke-Owned $git @('-C', $repo, 'rev-parse', 'HEAD', 'HEAD^{tree}') $repo 'checkout')
+    $commit = Require-Success (Invoke-Owned $git @('-C', $repo, 'cat-file', '-p', 'HEAD') $repo 'commit-object') # Real parents even with shallow checkout.
+    Save-Json "$root/identity.json" @{ checkout = $identity; commitObject = $commit; githubSha = $env:GITHUB_SHA; os = [Environment]::OSVersion.VersionString; powershell = "$($PSVersionTable.PSVersion)" }
+    # Freeze the reviewed safe Program/App/null-lifetime route and every product dependency.
+    foreach ($entry in @(@('CCP.Avalonia', '96e91bd4e8cdb0b055166bd93d5e42f2ef02d6dd'), @('CCP.Core', '287515eeafb5dacc3c8f2412d5be8bc92ff457c2'))) {
+        $tree = Require-Success (Invoke-Owned $git @('-C', $repo, 'rev-parse', "HEAD:$($entry[0])") $repo "tree-$($entry[0])")
+        if ($tree -ne $entry[1]) { throw "Unreviewed source tree: $($entry[0])" }
+    }
+    Require-Success (Invoke-Owned $git @('-C', $repo, 'archive', '--format=zip', "--output=$root/source.zip", 'HEAD', 'CCP.Avalonia', 'CCP.Core') $repo 'archive') | Out-Null
+    $patch = Join-Path $root 'url-dialog-original.patch'
+    [IO.File]::WriteAllText($patch, [IO.File]::ReadAllText("$PSScriptRoot/url-dialog-original.patch").Replace("`r`n", "`n"))
+    if ((Get-FileHash $patch).Hash -ne '234a5a02dd46cdc09ec6a78af76366d44aee5af71b9f4ad1caaffe79d2610807') { throw 'Inverse patch changed' }
+    # Inverse derived from ead7 -> 91486f3621ff483357f9113cb48b1f4d7e5b6b27.
+    # Original dialog blob 27210f53cac0fc997eb0fb42892fa997dc9737bb also equals owner 704c5451.
+    $dialog = 'CCP.Avalonia/Views/Dialogs/UrlPromptDialog.axaml.cs'
+    $tests = 'CCP.Avalonia/HeadlessSmoke.cs'
+    foreach ($mode in 'red', 'green') {
+        $pair = Join-Path $root $mode
+        $source = Join-Path $pair 'source'
+        Expand-Archive "$root/source.zip" $source
+        if ($mode -eq 'red') {
+            Require-Success (Invoke-Owned $git @('-C', $source, 'apply', '--unidiff-zero', '--check', $patch) $source 'inverse-check') | Out-Null
+            Require-Success (Invoke-Owned $git @('-C', $source, 'apply', '--unidiff-zero', $patch) $source 'inverse-apply') | Out-Null
+        }
+        $testHash = (Get-FileHash "$source/$tests" -Algorithm SHA256).Hash
+        if ($testHash -ne '097b76f6434ab5b164fb06b1c13ede6a39dd19aacb831f21f6d7c7e1e558cd34') { throw 'Test bytes changed' }
+        $expectedDialog = if ($mode -eq 'red') { '4e135e6f3261b2ced8389ac5a584628afa19c00132b072a4cc1230ab0d3a0437' } else { 'e3944bb609bc6d110b3f362bb98043ccdb3fd6266d26475aeaa5c5329f0b5381' }
+        if ((Get-FileHash "$source/$dialog" -Algorithm SHA256).Hash -ne $expectedDialog) { throw 'Dialog bytes changed' }
+        $before = @(Manifest $source)
+        Save-Json "$pair/source-hashes.json" $before
+        $buildEnv = New-Profile "$pair/build-profile"
+        $sdk = Require-Success (Invoke-Owned $dotnet @('--version') $source "$mode-sdk" 60 $buildEnv)
+        $runtimes = Require-Success (Invoke-Owned $dotnet @('--list-runtimes') $source "$mode-runtimes" 60 $buildEnv)
+        $versions = @([regex]::Matches($runtimes, '(?m)^Microsoft.NETCore.App (8\.0\.\d+) ') | ForEach-Object { [version]$_.Groups[1].Value })
+        if (!$versions.Count) { throw 'No stable .NET 8 runtime installed' }
+        $runtime = ($versions | Sort-Object -Descending | Select-Object -First 1).ToString()
+        Save-Json "$pair/toolchain.json" @{ sdk = $sdk; runtime = $runtime; dotnet = $dotnet }
+        if ($mode -eq 'red') { $redSdk = $sdk; $redRuntime = $runtime }
+        elseif ($sdk -ne $redSdk -or $runtime -ne $redRuntime) { throw 'Pair toolchain mismatch' }
+        $artifacts = Join-Path $pair 'artifacts'
+        $buildArgs = @('build', 'CCP.Avalonia/CCP.Avalonia.csproj', '-c', 'Release', '--artifacts-path', $artifacts, '--disable-build-servers')
+        Require-Success (Invoke-Owned $dotnet $buildArgs $source "$mode-build" 600 $buildEnv) | Out-Null
+        $after = @(Manifest $source)
+        if (($before | ConvertTo-Json -Depth 4) -cne ($after | ConvertTo-Json -Depth 4)) { throw 'Build changed source inputs' }
+        $bin = Join-Path $artifacts 'bin/CCP.Avalonia/release'
+        $config = @('CCP.Avalonia.runtimeconfig.json', 'CCP.Avalonia.deps.json') | ForEach-Object { (Get-FileHash "$bin/$_").Hash }
+        if ($mode -eq 'red') { $redConfig = $config }
+        elseif (($config -join ',') -ne ($redConfig -join ',')) { throw 'Pair runtime/dependency configuration mismatch' }
+        # Fresh process env BEFORE CorePaths/Localization/App initialize; no shell/caller/fetcher.
+        $runEnv = New-Profile "$pair/run-profile"
+        $runEnv.DOTNET_ROLL_FORWARD = 'Disable'
+        $runEnv.COREHOST_TRACE = '1'
+        $runEnv.COREHOST_TRACEFILE = "$pair/host-trace.log"
+        $runEnv.DOTNET_HOST_TRACE = '1' # .NET 10 host spelling; COREHOST remains for older hosts.
+        $runEnv.DOTNET_HOST_TRACEFILE = $runEnv.COREHOST_TRACEFILE
+        $runArgs = @('exec', '--fx-version', $runtime, '--roll-forward', 'Disable', "$bin/CCP.Avalonia.dll", '--smoke')
+        $result = Invoke-Owned $dotnet $runArgs $pair "$mode-smoke" 90 $runEnv
+        $trace = Get-Content $runEnv.COREHOST_TRACEFILE -Raw
+        if ($trace -notmatch ('Microsoft.NETCore.App[\\/]' + [regex]::Escape($runtime) + '[\\/]coreclr.dll')) { throw 'Missing selected .NET 8 CoreCLR evidence' }
+        $accepted = Test-SmokeResult $mode $result.Code $result.Output $result.Errors
+        Save-Json "$pair/result.json" @{ mode = $mode; exit = $result.Code; expectedClassification = $accepted; testSHA256 = $testHash; runtime = $runtime
+            passes = [regex]::Matches($result.Output, '(?m)^  \[PASS\] ').Count; failures = [regex]::Matches($result.Output, '(?m)^  \[FAIL\] ').Count }
+        if (!$accepted) { throw "$mode is not the required URL regression outcome; see raw logs" }
+        if (@(Get-ChildItem $runEnv.CCP_USERDATA_DIR -Force -Recurse).Count) { throw 'Smoke wrote application userdata' }
+    }
+    Save-Json "$root/result.json" @{ status = 'passed'; scope = 'Windows/.NET8 real headless dialogs, not native desktop/visual parity' }
+} catch {
+    $_ | Out-String | Set-Content "$root/error.log"
+    Save-Json "$root/result.json" @{ status = 'failed'; error = $_.ToString() }
+    throw
+} finally {
+    foreach ($mode in 'red', 'green') {
+        $pair = Join-Path $root $mode
+        if (Test-Path $pair) { Save-Json "$root/$mode-artifact-hashes.json" @(Manifest $pair) }
+    }
+}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,6 +91,23 @@ jobs:
       - name: Test app suite
         run: dotnet test Tests/ConditioningControlPanel.Tests/ConditioningControlPanel.Tests.csproj -c Release -p:ValidateExecutableReferencesMatchSelfContained=false
 
+      # Frozen lower-layer real-dialog regression: same tests, original guard then repaired guard.
+      - name: URL dialogs on Windows / .NET 8 (RED then GREEN)
+        if: ${{ !cancelled() }}
+        shell: pwsh
+        timeout-minutes: 25
+        run: ./.github/scripts/url-dialog-pair.ps1
+      - name: Preserve URL pair evidence, including failures
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-url-dialog-pair-${{ github.sha }}
+          if-no-files-found: error
+          include-hidden-files: true
+          path: |
+            ${{ runner.temp }}/url-dialog-pair/
+            !${{ runner.temp }}/url-dialog-pair/packages/**
+
   # Greps the compiler cannot do: APIs that compile fine in a net8.0 library and only fail at
   # runtime, plus the XAML clr-namespace tripwire. See the script for what and why.
   core-guards:

--- a/CCP.Avalonia/HeadlessSmoke.cs
+++ b/CCP.Avalonia/HeadlessSmoke.cs
@@ -35,8 +35,16 @@ namespace ConditioningControlPanel.Avalonia
             var s1 = ConditioningControlPanel.Localization.Loc.Get("section_achievements");
             Check("localization resolves a real string", s1 != "section_achievements", s1);
 
-            // The window is not constructed here: building a Window needs a platform backend, and
-            // asserting on the values it renders is what actually matters.
+            // Ported dialogs: assert their view models resolve real strings. Constructing the
+            // Windows themselves needs a platform backend, so --render-view covers visuals and
+            // this covers the content they bind to.
+            var upd = new Views.Dialogs.UpdateProgressViewModel();
+            Check("UpdateProgressDialog strings resolve",
+                  upd.LocTitle != "dialog_downloading_update", upd.LocTitle);
+
+            var url = new Views.Dialogs.UrlPromptViewModel();
+            Check("UrlPromptDialog strings resolve",
+                  url.LocCancel != "btn_cancel", url.LocCancel);
             Console.WriteLine();
             Console.WriteLine(failures == 0
                 ? "Linux head can produce every value it renders."

--- a/CCP.Avalonia/HeadlessSmoke.cs
+++ b/CCP.Avalonia/HeadlessSmoke.cs
@@ -1,5 +1,14 @@
 using System;
+using System.Threading.Tasks;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Threading;
 using ConditioningControlPanel;
+using ConditioningControlPanel.Avalonia.Views.Dialogs;
+using ConditioningControlPanel.Localization;
 using ConditioningControlPanel.Services.Moderation;
 
 namespace ConditioningControlPanel.Avalonia
@@ -35,9 +44,7 @@ namespace ConditioningControlPanel.Avalonia
             var s1 = ConditioningControlPanel.Localization.Loc.Get("section_achievements");
             Check("localization resolves a real string", s1 != "section_achievements", s1);
 
-            // Ported dialogs: assert their view models resolve real strings. Constructing the
-            // Windows themselves needs a platform backend, so --render-view covers visuals and
-            // this covers the content they bind to.
+            // Ported dialogs: assert their view models resolve real strings.
             var upd = new Views.Dialogs.UpdateProgressViewModel();
             Check("UpdateProgressDialog strings resolve",
                   upd.LocTitle != "dialog_downloading_update", upd.LocTitle);
@@ -45,11 +52,153 @@ namespace ConditioningControlPanel.Avalonia
             var url = new Views.Dialogs.UrlPromptViewModel();
             Check("UrlPromptDialog strings resolve",
                   url.LocCancel != "btn_cancel", url.LocCancel);
+
+            CheckUrlPrompt(Check);
             Console.WriteLine();
             Console.WriteLine(failures == 0
                 ? "Linux head can produce every value it renders."
                 : $"{failures} assertion(s) failed.");
             return failures == 0 ? 0 : 1;
+        }
+
+        private static void CheckUrlPrompt(Action<string, bool, string?> check)
+        {
+            Window? owner = null;
+            try
+            {
+                // Same backend as RenderProof, but no desktop lifetime or real shell/services.
+                AppBuilder.Configure<App>()
+                    .UseSkia()
+                    .UseHeadless(new AvaloniaHeadlessPlatformOptions { UseHeadlessDrawing = false })
+                    .SetupWithoutStarting();
+                check("URL prompt bootstrap has no desktop lifetime", Application.Current!.ApplicationLifetime is null, null);
+                owner = new Window();
+                owner.Show();
+
+                void WithDialog(string scenario, Action<UrlPromptDialog, TextBox, Task> test)
+                {
+                    var dialog = new UrlPromptDialog();
+                    try
+                    {
+                        var completion = dialog.ShowDialog(owner);
+                        Dispatcher.UIThread.RunJobs();
+                        check($"URL prompt {scenario}: starts open without a result/error",
+                            dialog.IsVisible && !completion.IsCompleted && dialog.Result is null
+                            && !dialog.FindControl<TextBlock>("TxtError")!.IsVisible, null);
+                        test(dialog, dialog.FindControl<TextBox>("TxtUrl")!, completion);
+                    }
+                    finally
+                    {
+                        if (dialog.IsVisible) dialog.Close();
+                        Dispatcher.UIThread.RunJobs();
+                    }
+                }
+
+                void PressKey(UrlPromptDialog dialog, PhysicalKey key)
+                {
+                    dialog.FindControl<TextBox>("TxtUrl")!.Focus();
+                    check($"URL prompt {key}: TxtUrl receives keyboard input",
+                        dialog.FindControl<TextBox>("TxtUrl")!.IsFocused, null);
+                    dialog.KeyPressQwerty(key, RawInputModifiers.None);
+                    // The key press may close/dispose the dialog; release on the inert owner then.
+                    (dialog.IsVisible ? dialog : owner).KeyReleaseQwerty(key, RawInputModifiers.None);
+                }
+
+                void Submit(UrlPromptDialog dialog, bool enter)
+                {
+                    if (enter) PressKey(dialog, PhysicalKey.Enter);
+                    else dialog.FindControl<Button>("BtnOk")!.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+                    Dispatcher.UIThread.RunJobs();
+                }
+
+                void Rejected(string scenario, UrlPromptDialog dialog, Task completion)
+                {
+                    var error = dialog.FindControl<TextBlock>("TxtError")!;
+                    var message = Loc.Get("deeper_url_prompt_invalid");
+                    check($"URL prompt {scenario}: rejects without completing",
+                        dialog.Result is null && dialog.IsVisible && !completion.IsCompleted
+                        && error.IsVisible && error.Text == message && message != "deeper_url_prompt_invalid",
+                        $"Result={dialog.Result ?? "<null>"}, visible={dialog.IsVisible}, completed={completion.IsCompleted}, errorVisible={error.IsVisible}, error={error.Text}");
+                }
+
+                void Accepted(string scenario, UrlPromptDialog dialog, Task completion, string expected)
+                {
+                    check($"URL prompt {scenario}: returns trimmed original and closes",
+                        dialog.Result == expected && !dialog.IsVisible && completion.IsCompletedSuccessfully,
+                        $"Result={dialog.Result ?? "<null>"}, visible={dialog.IsVisible}, completed={completion.Status}");
+                }
+
+                foreach (var enter in new[] { false, true })
+                {
+                    var submit = enter ? "Enter" : "Load";
+                    foreach (var input in new[] { "not a URL", "", "   ", "relative/path", "https://",
+                        "file:///tmp/example.mp4", "ftp://example.invalid/a", "data:text/plain,x", "javascript:void(0)" })
+                    {
+                        WithDialog($"{submit} '{input}'", (dialog, text, completion) =>
+                        {
+                            text.Text = input;
+                            Submit(dialog, enter);
+                            Rejected($"{submit} '{input}'", dialog, completion);
+                        });
+                    }
+
+                    foreach (var (input, expected) in new[]
+                    {
+                        ("  http://example.invalid/a  ", "http://example.invalid/a"),
+                        ("  https://example.invalid/a.ccpenh.json  ", "https://example.invalid/a.ccpenh.json"),
+                        ("  HTTPS://EXAMPLE.invalid:443/a/../b?q=%2f#Part  ", "HTTPS://EXAMPLE.invalid:443/a/../b?q=%2f#Part")
+                    })
+                    {
+                        WithDialog($"{submit} accepts '{input}'", (dialog, text, completion) =>
+                        {
+                            text.Text = input;
+                            Submit(dialog, enter);
+                            Accepted(submit, dialog, completion, expected);
+                        });
+                    }
+
+                    WithDialog($"{submit} correction", (dialog, text, completion) =>
+                    {
+                        text.Text = "not a URL";
+                        Submit(dialog, enter);
+                        Rejected($"{submit} before correction", dialog, completion);
+                        if (completion.IsCompleted) return; // Already failed; a closed window cannot be corrected.
+                        text.Text = "  https://example.invalid/corrected  ";
+                        Submit(dialog, enter);
+                        Accepted($"{submit} correction", dialog, completion, "https://example.invalid/corrected");
+                    });
+                }
+
+                foreach (var escape in new[] { false, true })
+                    foreach (var invalidFirst in new[] { false, true })
+                    {
+                        var scenario = $"{(escape ? "Escape" : "Cancel")} (invalid first: {invalidFirst})";
+                        WithDialog(scenario, (dialog, text, completion) =>
+                        {
+                            text.Text = "not a URL";
+                            if (invalidFirst)
+                            {
+                                Submit(dialog, false);
+                                Rejected(scenario, dialog, completion);
+                                if (completion.IsCompleted) return;
+                            }
+                            if (escape) PressKey(dialog, PhysicalKey.Escape);
+                            else dialog.FindControl<Button>("BtnCancel")!.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+                            Dispatcher.UIThread.RunJobs();
+                            check($"URL prompt {scenario}: closes without a result",
+                                dialog.Result is null && !dialog.IsVisible && completion.IsCompletedSuccessfully, null);
+                        });
+                    }
+            }
+            catch (Exception ex)
+            {
+                check("URL prompt fixture executes", false, ex.ToString());
+            }
+            finally
+            {
+                owner?.Close();
+                if (owner is not null) Dispatcher.UIThread.RunJobs();
+            }
         }
     }
 }

--- a/CCP.Avalonia/Views/Dialogs/ChatShortcutCaptureDialog.axaml
+++ b/CCP.Avalonia/Views/Dialogs/ChatShortcutCaptureDialog.axaml
@@ -1,0 +1,55 @@
+<!-- PORTED from ConditioningControlPanel/Dialogs/ChatShortcutCaptureDialog.xaml.
+     Structure, spacing and every resource key preserved. Deviations, all forced:
+       ResizeMode="NoResize"     -> CanResize="False"
+       ToolTip="..."             -> ToolTip.Tip="..."
+       KeyDown="Window_KeyDown"  -> wired in the constructor
+       {loc:Str key}             -> a binding (LocExtension is a WPF MarkupExtension)
+     Buttons and the CheckBox take a TextBlock child rather than Content: Avalonia parses "_" in
+     Content as an access key and every loc key here is snake_case. See CLAUDE.md. -->
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="ConditioningControlPanel.Avalonia.Views.Dialogs.ChatShortcutCaptureDialog"
+        x:DataType="d:ChatShortcutCaptureViewModel"
+        xmlns:d="clr-namespace:ConditioningControlPanel.Avalonia.Views.Dialogs"
+        Title="{Binding LocTitle}"
+        Width="380" SizeToContent="Height"
+        WindowStartupLocation="CenterOwner"
+        CanResize="False"
+        ShowInTaskbar="False"
+        Background="{DynamicResource DarkerBgBrush}"
+        Foreground="White"
+        FontFamily="Segoe UI"
+        Focusable="True">
+    <Border Padding="20" BorderBrush="{DynamicResource PinkBrush}" BorderThickness="1" CornerRadius="8">
+        <StackPanel>
+            <TextBlock Text="{Binding LocPrompt}"
+                       Foreground="White" FontSize="14" TextWrapping="Wrap" Margin="0,0,0,12"/>
+            <Border Background="{DynamicResource SurfaceBgBrush}" CornerRadius="6" Padding="12" Margin="0,0,0,12"
+                    BorderBrush="{DynamicResource PinkBrush}" BorderThickness="1">
+                <TextBlock x:Name="TxtCaptured" Text="{Binding LocListening}"
+                           Foreground="{DynamicResource PinkBrush}" FontSize="20" FontWeight="Bold"
+                           HorizontalAlignment="Center"/>
+            </Border>
+            <TextBlock Text="{Binding LocHint}"
+                       Foreground="{DynamicResource TextMutedBrush}" FontSize="11" TextWrapping="Wrap"
+                       Margin="0,0,0,12"/>
+            <CheckBox x:Name="ChkGlobal"
+                      Foreground="White" FontSize="12" Margin="0,0,0,12"
+                      ToolTip.Tip="{Binding LocGlobalTooltip}">
+                <TextBlock Text="{Binding LocGlobalCheckbox}"/>
+            </CheckBox>
+            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                <Button x:Name="BtnReset"
+                        Background="{DynamicResource SurfaceBgBrush}" Foreground="White"
+                        BorderBrush="#505050" BorderThickness="1" Padding="12,5" Margin="0,0,8,0" Cursor="Hand">
+                    <TextBlock Text="{Binding LocReset}"/>
+                </Button>
+                <Button x:Name="BtnCancel" IsCancel="True"
+                        Background="{DynamicResource SurfaceBgBrush}" Foreground="White"
+                        BorderBrush="#505050" BorderThickness="1" Padding="12,5" Cursor="Hand">
+                    <TextBlock Text="{Binding LocCancel}"/>
+                </Button>
+            </StackPanel>
+        </StackPanel>
+    </Border>
+</Window>

--- a/CCP.Avalonia/Views/Dialogs/ChatShortcutCaptureDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/ChatShortcutCaptureDialog.axaml.cs
@@ -1,0 +1,117 @@
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Markup.Xaml;
+using ConditioningControlPanel.Localization;
+
+namespace ConditioningControlPanel.Avalonia.Views.Dialogs
+{
+    /// <summary>
+    /// Modal dialog that listens for the next keypress and captures it as a chat
+    /// shortcut. Closes with <c>true</c> and <see cref="CapturedKey"/> and
+    /// <see cref="CapturedModifiers"/> set on success, or with <c>true</c> and
+    /// <see cref="ResetToDefault"/>=true if the user clicks Reset. Consumers use
+    /// <c>ShowDialog&lt;bool&gt;</c>; Avalonia has no <c>DialogResult</c>.
+    /// </summary>
+    public partial class ChatShortcutCaptureDialog : Window
+    {
+        private readonly CheckBox _chkGlobal;
+        private readonly TextBlock _txtCaptured;
+
+        public Key CapturedKey { get; private set; }
+
+        /// <summary>
+        /// Avalonia's <see cref="KeyModifiers"/>, not WPF's <c>ModifierKeys</c> — the latter lives
+        /// in System.Windows.Input, which the net8.0 head cannot reference.
+        /// </summary>
+        public KeyModifiers CapturedModifiers { get; private set; }
+
+        public bool ResetToDefault { get; private set; }
+
+        /// <summary>
+        /// State of the "activate from any app" checkbox at dialog close. Caller seeds it
+        /// from settings before <see cref="Window.ShowDialog{TResult}"/> and reads it back after.
+        /// </summary>
+        public bool GlobalHotkey
+        {
+            get => _chkGlobal.IsChecked == true;
+            set => _chkGlobal.IsChecked = value;
+        }
+
+        public ChatShortcutCaptureDialog()
+        {
+            AvaloniaXamlLoader.Load(this);
+            DataContext = new ChatShortcutCaptureViewModel();
+
+            _chkGlobal = this.FindControl<CheckBox>("ChkGlobal")!;
+            _txtCaptured = this.FindControl<TextBlock>("TxtCaptured")!;
+
+            // WPF wired these in markup; the porting rules put them in the constructor.
+            KeyDown += Window_KeyDown;
+            this.FindControl<Button>("BtnReset")!.Click += (_, _) => { ResetToDefault = true; Close(true); };
+            this.FindControl<Button>("BtnCancel")!.Click += (_, _) => Close(false);
+
+            Loaded += (_, _) => Focus();
+        }
+
+        private void Window_KeyDown(object? sender, KeyEventArgs e)
+        {
+            // Ignore modifier-only keys; we want a "real" key to bind to.
+            // WPF's Key.System/e.SystemKey dance has no Avalonia equivalent: Alt+X arrives here
+            // as the real key with KeyModifiers.Alt already set.
+            var key = e.Key;
+            if (IsModifierOnly(key)) return;
+
+            // Escape cancels.
+            if (key == Key.Escape)
+            {
+                e.Handled = true;
+                Close(false);
+                return;
+            }
+
+            // A bare letter/digit/symbol with no modifier would steal that key
+            // globally — typing it in any other app would fire our chat shortcut.
+            // Require at least one modifier; F-keys are accepted bare since they
+            // rarely collide with text input.
+            var mods = e.KeyModifiers;
+            if (mods == KeyModifiers.None && !IsFunctionKey(key))
+            {
+                e.Handled = true;
+                _txtCaptured.Text = Loc.Get("label_chat_shortcut_needs_modifier");
+                return;
+            }
+
+            CapturedKey = key;
+            CapturedModifiers = mods;
+            ResetToDefault = false;
+
+            e.Handled = true;
+            Close(true);
+        }
+
+        private static bool IsModifierOnly(Key k)
+        {
+            return k is Key.LeftCtrl or Key.RightCtrl
+                or Key.LeftShift or Key.RightShift
+                or Key.LeftAlt or Key.RightAlt
+                or Key.LWin or Key.RWin
+                or Key.System or Key.None;
+        }
+
+        private static bool IsFunctionKey(Key k) => k >= Key.F1 && k <= Key.F24;
+    }
+
+    /// <summary>Strings from CCP.Core's Loc. See the porting notes in the repo-root CLAUDE.md
+    /// for why {loc:Str} becomes a binding.</summary>
+    public sealed class ChatShortcutCaptureViewModel
+    {
+        public string LocTitle => Loc.Get("dialog_chat_shortcut_capture_title");
+        public string LocPrompt => Loc.Get("dialog_chat_shortcut_capture_prompt");
+        public string LocListening => Loc.Get("label_chat_shortcut_listening");
+        public string LocHint => Loc.Get("dialog_chat_shortcut_capture_hint");
+        public string LocGlobalCheckbox => Loc.Get("chat_shortcut_global_checkbox");
+        public string LocGlobalTooltip => Loc.Get("chat_shortcut_global_tooltip");
+        public string LocReset => Loc.Get("btn_reset_to_default");
+        public string LocCancel => Loc.Get("btn_cancel");
+    }
+}

--- a/CCP.Avalonia/Views/Dialogs/KnowledgeLinkEditorDialog.axaml
+++ b/CCP.Avalonia/Views/Dialogs/KnowledgeLinkEditorDialog.axaml
@@ -1,0 +1,73 @@
+<!-- PORTED from ConditioningControlPanel/Dialogs/KnowledgeLinkEditorDialog.xaml.
+     Deviations, all forced:
+       ResizeMode="NoResize"            -> CanResize="False"
+       {loc:Str key}                    -> a binding
+       Content="{loc:Str …}" on Button  -> a TextBlock child (Avalonia parses "_" as an access key)
+       SizeToContent="{loc:Str btn_height}" -> SizeToContent="Height"
+           The original is a latent WPF bug: a loc auto-pass swallowed the literal enum value, so it
+           only parses while the active language is English ("Height"); de.json gives "Höhe".
+       MessageBox.Show(validation)      -> the inline TxtError TextBlock below, which occupies the
+           row 3 spacer the original left empty. Avalonia has no MessageBox, and this is the same
+           shape UrlPromptDialog already uses. The hardcoded "Validation Error" caption has no
+           equivalent and drops out. -->
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="ConditioningControlPanel.Avalonia.Views.Dialogs.KnowledgeLinkEditorDialog"
+        x:DataType="d:KnowledgeLinkEditorViewModel"
+        xmlns:d="clr-namespace:ConditioningControlPanel.Avalonia.Views.Dialogs"
+        Title="{Binding LocTitle}"
+        Width="450" SizeToContent="Height"
+        WindowStartupLocation="CenterOwner"
+        Background="{DynamicResource DarkerBgBrush}"
+        CanResize="False">
+
+    <Grid Margin="20">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <!-- URL -->
+        <StackPanel Grid.Row="0" Margin="0,0,0,15">
+            <TextBlock Text="{Binding LocLabelUrl}" Foreground="{DynamicResource PinkBrush}" FontWeight="Bold" Margin="0,0,0,5"/>
+            <TextBox x:Name="TxtUrl" Background="{DynamicResource PanelBgBrush}" Foreground="White"
+                     BorderBrush="{DynamicResource PanelAccentBrush}" Padding="8" FontSize="12"/>
+        </StackPanel>
+
+        <!-- Title -->
+        <StackPanel Grid.Row="1" Margin="0,0,0,15">
+            <TextBlock Text="{Binding LocLabelTitle}" Foreground="{DynamicResource PinkBrush}" FontWeight="Bold" Margin="0,0,0,5"/>
+            <TextBox x:Name="TxtTitle" Background="{DynamicResource PanelBgBrush}" Foreground="White"
+                     BorderBrush="{DynamicResource PanelAccentBrush}" Padding="8" FontSize="12"/>
+        </StackPanel>
+
+        <!-- Description -->
+        <StackPanel Grid.Row="2" Margin="0,0,0,15">
+            <TextBlock Text="{Binding LocLabelDescription}" Foreground="{DynamicResource PinkBrush}" FontWeight="Bold" Margin="0,0,0,5"/>
+            <TextBox x:Name="TxtDescription" Background="{DynamicResource PanelBgBrush}" Foreground="White"
+                     BorderBrush="{DynamicResource PanelAccentBrush}" Padding="8" FontSize="12"
+                     Height="60" TextWrapping="Wrap" AcceptsReturn="True"/>
+        </StackPanel>
+
+        <!-- Validation (stands in for the WPF MessageBox) -->
+        <TextBlock x:Name="TxtError" Grid.Row="3" Foreground="#FFFF6B6B" FontSize="11"
+                   Margin="0,0,0,10" TextWrapping="Wrap" IsVisible="False"/>
+
+        <!-- Buttons -->
+        <StackPanel Grid.Row="4" Orientation="Horizontal" HorizontalAlignment="Right">
+            <Button x:Name="BtnCancel" Width="80" Margin="0,0,10,0"
+                    Background="{DynamicResource PanelAccentBrush}" Foreground="White" BorderThickness="0"
+                    Padding="8" Cursor="Hand">
+                <TextBlock Text="{Binding LocCancel}"/>
+            </Button>
+            <Button x:Name="BtnAdd" Width="80"
+                    Background="{DynamicResource PinkBrush}" Foreground="White" BorderThickness="0"
+                    Padding="8" Cursor="Hand">
+                <TextBlock Text="{Binding LocAdd}"/>
+            </Button>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/CCP.Avalonia/Views/Dialogs/KnowledgeLinkEditorDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/KnowledgeLinkEditorDialog.axaml.cs
@@ -1,0 +1,83 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using ConditioningControlPanel.Localization;
+using ConditioningControlPanel.Models;
+
+namespace ConditioningControlPanel.Avalonia.Views.Dialogs
+{
+    /// <summary>
+    /// Dialog for adding a new knowledge base link.
+    /// </summary>
+    public partial class KnowledgeLinkEditorDialog : Window
+    {
+        /// <summary>
+        /// The result of the dialog - the created link, or null if cancelled.
+        /// </summary>
+        public KnowledgeBaseLink? Result { get; private set; }
+
+        public KnowledgeLinkEditorDialog()
+        {
+            AvaloniaXamlLoader.Load(this);
+            DataContext = new KnowledgeLinkEditorViewModel();
+
+            var add = this.FindControl<Button>("BtnAdd")!;
+            var cancel = this.FindControl<Button>("BtnCancel")!;
+
+            add.Click += (_, _) => Accept();
+            cancel.Click += (_, _) => Close();
+
+            // WPF focused in the constructor; on Avalonia the window is not shown yet at that point.
+            Opened += (_, _) => this.FindControl<TextBox>("TxtUrl")!.Focus();
+        }
+
+        private void Accept()
+        {
+            var txtUrl = this.FindControl<TextBox>("TxtUrl")!;
+            var txtTitle = this.FindControl<TextBox>("TxtTitle")!;
+            var txtDescription = this.FindControl<TextBox>("TxtDescription")!;
+            var error = this.FindControl<TextBlock>("TxtError")!;
+
+            // Validate URL
+            var url = txtUrl.Text?.Trim();
+            if (string.IsNullOrWhiteSpace(url))
+            {
+                error.Text = Loc.Get("msg_enter_url");
+                error.IsVisible = true;
+                txtUrl.Focus();
+                return;
+            }
+
+            // Validate Title
+            var title = txtTitle.Text?.Trim();
+            if (string.IsNullOrWhiteSpace(title))
+            {
+                error.Text = Loc.Get("msg_enter_title");
+                error.IsVisible = true;
+                txtTitle.Focus();
+                return;
+            }
+
+            error.IsVisible = false;
+
+            // Create the link
+            Result = new KnowledgeBaseLink
+            {
+                Url = url,
+                Title = title,
+                Description = txtDescription.Text?.Trim() ?? string.Empty
+            };
+
+            Close();
+        }
+    }
+
+    public sealed class KnowledgeLinkEditorViewModel
+    {
+        public string LocTitle => Loc.Get("dialog_add_knowledge_link");
+        public string LocLabelUrl => Loc.Get("label_url_2");
+        public string LocLabelTitle => Loc.Get("label_title");
+        public string LocLabelDescription => Loc.Get("label_description_optional");
+        public string LocCancel => Loc.Get("btn_cancel");
+        public string LocAdd => Loc.Get("btn_add");
+    }
+}

--- a/CCP.Avalonia/Views/Dialogs/UpdateProgressDialog.axaml
+++ b/CCP.Avalonia/Views/Dialogs/UpdateProgressDialog.axaml
@@ -1,0 +1,37 @@
+<!-- PORTED from ConditioningControlPanel/Dialogs/UpdateProgressDialog.xaml.
+     Structure, spacing and every resource key preserved. Deviations, all forced:
+       WindowStyle="ToolWindow"  -> SystemDecorations="BorderOnly"
+       ResizeMode="NoResize"     -> CanResize="False"
+       {loc:Str key}             -> a binding (LocExtension is a WPF MarkupExtension) -->
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="ConditioningControlPanel.Avalonia.Views.Dialogs.UpdateProgressDialog"
+        x:DataType="d:UpdateProgressViewModel"
+        xmlns:d="clr-namespace:ConditioningControlPanel.Avalonia.Views.Dialogs"
+        Title="{Binding LocTitle}"
+        Height="150" Width="400"
+        WindowStartupLocation="CenterScreen"
+        CanResize="False"
+        SystemDecorations="BorderOnly"
+        Background="{DynamicResource DarkerBgBrush}">
+
+  <Grid Margin="20" RowDefinitions="Auto,Auto,Auto">
+
+    <!-- Title -->
+    <TextBlock Grid.Row="0" Text="{Binding LocHeading}"
+               Foreground="{DynamicResource PinkBrush}" FontSize="18" FontWeight="Bold" Margin="0,0,0,15"/>
+
+    <!-- Progress Bar -->
+    <Border Grid.Row="1" Background="{DynamicResource PanelBgBrush}" CornerRadius="4" Height="20" Padding="2">
+      <Grid>
+        <Border x:Name="ProgressFill" Background="{DynamicResource PinkBrush}" CornerRadius="3"
+                HorizontalAlignment="Left" Width="0"/>
+      </Grid>
+    </Border>
+
+    <!-- Progress Text -->
+    <TextBlock x:Name="TxtProgress" Grid.Row="2" Text="0%"
+               Foreground="#E0E0E0" FontSize="13"
+               HorizontalAlignment="Center" Margin="0,10,0,0"/>
+  </Grid>
+</Window>

--- a/CCP.Avalonia/Views/Dialogs/UpdateProgressDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/UpdateProgressDialog.axaml.cs
@@ -1,0 +1,32 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using ConditioningControlPanel.Localization;
+
+namespace ConditioningControlPanel.Avalonia.Views.Dialogs
+{
+    public partial class UpdateProgressDialog : Window
+    {
+        public UpdateProgressDialog()
+        {
+            AvaloniaXamlLoader.Load(this);
+            DataContext = new UpdateProgressViewModel();
+        }
+
+        /// <summary>Drives the fill width, exactly as the WPF code-behind does.</summary>
+        public void SetProgress(double fraction, double trackWidth)
+        {
+            var fill = this.FindControl<Border>("ProgressFill");
+            var text = this.FindControl<TextBlock>("TxtProgress");
+            if (fill is not null) fill.Width = System.Math.Clamp(fraction, 0, 1) * trackWidth;
+            if (text is not null) text.Text = $"{System.Math.Clamp(fraction, 0, 1) * 100:0}%";
+        }
+    }
+
+    /// <summary>Strings from CCP.Core's Loc. See the porting notes in the repo-root CLAUDE.md
+    /// for why {loc:Str} becomes a binding.</summary>
+    public sealed class UpdateProgressViewModel
+    {
+        public string LocTitle => Loc.Get("dialog_downloading_update");
+        public string LocHeading => Loc.Get("label_downloading_update");
+    }
+}

--- a/CCP.Avalonia/Views/Dialogs/UrlPromptDialog.axaml
+++ b/CCP.Avalonia/Views/Dialogs/UrlPromptDialog.axaml
@@ -1,0 +1,53 @@
+<!-- PORTED from ConditioningControlPanel/Views/Deeper/UrlPromptDialog.xaml.
+     Deviations, all forced:
+       ResizeMode="NoResize"   -> CanResize="False"
+       ShowInTaskbar="False"   -> ShowInTaskbar="False" (same)
+       Visibility="Collapsed"  -> IsVisible="False"
+       Cursor="Hand"           -> Cursor="Hand" (Avalonia has the same standard cursor)
+       {loc:Str key}           -> a binding
+     IsDefault/IsCancel exist in Avalonia and are kept, so Enter and Escape behave as before. -->
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="ConditioningControlPanel.Avalonia.Views.Dialogs.UrlPromptDialog"
+        x:DataType="d:UrlPromptViewModel"
+        xmlns:d="clr-namespace:ConditioningControlPanel.Avalonia.Views.Dialogs"
+        Title="{Binding LocTitle}"
+        Height="190" Width="500" MinHeight="160" MinWidth="380"
+        WindowStartupLocation="CenterOwner"
+        CanResize="False"
+        ShowInTaskbar="False"
+        Background="{DynamicResource DarkerBgBrush}">
+
+  <StackPanel Margin="20,16,20,16">
+    <TextBlock Text="{Binding LocLabel}"
+               Foreground="{DynamicResource TextLightBrush}"
+               FontSize="12" Margin="0,0,0,8" TextWrapping="Wrap"/>
+
+    <TextBox x:Name="TxtUrl" FontSize="12"
+             BorderBrush="{DynamicResource DeeperAccentTransparent40Brush}"
+             BorderThickness="1" Padding="8,6"/>
+
+    <TextBlock x:Name="TxtError" Foreground="#FFFF6B6B" FontSize="11"
+               Margin="0,6,0,0" TextWrapping="Wrap" IsVisible="False"/>
+
+    <DockPanel Margin="0,16,0,0" LastChildFill="False">
+      <Button DockPanel.Dock="Right" Name="BtnOk"
+              Padding="14,6" Cursor="Hand" FontSize="11" FontWeight="SemiBold"
+              IsDefault="True"
+              Background="{DynamicResource DeeperAccentBrush}"
+              Foreground="White" BorderThickness="0" Margin="8,0,0,0">
+        <!-- TextBlock child, not Content: Avalonia parses "_" in Content as an access key and
+             every loc key here is snake_case. See the porting notes in CLAUDE.md. -->
+        <TextBlock Text="{Binding LocLoad}"/>
+      </Button>
+      <Button DockPanel.Dock="Right" Name="BtnCancel"
+              Padding="14,6" Cursor="Hand" FontSize="11"
+              IsCancel="True"
+              Background="Transparent"
+              Foreground="{DynamicResource TextLightBrush}"
+              BorderBrush="{DynamicResource DeeperAccentTransparent40Brush}" BorderThickness="1">
+        <TextBlock Text="{Binding LocCancel}"/>
+      </Button>
+    </DockPanel>
+  </StackPanel>
+</Window>

--- a/CCP.Avalonia/Views/Dialogs/UrlPromptDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/UrlPromptDialog.axaml.cs
@@ -1,0 +1,54 @@
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml;
+using ConditioningControlPanel.Localization;
+
+namespace ConditioningControlPanel.Avalonia.Views.Dialogs
+{
+    public partial class UrlPromptDialog : Window
+    {
+        /// <summary>The entered URL, or null when the user cancelled.</summary>
+        public string? Result { get; private set; }
+
+        public UrlPromptDialog()
+        {
+            AvaloniaXamlLoader.Load(this);
+            DataContext = new UrlPromptViewModel();
+
+            var url = this.FindControl<TextBox>("TxtUrl")!;
+            var ok = this.FindControl<Button>("BtnOk")!;
+            var cancel = this.FindControl<Button>("BtnCancel")!;
+
+            // WPF wired KeyDown in markup; Avalonia's compiled bindings prefer code, and this
+            // keeps Enter working identically to the original's IsDefault path.
+            url.KeyDown += (_, e) => { if (e.Key == Key.Enter) Accept(url); };
+            ok.Click += (_, _) => Accept(url);
+            cancel.Click += (_, _) => Close();
+        }
+
+        private void Accept(TextBox url)
+        {
+            var text = url.Text?.Trim();
+            var error = this.FindControl<TextBlock>("TxtError")!;
+
+            if (string.IsNullOrWhiteSpace(text))
+            {
+                error.Text = Loc.Get("deeper_url_prompt_invalid");
+                error.IsVisible = true;
+                return;
+            }
+
+            Result = text;
+            Close();
+        }
+    }
+
+    public sealed class UrlPromptViewModel
+    {
+        public string LocTitle => Loc.Get("deeper_url_prompt_title");
+        public string LocLabel => Loc.Get("deeper_url_prompt_label");
+        public string LocLoad => Loc.Get("deeper_url_prompt_load");
+        public string LocCancel => Loc.Get("btn_cancel");
+    }
+}

--- a/CCP.Avalonia/Views/Dialogs/UrlPromptDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/UrlPromptDialog.axaml.cs
@@ -1,3 +1,4 @@
+using System;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;
@@ -32,7 +33,8 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
             var text = url.Text?.Trim();
             var error = this.FindControl<TextBlock>("TxtError")!;
 
-            if (string.IsNullOrWhiteSpace(text))
+            if (!Uri.TryCreate(text, UriKind.Absolute, out var uri)
+                || (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
             {
                 error.Text = Loc.Get("deeper_url_prompt_invalid");
                 error.IsVisible = true;


### PR DESCRIPTION
## Scope

New lower draft against #491 (`port/11-shell-docs-and-agent-config` at `c7098898758739bef661e9e3a1f1180e7a3fa53a`). This contains the reviewed lower dialog layer and URL-validation repair, plus focused CI-only additions. Workshop cells remain in the preserved local upper split; this does not replace, retarget, or propagate existing #492 or its descendants.

- Frozen lower source: `ead7b3c8e331c0fcbe5efc565ca7cce60736ba7e`, tree `664667ed2a714156a81d7512a85cdbc00f96e588`.
- Independently source/safety-reviewed head: `b7a9e38ea7db3fb71f90a035da9ef078987ed332`, tree `f935836510275978cc0cd5e826593440dd103aaa`.
- All application/Core/HeadlessSmoke bytes are unchanged from that lower source. Only the workflow and CI script/patch are added above it: 223 lines; complete layer 890 additions+deletions (<1000).

## Validation plan (actual Windows results pending)

Preserves every existing core-linux, core-guards, Windows solution-build and app-suite gate. Adds a bounded, isolated Windows same-test pair using explicit .NET 8 runtime selection and host-trace evidence: restore only the pinned original owning-dialog guard for RED, then run the reviewed fixed guard for GREEN. Unchanged real HeadlessSmoke dialogs exercise Load/Enter/Result/error/modal behavior; no normal app or URL-fetch consumer is invoked by this added path. RED must be the 18 specific original URL-validation failures (exit 1, 63 passes), not setup/build/startup failure; GREEN requires exit 0 and all 87 passes. Source/build/runtime/argv/logs and partial-failure artifacts are retained.

Independent local PowerShell parser/managed-only checks passed, but are **not Windows/.NET8 execution evidence**. First actual CI results and all existing job conclusions must be evaluated without weakening gates or automatically rerunning/fixing failures.

## Deliberately pending

Headless dialogs are not native desktop/visual parity. Native Windows/Linux interaction, focus/accessibility, caller integration and performance remain unverified. #492/242-descendant propagation, #940/#872 work, and main/#481 reconciliation are outside this draft. No merge, retarget, force push, or stack replay is requested.
