### PR TITLE
feat(race): EMI waits on the beat through 3 2 1

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
@@ -225,6 +225,7 @@ kart.emiModel()                  // the mounted race/assets/emi.glb root, or nul
 kart.emiReady(cb)                // cb(root) when she is mounted (fires at once if she already is)
 kart.setFace(i)                  // face atlas frame 0..4 (menus and results; never seen in race)
 kart.pose(name, opts)            // the pose layer, race/emiPoses.js
+kart.idle(dt)                    // the rider only, world parked (the `again` count: no physics, no camera)
 kart.dispose()
 ```
 `createKart` also takes `pixel` (race/pixel.js): the glb's textures land after the run's one
@@ -249,9 +250,12 @@ emoticons only, never a drawn face, never a speech line.
 export const POSES, PIVOTS;   // the pure preset table, and the four glb pivots a preset may name
 export function resolvePose(name, opts) -> flattened target
 export function createPoseLayer(model) -> { set(name, opts), update(dt, ctx), dispose, fraught, name }
+export function snapshotRest(model)     // bank the authored stance before a mixer moves it
 ```
 Poses: `cruise` (the rest), `drift`, `boost` -> `boostOut`, `air`, `landing` / `landingKerb`,
-`grab`, `clamp`, `tuck`, `throw`, `cheer`. `opts` = `{ side:-1|1, tier:1..3, hold:sec }`; sided
+`grab`, `clamp`, `tuck`, `throw`, `cheer`, and the countdown set `ready` -> `grip` and `launch`.
+`opts` = `{ side:-1|1, tier:1..3, hold:sec, amp:0..1 }` (`amp` scales the whole-body part only, so
+reduced motion keeps the gesture and loses the bounce); sided
 presets are authored for +1 and mirrored for -1. Every value is an offset on the pack's authored
 rest rotation, blended on damped springs (Law XI, never a linear tween), and a pose with a `hold`
 falls back to `next` on its own. `clamp` and `landingKerb` report `fraught` and emi.js takes the
@@ -265,6 +269,13 @@ degrees around from dead ahead, and the forward half of that arc hides behind he
 chase camera, so the grips sit at 66..79 degrees. Re-solve, do not eyeball: a hand that drops below
 the lip vanishes inside the cup. The hands ride the cup through the steer lean for free - the seat
 and `kart_cup` share the body group that tips.
+
+**The countdown.** `ready` -> `grip` is one beat of the 3 2 1 and `launch` is GO. Both counts drive
+them off the HUD's own ticks, never a hand-timed script: `intro.js` builds a layer over the menu
+stage's glb inside `count()` (written after `stage.update`, so it beats the idle clip, and disposed
+with the intro), and `run.js`'s `again` passes an `onTick` and leans on `kart.idle(dt)` to turn the
+springs while the world is still parked. `menu.js` calls `snapshotRest` the moment the glb lands so
+the layer offsets from the pack's stance and not from whatever frame the mixer was on.
 
 ### `race/pickups.js` (the passive pickups)
 ```js

--- a/ConditioningControlPanel/Resources/web/dtrh/race/emiPoses.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/emiPoses.js
@@ -9,10 +9,11 @@
  *   createPoseLayer(model, { }) -> { set(name, opts), update(dt, ctx), dispose, fraught, name }
  *   POSES                        the pure preset table (a node smoke reads it)
  *   PIVOTS                       the four glb pivots a preset is allowed to name
+ *   snapshotRest(model)          bank the authored stance before a mixer moves it
  *
  * `model` is the glb root (EMI_root clone). Every preset value is an OFFSET on
  * the pivot's authored rest rotation, so the model's own stance is never lost.
- * `opts`: { side: -1 | 1, tier: 1..3, hold: seconds }. A sided preset is authored
+ * `opts`: { side: -1 | 1, tier: 1..3, hold: seconds, amp: 0..1, arms: 0..1 }. A sided preset is authored
  * for side +1 (the kart's right, +x) and mirrored for -1: L and R swap and the y
  * and z of every rotation flip, along with the root lean.
  *
@@ -99,6 +100,22 @@ export const POSES = {
   // a personal best or a jackpot: both arms up
   cheer: { w: 9, zeta: 0.45, hold: 1.3, next: 'cruise', root: { lean: 0, tilt: -0.08, lift: 0.06, squash: 1.04 },
     shoulderL: [-2.60, 0, -0.35], shoulderR: [-2.60, 0, 0.35], footL: [-0.18, 0, 0], footR: [-0.18, 0, 0] },
+
+  // ---- the countdown, 3 2 1 GO (intro.js and run.js's `again` both drive these off the HUD ticks) ----
+  // up on the number: a bob off the brim, the weight rolling to one foot. Sided so the tap alternates
+  // beat to beat, `hold` short so it drops straight back into `grip` between the numbers.  dy +0.054
+  ready: { sided: 1, w: 12, zeta: 0.45, hold: 0.34, next: 'grip', breath: 1,
+    root: { lean: -0.06, tilt: -0.05, lift: 0.05, squash: 1.03 },
+    shoulderL: [-1.117, 0, -1.954], shoulderR: [-1.117, 0, 1.954], footL: [-0.26, 0, -0.06], footR: [0.06, 0, 0.04] },
+  // ...and down between them, hands re-gripping the brim. The long hold is the safety net: if a count
+  // is skipped or aborted she walks herself back to cruise instead of standing there mid-bob.  dy -0.011
+  grip: { w: 10, zeta: 0.6, hold: 1.2, next: 'cruise', breath: 1,
+    root: { lean: 0, tilt: 0.05, lift: -0.02, squash: 0.97 },
+    shoulderL: [-1.796, 0, -1.864], shoulderR: [-1.796, 0, 1.864], footL: [0.10, 0, 0], footR: [0.10, 0, 0] },
+  // GO: crouch onto the brim and shove, which is exactly where cameraWhip picks the run up.  dy -0.041
+  launch: { w: 16, zeta: 0.35, hold: 0.45, next: 'cruise',
+    root: { lean: 0, tilt: 0.16, lift: -0.07, squash: 0.84 },
+    shoulderL: [-1.995, 0, -2.043], shoulderR: [-1.995, 0, 2.043], footL: [0.30, 0, 0], footR: [0.30, 0, 0] },
 };
 
 const ZERO3 = [0, 0, 0];
@@ -130,7 +147,39 @@ export function resolvePose(name, opts = {}) {
   }
   if (side < 0) t.root.lean = -t.root.lean;
   if (opts.tier) t.root.lean *= 1 + 0.12 * clamp(+opts.tier || 0, 0, 3);   // a fatter drift leans harder
+  // `amp` scales the whole-body part of a pose and nothing else, so reduced motion keeps the gesture
+  // (the arms still move, she is still doing a thing) and only loses the bounce (Law VI).
+  if (opts.amp != null) {
+    const a = clamp(+opts.amp || 0, 0, 1);
+    t.root.lean *= a; t.root.tilt *= a; t.root.lift *= a;
+    t.root.squash = 1 + (t.root.squash - 1) * a;
+  }
+  // `arms` is the other half of that dial: how far the limbs commit, 1 being the authored pose. The
+  // rim grips are solved for the RUN's cup, and the menu stage sits her higher over a bigger one, so
+  // the intro asks for a fraction of the swing and keeps her hands inside the bore.
+  if (opts.arms != null) {
+    const a = clamp(+opts.arms || 0, 0, 1);
+    for (const k of PIVOTS) t[k] = [t[k][0] * a, t[k][1] * a, t[k][2] * a];
+  }
   return t;
+}
+
+/**
+ * Remember a model's authored stance while it is still authored. A mixer-driven model (the menu
+ * stage runs clips that key shoulderL/R) has moved by the time anything asks for a pose layer, so
+ * menu.js calls this the moment the glb lands and createPoseLayer prefers what it stored.
+ */
+export function snapshotRest(model) {
+  if (!model || !model.getObjectByName) return null;
+  const rest = {};
+  for (const k of PIVOTS) {
+    const o = model.getObjectByName(k);
+    if (o) rest[k] = [o.rotation.x, o.rotation.y, o.rotation.z];
+  }
+  rest.root = [model.rotation.x, model.rotation.z, model.position.y];
+  model.userData = model.userData || {};
+  model.userData.poseRest = rest;
+  return rest;
 }
 
 /**
@@ -139,24 +188,28 @@ export function resolvePose(name, opts = {}) {
  */
 export function createPoseLayer(model) {
   const find = (n) => (model && model.getObjectByName ? model.getObjectByName(n) || null : null);
+  const kept = (model && model.userData && model.userData.poseRest) || null;   // snapshotRest(), if anyone took one
   const piv = {}, rest = {}, sp = {};
   for (const k of PIVOTS) {
     const o = find(k);
     piv[k] = o;
-    rest[k] = o ? [o.rotation.x, o.rotation.y, o.rotation.z] : ZERO3;
+    rest[k] = (kept && kept[k]) || (o ? [o.rotation.x, o.rotation.y, o.rotation.z] : ZERO3);
     sp[k] = [new Spring(), new Spring(), new Spring()];
   }
   const ant0 = find('ant0');
-  const rootRest = model ? [model.rotation.x, model.rotation.z, model.position.y] : [0, 0, 0];
+  const rootRest = (kept && kept.root) || (model ? [model.rotation.x, model.rotation.z, model.position.y] : [0, 0, 0]);
   const sLean = new Spring(), sTilt = new Spring(), sLift = new Spring(), sSquash = new Spring(1);
   const sAntX = new Spring(), sAntZ = new Spring();
-  let name = 'cruise', target = resolvePose('cruise'), hold = 0;
+  let name = 'cruise', target = resolvePose('cruise'), hold = 0, opt = {};
   const api = { fraught: 0, get name() { return name; } };
 
   /** Set a pose. Unknown names are ignored (false) rather than blanking her stance. */
   function set(n, opts = {}) {
     if (!POSES[n]) return false;
     name = n;
+    // the shape of the caller, minus the timing: a pose that chains into `next` inherits it, so a
+    // count driven at `arms: 0.3` does not snap to a full swing the moment the beat times out
+    opt = { side: opts.side, tier: opts.tier, amp: opts.amp, arms: opts.arms };
     target = resolvePose(n, opts);
     hold = opts.hold != null ? Math.max(0, +opts.hold || 0) : (POSES[n].hold || 0);
     api.fraught = target.fraught;
@@ -168,7 +221,7 @@ export function createPoseLayer(model) {
     dt = Math.min(Math.max(+dt || 0, 0), 0.05);
     if (hold > 0) {
       hold -= dt;
-      if (hold <= 0) set(POSES[name].next || 'cruise');
+      if (hold <= 0) set(POSES[name].next || 'cruise', opt);
     }
     const w = target.w, z = target.zeta;
     for (const k of PIVOTS) {

--- a/ConditioningControlPanel/Resources/web/dtrh/race/intro.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/intro.js
@@ -19,7 +19,10 @@
  *                over the rim, the camera dips 8 cm, >_< then ^_^ 0.35 s on
  *   C  3.5..5.4  the cup rolls to the start gantry; the camera settles into a
  *                front seat (props.glb `gantry`, else two pink posts + a cream bar)
- *   D  5.4..     3 2 1 on the HUD with o_o, :3 on GO; play() resolves on GO
+ *   D  5.4..     3 2 1 on the HUD with o_o, :3 on GO; play() resolves on GO.
+ *                She waits on the beat, not still: a bob and a foot tap on
+ *                every number (race/emiPoses.js `ready`/`grip`), a crouch and
+ *                a shove on GO (`launch`), which is where cameraWhip takes over
  * Then the boot starts the run and installs cameraWhip: 0.8 s from the run's
  * own front seat to the chase seat while the run's kart takes over.
  *
@@ -32,6 +35,7 @@
 import * as THREE from 'three';
 import { loadPack } from './gltf.js';
 import { PODIUM_H, CUP_SCALE, PROPS_URL } from './menu.js';
+import { createPoseLayer } from './emiPoses.js';
 import { CAM_BACK, CAM_UP, CAM_LOOK_AHEAD, LANE_H } from './consts.js';
 
 const GANTRY_Z = -3.6, RIM_H = 0.75 * CUP_SCALE, PINK = 0xff69b4, CREAM = 0xf6e7c8;
@@ -162,9 +166,33 @@ export function createIntro({ stage, hud, audio = null, reducedMotion = false, l
     emi.face(FACE.wide);
     const onTick = (s) => {
       if (audio) { try { audio.sfx(s === 'go' ? 'streak_milestone' : 'ui_click', s === 'go' ? 0.7 : 0.5); } catch (e) { /* muted */ } }
+      poseBeat(s);
       if (s === 'go') { emi.face(FACE.cat); if (resolveGo) { const r = resolveGo; resolveGo = null; r(); } }
     };
     if (hud && typeof hud.countdown === 'function') hud.countdown({ onTick }); else onTick('go');
+  }
+  // ---- the countdown idle: she waits on the beat instead of standing there ----
+  // race/emiPoses.js over the stage's own glb. The layer only exists for the count, it is written
+  // AFTER stage.update(dt) so it wins over the idle clip's shoulders, and it hands the arms back on
+  // dispose. Reduced motion keeps the gesture and loses the bounce (`amp`, Law VI).
+  let poses = null, poseT = 0, beat = 0;
+  const poseAmp = reducedMotion ? 0.3 : 1;
+  // The grips are solved for the RUN's cup. Here she rides a 1.3x one and sits higher in it: her
+  // hands are 0.45 m over that rim and a full swing would leave them out past the saucer, waving at
+  // nothing. A third of it keeps them inside the bore and still reads as a fidget.
+  const POSE_ARMS = 0.3;
+  function poseLayer() {
+    if (poses || disposed) return poses;
+    const m = emi && typeof emi.model === 'function' ? emi.model() : null;
+    if (m) poses = createPoseLayer(m);
+    return poses;
+  }
+  /** One HUD tick: up on the number (the tap alternating), crouch and shove on GO. */
+  function poseBeat(s) {
+    const p = poseLayer();
+    if (!p) return;
+    if (s === 'go') p.set('launch', { amp: poseAmp, arms: POSE_ARMS });
+    else p.set('ready', { side: (beat++ % 2) ? -1 : 1, amp: poseAmp, arms: POSE_ARMS });
   }
   function skip() { if (!disposed) toLine(); }
   const onKey = (e) => { if (!e.repeat) skip(); };
@@ -191,6 +219,7 @@ export function createIntro({ stage, hud, audio = null, reducedMotion = false, l
   }
   function update(dt) {
     stage.update(dt);
+    if (poses) { poseT += dt; poses.update(dt, { t: poseT }); }   // after the mixer, so the count wins
     if (disposed || phase < 0) return;
     pollPad();
     if (atLine) { camPos.step(dt); camLook.step(dt); camera.lookAt(camLook.x); return; }
@@ -239,6 +268,7 @@ export function createIntro({ stage, hud, audio = null, reducedMotion = false, l
     if (disposed) return;
     disposed = true;
     window.removeEventListener('keydown', onKey); window.removeEventListener('pointerdown', onPointer);
+    if (poses) { poses.dispose(); poses = null; }   // the stage keeps the model; give it its stance back
     scene.remove(gantry); scene.remove(drops); drops.dispose();
     for (const x of own) x.dispose();
   }

--- a/ConditioningControlPanel/Resources/web/dtrh/race/kart.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/kart.js
@@ -509,6 +509,18 @@ export function createKart({ scene, layout, reducedMotion = false, pixel = null 
     rig.update(dt, ctx);
   }
 
+  /**
+   * The rider alone, with the world parked. run.js's `again` skips the intro but still counts 3 2 1,
+   * and nothing calls update() until start(), so her pose springs would otherwise be frozen and she
+   * would sit dead still through the count. No physics, no camera, no depth: just her.
+   */
+  function idle(dt) {
+    dt = clamp(+dt || 0, 0, 0.1);
+    elapsed += dt;
+    ctx.t = elapsed; ctx.speedNorm = 0; ctx.airborne = false; ctx.steerVel = 0; ctx.drift = false; ctx.lean = lean;
+    rig.update(dt, ctx);
+  }
+
   function camera(out) {
     out.pos.copy(cam.pos); out.look.copy(cam.look);
     if (out.up && out.up.copy) out.up.copy(cam.up);
@@ -534,7 +546,7 @@ export function createKart({ scene, layout, reducedMotion = false, pixel = null 
     listeners.length = 0;
   }
 
-  return { state, update, applyBoost, applySlow, pace, setMood: rig.setMood, setFraught: rig.setFraught, camera, group,
+  return { state, update, idle, applyBoost, applySlow, pace, setMood: rig.setMood, setFraught: rig.setFraught, camera, group,
     pulseTarget, setReach, setScale, setSway, onEvent, dispose,
     emiModel: () => rig.model(), emiReady: (cb) => rig.onReady(cb),
     setFace: (i) => rig.setFace(i), pose: (name, opts) => rig.pose(name, opts) };

--- a/ConditioningControlPanel/Resources/web/dtrh/race/menu.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/menu.js
@@ -82,6 +82,7 @@
 import * as THREE from 'three';
 import { wantsTouch } from './touch.js';
 import { loadPack, preparePixel, toInstanceGeometry, flattenRig, setFace, FACES } from './gltf.js';
+import { snapshotRest } from './emiPoses.js';
 import { PIXEL_STEPS, PIXEL_DEFAULT, normalizeBlock } from './pixel.js';
 import { createMenuFlashes } from './menuFlashes.js';
 import { vFovForAspect, bindViewportResize } from './viewport.js';
@@ -337,6 +338,7 @@ export function createStage({ renderer, pixel, reducedMotion = false, log = null
     });
     preparePixel(model, pixel);
     emi.root.add(model); emi.model = model;
+    snapshotRest(model);   // the authored stance, banked before the mixer below ever moves a shoulder
     // her real silhouette, for the band framing: the box the idle pose sits in, taken once.
     emi.root.updateMatrixWorld(true);
     const box = new THREE.Box3().setFromObject(model);

--- a/ConditioningControlPanel/Resources/web/dtrh/race/run.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/run.js
@@ -789,6 +789,9 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     if (!W) return;
     if (S.running && !S.paused && !S.hostPaused) {
       try { step(W, dt); } catch (e) { bridge.log && bridge.log('race step: ' + (e && e.stack || e)); }
+    } else if (!S.running && !S.ended) {
+      // the pre-roll count: the world is parked but she is not. Her pose springs only, no physics.
+      try { W.kart.idle(dt); } catch (e) { /* an old kart without idle() just stands there */ }
     }
     if (camOverride && camOverride(camera, dt, W, camOut) === false) camOverride = null;
     pixel.render(scene, camera);
@@ -845,10 +848,19 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     W = build(S.seed);
     try { renderer.compile(scene, camera); } catch (e) { /* a warm-up only: the first frame compiles what this missed */ }
   }
+  /** The same tick idle the intro plays, on the run's own rig: a bob per number, a shove on GO. */
+  function countTick() {
+    let beat = 0;
+    const amp = reducedMotion ? 0.3 : 1;
+    return (s) => {
+      if (!W || !W.kart.pose) return;
+      try { W.kart.pose(s === 'go' ? 'launch' : 'ready', { side: (beat++ % 2) ? -1 : 1, amp }); } catch (e) { /* no glb, no pose */ }
+    };
+  }
   function again() {
     reseed(settings.seedLock != null ? settings.seedLock >>> 0 : (Date.now() ^ Math.floor(Math.random() * 0x7fffffff)) >>> 0);
     setCameraOverride(preRollCamera());   // again skips the intro: the chase seat, then 3 2 1
-    hud.countdown().then(start);
+    hud.countdown({ onTick: countTick() }).then(start);
   }
   function exit() {
     trackSend('track-stop');

--- a/ConditioningControlPanel/Resources/web/dtrh/race/smoke/poses-smoke.mjs
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/smoke/poses-smoke.mjs
@@ -14,10 +14,12 @@
  *   3. the hold timer returns to `cruise` on its own;
  *   4. sided presets mirror (L and R swap, y and z and the root lean negate);
  *   5. the tuck's antDown is exactly zero upright and non-zero inverted, and the
- *      layer never touches a pivot the model does not have.
+ *      layer never touches a pivot the model does not have;
+ *   6. the countdown chain (ready -> grip -> cruise, launch -> cruise), the `amp`
+ *      dial for reduced motion, and snapshotRest surviving a mixer frame.
  * ==========================================================================*/
 
-import { POSES, PIVOTS, resolvePose, createPoseLayer } from '../emiPoses.js';
+import { POSES, PIVOTS, resolvePose, createPoseLayer, snapshotRest } from '../emiPoses.js';
 
 let fails = 0;
 const ok = (cond, what) => { if (!cond) { console.error('FAIL ' + what); fails++; } else console.log('  ok  ' + what); };
@@ -123,6 +125,58 @@ ok(!!POSES.cruise && !POSES.cruise.hold, 'cruise is the resting pose and never t
   B.set('cheer'); run(B, 1);
   ok(Number.isFinite(bare.kids.get('shoulderL').rotation.x), 'a pack missing three pivots still drives the one it has');
   ok(createPoseLayer(null).update(1 / 60, CTX) === undefined, 'no model at all is a no-op, not a throw');
+}
+
+/* ---- 6. the countdown idle, `amp` and the banked rest ------------------- */
+{
+  // 3 2 1: every number bobs her up (`ready`) and drops her back onto the brim (`grip`), and the
+  // grip's own hold is the safety net for a count that is skipped and never says GO.
+  const m = makeModel(), L = createPoseLayer(m);
+  ok(L.set('ready', { side: 1 }), 'set("ready") takes');
+  run(L, POSES.ready.hold + 0.05);
+  ok(L.name === 'grip', 'a countdown beat drops back into grip');
+  run(L, POSES.grip.hold + 0.2);
+  ok(L.name === 'cruise', 'and an abandoned count walks itself back to cruise');
+  L.set('launch');
+  run(L, 0.25);
+  ok(m.scale.y < 0.95 && m.position.y < 0, 'GO crouches: the root squashes and drops');
+  run(L, POSES.launch.hold + 2.5);
+  ok(L.name === 'cruise', 'and the launch hands over to cruise for the run');
+
+  const a = resolvePose('ready', { side: 1 }), b = resolvePose('ready', { side: -1 });
+  ok(near(b.footL[0], a.footR[0]), 'the countdown tap alternates: side -1 swaps the feet');
+  ok(near(a.shoulderL[0], b.shoulderR[0]) && near(a.shoulderL[2], -b.shoulderR[2]), 'but both hands stay on the brim either way');
+
+  // `amp` is the reduced-motion dial: the gesture survives, the bounce does not.
+  const full = resolvePose('ready'), quiet = resolvePose('ready', { amp: 0.3 }), flat = resolvePose('ready', { amp: 0 });
+  ok(Math.abs(quiet.root.lift) < Math.abs(full.root.lift) && Math.abs(quiet.root.lift) > 0, 'amp 0.3 keeps a smaller bob');
+  ok(near(flat.root.lift, 0) && near(flat.root.tilt, 0) && near(flat.root.squash, 1), 'amp 0 flattens the root entirely');
+  ok(near(flat.shoulderL[0], full.shoulderL[0]), 'and never touches the arms');
+
+  // `arms` is the other dial: the intro's cup is bigger and she sits higher in it, so it asks for a
+  // fraction of the swing - and the fraction has to survive the chain into `next`.
+  const half = resolvePose('ready', { arms: 0.5 });
+  ok(near(half.shoulderL[0], full.shoulderL[0] * 0.5) && near(half.footL[0], full.footL[0] * 0.5), 'arms 0.5 halves every limb');
+  ok(near(resolvePose('ready', { arms: 0 }).shoulderL[2], 0), 'arms 0 leaves her exactly as the pack authored her');
+  const m2 = makeModel(), L2 = createPoseLayer(m2);
+  L2.set('ready', { arms: 0.3 });
+  run(L2, POSES.ready.hold + 0.05);
+  ok(L2.name === 'grip', 'the beat still chains');
+  run(L2, 0.8);
+  ok(near(m2.kids.get('shoulderL').rotation.x, POSES.grip.shoulderL[0] * 0.3, 0.02), 'and grip inherits the arms dial instead of snapping to a full swing');
+}
+{
+  // snapshotRest: a mixer-driven model has moved by the time anyone asks for a layer, so the rest
+  // the layer offsets from must be the one banked while the stance was still the pack's.
+  const m = makeModel();
+  m.kids.get('shoulderL').rotation.set(-0.2443, 0, 0.5);
+  const kept = snapshotRest(m);
+  ok(!!kept && near(kept.shoulderL[2], 0.5), 'snapshotRest banks the authored rotation');
+  m.kids.get('shoulderL').rotation.set(1.1, 0, -2.2);        // the mixer, mid-clip
+  const L = createPoseLayer(m);
+  L.set('cruise'); run(L, 3);
+  ok(near(m.kids.get('shoulderL').rotation.z, 0.5 + POSES.cruise.shoulderL[2], 5e-3), 'and the layer offsets from the bank, not the mixer frame');
+  ok(snapshotRest(null) === null, 'snapshotRest(null) is null, not a throw');
 }
 
 console.log(fails ? `\n${fails} failure(s)` : '\nposes-smoke: all good');


### PR DESCRIPTION
Stacked on #965 (`feat/race-emi-idle`). Merge that one first.

Owner ask: *"emi jumps correctly inside the cup on the intro animation, we get a countdown, tho she stays still while the countdown happens, maybe we might wanna have her do something to not stay put all the time while we wait."*

### What changed
Three new poses in `race/emiPoses.js`, driven off the HUD's own ticks rather than a hand-timed timeline:

| | |
|---|---|
| `ready` | up on the number: a bob off the brim, the weight rolling onto one foot. Sided, so the tap and the little lean **alternate beat to beat**. Short hold -> `grip`. |
| `grip` | back down between the numbers, hands re-gripping the brim. Its 1.2 s hold is the safety net: a skipped or aborted count walks her back to `cruise` instead of stranding her mid-bob. |
| `launch` | GO: crouch onto the brim and shove, which is exactly where `cameraWhip` picks the run up. |

Both countdowns get it:
- **the intro** (`intro.js`): `count()` builds a pose layer over the menu stage's glb and `update()` writes it **after** `stage.update(dt)`, so it beats the idle clip's shoulders; disposed with the intro, which hands the model its stance back.
- **`again`** (`run.js`): it skips the intro but still counts 3 2 1 with the world parked, and nothing was ticking her springs there - `step()` only runs while `S.running`. So `kart.js` gains **`idle(dt)`**: the rider only, no physics, no camera, no depth.

Two dials on a pose, both inherited when a pose chains into its `next`:
- **`amp` 0..1** scales the whole-body part only - reduced motion keeps the gesture (her arms still move, she is still doing a thing) and loses the bounce.
- **`arms` 0..1** scales the limbs. The rim grips from #965 are solved for the **run's** cup; the menu stage sits her 0.45 m higher over a 1.3x one, where a full swing puts her hands out past the saucer waving at nothing. The intro asks for 0.3 of it, which keeps them inside the bore and still reads as a fidget.

`snapshotRest(model)` banks the authored stance the moment the glb lands (`menu.js`), because every clip in the pack keys `shoulderL`/`shoulderR` - without it a layer built later would offset from whatever frame the mixer was on.

### How verified
- `node smoke/poses-smoke.mjs` green, with a new section 6: the `ready -> grip -> cruise` chain, the launch crouch and its handover, the alternating tap, both dials, the dial surviving the chain, and `snapshotRest` beating a mixer frame. `gltf-smoke.mjs` and `fov-check.mjs` still green.
- Headless Chrome 1280x720 on `?scene=intro`, shooting off the live `.rh-count` text: `shots/intro-count-3-after.png`, `-2-`, `-1-`, `-go-` (+ `zoom-*` crops) against `shots/intro-count-3-before.png`. Before she is bolt upright for the whole count; after she lifts, tilts and shifts on every number, with the arms just clearing the brim. Zero console errors.
- The `again` path is code-reviewed rather than driven end to end headlessly (it needs a finished run): `reseed()` clears `S.ended`, so `frame()`'s new `!S.running && !S.ended` branch is live for exactly the pre-roll, and `kart.idle` is wrapped so a rig without it just stands there.

```
 .../Resources/web/dtrh/race/CONTRACT.md            | 13 ++++-
 .../Resources/web/dtrh/race/emiPoses.js            | 63 ++++++++++++++++++++--
 .../Resources/web/dtrh/race/intro.js               | 32 ++++++++++-
 .../Resources/web/dtrh/race/kart.js                | 14 ++++-
 .../Resources/web/dtrh/race/menu.js                |  2 +
 .../Resources/web/dtrh/race/run.js                 | 14 ++++-
 .../Resources/web/dtrh/race/smoke/poses-smoke.mjs  | 58 +++++++++++++++++++-
 7 files changed, 185 insertions(+), 11 deletions(-)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KTe1RA7EP5hGxkzFY1282C
