### PR TITLE
fix(mods): Infection Control gets its Goon Fuel rename and its tube fit back

### DIFF
--- a/ConditioningControlPanel/Models/BuiltInMods.cs
+++ b/ConditioningControlPanel/Models/BuiltInMods.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace ConditioningControlPanel.Models
 {
@@ -1937,6 +1937,43 @@ namespace ConditioningControlPanel.Models
                     RankSubject = "Infection Level",
                     PetName = "patient",
                     Collective = "patients"
+                },
+
+                // The FEATURE renames only, lifted from the pack's mod.json. The stub is not a
+                // transcription of all 125 replacements (achievements, flavour lines and the
+                // enhancement tree arrive with the pack), but the feature labels are what a user
+                // sees on the dashboard the moment the mod is activated, and "Goon Fuel" going
+                // missing is exactly what the port ticket reported. Both the singular and the
+                // plural spelling are listed because the UI probes BOTH (the dashboard card asks
+                // for "Mandatory Video", the preset detail row for "Mandatory Videos").
+                TextReplacements = new Dictionary<string, string>
+                {
+                    { "Lockdown", "Quarantine" },
+                    { "Flash Images", "Temptations" },
+                    { "Flash Image", "Temptations" },
+                    { "Subliminals", "Intrusive Thoughts" },
+                    { "Bouncing Text", "Persistent Urges" },
+                    { "Mandatory Videos", "Goon Fuel" },
+                    { "Mandatory Video", "Goon Fuel" },
+                    { "Bubble Pop", "Pharmacy" },
+                    { "Bubble Count", "Prescription Management" },
+                    { "Lock Cards", "Affirmations" },
+                    { "Lock Card", "Affirmations" },
+                    { "Mind Wipe", "Hypnotherapy" },
+                    { "Pink Filter", "Arousal Alert" },
+                    { "Spiral Overlay", "Hypnotic Resistance Overlay" }
+                },
+
+                // The nurse sits lower and smaller in her tube than the default avatar. Same five
+                // values the pack ships, so the fit does not jump when the pack finishes
+                // extracting (and is right on first activation if it never does).
+                TubeLayout = new ModTubeLayout
+                {
+                    AvatarOffsetX = 0,
+                    AvatarDetachedOffsetX = 0,
+                    AvatarScale = 0.9,
+                    AvatarOffsetY = 40,
+                    AvatarDetachedOffsetY = 40
                 },
 
                 SubliminalPool = new Dictionary<string, bool>

--- a/ConditioningControlPanel/Services/ModService.cs
+++ b/ConditioningControlPanel/Services/ModService.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
@@ -584,6 +584,7 @@ namespace ConditioningControlPanel.Services
 
                     sanitized[key] = val;
                 }
+                FillFeatureLabelAliases(sanitized);
                 manifest.TextReplacements = sanitized;
             }
 
@@ -1253,6 +1254,42 @@ namespace ConditioningControlPanel.Services
         public string MakeModAware(string text)
         {
             return ApplyTextReplacements(_activeMod.Manifest.TextReplacements, text);
+        }
+
+        /// <summary>
+        /// Feature labels the UI probes in BOTH a singular and a plural spelling. The English
+        /// literal in the code IS the lookup key (see MainWindow.UiUpdates ModAwareLabel), so a
+        /// manifest that renames only one spelling renames only some of the surfaces: Infection
+        /// Control ships "Mandatory Videos": "Goon Fuel" and the dashboard card, which probes
+        /// "Mandatory Video", kept saying Mandatory Video. That is the lost rename in the port
+        /// ticket, and it cannot be fixed in the pack alone because the pack is a downloaded
+        /// artifact, so the twin is filled in here for every mod, built-in or user-installed.
+        /// </summary>
+        private static readonly (string A, string B)[] FeatureLabelTwins =
+        {
+            ("Mandatory Videos", "Mandatory Video"),
+            ("Lock Cards", "Lock Card"),
+            ("Flash Images", "Flash Image"),
+            ("Bubble Pops", "Bubble Pop"),
+        };
+
+        /// <summary>
+        /// Copies a feature rename onto its missing singular/plural twin. Only ever ADDS a key,
+        /// so an author who spelled both forms out (and gave them different wording) is untouched.
+        /// Runs after the author's own entries are counted against the 200 cap: these are ours,
+        /// not theirs, and refusing a mod for a key it did not write would be nonsense.
+        /// </summary>
+        internal static void FillFeatureLabelAliases(IDictionary<string, string> replacements)
+        {
+            if (replacements == null) return;
+
+            foreach (var (a, b) in FeatureLabelTwins)
+            {
+                if (replacements.TryGetValue(a, out var valA) && !replacements.ContainsKey(b))
+                    replacements[b] = valA;
+                else if (replacements.TryGetValue(b, out var valB) && !replacements.ContainsKey(a))
+                    replacements[a] = valB;
+            }
         }
 
         /// <summary>

--- a/Tests/ConditioningControlPanel.Tests/ModFeatureLabelAliasTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/ModFeatureLabelAliasTests.cs
@@ -1,0 +1,119 @@
+using System.Collections.Generic;
+using ConditioningControlPanel.Models;
+using ConditioningControlPanel.Services;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// Mod feature-label renames: the singular/plural alias fill
+/// (<c>ModService.FillFeatureLabelAliases</c>, run from <c>SanitizeManifest</c>) and the Infection
+/// Control built-in stub.
+///
+/// <para><b>The lost rename (Infection Control port ticket).</b> The English literal in the UI IS
+/// the lookup key - <c>MainWindow.ModAwareLabel</c> probes <c>MakeModAware("Mandatory Video")</c>
+/// for the dashboard card and <c>"Mandatory Videos"</c> for the preset detail row. Infection
+/// Control's mod.json renames only the plural, so "Goon Fuel" appeared on one surface and the
+/// stock name stayed on the other. The pack is a downloaded artifact and cannot be patched from
+/// here, so the missing twin is filled in on load for every mod.</para>
+/// </summary>
+public class ModFeatureLabelAliasTests
+{
+    [Fact]
+    public void A_plural_only_rename_reaches_the_singular_probe()
+    {
+        var map = new Dictionary<string, string> { ["Mandatory Videos"] = "Goon Fuel" };
+
+        ModService.FillFeatureLabelAliases(map);
+
+        Assert.Equal("Goon Fuel", ModService.ApplyTextReplacements(map, "Mandatory Video"));
+        Assert.Equal("Goon Fuel", ModService.ApplyTextReplacements(map, "Mandatory Videos"));
+    }
+
+    [Fact]
+    public void A_singular_only_rename_reaches_the_plural_probe()
+    {
+        var map = new Dictionary<string, string> { ["Lock Card"] = "Affirmations" };
+
+        ModService.FillFeatureLabelAliases(map);
+
+        Assert.Equal("Affirmations", ModService.ApplyTextReplacements(map, "Lock Card"));
+        Assert.Equal("Affirmations", ModService.ApplyTextReplacements(map, "Lock Cards"));
+    }
+
+    /// <summary>
+    /// An author who spelled both forms out meant both forms. The fill only ever ADDS a key.
+    /// </summary>
+    [Fact]
+    public void An_author_supplied_twin_is_never_overwritten()
+    {
+        var map = new Dictionary<string, string>
+        {
+            ["Mandatory Videos"] = "Mandatory Playback",
+            ["Mandatory Video"] = "A Single Playback",
+        };
+
+        ModService.FillFeatureLabelAliases(map);
+
+        Assert.Equal("A Single Playback", map["Mandatory Video"]);
+        Assert.Equal("Mandatory Playback", map["Mandatory Videos"]);
+    }
+
+    [Fact]
+    public void A_manifest_that_renames_neither_form_gains_nothing()
+    {
+        var map = new Dictionary<string, string> { ["Bambi"] = "Unit" };
+
+        ModService.FillFeatureLabelAliases(map);
+
+        Assert.Single(map);
+    }
+
+    /// <summary>
+    /// The longest-key-first rule still decides, so filling the shorter twin cannot start
+    /// half-rewriting the longer phrase that contains it.
+    /// </summary>
+    [Fact]
+    public void The_longer_key_still_wins_over_the_alias()
+    {
+        var map = new Dictionary<string, string>
+        {
+            ["Mandatory Videos"] = "Goon Fuel",
+            ["Mandatory Video Attention Check"] = "Vitals Check",
+        };
+
+        ModService.FillFeatureLabelAliases(map);
+
+        Assert.Equal("Vitals Check", ModService.ApplyTextReplacements(map, "Mandatory Video Attention Check"));
+    }
+
+    /// <summary>
+    /// The built-in stub is what the user sees until the 200 MB pack finishes extracting (and
+    /// forever, if it never downloads). It has to carry the feature renames and the tube fit the
+    /// pack ships, or the mod activates wearing half of someone else's name.
+    /// </summary>
+    [Fact]
+    public void The_infection_control_stub_carries_the_pack_feature_renames()
+    {
+        var manifest = BuiltInMods.InfectionControl;
+        var map = manifest.TextReplacements;
+
+        Assert.NotNull(map);
+        Assert.Equal("Goon Fuel", ModService.ApplyTextReplacements(map, "Mandatory Video"));
+        Assert.Equal("Goon Fuel", ModService.ApplyTextReplacements(map, "Mandatory Videos"));
+        Assert.Equal("Affirmations", ModService.ApplyTextReplacements(map, "Lock Card"));
+        Assert.Equal("Affirmations", ModService.ApplyTextReplacements(map, "Lock Cards"));
+        Assert.Equal("Quarantine", ModService.ApplyTextReplacements(map, "Lockdown"));
+    }
+
+    [Fact]
+    public void The_infection_control_stub_carries_the_pack_tube_fit()
+    {
+        var layout = BuiltInMods.InfectionControl.TubeLayout;
+
+        Assert.NotNull(layout);
+        Assert.Equal(0.9, layout!.AvatarScale ?? 0);
+        Assert.Equal(40, layout.AvatarOffsetY);
+        Assert.Equal(40, layout.AvatarDetachedOffsetY);
+    }
+}


### PR DESCRIPTION
Port ticket from AbbyNormal, confirmed by the mod's author Mort: the Infection Control port
lost the "Goon Fuel" rename of the mandatory video feature.

## Root cause

The English literal in the UI IS the lookup key.
`ConditioningControlPanel/MainWindow/MainWindow.UiUpdates.cs:360` (`ModAwareLabel`) asks
`App.Mods.MakeModAware(englishText)` and only falls back to the localized string when the
mod changed nothing. The probes are not spelled consistently:

- `MainWindow.UiUpdates.cs:120` probes `"Mandatory Video"` (dashboard card)
- `MainWindow.UiUpdates.cs:148` probes `"Mandatory Videos"` (preset detail row)
- `MainWindow.UiUpdates.cs:159` probes `"Lock Cards"` (Takeover tab)

The pack's `mod.json` renames `"Mandatory Videos"` and `"Lock Card"`, one spelling each, so
"Goon Fuel" landed on the preset row and the dashboard card kept saying Mandatory Video,
while "Affirmations" landed on the card and the Takeover row kept saying Lock Cards. The
rename was never lost in transit, it was half-applied by a plain `string.Replace` map that
had no way to know the two spellings are the same feature.

## The fix

- `ConditioningControlPanel/Services/ModService.cs:1282` `FillFeatureLabelAliases` copies a
  feature rename onto its missing singular/plural twin, driven by the small curated table at
  `ModService.cs:1268`. It runs from `SanitizeManifest`
  (`ConditioningControlPanel/Services/ModService.cs:587`), which is on every load path:
  install (`ModService.cs:406`), bundled built-in (`ModService.cs:2196`) and installed mod
  (`ModService.cs:2460`). The pack is a downloaded artifact and cannot be patched from here,
  so the fix has to live on the load side, and it fixes third-party mods with the same
  spelling gap for free.
- It only ever ADDS a key, so an author who spelled both forms out keeps both wordings (test
  included). It runs after the author's own entries are counted against the 200-replacement
  cap, because these entries are ours rather than theirs. Longest-key-first ordering in
  `ApplyTextReplacements` (`ModService.cs:1301`) is unchanged, so a filled short twin can
  never half-rewrite a longer phrase that contains it (also tested).
- `ConditioningControlPanel/Models/BuiltInMods.cs:1949` gives the Infection Control stub the
  pack's feature renames, and `BuiltInMods.cs:1970` its `TubeLayout` (scale 0.9, offsets
  0/40). The stub had neither, so until the 231 MB pack finishes extracting, and forever if
  it never downloads, the mod activated with stock feature names and the default avatar fit
  rather than the nurse's own.

## What is NOT fixed here

The second half of the ticket says the avatar tube offset set for that mod is not saved
between runs. I could not find a code path that drops it: `TubeFitDialog.BtnSave_Click`
(`ConditioningControlPanel/Dialogs/TubeFitDialog.xaml.cs:328`) writes
`AppSettings.TubeLayoutOverridesByMod[App.Mods.ActiveModId]` and calls `Save()` explicitly,
`ModService.EffectiveTubeLayout` (`ConditioningControlPanel/Services/ModService.cs:1347`)
reads it back under the same key with the override winning over the manifest, the property
is serialized normally (`ConditioningControlPanel/Models/AppSettings.cs:1735`), and nothing
in the tree clears that dictionary. The reproducible defect on this side is the missing stub
`TubeLayout` fixed above, which is consistent with a report of the nurse sitting wrong. If
the reporter still sees a saved fit vanish after this ships, the next thing to ask for is
their `settings.json` `TubeLayoutOverridesByMod` block plus the `[TubeFit] Saved tube layout
override` log line, which will say whether the write happened and under which mod id.

## Tests

`Tests/ConditioningControlPanel.Tests/ModFeatureLabelAliasTests.cs` (7 tests): the alias fill
in both directions, an author-supplied twin surviving untouched, a manifest that renames
neither form gaining nothing, longest-key precedence, and the Infection Control stub
carrying the pack's renames and tube fit.

Full suite: 5338 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H1RfsRjhE77h2sjsSwAJ5B

