### PR TITLE
fix: possession target walk off the UI thread, and EMI collapsing into a pixel

### DIFF
--- a/ConditioningControlPanel/MainWindow/MainWindow.Possession.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.Possession.cs
@@ -252,6 +252,25 @@ namespace ConditioningControlPanel
 
         internal IReadOnlyList<PossessionTarget> GetPossessionTargets()
         {
+            // Off the UI thread this walk is not merely slow, it is illegal: the very first thing it
+            // reads is Window.Content, a dependency property, and DependencyObject.GetValue calls
+            // VerifyAccess. Three users hit exactly that as "Possession: target walk failed /
+            // InvalidOperationException: The calling thread cannot access this object" (ccp-bugs
+            // #1160, #1167, #1184). The caller that actually did it is fixed at its own layer
+            // (PossessionEvents marshals its settings reaction now), but this registry is public
+            // surface read from a dozen effects, so it degrades here instead of throwing: hand back
+            // the last good snapshot and leave the rebuild to the next UI-thread read.
+            //
+            // Deliberately NOT a blocking Invoke across to the UI thread: a background caller
+            // waiting on a dispatcher that is at that moment animating a ghost is how a haunt turns
+            // into a hang. The cache is marked dirty so the rebuild happens at the first safe read,
+            // still behind PossessionRebuildFloor.
+            if (!Dispatcher.CheckAccess())
+            {
+                _possessionCacheDirty = true;
+                return _possessionTargetCache ?? (IReadOnlyList<PossessionTarget>)Array.Empty<PossessionTarget>();
+            }
+
             try
             {
                 var now = DateTime.Now;

--- a/ConditioningControlPanel/Services/Possession/PossessionEvents.cs
+++ b/ConditioningControlPanel/Services/Possession/PossessionEvents.cs
@@ -119,26 +119,48 @@ public sealed class PossessionEvents
     }
 
     /// <summary>Any setting flip. The label nearest the cursor is the one the user was reading when
-    /// they did it, which makes the mis-typing land as an answer rather than as a coincidence.</summary>
+    /// they did it, which makes the mis-typing land as an answer rather than as a coincidence.
+    ///
+    /// <para>THREAD: unlike the two pointer triggers above, this one arrives on whatever thread wrote
+    /// the setting. AppSettings.OnPropertyChanged raises PropertyChanged inline with no marshalling,
+    /// and plenty of settings are written off the UI thread - the wake-word calibration sweep
+    /// (SherpaWakeService.ApplyAndReturn), the auth-token refresh in ProfileSyncService, chaos slot
+    /// bookkeeping. Reacting on that thread walked the host's registry from a thread pool worker,
+    /// where the first dependency-property read throws VerifyAccess: "Possession: target walk failed"
+    /// with InvalidOperationException (ccp-bugs #1160, #1167, #1184). Everything downstream of the
+    /// name filter touches the visual tree - NearestTarget walks the registry and measures bounds,
+    /// RequestReactive mutates the live ledger - so the whole reaction is posted to the UI thread.
+    /// BeginInvoke, not Invoke: a settings write must never block on a dispatcher that is busy
+    /// animating a ghost, and one skipped typo effect costs nothing.</para></summary>
     private void OnSettingChanged(object? sender, PropertyChangedEventArgs e)
     {
         var director = _director;
         if (director == null) return;
-        try
-        {
-            // The Possession settings themselves are exempt: reacting to "the user just turned the
-            // haunt down" by haunting them is the one joke that reads as the app ignoring consent.
-            var name = e?.PropertyName ?? "";
-            if (name.StartsWith("LockdownPossession", StringComparison.Ordinal)
-                || name.StartsWith("LockdownPhotosafe", StringComparison.Ordinal)
-                || name.StartsWith("LockdownTripwires", StringComparison.Ordinal)
-                || name.StartsWith("LockdownWarden", StringComparison.Ordinal))
-                return;
 
-            var label = director.NearestTarget(PossessionRole.Label);
-            if (label != null) director.RequestReactive("typo", label, PossessionRung.Drift);
-        }
-        catch (Exception ex) { App.Logger?.Debug("Possession reactive setting failed: {Error}", ex.Message); }
+        // The Possession settings themselves are exempt: reacting to "the user just turned the haunt
+        // down" by haunting them is the one joke that reads as the app ignoring consent. The test is
+        // a string compare and safe on any thread, so an exempt setting never pays for a hop.
+        var name = e?.PropertyName ?? "";
+        if (name.StartsWith("LockdownPossession", StringComparison.Ordinal)
+            || name.StartsWith("LockdownPhotosafe", StringComparison.Ordinal)
+            || name.StartsWith("LockdownTripwires", StringComparison.Ordinal)
+            || name.StartsWith("LockdownWarden", StringComparison.Ordinal))
+            return;
+
+        // Runs inline when we are already on the UI thread, which is the common case (a user
+        // flipping a toggle), so nothing about the timing of a hand-driven change moves.
+        Helpers.DispatcherHelper.RunOnUI(() =>
+        {
+            try
+            {
+                // Re-read: Detach may have happened while this was queued.
+                var d = _director;
+                if (d == null) return;
+                var label = d.NearestTarget(PossessionRole.Label);
+                if (label != null) d.RequestReactive("typo", label, PossessionRung.Drift);
+            }
+            catch (Exception ex) { App.Logger?.Debug("Possession reactive setting failed: {Error}", ex.Message); }
+        });
     }
 
     /// <summary>Name or caption says Start / Stop. Deliberately loose (the label is localized, the

--- a/ConditioningControlPanel/Windows/EmiDesk/EmiDeskWindow.Alive.cs
+++ b/ConditioningControlPanel/Windows/EmiDesk/EmiDeskWindow.Alive.cs
@@ -649,10 +649,20 @@ public partial class EmiDeskWindow
             var up = new CubicEase { EasingMode = EasingMode.EaseOut };
             var down = new CubicEase { EasingMode = EasingMode.EaseInOut };
 
+            // HoldEnd, NOT Stop, and this is the second half of the "EMI turns into a pink pixel"
+            // fix (ccp-bugs #1173, #1183 - see ResetCrtBase in EmiDeskWindow.Fx.cs). A Stop
+            // animation does not settle on its last keyframe; it hands the property straight back
+            // to the BASE value, and the base of CrtScale is whatever the last local write left
+            // there. The stretch is the only CrtScale animation in the widget that ever released
+            // the property, so it was the only one that could publish a stale base - and on the
+            // rarest clock in the file, which is why it read as random. Its last keyframe is
+            // already exactly 1.0, so holding it is what the animation was always meant to leave
+            // behind, and it now costs nothing whether the base is right or not. The other three
+            // CrtScale animators (CrtOn, CrtOff, AnimateScalePulse) have always held their end.
             var a = new DoubleAnimationUsingKeyFrames
             {
                 Duration = TimeSpan.FromMilliseconds(total),
-                FillBehavior = FillBehavior.Stop
+                FillBehavior = FillBehavior.HoldEnd
             };
             a.KeyFrames.Add(new EasingDoubleKeyFrame(
                 EmiAlive.StretchScale, KeyTime.FromPercent(EmiAlive.StretchUpMs / total), up));

--- a/ConditioningControlPanel/Windows/EmiDesk/EmiDeskWindow.Fx.cs
+++ b/ConditioningControlPanel/Windows/EmiDesk/EmiDeskWindow.Fx.cs
@@ -71,7 +71,14 @@ public partial class EmiDeskWindow
             TearDownReactions();
 
             // The window goes up first (the smoke has to be somewhere), but she does not.
+            //
+            // The BeginAnimation(null) pair is not decoration: an animation left holding this
+            // property (CrtOff holds 0.02, a bounce pulse holds 1.0) OUTRANKS a local write, so
+            // without the clear these two lines were silently doing nothing on every summon after
+            // the first. See ResetCrtBase for the rest of that story.
             BodyRoot.Visibility = Visibility.Hidden;
+            CrtScale.BeginAnimation(ScaleTransform.ScaleXProperty, null);
+            CrtScale.BeginAnimation(ScaleTransform.ScaleYProperty, null);
             CrtScale.ScaleX = 0.02;
             CrtScale.ScaleY = 0.02;
             Visibility = Visibility.Visible;
@@ -90,6 +97,12 @@ public partial class EmiDeskWindow
                 After(CrtOnMs + 20, () =>
                 {
                     if (_closingForGood) return;
+
+                    // THE PICTURE IS UP, SO THE BASE VALUE GOES BACK TO FULL SIZE. This is the fix
+                    // for "EMI disappears after a while into a small pink pixel" (ccp-bugs #1173,
+                    // #1183) and it is worth spelling out, because nothing about it is visible.
+                    ResetCrtBase(clearAnimations: false);
+
                     _transiting = false;
                     InputLocked = false;
 
@@ -110,8 +123,9 @@ public partial class EmiDeskWindow
                 _transiting = false;
                 InputLocked = false;
                 BodyRoot.Visibility = Visibility.Visible;
-                CrtScale.ScaleX = 1;
-                CrtScale.ScaleY = 1;
+                // ResetCrtBase, not two local writes: "showing her plain" has to beat an animation
+                // that may still be holding the power-off collapse, and a local write cannot.
+                ResetCrtBase(clearAnimations: true);
                 Visibility = Visibility.Visible;
                 RestartIdleBeats();
                 done?.Invoke();
@@ -174,10 +188,7 @@ public partial class EmiDeskWindow
             Hide();
             Visibility = Visibility.Hidden;
             BodyRoot.Visibility = Visibility.Visible;
-            CrtScale.BeginAnimation(ScaleTransform.ScaleXProperty, null);
-            CrtScale.BeginAnimation(ScaleTransform.ScaleYProperty, null);
-            CrtScale.ScaleX = 1;
-            CrtScale.ScaleY = 1;
+            ResetCrtBase(clearAnimations: true);
             _transiting = false;
             InputLocked = false;
             SetPose("idle");
@@ -195,6 +206,48 @@ public partial class EmiDeskWindow
     }
 
     // ------------------------------------------------------------------ CRT
+
+    /// <summary>
+    /// Put <c>CrtScale</c>'s BASE VALUE back to full size.
+    ///
+    /// <para>THE BUG THIS EXISTS FOR (ccp-bugs #1173, #1183: "EMI disappears after a while into a
+    /// small pink pixel", "the avatar is gone but I can still see her speech bubbles"). Four
+    /// separate animators write CrtScale: the power-on, the power-off, the bounce/thud pulse
+    /// (AnimateScalePulse) and the rare stretch (EmiDeskWindow.Alive.cs RunStretch). The first
+    /// three end HoldEnd, so what is on screen is the animation's own last keyframe and the base
+    /// value underneath is never read. The stretch ends FillBehavior.Stop, and a Stop animation
+    /// does not settle on its last keyframe: it hands the property back to whatever the BASE value
+    /// is.</para>
+    ///
+    /// <para>RunSummon wrote 0.02 into that base to hide her behind the smoke and never wrote
+    /// anything else, so from the first summon of a sitting the base was two percent. Nobody
+    /// noticed for twenty to forty minutes, which is the stretch's cooldown - then the stretch
+    /// finished, released the property, and the whole body collapsed onto its render-transform
+    /// origin as a couple of pink pixels. Everything outside BodyRoot kept working, which is why
+    /// the bubbles were still there and why she came back the moment a bounce (HoldEnd, ends at 1)
+    /// masked the base again: it reads as intermittent, and it is not.</para>
+    ///
+    /// <para><paramref name="clearAnimations"/> also drops whatever is holding the property, for
+    /// the two callers that need the value they write to be the value on screen. A local write
+    /// alone cannot beat a HoldEnd animation.</para>
+    /// </summary>
+    private void ResetCrtBase(bool clearAnimations)
+    {
+        try
+        {
+            if (clearAnimations)
+            {
+                CrtScale.BeginAnimation(ScaleTransform.ScaleXProperty, null);
+                CrtScale.BeginAnimation(ScaleTransform.ScaleYProperty, null);
+            }
+            CrtScale.ScaleX = 1;
+            CrtScale.ScaleY = 1;
+        }
+        catch (Exception ex)
+        {
+            Log.Debug(ex, "[EmiDesk] CRT base reset failed");
+        }
+    }
 
     /// <summary>
     /// The power-on: a dot, a horizontal line, then the picture. Four DISCRETE steps, no easing,

--- a/Tests/ConditioningControlPanel.Tests/EmiDeskLiveRunRegressionTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/EmiDeskLiveRunRegressionTests.cs
@@ -90,4 +90,45 @@ public class EmiDeskLiveRunRegressionTests
         Assert.DoesNotContain("WinWidthDip", Read("Services", "EmiDesk", "EmiState.cs"));
         Assert.DoesNotContain("WinWidthDip", Read("Windows", "EmiDesk", "EmiDeskWindow.xaml.cs"));
     }
+
+    [Fact]
+    public void The_crt_scale_never_falls_back_to_a_collapsed_base_value()
+    {
+        // "EMI disappears after a while into a small pink pixel" and "the avatar is gone but I can
+        // still see her speech bubbles" (ccp-bugs #1173, #1183). CrtScale has four animators; three
+        // of them hold their last keyframe, so the BASE value under them is invisible. The summon
+        // wrote 0.02 into that base to hide her behind the smoke and never wrote anything back, and
+        // the one animation that RELEASED the property - the stretch, on its 20-to-40 minute clock
+        // - handed the transform to that stale 0.02 and collapsed her whole body onto its transform
+        // origin. Everything outside BodyRoot (the bubble host, the FX layers) kept drawing, which
+        // is exactly what the reporters saw.
+        //
+        // Two source tripwires rather than a behavioural test, in the spirit of this file: the
+        // failure needs a live widget and the better part of an hour to show itself.
+        var fx = Read("Windows", "EmiDesk", "EmiDeskWindow.Fx.cs");
+        var alive = Read("Windows", "EmiDesk", "EmiDeskWindow.Alive.cs");
+
+        // 1. The summon puts the base back to full size once the power-on has landed.
+        Assert.Contains("private void ResetCrtBase(bool clearAnimations)", fx);
+        int preroll = fx.IndexOf("CrtScale.ScaleX = 0.02;", StringComparison.Ordinal);
+        int restore = fx.IndexOf("ResetCrtBase(clearAnimations: false);", StringComparison.Ordinal);
+        Assert.True(preroll >= 0 && restore > preroll,
+            "the summon's 0.02 pre-roll must be followed by a base reset in the same method");
+
+        // 2. And no CrtScale animation may release the property onto whatever the base happens to
+        //    be. The stretch is the only one that ever did; its last keyframe is already 1.0.
+        Assert.DoesNotContain("FillBehavior = FillBehavior.Stop", StretchBlockOf(alive));
+    }
+
+    /// <summary>The stretch's animation set-up, which is the only place in Alive.cs where a
+    /// FillBehavior lands on CrtScale (the weight shift's Stop is on WobbleRotate, whose base is a
+    /// harmless zero).</summary>
+    private static string StretchBlockOf(string alive)
+    {
+        int end = alive.IndexOf("CrtScale.BeginAnimation(ScaleTransform.ScaleXProperty", StringComparison.Ordinal);
+        Assert.True(end > 0, "Alive.cs no longer animates CrtScale - re-point this tripwire");
+        int start = alive.LastIndexOf("private void RunStretch()", end, StringComparison.Ordinal);
+        Assert.True(start >= 0, "the CrtScale animation in Alive.cs moved out of RunStretch");
+        return alive.Substring(start, end - start);
+    }
 }

--- a/Tests/ConditioningControlPanel.Tests/PossessionThreadAffinityTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/PossessionThreadAffinityTests.cs
@@ -1,0 +1,68 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// The haunt's registry is a WPF visual tree, so every read of it is UI-thread work.
+///
+/// <para><b>The bug.</b> Three users' logs carried "Possession: target walk failed" with
+/// InvalidOperationException from Dispatcher.VerifyAccess (ccp-bugs #1160, #1167, #1184). The
+/// caller was PossessionEvents' settings trigger: AppSettings raises PropertyChanged INLINE on
+/// whatever thread wrote the setting, and plenty of settings are written off the UI thread, so a
+/// background write walked MainWindow's visual tree from a thread pool worker. The very first
+/// thing GetPossessionTargets reads is Window.Content, a dependency property, and that throws.</para>
+///
+/// <para><b>Why source tripwires.</b> Reproducing it needs a realized MainWindow, an armed
+/// lockdown and a background settings write landing inside a 750 ms window. The fix is two lines in
+/// two files, and losing either of them silently brings the warning back, so both are pinned
+/// here.</para>
+/// </summary>
+public class PossessionThreadAffinityTests
+{
+    private static string RepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir != null && !Directory.Exists(Path.Combine(dir.FullName, "ConditioningControlPanel", "Resources")))
+            dir = dir.Parent;
+        Assert.True(dir != null, "could not locate the repo root from " + AppContext.BaseDirectory);
+        return dir!.FullName;
+    }
+
+    private static string Read(params string[] parts) =>
+        File.ReadAllText(Path.Combine(RepoRoot(), "ConditioningControlPanel", Path.Combine(parts)));
+
+    [Fact]
+    public void The_settings_trigger_reacts_on_the_ui_thread()
+    {
+        var src = Read("Services", "Possession", "PossessionEvents.cs");
+
+        // The reaction (NearestTarget walks the registry, RequestReactive mutates the live ledger)
+        // has to be posted, and posted rather than pumped: a settings write must never block on a
+        // dispatcher that is at that moment animating a ghost.
+        Assert.Contains("Helpers.DispatcherHelper.RunOnUI(", src);
+        Assert.DoesNotContain("RunOnUISync", src);
+
+        int hop = src.IndexOf("Helpers.DispatcherHelper.RunOnUI(", StringComparison.Ordinal);
+        int nearest = src.IndexOf("NearestTarget(PossessionRole.Label)", StringComparison.Ordinal);
+        Assert.True(hop >= 0 && nearest > hop,
+            "the registry read must happen INSIDE the dispatcher hop, not before it");
+    }
+
+    [Fact]
+    public void The_target_walk_refuses_to_run_off_the_ui_thread()
+    {
+        var src = Read("MainWindow", "MainWindow.Possession.cs");
+
+        // Belt for every other caller: the registry is public surface read from a dozen effects, so
+        // an off-thread read degrades to the last good snapshot instead of throwing.
+        int guard = src.IndexOf("if (!Dispatcher.CheckAccess())", StringComparison.Ordinal);
+        int walk = src.IndexOf("var root = Content as DependencyObject", StringComparison.Ordinal);
+        Assert.True(guard >= 0, "GetPossessionTargets lost its dispatcher-affinity guard");
+        Assert.True(walk > guard, "the guard must come before the first dependency-property read");
+
+        // And it must never wait on the UI thread to get an answer.
+        Assert.DoesNotContain("Dispatcher.Invoke(", src);
+    }
+}


### PR DESCRIPTION
Two unrelated user-facing defects, one commit each.

## A. "Possession: target walk failed" (thread affinity)

**Root cause.** `AppSettings.OnPropertyChanged` raises `PropertyChanged` **inline, on whatever thread wrote the setting**, with no marshalling. `PossessionEvents.OnSettingChanged` subscribes to it and reacted on that thread: `PossessionDirector.NearestTarget` -> `IPossessionHost.Targets` -> `MainWindow.GetPossessionTargets()`. The first thing that method reads is `Content`, a dependency property, and `DependencyObject.GetValue` calls `Dispatcher.VerifyAccess`. Off the UI thread that throws, which is exactly the stack in the three reports.

So the calling thread was **whichever background worker last wrote a setting while a lockdown was armed**. There are plenty: `SherpaWakeService.ApplyAndReturn` (the wake-word calibration sweep persists `SpeechWakeThreshold` from its own task), `ProfileSyncService` (`AuthToken` from an HTTP continuation), `ChaosUpgrades`, and any mod or remote path that writes settings outside `RunOnUISync`. The two pointer triggers in the same file were always fine: WPF input events are UI-thread by construction. `OnCountdownTick` was fine too, it comes off a `DispatcherTimer`.

The exception never surfaced to the user because `GetPossessionTargets` logs and swallows it, but the walk returned the stale cache, so reactive haunts quietly stopped landing for the rest of the lockdown.

**Fix, at both layers.**
- `Services/Possession/PossessionEvents.cs` - the reaction is posted with `DispatcherHelper.RunOnUI`. `BeginInvoke`, not `Invoke`: a settings write must never block on a dispatcher that is at that moment animating a ghost, and one skipped typo effect costs nothing. The property-name filter stays off-thread (a string compare), so exempt settings never pay for a hop, and a user flipping a toggle still runs inline on the UI thread exactly as before.
- `MainWindow/MainWindow.Possession.cs` - `GetPossessionTargets` checks `Dispatcher.CheckAccess()` before its first DP read and, off-thread, returns the last good snapshot and marks the cache dirty. The registry is public surface read from a dozen effects, so it degrades rather than throwing. **`PossessionRebuildFloor` is untouched**: the off-thread path only sets the dirty flag, the rebuild still happens on the next UI-thread read and is still floored at 750 ms.

Fixes CC-Labs-llc/ccp-bugs#1160, #1167, #1184

## B. EMI collapses into a small pink pixel

**Root cause.** `CrtScale` (the body's outer `ScaleTransform`) has four animators: `CrtOn`, `CrtOff`, `AnimateScalePulse` (bounce/thud) and `RunStretch`. The first three end `FillBehavior.HoldEnd`, so what is on screen is the animation's own last keyframe and the **base value** underneath is never read. `RunStretch` ended `FillBehavior.Stop`, and a Stop animation does not settle on its last keyframe - it hands the property straight back to the base.

`RunSummon` wrote `CrtScale.ScaleX/Y = 0.02` into that base to hide her behind the summon smoke and never wrote anything back. So from the first summon of a sitting the base was two percent, invisibly, for as long as some HoldEnd animation was masking it. The stretch is on a 20-to-40 minute cooldown; when it finally fired and released the property, her whole body collapsed onto its `RenderTransformOrigin`. `BubbleHost` and the FX layers are siblings of `BodyRoot`, not children, so they kept drawing at full size - which is why Nardda still had speech bubbles with no avatar - and the next bounce (HoldEnd, ends at 1.0) masked the base again, which is why it read as intermittent. Wobberjockey's second recording shows exactly that: the dot, then a full-size EMI the instant a line starts.

**Fix.**
- `Windows/EmiDesk/EmiDeskWindow.Fx.cs` - new `ResetCrtBase(bool clearAnimations)`. `RunSummon` calls it once the power-on has landed, so the base is never left collapsed. It also now clears the holding animations before writing its 0.02 pre-roll, and the "showing her plain" fallback and `FinishDismiss` go through the same helper: a local write cannot beat a `HoldEnd` animation, so both of those had been silent no-ops whenever one was in flight.
- `Windows/EmiDesk/EmiDeskWindow.Alive.cs` - the stretch holds its end value instead of releasing the property. Its last keyframe is already exactly 1.0, so this changes nothing visible and makes it independent of the base.

Fixes CC-Labs-llc/ccp-bugs#1173, #1183

### What I did NOT fix

**#1171 "EMI goes behind other apps".** Not reproduced and not fixed here, deliberately. Nothing in the app ever clears the desk window's `Topmost`; `EmiDeskWindow.xaml:17` sets it `True` and the only writer is the deliberate false/true toggle in `Services/EmiDesk/EmiOffers.cs:556` `ReassertTopmost`, which is called from exactly three places (`EmiChannels.cs:227`, `EmiGifRain.cs:77`, `EmiOffers.cs:448`). This looks like the plain Win32 behaviour where a topmost window created **later** sits above an existing one, so any other topmost window the app raises (fullscreen video, the Bambi browser, an overlay) wins the z-order and nothing puts her back. A fix means re-asserting on more events, or a slow watchdog, and the comment on `ReassertTopmost` says the author deliberately refused a timer so it cannot fight the user's alt-tab. That is an owner call, not a bug fix, so it is left open.

**"The labcoat pocket protector blinks."** Frames pulled from the first recording show her ID badge drawn in colour on some frames and in flat monochrome on others, and the sleeve silhouette differs between those same frames - they are different **pose PNGs** from the body sheet, not one pose flickering. `PaintOutfitOver` (`EmiDeskWindow.xaml.cs:936`) also cannot produce a repeating flicker: the first missing pose sets `_overArmed[outfit] = false` and stands the layer down for the sitting, one way. So this reads as a sheet inconsistency in the art (the badge is coloured on some frames of that outfit and not others), not a code defect. Worth an art pass, not a code change.

## Verification

- `dotnet build`: 0 errors, no new warnings in any touched file.
- `dotnet test`: 5315 passed, 0 failed (5312 before, plus the 3 added here).
- Not runtime-verified: bug B needs a live widget and the better part of an hour to show itself, so both fixes are additionally pinned as source tripwires (`PossessionThreadAffinityTests.cs`, and a new case in `EmiDeskLiveRunRegressionTests.cs`, which is the existing home for exactly this kind of guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H1RfsRjhE77h2sjsSwAJ5B
