### PR TITLE
Piece by Piece ramp b4: the ramp asks the host for its pictures

### DIFF
--- a/ConditioningControlPanel/Resources/web/piecebypiece/dev/ramp.html
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/dev/ramp.html
@@ -13,6 +13,7 @@
                ?fire=flash  fire one layer once on load
                ?only=blur   show only that sustained layer
                ?noturn=1    do not play the opening move (no video card)
+               ?media=host  use the host source instead of the fixtures
                ?still=1     kill fade-in transitions (a still frame, not a fade)
                ?seek=1200   jump one-shot animations forward, for a still
                ?quiet=1     hide the control panel (clean screenshots)
@@ -114,7 +115,7 @@
 
 <script type="module">
 import { attachRamp } from '../ramp/index.js';
-import { createFixtureMedia, loadFixtureList } from '../ramp/media.js';
+import { createFixtureMedia, createHostMedia, loadFixtureList } from '../ramp/media.js';
 
 const qs = new URLSearchParams(location.search);
 if (qs.get('quiet') === '1') document.getElementById('panel').classList.add('hidden');
@@ -153,8 +154,11 @@ const game = { ply: 0, side: 'w', clocks: { w: TOTAL, b: TOTAL } };
 const bus = createBus();
 window.PBP = { bus, game, board: null };
 
+/* ?media=host runs the shipping source. In a plain browser there is no
+   window.chrome.webview, so this is also the proof that the host path degrades
+   the way it promises: an empty pool, generated noise tiles, and no card. */
 const list = await loadFixtureList(new URL('./media.json', import.meta.url).href);
-const media = createFixtureMedia(list);
+const media = qs.get('media') === 'host' ? createHostMedia([]) : createFixtureMedia(list);
 const ramp = attachRamp({ bus, root: document.getElementById('fx'), stage: document.getElementById('stage'), media });
 window.PBP.ramp = ramp;
 

--- a/ConditioningControlPanel/Resources/web/piecebypiece/ramp/index.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/ramp/index.js
@@ -84,6 +84,24 @@ export function attachRamp(opts = {}) {
 
   const stack = createLayerStack({ root, front, stage, media, tuning, rng: schedule.rng });
 
+  // declared before the subscription below, which can fire the moment it is made
+  let hostHoldSec = null;     // pbp:settings.videoHoldSec, when the host sent one
+  let reducedMotion = false;  // pbp:settings.reducedMotion: the moving layers stop
+
+  // A host-backed pool (media.js createHostMedia) forwards the host's own
+  // settings frame. A fixture pool has no onSettings and this is simply skipped.
+  let unsubSettings = null;
+  if (media && typeof media.onSettings === 'function') {
+    try {
+      unsubSettings = media.onSettings((s) => {
+        hostHoldSec = Number.isFinite(s && s.videoHoldSec) ? s.videoHoldSec : null;
+        const wasReduced = reducedMotion;
+        reducedMotion = !!(s && s.reducedMotion);
+        if (reducedMotion && !wasReduced) stack.clear();   // drop what is mid-flight
+      });
+    } catch { warn('host settings could not be subscribed'); }
+  }
+
   let enabled = true;
   let disposed = false;
   let rafId = 0;
@@ -139,7 +157,9 @@ export function attachRamp(opts = {}) {
       ticks += 1;
       const m = liveMeter();
       const out = schedule.tick(t, liveHeat(t), m, { cardLive: stack.cardLive });
-      for (const kind of out.fire) stack.oneshot(kind, { heat: out.heat });
+      // reduced motion keeps the still layers (the melt, the blur, the veils)
+      // and drops everything that pops, falls or rushes at the player
+      if (!reducedMotion) for (const kind of out.fire) stack.oneshot(kind, { heat: out.heat });
       applySustained(out.sustained);
       if (t - lastBoardPush >= BOARD_PUSH_MS) { lastBoardPush = t; pushToBoard(m); }
     }
@@ -163,19 +183,21 @@ export function attachRamp(opts = {}) {
       // The card belongs to the side that just MOVED and is now waiting: it
       // rides over the board while the opponent thinks. In hotseat both sides
       // are local, so this is simply every turn.
+      if (reducedMotion) return;
       const waiting = otherSide(p && p.side === 'b' ? 'b' : 'w');
-      const holdMs = videoHoldMs(overrideMeter == null ? meter.meterFor(waiting) : clamp01(overrideMeter), tuning);
-      stack.videoCard({ holdMs, side: waiting });
+      const m = overrideMeter == null ? meter.meterFor(waiting) : clamp01(overrideMeter);
+      stack.videoCard({ holdMs: videoHoldMs(m, tuning, hostHoldSec), side: waiting });
     },
     capture(p) {
       const t = now();
       meter.noteCapture(p, t);
       const taker = p && p.by === 'b' ? 'b' : 'w';
+      if (reducedMotion) return;   // the meter still moved; only the burst is off
       // both sides feel it; the one who took the piece feels it harder
       stack.burst(schedule.burstFor('taker', meter.heatFor(taker, t)));
       stack.burst(schedule.burstFor('victim', meter.heatFor(otherSide(taker), t)));
     },
-    check() { stack.oneshot('flash', { heat: liveHeat(now()) }); },
+    check() { if (!reducedMotion) stack.oneshot('flash', { heat: liveHeat(now()) }); },
     grab(p) { stack.grab(p); },
     dragmove(p) { stack.dragmove(p); },
     drop(p) { stack.drop(p); },
@@ -206,6 +228,7 @@ export function attachRamp(opts = {}) {
     if (disposed) return;
     disposed = true;
     if (rafId) { try { cancelAnimationFrame(rafId); } catch { clearTimeout(rafId); } rafId = 0; }
+    if (unsubSettings) { try { unsubSettings(); } catch { /* gone */ } unsubSettings = null; }
     if (bus) for (const [type, fn] of bound) { try { bus.off(type, fn); } catch { /* gone already */ } }
     bound.length = 0;
     try { stack.dispose(); } catch { /* best effort */ }
@@ -222,6 +245,8 @@ export function attachRamp(opts = {}) {
       meter: liveMeter(),
       heat: liveHeat(t),
       override: overrideMeter,
+      hostHoldSec,
+      reducedMotion,
       model: meter.snapshot(t),
       layers: stack.debug ? stack.debug() : null,
       media: media.stats ? media.stats() : null,
@@ -236,7 +261,7 @@ export function attachRamp(opts = {}) {
       },
       /** Dev harness only: fire one layer by name right now. */
       fire(kind, o) {
-        if (kind === 'videoCard') stack.videoCard(o || { holdMs: videoHoldMs(liveMeter(), tuning) });
+        if (kind === 'videoCard') stack.videoCard(o || { holdMs: videoHoldMs(liveMeter(), tuning, hostHoldSec) });
         else stack.oneshot(kind, o || { heat: liveHeat(now()) });
       },
       /** Dev harness only: isolate ONE sustained layer (null shows them all). */

--- a/ConditioningControlPanel/Resources/web/piecebypiece/ramp/media.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/ramp/media.js
@@ -46,13 +46,19 @@ function shuffle(arr, rnd) {
 }
 
 /** The shared pool body both sources use. `entries` may be replaced by adopt(). */
-function createPool(entries, { rnd, label } = {}) {
+function createPool(entries, { rnd, label, lowWater = 0, onLow } = {}) {
   let all = [];
   const decks = {};      // kind -> remaining shuffled indices
   const recent = [];     // last NO_ECHO urls handed out
 
   function ingest(list) {
     all = [];
+    ingestInto(list, all);
+    for (const k of KINDS) delete decks[k];
+    recent.length = 0;
+  }
+
+  function ingestInto(list, out) {
     for (const raw of Array.isArray(list) ? list : []) {
       if (!raw) continue;
       const url = typeof raw === 'string' ? raw : raw.url;
@@ -64,10 +70,8 @@ function createPool(entries, { rnd, label } = {}) {
         else if (/\.gif(\?|$)/i.test(url)) kind = 'gif';
         else kind = 'image';
       }
-      all.push({ kind, url, name: (typeof raw === 'object' && raw.name) || url.split('/').pop() });
+      out.push({ kind, url, name: (typeof raw === 'object' && raw.name) || url.split('/').pop() });
     }
-    for (const k of KINDS) delete decks[k];
-    recent.length = 0;
   }
   ingest(entries);
 
@@ -80,6 +84,16 @@ function createPool(entries, { rnd, label } = {}) {
   }
 
   function has(kind) { return poolFor(kind).length > 0; }
+
+  /** Add entries without throwing away the deck we are part-way through. */
+  function extend(list) {
+    const seen = new Set(all.map((e) => e.url));
+    const before = all.length;
+    const add = [];
+    ingestInto(list, add);
+    for (const e of add) if (!seen.has(e.url)) { seen.add(e.url); all.push(e); }
+    return all.length - before;
+  }
 
   /** One url, non-repeating across a deck, echo-guarded on tiny pools. */
   function draw(kind) {
@@ -94,6 +108,9 @@ function createPool(entries, { rnd, label } = {}) {
     const url = all[idx].url;
     recent.push(url);
     while (recent.length > NO_ECHO) recent.shift();
+    // tell the owner when this kind is nearly spent, so a host-backed pool can
+    // ask for more BEFORE the deck runs dry and the layer has nothing to show
+    if (onLow && deck.length < lowWater) { try { onLow(k, deck.length); } catch { /* the asker's problem */ } }
     return url;
   }
 
@@ -106,7 +123,16 @@ function createPool(entries, { rnd, label } = {}) {
     return out;
   }
 
-  return { has, draw, drawTile, stats, adopt: ingest, get size() { return all.length; } };
+  return {
+    has, draw, drawTile, stats, adopt: ingest, extend,
+    get size() { return all.length; },
+    /** How many entries of a kind are still unused in the current deck. */
+    unused(kind) {
+      const k = KINDS.includes(kind) ? kind : 'image';
+      const deck = decks[k];
+      return deck ? deck.length : poolFor(k).length;
+    },
+  };
 }
 
 /**
@@ -121,21 +147,133 @@ export function createFixtureMedia(list, opts = {}) {
   return pool;
 }
 
+/* ---- the shipping source: the WebView2 host ------------------------------ */
+
+export const HOST_MSG = Object.freeze({
+  request: 'pbp:media-request',   // page -> host
+  media: 'pbp:media',             // host -> page
+  settings: 'pbp:settings',       // host -> page
+});
+const REQUEST_COUNT = 24;         // how many entries we ask for at a time
+const LOW_WATER = 4;              // ask again once a deck is down to this
+const REQUEST_GAP_MS = 4000;      // and never more often than this
+
+/** The host talks in three lists of urls; the pool wants entries. */
+function entriesFromFrame(frame) {
+  const out = [];
+  const push = (list, kind) => {
+    for (const url of Array.isArray(list) ? list : []) {
+      if (typeof url === 'string' && url) out.push({ kind, url });
+    }
+  };
+  push(frame && frame.images, 'image');
+  push(frame && frame.gifs, 'gif');
+  push(frame && frame.videos, 'video');
+  return out;
+}
+
 /**
- * Shipping source (STUB). The C# host has no Piece by Piece manifest yet; when
- * it grows one it will post the DtRH-shaped frame
- *   { type:'manifest', images:[...], videos:[...] }   // https://ccp.assets/ urls
- * and the page will call `media.adopt(entries)` with it. Nothing in the ramp
- * needs to change: adopt() is the same door createFixtureMedia uses.
+ * The shipping source. Same interface as createFixtureMedia, plus the bridge.
  *
- * Do NOT build the C# side from here - this is only the page-side seam.
+ * The page talks to C# exactly the way DtRH does (dtrh/bridge.js): objects out
+ * through window.chrome.webview.postMessage, objects in through its `message`
+ * event. Three frames:
+ *
+ *   page -> host  { type:'pbp:media-request', kinds:['image','gif','video'], count:24 }
+ *                 sent once at attach, and again whenever a deck runs below
+ *                 four unused entries (throttled, so a hot layer cannot spam
+ *                 the host while it is still answering the last ask).
+ *   host -> page  { type:'pbp:media', images:[...], gifs:[...], videos:[...] }
+ *                 https://ccp.assets/ urls from the user's own library, already
+ *                 filtered by their blocklists on the C# side. Any list may be
+ *                 empty, and an empty answer is a normal answer.
+ *   host -> page  { type:'pbp:settings', videoHoldSec, reducedMotion }
+ *                 once after boot. videoHoldSec becomes the base hold for the
+ *                 video card; reducedMotion turns the moving layers off.
+ *
+ * Outside WebView2 (the dev harness in a plain browser) there is no bridge, so
+ * this degrades to exactly what createFixtureMedia([]) does: an empty pool, a
+ * console.warn, and no throw anywhere.
+ *
+ * URL-ONLY, like every other pool here: no fetch, no canvas, no WebGL upload.
+ * The host may hand us remote CDN urls that send no CORS headers, and a plain
+ * <img>/<video>/background-image is the only road those can travel.
  */
-export function createHostMedia(entries) {
-  const pool = createPool(entries || [], { label: 'host' });
-  if (!pool.size) {
+export function createHostMedia(entries, opts = {}) {
+  const bridge = opts.bridge
+    || (typeof window !== 'undefined' && window.chrome && window.chrome.webview) || null;
+
+  let pool = null;
+  const requestNow = () => { if (pool) pool.request(); };
+  pool = createPool(entries || [], { label: 'host', lowWater: LOW_WATER, onLow: requestNow });
+  pool.kind = 'host';
+
+  // what the host told us about itself; the ramp reads these through onSettings
+  const settings = { videoHoldSec: null, reducedMotion: false };
+  const subs = new Set();
+  const gapMs = Number.isFinite(opts.requestGapMs) ? Math.max(0, opts.requestGapMs) : REQUEST_GAP_MS;
+  let lastAsk = -Infinity;
+  let listener = null;
+
+  const stamp = () => (typeof performance !== 'undefined' && performance.now ? performance.now() : Date.now());
+
+  function request() {
+    if (!bridge || typeof bridge.postMessage !== 'function') return false;
+    const t = stamp();
+    if (t - lastAsk < gapMs) return false;   // the host is still answering the last ask
+    lastAsk = t;
+    try {
+      bridge.postMessage({ type: HOST_MSG.request, kinds: KINDS.slice(), count: REQUEST_COUNT });
+      return true;
+    } catch { return false; }
+  }
+
+  function handle(data) {
+    if (!data || typeof data !== 'object') return;
+    if (data.type === HOST_MSG.media) {
+      const added = pool.extend(entriesFromFrame(data));
+      // an answer that brought nothing must not leave us asking in a tight
+      // loop, so the throttle stamp stands either way
+      if (!added && !pool.size) warnEmpty();
+      return;
+    }
+    if (data.type === HOST_MSG.settings) {
+      if (Number.isFinite(data.videoHoldSec) && data.videoHoldSec > 0) settings.videoHoldSec = data.videoHoldSec;
+      settings.reducedMotion = !!data.reducedMotion;
+      for (const fn of [...subs]) { try { fn({ ...settings }); } catch { /* a listener is not our problem */ } }
+    }
+  }
+
+  function warnEmpty() {
     try { console.warn('[pbp/ramp] host media pool is empty; the ramp runs without pictures.'); } catch { /* no console */ }
   }
-  pool.kind = 'host';
+
+  if (bridge && typeof bridge.addEventListener === 'function') {
+    listener = (e) => { try { handle(e && e.data); } catch { /* a bad frame is not a crash */ } };
+    try { bridge.addEventListener('message', listener); } catch { listener = null; }
+    request();
+  } else {
+    warnEmpty();
+  }
+
+  pool.settings = settings;
+  /** Subscribe to host settings. Fires immediately if they already arrived. */
+  pool.onSettings = (fn) => {
+    if (typeof fn !== 'function') return () => {};
+    subs.add(fn);
+    if (settings.videoHoldSec != null || settings.reducedMotion) { try { fn({ ...settings }); } catch { /* ignore */ } }
+    return () => subs.delete(fn);
+  };
+  pool.request = request;
+  /** For tests and for a host that pushes without being asked. */
+  pool.handleMessage = handle;
+  pool.dispose = () => {
+    subs.clear();
+    if (bridge && listener && typeof bridge.removeEventListener === 'function') {
+      try { bridge.removeEventListener('message', listener); } catch { /* gone */ }
+    }
+    listener = null;
+  };
   return pool;
 }
 

--- a/ConditioningControlPanel/Resources/web/piecebypiece/ramp/schedule.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/ramp/schedule.js
@@ -85,10 +85,19 @@ export function sustainedFor(meter, tuning = RAMP_TUNING, opts = {}) {
   };
 }
 
-/** How long the video card sticks over the board at this meter. */
-export function videoHoldMs(meter, tuning = RAMP_TUNING) {
+/**
+ * How long the video card sticks over the board at this meter.
+ *
+ * `baseSec` is the host's own setting (pbp:settings.videoHoldSec) when the
+ * user has one. It moves the FLOOR and the ceiling follows it, so the card
+ * still grows with the meter by the same proportion the tuning asks for
+ * instead of the user's setting being quietly overruled at a high meter.
+ */
+export function videoHoldMs(meter, tuning = RAMP_TUNING, baseSec = null) {
   const v = tuning.videoCard;
-  return Math.round(lerp(v.minHoldSec, v.maxHoldSec, clamp01(meter)) * 1000);
+  const min = Number.isFinite(baseSec) && baseSec > 0 ? baseSec : v.minHoldSec;
+  const max = min * (v.maxHoldSec / v.minHoldSec);
+  return Math.round(lerp(min, max, clamp01(meter)) * 1000);
 }
 
 /**

--- a/ConditioningControlPanel/Resources/web/piecebypiece/smoke/ramp-smoke.mjs
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/smoke/ramp-smoke.mjs
@@ -13,7 +13,7 @@
 
 import { createMeter, RAMP_TUNING, plainShare, clamp01 } from '../ramp/meter.js';
 import { createSchedule, makeRng, cadenceMs, sustainedFor, videoHoldMs } from '../ramp/schedule.js';
-import { createFixtureMedia, createHostMedia, noiseTileUrl } from '../ramp/media.js';
+import { createFixtureMedia, createHostMedia, HOST_MSG, noiseTileUrl } from '../ramp/media.js';
 
 let passed = 0;
 const failures = [];
@@ -24,7 +24,12 @@ function check(name, cond, detail) {
 }
 const near = (a, b, eps = 1e-9) => Math.abs(a - b) <= eps;
 function eq(name, got, want, eps = 1e-9) {
-  check(name, near(got, want, eps), `got ${got}, want ${want}`);
+  // numbers compare with a tolerance, anything else exactly: a string compared
+  // as a number is NaN, which used to fail a passing check
+  const same = typeof got === 'number' && typeof want === 'number'
+    ? near(got, want, eps)
+    : got === want;
+  check(name, same, `got ${got}, want ${want}`);
 }
 
 /* ---- the meter ----------------------------------------------------------- */
@@ -273,12 +278,110 @@ function replay(seed, heat, steps = 400, stepMs = 90) {
 }
 
 {
+  // no WebView2 around (a plain browser, or node): the host source has to
+  // behave exactly like an empty fixture pool and never throw
   const host = createHostMedia();
-  check('the host stub starts empty', host.size === 0);
+  check('with no bridge the host pool starts empty', host.size === 0);
   check('and never hands out a clip', host.draw('video') === null);
+  check('and still answers with a generated tile', typeof host.drawTile() === 'string');
+  check('and asking the host that is not there is simply false', host.request() === false);
   host.adopt([{ kind: 'image', url: 'https://ccp.assets/img/1.png' }]);
-  check('adopt() is the door the manifest will use', host.size === 1);
+  check('adopt() is the door the manifest uses', host.size === 1);
   check('and the pool answers after it', host.draw('image') === 'https://ccp.assets/img/1.png');
+}
+
+/* ---- the host bridge ----------------------------------------------------- */
+
+/** A stand-in for window.chrome.webview: records what the page posts. */
+function fakeBridge() {
+  const listeners = new Set();
+  const sent = [];
+  return {
+    sent,
+    postMessage(o) { sent.push(o); },
+    addEventListener(type, fn) { if (type === 'message') listeners.add(fn); },
+    removeEventListener(type, fn) { listeners.delete(fn); },
+    /** the host answering */
+    push(data) { for (const fn of [...listeners]) fn({ data }); },
+    get listening() { return listeners.size; },
+  };
+}
+
+{
+  const bridge = fakeBridge();
+  const host = createHostMedia([], { bridge });
+  const ask = bridge.sent[0];
+  check('the page asks the host at attach', !!ask);
+  eq('and asks with the agreed type', ask && ask.type, HOST_MSG.request);
+  check('the ask names all three kinds',
+    ask && ['image', 'gif', 'video'].every((k) => ask.kinds.includes(k)),
+    JSON.stringify(ask && ask.kinds));
+  check('and asks for a batch, not one at a time', ask && ask.count >= 8);
+
+  bridge.push({
+    type: HOST_MSG.media,
+    images: ['https://ccp.assets/a.png', 'https://ccp.assets/b.png'],
+    gifs: ['https://ccp.assets/c.gif'],
+    videos: ['https://ccp.assets/d.mp4'],
+  });
+  eq('the answer lands in the pool', host.size, 4);
+  eq('videos are drawable', host.draw('video'), 'https://ccp.assets/d.mp4');
+  check('gifs are drawable', host.draw('gif') === 'https://ccp.assets/c.gif');
+
+  // a second frame adds rather than replaces, and never duplicates
+  bridge.push({ type: HOST_MSG.media, images: ['https://ccp.assets/a.png', 'https://ccp.assets/e.png'] });
+  eq('a later frame adds only what is new', host.size, 5);
+
+  // empty lists are a normal answer, not an error
+  bridge.push({ type: HOST_MSG.media, images: [], gifs: [], videos: [] });
+  eq('an empty answer changes nothing', host.size, 5);
+
+  // and junk on the wire cannot take the page down
+  for (const junk of [null, undefined, 7, 'hello', {}, { type: 'other' }, { type: HOST_MSG.media, images: 3 }]) {
+    bridge.push(junk);
+  }
+  eq('junk frames are ignored', host.size, 5);
+
+  let got = null;
+  host.onSettings((s2) => { got = s2; });
+  bridge.push({ type: HOST_MSG.settings, videoHoldSec: 7, reducedMotion: true });
+  check('settings reach a subscriber', !!got);
+  eq('videoHoldSec comes through', got && got.videoHoldSec, 7);
+  eq('reducedMotion comes through', got && got.reducedMotion, true);
+
+  let late = null;
+  host.onSettings((s2) => { late = s2; });
+  check('a late subscriber is told at once', late && late.videoHoldSec === 7);
+
+  host.dispose();
+  eq('dispose lets go of the bridge', bridge.listening, 0);
+}
+
+{
+  // the low-water ask: a nearly spent deck must send the page back to the host
+  const bridge = fakeBridge();
+  // requestGapMs 0: the real throttle is four seconds and a test cannot wait
+  const host = createHostMedia([], { bridge, requestGapMs: 0 });
+  bridge.push({ type: HOST_MSG.media, images: ['/1.png', '/2.png', '/3.png'] });
+  const before = bridge.sent.length;
+  for (let i = 0; i < 12; i++) host.draw('image');
+  check('a drained deck asks the host for more', bridge.sent.length > before,
+    before + ' -> ' + bridge.sent.length);
+
+  // and with the real throttle in place, the same drain cannot spam the host
+  const b2 = fakeBridge();
+  const host2 = createHostMedia([], { bridge: b2 });
+  b2.push({ type: HOST_MSG.media, images: ['/1.png', '/2.png', '/3.png'] });
+  for (let i = 0; i < 12; i++) host2.draw('image');
+  eq('the throttle holds the asks to the one at attach', b2.sent.length, 1);
+}
+
+{
+  // the host's own hold setting moves the floor, and the meter still stretches it
+  eq('no host setting keeps the tuning floor', videoHoldMs(0, RAMP_TUNING, null), RAMP_TUNING.videoCard.minHoldSec * 1000);
+  eq('a host hold of 6s is the floor', videoHoldMs(0, RAMP_TUNING, 6), 6000);
+  check('and a full meter still stretches it', videoHoldMs(1, RAMP_TUNING, 6) > 6000);
+  eq('a nonsense hold falls back to the tuning', videoHoldMs(0, RAMP_TUNING, -3), RAMP_TUNING.videoCard.minHoldSec * 1000);
 }
 
 /* ---- report -------------------------------------------------------------- */


### PR DESCRIPTION
Fifth in the ramp stack, on top of #964. `createHostMedia()` was a documented stub; a C# host agent is now building the other side, so this is the real thing, built to the agreed frames.

## The wire

Same bridge DtRH uses (`dtrh/bridge.js`): objects out through `window.chrome.webview.postMessage`, objects in through its `message` event.

| direction | frame |
| --- | --- |
| page -> host | `{ type: 'pbp:media-request', kinds: ['image','gif','video'], count: 24 }` |
| host -> page | `{ type: 'pbp:media', images: [url...], gifs: [url...], videos: [url...] }` |
| host -> page | `{ type: 'pbp:settings', videoHoldSec: number, reducedMotion: boolean }` |

The ask goes out once at attach and again whenever a deck runs below four unused entries, throttled to one every four seconds so a hot layer cannot hammer the host while it is still answering the last one. A later media frame **adds** to the pool instead of replacing it and never repeats a url, so the deck the layers are part-way through survives a refill. Any list may be empty, and an empty answer is a normal answer.

## The settings

- **`videoHoldSec`** moves the video card's floor, and the ceiling follows it by the same proportion the tuning asks for. A user who wants short tapes gets short tapes that still grow with the meter, rather than having their setting overruled once the meter is high.
- **`reducedMotion`** keeps the still layers (the melt, the blur, the veils) and drops everything that pops, falls or rushes at the player, the card included. The meter still moves; only the moving pixels stop.

## Degrading

Outside WebView2 (the dev harness in a plain browser, or node) there is no bridge, and the host source then behaves exactly like `createFixtureMedia([])`: a `console.warn`, generated pink noise tiles instead of gifs, no video card, and no throw anywhere. `dev/ramp.html?media=host` runs that path on purpose, and the screenshot of it at meter 0.9 shows a readable board under noise: `Pictures/Screenshots/piecebypiece/b/hostmedia-degrade-m09.png`.

Still URL-only, like every pool in this game: no fetch, no canvas, no WebGL upload, because the host may hand us remote CDN urls that send no CORS headers.

## Test plan

- `node smoke/ramp-smoke.mjs` -> 111/111, 23 of them new. A fake bridge records what the page posts, answers it, and then feeds it junk (`null`, `7`, `'hello'`, `{}`, a media frame whose `images` is a number) to prove a bad frame cannot take the page down.
- `node smoke/shoot.mjs` -> 27 shots, zero console errors.
- The `eq` test helper compared everything numerically, so a string check read as `NaN` and failed while printing two identical values. It compares numbers with a tolerance and everything else exactly now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S4BKp6cQJFNixoQrarvSkd
