### PR TITLE
feat(pbp): ramp intensity model, schedule and media source

### DIFF
--- a/ConditioningControlPanel/Resources/web/piecebypiece/ramp/media.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/ramp/media.js
@@ -1,0 +1,148 @@
+/* ============================================================================
+ * ramp/media.js - where the ramp's pictures come from.
+ *
+ * TWO sources, ONE interface, so a layer never knows which one it is riding:
+ *
+ *   createFixtureMedia(list)  dev/test. `list` is the parsed dev/media.json:
+ *                             [{ kind:'image'|'gif'|'video', url }]. An EMPTY
+ *                             list is a supported state, not an error - draw()
+ *                             answers null, the video card never appears and
+ *                             the gif layers fall back to a pink noise tile.
+ *
+ *   createHostMedia()         the shipping source. STUB for now: the C# host
+ *                             will post the same manifest DtRH gets
+ *                             (DtrhAssetManifest -> https://ccp.assets/ urls,
+ *                             see dtrh/hostMedia.js) and the page will feed it
+ *                             in through `adopt()`. Until that lands it behaves
+ *                             exactly like an empty fixture source, so the ramp
+ *                             degrades instead of throwing.
+ *
+ * Everything is URL-only. No fetch, no blobs, no canvas, no WebGL upload: the
+ * manifest may carry remote CDN entries that send no CORS headers, and a plain
+ * <img>/<video>/background-image is the only road those can take (this is the
+ * same rule that keeps dtrh/hostMedia.js's two pools apart).
+ * ==========================================================================*/
+
+const KINDS = ['image', 'gif', 'video'];
+const NO_ECHO = 6;   // a reshuffled deck avoids repeating the last N draws
+
+/** A pink static tile, generated in-page, used wherever a gif is missing. */
+export function noiseTileUrl(seed = 2) {
+  const svg = '<svg xmlns="http://www.w3.org/2000/svg" width="160" height="160">'
+    + '<filter id="n"><feTurbulence type="fractalNoise" baseFrequency="0.9" numOctaves="'
+    + Math.max(1, seed | 0)
+    + '"/><feColorMatrix values="0.9 0 0 0 0.55  0 0.2 0 0 0.08  0 0 0.6 0 0.5  0 0 0 0.7 0"/></filter>'
+    + '<rect width="160" height="160" filter="url(#n)"/></svg>';
+  return 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent(svg);
+}
+
+/** Shuffle in place with an optional injected rng (tests want determinism). */
+function shuffle(arr, rnd) {
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor((rnd ? rnd() : Math.random()) * (i + 1));
+    const tmp = arr[i]; arr[i] = arr[j]; arr[j] = tmp;
+  }
+  return arr;
+}
+
+/** The shared pool body both sources use. `entries` may be replaced by adopt(). */
+function createPool(entries, { rnd, label } = {}) {
+  let all = [];
+  const decks = {};      // kind -> remaining shuffled indices
+  const recent = [];     // last NO_ECHO urls handed out
+
+  function ingest(list) {
+    all = [];
+    for (const raw of Array.isArray(list) ? list : []) {
+      if (!raw) continue;
+      const url = typeof raw === 'string' ? raw : raw.url;
+      if (!url || typeof url !== 'string') continue;
+      let kind = typeof raw === 'string' ? '' : String(raw.kind || '');
+      if (!KINDS.includes(kind)) {
+        // infer from the extension when the entry did not say
+        if (/\.(mp4|webm|m4v|mov)(\?|$)/i.test(url)) kind = 'video';
+        else if (/\.gif(\?|$)/i.test(url)) kind = 'gif';
+        else kind = 'image';
+      }
+      all.push({ kind, url, name: (typeof raw === 'object' && raw.name) || url.split('/').pop() });
+    }
+    for (const k of KINDS) delete decks[k];
+    recent.length = 0;
+  }
+  ingest(entries);
+
+  /** Indices of every entry usable as `kind` (a gif is also a fine image). */
+  function poolFor(kind) {
+    const want = kind === 'gif' ? ['gif'] : (kind === 'video' ? ['video'] : ['image', 'gif']);
+    const out = [];
+    for (let i = 0; i < all.length; i++) if (want.includes(all[i].kind)) out.push(i);
+    return out;
+  }
+
+  function has(kind) { return poolFor(kind).length > 0; }
+
+  /** One url, non-repeating across a deck, echo-guarded on tiny pools. */
+  function draw(kind) {
+    const k = KINDS.includes(kind) ? kind : 'image';
+    const pool = poolFor(k);
+    if (!pool.length) return null;
+    let deck = decks[k];
+    if (!deck || !deck.length) deck = decks[k] = shuffle(pool.slice(), rnd);
+    let idx = deck.pop();
+    // echo guard: on a pool bigger than the guard, skip a url we just used
+    if (pool.length > NO_ECHO && recent.includes(all[idx].url) && deck.length) idx = deck.pop();
+    const url = all[idx].url;
+    recent.push(url);
+    while (recent.length > NO_ECHO) recent.shift();
+    return url;
+  }
+
+  /** A gif url, or a generated pink noise tile when the pool has none. */
+  function drawTile() { return draw('gif') || draw('image') || noiseTileUrl(2 + ((Math.random() * 3) | 0)); }
+
+  function stats() {
+    const out = { label: label || 'pool', total: all.length };
+    for (const k of KINDS) out[k] = all.filter((e) => e.kind === k).length;
+    return out;
+  }
+
+  return { has, draw, drawTile, stats, adopt: ingest, get size() { return all.length; } };
+}
+
+/**
+ * Dev/test source. Pass the parsed dev/media.json (or []). An empty list is a
+ * first-class state: no video card, gifs become pink noise tiles.
+ */
+export function createFixtureMedia(list, opts = {}) {
+  const pool = createPool(list, { rnd: opts.rnd, label: 'fixture' });
+  return { kind: 'fixture', ...pool };
+}
+
+/**
+ * Shipping source (STUB). The C# host has no Piece by Piece manifest yet; when
+ * it grows one it will post the DtRH-shaped frame
+ *   { type:'manifest', images:[...], videos:[...] }   // https://ccp.assets/ urls
+ * and the page will call `media.adopt(entries)` with it. Nothing in the ramp
+ * needs to change: adopt() is the same door createFixtureMedia uses.
+ *
+ * Do NOT build the C# side from here - this is only the page-side seam.
+ */
+export function createHostMedia(entries) {
+  const pool = createPool(entries || [], { label: 'host' });
+  if (!pool.size) {
+    try { console.warn('[pbp/ramp] host media pool is empty; the ramp runs without pictures.'); } catch { /* no console */ }
+  }
+  return { kind: 'host', ...pool };
+}
+
+/** Load dev/media.json next to the harness. Never throws: [] on any failure. */
+export async function loadFixtureList(url) {
+  try {
+    const res = await fetch(url, { cache: 'no-cache' });
+    if (!res.ok) return [];
+    const json = await res.json();
+    return Array.isArray(json) ? json : (Array.isArray(json && json.entries) ? json.entries : []);
+  } catch { return []; }
+}
+
+export default createFixtureMedia;

--- a/ConditioningControlPanel/Resources/web/piecebypiece/ramp/meter.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/ramp/meter.js
@@ -1,0 +1,170 @@
+/* ============================================================================
+ * ramp/meter.js - the intensity model for Piece by Piece.
+ *
+ * One number per side, 0..1, built from three inputs: how little clock is left,
+ * how many pieces that side has TAKEN, and how many it has LOST. Taking ramps
+ * you harder than losing (captureWeight 1.5 vs lossWeight 1.0) - the player who
+ * is winning on the board gets the worse screen. Both sides end up melted.
+ *
+ * Pure and deterministic: every function takes the clock/counters it needs and
+ * `now` is passed in, so smoke tests replay the same numbers without a timer.
+ * ==========================================================================*/
+
+export const clamp = (v, lo, hi) => Math.min(hi, Math.max(lo, v));
+export const clamp01 = (v) => clamp(Number.isFinite(v) ? v : 0, 0, 1);
+export const lerp = (a, b, t) => a + (b - a) * clamp01(t);
+
+/** EVERY tunable in the ramp lives here. Layers read it, nothing hardcodes. */
+export const RAMP_TUNING = Object.freeze({
+  // --- the meter itself -----------------------------------------------------
+  clockWeight: 0.35,     // full weight of a fully drained clock
+  perPieceStep: 0.10,    // one piece of movement on the meter
+  captureWeight: 1.5,    // taking ramps you MORE than losing (owner rule)
+  lossWeight: 1.0,
+
+  // --- the capture kick: a decaying bump on top of the meter, both sides -----
+  burst: Object.freeze({ taker: 0.30, victim: 0.15, decayMs: 2600 }),
+
+  // --- sustained unlock thresholds (on the meter, not the kick) -------------
+  unlock: Object.freeze({ melt: 0.25, blur: 0.40, spiral: 0.55, overlay: 0.70 }),
+
+  // --- one-shot cadence bands (ms between spawns, slow at 0 heat) -----------
+  flash: Object.freeze({ slowMs: 4200, fastMs: 520, maxLive: 6 }),
+  gifRain: Object.freeze({ slowMs: 3000, fastMs: 620, maxLive: 12, fallMsMin: 2400, fallMsMax: 3900 }),
+
+  // --- sustained layer envelopes -------------------------------------------
+  melt: Object.freeze({ minAlpha: 0.10, maxAlpha: 0.52 }),
+  blurMaxPx: 3,          // HARD CAP: a move must always stay physically possible
+  spiral: Object.freeze({ minAlpha: 0.16, maxAlpha: 0.50, minHoldMs: 1400, maxHoldMs: 5200, gapMs: 9000 }),
+  overlay: Object.freeze({ minAlpha: 0.10, maxAlpha: 0.34 }),
+
+  // --- the video card + the drag glitch ------------------------------------
+  videoCard: Object.freeze({ minHoldSec: 4, maxHoldSec: 13, riseMs: 620, startJitter: 0.7 }),
+  glitchGrab: Object.freeze({ sizePx: 132, alpha: 0.85 }),
+
+  // --- what we hand back to the board (A's side, always guarded) -----------
+  wobbleScale: 1.0,
+  swayScale: 1.0,
+
+  // --- the effect-free share, ported from the Arcademy plainShare ramp ------
+  plain: Object.freeze({ early: 0.80, floor: 0.30 }),
+});
+
+/** Share of beats that must stay effect-free, so effects read as a spill and
+ *  not as a metronome. Ported from arcademy/engine/curves.js plainShare(). */
+export function plainShare(heat, tuning = RAMP_TUNING) {
+  const { early, floor } = tuning.plain;
+  return clamp01(early + (clamp01(floor) - early) * clamp01(heat));
+}
+
+const SIDES = ['w', 'b'];
+const otherSide = (s) => (s === 'w' ? 'b' : 'w');
+
+/**
+ * createMeter({ tuning }) - the live model.
+ *
+ * `meterFor(side)` is the pure formula (clock + counters). `heatFor(side, now)`
+ * is what the layers actually ride: the meter plus whatever is left of the last
+ * capture kick. The two are kept apart so the unlock thresholds never flicker
+ * on and off with a burst.
+ */
+export function createMeter({ tuning = RAMP_TUNING } = {}) {
+  const t = tuning;
+  const state = {
+    clocks: { w: 0, b: 0 },
+    total: 0,
+    active: 'w',
+    captures: { w: 0, b: 0 },   // pieces this side has TAKEN
+    losses: { w: 0, b: 0 },     // pieces this side has LOST
+    kick: { w: 0, b: 0 },       // capture burst amplitude at kickAt
+    kickAt: { w: 0, b: 0 },
+    ply: 0,
+    over: false,
+  };
+
+  /** Fraction of this side's clock still on the board (1 when we have no clock). */
+  function clockFrac(side) {
+    if (!(state.total > 0)) return 1;
+    return clamp01(state.clocks[side] / state.total);
+  }
+
+  /** The formula. clock 0.35 + 0.10*1.5 per capture + 0.10 per loss, clamped. */
+  function meterFor(side) {
+    const s = side === 'b' ? 'b' : 'w';
+    return clamp01(
+      t.clockWeight * (1 - clockFrac(s))
+      + t.perPieceStep * t.captureWeight * state.captures[s]
+      + t.perPieceStep * t.lossWeight * state.losses[s],
+    );
+  }
+
+  /** What is left of the capture kick for `side` at `now` (linear decay). */
+  function kickFor(side, now) {
+    const s = side === 'b' ? 'b' : 'w';
+    const amp = state.kick[s];
+    if (!(amp > 0)) return 0;
+    const age = now - state.kickAt[s];
+    if (age >= t.burst.decayMs || age < 0) return 0;
+    return amp * (1 - age / t.burst.decayMs);
+  }
+
+  /** meter + kick: the number every layer rides. */
+  const heatFor = (side, now) => clamp01(meterFor(side) + kickFor(side, now));
+
+  function setClock(payload) {
+    if (!payload) return;
+    if (Number.isFinite(payload.w)) state.clocks.w = payload.w;
+    if (Number.isFinite(payload.b)) state.clocks.b = payload.b;
+    if (Number.isFinite(payload.total) && payload.total > 0) state.total = payload.total;
+    if (payload.active === 'w' || payload.active === 'b') state.active = payload.active;
+  }
+
+  function setTurn(payload) {
+    if (!payload) return;
+    if (payload.side === 'w' || payload.side === 'b') state.active = payload.side;
+    if (Number.isFinite(payload.ply)) state.ply = payload.ply;
+    if (payload.clocks) setClock({ ...payload.clocks, total: payload.total });
+    else if (Number.isFinite(payload.total)) state.total = payload.total;
+  }
+
+  /** A capture: the taker gains a capture, the victim a loss, both get a kick. */
+  function noteCapture(payload, now) {
+    if (!payload) return;
+    const taker = payload.by === 'b' ? 'b' : (payload.by === 'w' ? 'w' : null);
+    const victim = payload.victimSide === 'b' ? 'b'
+      : (payload.victimSide === 'w' ? 'w' : (taker ? otherSide(taker) : null));
+    if (taker) { state.captures[taker] += 1; state.kick[taker] = t.burst.taker; state.kickAt[taker] = now; }
+    if (victim) { state.losses[victim] += 1; state.kick[victim] = t.burst.victim; state.kickAt[victim] = now; }
+  }
+
+  function reset() {
+    state.clocks = { w: 0, b: 0 }; state.total = 0; state.active = 'w';
+    state.captures = { w: 0, b: 0 }; state.losses = { w: 0, b: 0 };
+    state.kick = { w: 0, b: 0 }; state.kickAt = { w: 0, b: 0 };
+    state.ply = 0; state.over = false;
+  }
+
+  /** Everything a debug panel or a smoke test wants, in one readable object. */
+  function snapshot(now = 0) {
+    const out = { active: state.active, ply: state.ply, total: state.total, over: state.over, sides: {} };
+    for (const s of SIDES) {
+      out.sides[s] = {
+        clockMs: state.clocks[s], clockFrac: clockFrac(s),
+        captures: state.captures[s], losses: state.losses[s],
+        meter: meterFor(s), kick: kickFor(s, now), heat: heatFor(s, now),
+      };
+    }
+    return out;
+  }
+
+  return {
+    setClock, setTurn, noteCapture, reset, snapshot,
+    meterFor, heatFor, kickFor, clockFrac,
+    get active() { return state.active; },
+    get over() { return state.over; },
+    set over(v) { state.over = !!v; },
+    get ply() { return state.ply; },
+  };
+}
+
+export default createMeter;

--- a/ConditioningControlPanel/Resources/web/piecebypiece/ramp/schedule.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/ramp/schedule.js
@@ -1,0 +1,126 @@
+/* ============================================================================
+ * ramp/schedule.js - heat -> what fires, and what stays on.
+ *
+ * The shape is the Arcademy Distraction Engine's (engine/curves.js +
+ * engine/schedule.js): a cadence band per one-shot kind interpolated by heat, a
+ * seeded RNG so a replay is a replay, and the plainShare ramp so effects stay a
+ * SPILL at low heat instead of a metronome. Sustained layers are not rolled -
+ * they unlock at fixed meter thresholds and their strength tracks the meter.
+ *
+ * Pure except for the clock the caller passes in: `tick(now, heat, meter)`.
+ * ==========================================================================*/
+
+import { RAMP_TUNING, clamp01, lerp, plainShare } from './meter.js';
+
+/** mulberry32 - a tiny seeded PRNG so smoke tests replay exactly. */
+export function makeRng(seed) {
+  let a = 0;
+  const s = String(seed == null ? Math.random() : seed);
+  for (let i = 0; i < s.length; i++) { a = (a * 31 + s.charCodeAt(i)) >>> 0; }
+  return function next() {
+    a = (a + 0x6D2B79F5) >>> 0;
+    let x = a;
+    x = Math.imul(x ^ (x >>> 15), 1 | x);
+    x = (x + Math.imul(x ^ (x >>> 7), 61 | x)) ^ x;
+    return ((x ^ (x >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/** ms between spawns of `kind` at this heat (Infinity when the kind is idle). */
+export function cadenceMs(kind, heat, tuning = RAMP_TUNING) {
+  const band = tuning[kind];
+  if (!band) return Infinity;
+  return lerp(band.slowMs, band.fastMs, clamp01(heat));
+}
+
+/** The sustained stack for a meter value: which layers are on, and how hard. */
+export function sustainedFor(meter, tuning = RAMP_TUNING) {
+  const m = clamp01(meter);
+  const u = tuning.unlock;
+  // each layer's own 0..1 progress from its unlock point up to a full meter
+  const ramp = (from) => (m <= from ? 0 : clamp01((m - from) / Math.max(0.01, 1 - from)));
+  const meltR = ramp(u.melt);
+  const blurR = ramp(u.blur);
+  const spiralR = ramp(u.spiral);
+  const overR = ramp(u.overlay);
+  return {
+    melt: {
+      on: m >= u.melt,
+      alpha: m >= u.melt ? lerp(tuning.melt.minAlpha, tuning.melt.maxAlpha, meltR) : 0,
+    },
+    blur: {
+      on: m >= u.blur,
+      // HARD CAP: never past blurMaxPx, whatever the meter says
+      px: m >= u.blur ? Math.min(tuning.blurMaxPx, tuning.blurMaxPx * blurR) : 0,
+    },
+    spiral: {
+      on: m >= u.spiral,
+      alpha: m >= u.spiral ? lerp(tuning.spiral.minAlpha, tuning.spiral.maxAlpha, spiralR) : 0,
+      holdMs: Math.round(lerp(tuning.spiral.minHoldMs, tuning.spiral.maxHoldMs, spiralR)),
+    },
+    overlay: {
+      on: m >= u.overlay,
+      alpha: m >= u.overlay ? lerp(tuning.overlay.minAlpha, tuning.overlay.maxAlpha, overR) : 0,
+    },
+  };
+}
+
+/** How long the video card sticks over the board at this meter. */
+export function videoHoldMs(meter, tuning = RAMP_TUNING) {
+  const v = tuning.videoCard;
+  return Math.round(lerp(v.minHoldSec, v.maxHoldSec, clamp01(meter)) * 1000);
+}
+
+/**
+ * createSchedule({ tuning, seed })
+ *
+ * tick(now, heat, meter) -> { fire: ['flash', ...], sustained: {...} }
+ *
+ * Cadence is accumulated per kind (never a setInterval), so a paused tab or a
+ * long frame catches up by at most one spawn instead of dumping a backlog.
+ */
+export function createSchedule({ tuning = RAMP_TUNING, seed = 'pbp' } = {}) {
+  const rng = makeRng(seed);
+  const kinds = ['flash', 'gifRain'];
+  const nextAt = { flash: 0, gifRain: 0 };
+  let started = false;
+
+  function reset(now = 0) {
+    started = false;
+    for (const k of kinds) nextAt[k] = now;
+  }
+
+  function tick(now, heat, meter) {
+    const h = clamp01(heat);
+    const fire = [];
+    if (!started) { started = true; for (const k of kinds) nextAt[k] = now + cadenceMs(k, h, tuning); }
+    for (const k of kinds) {
+      const gap = cadenceMs(k, h, tuning);
+      if (!Number.isFinite(gap)) { nextAt[k] = now + 1000; continue; }
+      if (now >= nextAt[k]) {
+        // plainShare: the busier it gets, the fewer beats stay empty
+        if (rng() >= plainShare(h, tuning)) fire.push(k);
+        nextAt[k] = now + gap;
+      }
+      // a heat drop should pull the next spawn in, not strand it in the future
+      if (nextAt[k] - now > gap) nextAt[k] = now + gap;
+    }
+    return { fire, sustained: sustainedFor(meter == null ? h : meter, tuning), heat: h };
+  }
+
+  /** A capture kick: an immediate burst, bigger for the side that took a piece. */
+  function burstFor(role, heat, tuning2 = tuning) {
+    const h = clamp01(heat);
+    const base = role === 'taker' ? 2 : 1;
+    return {
+      flashes: base + Math.round(h * (role === 'taker' ? 3 : 2)),
+      gifs: role === 'taker' ? 1 + Math.round(h * 3) : Math.round(h * 2),
+      shakeMs: Math.round(lerp(160, 420, h)) * (role === 'taker' ? 1 : 0.6),
+      tuning: tuning2,
+    };
+  }
+
+  return { tick, reset, burstFor, rng };
+}
+
+export default createSchedule;


### PR DESCRIPTION
Part 1 of the Piece by Piece conditioning ramp (Agent B's stack). Pure math and the media seam, no pixels, so all of it is node-testable.

**`ramp/meter.js`** - `RAMP_TUNING` (every tunable in one object) plus the per-side intensity model:

```
meter(side) = clamp(0.35 * (1 - clockFrac)
                  + 0.10 * 1.5 * capturesMade
                  + 0.10 * piecesLost, 0, 1)
```

Capturing ramps you more than losing (1.5 vs 1.0), so whoever is ahead on material gets the worse screen. A capture also lays a decaying kick on both sides, bigger for the taker, that rides on top of the meter as "heat" - deliberately kept out of the meter itself so the sustained unlock thresholds never flicker on a burst.

**`ramp/schedule.js`** - heat to cadence, meter to the sustained stack, in the Arcademy Distraction Engine's shape: a slow/fast band per one-shot kind, a seeded mulberry32 so a replay replays, and the `plainShare` ramp (.80 to .30 effect-free share) so effects read as a spill rather than a metronome. Sustained layers unlock at fixed meter thresholds: melt .25, blur .40, spiral .55, gif overlay .70. Blur is hard-capped at 3px so a move always stays physically possible.

**`ramp/media.js`** - one interface, two sources. `createFixtureMedia(list)` reads `dev/media.json`; an empty list is a supported state, so the video card simply never appears and gifs fall back to a generated pink noise tile. `createHostMedia()` is the documented page-side seam for the C# manifest DtRH already posts (`https://ccp.assets/` urls) and behaves as an empty pool until that lands - no C# work here. URL-only throughout: no fetch, no canvas, no texture upload, because a remote manifest entry sends no CORS headers.

Verified in node: half clock gives .175, two captures .475, the victim .200, the kick decays to nothing at 2600ms, and blur tops out at exactly 3px at meter 1.0.

Stacked: `feat/pbp-b1b-attach` follows with `attachRamp` and the dev harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S4BKp6cQJFNixoQrarvSkd