### PR TITLE
feat(race): gif rain on the road blocks

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/chart/editor/triggerSets.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/chart/editor/triggerSets.js
@@ -25,7 +25,10 @@ export const TRIGGER_SETS = [
   { id: 'zap-cock-drain', name: 'zap cock drain', group: 'named', phrase: 'zap cock drain', mode: 'exact', color: '#ff5c6c', preset: 'flash-pulse' },
   { id: 'primped', name: 'primped and pampered', group: 'named', phrase: 'primped and pampered', mode: 'exact', color: '#ffb3d9', preset: 'treats' },
   { id: 'does-as-told', name: 'bambi does as she is told', group: 'named', phrase: "does as she(?:'s| is) told", mode: 'regex', color: '#c8a8ff', preset: 'spiral-air' },
-  { id: 'cockslut', name: 'bambi cockslut', group: 'named', phrase: 'cock ?slut', mode: 'regex', color: '#ee7078', preset: 'video' },
+  // cockslut asked for the video preset, whose bubble went dark on 2026-09-06: the row has been
+  // falling back to a plain effect ever since while its plate still said video. It gets gif rain
+  // instead (2026-09-08), which is the loud one the phrase wanted and a kind that still spawns.
+  { id: 'cockslut', name: 'bambi cockslut', group: 'named', phrase: 'cock ?slut', mode: 'regex', color: '#ee7078', preset: 'gif-rain' },
   { id: 'takeover', name: 'bambi takeover', group: 'named', phrase: 'take(?:s|n)? ?over', mode: 'regex', color: '#4060c0', preset: 'melt' },
   { id: 'awaken', name: 'bambi awaken', group: 'named', phrase: 'awaken|wake up|wide awake', mode: 'regex', color: '#ffd6a0', preset: 'flash-pulse' },
   { id: 'giggle-time', name: 'giggle time', group: 'named', phrase: 'giggle ?time', mode: 'regex', color: '#ffe066', preset: 'treats' },

--- a/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
@@ -209,6 +209,19 @@ reads the two counters back: `race.wordFlashStats()` (pops, capped, rolls, flash
 way: its row is a line of plain word faces and its beat sets `cue.mix = 'flash'`, which is now the
 only door a strobe charge comes through, so the recipes that need one still have a way to be served.
 
+**GIF RAIN ON A ROAD BLOCK (2026-09-08).** A trigger row is unavoidable, and most rows are the many
+`mark` word sets: a line of plain word faces with no effect of their own. One such row in six
+(`cues.js` `GIFRAIN_ROW_CHANCE`, rolled off the ROAD's seeded rng so a seed lays the same rain
+twice), from the gifrain bubble's own `minIntensity` upward and no other floor, puts a gifrain
+bubble in the MIDDLE of the line. Only the centre, so a row can pour exactly one cascade and never
+five; never over a golden centre the rabbit foot is owed; and never on a row that already pours
+something, which is why a `flash-pulse` line stays plain. The `gif-rain` preset itself
+(`triggerTheme.js`, plate theme `rain`, gold) is what a set asks for by name: `cockslut` asks for it
+since 2026-09-08, having pointed at the dark `video` bubble since that one went dark.
+`race/smoke/rows-check.mjs` holds the odds, the floor and the one-bubble rule;
+`race/smoke/gifrain-row-check.mjs` drives a real run and holds the cascades against the rain
+bubbles that were laid, reading `race.fxStats()` - every payload the mixer has poured.
+
 Placements: `lane` (rests on the road, h ~0.9, bobbing), `air` (along a ramp air line, h rises
 2..5), `spawn` (materialises ahead, wobbles laterally), `rain` (falls from `h = 9` to the road in
 about 4 s, rests 2 s, then fizzles). Collision is pass-through: pop when

--- a/ConditioningControlPanel/Resources/web/dtrh/race/cues.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/cues.js
@@ -33,6 +33,7 @@
 
 import { LANE_H, CEILING_H, LANE_X_MAX, POP_HIT_X } from './consts.js';
 import { themeFor } from './triggerTheme.js';
+import { KIND_BY_ID } from './bubbleKinds.js';
 
 /**
  * The words whose bubble is drawn BIG (race/wordFace.js): the ones the file is actually about.
@@ -136,6 +137,29 @@ export function wordFlash(rng, sinceMs) {
   return (typeof rng === 'function' ? rng() : Math.random()) < WORD_FLASH_CHANCE;
 }
 
+/** GIF RAIN ON A WORD ROW (2026-09-08). Most trigger rows are the many `mark` word sets: a line of
+ *  plain word faces with no effect of their own. One in six of those, past the gif rain bubble's own
+ *  intensity floor, puts a gifrain bubble in the MIDDLE of the line - the pictures come down, and the
+ *  row is still the word it was and still unavoidable. Only the centre, so a row can pour exactly one
+ *  cascade and never five; only a treat row, so a phrase written for a freeze or a spiral keeps the
+ *  effect it was written for; and never over the rabbit foot's golden centre, which was earned. */
+export const GIFRAIN_ROW_CHANCE = 1 / 6;
+/** The bubble it puts there. bubbleKinds.js owns the kind AND its intensity floor, so the road and
+ *  the row can never disagree about when the rain is allowed to start (no second floor here). */
+export const GIFRAIN_KIND = 'gifrain';
+/**
+ * Does this trigger row wear the rain? Pure, so the smoke can hold the odds and the floor. The
+ * caller draws from the ROAD's own seeded rng, the stream the rest of the chart rolls on, so a
+ * seed lays the same rain every time.
+ * @param kindId the kind the row resolved to, @param intensity 0..1, @param rng the road's rng
+ */
+export function gifRainRow(kindId, intensity, rng) {
+  const k = KIND_BY_ID[kindId], rain = KIND_BY_ID[GIFRAIN_KIND];
+  if (!k || k.kind !== 'treat' || !rain || rain.spawn === false) return false;   // an effect row keeps its effect
+  if (!(Number(intensity) >= (rain.minIntensity || 0))) return false;            // the rain's own floor, not a new one
+  return (typeof rng === 'function' ? rng() : Math.random()) < GIFRAIN_ROW_CHANCE;
+}
+
 const clamp = (v, a, b) => Math.max(a, Math.min(b, v));
 const conf01 = (e) => (Number.isFinite(Number(e.conf)) ? clamp(Number(e.conf), 0, 1) : 1);
 const weight01 = (e) => (Number.isFinite(Number(e.weight)) ? clamp(Number(e.weight), 0, 1) : 1);
@@ -189,7 +213,15 @@ export function cueFor(event, ctx = {}) {
       // This is the only door a strobe charge still comes through, so the recipes that need one
       // (pink lightning, snowblind, the full pour) are still on the table.
       if (row.preset === FLASH_PRESET) cue.mix = 'flash';
-      for (const x of ROW_X) cue.spawn.push({ kindId: gold && Math.abs(x) < 1e-6 ? 'golden' : kindId, placement: 'lane', x, h: LANE_H, at: 0, row: true, w: label || '', ink, big: true });
+      // and one word row in six, once the run is loud enough, has the rain hanging in the middle of it.
+      // Not over the golden centre, and not on a row that already pours something (the flash-pulse
+      // line is plain faces on purpose: its beat IS the effect, and the rain would talk over it).
+      const rain = !gold && !cue.mix && gifRainRow(kindId, intensity, rng);
+      for (const x of ROW_X) {
+        const mid = Math.abs(x) < 1e-6;
+        cue.spawn.push({ kindId: mid ? (gold ? 'golden' : (rain ? GIFRAIN_KIND : kindId)) : kindId,
+          placement: 'lane', x, h: LANE_H, at: 0, row: true, w: label || '', ink, big: true });
+      }
       cue.word = label || null;
       cue.pose = 'grab';
       break;

--- a/ConditioningControlPanel/Resources/web/dtrh/race/race.css
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/race.css
@@ -695,6 +695,24 @@
   background: repeating-linear-gradient(180deg, rgba(0, 0, 0, 0.55) 0 2px, rgba(0, 0, 0, 0) 2px 5px);
   mix-blend-mode: multiply;
 }
+/* gif-rain: gold, and it falls. It comes IN from over the top and keeps going out the bottom, so the
+   plate moves the way the pictures behind it do, with a streak trailing the letters on the way down. */
+.race-hud .rc-plate--rain {
+  color: #ffdf8f; text-shadow: 0 0 30px rgba(255, 200, 61, 0.95), 0 4px 10px rgba(0, 0, 0, 0.9);
+  animation: rcRain 1400ms cubic-bezier(0.3, 0.1, 0.3, 1) forwards;
+}
+.race-hud .rc-plate--rain::before {
+  content: ''; position: absolute; left: 50%; top: -46vh; width: 2px; height: 44vh; transform: translateX(-50%);
+  background: linear-gradient(180deg, rgba(255, 200, 61, 0), rgba(255, 223, 143, 0.75));
+  animation: rcRainStreak 620ms ease-in forwards;
+}
+@keyframes rcRain {
+  0%   { opacity: 0; transform: translate(-50%, -190%) scale(0.9); }
+  16%  { opacity: 1; transform: translate(-50%, -50%) scale(1.18); }
+  62%  { opacity: 1; transform: translate(-50%, -46%) scale(1.18); }
+  100% { opacity: 0; transform: translate(-50%, 40%) scale(1.06); }
+}
+@keyframes rcRainStreak { 0% { opacity: 0.9; } 70% { opacity: 0.35; } 100% { opacity: 0; } }
 /* treats: warm pink, and it lands on a bounce rather than a glide */
 .race-hud .rc-plate--bounce { animation: rcZoom 1400ms cubic-bezier(0.2, 1.7, 0.35, 1) forwards; }
 /* mark: a marked word, not a trigger moment. Small, and it does not come at you. */
@@ -715,10 +733,11 @@
 @media (prefers-reduced-motion: reduce) {
   .race-hud .rc-plate, .race-hud .rc-plate--blink, .race-hud .rc-plate--wall, .race-hud .rc-plate--frost,
   .race-hud .rc-plate--snap, .race-hud .rc-plate--split, .race-hud .rc-plate--spiral, .race-hud .rc-plate--melt,
-  .race-hud .rc-plate--bounce, .race-hud .rc-plate--mark {
+  .race-hud .rc-plate--bounce, .race-hud .rc-plate--mark, .race-hud .rc-plate--rain {
     animation: rcHold 1400ms linear forwards; transform: translate(-50%, -50%) scale(1); filter: none;
   }
-  .race-hud .rc-plate--pulse::before, .race-hud .rc-plate--gold .rc-plate-sparks { animation: none; opacity: 0; }
+  .race-hud .rc-plate--pulse::before, .race-hud .rc-plate--gold .rc-plate-sparks,
+  .race-hud .rc-plate--rain::before { animation: none; opacity: 0; }
   /* the flash fades in place too; the ghost keeps its own faintness, which is a reading and not a motion */
   .race-hud .rc-cap-word.rc-flash-word, .race-hud .rc-flash-word.is-accent,
   .race-hud .rc-flash-word.is-ghost { animation: none; }

--- a/ConditioningControlPanel/Resources/web/dtrh/race/run.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/run.js
@@ -325,6 +325,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     trailClear();
     mix.reset(); PACE.reset(); S.wobble = 0; clearMixChrome(); sync.reset(); wordOf.clear(); lineGot.clear(); lineDone.clear();
     wordyRows.clear(); lastFlashAt = -1e9; flashStats.pops = 0; flashStats.capped = 0; flashStats.rolls = 0; flashStats.flashes = 0;
+    fxFired.clear();
     hud.setScore(0); hud.setCombo(0, 1); hud.setBank(0); hud.setSpeed(0); hud.setFraught(0); hud.passiveClear(); TR.gild(0);
   }
 
@@ -420,7 +421,11 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
   }
 
   // ---- THE MIX: actions -> payloadFx + chrome, recipes -> the ledger ----
+  /** Every payload the mixer pours passes through here, so this tally is the whole truth about what
+   *  the run fired: race/smoke/gifrain-row-check.mjs reads it to hold a rain row to ONE cascade. */
+  const fxFired = new Map();
   const fire = (p, strength, durationMult) => {
+    fxFired.set(p.payload, (fxFired.get(p.payload) || 0) + 1);
     if (p.payload === 'video') { trackPause(true); send({ type: 'fire-payload', kind: 'video', strength, durationMult }); }
     else payloadFx.applyPayload({ payload: { kind: p.payload, overlay: p.overlayKind }, strength }, { durationMult });
   };
@@ -993,6 +998,8 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     /** THE WORD FLASH, for race/smoke/word-flash-check.mjs: word pops, the ones the 250 ms cap ate,
      *  the rolls that reached the rng and the flashes that came out of them. Never read by the game. */
     wordFlashStats: () => ({ ...flashStats }),
+    /** GIF RAIN, for race/smoke/gifrain-row-check.mjs: how many of each payload the mixer poured. */
+    fxStats: () => Object.fromEntries(fxFired),
     /** race/smoke/captions-check.mjs: one word at the band, the same call a pop makes. */
     debugWord: (text, o) => (captions ? captions.showWord(text, o || {}) != null : false),
     /** Which half of race/captions.js is driving the band on this build: 'flash' or 'type'. */

--- a/ConditioningControlPanel/Resources/web/dtrh/race/smoke/gifrain-row-check.mjs
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/smoke/gifrain-row-check.mjs
@@ -1,0 +1,206 @@
+/* ============================================================================
+ * race/smoke/gifrain-row-check.mjs - the gif rain, on the road blocks.
+ *
+ *   node race/smoke/gifrain-row-check.mjs        (from Resources/web/dtrh; 0 on pass)
+ *   RACE_SHOTS=1 node race/smoke/gifrain-row-check.mjs   (also writes shots/ png)
+ *
+ * Two halves. The pure one holds the table: the `gif-rain` preset wears the
+ * gifrain bubble, it has a plate class of its own in race.css, the catalogue set
+ * that asks for it is a real one, and the theme table and the catalogue are still
+ * level with each other.
+ *
+ * The browser one drives a real worded run, because the thing that can go wrong
+ * here is not in the table: a row that resolved to rain has to pour exactly ONE
+ * cascade. Five stacked would be the whole screen. So the run reads two counters
+ * back - `race.fxStats()`, every payload the mixer has poured, counted at the one
+ * door they all go through, and `race.wordFaces().placed`, every bubble the field
+ * has put on the road - and holds the cascades against the rain bubbles that were
+ * there to pour them.
+ *
+ * It never prints a line of a transcript. Everything below is counted.
+ *
+ * CHROME: `CHROME_PATH` if it is set, else the usual Windows install.
+ * ==========================================================================*/
+
+import { spawn } from 'node:child_process';
+import { createServer } from 'node:http';
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { readFileSync, mkdtempSync, rmSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, extname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { KIND_BY_ID } from '../bubbleKinds.js';
+import { THEME_BY_PRESET, PRESETS_IN_USE, kindForPreset } from '../triggerTheme.js';
+import { GIFRAIN_KIND, GIFRAIN_ROW_CHANCE } from '../cues.js';
+import { TRIGGER_SETS } from '../../chart/editor/triggerSets.js';
+import { wordedRoad, PEAKS_PER_SEC } from '../cloudChart.js';
+
+let fails = 0;
+const ok = (cond, what) => { if (!cond) { console.error('FAIL ' + what); fails++; } else console.log('  ok  ' + what); };
+const eq = (got, want, what) => ok(got === want, what + ' (got ' + JSON.stringify(got) + ', want ' + JSON.stringify(want) + ')');
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const HERE = resolve(fileURLToPath(import.meta.url), '..');
+const RACE = resolve(HERE, '..');
+const WEB = resolve(RACE, '../..');                        // Resources/web
+const SHOTS = process.env.RACE_SHOTS === '1' ? resolve(WEB, '../../../shots') : null;
+const read = (rel) => JSON.parse(readFileSync(resolve(RACE, rel), 'utf8'));
+const ROW = read('words/index.json').rows[0];              // the opening level
+const WORDS = { ...read('words/' + ROW.file), engine: ROW.engine };
+
+/* ============================================================================
+ * 1. the table: a preset, a bubble, a plate
+ * ==========================================================================*/
+const rain = THEME_BY_PRESET['gif-rain'];
+ok(!!rain, 'the theme table has a gif-rain row');
+eq(kindForPreset('gif-rain'), GIFRAIN_KIND, 'and it wears the gifrain bubble');
+ok(KIND_BY_ID[GIFRAIN_KIND] && KIND_BY_ID[GIFRAIN_KIND].spawn !== false, 'which is a bubble that still spawns');
+eq(KIND_BY_ID[GIFRAIN_KIND].payload, 'gifCascade', 'and whose payload is the cascade itself');
+const themes = Object.values(THEME_BY_PRESET).map((r) => r.theme);
+eq(new Set(themes).size, themes.length, 'every preset in the table still has a plate class of its own');
+const css = readFileSync(resolve(RACE, 'race.css'), 'utf8');
+const missing = [...new Set(themes)].filter((t) => !css.includes('.rc-plate--' + t));
+eq(missing.length, 0, 'and race.css carries one for every theme in it' + (missing.length ? ' (missing ' + missing.join(', ') + ')' : ''));
+ok(/\.rc-plate--rain\b/.test(css), 'the rain plate is written down');
+ok(/@keyframes rcRain\b/.test(css), 'with an animation of its own');
+ok(/prefers-reduced-motion[\s\S]*rc-plate--rain/.test(css), 'and it holds still under reduced motion (Law VI)');
+
+const sets = TRIGGER_SETS.filter((s) => s.preset === 'gif-rain');
+ok(sets.length >= 1, sets.length + ' trigger set(s) ask for it: ' + sets.map((s) => s.id).join(', '));
+ok(PRESETS_IN_USE.every((p) => THEME_BY_PRESET[p]), 'every preset the catalogue uses has a row in the theme table');
+ok(TRIGGER_SETS.every((s) => KIND_BY_ID[kindForPreset(s.preset)] && KIND_BY_ID[kindForPreset(s.preset)].spawn !== false),
+  'and not one set in the catalogue points at a darkened bubble');
+ok(GIFRAIN_ROW_CHANCE > 0 && GIFRAIN_ROW_CHANCE < 0.25, 'a word row wears the rain about one time in six, not most times');
+
+/* ============================================================================
+ * the browser: the web folder plus the fixture chart
+ * ==========================================================================*/
+/** The fixture road: the opening transcript, driven LOUD and with rows in it.
+ *
+ * Two liberties, both because of what the real file is. Its energy is pinned flat at the top,
+ * because the rain has an intensity floor of its own (bubbleKinds.js) and a headless run should
+ * not have to wait out a swell to reach it. And it says its first trigger phrase 106 seconds in,
+ * one every 55 seconds after that, so the fixture gets a plain word row every few seconds from the
+ * start - the same shape the transcript's own `mark` rows have. The rows are what is under test;
+ * how long the voice takes to say one is not. */
+const ROW_EVERY = 4;
+function hot(durationSec, perSec = PEAKS_PER_SEC) {
+  const n = Math.ceil(durationSec * perSec);
+  const peaks = new Float32Array(n * 2);
+  for (let i = 0; i < n; i++) { peaks[i * 2] = -0.9; peaks[i * 2 + 1] = 0.9; }
+  return peaks;
+}
+const road = wordedRoad({ peaks: hot(WORDS.durationSec), durationSec: WORDS.durationSec, name: ROW.title, hash: ROW.hash, words: WORDS });
+const rows = [];
+for (let t = 10, i = 0; t < 240; t += ROW_EVERY, i++) {
+  rows.push({ kind: 'trigger', t, dur: 0.5, label: 'blank', conf: 0.99, weight: 1, setId: 'w-blank', cue: 'mark', id: 'rr' + i });
+}
+road.events = [...road.events, ...rows].sort((x, y) => x.t - y.t);
+const FIXTURE = JSON.stringify(road);
+
+const CHROME = process.env.CHROME_PATH || 'C:/Program Files/Google/Chrome/Application/chrome.exe';
+const PORT = 8872, DEBUG_PORT = 9342;
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.mjs': 'text/javascript', '.css': 'text/css', '.json': 'application/json', '.glb': 'model/gltf-binary', '.png': 'image/png', '.webp': 'image/webp', '.jpg': 'image/jpeg', '.mp3': 'audio/mpeg', '.wav': 'audio/wav', '.svg': 'image/svg+xml', '.woff2': 'font/woff2' };
+
+if (!existsSync(CHROME)) { console.error('FAIL no chrome at ' + CHROME + ' (set CHROME_PATH)'); process.exit(1); }
+const server = createServer(async (req, res) => {
+  const path = decodeURIComponent(new URL(req.url, 'http://x').pathname);
+  if (path === '/fixture.json') { res.writeHead(200, { 'content-type': 'application/json' }); return res.end(FIXTURE); }
+  if (path.indexOf('..') >= 0) { res.writeHead(400); return res.end(); }
+  try {
+    const body = await readFile(join(WEB, path));
+    res.writeHead(200, { 'content-type': MIME[extname(path).toLowerCase()] || 'application/octet-stream' });
+    res.end(req.method === 'HEAD' ? undefined : body);
+  } catch (e) { res.writeHead(404, { 'content-type': 'text/plain' }); res.end('no'); }
+});
+await new Promise((r) => server.listen(PORT, '127.0.0.1', r));
+
+const prof = mkdtempSync(join(tmpdir(), 'race-gifrain-'));
+const chrome = spawn(CHROME, [
+  '--headless=new', `--remote-debugging-port=${DEBUG_PORT}`, `--user-data-dir=${prof}`,
+  '--no-first-run', '--no-default-browser-check', '--disable-gpu', '--mute-audio',
+  '--enable-unsafe-swiftshader', '--autoplay-policy=no-user-gesture-required',
+  '--window-size=1280,720', 'about:blank',
+], { stdio: 'ignore' });
+
+let page = null;
+for (let i = 0; i < 60 && !page; i++) {
+  await sleep(250);
+  try { page = (await (await fetch(`http://127.0.0.1:${DEBUG_PORT}/json/list`)).json()).find((t) => t.type === 'page'); } catch (e) { /* not up */ }
+}
+if (!page) { console.error('FAIL chrome never answered on the debug port'); await done(1); }
+
+const ws = new WebSocket(page.webSocketDebuggerUrl);
+await new Promise((r) => { ws.onopen = r; });
+let msgId = 0;
+const waits = new Map(), errs = [];
+ws.onmessage = (e) => {
+  const m = JSON.parse(e.data);
+  if (m.id && waits.has(m.id)) { waits.get(m.id)(m); waits.delete(m.id); }
+  if (m.method === 'Runtime.exceptionThrown') errs.push('thrown: ' + (m.params.exceptionDetails?.exception?.description || m.params.exceptionDetails?.text || '?'));
+  if (m.method === 'Runtime.consoleAPICalled' && m.params.type === 'error') errs.push(m.params.args.map((a) => a.value ?? a.description ?? '?').join(' '));
+};
+const cdp = (method, params) => new Promise((res) => { const i = ++msgId; waits.set(i, res); ws.send(JSON.stringify({ id: i, method, params })); });
+const ev = async (x) => (await cdp('Runtime.evaluate', { expression: x, returnByValue: true, awaitPromise: true })).result?.result?.value;
+const json = async (x) => JSON.parse(await ev(`JSON.stringify(${x})`));
+await cdp('Runtime.enable'); await cdp('Page.enable');
+await cdp('Emulation.setDeviceMetricsOverride', { width: 1280, height: 720, deviceScaleFactor: 1, mobile: false });
+
+const site = `http://127.0.0.1:${PORT}`;
+await cdp('Page.navigate', { url: `${site}/dtrh/race.html?autostart=1&intro=0&cards=0&chart=${encodeURIComponent(`${site}/fixture.json`)}` });
+let up = false;
+for (let i = 0; i < 120 && !up; i++) {
+  await sleep(250);
+  up = await ev(`!!(window.__race && window.__race.race && window.__race.race.track && window.__race.race.perf().running)`);
+}
+ok(up, 'the page boots the worded fixture road and the run is going');
+if (!up) { if (errs.length) console.error('    said: ' + errs.slice(0, 6).join(' | ')); await done(1); }
+
+/* ============================================================================
+ * 2. a rain row pours ONE cascade
+ *
+ * The pump takes the whole road at once, so every rain bubble that was laid gets
+ * popped, which is the worst case for stacking: if a row could pour more than one
+ * cascade, this is the run where it would.
+ * ==========================================================================*/
+let placed = {}, fx = {}, peak = 0, shots = 0;
+for (let i = 0; i < 260; i++) {
+  await ev(`window.__race.race.debugPickup('the_pump')`);
+  await sleep(400);
+  const live = await ev(`document.querySelectorAll('.sf-pfx-cascade').length`);
+  if (live > peak) peak = live;
+  if (SHOTS && live >= 3 && shots < 1) {
+    const png = (await cdp('Page.captureScreenshot', { format: 'png' })).result?.data;
+    if (png) {
+      await mkdir(SHOTS, { recursive: true });
+      const at = join(SHOTS, 'gifrain-row.png');
+      await writeFile(at, Buffer.from(png, 'base64'));
+      console.log('  --  shot: ' + at);
+      shots++;
+    }
+  }
+  fx = await json(`window.__race.race.fxStats()`);
+  placed = await json(`window.__race.race.wordFaces().placed`);
+  if ((fx.gifCascade || 0) >= 2 && (SHOTS ? shots : 1)) break;
+}
+const rainBubbles = placed[GIFRAIN_KIND] || 0, cascades = fx.gifCascade || 0;
+console.log(`  --  the road laid ${rainBubbles} rain bubbles; the mixer poured ${cascades} cascades, ${peak} pictures on the glass at once`);
+ok(rainBubbles > 0, 'the road laid the rain on it');
+ok(cascades > 0, 'and popping one poured a cascade');
+ok(cascades <= rainBubbles, 'never more cascades than there were rain bubbles to pour them: one row, one cascade');
+ok(peak > 0 && peak <= 14, `the pictures never stacked past the cascade's own cap (${peak} at once, cap 14)`);
+ok(!placed.flash && !placed.video, 'and the darkened kinds are still off the road');
+ok(errs.length === 0, 'not one console error in the whole run' + (errs.length ? ':\n    ' + errs.slice(0, 5).join('\n    ') : ''));
+
+await done(fails ? 1 : 0);
+
+async function done(code) {
+  try { ws && ws.close(); } catch (e) { /* never opened */ }
+  try { chrome.kill(); } catch (e) { /* already gone */ }
+  await new Promise((r) => server.close(r));
+  await sleep(300);
+  try { rmSync(prof, { recursive: true, force: true }); } catch (e) { /* chrome still has a lock */ }
+  if (code) console.error(`\n${fails} failure${fails === 1 ? '' : 's'}`);
+  else console.log('\ngifrain-row-check: all good');
+  process.exit(code);
+}

--- a/ConditioningControlPanel/Resources/web/dtrh/race/smoke/rows-check.mjs
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/smoke/rows-check.mjs
@@ -17,6 +17,8 @@
  *   2b. the flash bubble is dark and the WORD carries the flash instead: half the
  *      word pops, off the run's seeded rng, one flash per 250 ms, and the one
  *      preset that meant the flash pours a real one through THE MIX
+ *   2c. one word row in six wears the gif rain in the middle of the line, past the
+ *      rain bubble's own intensity floor, one bubble of it and never the golden one
  *   3. a trigger the spotter only half heard is the single treat it always was
  *   4. one event is one credit however many of its bubbles were popped
  *   5. a worded track halves the peak rain; nothing else on the road moves
@@ -35,11 +37,12 @@
  * It never prints a line of a transcript. Everything below is counted.
  * ==========================================================================*/
 
-import { cueFor, ROW_X, ROW_MAX_GAP, wordFlash, WORD_FLASH, WORD_FLASH_CHANCE, WORD_FLASH_GAP_MS } from '../cues.js';
+import { cueFor, ROW_X, ROW_MAX_GAP, wordFlash, WORD_FLASH, WORD_FLASH_CHANCE, WORD_FLASH_GAP_MS,
+  GIFRAIN_KIND, GIFRAIN_ROW_CHANCE } from '../cues.js';
 import { createScheduler, normalizeChart } from '../chart.js';
 import { KART_X_MAX, LANE_X_MAX, POP_HIT_X, POP_HIT_D, LANE_H, COMBO_HOLD_SEC, KART_BASE_SPEED, OPEN_PACE, makeRng } from '../consts.js';
 import { createScore } from '../score.js';
-import { THEME_BY_PRESET, kindForPreset } from '../triggerTheme.js';
+import { THEME_BY_PRESET, kindForPreset, PRESETS_IN_USE } from '../triggerTheme.js';
 import { KIND_BY_ID } from '../bubbleKinds.js';
 import { createCueSync, CUE_AHEAD_SEC, LATE_SEC } from '../sync.js';
 import { wordEventsFrom } from '../wordBubbles.js';
@@ -102,10 +105,12 @@ console.log('  --  the row: ' + ROW_X.length + ' bubbles, ' + ((LANE_X_MAX * 2) 
   + ' m apart, across ' + (LANE_X_MAX * 2).toFixed(2) + ' m of road');
 
 /* ---- 2. the row wears the preset ---------------------------------------- */
+// Under the gif rain's floor (2c), so this reads the row the preset table laid and nothing else.
+const QUIET = { intensity: (KIND_BY_ID.gifrain.minIntensity || 0) - 0.05 };
 let dressed = true;
 for (const preset of Object.keys(THEME_BY_PRESET)) {
   const kind = kindForPreset(preset);
-  const c = cueFor({ kind: 'trigger', t: 4, label: 'a phrase', conf: 0.9, cue: preset }, ctxFor({ 'a phrase': kind }));
+  const c = cueFor({ kind: 'trigger', t: 4, label: 'a phrase', conf: 0.9, cue: preset }, ctxFor({ 'a phrase': kind }, QUIET));
   const r = c.spawn.filter((s) => s.row);
   if (r.length !== ROW_X.length || r.some((s) => s.kindId !== kind) || KIND_BY_ID[kind].spawn === false) {
     ok(false, 'the ' + preset + ' row is a full row of the ' + kind + ' bubble');
@@ -115,7 +120,7 @@ for (const preset of Object.keys(THEME_BY_PRESET)) {
 }
 if (dressed) ok(true, 'every preset in the table lays a full row of its own bubble, and none of them is darkened');
 for (const preset of ['treats', 'mark']) {
-  const c = cueFor({ kind: 'trigger', t: 4, label: 'a phrase', conf: 0.9, cue: preset }, ctxFor({ 'a phrase': kindForPreset(preset) }));
+  const c = cueFor({ kind: 'trigger', t: 4, label: 'a phrase', conf: 0.9, cue: preset }, ctxFor({ 'a phrase': kindForPreset(preset) }, QUIET));
   eq(c.spawn.filter((s) => s.row && s.kindId === 'treat').length, ROW_X.length, 'a ' + preset + ' trigger is a row of treats, not an effect');
 }
 
@@ -144,6 +149,53 @@ const seedA = makeRng(7), seedB = makeRng(7);
 ok(Array.from({ length: 200 }, () => wordFlash(seedA, 999)).join() === Array.from({ length: 200 }, () => wordFlash(seedB, 999)).join(),
   'one seed, one sequence: a replay of a run flashes on the same words');
 ok(WORD_FLASH.durationMult < 0.3 && WORD_FLASH.strength < 30, 'and what it hands payloadFx is a blink, not the old flash bubble');
+
+/* ---- 2c. GIF RAIN: one word row in six, in the middle of the line -------- */
+// A word row is a line of plain faces; one in six of them, once the run is loud enough, hangs the
+// rain in the CENTRE of that line. The row must stay full width, and it must be able to pour one
+// cascade and never five, so exactly one bubble of the row may be the rain.
+const FLOOR = KIND_BY_ID.gifrain.minIntensity || 0;
+const rainRng = makeRng(0x9017);
+let rainRows = 0, plainRows = 0, wide = 0, manyRain = 0, offCentre = 0;
+for (let i = 0; i < 3000; i++) {
+  const c = cueFor({ kind: 'trigger', t: 4, label: 'blank', conf: 0.9, cue: 'mark' },
+    ctxFor({ blank: kindForPreset('mark') }, { intensity: 0.8, rng: rainRng }));
+  const r = c.spawn.filter((s) => s.row);
+  if (r.length === ROW_X.length) wide++;
+  const rain = r.filter((s) => s.kindId === GIFRAIN_KIND);
+  if (rain.length > 1) manyRain++;
+  if (rain.length === 1 && Math.abs(rain[0].x) > 1e-6) offCentre++;
+  if (rain.length) rainRows++; else plainRows++;
+}
+eq(wide, 3000, 'a rain row is still the full line across the road: unavoidable either way');
+eq(manyRain, 0, 'never more than one rain bubble in a row, so a row pours ONE cascade and not five');
+eq(offCentre, 0, 'and the one is always the middle bubble');
+ok(Math.abs(rainRows / 3000 - GIFRAIN_ROW_CHANCE) < 0.03,
+  Math.round((rainRows / 3000) * 100) + '% of word rows wear it (want ' + Math.round(GIFRAIN_ROW_CHANCE * 100) + '%, about one in six)');
+let below = 0;
+for (let i = 0; i < 2000; i++) {
+  const c = cueFor({ kind: 'trigger', t: 4, label: 'blank', conf: 0.9, cue: 'mark' },
+    ctxFor({ blank: kindForPreset('mark') }, { intensity: FLOOR - 0.01, rng: rainRng }));
+  if (c.spawn.some((s) => s.kindId === GIFRAIN_KIND)) below++;
+}
+eq(below, 0, 'under the gif rain bubble\'s own floor of ' + FLOOR + ' intensity it never starts');
+let stolen = 0;
+for (const preset of Object.keys(THEME_BY_PRESET)) {
+  const kind = kindForPreset(preset);
+  if (KIND_BY_ID[kind].kind === 'treat' || kind === GIFRAIN_KIND) continue;   // the word rows are the ones it may take
+  for (let i = 0; i < 200; i++) {
+    const c = cueFor({ kind: 'trigger', t: 4, label: 'a phrase', conf: 0.9, cue: preset },
+      ctxFor({ 'a phrase': kindForPreset(preset) }, { intensity: 0.95, rng: rainRng }));
+    if (c.spawn.some((s) => s.kindId === GIFRAIN_KIND)) stolen++;
+  }
+}
+eq(stolen, 0, 'and it never takes a row that was written for an effect of its own');
+const goldRain = cueFor({ kind: 'trigger', t: 4, label: 'blank', conf: 0.9, cue: 'mark' },
+  ctxFor({ blank: kindForPreset('mark') }, { intensity: 0.95, rng: makeRng(3), gold: () => true }));
+eq(goldRain.spawn.filter((s) => s.kindId === 'golden').length, 1, 'the rabbit foot still owns the centre when it is owed one');
+eq(goldRain.spawn.filter((s) => s.kindId === GIFRAIN_KIND).length, 0, 'and the rain never covers it');
+eq(kindForPreset('gif-rain'), GIFRAIN_KIND, 'the gif-rain preset wears the rain bubble');
+ok(PRESETS_IN_USE.every((p) => THEME_BY_PRESET[p]), 'every preset the catalogue uses has a row in the theme table');
 
 /* ---- 3. the unsure trigger is what it always was ------------------------- */
 const unsure = cueFor({ kind: 'trigger', t: 10, label: 'a phrase', conf: 0.3, cue: 'blackout' },

--- a/ConditioningControlPanel/Resources/web/dtrh/race/triggerTheme.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/triggerTheme.js
@@ -56,6 +56,9 @@ export const THEME_BY_PRESET = {
   'spiral-air':   { kind: 'spiral',     theme: 'spiral', color: '#c8a8ff', ink: '#0f0f1c', note: 'lilac, slow rotate while it zooms' },
   'melt':         { kind: 'braindrain', theme: 'melt',   color: '#4060c0', ink: '#f4f2ff', note: 'deep blue, letters sag and blur downward' },
   'video':        { kind: 'video',      theme: 'scan',   color: '#ff5c6c', ink: '#f4f2ff', note: 'red, scanlines' },
+  // gif rain (2026-09-08): the pictures come DOWN, so the plate comes down with them. Gold, the
+  // gifrain bubble's own tint, and a shade colder than golden-rain's so the two never read alike.
+  'gif-rain':     { kind: 'gifrain',    theme: 'rain',   color: '#ffc83d', ink: '#0f0f1c', note: 'gold, the letters fall in and keep falling out the bottom' },
   // A row of treats is not an effect: the road is what happens, and the plate is warm rather than loud.
   'treats':       { kind: 'treat',      theme: 'bounce', color: '#ffb3d9', ink: '#0f0f1c', note: 'warm pink, bouncy letters' },
   // A marked word, not a trigger moment: small, no zoom.


### PR DESCRIPTION
Stacked on #976 (`feat/race-word-flash`). **Review that one first**; this PR's diff is only the second commit.

Owner ask: "we might wanna add also gif rain as a trigger that can happen (on the road blocks)."

## What changed

Gif rain used to be a bubble you rolled into and nothing more. Now it can also be a trigger, on the line the road throws across your path.

**Two ways in.**

1. **A set asks for it by name.** New `gif-rain` preset in `triggerTheme.js` (kind `gifrain`, its own `rain` plate theme, gold `#ffc83d` a shade colder than `golden-rain` so the two never read alike; the plate falls in from above and keeps falling out the bottom). `chart/editor/triggerSets.js` points `cockslut` at it. That set had been asking for the `video` preset, whose bubble went dark on 2026-09-06, so its row has been silently falling back to a plain effect ever since while the plate still said video. Now it says what it does. No ids renamed, only that one preset value.

2. **A general chance, which is the bigger half.** Most trigger rows are the many `w-*` `mark` word sets: a full line of plain word faces with no effect of their own. One such row in six hangs the rain in the **middle** of the line.

## The rules, and why

| rule | why |
|---|---|
| centre bubble only, never the whole row | a row pours exactly **one** cascade, never five stacked |
| the row stays the full line, same word face | still unavoidable, still the phrase it was |
| gifrain's **own** `minIntensity` (0.45), no second floor invented | the floor already existed; a new one would be a second thing to keep in sync |
| rolled off the **road's seeded rng** | a seed lays the same rain twice |
| never over a golden centre | the rabbit foot earned that one |
| never on a row that already pours (`cue.mix`) | a phrase written for a freeze or a spiral keeps its own effect, and a `flash-pulse` line stays plain |
| treat rows only (`k.kind === 'treat'`) | an effect row keeps its effect |

The odds, the cap and the floor all live in `cues.js` (pure, node-loadable) so the smokes can hold them. `run.js` only gained a payload tally.

## Verified

- `node race/smoke/gifrain-row-check.mjs` — pure half: theme table level with the catalogue, a `.rc-plate--rain` class in `race.css`, `@keyframes rcRain`, reduced-motion covered, no catalogue set pointing at a darkened bubble. Browser half drives a real charted run on a row-dense fixture: **the road laid 2 rain bubbles, the mixer poured 2 cascades, 5 pictures on the glass at once** against the `MAX_CASCADE` cap of 14. Zero console errors.
- `rows-check.mjs` gained section 2c: 3000/3000 rain rows are the full width, never more than one rain bubble, always the centre, ~17% odds, nothing under the 0.45 floor, never steals an effect row, golden centre wins, `PRESETS_IN_USE` ⊆ `THEME_BY_PRESET`.
- Green: `rows-check`, `lyrics-road-check`, `words-check`, `chart-check`, `track-run-check`, `cloud-chart-check`, `word-flash-check`, `captions-check` (headless).
- `face-check.mjs` fails on "0 trigger rows passed under the sampler" — **pre-existing**, confirmed by re-running it on the merge base `c4953250c` with HEAD detached. Untouched by this stack.
- Shot of a gifrain row on the road: `C:\wt-race-fx\shots\gifrain-row.png` (not committed).

`run.js` edits stay inside the fx wiring (`fire()` + the debug object), clear of the `onExit` hook and the shutter call the other stack touches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KTe1RA7EP5hGxkzFY1282C
