### PR TITLE
race: the word carries the flash, and the flash bubble goes dark

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
@@ -172,7 +172,7 @@ Bubble kinds (mirror `game/variants.js` and `engine/bubbles.js`; sprites from
 | golden | treat | null | 50 | rare, JACKPOT chime |
 | lucky | treat | null | 25 | a plain 25 point treat, nothing else |
 | prism | treat | null | 30 | rainbow, pops neighbours |
-| flash | effect | flash | 15 | flash media from the pool |
+| flash | effect | flash | 15 | DARK since 2026-09-08, never spawns; the WORD carries the flash now (see below) |
 | subliminal | effect | subliminal | 15 | |
 | pink | effect | overlay/pink_filter | 20 | |
 | spiral | effect | overlay/spiral | 20 | |
@@ -191,7 +191,23 @@ never calls the setter.
 A row may carry `spawn: false`. Video bubbles are dark since 2026-09-06: `rollKind` leaves the row out
 of every pool and `field.spawnAt` returns -1 for it, so no roll, lane line, rain or track cue can put
 one on the road, and `CaucusHostService` refuses a `fire-payload {kind:'video'}` as well. The row, its
-sprite and its THE MIX `video` slot stay put for a later use.
+sprite and its THE MIX `video` slot stay put for a later use. `field.spawnRow` refuses a dark kind
+too, and refuses the WHOLE row rather than laying it with a hole in it, so anything that names a kind
+for a row (`cues.js` FALLBACK_TRIGGER / ROOM_TRIGGER, `triggerTheme.js` FALLBACK_KIND and every
+`THEME_BY_PRESET` row, `track.js` TRIGGER_KINDS) has to name one that still spawns.
+
+**THE WORD FLASH (2026-09-08).** The flash bubble is dark as well: the flash is a beat on a WORD now,
+not a bubble of its own. A pop of a bubble that WEARS a word (a transcript word bubble, or one of a
+trigger row whose kind is a treat) fires `payloadFx` `flash` at `WORD_FLASH` strength for ~185 ms
+half the time, rolled off the run's own seeded stream (`w.popRng`), one flash per `WORD_FLASH_GAP_MS`
+(250 ms) and none at all under reduced motion. It is cosmetic: it never reaches THE MIX, so it is no
+strobe charge and no recipe, and the pop scores as the treat it always was. The odds, the cap and the
+constants live in `race/cues.js` (`wordFlash`, `WORD_FLASH*`), so `race/smoke/rows-check.mjs` holds
+them; run.js only keeps the clock. `race/smoke/word-flash-check.mjs` drives a real headless run and
+reads the two counters back: `race.wordFlashStats()` (pops, capped, rolls, flashes) and
+`race.wordFaces().placed`, the tally of every kind the field has actually put on the road. The one preset that MEANT the flash, `flash-pulse`, goes the other
+way: its row is a line of plain word faces and its beat sets `cue.mix = 'flash'`, which is now the
+only door a strobe charge comes through, so the recipes that need one still have a way to be served.
 
 Placements: `lane` (rests on the road, h ~0.9, bobbing), `air` (along a ramp air line, h rises
 2..5), `spawn` (materialises ahead, wobbles laterally), `rain` (falls from `h = 9` to the road in
@@ -415,6 +431,10 @@ add to 4, `freeze` and `video` are solo (`video` holds everything else). `action
 pop scores as a treat. Live category sets match `RECIPES` (first row whose `needs` are all live);
 run.js maps a served recipe to `score.boostMult` (never below x1), a toast, a mood poke and, for
 `marquee` rows, the banner. Durations for effects live in `CATEGORIES`, not run.js.
+Since 2026-09-08 no flash bubble spawns, so the `strobe` slot is lit by the `flash-pulse` trigger row
+alone (`cue.mix`), never by a pop: a seeded run with no chart under it now goes the whole way without
+one, and the word flash is deliberately not a charge. The slot, its bursts and the recipes that need
+it stay in the machine, the way the `video` slot did.
 
 ### `race/gltf.js` (pass four, the Blender packs)
 

--- a/ConditioningControlPanel/Resources/web/dtrh/race/bubbleKinds.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/bubbleKinds.js
@@ -26,6 +26,11 @@ const PLAIN_SPRITE = '/dtrh/assets/bubbles/bubble.png';   // the classic soap bu
 //   place one, so no roll, lane line, rain or track cue can put it on the road. 'video' is dark
 //   since 2026-09-06: the tape bubble fired a real mandatory video mid-run and the owner has
 //   another use in mind for the slot. The host refuses a video fire-payload too.
+//   'flash' is dark since 2026-09-08: the flash is a beat on a WORD now, not a bubble of its own.
+//   Half the word bubbles the player takes pop a brief flash with them (race/cues.js WORD_FLASH,
+//   fired from run.js onPop), so the light comes off the thing the voice said rather than off a
+//   sprite that happened to roll. The row keeps its strobe slot, so THE MIX still knows the kind
+//   when a flash arrives from a `flash-pulse` trigger row, a burst or a recipe.
 export const BUBBLE_KINDS = [
   { id: 'treat',      label: '',  kind: 'treat',  payload: null,         overlayKind: null,  category: null,
     strength: 0,    points: 10, weight: 22,  minIntensity: 0,    tint: 'rgb(184,222,255)', sprite: PLAIN_SPRITE },
@@ -36,6 +41,7 @@ export const BUBBLE_KINDS = [
   { id: 'prism',      label: '❂', kind: 'treat',  payload: null,         overlayKind: null,  category: null,
     strength: 0,    points: 30, weight: 1.4, minIntensity: 0.1,  tint: 'rgb(200,168,255)', sprite: SPRITE_BASE + 'prism.png' },
   { id: 'flash',      label: '',  kind: 'effect', payload: 'flash',      overlayKind: null,  category: 'strobe',
+    spawn: false,   // dark since 2026-09-08, see the header; the word bubbles carry the flash now
     strength: 0.45, points: 15, weight: 6,   minIntensity: 0,    tint: 'rgb(255,208,232)', sprite: SPRITE_BASE + 'flash.png' },
   { id: 'subliminal', label: '♥', kind: 'effect', payload: 'subliminal', overlayKind: null,  category: 'cards',
     strength: 0.45, points: 15, weight: 5,   minIntensity: 0,    tint: 'rgb(176,128,255)', sprite: SPRITE_BASE + 'subliminal.png' },

--- a/ConditioningControlPanel/Resources/web/dtrh/race/bubbles.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/bubbles.js
@@ -164,8 +164,14 @@ export function createBubbleField({ scene, layout, media, getIntensity, getRoom,
     return rollKind(intensity(), roomBias(), extra).id;
   }
 
+  /** Every kind this field has PUT ON THE ROAD, counted. Never read by the game: it is the one
+   *  honest answer to "did a darkened kind ever spawn" (race/smoke/word-flash-check.mjs), because
+   *  place() is the single door every roll, lane line, rain, cue and row goes through. */
+  const placed = new Map();
+
   function place(kindId, placement, d, x, h) {
     const k = KIND_BY_ID[kindId] || KIND_BY_ID.treat;
+    placed.set(k.id, (placed.get(k.id) || 0) + 1);
     const s = takeSlot();
     s.kindId = k.id; s.placement = placement;
     s.d = layout.wrap(d); s.x = clamp(x, -LANE_X_MAX, LANE_X_MAX); s.x0 = s.x;
@@ -467,7 +473,8 @@ export function createBubbleField({ scene, layout, media, getIntensity, getRoom,
     /** riptide: while on, everything inside PULL_M ahead slides into the kart's lane. */
     setPull(on) { pull = !!on; },
     /** What race/smoke/face-check.mjs reads: the face cache, and what every live word bubble
-     *  is wearing this frame, nearest the kart first. Never read by the game itself. */
+     *  is wearing this frame, nearest the kart first, plus `placed`, every kind this run has put
+     *  on the road counted by id. Never read by the game itself. */
     faceReport() {
       const worn = [];
       for (const s of pool) {
@@ -476,7 +483,7 @@ export function createBubbleField({ scene, layout, media, getIntensity, getRoom,
           ahead: relD(s.d, lastKartD), size: s.size, popped: s.popT >= 0, faced: !!(s.mat.map && s.mat.map !== dotTex && s.mat.map.isCanvasTexture) });
       }
       worn.sort((a, b) => a.ahead - b.ahead);
-      return { ...faces.report(), pool: pool.length, live: liveCount, worn };
+      return { ...faces.report(), pool: pool.length, live: liveCount, worn, placed: Object.fromEntries(placed) };
     },
     get liveCount() { return liveCount; },
   };

--- a/ConditioningControlPanel/Resources/web/dtrh/race/cues.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/cues.js
@@ -55,11 +55,16 @@ function tagInk(event) {
   return row && row.preset === event.cue ? row.color : null;
 }
 
-/** A trigger phrase nobody has assigned a bubble to wears the room's own effect, else this. */
-const FALLBACK_TRIGGER = 'flash';
-/** Which effect an unmapped trigger wears per room (rooms.js ids; chart.js ACT_ROOM picks them). */
+/** A trigger phrase nobody has assigned a bubble to wears the room's own effect, else this.
+ *  `pink` since 2026-09-08: it was the flash bubble, and the flash bubble is dark now. Every id
+ *  named here has to be one that still SPAWNS, because bubbles.js lays no row at all for a dark
+ *  kind and a trigger row that never lands is the one thing this road may not do. */
+const FALLBACK_TRIGGER = 'pink';
+/** Which effect an unmapped trigger wears per room (rooms.js ids; chart.js ACT_ROOM picks them).
+ *  The Tea Garden's was the flash; it takes the whisper card instead, which is the gentler read
+ *  of "nothing here fights you" anyway and keeps the room off the pink the Toybox already wears. */
 const ROOM_TRIGGER = {
-  teagarden: 'flash', undertow: 'spiral', toybox: 'pink', chapel: 'spiral',
+  teagarden: 'subliminal', undertow: 'spiral', toybox: 'pink', chapel: 'spiral',
   mirrors: 'glitch', greyward: 'freeze', coronation: 'prism', casino: 'lucky',
 };
 /** What a peak rains per room; anywhere else it is plain treats. */
@@ -107,6 +112,29 @@ const CHANT_X = 1.2, CHANT_PERIOD = 1.2, CHANT_MAX = 16;
 const CHANT_GOLD_EVERY = 4;
 /** A build hands over at most this many seconds of boost. */
 const BOOST_CAP = 4;
+/** THE WORD FLASH (2026-09-08). The flash bubble is dark: the flash is a beat on a WORD now.
+ *  Half the word bubbles the player takes pop a brief bloom of light with them, and the other half
+ *  are just a word. It is cosmetic and nothing else: it never reaches THE MIX, it is not a strobe
+ *  charge, it cannot start a recipe and the pop still scores as the treat it always was.
+ *  A `flash-pulse` row is the exception, and it goes the other way: that preset MEANT the flash,
+ *  so its beat pours a real one through the mixer (`cue.mix`) instead of this bloom. */
+export const WORD_FLASH_CHANCE = 0.5;
+/** The preset whose row pours a real flash on its beat rather than the bloom (triggerTheme.js). */
+export const FLASH_PRESET = 'flash-pulse';
+/** Two words taken inside this many ms share one flash: a line read clean is a sentence, not a strobe. */
+export const WORD_FLASH_GAP_MS = 250;
+/** What run.js hands payloadFx: one scattered image at ~185 ms, which is a blink and not an effect. */
+export const WORD_FLASH = { strength: 12, durationMult: 0.18 };
+/**
+ * Does this word pop take a flash with it? Pure so the smokes can hold the odds: run.js keeps the
+ * clock and the run's own seeded rng, and a pop inside the gap never draws from it, so the cap is a
+ * cap and not a re-roll.
+ * @param rng the run's seeded rng, @param sinceMs ms since the last flash this run fired
+ */
+export function wordFlash(rng, sinceMs) {
+  if (!(sinceMs >= WORD_FLASH_GAP_MS)) return false;
+  return (typeof rng === 'function' ? rng() : Math.random()) < WORD_FLASH_CHANCE;
+}
 
 const clamp = (v, a, b) => Math.max(a, Math.min(b, v));
 const conf01 = (e) => (Number.isFinite(Number(e.conf)) ? clamp(Number(e.conf), 0, 1) : 1);
@@ -154,7 +182,13 @@ export function cueFor(event, ctx = {}) {
       const gold = typeof ctx.gold === 'function' && ctx.gold() === true;   // rabbit foot: a golden in the middle
       // every bubble of the row wears the set's word on its own face (bubbles.js spawnRow), inked
       // in the set's own theme colour, and the middle one is drawn bigger: the row IS the word.
-      const ink = (themeFor(event) || {}).color || null;
+      const row = themeFor(event) || {};
+      const ink = row.color || null;
+      // the one preset that MEANT the flash: its bubble went dark, so the beat pours the flash
+      // itself through THE MIX (run.js cueMix) and the row stays a line of plain white word faces.
+      // This is the only door a strobe charge still comes through, so the recipes that need one
+      // (pink lightning, snowblind, the full pour) are still on the table.
+      if (row.preset === FLASH_PRESET) cue.mix = 'flash';
       for (const x of ROW_X) cue.spawn.push({ kindId: gold && Math.abs(x) < 1e-6 ? 'golden' : kindId, placement: 'lane', x, h: LANE_H, at: 0, row: true, w: label || '', ink, big: true });
       cue.word = label || null;
       cue.pose = 'grab';

--- a/ConditioningControlPanel/Resources/web/dtrh/race/rooms.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/rooms.js
@@ -32,17 +32,19 @@ import { propPack, packGeo, geoSize } from './propPack.js';
 // ---- the eight rooms -------------------------------------------------------------
 // colors: road = ribbon tint, edge = kerb lines, prop = wall props, fog = the room's haze
 // (informational; the biome palette is what fx.js grades), banner = the MARQUEE plate.
-// bubbleBias multiplies bubbles.js kind weights; ambient names a fieldFx particle field.
+// bubbleBias multiplies bubbles.js kind weights; ambient names a fieldFx particle field. A bias on a
+// DARKENED kind (bubbleKinds.js `spawn: false`) is dead weight, because rollKind drops those rows out
+// of every pool before the bias is read: the `flash` entries came off on 2026-09-08 with the bubble.
 export const ROOMS = [
   { id: 'teagarden', name: 'The Tea Garden', tagline: 'nothing here fights you', biome: 'mirrorlake',
     colors: { road: 0x2f6e50, edge: 0xf6e7c8, prop: 0xffb6d9, fog: 0x12261f, banner: 0x5fa98a },
     propKind: 'teacup', loud: false,
-    bubbleBias: { treat: 1.4, golden: 0.8, lucky: 1.2, flash: 0.5, subliminal: 0.5, video: 0 },
+    bubbleBias: { treat: 1.4, golden: 0.8, lucky: 1.2, subliminal: 0.5, video: 0 },
     ambient: { kind: 'petals', colors: [[255, 182, 217], [191, 235, 216], [246, 231, 200]] } },
   { id: 'toybox', name: 'The Toybox', tagline: 'the floor bounces. so do you', biome: 'toybox',
     colors: { road: 0x33307f, edge: 0xffd23f, prop: 0xffd23f, fog: 0x14103a, banner: 0x6c63d8 },
     propKind: 'block', loud: true, propAlt: [0xff4d6d, 0x3a86ff],
-    bubbleBias: { treat: 1.2, prism: 1.5, flash: 1.3, glitch: 0.6 },
+    bubbleBias: { treat: 1.2, prism: 1.5, glitch: 0.6 },
     ambient: { kind: 'confetti', colors: [[255, 77, 109], [255, 210, 63], [58, 134, 255]] } },
   { id: 'casino', name: "The Fool's Casino", tagline: 'the wheel always pays. eventually', biome: 'casino',
     colors: { road: 0x5c1128, edge: 0xf2c14e, prop: 0xf2c14e, fog: 0x0b0508, banner: 0xa3122e },
@@ -57,7 +59,7 @@ export const ROOMS = [
   { id: 'mirrors', name: 'The Hall of Mirrors', tagline: 'the picture flips. your hand does not', biome: 'mirrors',
     colors: { road: 0x44454f, edge: 0x5be7d8, prop: 0xdde3f0, fog: 0x1a1e2c, banner: 0x9aa3c8 },
     propKind: 'mirror', loud: false,
-    bubbleBias: { prism: 1.6, glitch: 1.5, spiral: 1.2, flash: 1.2 },
+    bubbleBias: { prism: 1.6, glitch: 1.5, spiral: 1.2 },
     ambient: { kind: 'glints', colors: [[221, 227, 240], [91, 231, 216]] } },
   { id: 'chapel', name: 'The Pink Chapel', tagline: 'the spiral pins itself here', biome: 'chapel',
     colors: { road: 0x6c1c4c, edge: 0xf2c14e, prop: 0xffffff, fog: 0x2a0820, banner: 0xe23c9c },

--- a/ConditioningControlPanel/Resources/web/dtrh/race/run.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/run.js
@@ -56,7 +56,7 @@ import { KIND_BY_ID } from './bubbleKinds.js';
 import { createCocktail, CATEGORIES } from './cocktail.js';
 import { createBubbleField } from './bubbles.js';
 import { createTrackState } from './track.js';
-import { cueFor, resultTag, LANE_X } from './cues.js';
+import { cueFor, resultTag, LANE_X, wordFlash, WORD_FLASH, WORD_FLASH_GAP_MS } from './cues.js';
 import { createKart } from './kart.js';
 import { createScore } from './score.js';
 import { createRaceHud } from './hud.js';
@@ -158,6 +158,15 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
   // without words, and the panel is only built for `?wsync=1` or the first nudge.
   const popLog = createPopLog();
   const rowOf = new Map(), rowWatch = [];
+  // THE WORD FLASH (race/cues.js WORD_FLASH). The flash bubble is dark: half the words the player
+  // TAKES pop a brief bloom of light instead, off the run's own seeded rng so a seed replays the
+  // same. `wordyRows` is the trigger rows whose bubbles are plain word faces (a mark or treats
+  // preset, or a phrase the room dressed as a treat) - those pops are word beats and roll for a
+  // flash; a row that already fires an effect kind has its own light and rolls for nothing. The
+  // delete is the one-shot: a row is many bubbles and one word, so it flashes once at most.
+  const wordyRows = new Set();
+  let lastFlashAt = -1e9;
+  const flashStats = { pops: 0, capped: 0, rolls: 0, flashes: 0 };
   const WSYNC = flag('wsync') === '1';
   const ROW_LATE_SEC = 0.6;
   let syncHud = null;
@@ -288,7 +297,10 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     };
     const field = createBubbleField({ scene, layout, media, getIntensity: () => S.intensity, getRoom, getElapsed: () => S.elapsed, onTexture: pixel.filterTexture });
     const pickups = createPickups({ rng, spots: layout.chunks.flatMap((c) => c.features || []).filter((f) => f.type === 'pickup'), totalDepth: layout.totalDepth });
-    const w = { layout, tunnel, fx, dresser, walls, wallDom, kart, score, field, pickups, rng };
+    // the word flash rolls off its OWN seeded stream, for the same reason the DOM posters do: a draw
+    // that depends on what the player popped must never shift the rolls the ROAD is built from.
+    const popRng = makeRng(runSeed ^ 0x1d872b41);
+    const w = { layout, tunnel, fx, dresser, walls, wallDom, kart, score, field, pickups, rng, popRng };
     field.onPop((p) => onPop(w, p));
     field.onMiss((m) => onMiss(w, m));
     kart.onEvent((e) => onKart(w, e));
@@ -312,6 +324,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
       trackHold: 0, trackHoldFrom: 0, trackFog: 0, trackPaused: false, statsAt: 0, trackGap: 0, quiet: false, quietAt: -9 });
     trailClear();
     mix.reset(); PACE.reset(); S.wobble = 0; clearMixChrome(); sync.reset(); wordOf.clear(); lineGot.clear(); lineDone.clear();
+    wordyRows.clear(); lastFlashAt = -1e9; flashStats.pops = 0; flashStats.capped = 0; flashStats.rolls = 0; flashStats.flashes = 0;
     hud.setScore(0); hud.setCombo(0, 1); hud.setBank(0); hud.setSpeed(0); hud.setFraught(0); hud.passiveClear(); TR.gild(0);
   }
 
@@ -365,8 +378,27 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     const early = sync.claim(eventId);
     if (early && early.event.kind === 'trigger' && early.cue.word) captions.showPlate(early.event);
   }
+  /** THE WORD FLASH. Half the words the player TAKES pop a brief bloom of light with them: the
+   *  flash bubble is dark (bubbleKinds.js, 2026-09-08) and this is where its light went. Cosmetic
+   *  and nothing else - it never touches THE MIX, so it is no strobe charge, no recipe and no
+   *  change to what the pop scores. Two words taken inside WORD_FLASH_GAP_MS share one, so a line
+   *  read clean reads as a sentence rather than a strobe, and reduced motion takes none at all. */
+  function wordFlashPop(w) {
+    flashStats.pops++;
+    if (reducedMotion) return;
+    const since = (S.elapsed - lastFlashAt) * 1000;   // the RUN's clock: a paused game is not a gap
+    if (since < WORD_FLASH_GAP_MS) { flashStats.capped++; return; }
+    flashStats.rolls++;
+    if (!wordFlash(w.popRng, since)) return;
+    lastFlashAt = S.elapsed;
+    flashStats.flashes++;
+    payloadFx.applyPayload({ payload: { kind: 'flash' }, strength: WORD_FLASH.strength }, { durationMult: WORD_FLASH.durationMult });
+  }
   function onPop(w, p) {
     const word = !!p.eventId && wordOf.has(p.eventId);   // a bubble off the transcript, not a chunk golden
+    // a plain word face: the transcript's own bubble, or one of a trigger row that wears the phrase
+    // without firing an effect. delete() is the row's one-shot: many bubbles, one word, one flash.
+    if ((word || (!!p.eventId && wordyRows.delete(p.eventId))) && p.kind === 'treat') wordFlashPop(w);
     if (p.eventId) {
       const at = passTime(w, p.d);
       TR.taken(p.eventId); platePop(p.eventId); spendWord(w, p.eventId, false, at);
@@ -536,7 +568,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     const t = TR.setTrack(chart);
     audio.setRoute(routeOf(t));
     S.trackHold = 0; S.statsAt = 0; S.quiet = false; S.quietAt = -9; sync.reset(); wordOf.clear();
-    lineN.clear(); lineGot.clear(); lineDone.clear(); rowOf.clear(); rowWatch.length = 0;
+    lineN.clear(); lineGot.clear(); lineDone.clear(); rowOf.clear(); rowWatch.length = 0; wordyRows.clear();
     if (WSYNC && t && TR.lyrics) showSync(0); else refreshSync();
     for (const e of (t && t.chart && Array.isArray(t.chart.events) ? t.chart.events : [])) {
       if (e.kind === 'word' && e.p != null) lineN.set(e.p, (lineN.get(e.p) || 0) + 1);
@@ -598,6 +630,13 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
       } else if (rowId && e.kind === 'trigger' && TR.lyrics) {   // the sync log's line for a row: w is the set's label
         if (rowOf.size >= WORD_MEM) rowOf.delete(rowOf.keys().next().value);
         rowOf.set(e.id, { w: e.label, p: null, t: e.t, i: eventIndex(e.id), lane: null });
+      }
+      // a row of plain word FACES (the mark and treats presets, and any phrase the room dressed as
+      // a treat) is a word beat: its pop rolls for the brief flash the same way a transcript word
+      // does. A row wearing an effect kind already fires one and is left out of the roll.
+      if (rowId && e.kind === 'trigger' && row[0].w && (KIND_BY_ID[row[0].kindId] || {}).kind === 'treat') {
+        if (wordyRows.size >= WORD_MEM) wordyRows.delete(wordyRows.values().next().value);
+        wordyRows.add(e.id);
       }
     }
     for (const sp of loose) {
@@ -951,6 +990,9 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     trackEnded: () => { TR.end(); if (TR.track && S.running) endRun(); }, trackStats: () => TR.stats(), syncTrace: () => sync.trace(), debugPickup,
     /** What race/smoke/face-check.mjs reads: the word faces on the road this frame. */
     wordFaces: () => (W ? W.field.faceReport() : null),
+    /** THE WORD FLASH, for race/smoke/word-flash-check.mjs: word pops, the ones the 250 ms cap ate,
+     *  the rolls that reached the rng and the flashes that came out of them. Never read by the game. */
+    wordFlashStats: () => ({ ...flashStats }),
     /** race/smoke/captions-check.mjs: one word at the band, the same call a pop makes. */
     debugWord: (text, o) => (captions ? captions.showWord(text, o || {}) != null : false),
     /** Which half of race/captions.js is driving the band on this build: 'flash' or 'type'. */

--- a/ConditioningControlPanel/Resources/web/dtrh/race/smoke/lyrics-road-check.mjs
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/smoke/lyrics-road-check.mjs
@@ -63,7 +63,12 @@ eq(new Set(rows.map(([, r]) => r.theme)).size, rows.length, 'no two rows share a
 const dark = BUBBLE_KINDS.filter((k) => k.spawn === false).map((k) => k.id);
 ok(dark.length > 0 && rows.some(([, r]) => dark.includes(r.kind)), 'the table does point a row at a darkened kind (' + dark.join(', ') + ')');
 ok(rows.every(([p]) => !dark.includes(kindForPreset(p))), 'and kindForPreset never hands one out');
-eq(kindForPreset('video'), FALLBACK_KIND, 'the darkened row falls back to the flash bubble');
+eq(kindForPreset('video'), FALLBACK_KIND, 'the darkened row falls back to the fallback kind');
+// the fallback is not allowed to be a dark kind itself, or the row it saves still never lands
+ok(!!KIND_BY_ID[FALLBACK_KIND] && KIND_BY_ID[FALLBACK_KIND].spawn !== false, 'and the fallback kind (' + FALLBACK_KIND + ') is one that spawns');
+// the flash bubble is dark since 2026-09-08: no row of this table may point the road at one
+ok(dark.includes('flash'), 'the flash bubble is one of the darkened rows');
+ok(rows.every(([, r]) => r.kind !== 'flash'), 'and not one preset dresses its row as a flash any more');
 eq(kindForPreset('not-a-preset'), null, 'a preset nobody wrote a row for is null, not a guess');
 eq(themeFor({ kind: 'trigger', label: 'bambi sleep', setId: 'bambi-sleep', cue: 'blackout' }).theme, 'ink', 'themeFor reads the cue');
 eq(themeFor({ kind: 'trigger', label: 'good girl', setId: 'good-girl' }).theme, 'blink', 'and falls back to the set when the cue is gone');

--- a/ConditioningControlPanel/Resources/web/dtrh/race/smoke/rows-check.mjs
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/smoke/rows-check.mjs
@@ -14,6 +14,9 @@
  *      you steer around.
  *   2. the row wears the preset's own bubble, and a treats or mark preset is a
  *      row of treats rather than an effect
+ *   2b. the flash bubble is dark and the WORD carries the flash instead: half the
+ *      word pops, off the run's seeded rng, one flash per 250 ms, and the one
+ *      preset that meant the flash pours a real one through THE MIX
  *   3. a trigger the spotter only half heard is the single treat it always was
  *   4. one event is one credit however many of its bubbles were popped
  *   5. a worded track halves the peak rain; nothing else on the road moves
@@ -32,7 +35,7 @@
  * It never prints a line of a transcript. Everything below is counted.
  * ==========================================================================*/
 
-import { cueFor, ROW_X, ROW_MAX_GAP } from '../cues.js';
+import { cueFor, ROW_X, ROW_MAX_GAP, wordFlash, WORD_FLASH, WORD_FLASH_CHANCE, WORD_FLASH_GAP_MS } from '../cues.js';
 import { createScheduler, normalizeChart } from '../chart.js';
 import { KART_X_MAX, LANE_X_MAX, POP_HIT_X, POP_HIT_D, LANE_H, COMBO_HOLD_SEC, KART_BASE_SPEED, OPEN_PACE, makeRng } from '../consts.js';
 import { createScore } from '../score.js';
@@ -115,6 +118,32 @@ for (const preset of ['treats', 'mark']) {
   const c = cueFor({ kind: 'trigger', t: 4, label: 'a phrase', conf: 0.9, cue: preset }, ctxFor({ 'a phrase': kindForPreset(preset) }));
   eq(c.spawn.filter((s) => s.row && s.kindId === 'treat').length, ROW_X.length, 'a ' + preset + ' trigger is a row of treats, not an effect');
 }
+
+/* ---- 2b. THE FLASH: the bubble is dark, the word carries it -------------- */
+// The flash bubble went dark on 2026-09-08 (bubbleKinds.js). Two things have to hold after it:
+// nothing may dress a row as one, and the preset that MEANT the flash still fires a real one.
+eq(KIND_BY_ID.flash.spawn, false, 'the flash bubble is darkened');
+ok(Object.keys(THEME_BY_PRESET).every((p) => kindForPreset(p) !== 'flash'), 'and no preset puts one on the road');
+const pulse = cueFor({ kind: 'trigger', t: 4, label: 'zap cock drain', conf: 0.9, cue: 'flash-pulse' },
+  ctxFor({ 'zap cock drain': kindForPreset('flash-pulse') }));
+eq(pulse.spawn.filter((s) => s.row && s.kindId === 'treat').length, ROW_X.length, 'the flash-pulse row is a full line of plain word faces');
+eq(pulse.mix, 'flash', 'and its beat pours a real flash through THE MIX, so the strobe recipes keep a door');
+eq(cueFor({ kind: 'trigger', t: 4, label: 'good girl', conf: 0.9, cue: 'pink-blink' }, ctxFor({ 'good girl': 'pink' })).mix, null,
+  'no other trigger row pours one');
+// the odds themselves: half the words the player takes, off the run's own seeded rng, and two
+// words taken inside the gap share one flash rather than double-flashing.
+const frng = makeRng(0x51ede5);
+const N = 20000;
+let fired = 0;
+for (let i = 0; i < N; i++) if (wordFlash(frng, WORD_FLASH_GAP_MS)) fired++;
+ok(Math.abs(fired / N - WORD_FLASH_CHANCE) < 0.02, 'a word pop flashes ' + Math.round((fired / N) * 100) + '% of the time (want ' + Math.round(WORD_FLASH_CHANCE * 100) + '%)');
+let capped = 0;
+for (let i = 0; i < 500; i++) if (wordFlash(frng, WORD_FLASH_GAP_MS - 1)) capped++;
+eq(capped, 0, 'and a word taken inside ' + WORD_FLASH_GAP_MS + ' ms of the last flash takes none');
+const seedA = makeRng(7), seedB = makeRng(7);
+ok(Array.from({ length: 200 }, () => wordFlash(seedA, 999)).join() === Array.from({ length: 200 }, () => wordFlash(seedB, 999)).join(),
+  'one seed, one sequence: a replay of a run flashes on the same words');
+ok(WORD_FLASH.durationMult < 0.3 && WORD_FLASH.strength < 30, 'and what it hands payloadFx is a blink, not the old flash bubble');
 
 /* ---- 3. the unsure trigger is what it always was ------------------------- */
 const unsure = cueFor({ kind: 'trigger', t: 10, label: 'a phrase', conf: 0.3, cue: 'blackout' },

--- a/ConditioningControlPanel/Resources/web/dtrh/race/smoke/track-run-check.mjs
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/smoke/track-run-check.mjs
@@ -131,7 +131,13 @@ function chartEnergy(t) {
   // a sure trigger is a ROW across the road now (rows-check.mjs holds its geometry), all one kind
   ok(t.spawn.length > 1 && t.spawn.every((sp) => sp.row) && KIND_BY_ID[t.spawn[0].kindId].kind === 'effect' && t.word === 'good girl',
     'a trigger is a row of ' + t.spawn.length + ' effect bubbles and the word: ' + t.spawn[0].kindId);
-  ok(cueFor({ kind: 'trigger', label: 'never analysed' }, ctx).spawn.every((sp) => sp.kindId === 'flash'), 'an unmapped phrase falls back to flash');
+  // an unmapped phrase falls back to the room's own effect, else cues.js FALLBACK_TRIGGER. Whatever
+  // it lands on must be a kind that still SPAWNS: bubbles.js lays no row at all for a darkened one,
+  // and a trigger row that never lands is the one thing this road may not do.
+  const un = cueFor({ kind: 'trigger', label: 'never analysed' }, ctx).spawn;
+  const unKind = KIND_BY_ID[un[0].kindId];
+  ok(un.every((sp) => sp.kindId === un[0].kindId) && !!unKind && unKind.spawn !== false,
+    'an unmapped phrase falls back to a bubble that still spawns (' + un[0].kindId + ')');
   const w = cueFor({ kind: 'word', label: 'deeper' }, ctx);
   ok(w.spawn.length === 1 && w.spawn[0].kindId === 'treat' && w.spawn[0].h === LANE_H, 'a structure word is one lane treat');
   const c = cueFor({ kind: 'count', label: '1', n: 1, of: 10, last: true }, ctx);

--- a/ConditioningControlPanel/Resources/web/dtrh/race/smoke/word-flash-check.mjs
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/smoke/word-flash-check.mjs
@@ -1,0 +1,242 @@
+/* ============================================================================
+ * race/smoke/word-flash-check.mjs - THE WORD FLASH, and the dark flash bubble.
+ *
+ *   node race/smoke/word-flash-check.mjs          (from Resources/web/dtrh; 0 on pass)
+ *   RACE_SHOTS=1 node race/smoke/word-flash-check.mjs   (also writes shots/ png)
+ *
+ * Two halves, the same shape as captions-check.mjs. The first is pure: the flash
+ * row is darkened, nothing that names a kind for the ROAD names it any more, and
+ * a hundred thousand rolls of `rollKind` in every room never hand one out.
+ *
+ * The second drives a headless browser through a real worded run, because the two
+ * things this change can get wrong that no unit test sees are "a flash bubble is
+ * still on the road somewhere" and "the word pops never actually fire anything".
+ * It boots the fixture road, hands the run the pump so the kart takes words rather
+ * than steering for them, and reads two counters back: `wordFlashStats()` (word
+ * pops, the ones the 250 ms cap ate, the rolls that reached the rng and the
+ * flashes that came out) and `wordFaces().placed`, which is every kind the field
+ * has PUT on the road this run, counted at the one door every spawn goes through.
+ *
+ * It never prints a line of a transcript. Everything below is counted.
+ *
+ * CHROME: `CHROME_PATH` if it is set, else the usual Windows install.
+ * ==========================================================================*/
+
+import { spawn } from 'node:child_process';
+import { createServer } from 'node:http';
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { readFileSync, mkdtempSync, rmSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, extname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { BUBBLE_KINDS, KIND_BY_ID, rollKind } from '../bubbleKinds.js';
+import { THEME_BY_PRESET, kindForPreset, FALLBACK_KIND } from '../triggerTheme.js';
+import { WORD_FLASH_CHANCE, WORD_FLASH_GAP_MS } from '../cues.js';
+import { wordedRoad, PEAKS_PER_SEC } from '../cloudChart.js';
+import { makeRng } from '../consts.js';
+
+let fails = 0;
+const ok = (cond, what) => { if (!cond) { console.error('FAIL ' + what); fails++; } else console.log('  ok  ' + what); };
+const eq = (got, want, what) => ok(got === want, what + ' (got ' + JSON.stringify(got) + ', want ' + JSON.stringify(want) + ')');
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const HERE = resolve(fileURLToPath(import.meta.url), '..');
+const RACE = resolve(HERE, '..');
+const WEB = resolve(RACE, '../..');                        // Resources/web
+const SHOTS = process.env.RACE_SHOTS === '1' ? resolve(WEB, '../../../shots') : null;
+const read = (rel) => JSON.parse(readFileSync(resolve(RACE, rel), 'utf8'));
+const ROW = read('words/index.json').rows[0];              // the opening level
+const WORDS = { ...read('words/' + ROW.file), engine: ROW.engine };
+
+/* ============================================================================
+ * 1. the bubble is dark, and nothing points the road at it
+ * ==========================================================================*/
+eq(KIND_BY_ID.flash.spawn, false, 'the flash row is darkened');
+ok(KIND_BY_ID.flash.category === 'strobe', 'and it keeps its THE MIX slot, so a burst or a recipe still knows the kind');
+ok(Object.keys(THEME_BY_PRESET).every((p) => kindForPreset(p) !== 'flash'), 'no trigger preset dresses its row as a flash');
+ok(KIND_BY_ID[FALLBACK_KIND] && KIND_BY_ID[FALLBACK_KIND].spawn !== false, 'the darkened-kind fallback (' + FALLBACK_KIND + ') is a bubble that spawns');
+ok(!/^\s*bubbleBias:.*\bflash\s*:/m.test(readFileSync(resolve(RACE, 'rooms.js'), 'utf8')),
+  'and not one room still biases toward it (rooms.js reads as text: it wants three.js)');
+
+// every intensity, and a room biased HARD toward the dark kinds on top: the filter wins anyway,
+// because a darkened row is dropped before the weights are ever added up.
+const HOSTILE = { flash: 40, video: 40, treat: 0.2 };
+const rng = makeRng(0x9e3779b9);
+let rolls = 0, sawFlash = 0, sawDark = 0;
+for (const bias of [null, HOSTILE, { pink: 1.4, spiral: 1.5 }]) {
+  for (let i = 0; i < 40000; i++) {
+    const k = rollKind((i % 101) / 100, bias, null, rng);
+    rolls++;
+    if (k.id === 'flash') sawFlash++;
+    if (k.spawn === false) sawDark++;
+  }
+}
+eq(sawFlash, 0, rolls + ' rolls, every intensity, one of them a room begging for flashes: not one came out');
+eq(sawDark, 0, 'and not one darkened kind of any sort');
+ok(BUBBLE_KINDS.filter((k) => k.spawn !== false).length >= 10, 'the pool the road still draws from is not thin');
+
+/* ============================================================================
+ * the browser: the web folder plus the fixture chart
+ * ==========================================================================*/
+/** A curve shaped like a spoken track, the same swell lyrics-road-check.mjs uses. */
+function swell(durationSec, perSec = PEAKS_PER_SEC) {
+  const n = Math.ceil(durationSec * perSec);
+  const peaks = new Float32Array(n * 2);
+  for (let i = 0; i < n; i++) {
+    const a = 0.22 + 0.5 * Math.max(0, Math.sin(((i / perSec) / 40) * Math.PI * 2)) ** 2;
+    peaks[i * 2] = -a; peaks[i * 2 + 1] = a;
+  }
+  return peaks;
+}
+const road = wordedRoad({ peaks: swell(WORDS.durationSec), durationSec: WORDS.durationSec, name: ROW.title, hash: ROW.hash, words: WORDS });
+const FIXTURE = JSON.stringify(road);
+
+const CHROME = process.env.CHROME_PATH || 'C:/Program Files/Google/Chrome/Application/chrome.exe';
+const PORT = 8871, DEBUG_PORT = 9341;
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.mjs': 'text/javascript', '.css': 'text/css', '.json': 'application/json', '.glb': 'model/gltf-binary', '.png': 'image/png', '.webp': 'image/webp', '.jpg': 'image/jpeg', '.mp3': 'audio/mpeg', '.wav': 'audio/wav', '.svg': 'image/svg+xml', '.woff2': 'font/woff2' };
+
+if (!existsSync(CHROME)) { console.error('FAIL no chrome at ' + CHROME + ' (set CHROME_PATH)'); process.exit(1); }
+const server = createServer(async (req, res) => {
+  const path = decodeURIComponent(new URL(req.url, 'http://x').pathname);
+  if (path === '/fixture.json') { res.writeHead(200, { 'content-type': 'application/json' }); return res.end(FIXTURE); }
+  if (path.indexOf('..') >= 0) { res.writeHead(400); return res.end(); }
+  try {
+    const body = await readFile(join(WEB, path));
+    res.writeHead(200, { 'content-type': MIME[extname(path).toLowerCase()] || 'application/octet-stream' });
+    res.end(req.method === 'HEAD' ? undefined : body);
+  } catch (e) { res.writeHead(404, { 'content-type': 'text/plain' }); res.end('no'); }
+});
+await new Promise((r) => server.listen(PORT, '127.0.0.1', r));
+
+const prof = mkdtempSync(join(tmpdir(), 'race-wflash-'));
+const chrome = spawn(CHROME, [
+  '--headless=new', `--remote-debugging-port=${DEBUG_PORT}`, `--user-data-dir=${prof}`,
+  '--no-first-run', '--no-default-browser-check', '--disable-gpu', '--mute-audio',
+  '--enable-unsafe-swiftshader', '--autoplay-policy=no-user-gesture-required',
+  '--window-size=1280,720', 'about:blank',
+], { stdio: 'ignore' });
+
+let page = null;
+for (let i = 0; i < 60 && !page; i++) {
+  await sleep(250);
+  try { page = (await (await fetch(`http://127.0.0.1:${DEBUG_PORT}/json/list`)).json()).find((t) => t.type === 'page'); } catch (e) { /* not up */ }
+}
+if (!page) { console.error('FAIL chrome never answered on the debug port'); await done(1); }
+
+const ws = new WebSocket(page.webSocketDebuggerUrl);
+await new Promise((r) => { ws.onopen = r; });
+let msgId = 0;
+const waits = new Map(), errs = [];
+ws.onmessage = (e) => {
+  const m = JSON.parse(e.data);
+  if (m.id && waits.has(m.id)) { waits.get(m.id)(m); waits.delete(m.id); }
+  if (m.method === 'Runtime.exceptionThrown') errs.push('thrown: ' + (m.params.exceptionDetails?.exception?.description || m.params.exceptionDetails?.text || '?'));
+  if (m.method === 'Runtime.consoleAPICalled' && m.params.type === 'error') errs.push(m.params.args.map((a) => a.value ?? a.description ?? '?').join(' '));
+};
+const cdp = (method, params) => new Promise((res) => { const i = ++msgId; waits.set(i, res); ws.send(JSON.stringify({ id: i, method, params })); });
+const ev = async (x) => (await cdp('Runtime.evaluate', { expression: x, returnByValue: true, awaitPromise: true })).result?.result?.value;
+const json = async (x) => JSON.parse(await ev(`JSON.stringify(${x})`));
+await cdp('Runtime.enable'); await cdp('Page.enable');
+await cdp('Emulation.setDeviceMetricsOverride', { width: 1280, height: 720, deviceScaleFactor: 1, mobile: false });
+
+const site = `http://127.0.0.1:${PORT}`;
+await cdp('Page.navigate', { url: `${site}/dtrh/race.html?autostart=1&intro=0&cards=0&chart=${encodeURIComponent(`${site}/fixture.json`)}` });
+let up = false;
+for (let i = 0; i < 120 && !up; i++) {
+  await sleep(250);
+  up = await ev(`!!(window.__race && window.__race.race && window.__race.race.track && window.__race.race.perf().running)`);
+}
+ok(up, 'the page boots the worded fixture road and the run is going');
+if (!up) { if (errs.length) console.error('    said: ' + errs.slice(0, 6).join(' | ')); await done(1); }
+
+/* ============================================================================
+ * 2. the run: the kart takes words, and half of them flash
+ *
+ * The pump is the honest way to make a headless run TAKE the words: nobody is
+ * steering, and a word bubble sits in the lane its phrase was given. Every grant
+ * is 5 s of the whole road wide, which is exactly the case the 250 ms cap was
+ * written for (a row pops five bubbles in one frame and lights one flash).
+ * ==========================================================================*/
+/* The blink is ~185 ms of one scattered image. A screenshot over the wire is slower
+ * than that (the page's own frames own the main thread), so nothing outside the page
+ * can ever be pointed at one in time. Instead a watcher HOLDS the first blink: it
+ * clones the image the moment the game adds it, parks the clone's own animation
+ * ~90 ms in (the frame where a flash is at full strength) and leaves it there. The
+ * game removes its original on schedule and never sees the clone. What the picture
+ * shows is the real sprite, at its real size and angle, over the live road. */
+if (SHOTS) await ev(`(() => { window.__wf = { seen: 0, pin: true, held: false };
+  new MutationObserver((ms) => { for (const m of ms) for (const n of m.addedNodes) {
+    if (!(n.nodeType === 1 && n.classList && n.classList.contains('sf-pfx-flash'))) continue;
+    window.__wf.seen++;
+    if (!window.__wf.pin || window.__wf.held || !n.parentNode) continue;
+    const c = n.cloneNode(true);
+    c.dataset.wfPin = '1';
+    c.style.animationPlayState = 'paused';
+    c.style.animationDelay = '-90ms';
+    n.parentNode.appendChild(c);
+    window.__wf.held = true;
+  } }).observe(document.body, { subtree: true, childList: true });
+  return true; })()`);
+
+const WANT_ROLLS = 40;      // the floor the assertion wants
+const ENOUGH = 80;          // and how many it keeps gathering for, so the ratio means something
+let stats = { pops: 0, capped: 0, rolls: 0, flashes: 0 }, shots = 0;
+/** Wait, and while waiting photograph a pinned blink if the watcher above caught one. */
+async function napAndWatch(ms) {
+  const until = Date.now() + ms;
+  while (Date.now() < until) {
+    if (SHOTS && shots < 1) {
+      const live = await ev(`!!document.querySelector('.sf-pfx-flash[data-wf-pin]')`);
+      if (live) {
+        const png = (await cdp('Page.captureScreenshot', { format: 'png' })).result?.data;
+        await ev(`(() => { for (const e of document.querySelectorAll('[data-wf-pin]')) e.remove(); window.__wf.pin = false; return true; })()`);
+        if (png) {
+          await mkdir(SHOTS, { recursive: true });
+          const at = join(SHOTS, `word-flash-${++shots}.png`);
+          await writeFile(at, Buffer.from(png, 'base64'));
+          console.log('  --  shot: ' + at);
+        }
+      }
+    }
+    await sleep(60);
+  }
+}
+for (let i = 0; i < 240 && stats.rolls < ENOUGH; i++) {
+  await ev(`window.__race.race.debugPickup('the_pump')`);
+  await napAndWatch(500);
+  stats = await json(`window.__race.race.wordFlashStats()`);
+}
+if (SHOTS) console.log('  --  the glass took ' + await ev(`window.__wf.seen`) + ' flash images this run, ' + shots + ' of them shot');
+console.log(`  --  ${stats.pops} word pops: ${stats.capped} inside the ${WORD_FLASH_GAP_MS} ms cap, ${stats.rolls} rolled, ${stats.flashes} flashed`);
+ok(stats.pops >= WANT_ROLLS, `the run took ${stats.pops} word bubbles without anyone steering`);
+ok(stats.rolls >= WANT_ROLLS, `and ${stats.rolls} of them reached the roll (the rest shared a flash inside the cap)`);
+const ratio = stats.rolls ? stats.flashes / stats.rolls : 0;
+ok(Math.abs(ratio - WORD_FLASH_CHANCE) < 0.2, `about half of them flashed: ${Math.round(ratio * 100)}% over ${stats.rolls} rolls (want ${Math.round(WORD_FLASH_CHANCE * 100)}%)`);
+ok(stats.flashes > 0 && stats.flashes < stats.rolls, 'and it is a coin, not a rule: some flashed, some did not');
+ok(stats.capped > 0 ? true : true, `the cap ate ${stats.capped} pops that landed on a flash's heels`);
+
+/* ============================================================================
+ * 3. and not one flash bubble was ever put on the road
+ * ==========================================================================*/
+const placed = await json(`window.__race.race.wordFaces().placed`);
+const total = Object.values(placed).reduce((n, v) => n + v, 0);
+console.log('  --  the field placed: ' + Object.entries(placed).map(([k, n]) => k + ' ' + n).join(', '));
+ok(total > 100, `the field placed ${total} bubbles this run`);
+eq(placed.flash || 0, 0, 'and not one of them was a flash bubble');
+const dark = BUBBLE_KINDS.filter((k) => k.spawn === false).map((k) => k.id);
+ok(dark.every((id) => !placed[id]), 'nor any other darkened kind (' + dark.join(', ') + ')');
+ok(!!placed.treat, 'the plain treat is still the road');
+ok(errs.length === 0, 'not one console error in the whole run' + (errs.length ? ':\n    ' + errs.slice(0, 5).join('\n    ') : ''));
+
+await done(fails ? 1 : 0);
+
+async function done(code) {
+  try { ws && ws.close(); } catch (e) { /* never opened */ }
+  try { chrome.kill(); } catch (e) { /* already gone */ }
+  await new Promise((r) => server.close(r));
+  await sleep(300);
+  try { rmSync(prof, { recursive: true, force: true }); } catch (e) { /* chrome still has a lock */ }
+  if (code) console.error(`\n${fails} failure${fails === 1 ? '' : 's'}`);
+  else console.log('\nword-flash-check: all good');
+  process.exit(code);
+}

--- a/ConditioningControlPanel/Resources/web/dtrh/race/track.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/track.js
@@ -34,9 +34,12 @@ const SMOOTH_SEC = 2;
 const END_PAD = 0.25;
 /** The most of the file one frame may carry on its own: see the header. */
 const MAX_STEP_SEC = 1;
-/** The effect bubbles a trigger phrase may wear, dealt round robin over the chart's lexicon. */
+/** The effect bubbles a trigger phrase may wear, dealt round robin over the chart's lexicon.
+ *  A DARKENED row (bubbleKinds.js `spawn: false`) is dropped from the deal, not just a missing one:
+ *  bubbles.js lays no row at all for a dark kind, so dealing one would take that phrase's whole
+ *  unavoidable line off the road. 'flash' left by this door on 2026-09-08. */
 const TRIGGER_KINDS = ['flash', 'subliminal', 'pink', 'spiral', 'glitch', 'freeze']
-  .filter((id) => BUBBLE_KINDS.some((k) => k.id === id));
+  .filter((id) => BUBBLE_KINDS.some((k) => k.id === id && k.spawn !== false));
 
 const clamp01 = (v) => (v < 0 ? 0 : v > 1 ? 1 : v);
 

--- a/ConditioningControlPanel/Resources/web/dtrh/race/triggerTheme.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/triggerTheme.js
@@ -16,8 +16,10 @@
  *
  * DARK KINDS. `bubbleKinds.js` may darken a row (`spawn: false`) and a chart is
  * never allowed to place one, so a preset that points at a dark kind falls back
- * to `flash`. That check is made here, against the live table, so darkening one
- * more row never needs an edit in this file.
+ * to FALLBACK_KIND. That check is made here, against the live table, so darkening
+ * one more row never needs an edit in this file. It matters more than it reads:
+ * `bubbles.js spawnRow` lays NO row at all for a dark kind, so a preset left
+ * pointing at one would take the whole unavoidable line off the road.
  *
  * Node-clean: no DOM, no window.
  * ==========================================================================*/
@@ -25,8 +27,12 @@
 import { KIND_BY_ID } from './bubbleKinds.js';
 import { TRIGGER_SETS } from '../chart/editor/triggerSets.js';
 
-/** What a preset that points at a darkened kind wears instead. */
-export const FALLBACK_KIND = 'flash';
+/** What a preset that points at a darkened kind wears instead. `pink` since 2026-09-08 (the flash
+ *  bubble went dark with it): a preset that needed a fallback is a LOUD one (the tape, the pulse),
+ *  so a treat would quietly drop the effect the phrase was written for. Pink is the effect kind
+ *  that spawns at any intensity, and it sits in the tint slot of THE MIX, where it never fights
+ *  the strobe a `flash-pulse` row pours on the same beat. */
+export const FALLBACK_KIND = 'pink';
 /** And what an event with no preset at all, or one nobody wrote a row for, wears. */
 export const FALLBACK_THEME = 'mark';
 
@@ -42,7 +48,10 @@ export const THEME_BY_PRESET = {
   'freeze-snap':  { kind: 'freeze',     theme: 'frost',  color: '#8ae6ff', ink: '#0f0f1c', note: 'ice blue, frost crackle, hard stop at scale 1' },
   'snap-shake':   { kind: 'glitch',     theme: 'snap',   color: '#f4f2ff', ink: '#0f0f1c', note: 'white, one violent shake' },
   'glitch-shake': { kind: 'glitch',     theme: 'split',  color: '#ffd166', ink: '#0f0f1c', note: 'yellow, chromatic split' },
-  'flash-pulse':  { kind: 'flash',      theme: 'pulse',  color: '#ffffff', ink: '#0f0f1c', note: 'white flash behind, three pulses' },
+  // the flash bubble is dark (2026-09-08) and this preset is the one that MEANT it: the row is a
+  // line of plain word faces now, and cues.js pours the real flash through THE MIX on the beat, so
+  // the phrase still lights the room up and the strobe slot still has a way to be lit.
+  'flash-pulse':  { kind: 'treat',      theme: 'pulse',  color: '#ffffff', ink: '#0f0f1c', note: 'white flash behind, three pulses' },
   'golden-rain':  { kind: 'golden',     theme: 'gold',   color: '#ffd700', ink: '#0f0f1c', note: 'gold, sparkle shards fall off the letters' },
   'spiral-air':   { kind: 'spiral',     theme: 'spiral', color: '#c8a8ff', ink: '#0f0f1c', note: 'lilac, slow rotate while it zooms' },
   'melt':         { kind: 'braindrain', theme: 'melt',   color: '#4060c0', ink: '#f4f2ff', note: 'deep blue, letters sag and blur downward' },


### PR DESCRIPTION
The flash was a bubble you might roll into. Now it is a beat on a **word**: half the word bubbles you take pop a brief flash with them, so the light comes off the thing the voice just said rather than off a sprite that happened to roll. The flash bubble itself goes dark, the way the video one did.

## the word flash

- a pop of a bubble that WEARS a word (a transcript word bubble, or one of a trigger row whose kind is a plain treat) fires `payloadFx` `flash` at strength 12 for ~185 ms: one scattered image and the bloom, shorter and lighter than the old bubble's
- 50%, rolled off the run's own seeded stream (`w.popRng`, its own stream so a player-driven draw never shifts the road's rolls) - a seed replays the same run
- one flash per 250 ms: two words taken together share one, so a line read clean reads as a sentence and not a strobe. The cap runs off the RUN's clock, so a paused game is not a gap
- none at all under reduced motion
- **cosmetic and nothing else**: it never reaches THE MIX, so it is no strobe charge and no recipe, and the pop scores as the treat it always was
- trigger ROWS count only when the row is a line of plain word faces; a row that already fires an effect keeps its own beat, and a row that qualifies pops **one** flash for the whole line (a one-shot `delete()` on the row id), not one per bubble

The odds, the cap and the constants are pure and live in `race/cues.js` (`wordFlash`, `WORD_FLASH*`) so node can hold them; run.js only keeps the clock.

## the flash bubble, and everything that pointed at it

`spawn: false` on the flash row, with a dated header note - the row, its sprite and its THE MIX `strobe` slot stay put. `field.spawnRow` refuses a dark kind and refuses the WHOLE row rather than laying it with a hole, so anything that names a kind for a road had to be re-pointed or it would have silently deleted an unavoidable trigger line:

| named the flash | now | why |
|---|---|---|
| `triggerTheme.js` `FALLBACK_KIND` | `pink` | the presets that fall back are loud, so a treat would read as nothing; pink spawns at any intensity and sits in the **tint** slot, so it never fights the strobe |
| `cues.js` `FALLBACK_TRIGGER` | `pink` | same road, same reason |
| `cues.js` `ROOM_TRIGGER.teagarden` | `subliminal` | the tea garden is the quiet room; the whisper is its own note |
| `flash-pulse` preset (zap-cock-drain, awaken) | kind `treat`, `cue.mix = 'flash'` | it keeps its white pulse plate, its row is a line of word faces, and its beat pours the real flash through THE MIX - which is now the **only** door a strobe charge comes through, so the five recipes that need one are still served |
| `track.js` `TRIGGER_KINDS` | filtered | the round robin now drops any darkened kind by itself |
| `rooms.js` bubbleBias (teagarden, toybox, mirrors) | removed | a bias on a dark kind is dead weight |

A seeded run with no chart now never lights the strobe slot; the slot, bursts and recipes stay in the machine exactly like the retired `video` one. That is written down in `CONTRACT.md` along with the word flash itself.

## verified

`race/smoke/word-flash-check.mjs` is new. The pure half: the row is dark, no preset dresses a road as one, 120,000 `rollKind` rolls at every intensity - one pass with a room biased 40x toward flashes - and not one came out; the fallbacks all name kinds that spawn. `rows-check.mjs` holds the 50% over 20,000 seeded rolls, the 250 ms cap, the replay of a seed and the "this is a blink, not an effect" bounds.

The browser half drives a real worded run (the pump, so nobody has to steer) and reads two counters back:

```
  --  74 word pops: 8 inside the 250 ms cap, 66 rolled, 37 flashed
  ok  about half of them flashed: 56% over 66 rolls (want 50%)
  --  the field placed: golden 114, treat 123, braindrain 20, pink 5
  ok  the field placed 262 bubbles this run
  ok  and not one of them was a flash bubble (got 0, want 0)
  ok  not one console error in the whole run
```

Green: `rows-check`, `lyrics-road-check`, `words-check`, `chart-check`, `track-run-check`, `cloud-chart-check`, `word-flash-check`. `face-check` fails one line ("0 trigger rows passed under the sampler") **on main as well** - checked at the base commit, it is not from this branch.

Shot of the blink mid-frame is in the worktree under `shots/` (untracked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KTe1RA7EP5hGxkzFY1282C
