### PR TITLE
feat(pbp): soft-body flex, so the men move like silicone

### DIFF
--- a/ConditioningControlPanel/Resources/web/piecebypiece/board/jiggle.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/board/jiggle.js
@@ -1,0 +1,296 @@
+/* ============================================================================
+ * board/jiggle.js - the men are made of silicone, so they flex.
+ *
+ * Every piece carries one damped spring (a sideways bend plus a squash) and a
+ * vertex shader that reads it. The bend is weighted by height, so the base
+ * stays planted on its square and the tip does the swinging, the way a soft
+ * toy flicked at the top behaves. Nothing here scales the object: the whole
+ * deformation happens in the vertex shader, normals included, so the lighting
+ * follows the bend instead of sitting painted on a rigid shape.
+ *
+ * The spring lives in the piece's LOCAL space. World-space impulses (a slide
+ * direction, a drag delta) are rotated into it first, so a black man, who is
+ * turned to face down the board, leans the same way a white one does.
+ *
+ * Wiring, all of it optional, all of it one line at the call site:
+ *   pieces.js  attach on build, idle sway from the meter wobble
+ *   anim.js    land on arrival, buzz drives a fast small bend
+ *   drag.js    sag on grab, lag while the pointer drags it around
+ *   boot.js    update(dt) once a frame, after everything else has moved
+ * ==========================================================================*/
+
+import * as THREE from 'three';
+
+/** Every number that decides how the men feel. One place, on purpose. */
+export const TUNING = Object.freeze({
+  // Bend spring: about 4 Hz with a light damping, so a flick rings for roughly
+  // 0.8 s and shows two to three swings before it settles.
+  bendStiffness: 620,
+  bendDamping: 7.4,
+  // Squash rings faster and dies sooner; a landing should not keep pumping.
+  squashStiffness: 1150,
+  squashDamping: 11.5,
+  // Height weighting. Bend is quadratic (planted base, whippy tip), squash is
+  // linear so the body squats as one instead of only deflating the head.
+  bendWeightPow: 2.0,
+  squashWeightPow: 1.0,
+  volumeGain: 0.5,          // how far x/z inflate to pay for the lost height
+  // Impulses. All are divided by the piece's world height, so a king barely
+  // stirs where a pawn whips.
+  landBend: 3.2,
+  landSquash: 5.0,
+  captureGain: 1.75,        // the man doing the taking arrives harder
+  grabSquash: -2.6,         // negative squash is a stretch: the tip sags
+  grabBend: 1.1,
+  dragLag: 8,               // bend velocity per world unit of pointer travel
+  buzzAmp: 0.05,            // forced bend while a piece is giving check
+  buzzFastX: 62,
+  buzzFastZ: 47,
+  idleAmp: 0.08,            // forced bend at wobble 1.0, zero at wobble 0
+  idleFreq: 1.15,
+  idleCross: 0.72,          // the z lobe runs at a different rate than x
+  rippleWaves: 5.0,         // travelling ripple, scaled by the live bend
+  rippleSpeed: 9.0,
+  rippleGain: 0.22,
+  maxBend: 0.34,            // local units; the men are 1.0 tall in local space
+  maxSquash: 0.45,
+  reducedScale: 0.3,        // impulse multiplier when motion is turned down
+  substep: 1 / 240,         // the spring is stiff, so integrate it small
+});
+
+const CACHE_KEY = 'pbp-jiggle-1';
+const T = TUNING;
+const f = (n) => (Number.isInteger(n) ? n.toFixed(1) : String(n));
+
+const PRELUDE = `
+uniform vec2 uBend;
+uniform float uSquash;
+uniform float uHeight;
+uniform float uPhase;
+uniform float uTime;
+float pbpH(float y) { return clamp(y / max(uHeight, 0.0001), 0.0, 1.0); }
+`;
+
+const BEND_VERTEX = `#include <begin_vertex>
+{
+  float h = pbpH(position.y);
+  float wb = pow(h, ${f(T.bendWeightPow)});
+  float ws = pow(h, ${f(T.squashWeightPow)});
+  vec2 wave = uBend * (sin(h * ${f(T.rippleWaves)} - uTime * ${f(T.rippleSpeed)} + uPhase) * ${f(T.rippleGain)});
+  vec2 off = (uBend + wave) * wb;
+  transformed.y *= (1.0 - uSquash * ws);
+  transformed.xz *= (1.0 + ${f(T.volumeGain)} * uSquash);
+  transformed.x += off.x;
+  transformed.z += off.y;
+}`;
+
+// The normal is rotated by the derivative of the bend and rescaled by the
+// inverse of the squash. It is an approximation (the ripple term is left out)
+// but it is enough to keep a bent flank lit like a bent flank.
+const BEND_NORMAL = `#include <beginnormal_vertex>
+{
+  float h = pbpH(position.y);
+  vec2 slope = uBend * (${f(T.bendWeightPow)} * pow(h, ${f(T.bendWeightPow - 1)}) / max(uHeight, 0.0001));
+  objectNormal.y -= slope.x * objectNormal.x + slope.y * objectNormal.z;
+  float sy = max(1.0 - uSquash * pow(h, ${f(T.squashWeightPow)}), 0.05);
+  float sxz = max(1.0 + ${f(T.volumeGain)} * uSquash, 0.05);
+  objectNormal = normalize(vec3(objectNormal.x / sxz, objectNormal.y / sy, objectNormal.z / sxz));
+}`;
+
+function prefersReducedMotion() {
+  if (typeof window === 'undefined') return false;
+  if (window.PBP && window.PBP.reducedMotion) return true;
+  try { return !!window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches; }
+  catch { return false; }
+}
+
+export function createJiggle() {
+  const states = new Map();       // piece root -> spring state
+  const dir = new THREE.Vector3();
+  const inv = new THREE.Quaternion();
+  let clock = 0;
+  let wobble = 0;
+  let lastCost = 0;
+
+  const gain = () => (prefersReducedMotion() ? T.reducedScale : 1);
+
+  function install(material, u) {
+    material.userData.pbpJiggle = u;
+    material.onBeforeCompile = (shader) => {
+      shader.uniforms.uBend = u.uBend;
+      shader.uniforms.uSquash = u.uSquash;
+      shader.uniforms.uHeight = u.uHeight;
+      shader.uniforms.uPhase = u.uPhase;
+      shader.uniforms.uTime = u.uTime;
+      shader.vertexShader = PRELUDE + shader.vertexShader
+        .replace('#include <beginnormal_vertex>', BEND_NORMAL)
+        .replace('#include <begin_vertex>', BEND_VERTEX);
+    };
+    // Every jiggling material compiles the same program, so they share one
+    // cache entry; without a key of our own three would key them apart.
+    material.customProgramCacheKey = () => CACHE_KEY;
+    material.needsUpdate = true;
+  }
+
+  /** Give a freshly built piece its spring and hook up every mesh it owns. */
+  function attach(piece) {
+    if (states.has(piece)) return states.get(piece);
+    const u = {
+      uBend: { value: new THREE.Vector2(0, 0) },
+      uSquash: { value: 0 },
+      uHeight: { value: 1 },
+      uPhase: { value: Math.random() * Math.PI * 2 },
+      uTime: { value: 0 },
+    };
+    let height = 0;
+    piece.traverse((o) => {
+      if (!o.isMesh || !o.material) return;
+      if (o.geometry) {
+        if (!o.geometry.boundingBox) o.geometry.computeBoundingBox();
+        const bb = o.geometry.boundingBox;
+        if (bb) height = Math.max(height, o.position.y + bb.max.y);
+      }
+      const mats = Array.isArray(o.material) ? o.material : [o.material];
+      const next = mats.map((m) => {
+        // A material already bound to another piece would share its spring, so
+        // that piece gets its own copy. Art loaded from a glb can land here.
+        const mine = m.userData && m.userData.pbpJiggle;
+        const use = mine && mine !== u ? m.clone() : m;
+        if (!use.userData.pbpJiggle || use.userData.pbpJiggle !== u) install(use, u);
+        return use;
+      });
+      o.material = Array.isArray(o.material) ? next : next[0];
+    });
+    u.uHeight.value = height > 0.01 ? height : 1;
+    const world = (piece.scale.y || 1) * u.uHeight.value;
+    const state = {
+      piece, u,
+      bend: new THREE.Vector2(0, 0),
+      vel: new THREE.Vector2(0, 0),
+      squash: 0, sVel: 0,
+      forced: new THREE.Vector2(0, 0),
+      phase: Math.random() * Math.PI * 2,
+      height: u.uHeight.value,
+      world: world > 0.05 ? world : 1,
+    };
+    states.set(piece, state);
+    return state;
+  }
+
+  function release(piece) { states.delete(piece); }
+
+  const stateOf = (piece) => (piece ? states.get(piece) || null : null);
+
+  /** World-space x/z into the piece's own frame, so black leans like white. */
+  function toLocal(piece, x, z) {
+    inv.copy(piece.quaternion).invert();
+    dir.set(x, 0, z).applyQuaternion(inv);
+    return dir;
+  }
+
+  /** Kick the spring. bend is world x/z; squash is positive for a squat. */
+  function impulse(piece, { bend = null, squash = 0, local = false } = {}) {
+    const s = stateOf(piece);
+    if (!s) return;
+    const g = gain() / s.world;
+    if (bend) {
+      const v = local ? dir.set(bend[0], 0, bend[1]) : toLocal(piece, bend[0], bend[1]);
+      s.vel.x += v.x * g;
+      s.vel.y += v.z * g;
+    }
+    if (squash) s.sVel += squash * g;
+  }
+
+  /**
+   * A piece has arrived on its square after travelling `travel` (world x/z).
+   * The tip lags behind the travel, then whips through it.
+   */
+  function land(piece, travel = null) {
+    const s = stateOf(piece);
+    if (!s) return;
+    const hard = piece.userData.tookOne ? T.captureGain : 1;
+    piece.userData.tookOne = false;
+    let bx = 0, bz = 0;
+    if (travel) {
+      const len = Math.hypot(travel[0], travel[1]) || 1;
+      bx = (-travel[0] / len) * T.landBend * hard;
+      bz = (-travel[1] / len) * T.landBend * hard;
+    }
+    impulse(piece, { bend: [bx, bz], squash: T.landSquash * hard });
+  }
+
+  /** Lifted off the board: the tip stretches down under its own weight. */
+  function grab(piece) {
+    const s = stateOf(piece);
+    if (!s) return;
+    impulse(piece, { squash: T.grabSquash });
+    const a = Math.random() * Math.PI * 2;
+    impulse(piece, { bend: [Math.cos(a) * T.grabBend, Math.sin(a) * T.grabBend] });
+  }
+
+  /** Dragged: the tip trails the pointer by however far the body just moved. */
+  function lag(piece, dx, dz) {
+    if (!dx && !dz) return;
+    impulse(piece, { bend: [-dx * T.dragLag, -dz * T.dragLag] });
+  }
+
+  /** A bend held on for one frame, on top of the spring. Buzz and idle use it. */
+  function drive(piece, x, z) {
+    const s = stateOf(piece);
+    if (!s) return;
+    s.forced.x += x;
+    s.forced.y += z;
+  }
+
+  function step(s, dt) {
+    s.vel.x += (-T.bendStiffness * s.bend.x - T.bendDamping * s.vel.x) * dt;
+    s.vel.y += (-T.bendStiffness * s.bend.y - T.bendDamping * s.vel.y) * dt;
+    s.bend.x += s.vel.x * dt;
+    s.bend.y += s.vel.y * dt;
+    s.sVel += (-T.squashStiffness * s.squash - T.squashDamping * s.sVel) * dt;
+    s.squash += s.sVel * dt;
+  }
+
+  function update(dt) {
+    const t0 = performance.now();
+    clock += dt;
+    const steps = Math.max(1, Math.min(24, Math.ceil(dt / T.substep)));
+    const h = dt / steps;
+    const idle = wobble > 0.001 && !prefersReducedMotion() ? wobble * T.idleAmp : 0;
+    for (const [piece, s] of states) {
+      if (!piece.parent) { states.delete(piece); continue; }
+      for (let i = 0; i < steps; i++) step(s, h);
+      s.bend.x = THREE.MathUtils.clamp(s.bend.x, -T.maxBend, T.maxBend);
+      s.bend.y = THREE.MathUtils.clamp(s.bend.y, -T.maxBend, T.maxBend);
+      s.squash = THREE.MathUtils.clamp(s.squash, -T.maxSquash, T.maxSquash);
+      if (idle && !piece.userData.busy && !piece.userData.held) {
+        s.forced.x += Math.sin(clock * T.idleFreq + s.phase) * idle;
+        s.forced.y += Math.cos(clock * T.idleFreq * T.idleCross + s.phase * 1.7) * idle;
+      }
+      s.u.uBend.value.set(s.bend.x + s.forced.x, s.bend.y + s.forced.y);
+      s.u.uSquash.value = s.squash;
+      s.u.uTime.value = clock;
+      s.forced.set(0, 0);
+    }
+    lastCost = performance.now() - t0;
+  }
+
+  return {
+    attach, release, update, impulse, land, grab, lag, drive,
+    setWobble(v) { wobble = Math.max(0, Math.min(1, Number(v) || 0)); },
+    /** Harness and ramp entry point: poke(piece, {bend:[x,z], squash}). */
+    poke(piece, opts = {}) { impulse(piece, { bend: opts.bend || null, squash: opts.squash || 0 }); },
+    /** Live spring state for one piece, for the smoke harness. */
+    debug(piece) {
+      const s = stateOf(piece);
+      if (!s) return null;
+      return {
+        bend: [s.bend.x, s.bend.y], vel: [s.vel.x, s.vel.y],
+        squash: s.squash, squashVel: s.sVel,
+        height: s.height, world: s.world,
+        uBend: [s.u.uBend.value.x, s.u.uBend.value.y], uSquash: s.u.uSquash.value,
+      };
+    },
+    stats() { return { pieces: states.size, lastMs: lastCost, reduced: prefersReducedMotion() }; },
+  };
+}

--- a/ConditioningControlPanel/Resources/web/piecebypiece/board/pieces.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/board/pieces.js
@@ -77,7 +77,7 @@ function trim(type, mat) {
   return parts;
 }
 
-export function createPieces({ group, assetsBase = './assets/pieces/', hooks = {} }) {
+export function createPieces({ group, assetsBase = './assets/pieces/', hooks = {}, jiggle = null }) {
   const geoCache = new Map();
   const glb = new Map();          // type -> geometry from a supplied glb
   const bySquare = new Map();     // square -> piece object
@@ -97,11 +97,22 @@ export function createPieces({ group, assetsBase = './assets/pieces/', hooks = {
     body.castShadow = true;
     body.receiveShadow = true;
     root.add(body);
-    if (!glb.has(type)) for (const part of trim(type, mat)) { part.castShadow = true; root.add(part); }
+    // Trim is baked into the body's own space before it joins the piece: the
+    // flex shader reads position.y as a height up the piece, so a part that
+    // carried its own offset would bend around the wrong origin.
+    if (!glb.has(type)) for (const part of trim(type, mat)) {
+      part.updateMatrix();
+      part.geometry = part.geometry.clone().applyMatrix4(part.matrix);
+      part.position.set(0, 0, 0);
+      part.rotation.set(0, 0, 0);
+      part.castShadow = true;
+      root.add(part);
+    }
     root.scale.setScalar(HEIGHT[type]);
     // Knights (and any modelled piece) look at the far side.
     root.rotation.y = side === 'w' ? 0 : Math.PI;
     root.userData = { type, side, material: mat, scaleBase: HEIGHT[type], phase: Math.random() * Math.PI * 2 };
+    if (jiggle) jiggle.attach(root);
     return root;
   }
 
@@ -144,7 +155,7 @@ export function createPieces({ group, assetsBase = './assets/pieces/', hooks = {
     if (!piece) return null;
     bySquare.delete(from);
     const taken = bySquare.get(to) || null;
-    if (taken) { retire(taken); bySquare.delete(to); }
+    if (taken) { retire(taken); bySquare.delete(to); piece.userData.tookOne = true; }
     const was = piece.position.clone();
     place(piece, to);
     bySquare.set(to, piece);
@@ -203,10 +214,23 @@ export function createPieces({ group, assetsBase = './assets/pieces/', hooks = {
     }
   }
 
+  // The flex system talks in pieces; the board talks in squares. This is the
+  // translation, and it is what the harness and the ramp reach for.
+  const jiggleApi = jiggle ? {
+    poke(square, opts = {}) { jiggle.poke(bySquare.get(square), opts); },
+    debug(square) { return jiggle.debug(bySquare.get(square)); },
+    stats() { return jiggle.stats(); },
+    system: jiggle,
+  } : null;
+
   return {
     setPosition, pieceAt, move, remove, update, tryLoadGlb,
     pieces: bySquare,
-    setWobble(v) { wobble = Math.max(0, Math.min(1, Number(v) || 0)); },
+    jiggle: jiggleApi,
+    setWobble(v) {
+      wobble = Math.max(0, Math.min(1, Number(v) || 0));
+      if (jiggle) jiggle.setWobble(wobble);
+    },
     getWobble() { return wobble; },
   };
 }

--- a/ConditioningControlPanel/Resources/web/piecebypiece/boot.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/boot.js
@@ -10,6 +10,7 @@
 import { createScene } from './board/scene.js';
 import { createPieces } from './board/pieces.js';
 import { createAnim } from './board/anim.js';
+import { createJiggle } from './board/jiggle.js';
 import { createDrag } from './board/drag.js';
 import { createBus } from './game/events.js';
 import { createHotseat } from './game/hotseat.js';
@@ -42,13 +43,17 @@ function main() {
     return;
   }
 
-  const anim = createAnim({ group: view.pieceGroup });
-  const pieces = createPieces({ group: view.pieceGroup, hooks: anim.hooks });
+  // Soft-body flex. One system for the whole board; every piece gets its own
+  // spring out of it when pieces.js builds it.
+  const jiggle = createJiggle();
+  const anim = createAnim({ group: view.pieceGroup, jiggle });
+  const pieces = createPieces({ group: view.pieceGroup, hooks: anim.hooks, jiggle });
   // The board API the effects layer drives. Keep this surface stable.
   const board = {
     view,
     pieces,
     anim,
+    jiggle: pieces.jiggle,
     buzzCheck(square) { anim.buzz(pieces.pieceAt(square)); },
     setWobble(v) { pieces.setWobble(v); },
     setCameraSway(v) { view.setCameraSway(v); },
@@ -67,7 +72,7 @@ function main() {
     auto: Number(params.get('auto')) || 0,
   });
 
-  const drag = createDrag({ view, pieces, anim, bus, game });
+  const drag = createDrag({ view, pieces, anim, bus, game, jiggle });
   board.drag = drag;
 
   // `ramp` is filled in once the effects layer has attached. It is on the
@@ -83,6 +88,7 @@ function main() {
     pieces.update(dt);
     anim.update(dt);
     drag.update(dt);
+    jiggle.update(dt);   // last: it reads what everything else just decided
     if (window.PBP.game && window.PBP.game.update) window.PBP.game.update(dt);
     view.render();
     requestAnimationFrame(frame);


### PR DESCRIPTION
The men are meant to be made of silicone, so they should move like it: bend, jiggle, settle. Today the board only has a rigid landing squash on the object's scale and a meter-driven sway. This is the first half of the fix, the flex system itself.

## What it is

`board/jiggle.js` gives every piece one damped spring (a sideways bend, plus a squash) and a vertex shader that reads it:

- **bend** is weighted by `pow(y / height, 2)`, so the base stays planted on its square and the tip does the swinging, the way a soft toy flicked at the top behaves
- **squash** trades height for width (`y * (1 - s*w)`, `xz * (1 + 0.5*s)`), which is what a soft thing landing on a hard board does
- the **normal** is rotated by the derivative of the bend and rescaled by the inverse of the squash, so a bent flank is lit like a bent flank instead of a painted rigid one
- a small travelling **ripple**, scaled by the live bend, so the flex is not a single rigid arc

Every piece owns its uniforms. The materials in `pieces.js` are already built one per man, and a material that turns up already bound to another piece (art from a glb could) is cloned before it is hooked. All of them compile the same program and share one `customProgramCacheKey`, so there is exactly one shader for the whole board.

`uHeight` comes from the mesh bounding boxes, not from a constant, so this works unchanged on a single mesh glb of any height with its own material and vertex colours.

## What is wired here

- `pieces.js` attaches a spring as it builds a man, and feeds `setWobble(v)` in as a very small idle sway with a per-piece phase, so the men do not sway in unison. Zero at `v = 0`, and a piece the animator has taken (`userData.busy`) stands off.
- `boot.js` steps the system once a frame, last, after everything else has decided where the men are, and exposes `PBP.board.jiggle` with `poke(square, {bend, squash})` and `debug(square)`.
- Trim on a knight or a king is baked into the body's own space first. The shader reads `position.y` as a height up the piece, so a part carrying its own offset would have bent around the wrong origin.
- Reduced motion (`window.PBP.reducedMotion`, or the media query) drops impulses to 30 percent and turns the idle sway off.

The landing squash in `anim.js` is still the old scale for now. #975 replaces it and adds the grab, drag and buzz triggers, and the screenshot harness that proves all of it.

## Tuning

All of it is one frozen object at the top of `jiggle.js`. Bend stiffness 620 with damping 7.4 rings for about 0.8 s over three visible swings; squash 1150 with damping 11.5 dies sooner so a landing does not keep pumping. Idle amplitude 0.08 at full wobble.

## Checks

- `node smoke/rules-smoke.mjs` 43 checks pass
- `node smoke/ramp-smoke.mjs` 111 checks pass
- `node smoke/shot.mjs --drag e2:e4` clean boot, no console errors, the move plays
- the flex costs 0.005 ms a frame with 32 men on the board

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S4BKp6cQJFNixoQrarvSkd