### PR TITLE
feat(pbp): 3D board, placeholder pieces and the page shell

### DIFF
--- a/ConditioningControlPanel/Resources/web/piecebypiece/board/pieces.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/board/pieces.js
@@ -1,0 +1,204 @@
+/* ============================================================================
+ * board/pieces.js - the men on the board.
+ *
+ * Placeholder art: every type is a lathed profile (turned on a lathe, like real
+ * wooden chessmen) in a glossy silicone material. If a matching glb turns up in
+ * assets/pieces/ it is used instead, per type, without a reload. A glb must be a
+ * single mesh, +Y up, origin at the centre of its base, height exactly 1.0; it
+ * gets scaled to the type height below.
+ * ==========================================================================*/
+
+import * as THREE from 'three';
+import { squareToWorld } from './scene.js';
+
+export const TYPES = ['p', 'n', 'b', 'r', 'q', 'k'];
+export const GLB_NAMES = { p: 'pawn', n: 'knight', b: 'bishop', r: 'rook', q: 'queen', k: 'king' };
+export const HEIGHT = { p: 0.62, n: 0.80, b: 0.90, r: 0.70, q: 1.02, k: 1.15 };
+
+// Lathe profiles in NORMALISED space: y runs 0 (base) to 1 (crown), x is the
+// radius at that height. A piece is built at height 1 and then scaled by
+// HEIGHT[type], which is exactly the contract a supplied glb has to meet.
+const PROFILE = {
+  p: [[0,0],[0.34,0],[0.36,0.06],[0.26,0.14],[0.16,0.22],[0.145,0.46],[0.22,0.53],[0.13,0.58],[0.10,0.66],[0.17,0.74],[0.19,0.84],[0.14,0.94],[0.06,0.99],[0,1]],
+  r: [[0,0],[0.38,0],[0.40,0.07],[0.30,0.15],[0.26,0.58],[0.30,0.68],[0.38,0.72],[0.38,1.0],[0.30,1.0],[0.30,0.86],[0,0.84]],
+  n: [[0,0],[0.37,0],[0.39,0.07],[0.29,0.15],[0.24,0.30],[0.21,0.42],[0,0.44]],
+  b: [[0,0],[0.36,0],[0.38,0.06],[0.27,0.14],[0.17,0.26],[0.155,0.46],[0.24,0.54],[0.27,0.60],[0.20,0.64],[0.13,0.70],[0.15,0.80],[0.11,0.88],[0.06,0.95],[0.065,0.965],[0,0.97]],
+  q: [[0,0],[0.38,0],[0.40,0.06],[0.29,0.14],[0.18,0.28],[0.16,0.48],[0.26,0.58],[0.30,0.64],[0.23,0.70],[0.28,0.78],[0.20,0.84],[0.10,0.88],[0.11,0.94],[0.06,0.97],[0,0.98]],
+  k: [[0,0],[0.38,0],[0.40,0.06],[0.29,0.14],[0.19,0.28],[0.17,0.50],[0.27,0.60],[0.31,0.66],[0.24,0.72],[0.15,0.80],[0.13,0.86],[0.16,0.89],[0.10,0.90],[0,0.90]],
+};
+
+const SKIN = { w: { color: 0xFFF0F5, sheen: 0xFF9EC4 }, b: { color: 0x3B2A63, sheen: 0x7B6CFF } };
+
+function lathe(points, segments = 40) {
+  const geo = new THREE.LatheGeometry(points.map(([x, y]) => new THREE.Vector2(Math.max(x, 0.0001), y)), segments);
+  geo.computeVertexNormals();
+  return geo;
+}
+
+function material(side) {
+  const skin = SKIN[side] || SKIN.w;
+  return new THREE.MeshPhysicalMaterial({
+    color: skin.color, roughness: 0.35, clearcoat: 0.6, clearcoatRoughness: 0.22, metalness: 0.0,
+    sheen: 0.5, sheenColor: new THREE.Color(skin.sheen), sheenRoughness: 0.6,
+    emissive: new THREE.Color(skin.sheen), emissiveIntensity: 0,
+  });
+}
+
+/** Extra bits a lathe cannot turn, also in normalised space. */
+function trim(type, mat) {
+  const parts = [];
+  if (type === 'n') {
+    const neck = new THREE.Mesh(new THREE.CylinderGeometry(0.19, 0.23, 0.20, 20), mat);
+    neck.position.y = 0.50;
+    const head = new THREE.Mesh(new THREE.BoxGeometry(0.26, 0.46, 0.34), mat);
+    head.position.set(0, 0.68, -0.03);
+    head.rotation.x = -0.24;
+    const snout = new THREE.Mesh(new THREE.BoxGeometry(0.23, 0.20, 0.30), mat);
+    snout.position.set(0, 0.74, -0.26);
+    snout.rotation.x = 0.22;
+    const ear = new THREE.Mesh(new THREE.ConeGeometry(0.07, 0.18, 8), mat);
+    ear.position.set(0, 0.94, 0.04);
+    parts.push(neck, head, snout, ear);
+  } else if (type === 'q') {
+    const ball = new THREE.Mesh(new THREE.SphereGeometry(0.07, 16, 12), mat);
+    ball.position.y = 1.0;
+    parts.push(ball);
+  } else if (type === 'k') {
+    const up = new THREE.Mesh(new THREE.BoxGeometry(0.07, 0.20, 0.07), mat);
+    up.position.y = 0.94;
+    const across = new THREE.Mesh(new THREE.BoxGeometry(0.19, 0.065, 0.07), mat);
+    across.position.y = 0.965;
+    parts.push(up, across);
+  } else if (type === 'b') {
+    const ball = new THREE.Mesh(new THREE.SphereGeometry(0.058, 14, 10), mat);
+    ball.position.y = 0.99;
+    parts.push(ball);
+  }
+  return parts;
+}
+
+export function createPieces({ group, assetsBase = './assets/pieces/' }) {
+  const geoCache = new Map();
+  const glb = new Map();          // type -> geometry from a supplied glb
+  const bySquare = new Map();     // square -> piece object
+  let wobble = 0;
+  let clock = 0;
+
+  function geometryFor(type) {
+    if (glb.has(type)) return glb.get(type);
+    if (!geoCache.has(type)) geoCache.set(type, lathe(PROFILE[type]));
+    return geoCache.get(type);
+  }
+
+  function build(type, side) {
+    const root = new THREE.Group();
+    const mat = material(side);
+    const body = new THREE.Mesh(geometryFor(type), mat);
+    body.castShadow = true;
+    body.receiveShadow = true;
+    root.add(body);
+    if (!glb.has(type)) for (const part of trim(type, mat)) { part.castShadow = true; root.add(part); }
+    root.scale.setScalar(HEIGHT[type]);
+    // Knights (and any modelled piece) look at the far side.
+    root.rotation.y = side === 'w' ? 0 : Math.PI;
+    root.userData = { type, side, material: mat, phase: Math.random() * Math.PI * 2, lift: 0, tilt: 0 };
+    return root;
+  }
+
+  function place(piece, square) {
+    const p = squareToWorld(square, 0);
+    piece.position.set(p.x, 0, p.z);
+    piece.userData.home = { x: p.x, z: p.z };
+    piece.userData.square = square;
+  }
+
+  /** Position map: { e1: {type:'k', side:'w'}, ... }. Rebuilds only what moved. */
+  function setPosition(map) {
+    for (const [sq, piece] of [...bySquare]) {
+      const want = map[sq];
+      if (!want || want.type !== piece.userData.type || want.side !== piece.userData.side) {
+        group.remove(piece);
+        bySquare.delete(sq);
+      }
+    }
+    for (const sq of Object.keys(map)) {
+      if (bySquare.has(sq)) continue;
+      const { type, side } = map[sq];
+      const piece = build(type, side);
+      place(piece, sq);
+      group.add(piece);
+      bySquare.set(sq, piece);
+    }
+  }
+
+  function pieceAt(sq) { return bySquare.get(sq) || null; }
+
+  function move(from, to) {
+    const piece = bySquare.get(from);
+    if (!piece) return null;
+    bySquare.delete(from);
+    const taken = bySquare.get(to) || null;
+    if (taken) { group.remove(taken); bySquare.delete(to); }
+    place(piece, to);
+    bySquare.set(to, piece);
+    return piece;
+  }
+
+  function remove(sq) {
+    const piece = bySquare.get(sq);
+    if (piece) { group.remove(piece); bySquare.delete(sq); }
+    return piece || null;
+  }
+
+  function update(dt) {
+    clock += dt;
+    if (wobble <= 0.001) return;
+    for (const piece of bySquare.values()) {
+      if (piece.userData.held) continue;
+      const ph = piece.userData.phase;
+      piece.rotation.z = Math.sin(clock * 1.7 + ph) * 0.055 * wobble;
+      piece.rotation.x = Math.sin(clock * 1.3 + ph * 1.7) * 0.04 * wobble;
+      piece.position.y = Math.abs(Math.sin(clock * 0.9 + ph)) * 0.025 * wobble;
+    }
+  }
+
+  // --- optional glb art ------------------------------------------------------
+  // Probed with HEAD first so a missing file is a quiet 404, not a loader throw.
+  async function tryLoadGlb() {
+    let loader = null;
+    for (const type of TYPES) {
+      const url = assetsBase + GLB_NAMES[type] + '.glb';
+      try {
+        const head = await fetch(url, { method: 'HEAD' });
+        if (!head.ok) continue;
+        if (!loader) {
+          const mod = await import('three/addons/loaders/GLTFLoader.js');
+          loader = new mod.GLTFLoader();
+        }
+        const gltf = await loader.loadAsync(url);
+        let geo = null;
+        gltf.scene.traverse((o) => { if (!geo && o.isMesh) geo = o.geometry; });
+        if (!geo) continue;
+        glb.set(type, geo);
+        // Swap the art under any piece of this type already on the board.
+        for (const [sq, piece] of [...bySquare]) {
+          if (piece.userData.type !== type) continue;
+          const side = piece.userData.side;
+          group.remove(piece);
+          bySquare.delete(sq);
+          const next = build(type, side);
+          place(next, sq);
+          group.add(next);
+          bySquare.set(sq, next);
+        }
+      } catch { /* no art for this type, the lathe stands in */ }
+    }
+  }
+
+  return {
+    setPosition, pieceAt, move, remove, update, tryLoadGlb,
+    pieces: bySquare,
+    setWobble(v) { wobble = Math.max(0, Math.min(1, Number(v) || 0)); },
+    getWobble() { return wobble; },
+  };
+}

--- a/ConditioningControlPanel/Resources/web/piecebypiece/board/scene.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/board/scene.js
@@ -1,0 +1,185 @@
+/* ============================================================================
+ * board/scene.js - renderer, camera rig, lights and the board itself.
+ *
+ * Coordinate law for the whole game: one square is 1.0 world unit, the board is
+ * centred on the origin, +Y is up. File a..h maps to x -3.5..3.5, rank 1..8 maps
+ * to z 3.5..-3.5, so rank 1 (white's home) is the near edge of the +Z side.
+ * ==========================================================================*/
+
+import * as THREE from 'three';
+
+export const SQUARE = 1.0;
+export const FILES = 'abcdefgh';
+
+const CREAM = 0xF5E6C8;
+const PINK = 0xFF69B4;
+const BACKDROP = 0x1A1A3E;
+
+/** Square name ("e4") to the world position of its centre. */
+export function squareToWorld(sq, y = 0, out = new THREE.Vector3()) {
+  const f = FILES.indexOf(sq[0]);
+  const r = Number(sq[1]) - 1;
+  return out.set((f - 3.5) * SQUARE, y, (3.5 - r) * SQUARE);
+}
+
+/** World x/z to a square name, or null when the point is off the board. */
+export function worldToSquare(x, z) {
+  const f = Math.round(x / SQUARE + 3.5);
+  const r = Math.round(3.5 - z / SQUARE);
+  if (f < 0 || f > 7 || r < 0 || r > 7) return null;
+  return FILES[f] + (r + 1);
+}
+
+const easeInOut = (t) => (t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2);
+
+export function createScene({ canvas }) {
+  const renderer = new THREE.WebGLRenderer({ canvas, antialias: true, alpha: false });
+  renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
+  renderer.outputColorSpace = THREE.SRGBColorSpace;
+  renderer.toneMapping = THREE.ACESFilmicToneMapping;
+  renderer.toneMappingExposure = 1.06;
+  renderer.shadowMap.enabled = true;
+  renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+
+  const scene = new THREE.Scene();
+  scene.background = new THREE.Color(BACKDROP);
+  scene.fog = new THREE.Fog(BACKDROP, 14, 30);
+
+  const camera = new THREE.PerspectiveCamera(40, 1, 0.1, 120);
+
+  // --- lights: one soft key over the board, one pink rim from behind ---------
+  scene.add(new THREE.HemisphereLight(0x8f86d6, 0x141433, 0.55));
+  const key = new THREE.DirectionalLight(0xFFF3E4, 2.1);
+  key.position.set(4.5, 9.5, 5.5);
+  key.castShadow = true;
+  key.shadow.mapSize.set(1024, 1024);
+  key.shadow.radius = 3;
+  const cam = key.shadow.camera;
+  cam.left = -7; cam.right = 7; cam.top = 7; cam.bottom = -7; cam.near = 1; cam.far = 26;
+  scene.add(key, key.target);
+  const rim = new THREE.DirectionalLight(PINK, 1.15);
+  rim.position.set(-5.5, 3.2, -6.5);
+  scene.add(rim, rim.target);
+
+  // --- board ----------------------------------------------------------------
+  const boardGroup = new THREE.Group();
+  const pieceGroup = new THREE.Group();
+  scene.add(boardGroup, pieceGroup);
+
+  const plinthMat = new THREE.MeshPhysicalMaterial({ color: 0x241F45, roughness: 0.45, clearcoat: 0.35 });
+  const plinth = new THREE.Mesh(new THREE.BoxGeometry(9.4, 0.5, 9.4), plinthMat);
+  plinth.position.y = -0.33;
+  plinth.receiveShadow = true;
+  boardGroup.add(plinth);
+
+  const squareGeo = new THREE.BoxGeometry(SQUARE, 0.16, SQUARE);
+  const squares = new Map();
+  for (let f = 0; f < 8; f++) {
+    for (let r = 0; r < 8; r++) {
+      const light = (f + r) % 2 === 1; // a1 is dark, h1 is light
+      const mat = new THREE.MeshPhysicalMaterial({
+        color: light ? CREAM : PINK, roughness: light ? 0.42 : 0.34, clearcoat: 0.5, clearcoatRoughness: 0.3,
+      });
+      const mesh = new THREE.Mesh(squareGeo, mat);
+      mesh.position.set((f - 3.5) * SQUARE, -0.08, (3.5 - r) * SQUARE);
+      mesh.receiveShadow = true;
+      const name = FILES[f] + (r + 1);
+      mesh.userData.square = name;
+      mesh.userData.base = mat.color.clone();
+      boardGroup.add(mesh);
+      squares.set(name, mesh);
+    }
+  }
+
+  /** Tint squares for legal-move hints. `list` is [{square, color, glow}]. */
+  const tinted = new Set();
+  function setHighlights(list = []) {
+    for (const name of tinted) {
+      const m = squares.get(name);
+      if (m) m.material.emissive.setHex(0x000000);
+    }
+    tinted.clear();
+    for (const hit of list) {
+      const m = squares.get(hit.square);
+      if (!m) continue;
+      m.material.emissive.setHex(hit.color ?? 0xFF3FA4);
+      m.material.emissiveIntensity = hit.glow ?? 0.45;
+      tinted.add(hit.square);
+    }
+  }
+
+  // --- camera rig -----------------------------------------------------------
+  // Sits behind whichever side is to move and swings around with a small dolly.
+  const RADIUS = 9.7;
+  const HEIGHT = 7.0;
+  const LOOK = new THREE.Vector3(0, 0.55, 0);
+  let angleFrom = 0;
+  let angleTo = 0;
+  let swing = 1;
+  let sway = 0;
+  let clock = 0;
+  const lookAt = new THREE.Vector3();
+
+  function setSide(side, instant = false) {
+    const to = side === 'b' ? Math.PI : 0;
+    if (Math.abs(to - angleTo) < 1e-6 && swing >= 1) { if (instant) swing = 1; return; }
+    angleFrom = THREE.MathUtils.lerp(angleFrom, angleTo, easeInOut(Math.min(swing, 1)));
+    angleTo = to;
+    swing = instant ? 1 : 0;
+  }
+
+  function updateCamera(dt) {
+    if (swing < 1) swing = Math.min(1, swing + dt / 0.9);
+    const e = easeInOut(swing);
+    const ang = THREE.MathUtils.lerp(angleFrom, angleTo, e);
+    const dolly = 1 + 0.12 * Math.sin(Math.PI * e) * (swing < 1 ? 1 : 0);
+    const swayX = Math.sin(clock * 0.53) * 0.55 * sway;
+    const swayY = Math.sin(clock * 0.37 + 1.1) * 0.28 * sway;
+    camera.position.set(Math.sin(ang) * RADIUS * dolly + swayX, HEIGHT * dolly + swayY, Math.cos(ang) * RADIUS * dolly);
+    lookAt.copy(LOOK);
+    lookAt.x += Math.sin(clock * 0.29) * 0.4 * sway;
+    camera.lookAt(lookAt);
+    camera.rotateZ(Math.sin(clock * 0.23) * 0.035 * sway);
+  }
+
+  function resize() {
+    const w = canvas.clientWidth || window.innerWidth;
+    const h = canvas.clientHeight || window.innerHeight;
+    renderer.setSize(w, h, false);
+    camera.aspect = w / Math.max(1, h);
+    camera.updateProjectionMatrix();
+  }
+  window.addEventListener('resize', resize);
+  resize();
+
+  function update(dt) {
+    clock += dt;
+    updateCamera(dt);
+  }
+
+  function render() { renderer.render(scene, camera); }
+
+  // --- projection (the effects layer draws DOM over these) ------------------
+  const tmp = new THREE.Vector3();
+  function projectPoint(v) {
+    tmp.copy(v).project(camera);
+    const r = canvas.getBoundingClientRect();
+    return { x: r.left + (tmp.x * 0.5 + 0.5) * r.width, y: r.top + (-tmp.y * 0.5 + 0.5) * r.height };
+  }
+  function projectSquare(sq) {
+    if (!sq || !squares.has(sq)) return { x: 0, y: 0 };
+    return projectPoint(squareToWorld(sq, 0.45, tmp.clone()));
+  }
+
+  function dispose() {
+    window.removeEventListener('resize', resize);
+    renderer.dispose();
+  }
+
+  return {
+    renderer, scene, camera, boardGroup, pieceGroup, squares,
+    update, render, resize, dispose,
+    setSide, setHighlights, projectPoint, projectSquare,
+    setCameraSway(v) { sway = Math.max(0, Math.min(1, Number(v) || 0)); },
+  };
+}

--- a/ConditioningControlPanel/Resources/web/piecebypiece/boot.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/boot.js
@@ -1,0 +1,99 @@
+/* ============================================================================
+ * boot.js - entry point for Piece by Piece.
+ *
+ * Builds the 3D board, hands the effects layer its hooks, and runs the frame
+ * loop. window.PBP = { bus, game, board } is set before the first frame so the
+ * effects module can attach to a live board whatever order the imports settle.
+ * ==========================================================================*/
+
+import { createScene, FILES } from './board/scene.js';
+import { createPieces } from './board/pieces.js';
+import { createBus } from './game/events.js';
+
+const dom = {
+  canvas: document.getElementById('board-canvas'),
+  stage: document.getElementById('stage'),
+  fx: document.getElementById('fx'),
+  loader: document.getElementById('loader'),
+  nope: document.getElementById('nope'),
+  nopeMsg: document.getElementById('nope-msg'),
+};
+
+const START_FEN = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR';
+
+/** Placement field of a FEN to { e1: {type, side}, ... }. */
+export function positionFromFen(placement) {
+  const map = {};
+  const rows = String(placement).split(' ')[0].split('/');
+  for (let i = 0; i < rows.length && i < 8; i++) {
+    const rank = 8 - i;
+    let file = 0;
+    for (const ch of rows[i]) {
+      if (ch >= '1' && ch <= '8') { file += Number(ch); continue; }
+      if (file > 7) break;
+      map[FILES[file++] + rank] = { type: ch.toLowerCase(), side: ch === ch.toUpperCase() ? 'w' : 'b' };
+    }
+  }
+  return map;
+}
+
+function fail(message) {
+  dom.loader.hidden = true;
+  dom.nopeMsg.textContent = message;
+  dom.nope.hidden = false;
+}
+
+function main() {
+  const bus = createBus();
+  let view;
+  try {
+    view = createScene({ canvas: dom.canvas });
+  } catch (err) {
+    console.error('[pbp] the 3D board could not start', err);
+    fail('The 3D board could not start. Check that hardware acceleration is available.');
+    return;
+  }
+
+  const pieces = createPieces({ group: view.pieceGroup });
+  pieces.setPosition(positionFromFen(START_FEN));
+  view.setSide('w', true);
+  // The board API the effects layer drives. Keep this surface stable.
+  const board = {
+    view,
+    pieces,
+    setWobble(v) { pieces.setWobble(v); },
+    setCameraSway(v) { view.setCameraSway(v); },
+    projectSquare(sq) { return view.projectSquare(sq); },
+    setHighlights(list) { view.setHighlights(list); },
+    setSide(side, instant) { view.setSide(side, instant); },
+  };
+
+  window.PBP = { bus, game: null, board };
+
+  let last = performance.now();
+  function frame(now) {
+    const dt = Math.min(0.1, (now - last) / 1000);
+    last = now;
+    view.update(dt);
+    pieces.update(dt);
+    if (window.PBP.game && window.PBP.game.update) window.PBP.game.update(dt);
+    view.render();
+    requestAnimationFrame(frame);
+  }
+  requestAnimationFrame(frame);
+
+  dom.loader.classList.add('gone');
+  setTimeout(() => { dom.loader.hidden = true; }, 500);
+  bus.emit('local', { sides: ['w', 'b'] });
+  pieces.tryLoadGlb();          // optional art; missing files stay silent
+  attachEffects(bus, board);    // optional layer; the board plays fine without it
+}
+
+async function attachEffects(bus, board) {
+  try {
+    const m = await import('./ramp/index.js');
+    m.attachRamp({ bus, root: dom.fx, stage: dom.stage, board });
+  } catch (e) { console.warn('ramp missing', e); }
+}
+
+main();

--- a/ConditioningControlPanel/Resources/web/piecebypiece/game/events.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/game/events.js
@@ -1,0 +1,30 @@
+/* ============================================================================
+ * game/events.js - the one bus the board and the effects layer share.
+ *
+ * Deliberately tiny and synchronous. A listener that throws is logged and
+ * skipped so one bad handler can never stall a move or a frame.
+ * ==========================================================================*/
+
+export function createBus() {
+  const map = new Map(); // type -> Set<fn>
+
+  return {
+    on(type, fn) {
+      if (typeof fn !== 'function') return () => {};
+      if (!map.has(type)) map.set(type, new Set());
+      map.get(type).add(fn);
+      return () => this.off(type, fn);
+    },
+    off(type, fn) {
+      const set = map.get(type);
+      if (set) set.delete(fn);
+    },
+    emit(type, payload) {
+      const set = map.get(type);
+      if (!set || set.size === 0) return;
+      for (const fn of [...set]) {
+        try { fn(payload, type); } catch (err) { console.warn('[pbp] listener failed for ' + type, err); }
+      }
+    },
+  };
+}

--- a/ConditioningControlPanel/Resources/web/piecebypiece/index.html
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/index.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+<title>Piece by Piece</title>
+<link rel="stylesheet" href="./styles.css">
+<!--
+  Piece by Piece - a 3D chess board for the in-app browser games.
+  Standard chess rules, no house rules. three.js is resolved from the shared
+  vendored ESM build; the specifiers below are relative to this document so the
+  page works from any mount point (dev server root, or the app host).
+-->
+<script type="importmap">
+{
+  "imports": {
+    "three": "../vendor/three/three.module.min.js",
+    "three/addons/": "../vendor/three/addons/"
+  }
+}
+</script>
+</head>
+<body>
+  <!-- 3D layer. Agent-facing contract: #fx is an empty sibling ABOVE #stage and
+       is owned entirely by the effects module (ramp/index.js). -->
+  <div id="stage"><canvas id="board-canvas"></canvas></div>
+  <div id="fx"></div>
+
+  <div id="loader" class="loader">
+    <div class="loader-ring" aria-hidden="true"></div>
+    <p>Setting up the board...</p>
+  </div>
+
+  <div id="nope" class="nope" hidden>
+    <h1>piece by piece</h1>
+    <p id="nope-msg">The 3D board could not start. Check that hardware acceleration is available.</p>
+  </div>
+
+  <script type="module" src="./boot.js"></script>
+</body>
+</html>

--- a/ConditioningControlPanel/Resources/web/piecebypiece/styles.css
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/styles.css
@@ -1,0 +1,41 @@
+/* Piece by Piece - page chrome. The board itself is drawn in WebGL; everything
+   here is the frame around it. #fx is deliberately empty and untouched by the
+   board code: the effects layer owns it. */
+
+:root { --pbp-bg: #1A1A3E; --pbp-cream: #F5E6C8; --pbp-pink: #FF69B4; --pbp-ink: #E9E2F5; }
+
+* { box-sizing: border-box; }
+/* .loader/.nope are flex, which beats the user-agent rule for [hidden]. */
+[hidden] { display: none !important; }
+
+html, body {
+  margin: 0; padding: 0; height: 100%; overflow: hidden;
+  background: var(--pbp-bg); color: var(--pbp-ink);
+  font-family: 'Segoe UI', system-ui, -apple-system, sans-serif;
+  user-select: none; -webkit-user-select: none;
+}
+
+#stage { position: fixed; inset: 0; z-index: 1; }
+#stage canvas { display: block; width: 100%; height: 100%; touch-action: none; }
+
+/* Owned by the effects layer. Never written to by the board code. */
+#fx { position: fixed; inset: 0; z-index: 2; pointer-events: none; overflow: hidden; }
+
+.loader, .nope {
+  position: fixed; inset: 0; z-index: 3;
+  display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 18px;
+  background: var(--pbp-bg); text-align: center; transition: opacity 420ms ease;
+}
+.loader p { margin: 0; letter-spacing: 0.12em; text-transform: lowercase; opacity: 0.75; }
+.loader.gone { opacity: 0; pointer-events: none; }
+.loader-ring {
+  width: 46px; height: 46px; border-radius: 50%;
+  border: 3px solid rgba(245, 230, 200, 0.18); border-top-color: var(--pbp-pink);
+  animation: pbp-spin 900ms linear infinite;
+}
+@keyframes pbp-spin { to { transform: rotate(360deg); } }
+
+.nope h1 { margin: 0; font-size: 28px; letter-spacing: 0.16em; color: var(--pbp-pink); }
+.nope p { margin: 0; max-width: 30rem; line-height: 1.5; opacity: 0.8; }
+
+@media (prefers-reduced-motion: reduce) { .loader-ring { animation-duration: 2400ms; } }


### PR DESCRIPTION
Stacked on #953 (vendor). **Base: `feat/pbp-a1-vendor`.**

The board Piece by Piece is played on. Standard chess, unchanged: this PR is the table, not the rules.

## What lands
- **`index.html` / `styles.css`** - `#stage` holds the canvas, `#fx` is an empty sibling above it (pointer-events none) for the effects layer. three is resolved through an import map with relative specifiers, so the page works from a dev server root or from the app host without editing.
- **`board/scene.js`** - renderer, soft key light plus a pink rim, dark navy `#1A1A3E` backdrop, cream `#F5E6C8` and pink `#FF69B4` squares of exactly 1.0 unit, board centred on the origin. The camera sits behind the side to move and swings round with a small dolly on the turn change. Also owns the square/world maths, square highlights and `projectSquare`.
- **`board/pieces.js`** - placeholder men turned as `LatheGeometry` profiles in a glossy silicone material (`MeshPhysicalMaterial`, roughness 0.35, clearcoat 0.6). White side reads pink and cream, black side purple and navy. Pieces are built at height 1.0 and scaled per type, which is exactly the contract a supplied glb has to meet: `assets/pieces/{pawn,rook,knight,bishop,queen,king}.glb`, one mesh, +Y up, origin at the base centre, height 1.0. A glb that turns up is swapped in per type at runtime with no code change; a missing one quietly leaves the lathe standing.
- **`game/events.js`** - the small shared bus (`on` / `off` / `emit`). A listener that throws is logged and skipped so one bad handler cannot stall a frame.
- **`boot.js`** - builds the lot, exposes `window.PBP = { bus, game, board }` before the first frame, and optionally attaches `ramp/index.js` (the effects layer, owned separately). The page runs fine when that module is absent.

## Verified
Headless msedge, clean boot, no console errors. Screenshot: `C:/Users/PC/Pictures/Screenshots/piecebypiece/a/a2-board.png`.

Next in the stack: rules and clocks, then drag and animation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S4BKp6cQJFNixoQrarvSkd