### PR TITLE
feat(pbp): attachRamp, the layer seam and a board-free dev harness

### DIFF
--- a/ConditioningControlPanel/Resources/web/piecebypiece/dev/media.json
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/dev/media.json
@@ -1,0 +1,12 @@
+{
+  "note": "Dev fixtures for the ramp harness. These point at art already bundled with DtRH so the harness adds no binaries of its own. Empty the entries array to test the no-media path: no video card, gifs become pink noise tiles.",
+  "entries": [
+    { "kind": "image", "url": "/dtrh/assets/bubbles/effects/flash.png" },
+    { "kind": "image", "url": "/dtrh/assets/bubbles/effects/pinkfilter.png" },
+    { "kind": "image", "url": "/dtrh/assets/bubbles/effects/braindrain.png" },
+    { "kind": "image", "url": "/dtrh/assets/bubbles/effects/subliminal.png" },
+    { "kind": "gif", "url": "/dtrh/assets/bubbles/effects/spirals/sp6.gif" },
+    { "kind": "gif", "url": "/dtrh/assets/bubbles/effects/spirals/sp7.gif" },
+    { "kind": "video", "url": "/dtrh/assets/bubbles/spiral.webm" }
+  ]
+}

--- a/ConditioningControlPanel/Resources/web/piecebypiece/dev/ramp.html
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/dev/ramp.html
@@ -1,0 +1,206 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Piece by Piece - ramp harness</title>
+<!--
+  A board-free harness for the conditioning ramp. It fakes the bus the real
+  game exposes as window.PBP.bus, so every layer can be built, watched and
+  screenshotted without the 3D board existing.
+
+  URL params:  ?meter=0.6   pin the meter (overrides the fake game)
+               ?fire=flash  fire one layer once on load
+               ?quiet=1     hide the control panel (clean screenshots)
+-->
+<style>
+  :root { color-scheme: dark; }
+  body { margin: 0; background: #0b0714; color: #f3e8ff; font: 13px/1.45 system-ui, sans-serif; }
+  #wrap { position: relative; width: 100vw; height: 100vh; overflow: hidden; }
+  /* the placeholder board: a plain dark square with a chequer so blur and melt
+     have something legible to ruin */
+  #stage {
+    position: absolute; inset: 0;
+    background:
+      radial-gradient(circle at 50% 42%, #23193a 0%, #0b0714 72%),
+      repeating-conic-gradient(from 0deg at 50% 50%, #2b2145 0deg 90deg, #171029 90deg 180deg);
+    background-size: auto, 13vmin 13vmin;
+    display: grid; place-items: center;
+  }
+  #stage .plate {
+    width: 62vmin; height: 62vmin; border-radius: 10px;
+    background: repeating-conic-gradient(#efe3ff 0deg 90deg, #4b3a72 90deg 180deg) 0 0 / 15.5vmin 15.5vmin;
+    box-shadow: 0 24px 80px rgba(0,0,0,.65), 0 0 0 2px rgba(255,105,180,.35);
+  }
+  #stage .plate span {
+    display: block; text-align: center; padding-top: 26vmin;
+    font: 900 5vmin/1 system-ui, sans-serif; color: #120a20; letter-spacing: .04em;
+  }
+  #panel {
+    position: fixed; left: 10px; top: 10px; z-index: 40; width: 320px; max-height: 96vh; overflow: auto;
+    background: rgba(16,10,28,.92); border: 1px solid rgba(255,105,180,.35); border-radius: 10px; padding: 10px;
+  }
+  #panel.hidden { display: none; }
+  h1 { font-size: 13px; margin: 0 0 8px; color: #ff8ac4; letter-spacing: .04em; }
+  .row { display: flex; flex-wrap: wrap; gap: 4px; margin-bottom: 6px; }
+  button {
+    background: #2a1c40; color: #f3e8ff; border: 1px solid rgba(255,105,180,.4);
+    border-radius: 6px; padding: 4px 7px; font: inherit; cursor: pointer;
+  }
+  button:hover { background: #3b2758; }
+  label { display: block; margin: 6px 0 2px; color: #c8b3e8; }
+  input[type=range] { width: 100%; accent-color: #ff69b4; }
+  pre { margin: 6px 0 0; font: 11px/1.35 ui-monospace, Consolas, monospace; color: #b9a7d8; white-space: pre-wrap; }
+</style>
+</head>
+<body>
+<div id="wrap">
+  <div id="stage"><div class="plate"><span>BOARD</span></div></div>
+  <div id="fx" class="pbp-fx"></div>
+</div>
+
+<div id="panel">
+  <h1>ramp harness</h1>
+  <div class="row">
+    <button data-ev="turn-w">turn w</button>
+    <button data-ev="turn-b">turn b</button>
+    <button data-ev="check">check</button>
+    <button data-ev="gameover">gameover</button>
+  </div>
+  <div class="row">
+    <button data-ev="cap-w">capture by w</button>
+    <button data-ev="cap-b">capture by b</button>
+  </div>
+  <div class="row">
+    <button data-ev="grab">grab</button>
+    <button data-ev="dragmove">dragmove</button>
+    <button data-ev="drop">drop</button>
+  </div>
+  <div class="row">
+    <button data-ev="reset">reset</button>
+    <button data-ev="toggle">enable/disable</button>
+  </div>
+  <label>clock scrub <span id="clockLbl">100%</span></label>
+  <input id="clock" type="range" min="0" max="100" value="100">
+  <label>meter override <span id="meterLbl">off</span></label>
+  <input id="meter" type="range" min="-1" max="100" value="-1">
+  <pre id="out">booting...</pre>
+</div>
+<!-- headless runs read this: the page has no devtools, so errors are put in the
+     DOM where a --dump-dom pass can grep them. Empty text means a clean run. -->
+<div id="errors" data-count="0" style="display:none"></div>
+
+<script>
+/* the error sink has to be a classic script so it is installed BEFORE the
+   module below is fetched: a module that fails to import still lands here */
+(function () {
+  const sink = () => document.getElementById('errors');
+  window.__pbpErrors = [];
+  function record(kind, text) {
+    window.__pbpErrors.push(kind + ': ' + text);
+    const el = sink();
+    if (el) { el.textContent = window.__pbpErrors.join('\n'); el.dataset.count = String(window.__pbpErrors.length); }
+  }
+  window.addEventListener('error', (e) => record('error', (e && e.message) || String(e)));
+  window.addEventListener('unhandledrejection', (e) => record('rejection', String((e && e.reason) || e)));
+  const realError = console.error.bind(console);
+  console.error = (...a) => { record('console.error', a.map(String).join(' ')); realError(...a); };
+}());
+</script>
+
+<script type="module">
+import { attachRamp } from '../ramp/index.js';
+import { createFixtureMedia, loadFixtureList } from '../ramp/media.js';
+
+const qs = new URLSearchParams(location.search);
+if (qs.get('quiet') === '1') document.getElementById('panel').classList.add('hidden');
+
+/* ---- the fake bus: the same three-method surface the real game exposes ---- */
+function createBus() {
+  const map = new Map();
+  return {
+    on(type, fn) { if (!map.has(type)) map.set(type, new Set()); map.get(type).add(fn); },
+    off(type, fn) { const s = map.get(type); if (s) s.delete(fn); },
+    emit(type, payload) { const s = map.get(type); if (s) for (const fn of [...s]) fn(payload); },
+  };
+}
+
+/* ---- a fake game: just enough state to make the events coherent ---------- */
+const TOTAL = 300000;   // 5 minutes a side
+const game = { ply: 0, side: 'w', clocks: { w: TOTAL, b: TOTAL } };
+const bus = createBus();
+window.PBP = { bus, game, board: null };
+
+const list = await loadFixtureList(new URL('./media.json', import.meta.url).href);
+const media = createFixtureMedia(list);
+const ramp = attachRamp({ bus, root: document.getElementById('fx'), stage: document.getElementById('stage'), media });
+window.PBP.ramp = ramp;
+
+bus.emit('local', { sides: ['w', 'b'] });
+const emitClock = () => bus.emit('clock', { ...game.clocks, total: TOTAL, active: game.side });
+const emitTurn = (side) => {
+  game.side = side; game.ply += 1;
+  bus.emit('turn', { side, ply: game.ply, clocks: { ...game.clocks }, total: TOTAL });
+  emitClock();
+};
+emitTurn('w');
+setInterval(emitClock, 250);
+
+const PIECES = ['p', 'n', 'b', 'r', 'q'];
+const pick = (a) => a[(Math.random() * a.length) | 0];
+const square = () => 'abcdefgh'[(Math.random() * 8) | 0] + (1 + ((Math.random() * 8) | 0));
+
+const actions = {
+  'turn-w': () => emitTurn('w'),
+  'turn-b': () => emitTurn('b'),
+  'check': () => bus.emit('check', { side: game.side }),
+  'gameover': () => bus.emit('gameover', { result: '1-0', winner: 'w' }),
+  'cap-w': () => bus.emit('capture', { by: 'w', piece: pick(PIECES), square: square(), victimSide: 'b' }),
+  'cap-b': () => bus.emit('capture', { by: 'b', piece: pick(PIECES), square: square(), victimSide: 'w' }),
+  'grab': () => bus.emit('grab', { square: square(), piece: pick(PIECES), screen: { x: innerWidth * 0.5, y: innerHeight * 0.55 } }),
+  'dragmove': () => bus.emit('dragmove', { screen: { x: innerWidth * (0.3 + Math.random() * 0.4), y: innerHeight * (0.3 + Math.random() * 0.4) } }),
+  'drop': () => bus.emit('drop', { ok: true }),
+  'reset': () => { game.ply = 0; game.clocks = { w: TOTAL, b: TOTAL }; location.reload(); },
+  'toggle': () => ramp.setEnabled(!ramp.debug().enabled),
+};
+for (const btn of document.querySelectorAll('#panel button')) {
+  btn.addEventListener('click', () => { const fn = actions[btn.dataset.ev]; if (fn) fn(); });
+}
+
+const clockEl = document.getElementById('clock');
+clockEl.addEventListener('input', () => {
+  const frac = clockEl.value / 100;
+  document.getElementById('clockLbl').textContent = Math.round(frac * 100) + '%';
+  game.clocks.w = game.clocks.b = Math.round(TOTAL * frac);
+  emitClock();
+});
+
+const meterEl = document.getElementById('meter');
+function applyMeter() {
+  const v = Number(meterEl.value);
+  const on = v >= 0;
+  document.getElementById('meterLbl').textContent = on ? (v / 100).toFixed(2) : 'off';
+  ramp.debug().setMeter(on ? v / 100 : null);
+}
+meterEl.addEventListener('input', applyMeter);
+
+/* ?meter= and ?fire= drive the screenshot pass */
+if (qs.has('meter')) { meterEl.value = Math.round(Number(qs.get('meter')) * 100); applyMeter(); }
+if (qs.has('fire')) ramp.debug().fire(qs.get('fire'));
+
+const out = document.getElementById('out');
+setInterval(() => {
+  const d = ramp.debug();
+  const m = d.model.sides;
+  out.textContent = [
+    'side ' + d.side + '  ply ' + d.model.ply + '  enabled ' + d.enabled + '  ticks ' + d.ticks,
+    'meter ' + d.meter.toFixed(3) + '  heat ' + d.heat.toFixed(3),
+    'w  meter ' + m.w.meter.toFixed(2) + ' took ' + m.w.captures + ' lost ' + m.w.losses,
+    'b  meter ' + m.b.meter.toFixed(2) + ' took ' + m.b.captures + ' lost ' + m.b.losses,
+    'media ' + JSON.stringify(d.media),
+    'layers ' + JSON.stringify(d.layers && d.layers.counts),
+  ].join('\n');
+}, 200);
+</script>
+</body>
+</html>

--- a/ConditioningControlPanel/Resources/web/piecebypiece/ramp/index.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/ramp/index.js
@@ -1,0 +1,237 @@
+/* ============================================================================
+ * ramp/index.js - the conditioning ramp for Piece by Piece.
+ *
+ * The chess rules never change. What changes is the player: as a side's clock
+ * drains and as pieces come off the board, that side's screen gets busier,
+ * softer and harder to read. Taking a piece ramps you MORE than losing one, so
+ * the player who is ahead on material is also the one squinting.
+ *
+ * attachRamp({ bus, root, stage, media }) -> { dispose, setEnabled, debug }
+ *
+ * CONTRACT (the board owns these, this module only listens):
+ *   turn     {side,ply,clocks:{w,b},total}   capture {by,piece,square,victimSide}
+ *   check    {side}                          grab    {square,piece,screen:{x,y}}
+ *   dragmove {screen:{x,y}}                  drop    {ok}
+ *   gameover {result,winner}                 clock   {w,b,total,active}  every 250ms
+ *   local    {sides:[...]}                   once at boot
+ *
+ * NOTHING here may throw at import or at attach time. A missing bus, a missing
+ * #fx, a missing #stage, a missing media pool and a missing board API all
+ * degrade to a console.warn and a quieter ramp.
+ * ==========================================================================*/
+
+import { createMeter, RAMP_TUNING, clamp01 } from './meter.js';
+import { createSchedule, videoHoldMs } from './schedule.js';
+import { createLayerStack } from './layers/index.js';
+import { createFixtureMedia } from './media.js';
+
+const TICK_MS = 90;            // scheduling cadence; layers animate on their own
+const BOARD_PUSH_MS = 200;     // how often we hand the meter to A's board
+const CSS_ID = 'pbp-ramp-css';
+
+const warn = (msg) => { try { console.warn('[pbp/ramp] ' + msg); } catch { /* no console */ } };
+const otherSide = (s) => (s === 'w' ? 'b' : 'w');
+
+/** Inject ramp.css once, resolved next to this module (works from any page). */
+function ensureCss() {
+  try {
+    if (typeof document === 'undefined' || document.getElementById(CSS_ID)) return;
+    const link = document.createElement('link');
+    link.id = CSS_ID;
+    link.rel = 'stylesheet';
+    link.href = new URL('./ramp.css', import.meta.url).href;
+    (document.head || document.documentElement).appendChild(link);
+  } catch { warn('could not inject ramp.css'); }
+}
+
+/** A root to hang layers on. Falls back to a self-made one rather than dying. */
+function resolveRoot(root) {
+  if (root && root.appendChild) return root;
+  try {
+    if (typeof document === 'undefined') return null;
+    warn('no #fx root supplied; creating a fallback layer host');
+    const el = document.createElement('div');
+    el.className = 'pbp-fx pbp-fx-fallback';
+    document.body.appendChild(el);
+    return el;
+  } catch { return null; }
+}
+
+export function attachRamp(opts = {}) {
+  const bus = opts.bus && typeof opts.bus.on === 'function' ? opts.bus : null;
+  if (!bus) warn('no bus supplied; the ramp will sit idle');
+
+  ensureCss();
+  const root = resolveRoot(opts.root);
+  const stage = opts.stage && opts.stage.style ? opts.stage : null;
+  if (!stage) warn('no #stage supplied; CSS filter layers (melt tint, blur) are off');
+
+  const tuning = opts.tuning || RAMP_TUNING;
+  const media = opts.media || createFixtureMedia([]);
+  const meter = createMeter({ tuning });
+  const schedule = createSchedule({ tuning, seed: opts.seed || 'pbp-ramp' });
+
+  // The front plane carries the video card: in front of the POV, still
+  // click-through, so the player can hover the board they cannot see.
+  let front = null;
+  if (root) {
+    try {
+      front = document.createElement('div');
+      front.className = 'pbp-fx-front';
+      (root.parentNode || root).appendChild(front);
+    } catch { front = null; }
+  }
+
+  const stack = createLayerStack({ root, front, stage, media, tuning, rng: schedule.rng });
+
+  let enabled = true;
+  let disposed = false;
+  let rafId = 0;
+  let lastTick = 0;
+  let lastBoardPush = 0;
+  let ticks = 0;   // scheduling beats served, so a harness can prove the loop runs
+  let overrideMeter = null;   // dev harness: pin the meter regardless of the game
+  const applied = { melt: -1, blur: -1, spiral: -1, overlay: -1 };
+
+  const now = () => (typeof performance !== 'undefined' && performance.now ? performance.now() : Date.now());
+
+  /** The side the ramp is acting on: whoever is on the move. */
+  const actingSide = () => meter.active;
+  const liveMeter = () => (overrideMeter == null ? meter.meterFor(actingSide()) : clamp01(overrideMeter));
+  const liveHeat = (t) => (overrideMeter == null ? meter.heatFor(actingSide(), t) : clamp01(overrideMeter));
+
+  /** Hand the meter to A's board if it grew those knobs. Always guarded. */
+  function pushToBoard(m) {
+    try {
+      const board = (typeof window !== 'undefined' && window.PBP && window.PBP.board) || null;
+      if (!board) return;
+      if (typeof board.setWobble === 'function') board.setWobble(clamp01(m * tuning.wobbleScale));
+      if (typeof board.setCameraSway === 'function') board.setCameraSway(clamp01(m * tuning.swayScale));
+    } catch { /* A's board is optional and may change under us */ }
+  }
+
+  function applySustained(sus) {
+    for (const name of ['melt', 'blur', 'spiral', 'overlay']) {
+      const spec = sus[name];
+      const key = spec.on ? (spec.alpha != null ? spec.alpha : spec.px) : -1;
+      // retune only on a real change, so we are not writing style every 90ms
+      if (Math.abs(key - applied[name]) < 0.005) continue;
+      applied[name] = key;
+      stack.setSustained(name, spec);
+    }
+  }
+
+  function tick() {
+    rafId = 0;
+    if (disposed) return;
+    schedulePump();
+    if (!enabled) return;
+    const t = now();
+    if (t - lastTick >= TICK_MS) {
+      lastTick = t;
+      ticks += 1;
+      const m = liveMeter();
+      const out = schedule.tick(t, liveHeat(t), m);
+      for (const kind of out.fire) stack.oneshot(kind, { heat: out.heat });
+      applySustained(out.sustained);
+      if (t - lastBoardPush >= BOARD_PUSH_MS) { lastBoardPush = t; pushToBoard(m); }
+    }
+  }
+
+  function schedulePump() {
+    if (disposed || rafId) return;
+    try {
+      rafId = requestAnimationFrame(tick);
+    } catch {
+      rafId = setTimeout(tick, TICK_MS);   // no rAF (a test shim): still tick
+    }
+  }
+
+  /* ---- bus wiring --------------------------------------------------------- */
+  const handlers = {
+    local() { /* both sides are on this screen: nothing to gate, kept for parity */ },
+    clock(p) { meter.setClock(p); },
+    turn(p) {
+      meter.setTurn(p);
+      // The card belongs to the side that just MOVED and is now waiting: it
+      // rides over the board while the opponent thinks. In hotseat both sides
+      // are local, so this is simply every turn.
+      const waiting = otherSide(p && p.side === 'b' ? 'b' : 'w');
+      const holdMs = videoHoldMs(overrideMeter == null ? meter.meterFor(waiting) : clamp01(overrideMeter), tuning);
+      stack.videoCard({ holdMs, side: waiting });
+    },
+    capture(p) {
+      const t = now();
+      meter.noteCapture(p, t);
+      const taker = p && p.by === 'b' ? 'b' : 'w';
+      // both sides feel it; the one who took the piece feels it harder
+      stack.burst(schedule.burstFor('taker', meter.heatFor(taker, t)));
+      stack.burst(schedule.burstFor('victim', meter.heatFor(otherSide(taker), t)));
+    },
+    check() { stack.oneshot('flash', { heat: liveHeat(now()) }); },
+    grab(p) { stack.grab(p); },
+    dragmove(p) { stack.dragmove(p); },
+    drop(p) { stack.drop(p); },
+    gameover() {
+      meter.over = true;
+      setEnabled(false);
+    },
+  };
+  const bound = [];
+  if (bus) {
+    for (const [type, fn] of Object.entries(handlers)) {
+      const safe = (payload) => { try { fn(payload); } catch (e) { warn(type + ' handler: ' + (e && e.message)); } };
+      try { bus.on(type, safe); bound.push([type, safe]); } catch { warn('could not subscribe to ' + type); }
+    }
+  }
+
+  function setEnabled(on) {
+    enabled = !!on;
+    if (!enabled) {
+      stack.clear();
+      for (const k of Object.keys(applied)) applied[k] = -1;
+      pushToBoard(0);
+    } else { schedulePump(); }
+    return enabled;
+  }
+
+  function dispose() {
+    if (disposed) return;
+    disposed = true;
+    if (rafId) { try { cancelAnimationFrame(rafId); } catch { clearTimeout(rafId); } rafId = 0; }
+    if (bus) for (const [type, fn] of bound) { try { bus.off(type, fn); } catch { /* gone already */ } }
+    bound.length = 0;
+    try { stack.dispose(); } catch { /* best effort */ }
+    if (front && front.remove) front.remove();
+    pushToBoard(0);
+  }
+
+  function debug() {
+    const t = now();
+    return {
+      enabled,
+      ticks,
+      side: actingSide(),
+      meter: liveMeter(),
+      heat: liveHeat(t),
+      override: overrideMeter,
+      model: meter.snapshot(t),
+      layers: stack.debug ? stack.debug() : null,
+      media: media.stats ? media.stats() : null,
+      tuning,
+      /** Dev harness only: pin the meter (null gives the game back control). */
+      setMeter(v) { overrideMeter = v == null ? null : clamp01(v); return overrideMeter; },
+      /** Dev harness only: fire one layer by name right now. */
+      fire(kind, o) {
+        if (kind === 'videoCard') stack.videoCard(o || { holdMs: videoHoldMs(liveMeter(), tuning) });
+        else stack.oneshot(kind, o || { heat: liveHeat(now()) });
+      },
+      stack,
+    };
+  }
+
+  schedulePump();
+  return { dispose, setEnabled, debug };
+}
+
+export default attachRamp;

--- a/ConditioningControlPanel/Resources/web/piecebypiece/ramp/layers/index.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/ramp/layers/index.js
@@ -1,0 +1,59 @@
+/* ============================================================================
+ * ramp/layers/index.js - the layer stack the ramp drives.
+ *
+ * This file is the SEAM. `attachRamp` never talks to a layer directly: it hands
+ * this stack a heat number and a list of kinds to fire, and the stack owns the
+ * DOM. That keeps the meter/schedule math (which is node-testable) apart from
+ * the pixels (which are not).
+ *
+ * Right now every method is a counted no-op, so the ramp is fully wired and
+ * fully testable before a single pixel exists. The real layers (flash, gif
+ * rain, melt, blur, spiral, overlay, video card, glitch grab) land on top of
+ * this surface without the ramp changing.
+ * ==========================================================================*/
+
+/**
+ * createLayerStack(ctx) - ctx is { root, front, stage, media, tuning, rng }.
+ * Every method must be safe to call with a missing root, stage or media.
+ */
+export function createLayerStack(ctx = {}) {
+  const counts = { flash: 0, gifRain: 0, burst: 0, videoCard: 0, grab: 0, drop: 0 };
+  const sustained = { melt: null, blur: null, spiral: null, overlay: null };
+  let disposed = false;
+
+  return {
+    /** Fire one transient effect of `kind` at this heat. */
+    oneshot(kind) {
+      if (disposed) return;
+      if (counts[kind] == null) counts[kind] = 0;
+      counts[kind] += 1;
+    },
+    /** A capture kick: several one-shots at once, weighted by the burst spec. */
+    burst(spec) {
+      if (disposed || !spec) return;
+      counts.burst += 1;
+      for (let i = 0; i < (spec.flashes || 0); i++) this.oneshot('flash');
+      for (let i = 0; i < (spec.gifs || 0); i++) this.oneshot('gifRain');
+    },
+    /** Turn a sustained layer on/off and retune it. `spec` comes from schedule. */
+    setSustained(name, spec) {
+      if (disposed || !(name in sustained)) return;
+      sustained[name] = spec || null;
+    },
+    /** The video card: rises at the POV, holds, slides out the bottom. */
+    videoCard() { if (!disposed) counts.videoCard += 1; },
+    /** Drag handling: a glitch tile pinned to the piece under the cursor. */
+    grab() { if (!disposed) counts.grab += 1; },
+    dragmove() { /* per-frame; the real stack moves the tile here */ },
+    drop() { if (!disposed) counts.drop += 1; },
+    /** Snap everything off without a fade (suspend / dispose). */
+    clear() {
+      for (const k of Object.keys(sustained)) sustained[k] = null;
+    },
+    dispose() { disposed = true; this.clear(); },
+    /** Read-only view for the harness and the smoke tests. */
+    debug() { return { counts: { ...counts }, sustained: { ...sustained }, hasMedia: !!(ctx.media && ctx.media.size) }; },
+  };
+}
+
+export default createLayerStack;

--- a/ConditioningControlPanel/Resources/web/piecebypiece/ramp/ramp.css
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/ramp/ramp.css
@@ -1,0 +1,36 @@
+/* ============================================================================
+ * ramp/ramp.css - the ramp's two planes.
+ *
+ * BACK plane (.pbp-fx, the page's #fx): washes, flashes, falling gifs, the
+ * spiral veil. It sits over the board but under the HUD.
+ * FRONT plane (.pbp-fx-front): the video card only, so a tape can ride in front
+ * of the POV while everything else stays behind it.
+ *
+ * Both planes and everything in them are click-through. The player must always
+ * be able to reach a piece, even under a card they cannot see past - that is
+ * the whole point of the card. Layer styles land on top of this file.
+ * ==========================================================================*/
+
+.pbp-fx {
+  position: absolute; inset: 0; z-index: 4; overflow: hidden;
+  pointer-events: none !important;
+}
+.pbp-fx * { pointer-events: none !important; }
+
+/* a #fx the page never supplied: pin it to the viewport instead of a stage */
+.pbp-fx-fallback { position: fixed; }
+
+.pbp-fx-front {
+  position: fixed; inset: 0; z-index: 9; overflow: hidden;
+  pointer-events: none !important;
+}
+.pbp-fx-front * { pointer-events: none !important; }
+
+/* The stage carries the CSS filters (melt tint, blur). Transitioning the filter
+ * rather than snapping it keeps a retune from strobing; will-change keeps the
+ * board on its own layer so a filter change never repaints the whole page. */
+.pbp-stage-fx { transition: filter 420ms ease; will-change: filter; }
+
+@media (prefers-reduced-motion: reduce) {
+  .pbp-fx *, .pbp-fx-front * { animation-duration: 0.001ms !important; animation-iteration-count: 1 !important; }
+}


### PR DESCRIPTION
Part 2 of the ramp stack (on top of #954). This is the thing the board actually calls.

**`ramp/index.js`** - `attachRamp({bus, root, stage, media})` returning `{dispose, setEnabled, debug}`. Listens to the whole contract (`turn`, `capture`, `check`, `grab`, `dragmove`, `drop`, `clock`, `gameover`, `local`), drives the meter and pumps the schedule on rAF.

Nothing here may throw at import or attach time, so every dependency degrades instead of failing: a missing bus, a missing `#fx`, a missing `#stage`, an empty media pool and an absent board API each fall back to a `console.warn` and a quieter ramp. `window.PBP.board.setWobble` / `setCameraSway` are fed the meter behind `typeof` guards, since those belong to the board and may not exist yet.

The video card fires on **every** `turn`, for the side that just moved and is now waiting - in hotseat both sides are local, so that is simply every turn - with its hold scaled by that side's meter.

**`ramp/layers/index.js`** is the seam. `attachRamp` never touches DOM itself; it hands this stack a heat number and a list of kinds to fire. Every method is a counted no-op for now, so the ramp is wired and observable before a single pixel exists, and the layers land on top without the ramp changing.

**`ramp/ramp.css`** declares the two planes, both click-through: a back plane over the board for washes and bursts, and a front plane for the video card, so a tape can ride in front of the POV while the player still reaches the piece underneath.

**`dev/ramp.html`** is the harness: a fake bus, a placeholder board, a button for every contract event, a clock scrub slider and a meter override (`?meter=`, `?fire=`, `?quiet=1`). It installs a DOM error sink too, because the WebView2 host has no devtools and a headless `--dump-dom` pass is how a clean run gets proven. `dev/media.json` points at art DtRH already bundles, so the fixtures add no binaries to the repo.

Headless msedge at `?meter=0.95`: zero errors, media pool of 7, video card fires on the boot turn, one-shots spawning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S4BKp6cQJFNixoQrarvSkd