### PR TITLE
race: the end screen goes back to the menu, not out the door

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
@@ -316,7 +316,7 @@ below every `.sf-pfx` layer, and the Brake/End screens at z20 pick their own sta
 
 ### `race/run.js` + `raceBoot.js` + `race.html` (PR 5, integration)
 ```js
-export function createRace({ root, bridge, media, settings, seed }) ->
+export function createRace({ root, bridge, media, settings, seed, onExit }) ->
   { start(), prepare(), setPaused(b), dispose(), setCameraOverride(fn), setStage(s), reseed(seed), renderer, pixel, audio, hud, camera,
     setTrack(chart | null), replaceTrack(chart), trackClock(t, playing), trackEnded(), track }
 ```
@@ -334,6 +334,19 @@ and gates which bubble kinds may appear. Treat pops go to score; effect pops cal
 `payloadFx.applyPayload({ payload, strength }, { durationMult })`, `video`/`audio` go to the host
 through the `fire-payload` bridge message exactly like `chaosRun.js` does today. ESC = Brake
 (pause + end screen). Run end sends `run-ended` (below).
+
+**The End screen's `surface` goes BACK TO THE MENU, it never closes the page.** `onExit` is the way
+home: run.js stops the file, drops the world (`teardown`), resets the run state, re-arms the same
+chart at `t = 0` (so picking that level again replays it) and calls `onExit()`. raceBoot's
+`backToMenu` puts the lobby chrome, the menu stage, the menu theme and the levels panel's picked row
+back, clears `started` so `race` (and a host `cloud-run`) can fire again, and answers `true`. It
+answers `false` when there is no menu to go back to (`?autostart=1`, `?scene=intro`), and only then
+does the End screen fall through to `exit()` and close the page. `run-ended` is still sent exactly
+once per run, before any of this, and `payout-result` still resolves against it. The two REAL exits
+are unchanged: the host's `exit-request` and the menu's own `surface` verb, both of which post
+`exit` + `exit-done`. No host-protocol change: a host that only ever saw `exit` after a run now
+simply does not see one until the player asks to leave. `node race/smoke/menu-return-check.mjs`
+drives that whole path through the real page and holds it down.
 
 As built (PR 5 reality notes):
 - `race/input.js` is the single reader of keyboard + gamepad + touch:

--- a/ConditioningControlPanel/Resources/web/dtrh/race/run.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/run.js
@@ -2,13 +2,21 @@
  * race/run.js - the run brain of Racing Thoughts. Implements CONTRACT.md
  * "race/run.js + raceBoot.js + race.html (PR 5, integration)".
  *
- *   createRace({ root, bridge, media, settings, seed }) -> { start(), setPaused(b), dispose() }
+ *   createRace({ root, bridge, media, settings, seed, onExit }) -> { start(), setPaused(b), dispose() }
  *
  * Composes renderer + spine + tunnel + fx + rooms + bubbles + kart + score + hud
  * + pickups + payloadFx + screen shake and runs the frame loop. `root` holds the
  * <canvas>, the `.race-hud` div, the `.sf-hud` layer payloadFx draws into and, when
  * the online feed is on, race/wallDom.js's `.rh-wall3d` layer over the canvas.
  * Nothing here subtracts: the run ends only from the Brake (Esc) or the host.
+ *
+ * THE END SCREEN'S `surface` GOES BACK TO THE MENU, it does not close the page.
+ * `onExit` is raceBoot's way home: the run stops the file, drops the world and
+ * the run state, re-arms the same chart at t = 0 and hands the frame back, and
+ * raceBoot puts the menu stage up. Only two things still post exit / exit-done:
+ * the host's exit-request and the menu's own `surface` verb. With no onExit (or
+ * one that answers false, which is what `?autostart=1` does: there is no menu)
+ * the End screen falls back to the old ending and closes the page.
  *
  * Host traffic owned here: sends heartbeat, run-started, sfx, fire-payload
  * (video only), run-ended, exit, exit-done, and with a track loaded track-play,
@@ -90,7 +98,7 @@ function flag(key) {
 const clamp = (v, a, b) => Math.max(a, Math.min(b, v));
 const hex = (n) => '#' + ((n >>> 0) & 0xffffff).toString(16).padStart(6, '0');
 
-export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
+export function createRace({ root, bridge, media, settings = {}, seed = 1, onExit = null }) {
   const canvas = root.querySelector('canvas');
   const hudRoot = root.querySelector('.race-hud');
   const sfHud = root.querySelector('.sf-hud');
@@ -832,7 +840,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     if (payout && payout.finalXp != null) shown.title = (shown.title || 'the tea party') + ` · +${Math.round(payout.finalXp)} xp` + (payout.sparksEarned ? ` · ${payout.sparksEarned} sparks` : '');
     const pick = await hud.showEnd(shown, { beside: true });
     if (S.disposed) return;
-    if (pick === 'again') again(); else exit();
+    if (pick === 'again') again(); else leave();
   }
   /** Rebuild the world on a new seed (again, or the menu changing the seed rule). settings.seedLock pins again to one track.
    *  A world that was never built (the menu changing the rule before "race") stays unbuilt: prepare() / start() own that. */
@@ -849,6 +857,29 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     reseed(settings.seedLock != null ? settings.seedLock >>> 0 : (Date.now() ^ Math.floor(Math.random() * 0x7fffffff)) >>> 0);
     setCameraOverride(preRollCamera());   // again skips the intro: the chase seat, then 3 2 1
     hud.countdown().then(start);
+  }
+  /**
+   * `surface` on the End screen: the way back to the MENU. The world goes (the menu does not need
+   * it and `race` builds it again through prepare()), the run state resets, and the chart is re-armed
+   * at t = 0 so picking that same level again replays it from the top. raceBoot's onExit puts the
+   * menu stage and the menu theme back and answers true; false (no menu: `?autostart=1`) or no hook
+   * at all falls through to exit(), the old ending.
+   * The file is already stopped: endRun posted track-stop before the card came up and a second one
+   * would roll the cloud playlist a lap early (race/cloud.js onEnded).
+   */
+  function leave() {
+    if (!onExit) { exit(); return; }
+    try { payloadFx.cancelHeavy(); } catch (e) { /* nothing heavy */ }
+    if (captions) captions.clear();
+    audio.duck(false, 'end');
+    setCameraOverride(null);
+    teardown();
+    resetRunState(settings.seedLock != null ? settings.seedLock >>> 0 : (Date.now() ^ Math.floor(Math.random() * 0x7fffffff)) >>> 0);
+    S.started = false; S.hostPaused = false;
+    if (TR.track) setTrack(TR.track.chart);
+    let took = false;
+    try { took = onExit() !== false; } catch (e) { if (bridge.log) bridge.log('to menu: ' + e); }
+    if (!took) exit();
   }
   function exit() {
     trackSend('track-stop');

--- a/ConditioningControlPanel/Resources/web/dtrh/race/smoke/menu-return-check.mjs
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/smoke/menu-return-check.mjs
@@ -1,0 +1,135 @@
+/* ============================================================================
+ * race/smoke/menu-return-check.mjs - headless self-check for THE WAY BACK: the
+ * End screen's `surface` puts the menu back instead of closing the page.
+ *
+ *   node race/smoke/menu-return-check.mjs      (exits 0 on pass, 1 with a count)
+ *
+ * Nothing is stubbed and nothing leaves localhost: this drives the shipped page
+ * the way a player does - menu -> `race` -> Esc (the Brake) -> `end the run` ->
+ * the End card -> `surface` - and holds what has to be true on the other side.
+ *
+ * What it holds:
+ *   1. the End card's `surface` brings the MENU back: the column is on the
+ *      screen, the hud is in the lobby again, the menu stage has the frame and
+ *      the world was dropped
+ *   2. nothing posts `exit` on that path (only the menu's own verb and the
+ *      host's exit-request may), and `run-ended` was sent exactly once
+ *   3. `race` fires again from that menu and rebuilds the world it dropped
+ *   4. a charted run comes back with its track still loaded and its clock at
+ *      zero, so taking that same level again is a replay
+ *
+ * CHROME: `CHROME_PATH` if it is set, else the usual Windows install. Nothing is
+ * installed by this file and the profile it makes is deleted on the way out.
+ * ==========================================================================*/
+
+import { spawn } from 'node:child_process';
+import { createServer } from 'node:http';
+import { readFile } from 'node:fs/promises';
+import { mkdtempSync, rmSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, extname, dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const WEB = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');   // .../Resources/web
+const PORT = 8853, DEBUG = 9349;
+const CHROME = process.env.CHROME_PATH || 'C:/Program Files/Google/Chrome/Application/chrome.exe';
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.mjs': 'text/javascript', '.css': 'text/css', '.json': 'application/json', '.glb': 'model/gltf-binary', '.png': 'image/png', '.webp': 'image/webp', '.jpg': 'image/jpeg', '.mp3': 'audio/mpeg', '.wav': 'audio/wav', '.svg': 'image/svg+xml', '.woff2': 'font/woff2' };
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+let fails = 0;
+const ok = (cond, what) => { if (!cond) { console.error('FAIL ' + what); fails++; } else console.log('  ok  ' + what); };
+
+if (!existsSync(CHROME)) { console.error('no chrome at ' + CHROME + ' (set CHROME_PATH)'); process.exit(1); }
+const server = createServer(async (req, res) => {
+  const path = decodeURIComponent(req.url.split('?')[0]);
+  if (path.indexOf('..') >= 0) { res.writeHead(400); return res.end(); }
+  try {
+    const body = await readFile(join(WEB, path));
+    res.writeHead(200, { 'content-type': MIME[extname(path).toLowerCase()] || 'application/octet-stream' });
+    res.end(body);
+  } catch (e) { res.writeHead(404); res.end('no'); }
+});
+await new Promise((r) => server.listen(PORT, '127.0.0.1', r));
+const prof = mkdtempSync(join(tmpdir(), 'race-return-'));
+const chrome = spawn(CHROME, ['--headless=new', `--remote-debugging-port=${DEBUG}`, `--user-data-dir=${prof}`,
+  '--no-first-run', '--no-default-browser-check', '--disable-gpu', '--mute-audio', '--enable-unsafe-swiftshader',
+  '--autoplay-policy=no-user-gesture-required', '--window-size=1280,720', 'about:blank'], { stdio: 'ignore' });
+let page = null;
+for (let i = 0; i < 60 && !page; i++) {
+  await sleep(250);
+  try { page = (await (await fetch(`http://127.0.0.1:${DEBUG}/json/list`)).json()).find((t) => t.type === 'page'); } catch (e) { /* not up yet */ }
+}
+if (!page) { console.error('chrome never answered'); chrome.kill(); server.close(); process.exit(1); }
+const ws = new WebSocket(page.webSocketDebuggerUrl);
+await new Promise((r) => { ws.onopen = r; });
+let id = 0; const waits = new Map(); let frames = [];
+ws.onmessage = (e) => {
+  const m = JSON.parse(e.data);
+  if (m.id && waits.has(m.id)) { waits.get(m.id)(m); waits.delete(m.id); }
+  if (m.method === 'Runtime.consoleAPICalled') {
+    const line = m.params.args.map((a) => a.value ?? a.description ?? '?').join(' ');
+    if (line.indexOf('[race->host]') === 0) frames.push(line.slice(13));
+  }
+};
+const cdp = (method, params) => new Promise((res) => { const i = ++id; waits.set(i, res); ws.send(JSON.stringify({ id: i, method, params })); });
+const ev = async (x) => (await cdp('Runtime.evaluate', { expression: x, returnByValue: true, awaitPromise: true })).result?.result?.value;
+async function until(expr, tries = 80) {
+  for (let i = 0; i < tries; i++) { await sleep(250); if (await ev(expr)) return true; }
+  return false;
+}
+const sent = (type) => frames.filter((f) => f.indexOf(`"type":"${type}"`) >= 0).length;
+const MENU_UP = `!!(window.__race && window.__race.menu) && !document.querySelector('.rm-root').hidden`;
+const RUNNING = `!!(window.__race.race.perf().running)`;
+const CARD = `!!document.querySelector('.rh-screen.is-on')`;
+const END_CARD = `(()=>{const s=document.querySelector('.rh-screen.is-on');return !!s && !!s.querySelector('.rh-rows');})()`;
+const press = (label) => ev(`[...document.querySelectorAll('.rh-screen.is-on .rh-btn')].find((b)=>b.textContent===${JSON.stringify(label)}).click()`);
+/** menu -> race -> the Brake -> end the run -> the End card. */
+async function runToTheEndCard() {
+  await ev(`document.querySelector('.rm-btn[data-id=race]').click()`);
+  if (!await until(RUNNING)) return false;
+  await sleep(1200);
+  await ev(`window.dispatchEvent(new KeyboardEvent('keydown',{key:'Escape',code:'Escape',bubbles:true}))`);
+  if (!await until(CARD, 20)) return false;
+  await press('end the run');
+  return until(END_CARD, 40);
+}
+await cdp('Runtime.enable'); await cdp('Page.enable');
+await cdp('Emulation.setDeviceMetricsOverride', { width: 1280, height: 720, deviceScaleFactor: 1, mobile: false, screenWidth: 1280, screenHeight: 720 });
+
+console.log('1-3. the seeded run: the End card sends the page back to the menu');
+await cdp('Page.navigate', { url: `http://127.0.0.1:${PORT}/dtrh/race.html?intro=0&cards=0` });
+ok(await until(MENU_UP), 'the menu is the resting state');
+ok(await runToTheEndCard(), 'a run, the Brake, and the End card is up');
+ok(await ev(`window.__race.race.perf().running === false`), 'the run is over');
+await press('surface');
+ok(await until(MENU_UP, 40), 'and `surface` brings the menu back instead of closing the page');
+ok(await ev(`document.querySelector('.race-hud').classList.contains('is-lobby')`), 'the hud is back in the lobby');
+ok(await ev(`window.__race.race.perf().stage === true`), 'the menu stage has the frame again');
+ok(await ev(`window.__race.race.perf().world === false`), 'and the world was dropped, not left standing');
+ok(await ev(`!document.querySelector('.rh-screen.is-on')`), 'no card is left over the menu');
+ok(sent('run-ended') === 1, 'run-ended was sent exactly once for that run');
+ok(sent('exit') === 0, 'and nothing posted exit: only the menu verb and the host may');
+await ev(`document.querySelector('.rm-btn[data-id=race]').click()`);
+ok(await until(RUNNING, 60), '`race` fires again from that menu');
+ok(await ev(`window.__race.race.perf().world === true`), 'and prepare() rebuilt the world it dropped');
+
+console.log('4. a charted run comes back with its track re-armed at zero');
+frames = [];
+await cdp('Page.navigate', { url: `http://127.0.0.1:${PORT}/dtrh/race.html?intro=0&cards=0&chart=demo&dur=90` });
+ok(await until(MENU_UP), 'the menu is up with the demo chart loaded');
+ok(await ev(`!!window.__race.race.track`), 'the track is on the run');
+ok(await runToTheEndCard(), 'a charted run, ended from the Brake');
+ok(await ev(`window.__race.race.track.t > 1`), 'its clock ran');
+await press('surface');
+ok(await until(MENU_UP, 40), 'the menu is back');
+ok(await ev(`!!window.__race.race.track`), 'the track is still loaded on the menu');
+ok(await ev(`window.__race.race.track.t === 0`), 'and its clock is back at zero: the same level plays again');
+ok(await ev(`(()=>{const p=document.querySelector('.rm-track');return !!p && !p.hidden;})()`), 'the plate still names it');
+await ev(`document.querySelector('.rm-btn[data-id=race]').click()`);
+ok(await until(RUNNING, 60), 'the second take starts');
+await sleep(2000);
+ok(await ev(`window.__race.race.track.t > 1`), 'and the clock runs with it');
+
+ws.close(); chrome.kill(); server.close();
+try { rmSync(prof, { recursive: true, force: true }); } catch (e) { /* the profile is locked, windows will take it */ }
+console.log(fails ? `\nmenu-return-check: ${fails} failed` : '\nmenu-return-check: all good');
+process.exit(fails ? 1 : 0);

--- a/ConditioningControlPanel/Resources/web/dtrh/raceBoot.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/raceBoot.js
@@ -11,8 +11,10 @@
  * module import, the world build and the glb fetch, and hosts the wait note
  * and boot errors) -> on a first open the four introduction cards
  * (race/cards.js) -> the MENU is the resting state -> `race` plays the intro
- * on the menu stage -> the run starts under the camera whip. `surface` from
- * the menu is the same exit the End screen takes.
+ * on the menu stage -> the run starts under the camera whip. The End
+ * screen's `surface` comes BACK HERE (backToMenu, run.js `onExit`): the menu is
+ * the resting state either side of a run, and only the menu's own `surface`
+ * verb and the host's exit-request take the page away.
  *
  * Host messages owned here: init, manifest, favorites, ping, exit-request,
  * fullscreen, local-media, setting (run.js owns pause + payout-result). Sent
@@ -245,7 +247,28 @@ function trackError(message) {
   plate({ stage: 'error', message: String(message).slice(0, 80).toLowerCase() });
   errorTimer = setTimeout(() => plate(trackReady), 4000);
 }
-/** The one exit: the menu's `surface` and the host's exit-request (the End screen's own goes through run.js). */
+/**
+ * THE WAY BACK FROM THE END SCREEN (run.js `leave()` calls this through `onExit`). The run has
+ * already stopped the file, dropped its world and reset itself; this puts the front door back:
+ * the lobby chrome, the menu stage, the menu theme (menu.show -> theme(true)) and the levels
+ * panel's picked row. `started` goes false so `race` can fire again (race.prepare() rebuilds the
+ * world it just dropped) and a `cloud-run` from the host is heard again.
+ * Answers false when there is no menu to go back to (`?autostart=1` never built one, `?scene=intro`
+ * is on its way into a run) and run.js then closes the page the old way.
+ */
+function backToMenu() {
+  if (exiting || !race || !menu) return false;
+  started = false;
+  stopTrackClock();
+  if (errorTimer) { clearTimeout(errorTimer); errorTimer = 0; }
+  if (hudRoot) hudRoot.classList.add('is-lobby');
+  try { race.setStage(menu.stage); } catch (e) { host.log('to menu stage: ' + e); }
+  menu.show();
+  if (trackReady) plate(trackReady);
+  host.log('back to the menu');
+  return true;
+}
+/** The one exit: the menu's `surface` and the host's exit-request (the End screen's own goes back to the menu). */
 function surface() {
   if (exiting) return;
   exiting = true;
@@ -307,7 +330,7 @@ async function boot() {
     if (cloud && !hosted) settings.hostSfx = false;
     seed = settings.seedLock != null ? settings.seedLock : rollSeed();
     note('the road is drawing');
-    race = createRace({ root, bridge: cloud ? { ...host, isHosted: true } : host, media, settings, seed });
+    race = createRace({ root, bridge: cloud ? { ...host, isHosted: true } : host, media, settings, seed, onExit: backToMenu });
     // the persisted option sliders, before the first frame: the menu theme comes up at the right level
     try { if (race.audio && race.audio.setLevels) race.audio.setLevels({ music: opts.music, sfx: opts.sfx }); } catch (e) { host.log('levels: ' + e); }
     note('');
@@ -377,7 +400,9 @@ async function standaloneTrack() {
   const dur = chart.source.durationSec;
   startTrackClock = () => {
     if (trackTimer) return;
-    if (trackAudio) { const p = trackAudio.play(); if (p && p.catch) p.catch((e) => host.log('track audio: ' + e)); }
+    // from the top every time, the way race/cloud.js starts its element on `track-play`: a run
+    // taken again after the End screen sent us back to the menu is a replay, not a resume.
+    if (trackAudio) { try { trackAudio.currentTime = 0; } catch (e) { /* not seekable yet */ } const p = trackAudio.play(); if (p && p.catch) p.catch((e) => host.log('track audio: ' + e)); }
     race.trackClock(0, true);
     trackTimer = setInterval(() => {
       // with audio the file is the authority and its currentTime snaps the clock. Without it the run


### PR DESCRIPTION
Stacked on #958 (PR A1, the picked level row). Review that one first.

Owner: *"when exiting the run the page closes, instead we should go back to the main menu"*.

## what changed

**`race/run.js`** takes an `onExit` hook. The End card's `surface` now calls `leave()` instead of `exit()`: the file is already stopped (endRun posted `track-stop` before the card came up, and a second one would roll the cloud playlist a lap early), so it cancels the heavy fx, clears the caption band, unducks, drops the world (`teardown`), resets the run state and re-arms the same chart at `t = 0` before handing the frame back. `exit()` itself is unchanged and is still what runs when there is no way home.

**`raceBoot.js`** passes `backToMenu` as that hook. It clears `started`, stops the standalone track clock, puts `is-lobby` back on the hud, gives the frame to `menu.stage`, calls `menu.show()` (whose `theme(true)` brings the menu tune back up) and re-plates the loaded track so the levels panel's picked row is still lit. It answers `false` when there is no menu to go back to (`?autostart=1` returns from `boot()` before the menu is built, `?scene=intro` is on its way into a run), and only then does the End screen fall through to the old ending and close the page. `startTrackClock` now rewinds the `?chart=` dev audio to 0, the way `race/cloud.js` starts its element on `track-play`, so a second take is a replay and not a resume.

## what did NOT change

- **No `bridge.js` or protocol change**, and **nothing host-side is needed**. The two real exits are untouched: the host's `exit-request` and the menu's own `surface` verb both still post `exit` + `exit-done`. The only difference a host sees is that it no longer gets an `exit` at the end of every run - it gets one when the player asks to leave. `CaucusHostService` already flips `_runActive` false on `run-ended`, so its state is right either way, and `cloud-run` still auto-starts the next run because `started` is false again.
- `run-ended` is still sent exactly once per run, before any of this, and `payout-result` still resolves against it.

## verify

`node race/smoke/menu-return-check.mjs` is new and drives the whole path through the real page - menu, `race`, Esc, `end the run`, the End card, `surface` - and holds: the menu is back, the hud is in the lobby, the menu stage has the frame, the world was dropped, `run-ended` went once, **`exit` went zero times**, `race` fires again and rebuilds the world, and on a charted run the track is still loaded with its clock back at zero for a replay. All green, and so are levels-check, rows-check, cloud-check, fov-check, chart-check, touch-check and track-run-check.

Shots (1280x720, zero console errors): `shots/a2-end-card.png` -> `shots/a2-menu-back.png` -> `shots/a2-run-again.png`, plus `shots/a2-menu-back-charted.png`.

The shutter transition the owner asked for in the same breath is PR A3, stacked on this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KTe1RA7EP5hGxkzFY1282C
