### PR TITLE
fix(race): white mitts on the SIDE of the brim, where the chase camera can see them

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
@@ -247,7 +247,7 @@ emoticons only, never a drawn face, never a speech line.
 
 ### `race/emiPoses.js` (pass four, EMI's body)
 ```js
-export const POSES, PIVOTS;   // the pure preset table, and the four glb pivots a preset may name
+export const POSES, PIVOTS;   // the pure preset table (rotations + per-arm `reach`), and the four glb pivots a preset may name
 export function resolvePose(name, opts) -> flattened target
 export function createPoseLayer(model) -> { set(name, opts), update(dt, ctx), dispose, fraught, name }
 export function snapshotRest(model)     // bank the authored stance before a mixer moves it
@@ -262,13 +262,23 @@ falls back to `next` on its own. `clamp` and `landingKerb` report `fraught` and 
 max of that and the run brain's. run.js only ever calls `kart.pose(...)`; the layer exists only
 while the glb is mounted (the primitive EMI has no limbs to pose).
 
-**The rim grip.** Every pose that is meant to be *holding on* parks the glove on the cup's brim:
-lip top y 0.785, lip radius 0.500 in kart-body metres, the shoulder pivot at (-+0.312, 0.787,
-0.226) and a glove reach of 0.206 m. That short reach only meets the lip between about 32 and 77
-degrees around from dead ahead, and the forward half of that arc hides behind her own case from the
-chase camera, so the grips sit at 66..79 degrees. Re-solve, do not eyeball: a hand that drops below
-the lip vanishes inside the cup. The hands ride the cup through the steer lean for free - the seat
-and `kart_cup` share the body group that tips.
+**The rim grip.** Every pose that is meant to be *holding on* parks the glove on the SIDE of the
+cup's brim, the widest point of the lip on screen: lip top y 0.785, lip radius 0.500 in kart-body
+metres, the seat at (0, 0.395, 0.22) and the shoulder pivot at (-+0.312, 0.787, 0.196). The
+authored glove reach is only 0.206 m, which meets the lip between about 32 and 77 degrees around
+from dead ahead - the far arc, where the case hides the hands from the chase camera. So a holding
+pose also carries `reach: [L, R]`: `GRIP` = 1.28 stretches that arm along its own axis (a y-scale
+on the shoulder pivot, with `handL`/`thumbL` counter-scaled off their mounted base so the mitt does
+not go egg-shaped), which walks the grip out to 82..87 degrees, x -+0.51, z +0.02..0.07. A free
+hand keeps `reach` 1 (`grab`, `throw` right; `cheer` has no `reach` at all), and `opts.arms` fades
+the stretch with the angles. Re-solve, do not eyeball, and solve each pose against its OWN root
+attitude - lean, tilt, lift and squash move the shoulder, which is why `drift`'s two arms differ
+and `landingKerb` is asymmetric. A hand that drops below the lip vanishes inside the cup. The hands
+ride the cup through the steer lean for free - the seat and `kart_cup` share the body group that
+tips. So the mitts read at the game's real scale (the cup mouth is only ~113 px wide in a 1280
+frame), emi.js repaints `handL`/`handR`/`thumbL`/`thumbR` with their own white `emi_glove` material
+BEFORE `flattenRig` (the repaint is what splits them out of the merge) and scales the two hand
+nodes by `GLOVE_SCALE` 1.4. The case material is untouched.
 
 **The countdown.** `ready` -> `grip` is one beat of the 3 2 1 and `launch` is GO. Both counts drive
 them off the HUD's own ticks, never a hand-timed script: `intro.js` builds a layer over the menu

--- a/ConditioningControlPanel/Resources/web/dtrh/race/emi.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/emi.js
@@ -57,6 +57,8 @@ const SAUCER_R_GLB = 0.95, DISH_SQUEEZE = SAUCER_R / SAUCER_R_GLB;
 // This is geometry, not a transition, so reduced motion keeps every bit of it.
 const CUP_FOOT_R = 0.3, CUP_PIVOT_Y = CUP_Y, CUP_TIP_MAX = 0.38, CUP_SLIDE = 0.07;
 const OUTLINE = 'outline';   // the inverted hull's material name (gltf.js header, assets/README.md)
+const GLOVE_NODES = ['handL', 'handR', 'thumbL', 'thumbR'];   // repainted white, see gloveHands()
+const GLOVE_SCALE = 1.4;     // a mitt the chase camera can see on the brim, not an 8 px knuckle
 // The glb is metres, sole centre at the origin, +Z forward, case top at 1.00 m. 0.64 puts the case
 // at the old 1.25-scaled CRT's 0.525 m; with the sole on the tea (y 0.66) the case bottom lands at
 // 0.775, just clear of the cup rim at 0.75, so the legs stay in the cup and the case reads as before.
@@ -65,7 +67,12 @@ const OUTLINE = 'outline';   // the inverted hull's material name (gltf.js heade
 // the model) sits 0.30 below the rim: the tea disc cuts her at the chest and the legs are never seen.
 const GLB_SCALE = 0.8;        // owner call 2026-09-06: full size read too big in the bore
 const GLB_SINK = 0.28;       // metres below TEA_Y the sole rests; the case bottom lands 0.28 m under the rim
-const GLB_SEAT_Z = 0.25;     // the case spans z -0.59..0.08 in the model, so this centres it in the bore
+// The case spans z -0.59..0.08 in the model, so seated it runs -0.472..0.064 and a seat at 0.204
+// is the one that puts its middle on the bore's axis: 0.25 sat it 0.046 PROUD of centre. 0.22 is
+// inside that slack (0.016 proud, better centred than before) and buys the arms 30 mm of reach
+// backward: the shoulders come back to z 0.196, which is what lets a glove hold the SIDE of the
+// brim (z 0.03, the widest point) instead of the far arc, where the chase camera cannot read it.
+const GLB_SEAT_Z = 0.22;
 const CASE_TOP = [0.36, 0.99, -0.2];   // EMI_case local: the top corner sweat comes off
 const GLOW_Y = 0.62, GLOW_Z = 0.9;     // the screen light, model local (0.58 m ahead of the glass)
 
@@ -271,12 +278,46 @@ export function createEmiRig({ scene, reducedMotion = false, pixel = null }) {
    *  left to dispose() (the ones that go unshared are pushed onto `owned` at the call site). */
   const retire = (m) => { if (m.parent) m.parent.remove(m); if (m.geometry) m.geometry.dispose(); };
 
+  /**
+   * MAKE THE GLOVES GLOVES. The glb hands and thumbs ship on the case's own navy material, and
+   * against a pink brim from the chase camera that is two dark knobs the owner has to be told
+   * about. This repaints them cream BEFORE flattenRig, which is the whole trick: the merge keys on
+   * (pivot, material), so the pair leaves it as ONE white mesh per shoulder hosted on handL / handR
+   * - the same node emiPoses counter-scales when it stretches an arm out to the brim. The case
+   * material is never touched.
+   *
+   * Their outline hulls get a CLONE of the outline material for the same reason: it keeps them out
+   * of the arm's merged hull, so the black keyline is hosted on handL too and grows with the glove
+   * instead of hiding inside it. blackOutline() still catches both, the clone being named `outline`.
+   *
+   * Then the pair is scaled up. The cup's mouth is about 113 px across in a 1280 frame, so an
+   * authored hand lands on 8 of them: a cartoon mitt at GLOVE_SCALE is what the owner can actually
+   * see holding the brim. emiPoses reads the scale it finds here as the base it counter-scales from.
+   */
+  function gloveHands(root) {
+    const glove = new THREE.MeshStandardMaterial({ name: 'emi_glove', color: 0xFFFFFF, roughness: 0.45 });
+    let hull = null, hit = 0;
+    for (const n of GLOVE_NODES) {
+      const node = root.getObjectByName(n);
+      if (!node) continue;
+      node.traverse((o) => {
+        if (!o.isMesh || Array.isArray(o.material) || !o.material) return;
+        if (isOutline(o)) { o.material = hull || (hull = o.material.clone()); return; }
+        o.material = glove; hit++;
+      });
+    }
+    if (hull) owned.push(hull);
+    if (hit) owned.push(glove); else glove.dispose();   // a pack without hands: nothing painted, nothing leaked
+  }
+
   function mountGlb(pack) {
     if (dead || G) return;
     const root = pack.clone('EMI_root');
     const ant0 = root && root.getObjectByName('ant0'), ballpiv = root && root.getObjectByName('ballpiv');
     if (!root || !ant0 || !ballpiv) return;         // a pack without the contract pivots: the primitive stays
+    gloveHands(root);                                 // before the merge: the paint is what splits them off
     flattenRig(root, pack.animations);                // 69 draws a frame down to ~30: one per pivot and material
+    for (const n of ['handL', 'handR']) { const h = root.getObjectByName(n); if (h) h.scale.setScalar(GLOVE_SCALE); }
     blackOutline(root);
     const ballMats = [], glassMats = [];
     ownMaterials(root.getObjectByName('ball') || ballpiv, ballMats);

--- a/ConditioningControlPanel/Resources/web/dtrh/race/emiPoses.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/emiPoses.js
@@ -33,16 +33,33 @@ const ANT_MAX = 1.2;         // how far the tuck is allowed to drag the antenna 
  *
  * Everything below is in kart-body metres, the space the cup and the seat share:
  *   the cup's lip      top y 0.785, lip radius 0.500 (rMean 0.503; the handle is the outlier)
- *   the seat           (0, 0.395, 0.25), scale 0.8, so a model metre is 0.8 body metres
- *   a shoulder pivot   (-+0.312, 0.787, 0.226) with the root at rest - level with the lip
+ *   the seat           (0, 0.395, 0.22), scale 0.8, so a model metre is 0.8 body metres
+ *   a shoulder pivot   (-+0.312, 0.787, 0.196) with the root at rest - level with the lip
  *   the glove centre   [0.025, -0.2563, 0.0078] in shoulder-local (|u| 0.257 model = 0.206 body)
  *
- * That reach is short: the sphere it sweeps only meets the lip circle between about 32 and 77
- * degrees around from dead ahead, and the forward half of that arc is hidden behind her own case
- * from the chase camera. So every "holding on" pose parks the glove at 66..79 degrees, where the
- * hand is both reachable and SEEN. The old table's arms sat 0.109 m below the lip - inside the
- * cup, invisible - which is the bug this fixes.
+ * That reach is short. Unstretched it meets the lip circle only between about 32 and 77 degrees
+ * around from dead ahead, and 77 degrees still parks the hand at z +0.12: the FAR arc of the brim,
+ * where the chase camera reads it as a knob on the rim rather than a hand holding it. So a holding
+ * pose stretches the arm along its own axis (`reach`, 1.28 here, applied as a y scale on the
+ * shoulder with the hand counter-scaled so the glove stays a ball) and parks the glove at 82..87
+ * degrees, x -+0.51, z +0.02..0.07 - the WIDEST point of the brim, clear of her own case, side on
+ * to the camera. The first pass at this got the hands out of the cup (they used to sit 0.109 m
+ * under the lip, invisible) but left them on the far arc; this is the half that made them read.
+ *
+ * Every holding angle below is solved with that pose's OWN root attitude applied (lean, tilt, lift
+ * and the squash, which widens x and z by 0.6 of what it takes off y), because a 0.2 rad drift lean
+ * walks a glove 0.1 m off a rim that is only 0.5 m across. That is why the drift's two arms are so
+ * far apart, and why an unsided pose with a lean (landingKerb) is not symmetric either.
  * ------------------------------------------------------------------------ */
+
+/** A holding arm's stretch along its own axis, and the pair the table hands to `reach`. */
+const GRIP = 1.28;
+const GRIP2 = [GRIP, GRIP];
+/** The two pivots `reach` may stretch, and the nodes counter-scaled so the glove stays round.
+ *  emi.js's gloveHands() repaints hand + thumb before the merge, which is what makes handL / handR
+ *  the host of that merged glove mesh; a pack without them simply stretches nothing back. */
+const ARMS = ['shoulderL', 'shoulderR'];
+const HANDS = { shoulderL: ['handL', 'thumbL'], shoulderR: ['handR', 'thumbR'] };
 
 /**
  * The presets. `root` is { lean (z), tilt (x), lift (y), squash (y scale) }, the four pivots are
@@ -52,50 +69,53 @@ const ANT_MAX = 1.2;         // how far the tuck is allowed to drag the antenna 
  *
  * The `dy` in each comment is the glove centre's height against the lip: + is over the brim,
  * - is pressing down into it. A hand that leaves the rim on purpose (the drift point, the grab,
- * the throw, the cheer) says so.
+ * the throw, the cheer) says so, and drops its `reach` back to 1 while it is off.
+ *
+ * `reach` is [L, R]: how far each arm stretches along its own axis, 1 being the arm as authored.
+ * Only a hand that is HOLDING the brim stretches - see THE RIM GRIP above for why it has to.
  */
 export const POSES = {
   // both gloves on the brim, shoulders soft, the breath running                   dy +0.02
-  cruise: { w: 7, zeta: 0.7, hold: 0, breath: 1, root: { lean: 0, tilt: 0, lift: 0, squash: 1 },
-    shoulderL: [-1.449, 0, -1.903], shoulderR: [-1.449, 0, 1.903], footL: [0, 0, 0], footR: [0, 0, 0] },
+  cruise: { w: 7, zeta: 0.7, hold: 0, breath: 1, reach: GRIP2, root: { lean: 0, tilt: 0, lift: 0, squash: 1 },
+    shoulderL: [-1.498, 0, -2.089], shoulderR: [-1.498, 0, 2.089], footL: [0, 0, 0], footR: [0, 0, 0] },
 
-  // lean into the turn; the outside hand (shoulderL at side +1) rides up over the brim  dy +0.11 / +0.01
-  drift: { sided: 1, w: 9, zeta: 0.55, hold: 1.1, next: 'cruise', root: { lean: -0.20, tilt: 0.04, lift: 0, squash: 1 },
-    shoulderL: [-0.153, 0, -1.984], shoulderR: [-1.613, 0, 1.779], footL: [-0.12, 0, -0.10], footR: [0.10, 0, 0.06] },
+  // lean into the turn; the outside hand (shoulderL at side +1) rides up over the brim  dy +0.06 / 0.00
+  drift: { sided: 1, w: 9, zeta: 0.55, hold: 1.1, next: 'cruise', reach: GRIP2, root: { lean: -0.20, tilt: 0.04, lift: 0, squash: 1 },
+    shoulderL: [-2.096, 0, -1.834], shoulderR: [-1.206, 0, 2.458], footL: [-0.12, 0, -0.10], footR: [0.10, 0, 0.06] },
 
-  // the mini turbo: squash on the kick, hands push down on the brim              dy -0.02
-  boost: { w: 18, zeta: 0.6, hold: 0.11, next: 'boostOut', root: { lean: 0, tilt: 0.14, lift: -0.06, squash: 0.86 },
-    shoulderL: [-1.881, 0, -1.845], shoulderR: [-1.881, 0, 1.845], footL: [-0.20, 0, 0], footR: [-0.20, 0, 0] },
-  // ...then stretch, elbows straightening, hands still on it                     dy +0.05
-  boostOut: { w: 10, zeta: 0.38, hold: 0.55, next: 'cruise', root: { lean: 0, tilt: -0.07, lift: 0.05, squash: 1.10 },
-    shoulderL: [-1.185, 0, -2.026], shoulderR: [-1.185, 0, 2.026], footL: [0.16, 0, 0], footR: [0.16, 0, 0] },
+  // the mini turbo: squash on the kick, hands push down on the brim              dy -0.03
+  boost: { w: 18, zeta: 0.6, hold: 0.11, next: 'boostOut', reach: GRIP2, root: { lean: 0, tilt: 0.14, lift: -0.06, squash: 0.86 },
+    shoulderL: [-1.340, 0, -2.313], shoulderR: [-1.340, 0, 2.313], footL: [-0.20, 0, 0], footR: [-0.20, 0, 0] },
+  // ...then stretch, elbows straightening, hands still on it                     dy +0.06
+  boostOut: { w: 10, zeta: 0.38, hold: 0.55, next: 'cruise', reach: GRIP2, root: { lean: 0, tilt: -0.07, lift: 0.05, squash: 1.10 },
+    shoulderL: [-1.724, 0, -1.925], shoulderR: [-1.724, 0, 1.925], footL: [0.16, 0, 0], footR: [0.16, 0, 0] },
 
-  // off the ramp: arms lift clear of the brim, one leg kicks, a little nose up   dy +0.10
-  air: { w: 8, zeta: 0.5, hold: 3, next: 'cruise', root: { lean: 0, tilt: -0.16, lift: 0.04, squash: 1.03 },
-    shoulderL: [-0.494, 0, -1.994], shoulderR: [-0.494, 0, 1.994], footL: [-0.70, 0, -0.15], footR: [0.28, 0, 0.10] },
+  // off the ramp: arms ride high on the brim, one leg kicks, a little nose up    dy +0.09
+  air: { w: 8, zeta: 0.5, hold: 3, next: 'cruise', reach: GRIP2, root: { lean: 0, tilt: -0.16, lift: 0.04, squash: 1.03 },
+    shoulderL: [-0.955, 0, -1.773], shoulderR: [-0.955, 0, 1.773], footL: [-0.70, 0, -0.15], footR: [0.28, 0, 0.10] },
 
   // touchdown: squash hard with the overshoot, hands slap the brim               dy -0.02
-  landing: { w: 16, zeta: 0.35, hold: 0.28, next: 'cruise', root: { lean: 0, tilt: 0.06, lift: -0.05, squash: 0.82 },
-    shoulderL: [-1.869, 0, -1.907], shoulderR: [-1.869, 0, 1.907], footL: [0.22, 0, 0], footR: [0.22, 0, 0] },
-  // the same, kerbed: one hand jolts down, the other up, and a beat of fraught    dy -0.03 / +0.04
-  landingKerb: { w: 14, zeta: 0.30, hold: 0.5, next: 'cruise', fraught: 0.7, root: { lean: 0.16, tilt: 0.12, lift: -0.07, squash: 0.78 },
-    shoulderL: [-1.902, 0, -2.056], shoulderR: [-1.104, 0, 1.790], footL: [0.34, 0, 0.12], footR: [0.16, 0, -0.10] },
+  landing: { w: 16, zeta: 0.35, hold: 0.28, next: 'cruise', reach: GRIP2, root: { lean: 0, tilt: 0.06, lift: -0.05, squash: 0.82 },
+    shoulderL: [-1.132, 0, -2.303], shoulderR: [-1.132, 0, 2.303], footL: [0.22, 0, 0], footR: [0.22, 0, 0] },
+  // the same, kerbed: one hand jolts down, the other up, and a beat of fraught    dy -0.06 / +0.04
+  landingKerb: { w: 14, zeta: 0.30, hold: 0.5, next: 'cruise', fraught: 0.7, reach: GRIP2, root: { lean: 0.16, tilt: 0.12, lift: -0.07, squash: 0.78 },
+    shoulderL: [-0.847, 0, -2.686], shoulderR: [-1.059, 0, 2.170], footL: [0.34, 0, 0.12], footR: [0.16, 0, -0.10] },
 
   // a treat went by: the far hand keeps the brim, the near one reaches out (side +1 = her +x)
-  grab: { sided: 1, w: 12, zeta: 0.5, hold: 0.5, next: 'cruise', root: { lean: -0.10, tilt: -0.05, lift: 0.02, squash: 1 },
-    shoulderL: [-1.449, 0, -1.903], shoulderR: [-1.75, 0, 0.55], footL: [0, 0, 0], footR: [-0.10, 0, 0] },
+  grab: { sided: 1, w: 12, zeta: 0.5, hold: 0.5, next: 'cruise', reach: [GRIP, 1], root: { lean: -0.10, tilt: -0.05, lift: 0.02, squash: 1 },
+    shoulderL: [-1.908, 0, -1.962], shoulderR: [-1.75, 0, 0.55], footL: [0, 0, 0], footR: [-0.10, 0, 0] },
 
-  // an effect is pouring: hands clamp the brim and she gets small                dy  0.00
-  clamp: { w: 11, zeta: 0.7, hold: 1.2, next: 'cruise', fraught: 1, root: { lean: 0, tilt: 0.10, lift: -0.06, squash: 0.90 },
-    shoulderL: [-1.689, 0, -1.797], shoulderR: [-1.689, 0, 1.797], footL: [0.35, 0, 0.08], footR: [0.35, 0, -0.08] },
+  // an effect is pouring: hands clamp the brim and she gets small                dy -0.01
+  clamp: { w: 11, zeta: 0.7, hold: 1.2, next: 'cruise', fraught: 1, reach: GRIP2, root: { lean: 0, tilt: 0.10, lift: -0.06, squash: 0.90 },
+    shoulderL: [-1.291, 0, -2.302], shoulderR: [-1.291, 0, 2.302], footL: [0.35, 0, 0.08], footR: [0.35, 0, -0.08] },
 
-  // upside down in the Wheel: knees up, white knuckles on the brim, the antenna hangs   dy +0.01
-  tuck: { w: 10, zeta: 0.6, hold: 0, antDown: 1, root: { lean: 0, tilt: 0.18, lift: -0.08, squash: 0.94 },
-    shoulderL: [-1.612, 0, -1.736], shoulderR: [-1.612, 0, 1.736], footL: [-0.85, 0, 0.10], footR: [-0.85, 0, -0.10] },
+  // upside down in the Wheel: knees up, white knuckles on the brim, the antenna hangs   dy -0.01
+  tuck: { w: 10, zeta: 0.6, hold: 0, antDown: 1, reach: GRIP2, root: { lean: 0, tilt: 0.18, lift: -0.08, squash: 0.94 },
+    shoulderL: [-1.369, 0, -2.320], shoulderR: [-1.369, 0, 2.320], footL: [-0.85, 0, 0.10], footR: [-0.85, 0, -0.10] },
 
   // the item goes over the side: one hand holds, the other arcs over the brim (the low zeta IS the arc)
-  throw: { sided: 1, w: 14, zeta: 0.35, hold: 0.45, next: 'cruise', root: { lean: -0.07, tilt: 0.05, lift: 0.02, squash: 1 },
-    shoulderL: [-1.449, 0, -1.903], shoulderR: [-0.181, 0, 2.032], footL: [0, 0, 0], footR: [0.12, 0, 0] },
+  throw: { sided: 1, w: 14, zeta: 0.35, hold: 0.45, next: 'cruise', reach: [GRIP, 1], root: { lean: -0.07, tilt: 0.05, lift: 0.02, squash: 1 },
+    shoulderL: [-1.811, 0, -2.058], shoulderR: [-0.181, 0, 2.032], footL: [0, 0, 0], footR: [0.12, 0, 0] },
 
   // a personal best or a jackpot: both arms up
   cheer: { w: 9, zeta: 0.45, hold: 1.3, next: 'cruise', root: { lean: 0, tilt: -0.08, lift: 0.06, squash: 1.04 },
@@ -103,24 +123,27 @@ export const POSES = {
 
   // ---- the countdown, 3 2 1 GO (intro.js and run.js's `again` both drive these off the HUD ticks) ----
   // up on the number: a bob off the brim, the weight rolling to one foot. Sided so the tap alternates
-  // beat to beat, `hold` short so it drops straight back into `grip` between the numbers.  dy +0.054
-  ready: { sided: 1, w: 12, zeta: 0.45, hold: 0.34, next: 'grip', breath: 1,
+  // beat to beat, `hold` short so it drops straight back into `grip` between the numbers.  dy +0.056
+  ready: { sided: 1, w: 12, zeta: 0.45, hold: 0.34, next: 'grip', breath: 1, reach: GRIP2,
     root: { lean: -0.06, tilt: -0.05, lift: 0.05, squash: 1.03 },
-    shoulderL: [-1.117, 0, -1.954], shoulderR: [-1.117, 0, 1.954], footL: [-0.26, 0, -0.06], footR: [0.06, 0, 0.04] },
+    shoulderL: [-1.763, 0, -1.958], shoulderR: [-1.348, 0, 2.085], footL: [-0.26, 0, -0.06], footR: [0.06, 0, 0.04] },
   // ...and down between them, hands re-gripping the brim. The long hold is the safety net: if a count
   // is skipped or aborted she walks herself back to cruise instead of standing there mid-bob.  dy -0.011
-  grip: { w: 10, zeta: 0.6, hold: 1.2, next: 'cruise', breath: 1,
+  grip: { w: 10, zeta: 0.6, hold: 1.2, next: 'cruise', breath: 1, reach: GRIP2,
     root: { lean: 0, tilt: 0.05, lift: -0.02, squash: 0.97 },
-    shoulderL: [-1.796, 0, -1.864], shoulderR: [-1.796, 0, 1.864], footL: [0.10, 0, 0], footR: [0.10, 0, 0] },
-  // GO: crouch onto the brim and shove, which is exactly where cameraWhip picks the run up.  dy -0.041
-  launch: { w: 16, zeta: 0.35, hold: 0.45, next: 'cruise',
+    shoulderL: [-1.571, 0, -2.177], shoulderR: [-1.571, 0, 2.177], footL: [0.10, 0, 0], footR: [0.10, 0, 0] },
+  // GO: crouch onto the brim and shove, which is exactly where cameraWhip picks the run up.  dy -0.049
+  launch: { w: 16, zeta: 0.35, hold: 0.45, next: 'cruise', reach: GRIP2,
     root: { lean: 0, tilt: 0.16, lift: -0.07, squash: 0.84 },
-    shoulderL: [-1.995, 0, -2.043], shoulderR: [-1.995, 0, 2.043], footL: [0.30, 0, 0], footR: [0.30, 0, 0] },
+    shoulderL: [-1.425, 0, -2.362], shoulderR: [-1.425, 0, 2.362], footL: [0.30, 0, 0], footR: [0.30, 0, 0] },
 };
 
 const ZERO3 = [0, 0, 0];
+const REACH1 = [1, 1];
 const DEF_ROOT = { lean: 0, tilt: 0, lift: 0, squash: 1 };
 const clamp = (v, a, b) => Math.max(a, Math.min(b, v));
+/** A stretch is a scale: never zero, never a limb twice its length. */
+const reachOf = (v) => clamp(+v > 0 ? +v : 1, 0.5, 2);
 const flip = (k) => (k.endsWith('L') ? k.slice(0, -1) + 'R' : k.slice(0, -1) + 'L');
 
 /** Damped spring toward a target; zeta < 1 overshoots a little, which is the point (Law XI). */
@@ -145,6 +168,8 @@ export function resolvePose(name, opts = {}) {
     const src = p[side > 0 ? k : flip(k)] || ZERO3;
     t[k] = side > 0 ? [src[0], src[1], src[2]] : [src[0], -src[1], -src[2]];
   }
+  const rc = p.reach || REACH1;                                   // [L, R], mirrored with the rest
+  t.reach = side > 0 ? [reachOf(rc[0]), reachOf(rc[1])] : [reachOf(rc[1]), reachOf(rc[0])];
   if (side < 0) t.root.lean = -t.root.lean;
   if (opts.tier) t.root.lean *= 1 + 0.12 * clamp(+opts.tier || 0, 0, 3);   // a fatter drift leans harder
   // `amp` scales the whole-body part of a pose and nothing else, so reduced motion keeps the gesture
@@ -160,6 +185,7 @@ export function resolvePose(name, opts = {}) {
   if (opts.arms != null) {
     const a = clamp(+opts.arms || 0, 0, 1);
     for (const k of PIVOTS) t[k] = [t[k][0] * a, t[k][1] * a, t[k][2] * a];
+    t.reach = [1 + (t.reach[0] - 1) * a, 1 + (t.reach[1] - 1) * a];   // a fraction of the swing, a fraction of the stretch
   }
   return t;
 }
@@ -196,6 +222,12 @@ export function createPoseLayer(model) {
     rest[k] = (kept && kept[k]) || (o ? [o.rotation.x, o.rotation.y, o.rotation.z] : ZERO3);
     sp[k] = [new Spring(), new Spring(), new Spring()];
   }
+  // the arm stretch: one spring an arm, and the hand nodes that undo it on the glove. Each hand
+  // keeps the scale it was mounted at (emi.js sizes the mitts up), so the counter-scale divides
+  // that base instead of replacing it.
+  const sReach = { shoulderL: new Spring(1), shoulderR: new Spring(1) };
+  const hands = {};
+  for (const k of ARMS) hands[k] = HANDS[k].map(find).filter(Boolean).map((o) => ({ o, base: [o.scale.x, o.scale.y, o.scale.z] }));
   const ant0 = find('ant0');
   const rootRest = (kept && kept.root) || (model ? [model.rotation.x, model.rotation.z, model.position.y] : [0, 0, 0]);
   const sLean = new Spring(), sTilt = new Spring(), sLift = new Spring(), sSquash = new Spring(1);
@@ -230,6 +262,15 @@ export function createPoseLayer(model) {
       const tt = target[k], r = rest[k], s = sp[k];
       o.rotation.set(r[0] + s[0].step(tt[0], dt, w, z), r[1] + s[1].step(tt[1], dt, w, z), r[2] + s[2].step(tt[2], dt, w, z));
     }
+    // the stretch rides the same spring shape: the arm grows along its own axis toward the brim and
+    // the hand under it is divided back down, so the glove stays a ball instead of an egg
+    for (let i = 0; i < ARMS.length; i++) {
+      const o = piv[ARMS[i]];
+      if (!o) continue;
+      const k = clamp(sReach[ARMS[i]].step(target.reach[i], dt, w, z), 0.5, 2);
+      o.scale.set(1, k, 1);
+      for (const h of hands[ARMS[i]]) h.o.scale.set(h.base[0], h.base[1] / k, h.base[2]);
+    }
     const t = (ctx && ctx.t) || 0;
     const breath = target.breath ? BREATH_LIFT * Math.sin(t * (Math.PI * 2) / BREATH_SEC) : 0;
     model.rotation.x = rootRest[0] + sTilt.step(target.root.tilt, dt, w, z);
@@ -256,6 +297,7 @@ export function createPoseLayer(model) {
   /** Put the stance back the way the pack authored it (the rig frees the model right after). */
   function dispose() {
     for (const k of PIVOTS) { const o = piv[k]; if (o) o.rotation.set(rest[k][0], rest[k][1], rest[k][2]); }
+    for (const k of ARMS) { const o = piv[k]; if (o) o.scale.set(1, 1, 1); for (const h of hands[k]) h.o.scale.set(h.base[0], h.base[1], h.base[2]); }
     if (model) { model.rotation.x = rootRest[0]; model.rotation.z = rootRest[1]; model.position.y = rootRest[2]; model.scale.set(1, 1, 1); }
   }
 

--- a/ConditioningControlPanel/Resources/web/dtrh/race/smoke/poses-smoke.mjs
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/smoke/poses-smoke.mjs
@@ -16,7 +16,9 @@
  *   5. the tuck's antDown is exactly zero upright and non-zero inverted, and the
  *      layer never touches a pivot the model does not have;
  *   6. the countdown chain (ready -> grip -> cruise, launch -> cruise), the `amp`
- *      dial for reduced motion, and snapshotRest surviving a mixer frame.
+ *      dial for reduced motion, and snapshotRest surviving a mixer frame;
+ *   7. `reach`: a holding arm stretches along its own axis, the hand under it is
+ *      counter-scaled, the mirror swaps the pair and dispose() puts it all back.
  * ==========================================================================*/
 
 import { POSES, PIVOTS, resolvePose, createPoseLayer, snapshotRest } from '../emiPoses.js';
@@ -26,9 +28,13 @@ const ok = (cond, what) => { if (!cond) { console.error('FAIL ' + what); fails++
 const near = (a, b, eps = 1e-3) => Math.abs(a - b) <= eps;
 
 /* ---- a fake glb root ---------------------------------------------------- */
-const NODES = ['shoulderL', 'shoulderR', 'footL', 'footR', 'ant0'];
+const NODES = ['shoulderL', 'shoulderR', 'footL', 'footR', 'ant0', 'handL', 'handR', 'thumbL', 'thumbR'];
 function makeNode(name) {
-  return { name, rotation: { x: 0, y: 0, z: 0, set(a, b, c) { this.x = a; this.y = b; this.z = c; } } };
+  return {
+    name,
+    rotation: { x: 0, y: 0, z: 0, set(a, b, c) { this.x = a; this.y = b; this.z = c; } },
+    scale: { x: 1, y: 1, z: 1, set(a, b, c) { this.x = a; this.y = b; this.z = c; } },
+  };
 }
 function makeModel(names = NODES) {
   const kids = new Map(names.map((n) => [n, makeNode(n)]));
@@ -47,10 +53,13 @@ const run = (layer, sec, ctx = CTX, pre = null) => {
 };
 
 /* ---- 1. the table ------------------------------------------------------- */
-const KEYS = new Set(['sided', 'w', 'zeta', 'hold', 'next', 'breath', 'fraught', 'antDown', 'root', ...PIVOTS]);
+const KEYS = new Set(['sided', 'w', 'zeta', 'hold', 'next', 'breath', 'fraught', 'antDown', 'reach', 'root', ...PIVOTS]);
 for (const [name, p] of Object.entries(POSES)) {
   const bad = Object.keys(p).filter((k) => !KEYS.has(k));
   ok(bad.length === 0, `${name}: names only contract keys${bad.length ? ' (stray: ' + bad.join(', ') + ')' : ''}`);
+  if (p.reach !== undefined) {
+    ok(Array.isArray(p.reach) && p.reach.length === 2 && p.reach.every((v) => v >= 0.5 && v <= 2), `${name}.reach: [L, R] inside 0.5..2`);
+  }
   for (const k of PIVOTS) {
     if (p[k] === undefined) continue;
     ok(Array.isArray(p[k]) && p[k].length === 3 && p[k].every((v) => typeof v === 'number' && isFinite(v)), `${name}.${k}: three finite radians`);
@@ -164,6 +173,42 @@ ok(!!POSES.cruise && !POSES.cruise.hold, 'cruise is the resting pose and never t
   ok(L2.name === 'grip', 'the beat still chains');
   run(L2, 0.8);
   ok(near(m2.kids.get('shoulderL').rotation.x, POSES.grip.shoulderL[0] * 0.3, 0.02), 'and grip inherits the arms dial instead of snapping to a full swing');
+}
+/* ---- 7. the arm stretch that reaches the side of the brim --------------- */
+{
+  const m = makeModel(), L = createPoseLayer(m);
+  const grip = POSES.cruise.reach[0];
+  ok(grip > 1, 'cruise stretches both arms out to the brim');
+  L.set('cruise'); run(L, 3);
+  ok(near(m.kids.get('shoulderL').scale.y, grip, 5e-3), 'and the shoulder settles on that stretch');
+  ok(near(m.kids.get('handL').scale.y, 1 / grip, 5e-3), 'with the hand counter-scaled, so the glove stays a ball not an egg');
+  ok(near(m.kids.get('thumbR').scale.y, 1 / grip, 5e-3), 'and the thumb with it');
+  const sl = m.kids.get('shoulderL').scale;
+  ok(sl.x === 1 && sl.z === 1, 'an arm only ever grows along its own axis');
+  L.set('cheer', { hold: 99 }); run(L, 3);
+  ok(near(m.kids.get('shoulderL').scale.y, 1, 5e-3) && near(m.kids.get('handL').scale.y, 1, 5e-3), 'a pose off the brim (cheer) comes back to the authored arm');
+  L.dispose();
+  ok(m.kids.get('shoulderR').scale.y === 1 && m.kids.get('handR').scale.y === 1, 'dispose puts every scale back to 1');
+
+  // one hand on the brim, one hand off it: the mirror has to swap the pair with everything else
+  const g = resolvePose('grab', { side: 1 }), gm = resolvePose('grab', { side: -1 });
+  ok(g.reach[0] > 1 && g.reach[1] === 1, 'grab stretches only the hand that stays on the brim');
+  ok(gm.reach[0] === 1 && near(gm.reach[1], g.reach[0]), 'and side -1 swaps which arm that is');
+  ok(near(resolvePose('cruise', { arms: 0 }).reach[0], 1), 'arms 0 drops the stretch along with the swing');
+  ok(near(resolvePose('cruise', { arms: 0.5 }).reach[0], 1 + (grip - 1) * 0.5), 'and arms 0.5 takes half of it');
+
+  const bare = makeModel(['shoulderL', 'shoulderR', 'footL', 'footR']), B = createPoseLayer(bare);
+  B.set('cruise'); run(B, 3);
+  ok(near(bare.kids.get('shoulderL').scale.y, grip, 5e-3), 'a pack with no hand nodes still stretches, with nothing to counter and nothing to throw');
+
+  // emi.js mounts the mitts scaled up so they read at 8 px: the counter-scale divides that, never replaces it
+  const big = makeModel();
+  big.kids.get('handL').scale.set(1.4, 1.4, 1.4);
+  const G = createPoseLayer(big);
+  G.set('cruise'); run(G, 3);
+  ok(near(big.kids.get('handL').scale.y, 1.4 / grip, 5e-3) && near(big.kids.get('handL').scale.x, 1.4), 'a hand mounted larger keeps its size under the counter-scale');
+  G.dispose();
+  ok(near(big.kids.get('handL').scale.y, 1.4), 'and dispose hands it back at the size it was mounted');
 }
 {
   // snapshotRest: a mixer-driven model has moved by the time anyone asks for a layer, so the rest


### PR DESCRIPTION
Stacked on #969 (which is stacked on #965). Review/merge those first.

Follow-up on the grip pass: from the chase camera the hands did not READ as holding on. They sat on the FAR arc of the lip (z +0.13), in the model's own dark case material, half hidden behind her case - two small dark knobs.

**What changed**

- **They are gloves now.** `emi.js` repaints `handL`/`handR`/`thumbL`/`thumbR` with their own white `emi_glove` material *before* `flattenRig` - the repaint is what splits them out of the merge - and clones the outline material for their hulls so the black keyline is hosted on the hand and grows with it. The case material is untouched. Then the two hand nodes are scaled by `GLOVE_SCALE` 1.4: the cup mouth is only about 113 px across in a 1280 frame, so an authored hand lands on about 8 of them.
- **They hold the side of the brim.** `GLB_SEAT_Z` comes back to 0.22 (0.204 is dead centre in the bore and 0.25 sat her 0.046 proud, so this is better centred than before), which brings the shoulders to z 0.196. `emiPoses` gains a per-pose `reach: [L, R]`: `GRIP` 1.28 stretches a holding arm along its own axis as a y-scale on the shoulder pivot, with the hand and thumb counter-scaled off their mounted base so the mitt keeps its shape. That walks every grip from the old 66..79 degrees out to 82..87, x -+0.51, z +0.02..0.07 - the widest point of the lip on screen. Free hands keep 1 (`grab`, `throw` right), `cheer` has no `reach`, and `opts.arms` fades the stretch with the angles.
- Every holding angle was re-solved against the rim circle using each pose's **own** root attitude (lean, tilt, lift, squash), which is why `drift`'s two arms differ and `landingKerb` is asymmetric.

**Measured** (shot instant, `cruise`, 1280x720 chase camera): glove dy -0.001 / -0.002 off the lip top, r 0.521 / 0.522 against a lip radius of 0.500 - on the lip and 18 mm proud of it, so the mitt breaks the cup's outline against the road, which is what makes it read as a grip. Before this commit: r 0.512, dy +0.020, at z +0.133 (behind the case).

No camera change, no `.glb` edit, no rig change needed.

**Verified**: `poses-smoke` (+13 assertions covering the stretch settling, the hand/thumb counter-scale, x/z untouched, `cheer` returning to 1, `dispose` restoring, the one-armed `grab` and its mirror, `arms` 0 / 0.5, and a pack with no hand nodes) and `gltf-smoke` (75 assertions) both green; headless run at 1280x720 with zero console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KTe1RA7EP5hGxkzFY1282C
