### PR TITLE
feat(pbp): flash pops, gif rain, the pink melt and the blur cap

### DIFF
--- a/ConditioningControlPanel/Resources/web/piecebypiece/dev/ramp.html
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/dev/ramp.html
@@ -184,9 +184,10 @@ function applyMeter() {
 }
 meterEl.addEventListener('input', applyMeter);
 
-/* ?meter= and ?fire= drive the screenshot pass */
+/* ?meter=, ?fire= and ?prime= drive the screenshot pass */
 if (qs.has('meter')) { meterEl.value = Math.round(Number(qs.get('meter')) * 100); applyMeter(); }
-if (qs.has('fire')) ramp.debug().fire(qs.get('fire'));
+if (qs.has('prime')) ramp.debug().prime(Number(qs.get('prime')) || 5);
+if (qs.has('fire')) for (const kind of qs.get('fire').split(',')) ramp.debug().fire(kind.trim());
 
 const out = document.getElementById('out');
 setInterval(() => {

--- a/ConditioningControlPanel/Resources/web/piecebypiece/ramp/index.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/ramp/index.js
@@ -21,7 +21,7 @@
  * ==========================================================================*/
 
 import { createMeter, RAMP_TUNING, clamp01 } from './meter.js';
-import { createSchedule, videoHoldMs } from './schedule.js';
+import { createSchedule, videoHoldMs, sustainedFor } from './schedule.js';
 import { createLayerStack } from './layers/index.js';
 import { createFixtureMedia } from './media.js';
 
@@ -219,12 +219,23 @@ export function attachRamp(opts = {}) {
       layers: stack.debug ? stack.debug() : null,
       media: media.stats ? media.stats() : null,
       tuning,
-      /** Dev harness only: pin the meter (null gives the game back control). */
-      setMeter(v) { overrideMeter = v == null ? null : clamp01(v); return overrideMeter; },
+      /** Dev harness only: pin the meter (null gives the game back control).
+       *  Sustained layers are applied at once so a screenshot does not have to
+       *  wait for the next rAF beat (headless barely gets any). */
+      setMeter(v) {
+        overrideMeter = v == null ? null : clamp01(v);
+        applySustained(sustainedFor(liveMeter(), tuning));
+        return overrideMeter;
+      },
       /** Dev harness only: fire one layer by name right now. */
       fire(kind, o) {
         if (kind === 'videoCard') stack.videoCard(o || { holdMs: videoHoldMs(liveMeter(), tuning) });
         else stack.oneshot(kind, o || { heat: liveHeat(now()) });
+      },
+      /** Dev harness only: fill the screen for a screenshot without waiting. */
+      prime(n = 5) {
+        const heat = liveHeat(now());
+        for (let i = 0; i < n; i++) { stack.oneshot('flash', { heat }); stack.oneshot('gifRain', { heat }); }
       },
       stack,
     };

--- a/ConditioningControlPanel/Resources/web/piecebypiece/ramp/layers/blur.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/ramp/layers/blur.js
@@ -1,0 +1,40 @@
+/* ============================================================================
+ * layers/blur.js - the board goes soft.
+ *
+ * A CSS blur on #stage, contributed through the shared stage-filter composer
+ * so it stacks with the melt instead of overwriting it.
+ *
+ * THE HARD CAP IS THE POINT. RAMP_TUNING.blurMaxPx is 3px and this layer
+ * re-clamps to it even if a caller hands it something larger: at 3px a piece is
+ * still findable and a legal move is still physically possible. The ramp is
+ * meant to make you play badly, not to make the game unplayable. Anything that
+ * wants to actually hide the board (the spiral veil, the gif overlay, the video
+ * card) is a separate layer the player can see past by waiting.
+ * ==========================================================================*/
+
+export function createBlur(ctx) {
+  const cap = Number.isFinite(ctx.tuning && ctx.tuning.blurMaxPx) ? ctx.tuning.blurMaxPx : 3;
+  let disposed = false;
+  let px = 0;
+
+  /** spec is schedule.sustainedFor().blur: { on, px }. */
+  function set(spec) {
+    if (disposed) return;
+    const want = !!(spec && spec.on);
+    // re-clamp here as well as in the schedule: this is the last line before
+    // the pixels, and it is the one a future caller will forget
+    px = want ? Math.min(cap, Math.max(0, spec.px || 0)) : 0;
+    ctx.stageFilter.set('blur', px > 0.02 ? `blur(${px.toFixed(2)}px)` : '');
+  }
+
+  function clear() { px = 0; ctx.stageFilter.set('blur', ''); }
+
+  return {
+    set, clear,
+    dispose() { disposed = true; clear(); },
+    get px() { return px; },
+    fire() {}, show() {}, grab() {}, move() {}, drop() {},
+  };
+}
+
+export default createBlur;

--- a/ConditioningControlPanel/Resources/web/piecebypiece/ramp/layers/flash.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/ramp/layers/flash.js
@@ -1,0 +1,69 @@
+/* ============================================================================
+ * layers/flash.js - flash images popping at the edges and over the board.
+ *
+ * The DtRH scattered-image burst (payloadFx.flash), re-aimed at a chess board:
+ * most spawns hug the EDGES so the board stays readable early, and the hotter
+ * it gets the more of them land dead over the pieces. One image per pop, a hard
+ * live cap, and every node self-removes on animationend with a timer as a net.
+ * ==========================================================================*/
+
+/** Where a flash lands. Edge bands early, over the board once it is hot. */
+function place(ctx, heat) {
+  const overBoard = ctx.rng() < 0.18 + 0.42 * heat;
+  if (overBoard) return { left: ctx.rand(30, 70), top: ctx.rand(28, 70) };
+  // four edge bands, picked evenly, so pops ring the board instead of stacking
+  switch (ctx.randInt(0, 3)) {
+    case 0: return { left: ctx.rand(4, 96), top: ctx.rand(2, 16) };
+    case 1: return { left: ctx.rand(4, 96), top: ctx.rand(82, 96) };
+    case 2: return { left: ctx.rand(2, 16), top: ctx.rand(6, 94) };
+    default: return { left: ctx.rand(84, 97), top: ctx.rand(6, 94) };
+  }
+}
+
+export function createFlash(ctx) {
+  const t = (ctx.tuning && ctx.tuning.flash) || { maxLive: 6 };
+  let live = 0;
+  let disposed = false;
+  const nodes = new Set();
+
+  function fire(opts = {}) {
+    if (disposed || !ctx.hasRoot() || live >= t.maxLive) return;
+    const heat = Math.min(1, Math.max(0, opts.heat == null ? 0.5 : opts.heat));
+    const url = ctx.image() || ctx.tile();
+    if (!url) return;                     // no pictures at all: nothing to pop
+    const img = ctx.el('img', 'pbp-flash');
+    if (!img) return;
+    const at = place(ctx, heat);
+    // hotter = quicker and punchier, so a busy board reads as a strobe
+    const dur = Math.round(ctx.rand(1500, 2100) - heat * 700);
+    img.style.left = at.left + 'vw';
+    img.style.top = at.top + 'vh';
+    img.style.setProperty('--pbp-dur', dur + 'ms');
+    img.style.setProperty('--pbp-rot', ctx.rand(-9, 9).toFixed(2) + 'deg');
+    img.style.setProperty('--pbp-size', (16 + heat * 16).toFixed(1) + 'vmin');
+    img.style.setProperty('--pbp-peak', (0.55 + heat * 0.4).toFixed(2));
+    img.decoding = 'async';
+    img.src = url;
+
+    live += 1;
+    nodes.add(img);
+    const kill = () => {
+      if (!nodes.delete(img)) return;
+      live = Math.max(0, live - 1);
+      try { img.remove(); } catch { /* already gone */ }
+    };
+    img.addEventListener('animationend', kill, { once: true });
+    img.addEventListener('error', kill, { once: true });   // a dead url must not hold a slot
+    setTimeout(kill, dur + 700);                           // net for a missed animationend
+    ctx.mount(img);
+  }
+
+  function clear() {
+    for (const n of [...nodes]) { nodes.delete(n); try { n.remove(); } catch { /* gone */ } }
+    live = 0;
+  }
+
+  return { fire, clear, dispose() { disposed = true; clear(); }, set() {}, show() {}, grab() {}, move() {}, drop() {} };
+}
+
+export default createFlash;

--- a/ConditioningControlPanel/Resources/web/piecebypiece/ramp/layers/gifrain.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/ramp/layers/gifrain.js
@@ -1,0 +1,59 @@
+/* ============================================================================
+ * layers/gifrain.js - gifs falling down the screen, sprite count capped.
+ *
+ * The DtRH gif cascade (payloadFx.gifCascade), inverted: DtRH ran a 6s window
+ * with its own spawn timer, but here the ramp's schedule already fires this
+ * kind on a heat-scaled cadence, so ONE fire() is ONE sprite and the density
+ * falls out of the meter for free. A capture burst simply calls fire() several
+ * times in a row.
+ *
+ * When the media pool has no gifs the sprites become generated pink noise tiles
+ * rather than nothing, so an empty library still rains.
+ * ==========================================================================*/
+
+export function createGifRain(ctx) {
+  const t = (ctx.tuning && ctx.tuning.gifRain) || { maxLive: 12, fallMsMin: 2400, fallMsMax: 3900 };
+  let live = 0;
+  let disposed = false;
+  const nodes = new Set();
+
+  function fire(opts = {}) {
+    if (disposed || !ctx.hasRoot() || live >= t.maxLive) return;
+    const heat = Math.min(1, Math.max(0, opts.heat == null ? 0.5 : opts.heat));
+    const url = ctx.tile();
+    if (!url) return;
+    const img = ctx.el('img', 'pbp-rain');
+    if (!img) return;
+    // hotter rain falls faster and lands bigger; the left lane is free choice
+    const fall = Math.round(ctx.rand(t.fallMsMax, t.fallMsMin) - heat * 500);
+    img.style.left = ctx.rand(-2, 92).toFixed(1) + 'vw';
+    img.style.setProperty('--pbp-fall', Math.max(900, fall) + 'ms');
+    img.style.setProperty('--pbp-drift', ctx.rand(-9, 9).toFixed(1) + 'vw');
+    img.style.setProperty('--pbp-size', (11 + heat * 10).toFixed(1) + 'vmin');
+    img.style.setProperty('--pbp-peak', (0.5 + heat * 0.4).toFixed(2));
+    img.style.setProperty('--pbp-spin', ctx.rand(-24, 24).toFixed(1) + 'deg');
+    img.decoding = 'async';
+    img.src = url;
+
+    live += 1;
+    nodes.add(img);
+    const kill = () => {
+      if (!nodes.delete(img)) return;
+      live = Math.max(0, live - 1);
+      try { img.remove(); } catch { /* already gone */ }
+    };
+    img.addEventListener('animationend', kill, { once: true });
+    img.addEventListener('error', kill, { once: true });
+    setTimeout(kill, Math.max(900, fall) + 800);
+    ctx.mount(img);
+  }
+
+  function clear() {
+    for (const n of [...nodes]) { nodes.delete(n); try { n.remove(); } catch { /* gone */ } }
+    live = 0;
+  }
+
+  return { fire, clear, dispose() { disposed = true; clear(); }, set() {}, show() {}, grab() {}, move() {}, drop() {} };
+}
+
+export default createGifRain;

--- a/ConditioningControlPanel/Resources/web/piecebypiece/ramp/layers/index.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/ramp/layers/index.js
@@ -1,59 +1,159 @@
 /* ============================================================================
  * ramp/layers/index.js - the layer stack the ramp drives.
  *
- * This file is the SEAM. `attachRamp` never talks to a layer directly: it hands
- * this stack a heat number and a list of kinds to fire, and the stack owns the
- * DOM. That keeps the meter/schedule math (which is node-testable) apart from
- * the pixels (which are not).
+ * This file is the SEAM. `attachRamp` never touches DOM: it hands this stack a
+ * heat number and a list of kinds to fire, and the stack owns the pixels. That
+ * keeps the meter/schedule math (node-testable) apart from the layers (not).
  *
- * Right now every method is a counted no-op, so the ramp is fully wired and
- * fully testable before a single pixel exists. The real layers (flash, gif
- * rain, melt, blur, spiral, overlay, video card, glitch grab) land on top of
- * this surface without the ramp changing.
+ * Two planes, both click-through: `root` (#fx) carries everything, `front`
+ * carries the video card so a tape can ride in front of the POV. One shared
+ * FILTER COMPOSER owns `#stage`'s CSS filter, because melt and blur both write
+ * it and the last one to touch style.filter would otherwise erase the other.
  * ==========================================================================*/
+
+import { createFlash } from './flash.js';
+import { createGifRain } from './gifrain.js';
+import { createMelt } from './melt.js';
+import { createBlur } from './blur.js';
+
+/** A layer that has not been built yet: every call is a safe no-op. */
+const NOOP = Object.freeze({ set() {}, fire() {}, show() {}, grab() {}, move() {}, drop() {}, clear() {}, dispose() {} });
+
+/**
+ * ONE owner for `#stage`'s filter. Layers contribute a named fragment and the
+ * composer writes the concatenation, so melt and blur stack instead of fight.
+ */
+export function createStageFilter(stage) {
+  const parts = new Map();
+  let armed = false;
+  function write() {
+    if (!stage) return;
+    const css = [...parts.values()].filter(Boolean).join(' ');
+    try {
+      if (!armed) { stage.classList.add('pbp-stage-fx'); armed = true; }
+      stage.style.filter = css;
+    } catch { /* the stage went away under us */ }
+  }
+  return {
+    set(name, css) { if (css) parts.set(name, css); else parts.delete(name); write(); },
+    clear() { parts.clear(); write(); },
+    dispose() {
+      parts.clear();
+      if (!stage) return;
+      try { stage.style.filter = ''; stage.classList.remove('pbp-stage-fx'); } catch { /* gone */ }
+    },
+  };
+}
+
+/** The helpers every layer gets, so no layer re-implements random or mounting. */
+function makeCtx(ctx) {
+  const rng = typeof ctx.rng === 'function' ? ctx.rng : Math.random;
+  const media = ctx.media || null;
+  return {
+    ...ctx,
+    rng,
+    rand: (lo, hi) => lo + rng() * (hi - lo),
+    randInt: (lo, hi) => Math.floor(lo + rng() * (hi - lo + 1)),
+    pick: (arr) => arr[Math.floor(rng() * arr.length)],
+    /** A detached element, class already set. Null when there is no document. */
+    el(tag, cls) {
+      try {
+        const e = document.createElement(tag);
+        if (cls) e.className = cls;
+        return e;
+      } catch { return null; }
+    },
+    mount(e) { try { if (ctx.root && e) ctx.root.appendChild(e); } catch { /* no root */ } return e; },
+    mountFront(e) {
+      const host = ctx.front || ctx.root;
+      try { if (host && e) host.appendChild(e); } catch { /* no host */ }
+      return e;
+    },
+    /** A gif url, or a generated pink noise tile when the pool has no gifs. */
+    tile: () => (media && media.drawTile ? media.drawTile() : null),
+    image: () => (media && media.draw ? media.draw('image') : null),
+    video: () => (media && media.draw ? media.draw('video') : null),
+    hasRoot: () => !!ctx.root,
+  };
+}
 
 /**
  * createLayerStack(ctx) - ctx is { root, front, stage, media, tuning, rng }.
- * Every method must be safe to call with a missing root, stage or media.
+ * Every method must survive a missing root, a missing stage and empty media.
  */
 export function createLayerStack(ctx = {}) {
+  const base = makeCtx(ctx);
+  base.stageFilter = createStageFilter(ctx.stage || null);
+
+  const oneshot = {
+    flash: safe(() => createFlash(base)),
+    gifRain: safe(() => createGifRain(base)),
+  };
+  const sustained = {
+    melt: safe(() => createMelt(base)),
+    blur: safe(() => createBlur(base)),
+    spiral: NOOP,     // b2b
+    overlay: NOOP,    // b2b
+  };
+  const card = NOOP;  // b2b: the video card
+  const drag = NOOP;  // b2b: the glitch tile under a dragged piece
+
   const counts = { flash: 0, gifRain: 0, burst: 0, videoCard: 0, grab: 0, drop: 0 };
-  const sustained = { melt: null, blur: null, spiral: null, overlay: null };
   let disposed = false;
 
-  return {
-    /** Fire one transient effect of `kind` at this heat. */
-    oneshot(kind) {
+  /** A layer that throws while being built must not take the ramp with it. */
+  function safe(build) {
+    try { return build() || NOOP; } catch (e) {
+      try { console.warn('[pbp/ramp] layer failed to build: ' + (e && e.message)); } catch { /* no console */ }
+      return NOOP;
+    }
+  }
+
+  const api = {
+    oneshot(kind, opts) {
       if (disposed) return;
-      if (counts[kind] == null) counts[kind] = 0;
-      counts[kind] += 1;
+      const layer = oneshot[kind];
+      if (!layer) return;
+      counts[kind] = (counts[kind] || 0) + 1;
+      try { layer.fire(opts || {}); } catch { /* one bad spawn is not a crash */ }
     },
-    /** A capture kick: several one-shots at once, weighted by the burst spec. */
     burst(spec) {
       if (disposed || !spec) return;
       counts.burst += 1;
-      for (let i = 0; i < (spec.flashes || 0); i++) this.oneshot('flash');
-      for (let i = 0; i < (spec.gifs || 0); i++) this.oneshot('gifRain');
+      for (let i = 0; i < (spec.flashes || 0); i++) api.oneshot('flash', spec);
+      for (let i = 0; i < (spec.gifs || 0); i++) api.oneshot('gifRain', spec);
     },
-    /** Turn a sustained layer on/off and retune it. `spec` comes from schedule. */
     setSustained(name, spec) {
-      if (disposed || !(name in sustained)) return;
-      sustained[name] = spec || null;
+      if (disposed) return;
+      const layer = sustained[name];
+      if (!layer) return;
+      try { layer.set(spec || { on: false }); } catch { /* a retune is never fatal */ }
     },
-    /** The video card: rises at the POV, holds, slides out the bottom. */
-    videoCard() { if (!disposed) counts.videoCard += 1; },
-    /** Drag handling: a glitch tile pinned to the piece under the cursor. */
-    grab() { if (!disposed) counts.grab += 1; },
-    dragmove() { /* per-frame; the real stack moves the tile here */ },
-    drop() { if (!disposed) counts.drop += 1; },
-    /** Snap everything off without a fade (suspend / dispose). */
+    videoCard(opts) {
+      if (disposed) return;
+      counts.videoCard += 1;
+      try { card.show(opts || {}); } catch { /* no card is fine */ }
+    },
+    grab(p) { if (!disposed) { counts.grab += 1; try { drag.grab(p); } catch { /* ignore */ } } },
+    dragmove(p) { if (!disposed) { try { drag.move(p); } catch { /* per-frame, stay quiet */ } } },
+    drop(p) { if (!disposed) { counts.drop += 1; try { drag.drop(p); } catch { /* ignore */ } } },
     clear() {
-      for (const k of Object.keys(sustained)) sustained[k] = null;
+      for (const l of [...Object.values(oneshot), ...Object.values(sustained), card, drag]) {
+        try { l.clear(); } catch { /* best effort */ }
+      }
+      base.stageFilter.clear();
     },
-    dispose() { disposed = true; this.clear(); },
-    /** Read-only view for the harness and the smoke tests. */
-    debug() { return { counts: { ...counts }, sustained: { ...sustained }, hasMedia: !!(ctx.media && ctx.media.size) }; },
+    dispose() {
+      if (disposed) return;
+      disposed = true;
+      for (const l of [...Object.values(oneshot), ...Object.values(sustained), card, drag]) {
+        try { l.dispose(); } catch { /* best effort */ }
+      }
+      base.stageFilter.dispose();
+    },
+    debug() { return { counts: { ...counts }, hasMedia: !!(ctx.media && ctx.media.size) }; },
   };
+  return api;
 }
 
 export default createLayerStack;

--- a/ConditioningControlPanel/Resources/web/piecebypiece/ramp/layers/melt.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/ramp/layers/melt.js
@@ -1,0 +1,68 @@
+/* ============================================================================
+ * layers/melt.js - the pink melt: the board bleeds colour and softens.
+ *
+ * Two halves, the DtRH/Arcademy brain-drain look split by what it acts on:
+ *
+ *   1. a CSS FILTER on #stage (saturate + hue-rotate toward pink + a little
+ *      contrast loss) contributed through the shared stage-filter composer, so
+ *      it stacks with blur rather than overwriting it;
+ *   2. a DOM VEIL in #fx - the .sf-pfx-pink radial wash, screen-blended, with a
+ *      slow breathing drift so it reads as a melt and not as a flat gel.
+ *
+ * ONE element for the whole game (the DtRH holdOn posture): a retune writes
+ * opacity, it never appends a second veil.
+ * ==========================================================================*/
+
+export function createMelt(ctx) {
+  let veil = null;
+  let disposed = false;
+  let on = false;
+
+  function ensure() {
+    if (veil || disposed) return veil;
+    veil = ctx.el('div', 'pbp-melt');
+    ctx.mount(veil);
+    return veil;
+  }
+
+  /** spec is schedule.sustainedFor().melt: { on, alpha }. */
+  function set(spec) {
+    if (disposed) return;
+    const want = !!(spec && spec.on);
+    const alpha = want ? Math.min(1, Math.max(0, spec.alpha || 0)) : 0;
+
+    // the stage filter: how far the board has bled. Kept gentle - the melt is
+    // meant to make the board unpleasant to read, never to hide which square
+    // a piece is on (that job belongs to the layers above it).
+    ctx.stageFilter.set('melt', want
+      ? `saturate(${(1 + alpha * 1.5).toFixed(2)}) hue-rotate(${(-alpha * 26).toFixed(1)}deg) contrast(${(1 - alpha * 0.22).toFixed(2)})`
+      : '');
+
+    const el = want ? ensure() : veil;
+    if (!el) return;
+    try {
+      el.style.opacity = String(alpha);
+      el.classList.toggle('is-on', want);
+      // the drift slows as it deepens: a fast wobble reads as noise, a slow one
+      // as the board sinking
+      el.style.setProperty('--pbp-melt-ms', Math.round(9000 - alpha * 3200) + 'ms');
+    } catch { /* the veil went away under us */ }
+    on = want;
+  }
+
+  function clear() {
+    on = false;
+    ctx.stageFilter.set('melt', '');
+    if (veil) { try { veil.style.opacity = '0'; veil.classList.remove('is-on'); } catch { /* gone */ } }
+  }
+
+  function dispose() {
+    disposed = true;
+    clear();
+    if (veil) { try { veil.remove(); } catch { /* gone */ } veil = null; }
+  }
+
+  return { set, clear, dispose, get on() { return on; }, fire() {}, show() {}, grab() {}, move() {}, drop() {} };
+}
+
+export default createMelt;

--- a/ConditioningControlPanel/Resources/web/piecebypiece/ramp/ramp.css
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/ramp/ramp.css
@@ -34,3 +34,61 @@
 @media (prefers-reduced-motion: reduce) {
   .pbp-fx *, .pbp-fx-front * { animation-duration: 0.001ms !important; animation-iteration-count: 1 !important; }
 }
+
+/* ===========================================================================
+ * ONE-SHOTS
+ * ==========================================================================*/
+
+/* flash pops: an image punched over the board or ringing its edges. Sized and
+ * timed from custom properties the layer sets, so the animation is shared. */
+.pbp-flash {
+  position: absolute;
+  width: var(--pbp-size, 22vmin);
+  max-width: 38vmin; max-height: 38vmin;
+  border-radius: 10px;
+  filter: drop-shadow(0 0 26px rgba(255, 105, 180, 0.85));
+  animation: pbp-flash-pop var(--pbp-dur, 1600ms) ease forwards;
+  will-change: transform, opacity;
+}
+@keyframes pbp-flash-pop {
+  0%   { opacity: 0; transform: translate(-50%, -50%) rotate(var(--pbp-rot, 0deg)) scale(0.8); }
+  13%  { opacity: var(--pbp-peak, 0.85); transform: translate(-50%, -50%) rotate(var(--pbp-rot, 0deg)) scale(1); }
+  70%  { opacity: var(--pbp-peak, 0.85); transform: translate(-50%, -50%) rotate(var(--pbp-rot, 0deg)) scale(1.02); }
+  100% { opacity: 0; transform: translate(-50%, -50%) rotate(var(--pbp-rot, 0deg)) scale(1.07); }
+}
+
+/* falling gifs: one sprite per spawn, drifting sideways as it goes. */
+.pbp-rain {
+  position: absolute; top: -28vh;
+  width: var(--pbp-size, 14vmin);
+  border-radius: 8px;
+  filter: drop-shadow(0 0 14px rgba(255, 105, 180, 0.7));
+  animation: pbp-rain-fall var(--pbp-fall, 3200ms) linear forwards;
+  will-change: transform, opacity;
+}
+@keyframes pbp-rain-fall {
+  0%   { opacity: 0; transform: translate(0, 0) scale(0.5) rotate(0deg); }
+  12%  { opacity: var(--pbp-peak, 0.85); }
+  88%  { opacity: var(--pbp-peak, 0.85); }
+  100% { opacity: 0; transform: translate(var(--pbp-drift, 0), 145vh) scale(1) rotate(var(--pbp-spin, 0deg)); }
+}
+
+/* ===========================================================================
+ * SUSTAINED
+ * ==========================================================================*/
+
+/* the melt veil: a pink wash that breathes. ONE element for the whole game -
+ * a retune writes opacity, it never appends a second veil. */
+.pbp-melt {
+  position: absolute; inset: -12%;
+  background:
+    radial-gradient(circle at 50% 42%, rgba(255, 150, 205, 0.62) 0%, rgba(255, 20, 147, 0.7) 62%, rgba(120, 0, 70, 0.55) 100%);
+  mix-blend-mode: screen;
+  opacity: 0; transition: opacity 520ms ease;
+  will-change: opacity, transform;
+}
+.pbp-melt.is-on { animation: pbp-melt-drift var(--pbp-melt-ms, 9000ms) ease-in-out infinite alternate; }
+@keyframes pbp-melt-drift {
+  from { transform: translate(-1.5%, -1%) scale(1.02); }
+  to   { transform: translate(1.5%, 1.6%) scale(1.09); }
+}


### PR DESCRIPTION
The first four ramp layers, plus the registry that owns them. Stacked on #956.

**`flash.js`** - the DtRH scattered-image burst re-aimed at a chess board: most pops hug the **edges** so the board stays readable early, and the hotter it gets the more land dead over the pieces. Hard live cap; every node self-removes on `animationend`, with a timer as a net and an `error` handler so a dead url never holds a slot.

**`gifrain.js`** inverts the DtRH cascade. DtRH ran its own 6s spawn window, but the ramp's schedule already fires this kind on a heat-scaled cadence, so one `fire()` is one falling sprite and the density falls out of the meter for free. A capture burst is just several `fire()`s in a row. With no gifs in the pool the sprites become generated pink noise tiles, so an empty library still rains.

**`melt.js`** - the pink brain-drain look, split by what it acts on: a CSS filter on `#stage` (saturate, hue toward pink, a little contrast loss) plus a breathing radial veil in `#fx`. One element for the whole game, the DtRH `holdOn` posture: a retune writes opacity, it never appends a second veil.

**`blur.js`** is deliberately tiny, and the cap is the point. 3px, re-clamped here even though the schedule already clamped it, because this is the last line before the pixels and it is the one a future caller will forget. At 3px a piece is still findable and a legal move is still physically possible. The layers that genuinely hide the board are separate, and can be waited out.

The registry gains a shared **stage filter composer**: melt and blur both write `style.filter`, and whichever ran last would otherwise erase the other. Layers contribute a named fragment and the composer writes the concatenation. A layer that throws while being built is swapped for a no-op rather than taking the ramp down.

The harness grows `?prime=N` and a comma-list `?fire=`, because headless msedge under a virtual time budget serves only a couple of rAF beats and a screenshot cannot wait for the cadence.

Verified headless at meter 0.3 (melt only, board crisp, pops ringing the edges) and 0.9 (melt plus blur, pops over the board), zero console errors, one composed filter string carrying both contributions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S4BKp6cQJFNixoQrarvSkd