### PR TITLE
fix(awareness): deactivating a custom preset no longer wipes its triggers (#1185)

### DIFF
--- a/ConditioningControlPanel/App.xaml.cs
+++ b/ConditioningControlPanel/App.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.IO;
@@ -2219,6 +2219,12 @@ namespace ConditioningControlPanel
             AudioSync = new AudioSyncService(Haptics, Settings.Current.Haptics.AudioSync);
             KeywordTriggers = new KeywordTriggerService();
             KeywordPresets = new KeywordTriggerPresetService();
+
+            // ccp-bugs#1185: repair any installed CUSTOM preset whose source trigger list has
+            // drifted from its live clones before the user can deactivate it. After a deactivate
+            // the clones are gone and the edits are unrecoverable, so this has to run at launch.
+            try { KeywordPresets.SyncInstalledCustomSources(); }
+            catch (Exception ex) { Logger?.Warning("Custom preset source sync failed: {Error}", ex.Message); }
 
             // Drain any preset re-installs queued by SettingsService.MergeBuiltInAwarenessPresets
             // when a built-in preset's version was bumped on this launch. This re-clones the

--- a/ConditioningControlPanel/Dialogs/AwarenessPresetDetailDialog.xaml.cs
+++ b/ConditioningControlPanel/Dialogs/AwarenessPresetDetailDialog.xaml.cs
@@ -192,26 +192,14 @@ namespace ConditioningControlPanel
         private void MirrorLiveClonesToCustomSource()
         {
             if (_preset.IsBuiltIn) return;
-            var installed = App.KeywordPresets?.IsInstalled(_preset.Id) == true;
-            if (!installed) return;
+            if (App.KeywordPresets?.IsInstalled(_preset.Id) != true) return;
 
             var settings = App.Settings?.Current;
             if (settings == null) return;
 
-            var prefix = "preset:" + _preset.Id + ":";
-            var live = settings.KeywordTriggers
-                .Where(t => t?.Id?.StartsWith(prefix, StringComparison.Ordinal) == true)
-                .ToList();
-
-            var synced = new List<KeywordTrigger>();
-            foreach (var clone in live)
-            {
-                var copy = clone.Clone();
-                copy.Id = clone.Id!.Substring(prefix.Length);
-                copy.LastTriggeredAt = DateTime.MinValue;
-                synced.Add(copy);
-            }
-            _preset.Triggers = synced;
+            // One shared implementation with the service (ccp-bugs#1185): the card's Activate
+            // pill uninstalls without ever opening this dialog, so the mirror cannot live here.
+            Services.KeywordTriggerPresetService.SyncCustomSourceFromClones(_preset, settings.KeywordTriggers);
         }
 
         // ============================================================

--- a/ConditioningControlPanel/Services/KeywordTriggerPresetService.cs
+++ b/ConditioningControlPanel/Services/KeywordTriggerPresetService.cs
@@ -121,6 +121,16 @@ namespace ConditioningControlPanel.Services
             if (settings == null || preset == null) return false;
 
             var prefix = TriggerIdPrefix + presetId + ":";
+
+            // THE DEACTIVATE WIPE (ccp-bugs#1185). The editor mutates the LIVE clones in
+            // settings.KeywordTriggers; preset.Triggers is only the seed the next install
+            // re-clones from. Removing the clones without mirroring them back therefore threw
+            // away every edit made since the preset was activated - a preset whose triggers
+            // were added while it was ON came back as blank keyword rows with a default
+            // subliminal action. Mirror first, then remove, on EVERY uninstall path (the card's
+            // Activate pill did not go through the detail dialog, which is where the only
+            // mirror used to live).
+            SyncCustomSourceFromClones(preset, settings.KeywordTriggers);
             int removed = settings.KeywordTriggers.RemoveAll(t =>
                 t.Id?.StartsWith(prefix, StringComparison.Ordinal) == true);
 
@@ -243,6 +253,73 @@ namespace ConditioningControlPanel.Services
                 App.Settings?.Save();
                 App.Logger?.Information("RefreshAiGating: adjusted {Count} avatar-comment actions (aiAvailable={Ai})",
                     touched, aiAvailable);
+            }
+        }
+
+        /// <summary>
+        /// Mirrors a custom preset's LIVE cloned triggers (the ones the editor actually mutates,
+        /// living in <c>settings.KeywordTriggers</c> under the <c>preset:&lt;id&gt;:</c> prefix) back
+        /// into <see cref="KeywordTriggerPreset.Triggers"/>, which is the seed a later install
+        /// re-clones from.
+        ///
+        /// <para>Built-in presets are skipped: their source of truth is the JSON in
+        /// <c>Resources/AwarenessPresets/</c>, not the user's copy.</para>
+        ///
+        /// <para>A preset with NO live clones is left alone. That is the safety catch: if the
+        /// clones are missing for any reason other than "the user deleted every trigger" (which
+        /// already strips the source entry as it goes), blanking the source list here would be a
+        /// second, worse data loss than the one this method exists to prevent.</para>
+        ///
+        /// <para>Pure apart from the two arguments, so the contract is unit testable without an
+        /// App spine. Returns the number of triggers mirrored.</para>
+        /// </summary>
+        internal static int SyncCustomSourceFromClones(KeywordTriggerPreset? preset, IList<KeywordTrigger>? liveTriggers)
+        {
+            if (preset == null || preset.IsBuiltIn || liveTriggers == null) return 0;
+            if (string.IsNullOrEmpty(preset.Id)) return 0;
+
+            var prefix = TriggerIdPrefix + preset.Id + ":";
+            var synced = new List<KeywordTrigger>();
+
+            foreach (var clone in liveTriggers)
+            {
+                if (clone?.Id == null) continue;
+                if (!clone.Id.StartsWith(prefix, StringComparison.Ordinal)) continue;
+
+                var copy = clone.Clone();
+                copy.Id = clone.Id.Substring(prefix.Length);
+                copy.LastTriggeredAt = DateTime.MinValue;
+                synced.Add(copy);
+            }
+
+            if (synced.Count == 0) return 0;
+
+            preset.Triggers = synced;
+            return synced.Count;
+        }
+
+        /// <summary>
+        /// Heals every INSTALLED custom preset whose source list has drifted from its live clones.
+        /// Called once at startup so a preset damaged by a pre-fix build is repaired while its
+        /// clones are still on disk - after a deactivate the clones are gone and nothing can bring
+        /// the lost triggers back.
+        /// </summary>
+        public void SyncInstalledCustomSources()
+        {
+            var settings = App.Settings?.Current;
+            if (settings == null) return;
+
+            int healed = 0;
+            foreach (var preset in settings.KeywordTriggerPresets)
+            {
+                if (preset == null || preset.IsBuiltIn || !preset.MasterEnabled) continue;
+                if (SyncCustomSourceFromClones(preset, settings.KeywordTriggers) > 0) healed++;
+            }
+
+            if (healed > 0)
+            {
+                App.Settings?.Save();
+                App.Logger?.Information("SyncInstalledCustomSources: refreshed the source list of {Count} installed custom preset(s)", healed);
             }
         }
 

--- a/Tests/ConditioningControlPanel.Tests/AwarenessPresetSourceSyncTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/AwarenessPresetSourceSyncTests.cs
@@ -1,0 +1,185 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using ConditioningControlPanel.Models;
+using ConditioningControlPanel.Services;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// The custom-Awareness-preset source sync
+/// (<c>KeywordTriggerPresetService.SyncCustomSourceFromClones</c>), which is what stands between a
+/// deactivate click and the user's trigger list.
+///
+/// <para><b>The data loss (ccp-bugs#1185).</b> An installed preset lives twice: the SOURCE list in
+/// <c>preset.Triggers</c>, and one LIVE CLONE per trigger in <c>settings.KeywordTriggers</c> under
+/// the id prefix <c>preset:&lt;presetId&gt;:</c>. The editor writes to the clones; a trigger added
+/// while the preset is active is appended to the source list BLANK. Uninstall used to delete the
+/// clones with no mirror-back, so everything authored since activation went with them - the
+/// reporter's "only the first two triggers had any info in them, the rest are just a list of empty
+/// word triggers and the blank subliminal action". The mirror now runs inside
+/// <c>UninstallPreset</c>, so the card's Activate pill is covered as well as the detail dialog.</para>
+///
+/// <para>The helper is a pure static over two lists, so these run with no App spine, no settings
+/// file and no WPF.</para>
+/// </summary>
+public class AwarenessPresetSourceSyncTests
+{
+    private const string PresetId = "custom.mine";
+    private const string Prefix = "preset:" + PresetId + ":";
+
+    private static KeywordTrigger Trigger(string id, string keyword, params KeywordAction[] actions) => new()
+    {
+        Id = id,
+        Keyword = keyword,
+        Enabled = true,
+        Actions = actions.ToList(),
+    };
+
+    private static KeywordAction Comment(string prompt) =>
+        new AvatarCommentAction { PromptTemplate = prompt, RequireAiAvailable = false };
+
+    private static KeywordTriggerPreset Preset(params KeywordTrigger[] triggers) => new()
+    {
+        Id = PresetId,
+        Name = "My Words",
+        IsBuiltIn = false,
+        MasterEnabled = true,
+        Triggers = triggers.ToList(),
+    };
+
+    /// <summary>Everything InstallPreset does to a source trigger: clone it, prefix its id.</summary>
+    private static List<KeywordTrigger> Install(KeywordTriggerPreset preset)
+    {
+        var live = new List<KeywordTrigger>();
+        foreach (var source in preset.Triggers)
+        {
+            var clone = source.Clone();
+            clone.Id = Prefix + source.Id;
+            live.Add(clone);
+        }
+        return live;
+    }
+
+    /// <summary>Everything UninstallPreset does after the mirror: drop this preset's clones.</summary>
+    private static void Uninstall(List<KeywordTrigger> live) =>
+        live.RemoveAll(t => t.Id?.StartsWith(Prefix, StringComparison.Ordinal) == true);
+
+    [Fact]
+    public void Sync_copies_live_edits_back_over_the_source_list()
+    {
+        var preset = Preset(Trigger("t1", "good girl", Comment("praise her")));
+        var live = Install(preset);
+
+        live[0].Keyword = "such a good girl";
+        live[0].Actions.Add(Comment("and again"));
+
+        var count = KeywordTriggerPresetService.SyncCustomSourceFromClones(preset, live);
+
+        Assert.Equal(1, count);
+        Assert.Equal("such a good girl", preset.Triggers[0].Keyword);
+        Assert.Equal(2, preset.Triggers[0].Actions.Count);
+    }
+
+    [Fact]
+    public void Sync_strips_the_preset_prefix_so_a_reinstall_does_not_double_it()
+    {
+        var preset = Preset(Trigger("t1", "drop", Comment("down you go")));
+        var live = Install(preset);
+
+        KeywordTriggerPresetService.SyncCustomSourceFromClones(preset, live);
+
+        Assert.Equal("t1", preset.Triggers[0].Id);
+        Assert.Equal(DateTime.MinValue, preset.Triggers[0].LastTriggeredAt);
+    }
+
+    /// <summary>
+    /// The reported case, end to end: five triggers, three of them authored while the preset was
+    /// active (so their source rows are blank), then Activate is clicked twice.
+    /// </summary>
+    [Fact]
+    public void Deactivate_then_reactivate_keeps_all_five_triggers_whole()
+    {
+        // Two triggers authored BEFORE activation - these are the two that used to survive.
+        var preset = Preset(
+            Trigger("t1", "good girl", Comment("praise 1")),
+            Trigger("t2", "sleepy", Comment("praise 2")));
+        var live = Install(preset);
+
+        // Three added WHILE installed. The editor appends a blank source row and puts the real
+        // content on the live clone only - this asymmetry is the bug's fuel.
+        for (int i = 3; i <= 5; i++)
+        {
+            preset.Triggers.Add(Trigger("t" + i, ""));
+            live.Add(Trigger(Prefix + "t" + i, "keyword " + i, Comment("praise " + i)));
+        }
+
+        // Deactivate (mirror, then drop the clones) and Activate again.
+        KeywordTriggerPresetService.SyncCustomSourceFromClones(preset, live);
+        Uninstall(live);
+        var reinstalled = Install(preset);
+
+        Assert.Equal(5, preset.Triggers.Count);
+        Assert.Equal(5, reinstalled.Count);
+        Assert.All(preset.Triggers, t => Assert.False(string.IsNullOrWhiteSpace(t.Keyword)));
+        Assert.All(preset.Triggers, t => Assert.Single(t.Actions));
+        Assert.Equal("keyword 5", preset.Triggers[4].Keyword);
+    }
+
+    [Fact]
+    public void Sync_ignores_clones_belonging_to_another_preset()
+    {
+        var preset = Preset(Trigger("t1", "mine", Comment("mine")));
+        var live = Install(preset);
+        live.Add(Trigger("preset:someone.else:t1", "theirs", Comment("theirs")));
+        live.Add(Trigger("loose", "not from a preset at all"));
+
+        KeywordTriggerPresetService.SyncCustomSourceFromClones(preset, live);
+
+        Assert.Single(preset.Triggers);
+        Assert.Equal("mine", preset.Triggers[0].Keyword);
+    }
+
+    /// <summary>
+    /// The safety catch. No clones means "not installed" (or already uninstalled), NOT "the user
+    /// deleted everything" - overwriting the source with an empty list there would turn the mirror
+    /// into a second, worse wipe.
+    /// </summary>
+    [Fact]
+    public void Sync_leaves_the_source_alone_when_there_are_no_clones()
+    {
+        var preset = Preset(Trigger("t1", "keep me", Comment("still here")));
+
+        var count = KeywordTriggerPresetService.SyncCustomSourceFromClones(preset, new List<KeywordTrigger>());
+
+        Assert.Equal(0, count);
+        Assert.Single(preset.Triggers);
+        Assert.Equal("keep me", preset.Triggers[0].Keyword);
+    }
+
+    /// <summary>
+    /// A built-in preset's source list is the shipped pack, not the user's work: it must never be
+    /// rewritten from the clones, or the next app update could not correct it.
+    /// </summary>
+    [Fact]
+    public void Sync_never_touches_a_built_in_preset()
+    {
+        var preset = Preset(Trigger("t1", "shipped", Comment("shipped")));
+        preset.IsBuiltIn = true;
+        var live = Install(preset);
+        live[0].Keyword = "edited live";
+
+        var count = KeywordTriggerPresetService.SyncCustomSourceFromClones(preset, live);
+
+        Assert.Equal(0, count);
+        Assert.Equal("shipped", preset.Triggers[0].Keyword);
+    }
+
+    [Fact]
+    public void Sync_tolerates_nulls()
+    {
+        Assert.Equal(0, KeywordTriggerPresetService.SyncCustomSourceFromClones(null, new List<KeywordTrigger>()));
+        Assert.Equal(0, KeywordTriggerPresetService.SyncCustomSourceFromClones(Preset(), null));
+    }
+}


### PR DESCRIPTION
Closes CC-Labs-llc/ccp-bugs#1185.

## The bug

Clicking Activate to turn a custom Awareness preset OFF and then back ON came back with
"only the first two triggers had any info in them, the rest are just a list of empty word
triggers and the blank subliminal action".

## Root cause

An installed preset lives twice. `preset.Triggers` is the SOURCE list, and
`InstallPreset` clones one live trigger per source row into `settings.KeywordTriggers`
under the id prefix `preset:<presetId>:`
(`ConditioningControlPanel/Services/KeywordTriggerPresetService.cs:70`). The editor mutates
the live clones; a trigger added while the preset is active gets a BLANK row appended to
the source list (`ConditioningControlPanel/Dialogs/AwarenessPresetDetailDialog.xaml.cs`,
`AddNewTrigger`).

`UninstallPreset` removed the clones with no mirror back to the source, so everything
authored since activation went with them. On the next activate, `InstallPreset` re-cloned
the blank source rows and `KeywordTriggerService.RebuildActionsFromFlatFields`
(`ConditioningControlPanel/Services/KeywordTriggerPresetService.cs:96`) synthesised the
default subliminal action on each, which is exactly what the reporter saw. The two
survivors were the triggers authored BEFORE the preset was first switched on.

A mirror did exist, but only in the detail dialog's install button. The preset card's
Activate pill (`ConditioningControlPanel/MainWindow/MainWindow.Awareness.cs:1012`) never
opens that dialog, so the path most likely to be clicked by accident was the one with no
protection.

## The fix

- `ConditioningControlPanel/Services/KeywordTriggerPresetService.cs:276`
  `SyncCustomSourceFromClones` is the single mirror implementation: it copies the live
  clones back over the custom preset's source list, strips the `preset:<id>:` prefix from
  each id, and clears the runtime cooldown.
- `ConditioningControlPanel/Services/KeywordTriggerPresetService.cs:133` calls it at the
  top of `UninstallPreset`, so every deactivate path is covered.
- `ConditioningControlPanel/Dialogs/AwarenessPresetDetailDialog.xaml.cs:202` now delegates
  to it instead of keeping a second copy of the logic.
- `ConditioningControlPanel/Services/KeywordTriggerPresetService.cs:307`
  `SyncInstalledCustomSources` repairs presets that have already drifted, and
  `ConditioningControlPanel/App.xaml.cs:2226` runs it at startup. After a deactivate the
  clones are gone and the edits are unrecoverable, so the repair only works while the
  preset is still installed.

Two safety catches, both covered by tests: a built-in preset is never rewritten from its
clones (its source is the shipped pack, not the user's work), and an empty clone list
leaves the source list alone, so the mirror cannot turn into a second wipe.

## Tests

`Tests/ConditioningControlPanel.Tests/AwarenessPresetSourceSyncTests.cs` (7 tests),
including the reported case end to end: five triggers, three of them authored while the
preset was active, deactivate then reactivate, all five still whole.

Full suite: 5338 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H1RfsRjhE77h2sjsSwAJ5B
