### PR TITLE
feat(race): the picked level row is the status, and back never leaves the screen

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/race/CLOUD.md
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/CLOUD.md
@@ -71,6 +71,25 @@ worked on (`naming`, `reading`, `decoding`, `charting`, then `playing` / `paused
 Deciding `hand-tuned` costs NO NETWORK: the index is same origin and already
 fetched, and the key is the `cloudId` off the url.
 
+**The picked row IS the status.** A tap opens nothing under the list: THAT row lights
+(`is-picked`, a lit plate with a hard stripe down its left edge - background, never
+`box-shadow`, so the focus ring still fits around it) and grows its own progress bar under
+the title, teal and full once the road is in hand (`is-loaded`). The bar carries the same
+number the menu's track plate used to: the web lane's chart steps through
+`levels.setStage(id, word)`, a host's `track-progress` pct through `levels.setTrack(state)`.
+`setTrack` answers TRUE when it painted that state on a row, and `raceBoot.plate()` passes
+the answer on as `menu.setTrack(state, onRow)`: the verbs still follow it (`race the track`)
+and the plate stays down. A pasted link and a file the host picked are claimed by nobody, so
+they still get the plate. WHICH row is picked is read live off `cloud.state` on the web -
+`play the set` rolling on to level 4 lights level 4, a pasted link playing lights nothing -
+and off the last tap on a desktop host, which owns playback.
+
+**`back` is always on screen.** Eleven rows are taller than a phone, so `.rm-levels-foot` is
+`position: sticky` against the bottom of the scrolling column (`.rm-col`, whose bottom
+padding is now the `--rm-pad-b` variable the foot reaches past, since sticky sticks to the
+content box). It is still the LAST row in the DOM, so `rows()` / `els()` and the arrow, pad
+and smoke walks keep the order they always had.
+
 **Two hosts, one panel.** On the web a tap hands that one track to `race/cloud.js`
 and the run follows the element. On a desktop host (`trackPick: true`) the desktop
 owns playback, so a tap posts `cloud-open { url }` with the track's PAGE url and

--- a/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
@@ -443,6 +443,12 @@ createIntro({ stage, hud, audio, reducedMotion, log }) -> { play(): Promise, ski
 cameraWhip(sec) / resultsCamera({ tier, reducedMotion }) / preRollCamera() -> fn(camera, dt, w, camOut), `false` when done
 resultTier(total, best, personalBest) -> 0..4 (the face index)
 ```
+- THE LEVELS PANEL owns its own status (race/levels.js, CLOUD.md "the picked row IS the status"): the row a
+  player tapped lights and carries the load bar itself, so `menu.setTrack(state, onRow)` takes a second
+  argument - `onRow` true (raceBoot got it from `levels.setTrack(state)`) keeps the verbs following the state
+  and holds the plate down, because the row is already saying it. A pasted link or a picked file is claimed by
+  nobody and still gets the plate. `.rm-levels-foot` is `position: sticky` at the bottom of `.rm-col` so `back`
+  is on screen at every scroll position, and it is still the last row `rows()` / `els()` hand over.
 - Boot order: splash (a 1 s title flash) -> menu (the resting state) -> `race` -> intro on the menu stage -> run under the
   camera whip. `?autostart=1` skips menu and intro (the headless checks depend on it), `?intro=0` skips the intro only,
   `?scene=intro` boots straight into the intro. `surface` from the menu sends the same `exit` + `exit-done` the End screen does.

--- a/ConditioningControlPanel/Resources/web/dtrh/race/levels.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/levels.js
@@ -31,6 +31,23 @@
  * costs NO NETWORK: the index is same-origin and already fetched, and the key is
  * the cloudId off the url.
  *
+ * THE PICKED ROW IS THE STATUS. Tapping a level opens no second panel anywhere:
+ * THAT ROW lights (`is-picked`, a pink plate a thumb cannot miss) and grows a
+ * progress bar under its title, and the bar carries the same number the menu's
+ * track plate used to - the web lane's chart steps (reading, decoding, charting,
+ * naming) through `setStage`, a host's `track-progress` pct through `setTrack`.
+ * `setTrack(state)` answers TRUE when it painted that state on a row, and
+ * raceBoot hides the plate for exactly that answer: a pasted link and a picked
+ * file still get the plate, a listed level never does. WHICH row is picked is
+ * read live off the player on the web (`play the set` rolling on to level 4
+ * lights level 4; a pasted link playing lights nothing) and off the last tap on
+ * a desktop host, which owns playback and reports back through track-progress.
+ *
+ * `back` IS ALWAYS ON SCREEN. Eleven rows are taller than a phone, so the foot
+ * is `position: sticky` against the bottom of the scrolling column (menu.css).
+ * It rides the bottom edge at every scroll position and is still the LAST row
+ * the keyboard and the pad walk to, so no index math moved.
+ *
  * THE PASTE BOX IS STILL THERE. `or paste a link` opens lane W1's panel under
  * the list, unchanged, so a track that is not one of the levels is still one
  * paste away.
@@ -58,6 +75,22 @@ export const ROAD_MARK = 'road';
 export const AGAIN_MARK = 'again';
 export const OVER_THERE_LINE = 'press play over there';
 export const EMPTY_LINE = 'no levels on this build, paste a link instead';
+
+/**
+ * How full the picked row's bar is on each step, so one number can come from two
+ * very different places. The four on the left are race/cloudChart.js's own words
+ * (the web lane, through setStage); the rest are the host's `track-progress`
+ * stages (CHART.md), which also carry a real pct and use it when they do.
+ */
+export const STAGE_PCT = {
+  reading: 0.3, decoding: 0.55, charting: 0.75, naming: 0.9,
+  opening: 0.08, fetching: 0.35, decode: 0.55, energy: 0.75, words: 0.9, loading: 0.15,
+};
+/** The mark a host's stage puts on the picked row. The web lane's own words are already marks. */
+export const STAGE_MARK = {
+  opening: 'over there', fetching: 'loading', decode: 'reading', energy: 'charting', words: 'naming',
+  ready: 'loaded', error: 'would not load',
+};
 
 /** The verb's whole visibility rule: a build that carries the levels, host or no host. */
 export function levelsEnabled(settings) {
@@ -149,6 +182,8 @@ export function createLevels({ settings = {}, sets = [], cloud = null, index = n
   let levelRows = [], tailRows = [], backRow = null;
   let pasteOpen = false, disposed = false;
   let stageId = '', stageWord = '';
+  let pickedId = '';                 // the last level TAPPED here; the web player below can outvote it
+  let prog = null;                   // { pct, mark } from a host's track-progress, or null
   let last = '';
   let onPick = null, onClose = null, onRefresh = null;
 
@@ -176,10 +211,40 @@ export function createLevels({ settings = {}, sets = [], cloud = null, index = n
     return st.playing ? 'playing' : 'paused';
   }
 
-  /** The small mark on the right of a row. State first, then memory, then the road it will get. */
+  /**
+   * WHICH ROW IS THE PICKED ONE. On the web the player is the truth: whatever race/cloud.js
+   * holds right now is what the panel lights, so `play the set` rolling on lights the next
+   * row by itself and a pasted link playing lights NOTHING (it is not on this list, and its
+   * status belongs to the menu's plate). With no player here - a desktop host, which owns
+   * playback outright - the last tap is all there is, and the host's progress lands on it.
+   */
+  function pickedLevel() {
+    if (!desktop && cloud) {
+      let st = null;
+      try { st = cloud.state; } catch (e) { st = null; }
+      if (st && st.at >= 0) {
+        const cur = st.list[st.at];
+        return (cur && levels.find((l) => l.id === cur.id)) || null;
+      }
+    }
+    return (pickedId && levels.find((l) => l.id === pickedId)) || null;
+  }
+
+  /** How full the picked row's bar is, 0..1. -1 means this row carries no bar at all. */
+  function pctOf(lv) {
+    if (lv !== pickedLevel()) return -1;
+    const live = playerState(lv);
+    if (live === 'loaded' || live === 'playing' || live === 'paused') return 1;
+    if (live && STAGE_PCT[live] != null) return STAGE_PCT[live];
+    if (prog) return prog.pct;
+    return live ? STAGE_PCT.loading : 0;
+  }
+
+  /** The small mark on the right of a row. State first, then the host's, then memory, then the road it will get. */
   function markOf(lv) {
     const live = playerState(lv);
     if (live) return live;
+    if (prog && prog.mark && lv === pickedLevel()) return prog.mark;
     if (lv.id === last) return AGAIN_MARK;
     return authored(lv) ? HAND_MARK : ROAD_MARK;
   }
@@ -188,6 +253,7 @@ export function createLevels({ settings = {}, sets = [], cloud = null, index = n
   /** A tap on a level. One track, one run. On a desktop it is a door, not a download. */
   function tap(lv) {
     remember(lv.id);
+    pickedId = lv.id; prog = null;   // the row itself is the answer from here on
     if (desktop) {
       call('open', FILE_PAGE + lv.id, lv.title);
       call('toast', OVER_THERE_LINE);
@@ -204,6 +270,7 @@ export function createLevels({ settings = {}, sets = [], cloud = null, index = n
   function playSet() {
     if (!levels.length) return;
     remember(levels[0].id);
+    pickedId = levels[0].id; prog = null;
     say(set.title + ': all ' + levels.length);
     call('play', levels.map(entry));
     paint();
@@ -233,12 +300,20 @@ export function createLevels({ settings = {}, sets = [], cloud = null, index = n
 
   function paint() {
     if (!slotEl || disposed) return;
+    const picked = pickedLevel();
     for (let i = 0; i < levels.length; i++) {
       const b = levelEls[i]; if (!b) continue;
       const lv = levels[i], mark = markOf(lv), m = b.querySelector('.rm-level-mark');
       if (m && m.textContent !== mark) m.textContent = mark;
       b.classList.toggle('is-on', !!playerState(lv));
       b.classList.toggle('is-hand', authored(lv));
+      // the picked row IS the status: it lights, and the bar under its title is the load
+      const pct = pctOf(lv), on = pct >= 0;
+      b.classList.toggle('is-picked', on);
+      b.classList.toggle('is-loaded', pct >= 1);
+      if (on) b.setAttribute('aria-current', 'true'); else b.removeAttribute('aria-current');
+      const fill = b.querySelector('.rm-level-bar > i');
+      if (fill) fill.style.width = `${Math.round(Math.max(0, Math.min(1, pct)) * 100)}%`;
     }
     const pasteBtn = tailEls[tailEls.length - 1];
     if (pasteBtn && cloudUi) {
@@ -270,6 +345,8 @@ export function createLevels({ settings = {}, sets = [], cloud = null, index = n
       elm('span', 'rm-level-title', b, lv.title);
       elm('span', 'rm-level-len', b, mmss(lv.durationSec));
       elm('span', 'rm-level-mark', b, '');
+      // the bar lives IN the row, under the title, and only the picked row ever shows it
+      const bar = elm('i', 'rm-level-bar', b); elm('i', '', bar);
       b.addEventListener('click', (ev) => { ev.stopPropagation(); if (onPick) onPick(i); });
       levelEls.push(b);
       levelRows.push({ id: 'lv-' + lv.n, label: lv.title, press: () => tap(lv) });
@@ -314,7 +391,32 @@ export function createLevels({ settings = {}, sets = [], cloud = null, index = n
     paint,
     /** Lane W2's progress, landing on the row it belongs to. '' takes the stage word off again. */
     setStage(id, word) { stageId = String(id || ''); stageWord = String(word || ''); paint(); },
-    get state() { return { desktop, sets: sets.length, levels: levels.length, pasteOpen, last, stage: stageWord }; },
+    /**
+     * The state the menu's track plate would have shown. TRUE when this panel painted it on a
+     * picked row instead, which is raceBoot's whole rule for hiding the plate.
+     *   picking  a file dialog: not a level at all, so the pick is dropped and the plate takes it
+     *   null     nothing loaded any more: the row goes back to being a row
+     * A state with no picked row under it (a pasted link, a file) is never claimed.
+     */
+    setTrack(state) {
+      const st = state && state.stage ? state : null;
+      if (!st || st.stage === 'picking' || st.stage === 'cancelled') {
+        if (!st || st.stage === 'picking') { pickedId = ''; prog = null; }
+        paint();
+        return false;
+      }
+      if (!pickedLevel()) { prog = null; paint(); return false; }
+      const pct = Number(st.pct);
+      prog = {
+        pct: st.stage === 'ready' ? 1 : (isFinite(pct) && pct > 0 ? Math.max(0, Math.min(1, pct)) : (STAGE_PCT[st.stage] || 0)),
+        mark: STAGE_MARK[st.stage] || '',
+      };
+      paint();
+      return true;
+    },
+    /** Which level the panel is lit on right now, or ''. The smoke's window on the pick. */
+    get picked() { const lv = pickedLevel(); return lv ? lv.id : ''; },
+    get state() { return { desktop, sets: sets.length, levels: levels.length, pasteOpen, last, stage: stageWord, picked: (pickedLevel() || {}).id || '' }; },
     dispose() { disposed = true; try { if (cloud) cloud.dispose(); } catch (e) { /* already gone */ } },
   };
 }

--- a/ConditioningControlPanel/Resources/web/dtrh/race/menu.css
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/menu.css
@@ -33,7 +33,10 @@
   /* `safe center` so a column taller than the screen starts at the top and scrolls, instead of
      centring and putting the first verbs above the scrollable area where nothing can reach them */
   justify-content: center; justify-content: safe center;
-  padding: calc(6vh + var(--rm-sa-t)) calc(28px + var(--rm-sa-r)) calc(6vh + var(--rm-sa-b)) calc(5vw + var(--rm-sa-l));
+  /* the bottom pad is a variable because a sticky foot inside this column (the levels panel's
+     `back`) has to reach past it to the real bottom edge: Chrome sticks to the CONTENT box. */
+  --rm-pad-b: calc(6vh + var(--rm-sa-b));
+  padding: calc(6vh + var(--rm-sa-t)) calc(28px + var(--rm-sa-r)) var(--rm-pad-b) calc(5vw + var(--rm-sa-l));
   min-width: 0; overflow-y: auto; overscroll-behavior: contain; -webkit-overflow-scrolling: touch;
   scrollbar-width: thin; scrollbar-color: rgba(255, 105, 180, 0.5) transparent;
   background: linear-gradient(90deg, rgba(18, 11, 36, 0.92) 0%, rgba(18, 11, 36, 0.86) 78%, rgba(18, 11, 36, 0) 100%);
@@ -137,7 +140,7 @@
 #race-root .rm-levels { display: flex; flex-direction: column; gap: 4px; }
 #race-root .rm-levels-set { margin-top: 0; margin-bottom: 6px; color: #ffd6ea; letter-spacing: 0.08em; text-transform: uppercase; }
 #race-root .rm-level-btn {
-  display: grid; grid-template-columns: 2.4em 1fr auto; grid-template-areas: 'n title len' 'n mark mark';
+  display: grid; grid-template-columns: 2.4em 1fr auto; grid-template-areas: 'n title len' 'n bar bar' 'n mark mark';
   gap: 0 10px; align-items: center; width: 100%; min-height: 48px; text-align: left;
   padding: 7px 14px 7px 28px; font-size: 16px;
 }
@@ -149,8 +152,37 @@
 #race-root .rm-level-btn.is-hand .rm-level-mark { color: var(--pink, #ff69b4); }
 #race-root .rm-level-btn.is-on .rm-level-title { color: #fff; }
 #race-root .rm-level-btn.is-on .rm-level-mark { color: #ffd6ea; }
+/* THE PICKED ROW. The row a player tapped is the only status this panel has: a lit plate with a
+   hard stripe down its left edge and its own bar under the title. Nothing opens below the list,
+   so there is nothing to scroll down to and read. The stripe is background, never box-shadow, so
+   the FOCUS ring still fits around it and the two states never fight over one property: focus is
+   where the arrows are, picked is what is loading. */
+#race-root .rm-level-btn.is-picked {
+  background-color: rgba(255, 105, 180, 0.2);
+  background-image: linear-gradient(90deg, var(--pink, #ff69b4) 0 5px, rgba(255, 105, 180, 0) 5px);
+}
+#race-root .rm-level-btn.is-picked .rm-level-title { color: #fff; }
+#race-root .rm-level-btn.is-picked .rm-level-mark { color: #ffd6ea; }
+#race-root .rm-level-bar { grid-area: bar; display: none; height: 5px; margin: 5px 0 3px; background: rgba(255, 255, 255, 0.12); box-shadow: 0 0 0 2px #2b1b3f; }
+#race-root .rm-level-bar > i { display: block; height: 100%; width: 0; background: var(--pink, #ff69b4); transition: width 0.25s linear; }
+#race-root .rm-level-btn.is-picked .rm-level-bar { display: block; }
+/* in hand: the bar fills and goes the same teal the track plate has always gone when a road is ready */
+#race-root .rm-level-btn.is-loaded {
+  background-color: rgba(91, 231, 216, 0.16);
+  background-image: linear-gradient(90deg, #5be7d8 0 5px, rgba(91, 231, 216, 0) 5px);
+}
+#race-root .rm-level-btn.is-loaded .rm-level-bar > i { background: #5be7d8; }
+#race-root .rm-level-btn.is-loaded .rm-level-mark { color: #5be7d8; }
 #race-root .rm-levels-tail, #race-root .rm-levels-foot { display: flex; flex-direction: column; gap: 4px; margin-top: 6px; }
 #race-root .rm-levels-btn { align-self: flex-start; }
+/* `back` IS ALWAYS ON SCREEN. Eleven levels are taller than any phone and taller than most windows,
+   so the foot rides the bottom edge of the scrolling column instead of sitting at the end of it.
+   Still the last row in the DOM, so the arrows, the pad and the smokes walk the same order. */
+#race-root .rm-levels-foot {
+  position: sticky; bottom: calc(-1 * var(--rm-pad-b, 0px)); z-index: 2; align-items: flex-start;
+  padding: 10px 0 calc(var(--rm-pad-b, 0px) + 8px); margin-top: 8px;
+  background: linear-gradient(180deg, rgba(13, 10, 20, 0) 0%, rgba(13, 10, 20, 0.9) 38%, rgba(13, 10, 20, 0.97) 100%);
+}
 #race-root .rm-cloud-paste { margin-top: 8px; padding-top: 8px; border-top: 1px solid rgba(255, 105, 180, 0.22); }
 #race-root .rm-cloud-paste[hidden] { display: none; }
 
@@ -216,7 +248,8 @@
   #race-root .rm-root { grid-template-columns: 1fr; }
   #race-root .rm-col {
     justify-content: flex-start;
-    padding: calc(4vh + var(--rm-sa-t)) calc(22px + var(--rm-sa-r)) calc(4vh + var(--rm-sa-b)) calc(22px + var(--rm-sa-l));
+    --rm-pad-b: calc(4vh + var(--rm-sa-b));
+    padding: calc(4vh + var(--rm-sa-t)) calc(22px + var(--rm-sa-r)) var(--rm-pad-b) calc(22px + var(--rm-sa-l));
     background: linear-gradient(180deg, rgba(18, 11, 36, 0.94) 0%, rgba(18, 11, 36, 0.86) 70%, rgba(18, 11, 36, 0) 100%);
   }
   /* the verbs go to the bottom. A column too tall to fit eats the auto margin and scrolls, top first. */
@@ -315,7 +348,8 @@
    The keyboard footer and the tagline are the two lines a thumb never needs, so they go first. */
 @media (max-height: 480px) {
   #race-root .rm-col, #race-root .rc-col {
-    gap: 8px; padding-top: calc(8px + var(--rm-sa-t)); padding-bottom: calc(8px + var(--rm-sa-b));
+    gap: 8px; --rm-pad-b: calc(8px + var(--rm-sa-b));
+    padding-top: calc(8px + var(--rm-sa-t)); padding-bottom: var(--rm-pad-b);
   }
   #race-root .rm-title, #race-root .rc-word { font-size: clamp(20px, 3.2vw, 26px); }
   #race-root .rm-tag, #race-root .rm-foot { display: none; }
@@ -333,6 +367,8 @@
   /* the rows keep their 48 px: a short screen scrolls the column, it does not shrink the target */
   #race-root .rm-level-btn { font-size: 15px; padding: 5px 14px 5px 28px; }
   #race-root .rm-level-mark { font-size: 10px; }
+  #race-root .rm-level-bar { height: 4px; margin: 3px 0 2px; }
+  #race-root .rm-levels-foot { margin-top: 4px; padding: 4px 0 2px; }
   #race-root .rm-h { margin-bottom: 2px; font-size: 16px; }
   #race-root .rm-row { padding: 5px 12px; font-size: 15px; }
   #race-root .rm-row-hint, #race-root .rm-hint { font-size: 10px; margin-top: 2px; }

--- a/ConditioningControlPanel/Resources/web/dtrh/race/menu.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/menu.js
@@ -3,8 +3,10 @@
  *
  *   createMenu({ root, renderer, pixel, audio, settings, log, send }) ->
  *     { show(), hide(), onPick(cb), options, stage: { update(dt), render(), dispose() }, dispose() }
- *   onPick yields 'race' | 'track' | 'clear' | 'story' | 'surface'; setTrack(state | null) drives the
- *   track plate (CHART.md: the host's track-progress and the chart that lands). refreshView() parks
+ *   onPick yields 'race' | 'track' | 'clear' | 'story' | 'surface'; setTrack(state | null, onRow) drives the
+ *   track plate (CHART.md: the host's track-progress and the chart that lands) - `onRow` is the levels
+ *   panel saying it painted that state on the picked row itself, so only the verbs follow it and the
+ *   plate stays down (a pasted link and a picked file still get the plate). refreshView() parks
  *   the stage where the column would park it even while the menu is hidden (race/cards.js borrows it).
  *   setLocalMedia(frame) and settingEcho(frame) feed the media panel below; `send` is the only way out
  *   to the host from in here, and only that panel uses it.
@@ -679,11 +681,15 @@ export function createMenu({ root, renderer, pixel, audio, settings = {}, log = 
    * durationSec, countable, partial, authored, message }; stage 'ready' is a chart in hand (partial
    * while the words are still landing, authored when a person wrote it rather than the analysis).
    * Null clears the plate and the verbs read as the seeded run again.
+   *
+   * `onRow` is raceBoot saying the LEVELS panel already painted this state on the picked row
+   * (race/levels.js): the verbs still follow it - `race the track` is the whole point of knowing -
+   * but the plate stays down, because two places saying the same thing is one place too many.
    */
-  function setTrack(state) {
+  function setTrack(state, onRow) {
     trackState = state && state.stage ? state : null;
     const st = trackState, ready = !!st && st.stage === 'ready';
-    trackEl.hidden = !st || st.stage === 'cancelled';
+    trackEl.hidden = !st || st.stage === 'cancelled' || !!onRow;
     trackEl.classList.toggle('is-ready', ready); trackEl.classList.toggle('is-error', !!st && st.stage === 'error');
     trackEl.classList.toggle('is-busy', !!st && !ready && st.stage !== 'error');
     if (st) {

--- a/ConditioningControlPanel/Resources/web/dtrh/race/smoke/levels-check.mjs
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/smoke/levels-check.mjs
@@ -24,6 +24,10 @@
  *      not, and neither of them cost a request
  *   4. a tap is a ONE TRACK run: that track and nothing else, and the run's
  *      clock is the file's clock
+ *  4b. the tapped row IS the status: it alone is `is-picked`, it alone grows a
+ *      progress bar, a road in hand fills that bar and reads `loaded`, the old
+ *      bottom plate stays down for a listed level, and `back` is pinned to the
+ *      bottom of the column (still the last row the arrows walk)
  *   5. `again` lands on the last level played, and it survives a reload
  *   6. `play the set` is the whole list in order, the first one is the authored
  *      chart, and the end of a file rolls the lap on to the next level
@@ -225,6 +229,29 @@ await sleep(3000);
   ok(st.list.length === 1 && st.list[0].id === 'stub-two', 'a tap plays that level and NOTHING else: ' + JSON.stringify(st.list.map((e) => e.id)));
   ok(st.at === 0 && st.busy === false, 'and it is the track in hand');
   ok(await ev(`document.querySelector('.rm-track-name').textContent`) === 'The Second One', 'the plate names it');
+}
+
+/* ---- 4b. the picked row IS the status, and `back` never leaves the screen ---- */
+{
+  const rows = await json(`[...document.querySelectorAll('.rm-levels .rm-level-btn')].map(b=>({
+    id: b.dataset.id, picked: b.classList.contains('is-picked'), loaded: b.classList.contains('is-loaded'),
+    bar: b.querySelector('.rm-level-bar') ? getComputedStyle(b.querySelector('.rm-level-bar')).display : 'none',
+    fill: b.querySelector('.rm-level-bar > i') ? b.querySelector('.rm-level-bar > i').style.width : '',
+    mark: b.querySelector('.rm-level-mark').textContent,
+  }))`);
+  const two = rows.find((r) => r.id === 'lv-2'), one = rows.find((r) => r.id === 'lv-1');
+  ok(two.picked && !one.picked, 'the row that was tapped is the picked one, and it is the only one');
+  ok(two.bar === 'block' && one.bar === 'none', 'the picked row grew its own progress bar and no other row has one');
+  ok(two.fill === '100%' && two.loaded, `the road is in hand, so the bar is full and the row reads loaded (${two.fill}, mark "${two.mark}")`);
+  ok(await ev(`window.__race.levels.state.picked`) === 'stub-two', 'and the panel names that level as the picked one');
+  // the plate under the list is exactly what the picked row replaces: it stays down for a level
+  ok(await ev(`document.querySelector('.rm-track').hidden === true`), 'the old bottom row (the track plate) is NOT shown for a listed level');
+  const back = await json(`(()=>{const col=document.querySelector('.rm-col'); col.scrollTop = 99999;
+    const b=document.querySelector('.rm-levels-foot .rm-btn[data-id=back]'), f=document.querySelector('.rm-levels-foot'), r=b.getBoundingClientRect();
+    return { pos: getComputedStyle(f).position, top: Math.round(r.top), bottom: Math.round(r.bottom), h: innerHeight, last: b === [...document.querySelectorAll('.rm-cloud [role=menuitem]')].pop() };})()`);
+  ok(back.pos === 'sticky', 'the foot is pinned to the bottom of the scrolling column');
+  ok(back.top >= 0 && back.bottom <= back.h, `so back is on the screen with the column scrolled to the end (${back.top}..${back.bottom} of ${back.h})`);
+  ok(back.last === true, 'and it is still the LAST row, so the arrows and the pad walk the order they always did');
 }
 await click('.rm-levels-foot .rm-btn[data-id=back]');
 await click('.rm-list .rm-btn[data-id=race]');

--- a/ConditioningControlPanel/Resources/web/dtrh/raceBoot.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/raceBoot.js
@@ -228,8 +228,17 @@ bridge.on('track-progress', (m) => {
   // a cancelled dialog leaves whatever was loaded before in place; any other stage is the host at work
   plate(m.stage === 'cancelled' ? trackReady : { stage: m.stage, pct: m.pct, name: m.name });
 });
-/** The menu's plate, when there is a menu to show it on (the run has the toast instead). */
-function plate(state) { try { if (menu && !started) menu.setTrack(state); } catch (e) { host.log('plate: ' + e); } }
+/**
+ * Where a track's progress goes while the menu is up (the run has the toast instead). The LEVELS
+ * panel gets first refusal: a state that belongs to a row picked in there is painted ON that row,
+ * bar and all, and the plate stays down. Anything the panel does not claim - a pasted link, a file
+ * the host picked, the seeded road - is the plate's, exactly as it always was.
+ */
+function plate(state) {
+  let onRow = false;
+  try { onRow = !!(levels && levels.setTrack(state)); } catch (e) { host.log('levels plate: ' + e); }
+  try { if (menu && !started) menu.setTrack(state, onRow); } catch (e) { host.log('plate: ' + e); }
+}
 function trackError(message) {
   host.log('track-error: ' + message);
   try { if (race && race.hud) race.hud.toast(String(message).slice(0, 60).toLowerCase(), 'effect'); } catch (e) { /* no hud yet */ }


### PR DESCRIPTION
Two things off the menu, both from the owner.

## 1. picking a level says so on the row

Before: tapping a level opened a separate plate under the list with the song name and a
progress bar. It read as a second thing rather than an answer about the row that was tapped.

Now the row IS the answer. It lights (a hard stripe down its left edge - background, never
box-shadow, so the keyboard focus ring still fits around it and the two states never fight),
and it grows its own progress bar under the title: pink while the road is being read, teal
and full once it is in hand, with the word on the right going `loading` -> `reading` ->
`charting` -> `loaded` / `playing`.

- `race/levels.js` gains `setTrack(state)`, which takes exactly what the menu plate used to
  and answers TRUE when it painted that state on a row. `setStage(id, word)` still feeds it
  the web lane's chart steps.
- `raceBoot.js` `plate()` gives the panel first refusal and passes the answer to
  `menu.setTrack(state, onRow)`: the verbs still follow the state (`race the track`), the
  plate stays down for a listed level, and it still shows for a pasted link or a file the
  host picked - those belong to nobody on the list.
- Which row is picked is read LIVE off `cloud.state` on the web (so `play the set` rolling
  on to level 4 lights level 4, and a pasted link playing lights nothing), and off the last
  tap on a desktop host, whose `track-progress` then lands on that row.

Both hosts: the web `cloud` lane and the desktop `trackPick` lane (where a tap posts
`cloud-open` and the host reports back) paint the same row the same way.

## 2. `back` without scrolling

`.rm-levels-foot` is now `position: sticky` against the bottom of the scrolling column, so
with eleven levels on a phone `back` is on screen at every scroll position. `.rm-col`'s
bottom padding became the `--rm-pad-b` variable so the foot can reach past it (sticky sticks
to the content box, not the padding box). It is still the LAST row in the DOM, so `rows()` /
`els()`, the arrow walk, the pad walk and the smokes keep the order they always had.

## how it was verified

- `node race/smoke/levels-check.mjs` - all green, with a new section 4b: exactly one row is
  `is-picked`, only that row has a bar, a road in hand fills it and reads `loaded`, the old
  bottom plate is hidden for a listed level, the foot computes as `sticky`, `back` is inside
  the viewport with the column scrolled to the end, and it is still the last `[role=menuitem]`.
- `rows-check`, `cloud-check`, `fov-check`, `chart-check`, `touch-check`, `track-run-check`: green.
- Headless Chrome shots of the real shipped list at 1280x720 and at a landscape phone
  (844x390), loading and loaded, plus the column scrolled to the end. Zero console errors.

## git diff --stat origin/main...HEAD

```
 .../Resources/web/dtrh/race/CLOUD.md               |  19 ++++
 .../Resources/web/dtrh/race/CONTRACT.md            |   6 ++
 .../Resources/web/dtrh/race/levels.js              | 106 ++++++++++++++++++++-
 .../Resources/web/dtrh/race/menu.css               |  44 ++++++++-
 .../Resources/web/dtrh/race/menu.js                |  14 ++-
 .../Resources/web/dtrh/race/smoke/levels-check.mjs |  27 ++++++
 .../Resources/web/dtrh/raceBoot.js                 |  13 ++-
 7 files changed, 217 insertions(+), 12 deletions(-)
```

No host protocol change: `bridge.js` and every message type are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KTe1RA7EP5hGxkzFY1282C
