### PR TITLE
Piece by Piece ramp b3: smoke tests, a screenshot pass and the veil budget

### DIFF
--- a/ConditioningControlPanel/Resources/web/piecebypiece/dev/ramp.html
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/dev/ramp.html
@@ -11,6 +11,10 @@
 
   URL params:  ?meter=0.6   pin the meter (overrides the fake game)
                ?fire=flash  fire one layer once on load
+               ?only=blur   show only that sustained layer
+               ?noturn=1    do not play the opening move (no video card)
+               ?still=1     kill fade-in transitions (a still frame, not a fade)
+               ?seek=1200   jump one-shot animations forward, for a still
                ?quiet=1     hide the control panel (clean screenshots)
 -->
 <style>
@@ -115,6 +119,24 @@ import { createFixtureMedia, loadFixtureList } from '../ramp/media.js';
 const qs = new URLSearchParams(location.search);
 if (qs.get('quiet') === '1') document.getElementById('panel').classList.add('hidden');
 
+/* A screenshot pass sees almost no wall-clock time, so every layer would be
+   caught at the very start of its fade and the picture would show nothing.
+   ?still=1 removes the fades (sustained layers snap to their real value) and
+   ?seek= winds one-shot keyframes forward. Both are harness-only: the shipping
+   ramp keeps its transitions. */
+if (qs.get('still') === '1') {
+  const s = document.createElement('style');
+  s.textContent = '#stage, .pbp-fx > *, .pbp-fx-front, .pbp-fx-front * { transition-duration: 0s !important; }';
+  document.head.appendChild(s);
+}
+const seekAnimations = () => {
+  if (!qs.has('seek')) return;
+  const ms = Math.max(0, Number(qs.get('seek')) || 0);
+  for (const el of document.querySelectorAll('.pbp-fx > *, .pbp-fx-front, .pbp-fx-front *')) {
+    try { el.style.animationDelay = '-' + ms + 'ms'; } catch { /* gone */ }
+  }
+};
+
 /* ---- the fake bus: the same three-method surface the real game exposes ---- */
 function createBus() {
   const map = new Map();
@@ -143,7 +165,10 @@ const emitTurn = (side) => {
   bus.emit('turn', { side, ply: game.ply, clocks: { ...game.clocks }, total: TOTAL });
   emitClock();
 };
-emitTurn('w');
+/* ?noturn=1 keeps the opening move (and so the video card it fires) out of a
+   screenshot that is meant to show one other layer on a clean board */
+if (new URLSearchParams(location.search).get('noturn') === '1') emitClock();
+else emitTurn('w');
 setInterval(emitClock, 250);
 
 const PIECES = ['p', 'n', 'b', 'r', 'q'];
@@ -186,6 +211,7 @@ meterEl.addEventListener('input', applyMeter);
 
 /* ?meter=, ?fire= and ?prime= drive the screenshot pass */
 if (qs.has('meter')) { meterEl.value = Math.round(Number(qs.get('meter')) * 100); applyMeter(); }
+if (qs.has('only')) ramp.debug().only(qs.get('only'));
 if (qs.has('prime')) ramp.debug().prime(Number(qs.get('prime')) || 5);
 /* a fire name is either a harness event (grab, cap-w, check, ...) or a layer
    the ramp can fire directly (flash, gifRain, videoCard) */
@@ -196,6 +222,7 @@ if (qs.has('fire')) {
     else ramp.debug().fire(kind);
   }
 }
+seekAnimations();
 
 const out = document.getElementById('out');
 setInterval(() => {

--- a/ConditioningControlPanel/Resources/web/piecebypiece/ramp/index.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/ramp/index.js
@@ -91,7 +91,14 @@ export function attachRamp(opts = {}) {
   let lastBoardPush = 0;
   let ticks = 0;   // scheduling beats served, so a harness can prove the loop runs
   let overrideMeter = null;   // dev harness: pin the meter regardless of the game
-  const applied = { melt: -1, blur: -1, spiral: -1, overlay: -1 };
+  let solo = null;            // dev harness: show ONE sustained layer, for a screenshot
+  // OFF is the "this layer is currently off" key; UNSET is "we have never
+  // written it". They must differ, or a forced re-apply of an off layer reads
+  // as no change and is skipped, which is how a solo call once left the layers
+  // it was meant to hide still showing.
+  const OFF = -1;
+  const UNSET = Number.NaN;
+  const applied = { melt: UNSET, blur: UNSET, spiral: UNSET, overlay: UNSET };
 
   const now = () => (typeof performance !== 'undefined' && performance.now ? performance.now() : Date.now());
 
@@ -112,10 +119,10 @@ export function attachRamp(opts = {}) {
 
   function applySustained(sus) {
     for (const name of ['melt', 'blur', 'spiral', 'overlay']) {
-      const spec = sus[name];
-      const key = spec.on ? (spec.alpha != null ? spec.alpha : spec.px) : -1;
+      const spec = solo && solo !== name ? { on: false } : sus[name];
+      const key = spec.on ? (spec.alpha != null ? spec.alpha : spec.px) : OFF;
       // retune only on a real change, so we are not writing style every 90ms
-      if (Math.abs(key - applied[name]) < 0.005) continue;
+      if (Math.abs(key - applied[name]) < 0.005) continue;   // NaN fails this, as it should
       applied[name] = key;
       stack.setSustained(name, spec);
     }
@@ -131,7 +138,7 @@ export function attachRamp(opts = {}) {
       lastTick = t;
       ticks += 1;
       const m = liveMeter();
-      const out = schedule.tick(t, liveHeat(t), m);
+      const out = schedule.tick(t, liveHeat(t), m, { cardLive: stack.cardLive });
       for (const kind of out.fire) stack.oneshot(kind, { heat: out.heat });
       applySustained(out.sustained);
       if (t - lastBoardPush >= BOARD_PUSH_MS) { lastBoardPush = t; pushToBoard(m); }
@@ -189,7 +196,7 @@ export function attachRamp(opts = {}) {
     enabled = !!on;
     if (!enabled) {
       stack.clear();
-      for (const k of Object.keys(applied)) applied[k] = -1;
+      for (const k of Object.keys(applied)) applied[k] = UNSET;
       pushToBoard(0);
     } else { schedulePump(); }
     return enabled;
@@ -224,13 +231,20 @@ export function attachRamp(opts = {}) {
        *  wait for the next rAF beat (headless barely gets any). */
       setMeter(v) {
         overrideMeter = v == null ? null : clamp01(v);
-        applySustained(sustainedFor(liveMeter(), tuning));
+        applySustained(sustainedFor(liveMeter(), tuning, { cardLive: stack.cardLive }));
         return overrideMeter;
       },
       /** Dev harness only: fire one layer by name right now. */
       fire(kind, o) {
         if (kind === 'videoCard') stack.videoCard(o || { holdMs: videoHoldMs(liveMeter(), tuning) });
         else stack.oneshot(kind, o || { heat: liveHeat(now()) });
+      },
+      /** Dev harness only: isolate ONE sustained layer (null shows them all). */
+      only(name) {
+        solo = name || null;
+        for (const k of Object.keys(applied)) applied[k] = UNSET;
+        applySustained(sustainedFor(liveMeter(), tuning, { cardLive: stack.cardLive }));
+        return solo;
       },
       /** Dev harness only: fill the screen for a screenshot without waiting. */
       prime(n = 5) {

--- a/ConditioningControlPanel/Resources/web/piecebypiece/ramp/layers/glitchgrab.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/ramp/layers/glitchgrab.js
@@ -37,7 +37,10 @@ export function createGlitchGrab(ctx) {
   function flush() {
     raf = 0;
     if (!el || !pending || disposed) return;
-    try { el.style.transform = `translate3d(${pending.x}px, ${pending.y}px, 0) translate(-50%, -50%)`; } catch { /* gone */ }
+    // hung up and to the left of the pointer rather than centred on it: the
+    // sticker is wider than a square, and dead-centre it would cover the very
+    // square the player is aiming at. Distraction yes, blindfold no.
+    try { el.style.transform = `translate3d(${pending.x}px, ${pending.y}px, 0) translate(-82%, -82%)`; } catch { /* gone */ }
   }
 
   function moveTo(screen) {

--- a/ConditioningControlPanel/Resources/web/piecebypiece/ramp/layers/index.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/ramp/layers/index.js
@@ -155,7 +155,9 @@ export function createLayerStack(ctx = {}) {
       }
       base.stageFilter.dispose();
     },
-    debug() { return { counts: { ...counts }, hasMedia: !!(ctx.media && ctx.media.size) }; },
+    /** True while a tape is over the board; the veils read this and step back. */
+    get cardLive() { return !!card.live; },
+    debug() { return { counts: { ...counts }, cardLive: !!card.live, hasMedia: !!(ctx.media && ctx.media.size) }; },
   };
   return api;
 }

--- a/ConditioningControlPanel/Resources/web/piecebypiece/ramp/media.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/ramp/media.js
@@ -115,7 +115,10 @@ function createPool(entries, { rnd, label } = {}) {
  */
 export function createFixtureMedia(list, opts = {}) {
   const pool = createPool(list, { rnd: opts.rnd, label: 'fixture' });
-  return { kind: 'fixture', ...pool };
+  // assign, never spread: `size` is a getter and a spread would freeze it at
+  // whatever it read once, so a later adopt() would go unnoticed
+  pool.kind = 'fixture';
+  return pool;
 }
 
 /**
@@ -132,7 +135,8 @@ export function createHostMedia(entries) {
   if (!pool.size) {
     try { console.warn('[pbp/ramp] host media pool is empty; the ramp runs without pictures.'); } catch { /* no console */ }
   }
-  return { kind: 'host', ...pool };
+  pool.kind = 'host';
+  return pool;
 }
 
 /** Load dev/media.json next to the harness. Never throws: [] on any failure. */

--- a/ConditioningControlPanel/Resources/web/piecebypiece/ramp/meter.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/ramp/meter.js
@@ -34,7 +34,14 @@ export const RAMP_TUNING = Object.freeze({
 
   // --- sustained layer envelopes -------------------------------------------
   melt: Object.freeze({ minAlpha: 0.10, maxAlpha: 0.52 }),
-  blurMaxPx: 3,          // HARD CAP: a move must always stay physically possible
+  blurMaxPx: 3,
+  // THE VEIL BUDGET. The two full-screen gif veils (spiral, overlay) may cover
+  // this much between them and no more, and they step back to `cardVeilDamp` of
+  // that while a video card is over the board. Without it the top of the ramp
+  // is three walls at once and the board stops existing, which is a different
+  // game to the one being played.
+  veilBudget: 0.62,
+  cardVeilDamp: 0.45,          // HARD CAP: a move must always stay physically possible
   spiral: Object.freeze({ minAlpha: 0.16, maxAlpha: 0.50, minHoldMs: 1400, maxHoldMs: 5200, gapMs: 9000 }),
   overlay: Object.freeze({ minAlpha: 0.10, maxAlpha: 0.34 }),
 

--- a/ConditioningControlPanel/Resources/web/piecebypiece/ramp/schedule.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/ramp/schedule.js
@@ -33,8 +33,14 @@ export function cadenceMs(kind, heat, tuning = RAMP_TUNING) {
   return lerp(band.slowMs, band.fastMs, clamp01(heat));
 }
 
-/** The sustained stack for a meter value: which layers are on, and how hard. */
-export function sustainedFor(meter, tuning = RAMP_TUNING) {
+/**
+ * The sustained stack for a meter value: which layers are on, and how hard.
+ *
+ * `opts.cardLive` says a video card is currently over the board. The veils step
+ * back while it is, so the card is the thing you cannot see past, rather than
+ * the last straw on top of two other walls.
+ */
+export function sustainedFor(meter, tuning = RAMP_TUNING, opts = {}) {
   const m = clamp01(meter);
   const u = tuning.unlock;
   // each layer's own 0..1 progress from its unlock point up to a full meter
@@ -43,10 +49,24 @@ export function sustainedFor(meter, tuning = RAMP_TUNING) {
   const blurR = ramp(u.blur);
   const spiralR = ramp(u.spiral);
   const overR = ramp(u.overlay);
+
+  // the two full-screen veils share one budget: they are the only layers that
+  // can hide the board outright, and at a full meter they would otherwise sum
+  // past opaque. Damped further while a card is up.
+  const damp = opts.cardLive ? tuning.cardVeilDamp : 1;
+  let spiralA = (m >= u.spiral ? lerp(tuning.spiral.minAlpha, tuning.spiral.maxAlpha, spiralR) : 0) * damp;
+  let overA = (m >= u.overlay ? lerp(tuning.overlay.minAlpha, tuning.overlay.maxAlpha, overR) : 0) * damp;
+  const veil = spiralA + overA;
+  if (veil > tuning.veilBudget) {
+    const k = tuning.veilBudget / veil;
+    spiralA *= k; overA *= k;
+  }
   return {
     melt: {
       on: m >= u.melt,
-      alpha: m >= u.melt ? lerp(tuning.melt.minAlpha, tuning.melt.maxAlpha, meltR) : 0,
+      // the melt is a full-screen wash too, so it steps back with the veils:
+      // three transparent things stacked stop being transparent
+      alpha: (m >= u.melt ? lerp(tuning.melt.minAlpha, tuning.melt.maxAlpha, meltR) : 0) * damp,
     },
     blur: {
       on: m >= u.blur,
@@ -55,12 +75,12 @@ export function sustainedFor(meter, tuning = RAMP_TUNING) {
     },
     spiral: {
       on: m >= u.spiral,
-      alpha: m >= u.spiral ? lerp(tuning.spiral.minAlpha, tuning.spiral.maxAlpha, spiralR) : 0,
+      alpha: spiralA,
       holdMs: Math.round(lerp(tuning.spiral.minHoldMs, tuning.spiral.maxHoldMs, spiralR)),
     },
     overlay: {
       on: m >= u.overlay,
-      alpha: m >= u.overlay ? lerp(tuning.overlay.minAlpha, tuning.overlay.maxAlpha, overR) : 0,
+      alpha: overA,
     },
   };
 }
@@ -90,7 +110,7 @@ export function createSchedule({ tuning = RAMP_TUNING, seed = 'pbp' } = {}) {
     for (const k of kinds) nextAt[k] = now;
   }
 
-  function tick(now, heat, meter) {
+  function tick(now, heat, meter, opts) {
     const h = clamp01(heat);
     const fire = [];
     if (!started) { started = true; for (const k of kinds) nextAt[k] = now + cadenceMs(k, h, tuning); }
@@ -105,7 +125,7 @@ export function createSchedule({ tuning = RAMP_TUNING, seed = 'pbp' } = {}) {
       // a heat drop should pull the next spawn in, not strand it in the future
       if (nextAt[k] - now > gap) nextAt[k] = now + gap;
     }
-    return { fire, sustained: sustainedFor(meter == null ? h : meter, tuning), heat: h };
+    return { fire, sustained: sustainedFor(meter == null ? h : meter, tuning, opts), heat: h };
   }
 
   /** A capture kick: an immediate burst, bigger for the side that took a piece. */

--- a/ConditioningControlPanel/Resources/web/piecebypiece/smoke/ramp-smoke.mjs
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/smoke/ramp-smoke.mjs
@@ -1,0 +1,292 @@
+/* ============================================================================
+ * smoke/ramp-smoke.mjs - node tests for the ramp's math.
+ *
+ *   node ConditioningControlPanel/Resources/web/piecebypiece/smoke/ramp-smoke.mjs
+ *
+ * Everything under test is pure or clock-injected, so there is no DOM, no
+ * timer and no browser here. The seeded RNG means a failure is reproducible and
+ * a passing run is a promise about the numbers, not about a lucky draw.
+ *
+ * The layers are NOT tested here - they are pixels, and the headless shoot pass
+ * (smoke/shoot.mjs) is what looks at those.
+ * ==========================================================================*/
+
+import { createMeter, RAMP_TUNING, plainShare, clamp01 } from '../ramp/meter.js';
+import { createSchedule, makeRng, cadenceMs, sustainedFor, videoHoldMs } from '../ramp/schedule.js';
+import { createFixtureMedia, createHostMedia, noiseTileUrl } from '../ramp/media.js';
+
+let passed = 0;
+const failures = [];
+
+function check(name, cond, detail) {
+  if (cond) { passed += 1; return; }
+  failures.push(name + (detail ? ' -> ' + detail : ''));
+}
+const near = (a, b, eps = 1e-9) => Math.abs(a - b) <= eps;
+function eq(name, got, want, eps = 1e-9) {
+  check(name, near(got, want, eps), `got ${got}, want ${want}`);
+}
+
+/* ---- the meter ----------------------------------------------------------- */
+
+const TOTAL = 300000;
+function freshMeter() {
+  const m = createMeter({});
+  m.setClock({ w: TOTAL, b: TOTAL, total: TOTAL, active: 'w' });
+  return m;
+}
+
+{
+  const m = freshMeter();
+  eq('fresh meter is zero', m.meterFor('w'), 0);
+  eq('no clock at all reads as a full clock', createMeter({}).meterFor('w'), 0);
+}
+
+{
+  const m = freshMeter();
+  m.setClock({ w: TOTAL / 2, b: TOTAL });
+  eq('half a clock is 0.35 * 0.5', m.meterFor('w'), 0.175);
+  eq('the other side is untouched', m.meterFor('b'), 0);
+  m.setClock({ w: 0 });
+  eq('a dead clock is the full clock weight', m.meterFor('w'), RAMP_TUNING.clockWeight);
+}
+
+{
+  // the owner rule, stated as a test: taking ramps you MORE than losing
+  const taker = freshMeter();
+  taker.noteCapture({ by: 'w', victimSide: 'b' }, 0);
+  eq('one capture ramps the taker 0.15', taker.meterFor('w'), 0.15);
+  eq('one capture ramps the victim 0.10', taker.meterFor('b'), 0.10);
+  check('capturing ramps harder than losing', taker.meterFor('w') > taker.meterFor('b'));
+  eq('the weights are 1.5 and 1.0',
+    taker.meterFor('w') / taker.meterFor('b'), RAMP_TUNING.captureWeight / RAMP_TUNING.lossWeight, 1e-9);
+}
+
+{
+  const m = freshMeter();
+  for (let i = 0; i < 30; i++) m.noteCapture({ by: 'w', victimSide: 'b' }, 0);
+  eq('the meter clamps at 1', m.meterFor('w'), 1);
+  eq('and so does the victim side', m.meterFor('b'), 1);
+}
+
+{
+  // a capture missing victimSide still has to move both sides
+  const m = freshMeter();
+  m.noteCapture({ by: 'b' }, 0);
+  eq('victimSide is inferred from the taker', m.meterFor('w'), 0.10);
+  eq('and the taker still got a capture', m.meterFor('b'), 0.15);
+}
+
+{
+  const m = freshMeter();
+  m.noteCapture({ by: 'w', victimSide: 'b' }, 1000);
+  const d = RAMP_TUNING.burst.decayMs;
+  eq('the kick lands at full amplitude', m.kickFor('w', 1000), RAMP_TUNING.burst.taker);
+  eq('the victim kick is smaller', m.kickFor('b', 1000), RAMP_TUNING.burst.victim);
+  check('the taker kick is the bigger one', m.kickFor('w', 1000) > m.kickFor('b', 1000));
+  eq('the kick is half gone at half the decay', m.kickFor('w', 1000 + d / 2), RAMP_TUNING.burst.taker / 2, 1e-9);
+  eq('the kick is gone at the decay', m.kickFor('w', 1000 + d), 0);
+  eq('and stays gone after it', m.kickFor('w', 1000 + d * 4), 0);
+  eq('heat is meter plus kick', m.heatFor('w', 1000), 0.15 + RAMP_TUNING.burst.taker, 1e-9);
+  eq('heat falls back to the meter', m.heatFor('w', 1000 + d), 0.15);
+}
+
+{
+  const m = freshMeter();
+  m.setTurn({ side: 'b', ply: 7, clocks: { w: 1000, b: 2000 }, total: TOTAL });
+  check('turn sets the acting side', m.active === 'b');
+  check('turn carries the ply', m.ply === 7);
+  check('turn carries the clocks', m.meterFor('w') > m.meterFor('b'));
+  m.reset();
+  eq('reset zeroes the model', m.meterFor('w') + m.meterFor('b'), 0);
+}
+
+{
+  // nothing in the model may throw on a malformed payload
+  const m = freshMeter();
+  let threw = false;
+  try {
+    m.setClock(null); m.setTurn(null); m.noteCapture(null, 0);
+    m.setClock({ w: 'x', total: -1 }); m.noteCapture({ by: 'q' }, 0);
+  } catch { threw = true; }
+  check('a malformed payload never throws', !threw);
+  eq('and never corrupts the meter', m.meterFor('w'), 0);
+}
+
+/* ---- the schedule -------------------------------------------------------- */
+
+{
+  eq('plainShare is 0.80 with no heat', plainShare(0), 0.80);
+  eq('plainShare is 0.30 at full heat', plainShare(1), 0.30);
+  check('plainShare only ever falls', plainShare(0.2) > plainShare(0.8));
+}
+
+{
+  eq('flash cadence at rest', cadenceMs('flash', 0), RAMP_TUNING.flash.slowMs);
+  eq('flash cadence at full heat', cadenceMs('flash', 1), RAMP_TUNING.flash.fastMs);
+  check('cadence shortens as heat rises', cadenceMs('gifRain', 0.2) > cadenceMs('gifRain', 0.9));
+  check('an unknown kind never spawns', cadenceMs('nope', 1) === Infinity);
+}
+
+{
+  const u = RAMP_TUNING.unlock;
+  for (const [name, at] of Object.entries(u)) {
+    check(name + ' is off just under its unlock', sustainedFor(at - 0.001)[name].on === false);
+    check(name + ' is on at its unlock', sustainedFor(at)[name].on === true);
+  }
+  check('nothing is on at meter zero', Object.values(sustainedFor(0)).every((s) => !s.on));
+  check('everything is on at meter one', Object.values(sustainedFor(1)).every((s) => s.on));
+}
+
+{
+  // THE cap. A sweep, not a spot check: this is the one that keeps the game playable.
+  let worst = 0;
+  for (let i = 0; i <= 2000; i++) worst = Math.max(worst, sustainedFor(i / 2000).blur.px);
+  check('blur never passes its cap', worst <= RAMP_TUNING.blurMaxPx + 1e-12, 'worst ' + worst);
+  eq('blur reaches the cap at meter one', sustainedFor(1).blur.px, RAMP_TUNING.blurMaxPx);
+  // and a caller handing in nonsense still cannot get past the clamp
+  check('an out-of-range meter is clamped', sustainedFor(9).blur.px <= RAMP_TUNING.blurMaxPx);
+}
+
+{
+  // the melt only ever deepens
+  let prev = -1, ok = true;
+  for (let i = 0; i <= 100; i++) {
+    const v = sustainedFor(i / 100).melt.alpha;
+    if (v < prev - 1e-12) ok = false;
+    prev = v;
+  }
+  check('melt alpha only ever rises', ok);
+  check('the spiral hold grows with the meter', sustainedFor(1).spiral.holdMs > sustainedFor(0.6).spiral.holdMs);
+
+  // THE VEIL BUDGET. The two full-screen veils are the only layers that can
+  // hide the board outright, so their SUM is what has to behave: it may rise
+  // with the meter, but it may never pass the budget, and a card over the
+  // board pushes it back down. This is the other half of the blur cap.
+  const veil = (m, o) => { const s2 = sustainedFor(m, RAMP_TUNING, o); return s2.spiral.alpha + s2.overlay.alpha; };
+  let worst = 0, rises = true, last = -1;
+  for (let i = 0; i <= 1000; i++) {
+    const v = veil(i / 1000);
+    worst = Math.max(worst, v);
+    if (v < last - 1e-9) rises = false;
+    last = v;
+  }
+  check('the veils never pass their budget', worst <= RAMP_TUNING.veilBudget + 1e-9, 'worst ' + worst);
+  check('the combined veil only ever rises', rises);
+  check('a card over the board pushes the veils back',
+    veil(1, { cardLive: true }) < veil(1) * 0.7,
+    veil(1, { cardLive: true }).toFixed(3) + ' vs ' + veil(1).toFixed(3));
+  check('a card over the board damps the melt as well',
+    sustainedFor(1, RAMP_TUNING, { cardLive: true }).melt.alpha < sustainedFor(1).melt.alpha);
+  check('the board is never fully covered at a full meter',
+    veil(1) + sustainedFor(1).melt.alpha < 1.2);
+}
+
+{
+  eq('the card holds its floor at meter zero', videoHoldMs(0), RAMP_TUNING.videoCard.minHoldSec * 1000);
+  eq('and its ceiling at meter one', videoHoldMs(1), RAMP_TUNING.videoCard.maxHoldSec * 1000);
+  check('the hold grows with the meter', videoHoldMs(0.8) > videoHoldMs(0.2));
+}
+
+/* ---- determinism --------------------------------------------------------- */
+
+{
+  const a = makeRng('seed-a'), b = makeRng('seed-a'), c = makeRng('seed-b');
+  const draw = (r, n) => Array.from({ length: n }, () => r());
+  const av = draw(a, 12), bv = draw(b, 12), cv = draw(c, 12);
+  check('the same seed replays exactly', av.every((v, i) => v === bv[i]));
+  check('a different seed does not', av.some((v, i) => v !== cv[i]));
+  check('every draw is inside 0..1', av.every((v) => v >= 0 && v < 1));
+}
+
+/** Run a schedule over a fixed timeline and collect what it fired. */
+function replay(seed, heat, steps = 400, stepMs = 90) {
+  const s = createSchedule({ seed });
+  const fired = [];
+  for (let i = 1; i <= steps; i++) {
+    const out = s.tick(i * stepMs, heat, heat);
+    for (const k of out.fire) fired.push(i + ':' + k);
+  }
+  return fired;
+}
+
+{
+  const one = replay('replay', 0.6);
+  const two = replay('replay', 0.6);
+  check('a seeded schedule replays exactly', one.join('|') === two.join('|'));
+  check('a different seed diverges', replay('other', 0.6).join('|') !== one.join('|'));
+}
+
+{
+  const cold = replay('heat', 0.05).length;
+  const warm = replay('heat', 0.5).length;
+  const hot = replay('heat', 0.95).length;
+  check('a cold board is quiet', cold < warm, `cold ${cold} warm ${warm}`);
+  check('a hot board is busy', warm < hot, `warm ${warm} hot ${hot}`);
+  check('even a cold board is not silent', cold > 0);
+}
+
+{
+  const s = createSchedule({ seed: 'burst' });
+  const taker = s.burstFor('taker', 0.8);
+  const victim = s.burstFor('victim', 0.8);
+  check('a capture burst spends more on the taker', taker.flashes > victim.flashes);
+  check('and shakes the taker harder', taker.shakeMs > victim.shakeMs);
+  check('a burst at rest still fires something', s.burstFor('taker', 0).flashes > 0);
+}
+
+/* ---- media --------------------------------------------------------------- */
+
+{
+  const empty = createFixtureMedia([]);
+  check('an empty pool has no images', empty.has('image') === false);
+  check('an empty pool has no videos', empty.has('video') === false);
+  check('an empty pool draws nothing', empty.draw('image') === null);
+  check('the video card gets nothing to play', empty.draw('video') === null);
+  const tile = empty.drawTile();
+  check('but a tile is always available', typeof tile === 'string' && tile.startsWith('data:image/svg+xml'));
+  check('the noise tile is a real data uri', noiseTileUrl(2).length > 80);
+  check('stats survive an empty pool', empty.stats().total === 0);
+}
+
+{
+  const list = [
+    { kind: 'image', url: '/a.png' }, { kind: 'image', url: '/b.png' },
+    { kind: 'gif', url: '/c.gif' }, { kind: 'video', url: '/d.webm' },
+  ];
+  const m = createFixtureMedia(list);
+  check('images and gifs both count as images', m.has('image'));
+  check('the video is found', m.draw('video') === '/d.webm');
+  check('a gif draw is a gif', m.draw('gif') === '/c.gif');
+  const deck = Array.from({ length: 3 }, () => m.draw('image'));
+  check('a deck hands out every entry before repeating', new Set(deck).size === 3, deck.join(','));
+  check('stats count each kind', m.stats().video === 1 && m.stats().gif === 1 && m.stats().image === 2);
+}
+
+{
+  // kinds may be omitted: the extension has to be enough
+  const m = createFixtureMedia(['/x.mp4', '/y.gif', '/z.jpg']);
+  check('an mp4 is inferred as a video', m.draw('video') === '/x.mp4');
+  check('a gif is inferred as a gif', m.draw('gif') === '/y.gif');
+  check('anything else is an image', m.has('image'));
+  check('junk entries are dropped', createFixtureMedia([null, {}, 3, '']).stats().total === 0);
+}
+
+{
+  const host = createHostMedia();
+  check('the host stub starts empty', host.size === 0);
+  check('and never hands out a clip', host.draw('video') === null);
+  host.adopt([{ kind: 'image', url: 'https://ccp.assets/img/1.png' }]);
+  check('adopt() is the door the manifest will use', host.size === 1);
+  check('and the pool answers after it', host.draw('image') === 'https://ccp.assets/img/1.png');
+}
+
+/* ---- report -------------------------------------------------------------- */
+
+const total = passed + failures.length;
+if (failures.length) {
+  console.error(`FAIL  ${failures.length}/${total} checks failed:`);
+  for (const f of failures) console.error('  - ' + f);
+  process.exit(1);
+}
+console.log(`ok  ${passed}/${total} ramp checks passed`);

--- a/ConditioningControlPanel/Resources/web/piecebypiece/smoke/shoot.mjs
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/smoke/shoot.mjs
@@ -1,0 +1,125 @@
+/* ============================================================================
+ * smoke/shoot.mjs - screenshot every ramp layer at three meter settings.
+ *
+ * The ramp ships inside WebView2, which has no devtools, so the only way to see
+ * a layer is to photograph it. This drives headless msedge over the dev harness
+ * once per (layer, meter) pair and writes a PNG a human can look at.
+ *
+ * Two rules this file is careful about, both learned the hard way:
+ *   - ONE browser process at a time. The machine runs other agents' servers and
+ *     a fan-out of headless Chromium would take the box down.
+ *   - rAF is nearly starved under --virtual-time-budget, so the harness is told
+ *     to pin the meter (?meter=) and to pre-spawn one-shots (?prime=) rather
+ *     than being left to schedule them itself.
+ *
+ * Usage (the dev server must already be up):
+ *     python -m http.server 8822       # from Resources/web
+ *     node smoke/shoot.mjs [--layer flash] [--out DIR] [--port 8822]
+ * ==========================================================================*/
+
+import { spawn } from 'node:child_process';
+import { mkdirSync, rmSync, existsSync } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+const argv = process.argv.slice(2);
+const arg = (name, dflt) => {
+  const i = argv.indexOf('--' + name);
+  return i >= 0 && argv[i + 1] ? argv[i + 1] : dflt;
+};
+
+const PORT = arg('port', '8822');
+const OUT = path.resolve(arg('out', 'C:/Users/PC/Pictures/Screenshots/piecebypiece/b'));
+const PROFILE = path.join(os.tmpdir(), 'pbp-shoot-edge');
+const ONLY_LAYER = arg('layer', null);
+const METERS = [0.3, 0.6, 0.9];
+
+const EDGE = [
+  'C:/Program Files (x86)/Microsoft/Edge/Application/msedge.exe',
+  'C:/Program Files/Microsoft/Edge/Application/msedge.exe',
+].find((p) => existsSync(p));
+
+/* Each layer says how to make itself visible in a single still frame.
+ * `only` isolates a sustained layer; `fire` spawns a one-shot (or a harness
+ * event); `budget` is the virtual time the page is allowed before the shot. */
+const SHOTS = [
+  { name: 'flash', only: 'none', fire: 'flash,flash,flash,flash', seek: 320, budget: 900 },
+  { name: 'gifRain', only: 'none', fire: 'gifRain,gifRain,gifRain,gifRain,gifRain,gifRain', seek: 1300, budget: 1400 },
+  { name: 'melt', only: 'melt', budget: 1200 },
+  { name: 'blur', only: 'blur', budget: 1200 },
+  { name: 'spiral', only: 'spiral', budget: 1600 },
+  { name: 'overlay', only: 'overlay', budget: 1600 },
+  { name: 'videoCard', only: 'none', fire: 'videoCard', budget: 2600 },
+  { name: 'glitchGrab', only: 'none', fire: 'grab', budget: 1200 },
+  // and one shot of the whole stack, which is what the player actually sees
+  { name: 'all', prime: 6, card: true, seek: 500, budget: 1600 },
+];
+
+function urlFor(shot, meter) {
+  // still=1 because a headless page sees no wall-clock time: without it every
+  // layer is photographed at the first frame of its fade, which is nothing
+  const q = new URLSearchParams({ meter: String(meter), quiet: '1', still: '1' });
+  if (shot.seek) q.set('seek', String(shot.seek));
+  if (shot.only) q.set('only', shot.only);
+  if (shot.prime) q.set('prime', String(shot.prime));
+  if (shot.fire) q.set('fire', shot.fire);
+  // every layer but the card itself is photographed on a board the card is not
+  // covering; the `all` shot keeps it, because that is what the player sees
+  if (shot.card !== true) q.set('noturn', '1');
+  return `http://localhost:${PORT}/piecebypiece/dev/ramp.html?${q}`;
+}
+
+/** One headless run, resolved when the process exits. Never runs in parallel. */
+function shoot(url, file, budget) {
+  return new Promise((resolve) => {
+    const args = [
+      '--headless=new', '--disable-gpu', '--no-first-run', '--no-default-browser-check',
+      '--disable-background-networking', '--disable-extensions', '--mute-audio',
+      '--autoplay-policy=no-user-gesture-required',
+      `--user-data-dir=${PROFILE}`,
+      '--window-size=1280,800',
+      `--virtual-time-budget=${budget}`,
+      '--dump-dom',
+      `--screenshot=${file}`,
+      url,
+    ];
+    const child = spawn(EDGE, args, { stdio: ['ignore', 'pipe', 'pipe'] });
+    let dom = '';
+    child.stdout.on('data', (b) => { dom += b; });
+    child.stderr.on('data', () => { /* Edge is chatty on stderr; the DOM is truth */ });
+    const kill = setTimeout(() => { try { child.kill(); } catch { /* gone */ } }, 45000);
+    child.on('exit', () => {
+      clearTimeout(kill);
+      const m = /id="errors" data-count="(\d+)"/.exec(dom);
+      const errors = m ? Number(m[1]) : -1;
+      let text = '';
+      if (errors > 0) {
+        const t = /id="errors"[^>]*>([\s\S]*?)<\/div>/.exec(dom);
+        text = t ? t[1].trim().slice(0, 400) : '';
+      }
+      resolve({ errors, text, ticks: /ticks (\d+)/.exec(dom)?.[1] });
+    });
+  });
+}
+
+async function main() {
+  if (!EDGE) { console.error('msedge.exe not found'); process.exit(2); }
+  mkdirSync(OUT, { recursive: true });
+  try { rmSync(PROFILE, { recursive: true, force: true }); } catch { /* first run */ }
+
+  let bad = 0;
+  for (const shot of SHOTS) {
+    if (ONLY_LAYER && shot.name !== ONLY_LAYER) continue;
+    for (const meter of METERS) {
+      const file = path.join(OUT, `layer-${shot.name}-m${String(meter).replace('.', '')}.png`);
+      const res = await shoot(urlFor(shot, meter), file, shot.budget);
+      const tag = res.errors === 0 ? 'ok  ' : (res.errors < 0 ? 'DOM?' : 'ERR ');
+      if (res.errors !== 0) bad += 1;
+      console.log(`${tag} ${shot.name} @ ${meter}  ->  ${path.basename(file)}${res.text ? '\n     ' + res.text : ''}`);
+    }
+  }
+  console.log(bad ? `\n${bad} run(s) reported page errors` : '\nall runs clean, zero console errors');
+  process.exit(bad ? 1 : 0);
+}
+
+main();


### PR DESCRIPTION
Fourth in the ramp stack, on top of #960. Tests and the pictures that come with them, plus the four fixes those pictures found.

## What is here

**`smoke/ramp-smoke.mjs`** - 88 node checks, no browser, seeded so a failure reproduces. It states the design as assertions rather than describing it:

- capturing a piece ramps you harder than losing one (the owner rule, as a test);
- the blur never passes 3px, checked with a 2000-step sweep over the whole meter range;
- every unlock is off just under its threshold and on at it;
- a malformed bus payload changes no state;
- the media pool degrades to nothing when it is empty, and `adopt()` is visible to callers.

Run it with `node smoke/ramp-smoke.mjs`.

**`smoke/shoot.mjs`** - photographs every layer at meter 0.3, 0.6 and 0.9 through headless msedge, strictly one browser process at a time, into `Pictures/Screenshots/piecebypiece/b/`. It also greps the harness error sink out of the dumped DOM, so a run reports page errors instead of hiding them. All 27 shots come back with zero console errors.

## What looking at the pictures found

1. **A solo re-apply was skipped.** `applied[name]` used `-1` for both "this layer is off" and "we have never written this layer", so a forced re-apply of an off layer read as no change. Isolating one layer left the others on. Now the two states are different values.
2. **`createFixtureMedia` froze its own `size` getter** by spreading the pool into a new object, so a later `adopt()` went unnoticed. It assigns now, and there is a test.
3. **The grab sticker sat dead centre on the pointer**, covering the very square the player was aiming at. It hangs up and to the left now: distraction, not blindfold.
4. **At a full meter the board stopped existing.** Melt, spiral veil, gif overlay and a video card stacked into an opaque wall.

## The veil budget

The fourth one is now a rule. `RAMP_TUNING` gains:

- `veilBudget: 0.62` - the two full-screen gif veils share one alpha budget and are scaled down together when they would pass it;
- `cardVeilDamp: 0.45` - while a tape is over the board, the washes step back, so the card is the thing you cannot see past rather than the last straw on three other things.

Same law as the 3px blur cap: the ramp makes you play badly, it does not make the game unplayable. Both are enforced in `sustainedFor` and both have a sweep test.

## Harness

`dev/ramp.html` grew `?only=`, `?noturn=`, `?still=` and `?seek=`. A headless page sees almost no wall-clock time, so without them every screenshot catches the first frame of a fade, which is nothing at all.

## Test plan

- `node smoke/ramp-smoke.mjs` -> 88/88.
- `python -m http.server 8822` from `Resources/web`, then `node smoke/shoot.mjs` -> 27 clean shots.
- Every screenshot was opened and read, not just counted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S4BKp6cQJFNixoQrarvSkd
