### PR TITLE
feat(pbp): chess glyphs float over the men from above

### DIFF
--- a/ConditioningControlPanel/Resources/web/piecebypiece/board/glyphs.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/board/glyphs.js
@@ -1,0 +1,205 @@
+/* ============================================================================
+ * board/glyphs.js - the classic chess glyphs, floating over the men.
+ *
+ * The men are toys. From straight above a toy king and a toy queen are two
+ * blobs, so as the camera climbs, a chess glyph fades in over each one: cream
+ * outlined figures for white, lavender for black, the ones everybody already
+ * reads. They are Sprites with a CanvasTexture, so there is one draw per man
+ * and no geometry to keep in step.
+ *
+ * How they behave:
+ *   - one sprite per man, parked at the piece's own height (userData.scaleBase,
+ *     which is the top of the man whether he is a lathe or a glb) plus a lift
+ *   - they follow whatever the piece does, being placed from its live position
+ *     every frame, and go the moment the man leaves the board
+ *   - depthTest off and a high render order, so a tall man never eats his own
+ *     glyph, and raycast off, so they are invisible to drag.js
+ *   - the fade is driven by the camera's actual elevation over the board, not
+ *     by which preset is on: orbiting overhead by hand brings them in too
+ *
+ * Wiring: boot.js builds one of these. It ticks itself off scene.onBeforeRender
+ * (chaining whatever was there), which the renderer calls once a frame with the
+ * camera already up to date, so the board's frame loop needs no new line.
+ * ==========================================================================*/
+
+import * as THREE from 'three';
+
+/** Every number that decides how the glyphs read. One place, on purpose. */
+export const GLYPH_TUNING = Object.freeze({
+  size: 0.70,          // sprite size in world units; a square is 1.0
+  lift: 0.24,          // how far above the man's own head it floats
+  settle: 0.72,        // ... and how much of that height it gives back as the
+                       // camera comes overhead, where a tall float would throw
+                       // the glyph a half square off its own man
+  fadeLo: 56,          // degrees of elevation: fully out at or under this
+  fadeHi: 74,          // and fully in at or over this, so about 65 is halfway
+  fadeRate: 7.0,       // e-fold rate of the opacity chase
+  px: 128,             // texture size, per glyph
+  ink: '#241A3B',      // the outline both sides wear
+  white: '#F5E6C8',
+  black: '#AB90FF',
+});
+
+const WHITE = { k: '♔', q: '♕', r: '♖', b: '♗', n: '♘', p: '♙' };
+const BLACK = { k: '♚', q: '♛', r: '♜', b: '♝', n: '♞', p: '♟' };
+const LETTER = { k: 'K', q: 'Q', r: 'R', b: 'B', n: 'N', p: 'P' };
+const FONT = '"Segoe UI Symbol", "Segoe UI", "DejaVu Sans", "Arial Unicode MS", system-ui, sans-serif';
+
+const clamp01 = (v) => Math.max(0, Math.min(1, v));
+const smooth = (t) => t * t * (3 - 2 * t);
+
+function prefersReducedMotion() {
+  if (typeof window === 'undefined') return false;
+  const pbp = window.PBP;
+  if (pbp && (pbp.reducedMotion || (pbp.settings && pbp.settings.reducedMotion))) return true;
+  try { return !!window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches; }
+  catch { return false; }
+}
+
+/**
+ * Is this glyph actually in the fonts we asked for? A missing one is drawn as
+ * the "no such glyph" box, so it measures the same width as a codepoint no
+ * font can ever carry. Firefox and Edge both ship the chess figures on
+ * Windows; this is the belt for anything that does not.
+ */
+function glyphAvailable(ctx, ch) {
+  const tofu = ctx.measureText('\u{10FFFF}').width;   // no font has this one
+  const w = ctx.measureText(ch).width;
+  return w > 0 && Math.abs(w - tofu) > 0.1;
+}
+
+/** One glyph, drawn once, kept as a texture. */
+function glyphTexture(type, side, T) {
+  const px = T.px;
+  const canvas = document.createElement('canvas');
+  canvas.width = px; canvas.height = px;
+  const ctx = canvas.getContext('2d');
+  ctx.font = Math.round(px * 0.74) + 'px ' + FONT;
+  const wanted = (side === 'w' ? WHITE : BLACK)[type];
+  const ch = glyphAvailable(ctx, wanted) ? wanted : LETTER[type];
+  if (ch !== wanted) ctx.font = '700 ' + Math.round(px * 0.6) + 'px ' + FONT;
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  ctx.lineJoin = 'round';
+  // A soft drop under it, then the outline, then the face: the glyph has to
+  // hold up over a cream square and over a pink one.
+  ctx.shadowColor = 'rgba(20, 14, 40, 0.55)';
+  ctx.shadowBlur = px * 0.09;
+  ctx.shadowOffsetY = px * 0.03;
+  ctx.lineWidth = px * 0.085;
+  ctx.strokeStyle = T.ink;
+  ctx.strokeText(ch, px / 2, px * 0.53);
+  ctx.shadowColor = 'transparent';
+  ctx.fillStyle = side === 'w' ? T.white : T.black;
+  ctx.fillText(ch, px / 2, px * 0.53);
+  const tex = new THREE.CanvasTexture(canvas);
+  tex.colorSpace = THREE.SRGBColorSpace;
+  tex.anisotropy = 2;
+  return tex;
+}
+
+/**
+ * @param view    what createScene handed back (scene, camera, ...)
+ * @param pieces  what createPieces handed back; `pieces.pieces` is the live
+ *                square -> man map, and a captured man is out of it at once
+ */
+export function createGlyphs({ view, pieces, tuning = {} }) {
+  const T = Object.freeze({ ...GLYPH_TUNING, ...tuning });
+  const group = new THREE.Group();
+  group.name = 'glyphs';
+  group.renderOrder = 900;
+  view.scene.add(group);
+
+  const materials = new Map();   // "type:side" -> one shared SpriteMaterial
+  const sprites = new Map();     // piece object -> its sprite
+  const seen = new Set();
+  let shown = 0;                 // live opacity, 0..1
+  let last = 0;
+
+  function materialFor(type, side) {
+    const key = type + ':' + side;
+    let mat = materials.get(key);
+    if (!mat) {
+      mat = new THREE.SpriteMaterial({
+        map: glyphTexture(type, side, T),
+        transparent: true, depthTest: false, depthWrite: false, fog: false,
+        sizeAttenuation: true, opacity: shown,
+      });
+      materials.set(key, mat);
+    }
+    return mat;
+  }
+
+  function spriteFor(piece) {
+    const sp = new THREE.Sprite(materialFor(piece.userData.type, piece.userData.side));
+    sp.scale.setScalar(T.size);
+    sp.renderOrder = 900;
+    sp.castShadow = false;
+    sp.receiveShadow = false;
+    sp.raycast = () => {};   // never in drag.js's way
+    return sp;
+  }
+
+  /** Degrees of the camera above the board plane, straight from the camera. */
+  function elevation() {
+    const p = view.camera.position;
+    return Math.atan2(p.y, Math.hypot(p.x, p.z)) * 180 / Math.PI;
+  }
+
+  function update(dt) {
+    // 32 men at most, so this is a plain walk of the live map: a man who has
+    // been taken is out of it already, and a promoted one is a new object.
+    seen.clear();
+    for (const piece of pieces.pieces.values()) {
+      seen.add(piece);
+      let sp = sprites.get(piece);
+      if (!sp) { sp = spriteFor(piece); sprites.set(piece, sp); group.add(sp); }
+      // Straight down, a glyph floating a whole man's height above the board
+      // lands off to one side of him, so the float shrinks as the view rises.
+      const h = ((piece.userData.scaleBase || 1) + T.lift) * (1 - T.settle * shown);
+      sp.position.set(piece.position.x, piece.position.y + h, piece.position.z);
+    }
+    for (const [piece, sp] of sprites) {
+      if (seen.has(piece)) continue;
+      group.remove(sp);
+      sprites.delete(piece);
+    }
+
+    const want = smooth(clamp01((elevation() - T.fadeLo) / (T.fadeHi - T.fadeLo)));
+    if (prefersReducedMotion()) shown = want;
+    else shown += (want - shown) * (1 - Math.exp(-T.fadeRate * Math.max(0, dt)));
+    if (Math.abs(want - shown) < 0.003) shown = want;
+    group.visible = shown > 0.004;
+    if (group.visible) for (const mat of materials.values()) mat.opacity = shown;
+  }
+
+  // The renderer calls this once a frame, with the camera already placed for
+  // the frame. Anything that was on the scene before keeps its turn.
+  const previous = view.scene.onBeforeRender;
+  function tick() {
+    const now = performance.now();
+    const dt = last ? Math.min(0.1, (now - last) / 1000) : 0;
+    last = now;
+    update(dt);
+  }
+  view.scene.onBeforeRender = function onBeforeRender(...args) {
+    if (previous) previous.apply(this, args);
+    tick();
+  };
+
+  return {
+    group,
+    update,
+    /** 0 when they are out of sight, 1 when they are fully in. */
+    shown() { return shown; },
+    elevation,
+    dispose() {
+      view.scene.onBeforeRender = previous || (() => {});
+      for (const sp of sprites.values()) group.remove(sp);
+      sprites.clear();
+      for (const mat of materials.values()) { mat.map?.dispose(); mat.dispose(); }
+      materials.clear();
+      view.scene.remove(group);
+    },
+  };
+}

--- a/ConditioningControlPanel/Resources/web/piecebypiece/boot.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/boot.js
@@ -12,6 +12,7 @@ import { createPieces } from './board/pieces.js';
 import { createAnim } from './board/anim.js';
 import { createJiggle } from './board/jiggle.js';
 import { createDrag } from './board/drag.js';
+import { createGlyphs } from './board/glyphs.js';
 import { createBus } from './game/events.js';
 import { createHotseat } from './game/hotseat.js';
 import { DEFAULT_MS } from './game/clock.js';
@@ -85,6 +86,9 @@ function main() {
   window.PBP.camera = view.cameraRig;
   view.cameraRig.setDragGuard(() => drag.isDragging());
   view.cameraRig.attachUi();
+  // From overhead the toys are unreadable, so the classic glyphs fade in over
+  // them. It ticks itself off the renderer, so the frame loop stays as it was.
+  window.PBP.glyphs = createGlyphs({ view, pieces });
   // --- end camera ---
 
   let last = performance.now();


### PR DESCRIPTION
Stacked on #981 (`feat/pbp-i1`), which is where the top view comes from.

From straight above, a toy king and a toy queen are two blobs. So as the camera climbs, the classic chess glyph fades in over each man: cream outlined figures for white, lavender for black, the ones everybody already reads.

## What is in it

`board/glyphs.js`, one new file.

- One `THREE.Sprite` per man, `sizeAttenuation` on, `raycast` disabled so `drag.js` never sees them, no shadows, and `depthTest` off with a high render order so a tall man cannot eat his own glyph.
- The glyphs are drawn once each into a `CanvasTexture`: outline, drop, then face, at 128 px. Twelve textures and twelve materials for the whole board, shared by every man of that type and side.
- **Font check:** a missing glyph is drawn as the "no such glyph" box, so it measures the same width as a codepoint no font can carry. When the figure is missing, the sprite falls back to the letters K Q R B N P. Edge and Firefox on Windows both have the figures (the screenshots are Edge), so this is only the belt.
- **The fade is the camera, not the preset.** Every frame it reads the camera's real elevation over the board: fully out at 56 degrees, fully in at 74, so about 65 is halfway. A free orbit overhead brings them in exactly like the top button does. Reduced motion snaps instead of fading.
- The float shrinks as the view rises. A glyph parked a whole man's height above the board lands about half a square off its own man when seen from straight above, so at the overhead end it settles down onto him. With `depthTest` off it still draws over everything.
- Sprites follow the men from their live positions every frame, and a man who has been taken is out of `pieces.pieces` at once, so his glyph goes with him. 32 objects, one plain map walk.
- It ticks itself off `scene.onBeforeRender` (chaining whatever was there), which the renderer calls once a frame with the camera already placed, so the frame loop in boot.js is untouched.

`boot.js`: three lines inside the block this stack already owns, plus one import.

## How it was proved

Screenshots, all looked at:

| shot | what it shows |
|---|---|
| `i/10-top-glyphs.png` | the top view, whole opening position readable at a glance, cream for white and lavender for black, hollow figures against filled ones |
| `i/11-fade-65.png` | 65.2 degrees of elevation: glyphs at 0.46, half ghosted over the men, both readable |
| `i/12-free-overhead.png` | a free hand orbit at 82.6 degrees, board turned to an arbitrary angle, glyphs at 0.88 with `preset: null`. The fade is not preset driven |
| `i/13-normal-noglyph.png` | the normal view, elevation 36.2, glyphs at exactly 0, nothing drawn |
| `i/14-top-drag.png` | `--drag e2:e4` from inside the top view: grab, dragmove, turn, drop, fen `...4P3...b KQkq`. The pawn's glyph moved to e4 with him, e2 is bare, and the sprites did not block the pick |

Reported live: `{elev: 65.2, shown: 0.513}`, `{elev: 82.6, shown: 0.879, preset: null}`, `{elev: 36.2, shown: 0}`, and 32 sprites for 32 men.

Smokes on this branch: `ramp-smoke` 111/111, `rules-smoke` 43/43, `jiggle-shot` clean with the flex numbers unchanged. Every page load was a clean boot with no console errors.

## What is NOT in it

- No glyph for a promoted man beyond what falls out of the rebuild: a promotion makes a new piece object, so it simply gets the new sprite on the next frame.
- No settings switch to force them on at any angle. If the owner wants that, it is one line on the tuning object.
- The two big soft discs under the kings in the top shots are the crown and tiara meshes from the piece art catching the key light, not the glyphs.

## Touches outside my lane

None beyond the boot.js block this stack already owns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CQdAN3aDyhnnXWjBtkH1mD
