### PR TITLE
feat(pbp): page-side bridge and the two boot.js lines that use it

### DIFF
--- a/ConditioningControlPanel/Resources/web/piecebypiece/boot.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/boot.js
@@ -13,6 +13,7 @@ import { createDrag } from './board/drag.js';
 import { createBus } from './game/events.js';
 import { createHotseat } from './game/hotseat.js';
 import { DEFAULT_MS } from './game/clock.js';
+import { postToHost, onHostMessage, signalReady } from './bridge.js';
 
 const dom = {
   canvas: document.getElementById('board-canvas'),
@@ -69,7 +70,20 @@ function main() {
   const drag = createDrag({ view, pieces, anim, bus, game });
   board.drag = drag;
 
-  window.PBP = { bus, game, board };
+  // Host settings, with the standalone defaults already in place: the effects
+  // layer reads window.PBP.settings and must never have to wait for a frame
+  // that only arrives inside the desktop app.
+  window.PBP = { bus, game, board, settings: { videoHoldSec: 15, reducedMotion: false } };
+  onHostMessage((m) => {
+    if (m.type !== 'pbp:settings') return;
+    const { type, ...values } = m;   // the envelope's own key is not a setting
+    Object.assign(window.PBP.settings, values);
+  });
+  // Esc closes the board - but never mid-drag, where it is "put the piece back".
+  window.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape' && !drag.isDragging()) postToHost({ type: 'pbp:exit' });
+  });
+  signalReady();
 
   let last = performance.now();
   function frame(now) {

--- a/ConditioningControlPanel/Resources/web/piecebypiece/bridge.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/bridge.js
@@ -1,0 +1,108 @@
+/* ============================================================================
+ * bridge.js - the postMessage contract with the WPF host
+ * (ChaosWebViewHost / PieceByPieceHostService).
+ *
+ * Transport: window.chrome.webview.postMessage (JS->C#) and the host's
+ * PostWebMessageAsJson (C#->JS). Every export here is a SAFE NO-OP when there
+ * is no host - the page is meant to run from a plain dev server too, and
+ * `isHosted` is the one thing to branch on if a caller needs to know.
+ *
+ * The four messages, and nothing else:
+ *
+ *   host -> page   { type: 'pbp:settings', videoHoldSec, reducedMotion }   once
+ *   page -> host   { type: 'pbp:media-request', kinds: [...], count }
+ *   host -> page   { type: 'pbp:media', images: [...], gifs: [...], videos: [...] }
+ *   page -> host   { type: 'pbp:exit' }
+ *
+ * plus the shell conventions the host also speaks: `ready` (which is what
+ * makes it flush its queued settings frame), a `heartbeat` every couple of
+ * seconds, and a `pong` answer to its `ping`.
+ *
+ * Neither side can race the other's boot: the host queues everything until
+ * `ready`, and anything that lands here before a listener is registered is
+ * buffered and replayed in arrival order.
+ * ==========================================================================*/
+
+const webview = (window.chrome && window.chrome.webview) || null;
+
+/** True when the page is running inside the desktop host. */
+export const isHosted = !!webview;
+
+const listeners = [];     // fn(msg)
+const preBuffer = [];     // messages that arrived before any listener existed
+let heartbeat = 0;        // setInterval handle, 0 when not beating
+
+if (webview) {
+  webview.addEventListener('message', (e) => {
+    const m = e && e.data;
+    if (!m || typeof m.type !== 'string') return;
+    // The host's liveness probe. Answered here rather than left to a caller:
+    // a missed pong closes the window, and no feature should be able to
+    // forget about it.
+    if (m.type === 'ping') { postToHost({ type: 'pong' }); return; }
+    if (listeners.length === 0) { preBuffer.push(m); return; }
+    deliver(m);
+  });
+}
+
+function deliver(m) {
+  for (const fn of listeners) {
+    try { fn(m); } catch (err) { console.warn('[pbp] host message handler threw', err); }
+  }
+}
+
+/**
+ * Post a message object (it must carry a string `type`) to the host.
+ * No-op, never a throw, when there is no host or the host has gone away.
+ */
+export function postToHost(msg) {
+  if (!webview) return;
+  try { webview.postMessage(msg); } catch (err) { /* host gone; nothing to do */ }
+}
+
+/**
+ * Listen for host -> page messages. Returns an unsubscribe function.
+ * The first listener to register drains anything that arrived before it.
+ */
+export function onHostMessage(fn) {
+  if (typeof fn !== 'function') return () => {};
+  listeners.push(fn);
+  if (preBuffer.length) {
+    const queued = preBuffer.splice(0, preBuffer.length);
+    for (const m of queued) deliver(m);
+  }
+  return () => {
+    const i = listeners.indexOf(fn);
+    if (i >= 0) listeners.splice(i, 1);
+  };
+}
+
+/**
+ * Announce boot completion, then keep beating. The host holds its `pbp:settings`
+ * frame until this lands, and its heartbeat watchdog only starts counting once
+ * it has - so this is what turns the bridge on in both directions.
+ */
+export function signalReady() {
+  postToHost({ type: 'ready' });
+  if (!webview || heartbeat) return;
+  heartbeat = setInterval(() => postToHost({ type: 'heartbeat' }), 2000);
+}
+
+/**
+ * Ask the host for media from the player's own library. Kinds are any of
+ * 'image', 'gif', 'video'; the reply is one `pbp:media` message carrying an
+ * array per kind, and ANY of those arrays may be empty - a fresh install has
+ * no media at all.
+ */
+export function requestMedia(kinds, count) {
+  postToHost({
+    type: 'pbp:media-request',
+    kinds: Array.isArray(kinds) && kinds.length ? kinds : ['image', 'gif', 'video'],
+    count: Number(count) > 0 ? Math.floor(Number(count)) : 24,
+  });
+}
+
+/** Ask the host to close the window. */
+export function exitToHost() {
+  postToHost({ type: 'pbp:exit' });
+}


### PR DESCRIPTION
Stacked on #970. The page half of the host protocol from #968, and the last piece of the C lane.

## `bridge.js`

The postMessage contract with `PieceByPieceHostService`, and nothing more:

| export | what it does |
|---|---|
| `postToHost(obj)` | JS -> C#. No-op, never a throw, with no host attached |
| `onHostMessage(fn)` | C# -> JS. Returns an unsubscribe. The first listener drains anything that arrived before it, in arrival order |
| `signalReady()` | posts `ready` (which is what makes the host flush its queued `pbp:settings`), then a `heartbeat` every 2s |
| `requestMedia(kinds, count)` | `pbp:media-request`, defaulted to all three kinds and 24 |
| `exitToHost()` | `pbp:exit` |
| `isHosted` | the one thing to branch on |

Every export is a safe no-op when `window.chrome?.webview` is absent, so the page still runs from a plain static server (which is what the smoke harness drives).

The host's `ping` is answered inside the bridge rather than left to a caller: a missed pong closes the window, and no feature should be able to forget about it.

## `boot.js`

The minimum, and nothing else of Agent A's page is touched:

- `window.PBP.settings` seeded with the standalone defaults (`videoHoldSec: 15`, `reducedMotion: false`) on the same line the object is created, so the effects layer never has to wait for a frame that only arrives inside the desktop app
- a `pbp:settings` forwarder that drops the envelope's own `type` key before merging
- `Escape` -> `pbp:exit`, guarded on `drag.isDragging()` - mid-drag, Esc is "put the piece back", not "leave"
- `signalReady()`

There was no existing exit path to wire into (no `keydown` listener anywhere in `board/`, `game/` or `index.html`), so this adds the only one. `ramp/` is untouched.

Both files pass `node --check`. No C# changed, so no build gate applies to this one; the new file is picked up by the existing `Resources\web\**\*` content glob with no csproj edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S4BKp6cQJFNixoQrarvSkd
