### PR TITLE
feat(pbp): chess rules, clocks and hotseat play

### DIFF
--- a/ConditioningControlPanel/Resources/web/piecebypiece/boot.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/boot.js
@@ -6,36 +6,21 @@
  * effects module can attach to a live board whatever order the imports settle.
  * ==========================================================================*/
 
-import { createScene, FILES } from './board/scene.js';
+import { createScene } from './board/scene.js';
 import { createPieces } from './board/pieces.js';
 import { createBus } from './game/events.js';
+import { createHotseat } from './game/hotseat.js';
+import { DEFAULT_MS } from './game/clock.js';
 
 const dom = {
   canvas: document.getElementById('board-canvas'),
+  hud: { w: document.getElementById('time-w'), b: document.getElementById('time-b'), status: document.getElementById('status') },
   stage: document.getElementById('stage'),
   fx: document.getElementById('fx'),
   loader: document.getElementById('loader'),
   nope: document.getElementById('nope'),
   nopeMsg: document.getElementById('nope-msg'),
 };
-
-const START_FEN = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR';
-
-/** Placement field of a FEN to { e1: {type, side}, ... }. */
-export function positionFromFen(placement) {
-  const map = {};
-  const rows = String(placement).split(' ')[0].split('/');
-  for (let i = 0; i < rows.length && i < 8; i++) {
-    const rank = 8 - i;
-    let file = 0;
-    for (const ch of rows[i]) {
-      if (ch >= '1' && ch <= '8') { file += Number(ch); continue; }
-      if (file > 7) break;
-      map[FILES[file++] + rank] = { type: ch.toLowerCase(), side: ch === ch.toUpperCase() ? 'w' : 'b' };
-    }
-  }
-  return map;
-}
 
 function fail(message) {
   dom.loader.hidden = true;
@@ -55,8 +40,6 @@ function main() {
   }
 
   const pieces = createPieces({ group: view.pieceGroup });
-  pieces.setPosition(positionFromFen(START_FEN));
-  view.setSide('w', true);
   // The board API the effects layer drives. Keep this surface stable.
   const board = {
     view,
@@ -68,7 +51,17 @@ function main() {
     setSide(side, instant) { view.setSide(side, instant); },
   };
 
-  window.PBP = { bus, game: null, board };
+  const params = new URLSearchParams(location.search);
+  const game = createHotseat({
+    bus,
+    board,
+    hud: dom.hud,
+    clockMs: Number(params.get('clock')) > 0 ? Number(params.get('clock')) * 1000 : DEFAULT_MS,
+    fen: params.get('fen') || undefined,
+    auto: Number(params.get('auto')) || 0,
+  });
+
+  window.PBP = { bus, game, board };
 
   let last = performance.now();
   function frame(now) {
@@ -84,9 +77,13 @@ function main() {
 
   dom.loader.classList.add('gone');
   setTimeout(() => { dom.loader.hidden = true; }, 500);
-  bus.emit('local', { sides: ['w', 'b'] });
   pieces.tryLoadGlb();          // optional art; missing files stay silent
-  attachEffects(bus, board);    // optional layer; the board plays fine without it
+  // Give the optional effects layer a chance to subscribe before the first
+  // turn is dealt; it is optional, so a missing module must not hold the game.
+  attachEffects(bus, board).then(() => {
+    bus.emit('local', { sides: ['w', 'b'] });
+    game.start();
+  });
 }
 
 async function attachEffects(bus, board) {

--- a/ConditioningControlPanel/Resources/web/piecebypiece/game/clock.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/game/clock.js
@@ -1,0 +1,85 @@
+/* ============================================================================
+ * game/clock.js - two clocks, 15 minutes a side, no increment.
+ *
+ * Ticks four times a second. Running out is a loss, exactly as over the board.
+ * The clock measures real elapsed time rather than counting ticks, so a stalled
+ * tab or a slow frame cannot hand anyone free seconds.
+ * ==========================================================================*/
+
+export const DEFAULT_MS = 15 * 60 * 1000;
+export const TICK_MS = 250;
+
+/** "9:07" style, or "0:09.4" under ten seconds. */
+export function formatClock(ms) {
+  const left = Math.max(0, ms);
+  const total = Math.floor(left / 1000);
+  const min = Math.floor(total / 60);
+  const sec = total % 60;
+  if (left < 10000) return `${min}:${String(sec).padStart(2, '0')}.${Math.floor((left % 1000) / 100)}`;
+  return `${min}:${String(sec).padStart(2, '0')}`;
+}
+
+export function createClock({ perSideMs = DEFAULT_MS, onTick, onFlag, now = () => Date.now() } = {}) {
+  const left = { w: perSideMs, b: perSideMs };
+  let active = null;
+  let since = 0;
+  let timer = null;
+  let flagged = null;
+
+  function drain() {
+    if (!active) return;
+    const t = now();
+    left[active] = Math.max(0, left[active] - (t - since));
+    since = t;
+    if (left[active] === 0 && !flagged) {
+      flagged = active;
+      const side = active;
+      stop();
+      if (onFlag) onFlag(side);
+    }
+  }
+
+  function snapshot() {
+    return { w: left.w, b: left.b, total: perSideMs, active };
+  }
+
+  function tick() {
+    drain();
+    if (onTick) onTick(snapshot());
+  }
+
+  function start(side) {
+    if (flagged) return;
+    drain();
+    active = side;
+    since = now();
+    if (!timer) { timer = setInterval(tick, TICK_MS); timer.unref?.(); } // unref: node tests never hang on a clock
+  }
+
+  function stop() {
+    drain();
+    active = null;
+    if (timer) { clearInterval(timer); timer = null; }
+  }
+
+  return {
+    start,
+    stop,
+    /** Hand the move over: charge the mover, run the other side's clock. */
+    press(next) { start(next); },
+    snapshot,
+    remaining(side) { drain(); return left[side]; },
+    flagged: () => flagged,
+    isRunning: () => active !== null,
+    /** Only for tests: charge a side without waiting in real time. */
+    debit(side, ms) {
+      drain();
+      left[side] = Math.max(0, left[side] - ms);
+      if (left[side] === 0 && !flagged) { flagged = side; const s = side; stop(); if (onFlag) onFlag(s); }
+    },
+    reset() {
+      stop();
+      left.w = perSideMs; left.b = perSideMs; flagged = null;
+    },
+  };
+}

--- a/ConditioningControlPanel/Resources/web/piecebypiece/game/hotseat.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/game/hotseat.js
@@ -1,0 +1,137 @@
+/* ============================================================================
+ * game/hotseat.js - two players, one screen, one board.
+ *
+ * Owns the whole match: the referee (rules.js), the two clocks (clock.js), the
+ * men on the board and every event the effects layer listens to. The camera
+ * swings to whoever is to move, so the player in the seat always looks down the
+ * board from their own side.
+ * ==========================================================================*/
+
+import { createRules } from './rules.js';
+import { createClock, DEFAULT_MS, formatClock } from './clock.js';
+
+export function createHotseat({ bus, board, hud = null, clockMs = DEFAULT_MS, fen, auto = 0, autoDelay = 0.45 }) {
+  const rules = createRules(fen);
+  const pieces = board.pieces;
+  let over = null;
+  let autoLeft = Math.max(0, Number(auto) || 0);
+  let autoWait = 0.6;
+
+  const clock = createClock({
+    perSideMs: clockMs,
+    onTick: (snap) => { bus.emit('clock', snap); paint(); },
+    onFlag: (side) => finish({ result: 'flag', winner: side === 'w' ? 'b' : 'w', reason: 'flag' }),
+  });
+
+  function clocks() {
+    const s = clock.snapshot();
+    return { w: s.w, b: s.b, total: s.total };
+  }
+
+  function paint() {
+    if (!hud) return;
+    const s = clock.snapshot();
+    hud.w.textContent = formatClock(s.w);
+    hud.b.textContent = formatClock(s.b);
+    hud.w.classList.toggle('on', s.active === 'w' && !over);
+    hud.b.classList.toggle('on', s.active === 'b' && !over);
+    if (over) hud.status.textContent = statusLine(over);
+    else hud.status.textContent = rules.inCheck() ? 'check' : (rules.turn() === 'w' ? 'white to move' : 'black to move');
+  }
+
+  function statusLine(end) {
+    const who = end.winner === 'w' ? 'white' : 'black';
+    if (end.result === 'checkmate') return 'checkmate, ' + who + ' wins';
+    if (end.result === 'flag') return 'time, ' + who + ' wins';
+    if (end.result === 'resign') return who + ' wins by resignation';
+    if (end.result === 'stalemate') return 'stalemate, a draw';
+    return 'a draw by ' + (end.reason || 'agreement');
+  }
+
+  function finish(end) {
+    if (over) return;
+    over = end;
+    autoLeft = 0;
+    clock.stop();
+    paint();
+    bus.emit('gameover', { result: end.result, winner: end.winner ?? null });
+  }
+
+  /** Whose men the player in the seat may pick up right now. */
+  function canPick(square) {
+    if (over || !square) return false;
+    const man = rules.pieceAt(square);
+    return !!man && man.color === rules.turn();
+  }
+
+  function legalTargets(square) {
+    return canPick(square) ? rules.targets(square) : [];
+  }
+
+  function tryMove(from, to, promotion = 'q') {
+    if (over) return null;
+    const played = rules.move(from, to, promotion);
+    if (!played) return null;
+
+    // The men follow the referee.
+    if (played.capturedSquare && played.capturedSquare !== to) pieces.remove(played.capturedSquare);
+    pieces.move(from, to);
+    const hop = rules.rookHop(played);
+    if (hop) pieces.move(hop.from, hop.to);
+    if (played.promotion) pieces.setPosition(rules.position());
+
+    if (played.captured) {
+      bus.emit('capture', {
+        by: played.side,
+        piece: played.captured,          // the man that came off
+        square: played.capturedSquare,
+        victimSide: played.capturedSide,
+      });
+    }
+    if (played.check) bus.emit('check', { side: played.turn });
+
+    const end = rules.result();
+    if (end) {
+      finish(end);
+    } else {
+      clock.press(played.turn);
+      board.setSide(played.turn);
+      bus.emit('turn', { side: played.turn, ply: rules.ply(), clocks: clocks(), total: clockMs });
+    }
+    paint();
+    return played;
+  }
+
+  function resign(side) {
+    finish({ result: 'resign', winner: side === 'w' ? 'b' : 'w', reason: 'resignation' });
+  }
+
+  /** Demo and smoke helper: play n random legal moves, then sit still. */
+  function update(dt) {
+    if (autoLeft <= 0 || over) return;
+    autoWait -= dt;
+    if (autoWait > 0) return;
+    autoWait = autoDelay;
+    const all = rules.chess.moves({ verbose: true });
+    if (all.length === 0) { autoLeft = 0; return; }
+    const pick = all[Math.floor(Math.random() * all.length)];
+    autoLeft--;
+    tryMove(pick.from, pick.to, 'q');
+  }
+
+  function start() {
+    pieces.setPosition(rules.position());
+    board.setSide(rules.turn(), true);
+    clock.start(rules.turn());
+    paint();
+    bus.emit('turn', { side: rules.turn(), ply: rules.ply(), clocks: clocks(), total: clockMs });
+  }
+
+  return {
+    rules, clock, start, update, tryMove, canPick, legalTargets, resign,
+    turn: () => rules.turn(),
+    isOver: () => !!over,
+    result: () => over,
+    autoRemaining: () => autoLeft,
+  };
+}

--- a/ConditioningControlPanel/Resources/web/piecebypiece/game/rules.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/game/rules.js
@@ -1,0 +1,115 @@
+/* ============================================================================
+ * game/rules.js - the referee.
+ *
+ * A thin wrapper over chess.js. Standard chess, no house rules: everything the
+ * board and the effects layer know about legality comes from here, so there is
+ * exactly one place that decides what a position allows.
+ * ==========================================================================*/
+
+import { Chess } from '../vendor/chess.js';
+
+/** Result of a finished game, or null while it is still on. */
+export function readResult(chess) {
+  if (chess.isCheckmate()) return { result: 'checkmate', winner: chess.turn() === 'w' ? 'b' : 'w', reason: 'checkmate' };
+  if (chess.isStalemate()) return { result: 'stalemate', winner: null, reason: 'stalemate' };
+  if (chess.isInsufficientMaterial()) return { result: 'draw', winner: null, reason: 'insufficient material' };
+  if (chess.isThreefoldRepetition()) return { result: 'draw', winner: null, reason: 'threefold repetition' };
+  if (chess.isDrawByFiftyMoves()) return { result: 'draw', winner: null, reason: 'fifty move rule' };
+  if (chess.isDraw()) return { result: 'draw', winner: null, reason: 'draw' };
+  return null;
+}
+
+export function createRules(fen) {
+  const chess = fen ? new Chess(fen) : new Chess();
+
+  /** The position as the board wants it: { e1: {type, side}, ... }. */
+  function position() {
+    const map = {};
+    for (const row of chess.board()) {
+      for (const cell of row) {
+        if (cell) map[cell.square] = { type: cell.type, side: cell.color };
+      }
+    }
+    return map;
+  }
+
+  /** Legal destinations from a square, verbose, for highlighting and dragging. */
+  function movesFrom(square) {
+    if (!square) return [];
+    try { return chess.moves({ square, verbose: true }); } catch { return []; }
+  }
+
+  function targets(square) {
+    return movesFrom(square).map((m) => m.to);
+  }
+
+  function legalMove(from, to) {
+    return movesFrom(from).find((m) => m.to === to) || null;
+  }
+
+  /**
+   * Play a move. Returns null when it is not legal, otherwise a plain record:
+   * { from, to, san, piece, side, captured, capturedSide, square, check,
+   *   promotion, castle, enPassant }.
+   * `captured` is the type of the man that came off, `square` is where it stood
+   * (which is not `to` for an en passant capture).
+   */
+  function move(from, to, promotion = 'q') {
+    const legal = legalMove(from, to);
+    if (!legal) return null;
+    let played;
+    try { played = chess.move({ from, to, promotion: legal.promotion ? promotion : undefined }); } catch { return null; }
+    if (!played) return null;
+    const side = played.color;
+    const victimSide = side === 'w' ? 'b' : 'w';
+    const enPassant = played.isEnPassant ? played.isEnPassant() : String(played.flags || '').includes('e');
+    let capturedSquare = null;
+    if (played.captured) {
+      capturedSquare = enPassant ? played.to[0] + (side === 'w' ? Number(played.to[1]) - 1 : Number(played.to[1]) + 1) : played.to;
+    }
+    return {
+      from: played.from,
+      to: played.to,
+      san: played.san,
+      piece: played.piece,
+      side,
+      captured: played.captured || null,
+      capturedSide: played.captured ? victimSide : null,
+      capturedSquare,
+      promotion: played.promotion || null,
+      enPassant,
+      castle: String(played.flags || '').includes('k') ? 'k' : (String(played.flags || '').includes('q') ? 'q' : null),
+      check: chess.isCheck(),
+      turn: chess.turn(),
+    };
+  }
+
+  /** A castling king move drags the rook with it. Returns {from,to} or null. */
+  function rookHop(played) {
+    if (!played || !played.castle) return null;
+    const rank = played.side === 'w' ? '1' : '8';
+    return played.castle === 'k'
+      ? { from: 'h' + rank, to: 'f' + rank }
+      : { from: 'a' + rank, to: 'd' + rank };
+  }
+
+  /** One random legal move, for the demo and the smoke run. */
+  function randomMove(rand = Math.random) {
+    const all = chess.moves({ verbose: true });
+    if (all.length === 0) return null;
+    const pick = all[Math.floor(rand() * all.length)];
+    return move(pick.from, pick.to, 'q');
+  }
+
+  return {
+    chess,
+    position, movesFrom, targets, legalMove, move, rookHop, randomMove,
+    turn: () => chess.turn(),
+    inCheck: () => chess.isCheck(),
+    isOver: () => chess.isGameOver(),
+    result: () => readResult(chess),
+    fen: () => chess.fen(),
+    ply: () => chess.history().length,
+    pieceAt: (sq) => chess.get(sq) || null,
+  };
+}

--- a/ConditioningControlPanel/Resources/web/piecebypiece/index.html
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/index.html
@@ -24,6 +24,13 @@
   <!-- 3D layer. Agent-facing contract: #fx is an empty sibling ABOVE #stage and
        is owned entirely by the effects module (ramp/index.js). -->
   <div id="stage"><canvas id="board-canvas"></canvas></div>
+
+  <div id="hud" class="hud">
+    <div class="chip"><span class="who">black</span><span class="time" id="time-b">15:00</span></div>
+    <p class="status" id="status">white to move</p>
+    <div class="chip"><span class="who">white</span><span class="time" id="time-w">15:00</span></div>
+  </div>
+
   <div id="fx"></div>
 
   <div id="loader" class="loader">

--- a/ConditioningControlPanel/Resources/web/piecebypiece/styles.css
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/styles.css
@@ -18,11 +18,28 @@ html, body {
 #stage { position: fixed; inset: 0; z-index: 1; }
 #stage canvas { display: block; width: 100%; height: 100%; touch-action: none; }
 
+/* Clocks and status. Sits under #fx on purpose, so the effects layer can wash
+   over it as things get busier. */
+.hud {
+  position: fixed; right: 22px; top: 22px; bottom: 22px; z-index: 2;
+  display: flex; flex-direction: column; align-items: flex-end; justify-content: space-between;
+  pointer-events: none; text-align: right;
+}
+.chip {
+  display: flex; flex-direction: column; gap: 2px; padding: 10px 16px; border-radius: 12px;
+  background: rgba(20, 20, 46, 0.55); border: 1px solid rgba(245, 230, 200, 0.12);
+  backdrop-filter: blur(3px);
+}
+.chip .who { font-size: 11px; letter-spacing: 0.18em; text-transform: uppercase; opacity: 0.55; }
+.chip .time { font-size: 26px; font-variant-numeric: tabular-nums; opacity: 0.7; transition: color 200ms ease, opacity 200ms ease; }
+.chip .time.on { color: var(--pbp-pink); opacity: 1; }
+.status { margin: 0; font-size: 13px; letter-spacing: 0.14em; text-transform: lowercase; opacity: 0.6; }
+
 /* Owned by the effects layer. Never written to by the board code. */
-#fx { position: fixed; inset: 0; z-index: 2; pointer-events: none; overflow: hidden; }
+#fx { position: fixed; inset: 0; z-index: 3; pointer-events: none; overflow: hidden; }
 
 .loader, .nope {
-  position: fixed; inset: 0; z-index: 3;
+  position: fixed; inset: 0; z-index: 4;
   display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 18px;
   background: var(--pbp-bg); text-align: center; transition: opacity 420ms ease;
 }


### PR DESCRIPTION
Stacked on #955 (board). **Base: `feat/pbp-a2-board`.**

The board becomes a game. Standard chess throughout, refereed by the vendored chess.js.

## What lands
- **`game/rules.js`** - the single place that decides legality, so the board, the drag layer and the effects layer never disagree. Legal moves for a square, playing a move, and the result of a finished game: checkmate, stalemate, insufficient material, threefold repetition, fifty moves. A move record carries what came off and from which square, so en passant (the victim is not on the destination square), castling (`rookHop`) and promotion all report cleanly.
- **`game/clock.js`** - 15 minutes a side, no increment, a 250 ms tick, running out is a loss. It measures elapsed real time rather than counting ticks, so a stalled tab or a slow frame cannot hand anyone free seconds. The interval is unref'd, which keeps node tests from hanging on a running clock.
- **`game/hotseat.js`** - both players at one screen. Owns the referee, the clocks, the men and every event the effects layer listens to. The camera swings to whoever is to move.
- **`boot.js` / `index.html` / `styles.css`** - clocks and a status line in a small HUD that sits *under* `#fx` on purpose, so the effects layer can wash over it. Query parameters: `?auto=n` (play n random legal moves then stop, used by the screenshot harness), `?clock=<seconds>`, `?fen=<fen>`.

## Events on the bus (the agreed contract)
| Event | Payload |
|---|---|
| `local` | `{sides:['w','b']}` once at boot |
| `turn` | `{side, ply, clocks:{w,b}, total}` |
| `capture` | `{by, piece, square, victimSide}` - `piece` is the man that came off and `square` is where it stood, which is not the destination for en passant |
| `check` | `{side}` - the side now in check |
| `clock` | `{w, b, total, active}` every 250 ms |
| `gameover` | `{result:'checkmate'\|'stalemate'\|'draw'\|'resign'\|'flag', winner:'w'\|'b'\|null}` |

The first `turn` is emitted after the effects layer has had its chance to subscribe, so nothing misses the opening.

## Verified
Headless msedge, clean boot, no console errors, mid-game board after `?auto=12`. Screenshot: `C:/Users/PC/Pictures/Screenshots/piecebypiece/a/a3-midgame.png`. Node checks for the referee, the clocks and a whole game arrive with the smoke PR at the top of the stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S4BKp6cQJFNixoQrarvSkd