### PR TITLE
feat(pbp): the spiral veil, gif overlay, video card and drag glitch

### DIFF
--- a/ConditioningControlPanel/Resources/web/piecebypiece/dev/ramp.html
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/dev/ramp.html
@@ -187,7 +187,15 @@ meterEl.addEventListener('input', applyMeter);
 /* ?meter=, ?fire= and ?prime= drive the screenshot pass */
 if (qs.has('meter')) { meterEl.value = Math.round(Number(qs.get('meter')) * 100); applyMeter(); }
 if (qs.has('prime')) ramp.debug().prime(Number(qs.get('prime')) || 5);
-if (qs.has('fire')) for (const kind of qs.get('fire').split(',')) ramp.debug().fire(kind.trim());
+/* a fire name is either a harness event (grab, cap-w, check, ...) or a layer
+   the ramp can fire directly (flash, gifRain, videoCard) */
+if (qs.has('fire')) {
+  for (const raw of qs.get('fire').split(',')) {
+    const kind = raw.trim();
+    if (actions[kind]) actions[kind]();
+    else ramp.debug().fire(kind);
+  }
+}
 
 const out = document.getElementById('out');
 setInterval(() => {

--- a/ConditioningControlPanel/Resources/web/piecebypiece/ramp/layers/glitchgrab.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/ramp/layers/glitchgrab.js
@@ -1,0 +1,82 @@
+/* ============================================================================
+ * layers/glitchgrab.js - a glitching tile stuck to the piece you are dragging.
+ *
+ * On `grab` a small tile appears over the projected screen position of the
+ * dragged piece and shudders there; every `dragmove` moves it; `drop` removes
+ * it. So the one thing the player most needs to see - the piece in their hand -
+ * is the one thing wearing a glitch.
+ *
+ * ONE reused element (grab/drop can fire many times a game), moved by transform
+ * only, so a per-frame dragmove never touches layout. The tile is deliberately
+ * SMALLER than the piece it covers is tall: it should sit on the piece like a
+ * sticker, not blot out the destination square.
+ *
+ * `screen` comes from the board's own projection (A's projectSquare feeds it),
+ * so this layer never needs to know where anything is in 3D.
+ * ==========================================================================*/
+
+export function createGlitchGrab(ctx) {
+  const t = (ctx.tuning && ctx.tuning.glitchGrab) || { sizePx: 132, alpha: 0.85 };
+  let el = null;
+  let disposed = false;
+  let holding = false;
+  let raf = 0;
+  let pending = null;
+
+  function ensure() {
+    if (el || disposed) return el;
+    el = ctx.el('div', 'pbp-grab');
+    if (el) {
+      el.style.setProperty('--pbp-grab-size', (t.sizePx || 132) + 'px');
+      ctx.mount(el);
+    }
+    return el;
+  }
+
+  /** Write the transform on the next frame, so a 120Hz drag writes once. */
+  function flush() {
+    raf = 0;
+    if (!el || !pending || disposed) return;
+    try { el.style.transform = `translate3d(${pending.x}px, ${pending.y}px, 0) translate(-50%, -50%)`; } catch { /* gone */ }
+  }
+
+  function moveTo(screen) {
+    if (!screen || !Number.isFinite(screen.x) || !Number.isFinite(screen.y)) return;
+    pending = { x: Math.round(screen.x), y: Math.round(screen.y) };
+    if (raf) return;
+    try { raf = requestAnimationFrame(flush); } catch { flush(); }
+  }
+
+  function grab(p) {
+    if (disposed) return;
+    const node = ensure();
+    if (!node) return;
+    const url = ctx.tile();
+    try {
+      if (url) node.style.backgroundImage = `url("${url}")`;
+      node.style.opacity = String(t.alpha == null ? 0.85 : t.alpha);
+      node.classList.add('is-on');
+    } catch { /* gone */ }
+    holding = true;
+    moveTo(p && p.screen);
+  }
+
+  function move(p) { if (holding && !disposed) moveTo(p && p.screen); }
+
+  function drop() {
+    holding = false;
+    if (el) { try { el.classList.remove('is-on'); el.style.opacity = '0'; } catch { /* gone */ } }
+  }
+
+  function clear() { drop(); }
+
+  function dispose() {
+    disposed = true;
+    if (raf) { try { cancelAnimationFrame(raf); } catch { /* ignore */ } raf = 0; }
+    if (el) { try { el.remove(); } catch { /* gone */ } el = null; }
+  }
+
+  return { grab, move, drop, clear, dispose, get holding() { return holding; }, set() {}, fire() {}, show() {} };
+}
+
+export default createGlitchGrab;

--- a/ConditioningControlPanel/Resources/web/piecebypiece/ramp/layers/index.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/ramp/layers/index.js
@@ -15,6 +15,10 @@ import { createFlash } from './flash.js';
 import { createGifRain } from './gifrain.js';
 import { createMelt } from './melt.js';
 import { createBlur } from './blur.js';
+import { createSpiral } from './spiral.js';
+import { createOverlay } from './overlay.js';
+import { createVideoCard } from './videocard.js';
+import { createGlitchGrab } from './glitchgrab.js';
 
 /** A layer that has not been built yet: every call is a safe no-op. */
 const NOOP = Object.freeze({ set() {}, fire() {}, show() {}, grab() {}, move() {}, drop() {}, clear() {}, dispose() {} });
@@ -92,11 +96,11 @@ export function createLayerStack(ctx = {}) {
   const sustained = {
     melt: safe(() => createMelt(base)),
     blur: safe(() => createBlur(base)),
-    spiral: NOOP,     // b2b
-    overlay: NOOP,    // b2b
+    spiral: safe(() => createSpiral(base)),
+    overlay: safe(() => createOverlay(base)),
   };
-  const card = NOOP;  // b2b: the video card
-  const drag = NOOP;  // b2b: the glitch tile under a dragged piece
+  const card = safe(() => createVideoCard(base));
+  const drag = safe(() => createGlitchGrab(base));
 
   const counts = { flash: 0, gifRain: 0, burst: 0, videoCard: 0, grab: 0, drop: 0 };
   let disposed = false;

--- a/ConditioningControlPanel/Resources/web/piecebypiece/ramp/layers/overlay.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/ramp/layers/overlay.js
@@ -1,0 +1,69 @@
+/* ============================================================================
+ * layers/overlay.js - the fullscreen gif overlay.
+ *
+ * The last sustained layer to unlock (meter .70). One element covering the
+ * whole plane with a single looping gif at a low alpha, re-picked every few
+ * seconds so it never settles into wallpaper. It is the top of the ramp: by the
+ * time this is on, the player is reading the board through a moving picture.
+ *
+ * Semi-transparent by design and click-through like everything else, so the
+ * board underneath is dimmed and distracting rather than gone. With no gifs in
+ * the pool it wears a generated pink noise tile instead of vanishing.
+ * ==========================================================================*/
+
+const REDRESS_MS = 6500;   // how often the overlay swaps its picture
+
+export function createOverlay(ctx) {
+  let el = null;
+  let disposed = false;
+  let on = false;
+  let timer = 0;
+
+  function ensure() {
+    if (el || disposed) return el;
+    el = ctx.el('div', 'pbp-overlay');
+    ctx.mount(el);
+    return el;
+  }
+
+  function dress() {
+    if (!el || disposed) return;
+    const url = ctx.tile();
+    try { if (url) el.style.backgroundImage = `url("${url}")`; } catch { /* gone */ }
+  }
+
+  function arm() {
+    if (timer || disposed) return;
+    timer = setInterval(() => { if (on && !disposed) dress(); }, REDRESS_MS);
+  }
+
+  /** spec is schedule.sustainedFor().overlay: { on, alpha }. */
+  function set(spec) {
+    if (disposed) return;
+    const want = !!(spec && spec.on);
+    const alpha = want ? Math.min(1, Math.max(0, spec.alpha || 0)) : 0;
+    if (want && !el) { ensure(); dress(); }
+    if (want) arm();
+    if (!el) return;
+    try {
+      el.style.opacity = String(alpha);
+      el.classList.toggle('is-on', want);
+    } catch { /* gone */ }
+    on = want;
+  }
+
+  function clear() {
+    on = false;
+    if (el) { try { el.style.opacity = '0'; el.classList.remove('is-on'); } catch { /* gone */ } }
+  }
+
+  function dispose() {
+    disposed = true;
+    if (timer) { clearInterval(timer); timer = 0; }
+    if (el) { try { el.remove(); } catch { /* gone */ } el = null; }
+  }
+
+  return { set, clear, dispose, get on() { return on; }, fire() {}, show() {}, grab() {}, move() {}, drop() {} };
+}
+
+export default createOverlay;

--- a/ConditioningControlPanel/Resources/web/piecebypiece/ramp/layers/spiral.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/ramp/layers/spiral.js
@@ -1,0 +1,87 @@
+/* ============================================================================
+ * layers/spiral.js - the fullscreen spiral veil.
+ *
+ * The DtRH .sf-pfx-spiral posture, ported: ONE element for the whole game,
+ * screen-blended, spinning slowly, over-scanned so a rotation never bares a
+ * corner. What is ported is the structure and the envelope, not the artwork -
+ * the image comes from the player's own pool, and when the pool has no gif the
+ * element falls back to a CSS pinwheel so Piece by Piece never has to reach
+ * into another game's asset folder.
+ *
+ * Unlike melt and blur this one PULSES rather than sitting on: it unlocks at
+ * meter .55 and then comes and goes, and what grows with the meter is how long
+ * each pass holds. A veil you can wait out is a veil the player learns to wait
+ * out, which is the whole trick.
+ * ==========================================================================*/
+
+export function createSpiral(ctx) {
+  const t = (ctx.tuning && ctx.tuning.spiral) || { gapMs: 9000 };
+  let el = null;
+  let disposed = false;
+  let showing = false;
+  let lastEndAt = -Infinity;
+  let holdTimer = 0;
+  let spec = { on: false, alpha: 0, holdMs: 0 };
+
+  const now = () => (typeof performance !== 'undefined' && performance.now ? performance.now() : Date.now());
+
+  function ensure() {
+    if (el || disposed) return el;
+    el = ctx.el('div', 'pbp-spiral');
+    ctx.mount(el);
+    return el;
+  }
+
+  /** Re-pick the imagery for this pass: a pool gif, else the CSS pinwheel. */
+  function dress(node) {
+    const url = ctx.tile();
+    try {
+      if (url) { node.style.backgroundImage = `url("${url}")`; node.classList.remove('is-drawn'); }
+      else { node.style.backgroundImage = ''; node.classList.add('is-drawn'); }
+      // a hotter veil turns faster, which reads as being pulled in harder
+      node.style.setProperty('--pbp-spiral-ms', Math.round(20000 - (spec.alpha || 0) * 12000) + 'ms');
+    } catch { /* the veil went away under us */ }
+  }
+
+  function hide() {
+    showing = false;
+    lastEndAt = now();
+    if (holdTimer) { clearTimeout(holdTimer); holdTimer = 0; }
+    if (el) { try { el.style.opacity = '0'; el.classList.remove('is-on'); } catch { /* gone */ } }
+  }
+
+  function show() {
+    const node = ensure();
+    if (!node) return;
+    showing = true;
+    dress(node);
+    try { node.style.opacity = String(spec.alpha || 0); node.classList.add('is-on'); } catch { /* gone */ }
+    if (holdTimer) clearTimeout(holdTimer);
+    holdTimer = setTimeout(() => { holdTimer = 0; if (!disposed) hide(); }, Math.max(600, spec.holdMs || 1400));
+  }
+
+  /** spec is schedule.sustainedFor().spiral: { on, alpha, holdMs }. */
+  function set(next) {
+    if (disposed) return;
+    spec = next || { on: false, alpha: 0, holdMs: 0 };
+    if (!spec.on) { if (showing) hide(); return; }
+    if (showing) {
+      // a retune mid-pass just refreshes the strength, it never restarts
+      if (el) { try { el.style.opacity = String(spec.alpha || 0); } catch { /* gone */ } }
+      return;
+    }
+    if (now() - lastEndAt >= (t.gapMs || 9000)) show();
+  }
+
+  function clear() { hide(); }
+
+  function dispose() {
+    disposed = true;
+    if (holdTimer) { clearTimeout(holdTimer); holdTimer = 0; }
+    if (el) { try { el.remove(); } catch { /* gone */ } el = null; }
+  }
+
+  return { set, clear, dispose, get showing() { return showing; }, fire() {}, show() {}, grab() {}, move() {}, drop() {} };
+}
+
+export default createSpiral;

--- a/ConditioningControlPanel/Resources/web/piecebypiece/ramp/layers/videocard.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/ramp/layers/videocard.js
@@ -1,0 +1,102 @@
+/* ============================================================================
+ * layers/videocard.js - the tape that rides in front of the POV.
+ *
+ * The DtRH video card (payloadFx.videoCard), re-choreographed for a board game:
+ * the tape RUSHES UP AT THE POV from the top of the screen, HOLDS there
+ * semi-transparent over the board, then SLIDES OUT THE BOTTOM. One card at a
+ * time, on the FRONT plane, in a vibrating electric cage.
+ *
+ * It fires on every `turn`, for the side that just moved and is now WAITING, so
+ * the tape covers exactly the stretch where the player has nothing to do but
+ * look. Hold time is scaled by that side's meter (RAMP_TUNING.videoCard, 4s to
+ * 13s). Semi-transparent, so the board is legible THROUGH it - and the card is
+ * click-through like every other layer, so the player can still reach a piece
+ * underneath. Having to play through it is the point; being unable to is not.
+ *
+ * Mechanics carried over from DtRH because they were paid for in bug reports:
+ *   - a plain <video> with NO crossOrigin, so a remote pool url still plays;
+ *   - born muted, since a card that talks over the game is a different feature;
+ *   - a random start offset, so the same clip is never the same card;
+ *   - an explicit unload on removal (removeAttribute('src') + load()), because
+ *     Chromium counts a merely removed element's decoder against the per-page
+ *     media cap until GC.
+ * ==========================================================================*/
+
+export function createVideoCard(ctx) {
+  const t = (ctx.tuning && ctx.tuning.videoCard) || { riseMs: 620, startJitter: 0.7 };
+  let card = null;      // the one live card
+  let disposed = false;
+  let timers = [];
+
+  const track = (id) => { timers.push(id); return id; };
+  const untrack = () => { for (const id of timers) clearTimeout(id); timers = []; };
+
+  function show(opts = {}) {
+    if (disposed || card) return;                    // one card at a time
+    const url = ctx.video();
+    if (!url) return;                                // no clips in the pool: skip
+    const wrap = ctx.el('div', 'pbp-card');
+    const frame = ctx.el('div', 'pbp-card-frame');
+    const vid = ctx.el('video', null);
+    if (!wrap || !frame || !vid) return;
+
+    vid.loop = true; vid.playsInline = true; vid.autoplay = true; vid.muted = true;
+    vid.preload = 'auto';
+    // a random start offset so the same clip never opens on the same frame
+    vid.addEventListener('loadedmetadata', () => {
+      try {
+        const d = vid.duration;
+        if (Number.isFinite(d) && d > 1) vid.currentTime = ctx.rand(0, d * (t.startJitter || 0.7));
+      } catch { /* seeking is best effort */ }
+    }, { once: true });
+    vid.src = url;
+    frame.appendChild(vid);
+    wrap.appendChild(frame);
+    ctx.mountFront(wrap);
+    card = wrap;
+
+    const play = () => { try { const p = vid.play(); if (p && p.catch) p.catch(() => {}); } catch { /* blocked */ } };
+    play();
+
+    let removed = false;
+    function remove() {
+      if (removed) return;
+      removed = true;
+      try { wrap.classList.remove('is-in'); wrap.classList.add('is-out'); } catch { /* gone */ }
+      try { vid.pause(); } catch { /* gone */ }
+      // explicit unload: a removed element's decoder counts against Chromium's
+      // per-page media cap until GC, and this card fires every single turn
+      track(setTimeout(() => {
+        try { vid.removeAttribute('src'); vid.load(); } catch { /* gone */ }
+        try { wrap.remove(); } catch { /* gone */ }
+        if (card === wrap) card = null;
+      }, 760));
+    }
+
+    // rush at the face on the next frame, hold, then slide out the bottom
+    try { requestAnimationFrame(() => { if (!disposed && !removed) wrap.classList.add('is-in'); }); } catch { wrap.classList.add('is-in'); }
+    const holdMs = Math.max(1200, opts.holdMs || 6000);
+    track(setTimeout(remove, holdMs));
+    card = wrap;
+    card._remove = remove;
+  }
+
+  function clear() {
+    untrack();
+    if (card) {
+      const c = card;
+      try { if (c._remove) c._remove(); else c.remove(); } catch { /* gone */ }
+      if (card === c) card = null;
+    }
+  }
+
+  function dispose() {
+    disposed = true;
+    untrack();
+    if (card) { try { card.remove(); } catch { /* gone */ } card = null; }
+  }
+
+  return { show, clear, dispose, get live() { return !!card; }, set() {}, fire() {}, grab() {}, move() {}, drop() {} };
+}
+
+export default createVideoCard;

--- a/ConditioningControlPanel/Resources/web/piecebypiece/ramp/ramp.css
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/ramp/ramp.css
@@ -92,3 +92,118 @@
   from { transform: translate(-1.5%, -1%) scale(1.02); }
   to   { transform: translate(1.5%, 1.6%) scale(1.09); }
 }
+
+/* the spiral veil: ONE element, screen-blended, over-scanned so a rotation
+ * never bares a corner (the DtRH .sf-pfx-spiral posture). It PULSES rather than
+ * sitting on - the hold grows with the meter - so it can be waited out. */
+.pbp-spiral {
+  position: absolute; inset: 0;
+  background-position: center; background-size: cover; background-repeat: no-repeat;
+  mix-blend-mode: screen;
+  opacity: 0; transition: opacity 620ms ease;
+  transform-origin: 50% 50%; scale: 1.6;
+  will-change: opacity, transform;
+}
+.pbp-spiral.is-on { animation: pbp-spin var(--pbp-spiral-ms, 16000ms) linear infinite; }
+/* no gif in the pool: draw the spiral instead of reaching into another game's
+ * asset folder. A spun pinwheel reads the same at this opacity. */
+.pbp-spiral.is-drawn {
+  background-image:
+    repeating-conic-gradient(from 0deg at 50% 50%,
+      rgba(255, 105, 180, 0.9) 0deg 9deg, rgba(28, 8, 34, 0.9) 9deg 18deg);
+  -webkit-mask-image: radial-gradient(circle at 50% 50%, #000 26%, transparent 74%);
+  mask-image: radial-gradient(circle at 50% 50%, #000 26%, transparent 74%);
+}
+@keyframes pbp-spin { to { transform: rotate(360deg); } }
+
+/* the fullscreen gif overlay: the top of the ramp. Semi-transparent by design,
+ * so the board is dimmed and distracting rather than gone. */
+.pbp-overlay {
+  position: absolute; inset: 0;
+  background-position: center; background-size: cover; background-repeat: no-repeat;
+  background-color: rgba(24, 6, 30, 0.35);
+  mix-blend-mode: screen;
+  opacity: 0; transition: opacity 900ms ease, background-image 300ms ease;
+  will-change: opacity;
+}
+
+/* ===========================================================================
+ * THE VIDEO CARD (front plane)
+ * ==========================================================================*/
+
+/* rushes up at the POV from the top, holds semi-transparent over the board,
+ * slides out the bottom. Click-through like everything else: the player can
+ * still reach the piece underneath, they just cannot see it. */
+.pbp-card {
+  position: fixed; left: 50%; top: 50%;
+  width: min(72vmin, 88vw);
+  transform: translate(-50%, -186%) scale(0.42);
+  opacity: 0;
+  transition: transform 620ms cubic-bezier(0.16, 0.9, 0.3, 1), opacity 380ms ease;
+  will-change: transform, opacity;
+}
+.pbp-card.is-in { transform: translate(-50%, -50%) scale(1); opacity: 0.76; }
+.pbp-card.is-out {
+  transform: translate(-50%, 190%) scale(0.86); opacity: 0;
+  transition: transform 700ms cubic-bezier(0.5, 0, 0.75, 0), opacity 600ms ease;
+}
+/* the cage carries the shudder so its animation never fights the card's own
+ * transform transition (both would target transform) */
+.pbp-card-frame {
+  position: relative; border-radius: 14px; overflow: hidden;
+  border: 3px solid rgba(255, 46, 46, 0.95);
+  box-shadow: 0 0 0 3px rgba(255, 0, 0, 0.35), 0 0 42px rgba(255, 30, 30, 0.7),
+    0 0 96px rgba(255, 0, 40, 0.36), 0 18px 60px rgba(0, 0, 0, 0.6);
+  animation: pbp-card-shake 0.09s steps(2) infinite, pbp-card-arc 0.9s steps(3) infinite;
+}
+.pbp-card-frame::after {
+  content: ''; position: absolute; inset: 0; border-radius: 11px;
+  box-shadow: inset 0 0 26px rgba(255, 60, 60, 0.55), inset 0 0 5px rgba(255, 230, 230, 0.9);
+  mix-blend-mode: screen;
+  animation: pbp-card-flicker 0.14s steps(2) infinite;
+}
+/* aspect-ratio, not intrinsic size: a clip that has not reported its
+ * dimensions yet (or that this build cannot decode) would otherwise collapse
+ * the frame to a red line instead of a card */
+.pbp-card video {
+  display: block; width: 100%; max-height: 74vh;
+  aspect-ratio: 16 / 10; object-fit: cover;
+  background: #150a20;
+}
+@keyframes pbp-card-shake {
+  0%   { transform: translate(1px, -0.8px); }
+  25%  { transform: translate(-1.2px, 0.5px); }
+  50%  { transform: translate(0.7px, 1.1px); }
+  75%  { transform: translate(-0.6px, -1.1px); }
+  100% { transform: translate(1.1px, 0.6px); }
+}
+@keyframes pbp-card-arc {
+  0%, 14%, 26%, 52%, 66%, 100% { border-color: rgba(255, 46, 46, 0.95); }
+  18% { border-color: rgba(255, 214, 214, 1); }
+  58% { border-color: rgba(255, 150, 150, 1); }
+}
+@keyframes pbp-card-flicker { 0%, 100% { opacity: 0.5; } 45% { opacity: 1; } }
+
+/* ===========================================================================
+ * THE DRAG GLITCH
+ * ==========================================================================*/
+
+/* stuck to the piece in your hand. Smaller than the piece is tall, so it reads
+ * as a sticker on the piece and never blots out the destination square. */
+.pbp-grab {
+  position: fixed; left: 0; top: 0;
+  width: var(--pbp-grab-size, 132px); height: var(--pbp-grab-size, 132px);
+  background-position: center; background-size: cover; background-repeat: no-repeat;
+  border-radius: 8px;
+  opacity: 0; transition: opacity 140ms ease;
+  will-change: transform, opacity;
+}
+.pbp-grab.is-on {
+  animation: pbp-grab-glitch 0.13s steps(2) infinite;
+  filter: drop-shadow(0 0 16px rgba(255, 40, 90, 0.8));
+}
+@keyframes pbp-grab-glitch {
+  0%   { filter: hue-rotate(0deg) saturate(1.4) drop-shadow(0 0 16px rgba(255, 40, 90, 0.8)); }
+  50%  { filter: hue-rotate(48deg) saturate(2) drop-shadow(-3px 0 12px rgba(0, 220, 255, 0.7)); }
+  100% { filter: hue-rotate(-32deg) saturate(1.7) drop-shadow(3px 0 12px rgba(255, 0, 140, 0.8)); }
+}


### PR DESCRIPTION
The four layers that actually take the board away from you. Stacked on #959.

**`spiral.js`** - the DtRH `.sf-pfx-spiral` posture: one element, screen-blended, spinning, over-scanned so a rotation never bares a corner. What is ported is the structure and the envelope, not the artwork: the image comes from the player's own pool, and with no gif it falls back to a CSS pinwheel, so Piece by Piece never reaches into another game's asset folder. Unlike melt and blur this one **pulses** - it unlocks at meter .55 and then comes and goes, and what grows with the meter is how long each pass holds. A veil you can wait out is a veil the player learns to wait out.

**`overlay.js`** - the top of the ramp (meter .70): one gif over the whole plane at a low alpha, re-picked every few seconds so it never settles into wallpaper. Semi-transparent by design, so the board is dimmed and distracting rather than gone.

**`videocard.js`** - the DtRH card re-choreographed for a board game: the tape rushes up at the POV from the top, holds semi-transparent over the board, then slides out the bottom. One at a time, in the vibrating electric cage. It fires on **every** `turn`, for the side that just moved and is now waiting - exactly the stretch where the player has nothing to do but look - with the hold scaled by that side's meter (4s to 13s). Click-through like every other layer: having to play through it is the point, being unable to is not.

The mechanics that were paid for in DtRH bug reports come with it: a bare `<video>` with no `crossOrigin` so a remote pool url still plays, born muted, a random start offset so the same clip is never the same card, and an explicit unload on removal (`removeAttribute('src')` + `load()`), because Chromium counts a removed element's decoder against the per-page media cap until GC - and this card fires every single turn. The video carries an `aspect-ratio` rather than relying on intrinsic size, so a clip that has not reported its dimensions yet renders as a card instead of a red line (caught in a headless shot).

**`glitchgrab.js`** sticks a shuddering tile to the piece in your hand: it appears on `grab` at the board's own projected screen position, follows every `dragmove`, and goes on `drop`. One reused element moved by transform only and coalesced through rAF, so a 120Hz drag writes once a frame and never touches layout. Sized smaller than a piece is tall, so it reads as a sticker on the piece and never blots out the destination square.

Verified headless at meter .55 (card riding in front, spiral just barely lit) and .92 (the whole stack), with a capture landing 1 taken / 1 lost on the model and both bursts firing. Zero console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S4BKp6cQJFNixoQrarvSkd