### PR TITLE
fix(lock card): a phrase with an ellipsis or curly quotes can be typed (#1169)

### DIFF
--- a/ConditioningControlPanel/Services/LockCard/LockCardText.cs
+++ b/ConditioningControlPanel/Services/LockCard/LockCardText.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Text;
+
+namespace ConditioningControlPanel.Services
+{
+    /// <summary>
+    /// The ONE normaliser every lock-card answer comparison runs through.
+    ///
+    /// <para><b>The bug (ccp-bugs#1169).</b> A card whose phrase carried a typographic ellipsis
+    /// (U+2026) was unpassable: the user types three full stops, the phrase holds one character,
+    /// and an ordinal compare says no forever. There is no keyboard route to U+2026, so the card
+    /// could never be solved and the run could not move on. The same trap is set by curly quotes
+    /// and apostrophes (U+2018/U+2019/U+201C/U+201D), which Word, the Mod Creator's autocorrect
+    /// and every AI-written phrase produce by default, and by non-breaking spaces.</para>
+    ///
+    /// <para>Normalising is safe here because a lock card asks the user to RECITE a line, not to
+    /// reproduce its typography. Case is already ignored by the callers; this adds punctuation
+    /// shape and whitespace on top.</para>
+    ///
+    /// <para>Pure and static so every compare path shares one definition - the session lock card,
+    /// a lockdown card and a mod-supplied or AI-supplied phrase all funnel through
+    /// <c>LockCardWindow</c> - and so the contract is unit testable without a window.</para>
+    /// </summary>
+    internal static class LockCardText
+    {
+        /// <summary>
+        /// Folds a phrase or a typed answer to its comparable form: typographic punctuation
+        /// flattened to ASCII, whitespace collapsed to single spaces, ends trimmed. Case is left
+        /// alone - callers compare with <see cref="StringComparison.OrdinalIgnoreCase"/>.
+        /// </summary>
+        internal static string Normalize(string? text)
+        {
+            if (string.IsNullOrEmpty(text)) return "";
+
+            var sb = new StringBuilder(text.Length + 4);
+            bool pendingSpace = false;
+
+            foreach (var raw in text)
+            {
+                // Every flavour of space (incl. NBSP U+00A0 and the narrow/figure spaces) folds to
+                // one, and a run of them never reaches the output as more than a single space.
+                // A leading run never opens one and a trailing run is never flushed: that is the trim.
+                if (char.IsWhiteSpace(raw))
+                {
+                    if (sb.Length > 0) pendingSpace = true;
+                    continue;
+                }
+
+                if (IsInvisible(raw)) continue;
+
+                if (pendingSpace)
+                {
+                    sb.Append(' ');
+                    pendingSpace = false;
+                }
+                sb.Append(MapPunctuation(raw));
+            }
+
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// True when a typed answer matches an expected phrase once both are normalised.
+        /// </summary>
+        internal static bool Matches(string? typed, string? expected)
+            => string.Equals(Normalize(typed), Normalize(expected), StringComparison.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// True when what has been typed so far is still on track for the phrase. Drives the
+        /// mistake counter, which must not score an error just because the user is spelling an
+        /// ellipsis out as three characters where the phrase holds one.
+        /// </summary>
+        internal static bool IsPrefixOf(string? typed, string? expected)
+        {
+            var t = Normalize(typed);
+            if (t.Length == 0) return true;
+            return Normalize(expected).StartsWith(t, StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Zero-width and format marks: they carry no sound, cannot be typed, and are exactly what
+        /// a paste out of a rich-text editor leaves behind. Dropped outright.
+        /// </summary>
+        private static bool IsInvisible(char c)
+            => c == (char)0x00AD      // soft hyphen
+            || c == (char)0x200B      // zero-width space
+            || c == (char)0x200C      // zero-width non-joiner
+            || c == (char)0x200D      // zero-width joiner
+            || c == (char)0xFEFF;     // BOM / zero-width no-break space
+
+        /// <summary>
+        /// One character in, its ASCII shape out. Multi-character expansions come back as a
+        /// string, which is why this is not a char-to-char map. Every entry here is a VISIBLE
+        /// character, so the map stays reviewable in a diff.
+        /// </summary>
+        private static string MapPunctuation(char c) => c switch
+        {
+            '…' => "...",                                                  // horizontal ellipsis
+            '‘' or '’' or '‛' or 'ʼ' => "'",                 // curly / modifier apostrophes
+            '“' or '”' or '‟' => "\"",                            // curly double quotes
+            '–' or '—' or '‒' or '―' or '−' => "-",     // en / em / figure / bar / minus
+            _ => c.ToString(),
+        };
+    }
+}

--- a/ConditioningControlPanel/Windows/LockCardWindow.xaml.cs
+++ b/ConditioningControlPanel/Windows/LockCardWindow.xaml.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
@@ -737,11 +737,12 @@ namespace ConditioningControlPanel
             // Track characters typed for achievement
             _totalCharsTyped++;
             
-            // Check for errors (input doesn't match phrase prefix)
+            // Check for errors (input doesn't match phrase prefix).
+            // Both sides go through LockCardText so typing "..." against a phrase that holds a
+            // typographic ellipsis is not scored as a mistake (ccp-bugs#1169).
             if (input.Length > 0)
             {
-                var expectedPrefix = _phrase.Substring(0, Math.Min(input.Length, _phrase.Length));
-                if (!string.Equals(input, expectedPrefix, StringComparison.OrdinalIgnoreCase))
+                if (!LockCardText.IsPrefixOf(input, _phrase))
                 {
                     _totalErrors++;
                 }
@@ -750,13 +751,22 @@ namespace ConditioningControlPanel
             // Sync to all other windows
             SyncInputToAllWindows(input);
             
-            // Check if the input matches the phrase (case-insensitive)
-            if (string.Equals(input.Trim(), _phrase, StringComparison.OrdinalIgnoreCase))
+            // Check if the input matches the phrase (case-insensitive, punctuation-shape-insensitive).
+            // A phrase carrying a character with no keyboard route (U+2026, curly quotes, an NBSP)
+            // used to make the card unpassable: the user types the only thing they CAN type and an
+            // ordinal compare says no forever (ccp-bugs#1169).
+            if (LockCardText.Matches(input, _phrase))
             {
                 // The gate lives at THIS call site only. The spoken-solve path calls
                 // RegisterSuccessfulRepeat directly and must never be gated on typing (in voice mode
                 // the whole InputBorder is collapsed and nothing is ever typed).
-                if (HasTypedEnough(_keystrokes, _phrase.Length))
+                //
+                // The bar is the SHORTER of the two lengths. The match above already proved the
+                // input is equivalent to the phrase, so a shorter input can only mean the user
+                // typed a compact form of something the phrase spells out (an IME's single "..."
+                // glyph for three full stops). Charging them for characters they had no reason to
+                // type would re-brick the card the normaliser just unbricked.
+                if (HasTypedEnough(_keystrokes, Math.Min(_phrase.Length, input.Length)))
                 {
                     RegisterSuccessfulRepeat();
                 }

--- a/Tests/ConditioningControlPanel.Tests/LockCardTextTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/LockCardTextTests.cs
@@ -1,0 +1,119 @@
+using ConditioningControlPanel.Services;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// The lock-card answer normaliser (<c>LockCardText</c>).
+///
+/// <para><b>The trap (ccp-bugs#1169).</b> A card whose phrase carries a typographic ellipsis
+/// (U+2026) was unpassable, reported against the Infection Control mod: the user types three full
+/// stops, the phrase holds one character no keyboard produces, and an ordinal compare says no
+/// forever. Curly quotes and a non-breaking space set the same trap, and they arrive by default
+/// from Word, from a mod author's autocorrect and from every AI-written phrase.</para>
+///
+/// <para>What must NOT change: a WRONG answer is still wrong. Normalising touches punctuation
+/// SHAPE and whitespace only, never letters, digits or word order.</para>
+/// </summary>
+public class LockCardTextTests
+{
+    private const string Ellipsis = "…";
+    private const string LeftSingle = "‘";
+    private const string RightSingle = "’";
+    private const string LeftDouble = "“";
+    private const string RightDouble = "”";
+    private const string Nbsp = " ";
+    private const string ZeroWidthSpace = "​";
+    private const string EmDash = "—";
+
+    [Fact]
+    public void Typed_dots_pass_a_phrase_written_with_a_typographic_ellipsis()
+    {
+        var phrase = "good girls don" + RightSingle + "t think" + Ellipsis;
+
+        Assert.True(LockCardText.Matches("good girls don't think...", phrase));
+    }
+
+    [Fact]
+    public void Typed_ellipsis_passes_a_phrase_written_with_three_dots()
+    {
+        Assert.True(LockCardText.Matches("deeper" + Ellipsis, "deeper..."));
+    }
+
+    [Theory]
+    [InlineData("she said \"obey\"")]
+    [InlineData("she said “obey”")]
+    public void Curly_and_straight_quotes_are_the_same_answer(string typed)
+    {
+        Assert.True(LockCardText.Matches(typed, "she said " + LeftDouble + "obey" + RightDouble));
+    }
+
+    [Fact]
+    public void Curly_apostrophes_fold_to_straight_ones()
+    {
+        Assert.True(LockCardText.Matches("i can't resist", "i can" + RightSingle + "t resist"));
+        Assert.True(LockCardText.Matches("i can" + LeftSingle + "t resist", "i can't resist"));
+    }
+
+    [Fact]
+    public void Dashes_of_every_width_fold_together()
+    {
+        Assert.True(LockCardText.Matches("empty - obedient", "empty " + EmDash + " obedient"));
+    }
+
+    [Fact]
+    public void Non_breaking_and_zero_width_characters_do_not_block_a_match()
+    {
+        Assert.True(LockCardText.Matches("obey and drop", "obey" + Nbsp + "and" + ZeroWidthSpace + " drop"));
+    }
+
+    [Fact]
+    public void Case_leading_and_trailing_space_and_double_spaces_are_forgiven()
+    {
+        Assert.True(LockCardText.Matches("   OBEY   AND    DROP  ", "obey and drop"));
+    }
+
+    [Fact]
+    public void A_wrong_answer_is_still_wrong()
+    {
+        Assert.False(LockCardText.Matches("obey and drip", "obey and drop"));
+        Assert.False(LockCardText.Matches("drop and obey", "obey and drop"));
+        Assert.False(LockCardText.Matches("obey", "obey and drop"));
+        Assert.False(LockCardText.Matches("", "obey and drop"));
+    }
+
+    [Fact]
+    public void Normalize_flattens_punctuation_and_collapses_whitespace()
+    {
+        Assert.Equal("good girl... i can't stop", LockCardText.Normalize("  good girl" + Ellipsis + "  i can" + RightSingle + "t	stop "));
+        Assert.Equal("", LockCardText.Normalize(null));
+        Assert.Equal("", LockCardText.Normalize("   "));
+    }
+
+    /// <summary>
+    /// The mistake counter runs off the prefix check, so it has to speak the same dialect as the
+    /// match: half-typed "..." against a one-character ellipsis is progress, not an error.
+    /// </summary>
+    [Fact]
+    public void Prefix_check_tracks_a_partly_typed_answer()
+    {
+        var phrase = "hush now" + Ellipsis + " sleep";
+
+        Assert.True(LockCardText.IsPrefixOf("", phrase));
+        Assert.True(LockCardText.IsPrefixOf("hush", phrase));
+        Assert.True(LockCardText.IsPrefixOf("hush now.", phrase));
+        Assert.True(LockCardText.IsPrefixOf("hush now...", phrase));
+        Assert.True(LockCardText.IsPrefixOf("HUSH NOW... SLE", phrase));
+        Assert.False(LockCardText.IsPrefixOf("hush then", phrase));
+    }
+
+    /// <summary>
+    /// A trailing space mid-typing must not read as a mistake: it is collapsed away, leaving the
+    /// prefix exactly as long as the letters the user has actually committed.
+    /// </summary>
+    [Fact]
+    public void Prefix_check_survives_a_trailing_space()
+    {
+        Assert.True(LockCardText.IsPrefixOf("hush ", "hush now"));
+    }
+}


### PR DESCRIPTION
Closes CC-Labs-llc/ccp-bugs#1169.

## The bug

Reported by Wobberjockey against the Infection Control mod: a lock card whose expected
answer contains "..." cannot be passed.

## Root cause

The phrase carries U+2026 (a single horizontal ellipsis), which no keyboard produces. The
compare was a plain ordinal one against the raw phrase
(`ConditioningControlPanel/Windows/LockCardWindow.xaml.cs:754` before this change), so the
user types the only thing they can type, three full stops, and the card never clears. The
run cannot move on and the window stays up. Curly quotes and apostrophes
(U+2018/U+2019/U+201C/U+201D) and a non-breaking space set the identical trap, and they
are what Word, the Mod Creator's autocorrect and every AI-written `customPhrase` produce
by default.

## The fix

`ConditioningControlPanel/Services/LockCard/LockCardText.cs` (new) is the one normaliser
every typed compare runs through:

- `Normalize` (`LockCardText.cs:31`) folds typographic punctuation to its ASCII shape
  (U+2026 to "...", curly quotes to straight, en/em/figure dashes to "-"), drops zero-width
  and format marks, collapses every flavour of whitespace to single spaces and trims. Case
  is left to the callers, which already compare `OrdinalIgnoreCase`.
- `Matches` (`LockCardText.cs:65`) is the completion check, wired at
  `ConditioningControlPanel/Windows/LockCardWindow.xaml.cs:758`.
- `IsPrefixOf` (`LockCardText.cs:73`) is the mistake counter's check, wired at
  `ConditioningControlPanel/Windows/LockCardWindow.xaml.cs:745`, so spelling an ellipsis out
  as three characters is progress rather than three errors.

Every lock card funnels through this window (session cards, lockdown cards, mod and
AI-supplied phrases all reach it via `ShowLockCard`), so one helper covers all of them. The
spoken-solve path needs nothing: `Services/Speech/SpeechService.Normalize` already strips
punctuation entirely before scoring.

The anti-cheat gate (`ConditioningControlPanel/Windows/LockCardWindow.xaml.cs:769`) now
measures keystrokes against the shorter of phrase and input. `Matches` has already proved
the two are equivalent at that point, so a shorter input can only mean the user typed a
compact form of something the phrase spells out; requiring characters they had no reason to
type would re-brick the card the normaliser just unbricked. Paste, undo and drop are
unaffected: those routes still arrive with near-zero keystroke credit.

Normalising is safe here because a lock card asks the user to RECITE a line, not to
reproduce its typography. Letters, digits and word order are untouched, and a wrong answer
is still wrong.

## Tests

`Tests/ConditioningControlPanel.Tests/LockCardTextTests.cs` (12 tests): typed dots against
a U+2026 phrase and the reverse, curly against straight quotes both ways, dashes, NBSP and
zero-width space, case and whitespace, the partial-typing prefix contract, and a block of
wrong answers that must stay wrong.

Full suite: 5338 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H1RfsRjhE77h2sjsSwAJ5B
