### PR TITLE
feat(pbp): drag, drop and the weight of the men

### DIFF
--- a/ConditioningControlPanel/Resources/web/piecebypiece/board/anim.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/board/anim.js
@@ -1,0 +1,133 @@
+/* ============================================================================
+ * board/anim.js - the weight and the wobble.
+ *
+ * Everything that makes the men feel like objects rather than sprites: a moved
+ * piece arcs across and squashes as it lands, a captured piece is knocked over,
+ * rolls once and sinks into the board, and the piece giving check buzzes like a
+ * wand. Hooks into pieces.js so the game code never has to ask for any of it.
+ * ==========================================================================*/
+
+import * as THREE from 'three';
+
+const SLIDE = 0.30;   // seconds a piece takes to cross to its square
+const SQUASH = 0.36;
+const BUZZ = 0.7;
+const FALL = 0.55;
+const SINK = 0.7;
+
+const ease = (t) => (t < 0.5 ? 2 * t * t : 1 - Math.pow(-2 * t + 2, 2) / 2);
+
+export function createAnim({ group }) {
+  const slides = [];
+  const squashes = [];
+  const tumbles = [];
+  const buzzes = [];
+  const byPiece = new Map(); // piece -> its live squash, so two landings never fight
+
+  const base = (piece) => piece.userData.scaleBase || 1;
+
+  function squash(piece) {
+    const live = byPiece.get(piece);
+    if (live) live.t = 0;
+    else { const s = { piece, t: 0 }; byPiece.set(piece, s); squashes.push(s); }
+  }
+
+  const sliding = (piece) => slides.some((s) => s.piece === piece);
+
+  /** A piece has been placed on `to`; play it as travel rather than a jump. */
+  function slide(piece, from, to = null, hop = null) {
+    if (!from) return;
+    const dest = to || piece.position.clone();
+    if (from.distanceToSquared(dest) < 1e-6) return;
+    piece.userData.busy = true;   // hands the piece to us; idle wobble stands off
+    slides.push({ piece, from: from.clone(), to: dest, t: 0, hop: hop ?? Math.min(0.42, 0.12 + from.distanceTo(dest) * 0.05) });
+    piece.position.copy(from);
+  }
+
+  /** Knocked over, one roll, then down through the board and gone. */
+  function tumble(piece) {
+    const axis = new THREE.Vector3(Math.random() < 0.5 ? 1 : -1, 0, Math.random() * 2 - 1).normalize();
+    tumbles.push({ piece, axis, t: 0, start: piece.position.y });
+  }
+
+  /** The piece giving check gets the wand treatment. */
+  function buzz(piece) {
+    if (!piece) return;
+    buzzes.push({ piece, t: 0 });
+  }
+
+  function update(dt) {
+    for (let i = slides.length - 1; i >= 0; i--) {
+      const s = slides[i];
+      s.t += dt;
+      const p = Math.min(1, s.t / SLIDE);
+      s.piece.position.lerpVectors(s.from, s.to, ease(p));
+      s.piece.position.y = s.to.y + Math.sin(Math.PI * p) * s.hop;
+      if (p >= 1) {
+        s.piece.position.copy(s.to);
+        slides.splice(i, 1);
+        if (!sliding(s.piece)) s.piece.userData.busy = false;
+        squash(s.piece);
+      }
+    }
+
+    for (let i = squashes.length - 1; i >= 0; i--) {
+      const s = squashes[i];
+      s.t += dt;
+      const p = Math.min(1, s.t / SQUASH);
+      const a = 0.26 * Math.exp(-4.2 * p) * Math.cos(p * Math.PI * 3);
+      const b = base(s.piece);
+      s.piece.scale.set(b * (1 + a * 0.55), b * (1 - a), b * (1 + a * 0.55));
+      if (p >= 1) { s.piece.scale.setScalar(b); byPiece.delete(s.piece); squashes.splice(i, 1); }
+    }
+
+    for (let i = tumbles.length - 1; i >= 0; i--) {
+      const t = tumbles[i];
+      t.t += dt;
+      const fall = Math.min(1, t.t / FALL);
+      t.piece.setRotationFromAxisAngle(t.axis, ease(fall) * (Math.PI / 2 + Math.PI * 2));
+      if (t.t > FALL) {
+        const sink = Math.min(1, (t.t - FALL) / SINK);
+        t.piece.position.y = t.start - sink * 1.1;
+        const mat = t.piece.userData.material;
+        if (mat) { mat.transparent = true; mat.opacity = 1 - sink; }
+        if (sink >= 1) { group.remove(t.piece); tumbles.splice(i, 1); }
+      }
+    }
+
+    for (let i = buzzes.length - 1; i >= 0; i--) {
+      const b = buzzes[i];
+      if (sliding(b.piece)) continue;   // let it land before it rattles
+      if (!b.home) b.home = { x: b.piece.position.x, z: b.piece.position.z };
+      b.t += dt;
+      const p = Math.min(1, b.t / BUZZ);
+      const amp = 0.035 * (1 - p);
+      b.piece.position.x = b.home.x + Math.sin(b.t * 62) * amp;
+      b.piece.position.z = b.home.z + Math.cos(b.t * 47) * amp * 0.6;
+      const mat = b.piece.userData.material;
+      if (mat) mat.emissiveIntensity = 0.55 * (1 - p);
+      if (p >= 1) {
+        b.piece.position.set(b.home.x, b.piece.position.y, b.home.z);
+        if (mat) mat.emissiveIntensity = 0;
+        buzzes.splice(i, 1);
+      }
+    }
+  }
+
+  /** A refused drop: spring back to where it came from, with a wobble to say no. */
+  function springBack(piece) {
+    const home = piece.userData.home;
+    if (!home) return;
+    slide(piece, piece.position.clone(), new THREE.Vector3(home.x, 0, home.z), 0.1);
+    buzz(piece);
+  }
+
+  return {
+    update, squash, slide, tumble, buzz, springBack,
+    hooks: {
+      onMoved: (piece, from) => slide(piece, from),
+      onCaptured: (piece) => tumble(piece),
+    },
+    busy: () => slides.length + tumbles.length > 0,
+  };
+}

--- a/ConditioningControlPanel/Resources/web/piecebypiece/board/drag.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/board/drag.js
@@ -1,0 +1,161 @@
+/* ============================================================================
+ * board/drag.js - picking a man up and putting him down.
+ *
+ * Pointer down raycasts the men, the held piece follows the cursor a beat
+ * behind and hangs above the board, the squares it may legally land on glow,
+ * and a drop either snaps home or springs back with a wobble. The screen
+ * position of the held piece goes out on the bus every frame so the effects
+ * layer can draw over it.
+ * ==========================================================================*/
+
+import * as THREE from 'three';
+import { worldToSquare } from './scene.js';
+
+const LIFT = 1.15;      // how high above the board a held piece rides
+const LAG = 11;         // follow stiffness; lower is lazier
+const TILT = 0.22;      // how far it leans into the direction of travel
+
+export function createDrag({ view, pieces, anim, bus, game }) {
+  const canvas = view.renderer.domElement;
+  const ray = new THREE.Raycaster();
+  const ndc = new THREE.Vector2();
+  const plane = new THREE.Plane(new THREE.Vector3(0, 1, 0), 0);
+  const hit = new THREE.Vector3();
+  const target = new THREE.Vector3();
+
+  let held = null;        // the piece object under the cursor
+  let from = null;        // the square it was picked up from
+  let legal = [];
+  let hover = null;
+
+  function toNdc(ev) {
+    const r = canvas.getBoundingClientRect();
+    ndc.set(((ev.clientX - r.left) / r.width) * 2 - 1, -((ev.clientY - r.top) / r.height) * 2 + 1);
+    ray.setFromCamera(ndc, view.camera);
+  }
+
+  /** Where the cursor meets the board, as a square name (or null, off board). */
+  function squareUnder(ev) {
+    toNdc(ev);
+    if (!ray.ray.intersectPlane(plane, hit)) return null;
+    return worldToSquare(hit.x, hit.z);
+  }
+
+  function pieceUnder(ev) {
+    toNdc(ev);
+    const hits = ray.intersectObjects(view.pieceGroup.children, true);
+    for (const h of hits) {
+      let node = h.object;
+      while (node && node.parent !== view.pieceGroup) node = node.parent;
+      if (node && node.userData.square) return node;
+    }
+    return null;
+  }
+
+  function glow() {
+    view.setHighlights(legal.map((sq) => ({
+      square: sq,
+      color: sq === hover ? 0xFFFFFF : 0xFF3FA4,
+      glow: sq === hover ? 0.85 : 0.42,
+    })));
+  }
+
+  function onDown(ev) {
+    if (held || ev.button > 0) return;
+    const square = squareUnder(ev);
+    const piece = pieceUnder(ev) || (square ? pieces.pieceAt(square) : null);
+    if (!piece || !piece.userData.square) return;
+    const sq = piece.userData.square;
+    if (!game.canPick(sq)) return;
+
+    held = piece;
+    from = sq;
+    legal = game.legalTargets(sq);
+    hover = null;
+    held.userData.held = true;
+    held.userData.busy = true;
+    target.copy(held.position);
+    glow();
+    canvas.setPointerCapture?.(ev.pointerId);
+    bus.emit('grab', { square: sq, piece: piece.userData.type, screen: view.projectPoint(held.position) });
+    ev.preventDefault();
+  }
+
+  function onMove(ev) {
+    if (!held) return;
+    toNdc(ev);
+    if (ray.ray.intersectPlane(plane, hit)) target.set(hit.x, LIFT, hit.z);
+    const next = worldToSquare(hit.x, hit.z);
+    if (next !== hover) { hover = legal.includes(next) ? next : null; glow(); }
+  }
+
+  function onUp(ev) {
+    if (!held) return;
+    const piece = held;
+    const start = from;
+    const to = squareUnder(ev);
+    held = null;
+    from = null;
+    hover = null;
+    legal = [];
+    view.setHighlights([]);
+    piece.userData.held = false;
+    piece.rotation.x = 0;
+    piece.rotation.z = 0;
+    canvas.releasePointerCapture?.(ev.pointerId);
+
+    // A legal drop is played by the game, which moves the man and lets anim.js
+    // fly it down from where it was being held.
+    const played = to && to !== start ? game.tryMove(start, to) : null;
+    if (played) {
+      bus.emit('drop', { ok: true });
+    } else {
+      anim.springBack(piece);
+      bus.emit('drop', { ok: false });
+    }
+  }
+
+  function onCancel() {
+    if (!held) return;
+    const piece = held;
+    held = null; from = null; hover = null; legal = [];
+    view.setHighlights([]);
+    piece.userData.held = false;
+    piece.rotation.x = 0;
+    piece.rotation.z = 0;
+    anim.springBack(piece);
+    bus.emit('drop', { ok: false });
+  }
+
+  /** Lagged follow, a lean into the travel, and the per-frame screen ping. */
+  function update(dt) {
+    if (!held) return;
+    const k = 1 - Math.exp(-LAG * dt);
+    const dx = target.x - held.position.x;
+    const dz = target.z - held.position.z;
+    held.position.x += dx * k;
+    held.position.y += (target.y - held.position.y) * k;
+    held.position.z += dz * k;
+    held.rotation.z = THREE.MathUtils.clamp(-dx * TILT, -0.35, 0.35);
+    held.rotation.x = THREE.MathUtils.clamp(dz * TILT, -0.35, 0.35);
+    bus.emit('dragmove', { screen: view.projectPoint(held.position) });
+  }
+
+  canvas.addEventListener('pointerdown', onDown);
+  canvas.addEventListener('pointermove', onMove);
+  canvas.addEventListener('pointerup', onUp);
+  canvas.addEventListener('pointercancel', onCancel);
+  window.addEventListener('blur', onCancel);
+
+  return {
+    update,
+    isDragging: () => !!held,
+    dispose() {
+      canvas.removeEventListener('pointerdown', onDown);
+      canvas.removeEventListener('pointermove', onMove);
+      canvas.removeEventListener('pointerup', onUp);
+      canvas.removeEventListener('pointercancel', onCancel);
+      window.removeEventListener('blur', onCancel);
+    },
+  };
+}

--- a/ConditioningControlPanel/Resources/web/piecebypiece/board/pieces.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/board/pieces.js
@@ -77,7 +77,7 @@ function trim(type, mat) {
   return parts;
 }
 
-export function createPieces({ group, assetsBase = './assets/pieces/' }) {
+export function createPieces({ group, assetsBase = './assets/pieces/', hooks = {} }) {
   const geoCache = new Map();
   const glb = new Map();          // type -> geometry from a supplied glb
   const bySquare = new Map();     // square -> piece object
@@ -101,7 +101,7 @@ export function createPieces({ group, assetsBase = './assets/pieces/' }) {
     root.scale.setScalar(HEIGHT[type]);
     // Knights (and any modelled piece) look at the far side.
     root.rotation.y = side === 'w' ? 0 : Math.PI;
-    root.userData = { type, side, material: mat, phase: Math.random() * Math.PI * 2, lift: 0, tilt: 0 };
+    root.userData = { type, side, material: mat, scaleBase: HEIGHT[type], phase: Math.random() * Math.PI * 2 };
     return root;
   }
 
@@ -133,20 +133,28 @@ export function createPieces({ group, assetsBase = './assets/pieces/' }) {
 
   function pieceAt(sq) { return bySquare.get(sq) || null; }
 
+  /** A man leaves the board. anim.js takes him if it wants a send-off. */
+  function retire(piece) {
+    if (hooks.onCaptured) hooks.onCaptured(piece);
+    else group.remove(piece);
+  }
+
   function move(from, to) {
     const piece = bySquare.get(from);
     if (!piece) return null;
     bySquare.delete(from);
     const taken = bySquare.get(to) || null;
-    if (taken) { group.remove(taken); bySquare.delete(to); }
+    if (taken) { retire(taken); bySquare.delete(to); }
+    const was = piece.position.clone();
     place(piece, to);
     bySquare.set(to, piece);
+    if (hooks.onMoved) hooks.onMoved(piece, was);
     return piece;
   }
 
   function remove(sq) {
     const piece = bySquare.get(sq);
-    if (piece) { group.remove(piece); bySquare.delete(sq); }
+    if (piece) { retire(piece); bySquare.delete(sq); }
     return piece || null;
   }
 
@@ -154,7 +162,7 @@ export function createPieces({ group, assetsBase = './assets/pieces/' }) {
     clock += dt;
     if (wobble <= 0.001) return;
     for (const piece of bySquare.values()) {
-      if (piece.userData.held) continue;
+      if (piece.userData.held || piece.userData.busy) continue;
       const ph = piece.userData.phase;
       piece.rotation.z = Math.sin(clock * 1.7 + ph) * 0.055 * wobble;
       piece.rotation.x = Math.sin(clock * 1.3 + ph * 1.7) * 0.04 * wobble;

--- a/ConditioningControlPanel/Resources/web/piecebypiece/board/scene.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/board/scene.js
@@ -112,7 +112,7 @@ export function createScene({ canvas }) {
   // Sits behind whichever side is to move and swings around with a small dolly.
   const RADIUS = 9.7;
   const HEIGHT = 7.0;
-  const LOOK = new THREE.Vector3(0, 0.55, 0);
+  const LOOK = new THREE.Vector3(0, 0.10, 0);
   let angleFrom = 0;
   let angleTo = 0;
   let swing = 1;
@@ -166,9 +166,11 @@ export function createScene({ canvas }) {
     const r = canvas.getBoundingClientRect();
     return { x: r.left + (tmp.x * 0.5 + 0.5) * r.width, y: r.top + (-tmp.y * 0.5 + 0.5) * r.height };
   }
-  function projectSquare(sq) {
+  // Default height is roughly where a man's middle sits, which is what the
+  // effects layer wants to draw over. Pass 0 for the square itself.
+  function projectSquare(sq, height = 0.45) {
     if (!sq || !squares.has(sq)) return { x: 0, y: 0 };
-    return projectPoint(squareToWorld(sq, 0.45, tmp.clone()));
+    return projectPoint(squareToWorld(sq, height, tmp.clone()));
   }
 
   function dispose() {

--- a/ConditioningControlPanel/Resources/web/piecebypiece/boot.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/boot.js
@@ -8,6 +8,8 @@
 
 import { createScene } from './board/scene.js';
 import { createPieces } from './board/pieces.js';
+import { createAnim } from './board/anim.js';
+import { createDrag } from './board/drag.js';
 import { createBus } from './game/events.js';
 import { createHotseat } from './game/hotseat.js';
 import { DEFAULT_MS } from './game/clock.js';
@@ -39,14 +41,17 @@ function main() {
     return;
   }
 
-  const pieces = createPieces({ group: view.pieceGroup });
+  const anim = createAnim({ group: view.pieceGroup });
+  const pieces = createPieces({ group: view.pieceGroup, hooks: anim.hooks });
   // The board API the effects layer drives. Keep this surface stable.
   const board = {
     view,
     pieces,
+    anim,
+    buzzCheck(square) { anim.buzz(pieces.pieceAt(square)); },
     setWobble(v) { pieces.setWobble(v); },
     setCameraSway(v) { view.setCameraSway(v); },
-    projectSquare(sq) { return view.projectSquare(sq); },
+    projectSquare(sq, height) { return view.projectSquare(sq, height); },
     setHighlights(list) { view.setHighlights(list); },
     setSide(side, instant) { view.setSide(side, instant); },
   };
@@ -61,6 +66,9 @@ function main() {
     auto: Number(params.get('auto')) || 0,
   });
 
+  const drag = createDrag({ view, pieces, anim, bus, game });
+  board.drag = drag;
+
   window.PBP = { bus, game, board };
 
   let last = performance.now();
@@ -69,6 +77,8 @@ function main() {
     last = now;
     view.update(dt);
     pieces.update(dt);
+    anim.update(dt);
+    drag.update(dt);
     if (window.PBP.game && window.PBP.game.update) window.PBP.game.update(dt);
     view.render();
     requestAnimationFrame(frame);

--- a/ConditioningControlPanel/Resources/web/piecebypiece/game/hotseat.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/game/hotseat.js
@@ -88,7 +88,10 @@ export function createHotseat({ bus, board, hud = null, clockMs = DEFAULT_MS, fe
         victimSide: played.capturedSide,
       });
     }
-    if (played.check) bus.emit('check', { side: played.turn });
+    if (played.check) {
+      if (board.buzzCheck) board.buzzCheck(played.to);   // the man giving check rattles
+      bus.emit('check', { side: played.turn });
+    }
 
     const end = rules.result();
     if (end) {


### PR DESCRIPTION
Fourth of five. Bases on `feat/pbp-a3-rules`.

**Dragging** (`board/drag.js`): pointer down raycasts the men, the held piece rides above the board a beat behind the cursor and leans into the travel, legal landing squares glow (the one under the cursor brighter), and letting go either plays the move or springs the piece back with a wobble.

**Weight** (`board/anim.js`): a moved piece arcs across and squashes as it lands, a captured piece is knocked over, rolls once and sinks through the board, and the piece giving check rattles like a wand. `pieces.js` hands moves and captures over through hooks, so game code never has to ask for an animation.

Contract for the effects layer, unchanged from the agreement: `grab {square, piece, screen}` on pointer down, `dragmove {screen}` every frame while held, `drop {ok}` on release. `window.PBP.board.projectSquare(sq, height)` now takes a height so callers can aim at a man's body or at the square itself.

Camera look point dropped to y 0.10 so the board sits properly in frame.

Checked in headless msedge: clean boot, no console errors, and a scripted e2-e4 drag fires grab, dragmove, turn, drop and reaches the referee.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S4BKp6cQJFNixoQrarvSkd