### PR TITLE
feat(pbp): dust when he lands

### DIFF
--- a/ConditioningControlPanel/Resources/web/piecebypiece/board/anim.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/board/anim.js
@@ -8,6 +8,16 @@
  *
  * The landing squash is not a scale any more: it is handed to jiggle.js, which
  * bends and squashes the mesh itself so the man lands like silicone.
+ *
+ * Bus events this file emits, once bindBus(bus, project) has been called (the
+ * board is silent without it; the dust and the sound listen):
+ *   land    {square, piece, side, capture, height, world:{x,y,z}, screen:{x,y}}
+ *           the frame a flight ends and the man touches his square; `capture`
+ *           is true when he took the man who stood there. A refused drop's
+ *           spring-back lands too, with `refused: true`.
+ *   sunk    {piece, side}  a captured man has finished sinking and is gone.
+ * A Blender capture animation later only has to emit `land` at the frame of
+ * contact for the dust and the thud to keep working.
  * ==========================================================================*/
 
 import * as THREE from 'three';
@@ -31,6 +41,25 @@ export function createAnim({ group, jiggle = null }) {
   const tumbles = [];
   const buzzes = [];
 
+  // --- J: bus hooks ---
+  let emit = () => {};
+  let project = () => null;
+  function bindBus(bus, projectFn = null) {
+    emit = bus && typeof bus.emit === 'function' ? (t, p) => bus.emit(t, p) : () => {};
+    if (typeof projectFn === 'function') project = projectFn;
+  }
+  function landed(piece, at, refused) {
+    const d = piece.userData;
+    emit('land', {
+      square: d.square || null, piece: d.type, side: d.side,
+      capture: !!d.tookOne && !refused, refused: !!refused,
+      height: d.scaleBase || 1,
+      world: { x: at.x, y: at.y, z: at.z },
+      screen: project(at),
+    });
+  }
+  // --- end J ---
+
   /** Landing flex. `travel` is the world x/z the man just crossed, or null. */
   function squash(piece, travel = null) {
     if (jiggle) jiggle.land(piece, travel);
@@ -44,7 +73,8 @@ export function createAnim({ group, jiggle = null }) {
     const dest = to || piece.position.clone();
     if (from.distanceToSquared(dest) < 1e-6) return;
     piece.userData.busy = true;   // hands the piece to us; idle wobble stands off
-    slides.push({ piece, from: from.clone(), to: dest, t: 0, hop: hop ?? Math.min(0.42, 0.12 + from.distanceTo(dest) * 0.05) });
+    slides.push({ piece, from: from.clone(), to: dest, t: 0, hop: hop ?? Math.min(0.42, 0.12 + from.distanceTo(dest) * 0.05), refused: !!piece.userData.refusedDrop });
+    piece.userData.refusedDrop = false;
     piece.position.copy(from);
   }
 
@@ -71,6 +101,7 @@ export function createAnim({ group, jiggle = null }) {
         s.piece.position.copy(s.to);
         slides.splice(i, 1);
         if (!sliding(s.piece)) s.piece.userData.busy = false;
+        landed(s.piece, s.to, s.refused);   // J: before squash, which spends tookOne
         squash(s.piece, [s.to.x - s.from.x, s.to.z - s.from.z]);
       }
     }
@@ -84,7 +115,10 @@ export function createAnim({ group, jiggle = null }) {
         const sink = Math.min(1, (t.t - FALL) / SINK);
         t.piece.position.y = t.start - sink * 1.1;
         for (const mat of skins(t.piece)) { mat.transparent = true; mat.opacity = 1 - sink; }
-        if (sink >= 1) { group.remove(t.piece); tumbles.splice(i, 1); }
+        if (sink >= 1) {
+          group.remove(t.piece); tumbles.splice(i, 1);
+          emit('sunk', { piece: t.piece.userData.type, side: t.piece.userData.side });   // J
+        }
       }
     }
 
@@ -115,12 +149,13 @@ export function createAnim({ group, jiggle = null }) {
   function springBack(piece) {
     const home = piece.userData.home;
     if (!home) return;
+    piece.userData.refusedDrop = true;   // J: the landing says so on the bus
     slide(piece, piece.position.clone(), new THREE.Vector3(home.x, 0, home.z), 0.1);
     buzz(piece);
   }
 
   return {
-    update, squash, slide, tumble, buzz, springBack,
+    update, squash, slide, tumble, buzz, springBack, bindBus,
     hooks: {
       onMoved: (piece, from) => slide(piece, from),
       onCaptured: (piece) => tumble(piece),

--- a/ConditioningControlPanel/Resources/web/piecebypiece/board/dust.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/board/dust.js
@@ -1,0 +1,273 @@
+/* ============================================================================
+ * board/dust.js - what the board does when a man lands on it.
+ *
+ * A landing is the beat the player performs forty times a game, so it pays out
+ * every time, and cheaply: a ring of soft cream-and-pink motes puffs outward
+ * along the board from the man's base and fades in half a second, the square
+ * under him flashes pink for a few frames, and a faint ripple ring spreads out
+ * and dies. A capture makes it all bigger. A king landing throws a few gold
+ * sparks off his crown.
+ *
+ * All the motes live in ONE THREE.Points with a ring buffer of slots; each
+ * burst writes its slots and the vertex shader animates them from their spawn
+ * time, so a burst costs one attribute upload and the whole system is one
+ * draw call. Flashes and rings are tiny pooled meshes.
+ *
+ * Wiring:
+ *   boot.js  createDust({ scene, bus }) and update(dt, camera, renderer) once
+ *            a frame; it listens on the bus for anim.js's `land`
+ *   settings window.PBP.settings.reducedMotion (or the media query) makes it
+ *            smaller and shorter; a refused drop's landing puffs less
+ * ==========================================================================*/
+
+import * as THREE from 'three';
+
+/** Every number that decides how a landing looks. */
+export const TUNING = Object.freeze({
+  pool: 256,               // motes alive at once; a burst past this recycles the oldest
+  count: 14,               // motes per landing
+  countReduced: 6,
+  life: 0.5,               // seconds a mote lives
+  lifeReduced: 0.25,
+  spread: 0.5,             // world units the ring travels, times the man's height
+  rise: 0.07,              // how far a mote lifts before it settles
+  size: 0.15,              // world size of a mote at a pawn's height
+  captureGain: 1.6,        // taking a man: bigger and wider
+  refusedGain: 0.45,       // a spring-back landing: a shrug of dust
+  colorCream: 0xFFF1E0,
+  colorPink: 0xFFB0D8,
+  flashSec: 0.14,
+  flashAlpha: 0.6,
+  flashColor: 0xFF8FCB,
+  ringSec: 0.42,
+  ringFrom: 0.35,          // ring scale at birth, in squares
+  ringTo: 0.9,
+  ringAlpha: 0.5,
+  ringColor: 0xFFC2E4,
+  sparks: 8,               // the king's crown
+  sparkLife: 0.45,
+  sparkColor: 0xFFE39A,
+  sparkRise: 0.35,
+  flashPool: 4,
+  ringPool: 4,
+});
+
+const T = TUNING;
+
+const VERT = `
+attribute vec3 aDir;
+attribute float aSpawn;
+attribute float aLife;
+attribute float aSize;
+attribute float aRise;
+attribute vec3 aColor;
+uniform float uTime;
+uniform float uScale;
+varying float vAlpha;
+varying vec3 vColor;
+void main() {
+  float age = (uTime - aSpawn) / max(aLife, 0.001);
+  vColor = aColor;
+  if (age < 0.0 || age > 1.0) { gl_Position = vec4(2.0, 2.0, 2.0, 1.0); gl_PointSize = 0.0; vAlpha = 0.0; return; }
+  float reach = 1.0 - pow(1.0 - age, 2.2);
+  vec3 p = position + aDir * reach;
+  p.y += aRise * sin(3.14159 * min(age * 1.6, 1.0)) * (1.0 - age * 0.5);
+  vec4 mv = modelViewMatrix * vec4(p, 1.0);
+  float grow = 0.6 + 0.8 * reach;
+  gl_PointSize = aSize * grow * uScale / max(-mv.z, 0.05);
+  vAlpha = pow(1.0 - age, 1.4) * 0.85;
+  gl_Position = projectionMatrix * mv;
+}`;
+
+const FRAG = `
+varying float vAlpha;
+varying vec3 vColor;
+void main() {
+  float d = length(gl_PointCoord - 0.5) * 2.0;
+  float a = smoothstep(1.0, 0.3, d) * vAlpha;
+  if (a < 0.01) discard;
+  gl_FragColor = vec4(vColor, a);
+}`;
+
+function reduced() {
+  if (typeof window === 'undefined') return false;
+  const s = window.PBP && window.PBP.settings;
+  if ((s && s.reducedMotion) || (window.PBP && window.PBP.reducedMotion)) return true;
+  try { return !!window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches; }
+  catch { return false; }
+}
+
+export function createDust({ scene, bus = null }) {
+  let clock = 0;
+  let cursor = 0;
+  let bursts = 0;
+  const cream = new THREE.Color(T.colorCream);
+  const pink = new THREE.Color(T.colorPink);
+  const tmp = new THREE.Color();
+
+  // --- the motes ------------------------------------------------------------
+  const geo = new THREE.BufferGeometry();
+  const N = T.pool;
+  const pos = new Float32Array(N * 3);
+  const dir = new Float32Array(N * 3);
+  const spawn = new Float32Array(N).fill(-1e9);
+  const life = new Float32Array(N).fill(1);
+  const size = new Float32Array(N);
+  const rise = new Float32Array(N);
+  const color = new Float32Array(N * 3);
+  geo.setAttribute('position', new THREE.BufferAttribute(pos, 3));
+  geo.setAttribute('aDir', new THREE.BufferAttribute(dir, 3));
+  geo.setAttribute('aSpawn', new THREE.BufferAttribute(spawn, 1));
+  geo.setAttribute('aLife', new THREE.BufferAttribute(life, 1));
+  geo.setAttribute('aSize', new THREE.BufferAttribute(size, 1));
+  geo.setAttribute('aRise', new THREE.BufferAttribute(rise, 1));
+  geo.setAttribute('aColor', new THREE.BufferAttribute(color, 3));
+  geo.boundingSphere = new THREE.Sphere(new THREE.Vector3(0, 0.5, 0), 8);   // never culled
+  const uniforms = { uTime: { value: 0 }, uScale: { value: 400 } };
+  const motes = new THREE.Points(geo, new THREE.ShaderMaterial({
+    uniforms, vertexShader: VERT, fragmentShader: FRAG,
+    transparent: true, depthWrite: false, depthTest: true,
+  }));
+  motes.frustumCulled = false;
+  motes.renderOrder = 5;
+  motes.raycast = () => {};
+  scene.add(motes);
+
+  /** Write one mote into the next slot. */
+  function mote(x, y, z, dx, dy, dz, sz, up, lifeSec, col) {
+    const i = cursor++ % N;
+    pos[i * 3] = x; pos[i * 3 + 1] = y; pos[i * 3 + 2] = z;
+    dir[i * 3] = dx; dir[i * 3 + 1] = dy; dir[i * 3 + 2] = dz;
+    spawn[i] = clock;
+    life[i] = lifeSec;
+    size[i] = sz;
+    rise[i] = up;
+    color[i * 3] = col.r; color[i * 3 + 1] = col.g; color[i * 3 + 2] = col.b;
+  }
+
+  function upload() {
+    for (const a of Object.values(geo.attributes)) a.needsUpdate = true;
+  }
+
+  // --- flashes and rings ----------------------------------------------------
+  const flat = (geometry, hex, y) => {
+    const m = new THREE.Mesh(geometry, new THREE.MeshBasicMaterial({
+      color: hex, transparent: true, opacity: 0, depthWrite: false, fog: false, toneMapped: false,
+    }));
+    m.rotation.x = -Math.PI / 2;
+    m.position.y = y;
+    m.visible = false;
+    m.raycast = () => {};
+    m.renderOrder = 4;
+    scene.add(m);
+    return m;
+  };
+  const flashGeo = new THREE.PlaneGeometry(0.96, 0.96);
+  const ringGeo = new THREE.RingGeometry(0.42, 0.5, 48);
+  const flashes = Array.from({ length: T.flashPool }, () => ({ mesh: flat(flashGeo, T.flashColor, 0.004), t: 1e9, alpha: 0 }));
+  const rings = Array.from({ length: T.ringPool }, () => ({ mesh: flat(ringGeo, T.ringColor, 0.005), t: 1e9, gain: 1 }));
+  let fCursor = 0;
+  let rCursor = 0;
+
+  function flash(x, z, alpha) {
+    const f = flashes[fCursor++ % flashes.length];
+    f.mesh.position.set(x, 0.004, z);
+    f.mesh.visible = true;
+    f.t = 0; f.alpha = alpha;
+  }
+
+  function ring(x, z, gain) {
+    const r = rings[rCursor++ % rings.length];
+    r.mesh.position.set(x, 0.005, z);
+    r.mesh.visible = true;
+    r.t = 0; r.gain = gain;
+  }
+
+  // --- the landing ----------------------------------------------------------
+  /**
+   * A man has touched down. `at` is world x/y/z of his base, `height` his
+   * height in squares, `kind` one of 'move' | 'capture' | 'refused'.
+   */
+  function puff(at, height = 1, kind = 'move', type = null) {
+    const low = reduced();
+    const gain = kind === 'capture' ? T.captureGain : kind === 'refused' ? T.refusedGain : 1;
+    const h = Math.max(0.4, Math.min(1.6, height));
+    const n = Math.round((low ? T.countReduced : T.count) * (kind === 'capture' ? 1.4 : 1));
+    const lifeSec = low ? T.lifeReduced : T.life;
+    const reach = T.spread * h * gain * (low ? 0.6 : 1);
+    for (let i = 0; i < n; i++) {
+      const a = (i / n) * Math.PI * 2 + Math.random() * 0.5;
+      const d = reach * (0.7 + Math.random() * 0.6);
+      tmp.copy(cream).lerp(pink, Math.random());
+      mote(at.x + Math.cos(a) * 0.12, at.y + 0.03, at.z + Math.sin(a) * 0.12,
+        Math.cos(a) * d, 0, Math.sin(a) * d,
+        T.size * (0.7 + Math.random() * 0.6) * Math.sqrt(h) * gain, T.rise * (0.5 + Math.random()),
+        lifeSec * (0.8 + Math.random() * 0.4), tmp);
+    }
+    if (type === 'k' && !low) {
+      tmp.setHex(T.sparkColor);
+      for (let i = 0; i < T.sparks; i++) {
+        const a = Math.random() * Math.PI * 2;
+        const d = 0.08 + Math.random() * 0.12;
+        mote(at.x, at.y + h * 0.96, at.z, Math.cos(a) * d, 0.1, Math.sin(a) * d,
+          0.06 + Math.random() * 0.04, T.sparkRise * (0.6 + Math.random() * 0.6), T.sparkLife, tmp);
+      }
+    }
+    upload();
+    flash(at.x, at.z, T.flashAlpha * (low ? 0.5 : 1) * (kind === 'refused' ? 0.5 : 1));
+    if (!low && kind !== 'refused') ring(at.x, at.z, gain);
+    bursts++;
+  }
+
+  let unsub = null;
+  if (bus && typeof bus.on === 'function') {
+    unsub = bus.on('land', (p) => {
+      if (!p || !p.world) return;
+      puff(p.world, p.height, p.capture ? 'capture' : p.refused ? 'refused' : 'move', p.piece);
+    });
+  }
+
+  function update(dt, camera, renderer) {
+    clock += dt;
+    uniforms.uTime.value = clock;
+    if (camera && renderer) {
+      const hpx = renderer.domElement.height || 1;
+      uniforms.uScale.value = (hpx * (camera.projectionMatrix.elements[5] || 1)) / 2;
+    }
+    for (const f of flashes) {
+      if (!f.mesh.visible) continue;
+      f.t += dt;
+      const p = f.t / T.flashSec;
+      if (p >= 1) { f.mesh.visible = false; continue; }
+      f.mesh.material.opacity = f.alpha * (1 - p);
+    }
+    for (const r of rings) {
+      if (!r.mesh.visible) continue;
+      r.t += dt;
+      const p = r.t / T.ringSec;
+      if (p >= 1) { r.mesh.visible = false; continue; }
+      const s = THREE.MathUtils.lerp(T.ringFrom, T.ringTo * r.gain, 1 - Math.pow(1 - p, 2));
+      r.mesh.scale.setScalar(s * 2);   // the ring geometry is half a square across
+      r.mesh.material.opacity = T.ringAlpha * (1 - p);
+    }
+  }
+
+  return {
+    update, puff,
+    /** For the harness: how many bursts fired and how many motes are alive. */
+    stats() {
+      let alive = 0;
+      for (let i = 0; i < N; i++) if (clock - spawn[i] >= 0 && clock - spawn[i] <= life[i]) alive++;
+      return { bursts, alive, flashes: flashes.filter((f) => f.mesh.visible).length, rings: rings.filter((r) => r.mesh.visible).length, reduced: reduced(), clock };
+    },
+    dispose() {
+      if (unsub) unsub();
+      scene.remove(motes);
+      geo.dispose();
+      motes.material.dispose();
+      for (const f of flashes) { scene.remove(f.mesh); f.mesh.material.dispose(); }
+      for (const r of rings) { scene.remove(r.mesh); r.mesh.material.dispose(); }
+      flashGeo.dispose(); ringGeo.dispose();
+    },
+  };
+}

--- a/ConditioningControlPanel/Resources/web/piecebypiece/boot.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/boot.js
@@ -93,23 +93,28 @@ function main() {
   // --- J: the feel (outline, dust, sound) ---
   // Settings are merged, never replaced: the host bridge may have filled some.
   window.PBP.settings = Object.assign({ outline: true, sfxVolume: 0.6 }, window.PBP.settings || {});
+  anim.bindBus(bus, (v) => view.projectPoint(v));   // anim.js speaks `land` and `sunk`
   // Loaded late and guarded, so a missing module never holds the game. The
   // per-frame updates ride on view.render, which the loop calls last, after
-  // jiggle.update has written the flex the outline reads.
+  // jiggle.update has written the flex the outline reads; the dt is the
+  // loop's own (taken off view.update), so a stepped harness clock stays true.
   const feelLate = [];
-  let feelLast = performance.now();
+  let feelDt = 0;
+  const updateBase = view.update;
+  view.update = (dt) => { feelDt = dt; updateBase(dt); };
   const renderBase = view.render;
   view.render = () => {
-    const now = performance.now();
-    const dt = Math.min(0.1, (now - feelLast) / 1000);
-    feelLast = now;
-    for (const fn of feelLate) fn(dt);
+    for (const fn of feelLate) fn(feelDt);
     renderBase();
   };
   import('./board/outline.js').then((m) => {
     board.outline = m.createOutline({ group: view.pieceGroup, bus });
     feelLate.push((dt) => board.outline.update(dt, view.camera, view.renderer));
   }).catch((e) => console.warn('[pbp] outline missing', e));
+  import('./board/dust.js').then((m) => {
+    board.dust = m.createDust({ scene: view.scene, bus });
+    feelLate.push((dt) => board.dust.update(dt, view.camera, view.renderer));
+  }).catch((e) => console.warn('[pbp] dust missing', e));
   // --- end J ---
 
   let last = performance.now();

--- a/ConditioningControlPanel/Resources/web/piecebypiece/smoke/feel-shot.mjs
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/smoke/feel-shot.mjs
@@ -1,0 +1,240 @@
+/* ============================================================================
+ * smoke/feel-shot.mjs - proof that a landing pays out.
+ *
+ * Loads the board in headless msedge, takes the frame loop over (the same
+ * rAF hand-over jiggle-shot uses, so a screenshot never costs game time),
+ * drags a pawn and captures the frame right after it lands, dust mid-burst;
+ * then loads a position with a take on the board and does it again. Every
+ * `land` the bus carries is logged with its payload, the dust reports how many
+ * motes are alive, and reduced motion is checked to puff smaller.
+ *
+ *   node smoke/feel-shot.mjs [--url <page url>] [--out <dir>] [--wait <ms>]
+ *
+ * Needs a static server on the web root, for example:
+ *   python -m http.server 8825   (run from Resources/web)
+ * Exits non-zero when the page logged an error, when no `land` arrived, or
+ * when the dust did not burst.
+ * ==========================================================================*/
+
+import { spawn } from 'node:child_process';
+import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const EDGE = process.env.PBP_EDGE
+  || 'C:/Program Files (x86)/Microsoft/Edge/Application/msedge.exe';
+
+function arg(name, fallback) {
+  const i = process.argv.indexOf('--' + name);
+  return i > -1 && process.argv[i + 1] ? process.argv[i + 1] : fallback;
+}
+
+const url = arg('url', 'http://localhost:8825/piecebypiece/index.html?hotseat=1');
+const outDir = arg('out', 'C:/Users/PC/Pictures/Screenshots/piecebypiece/j');
+const waitMs = Number(arg('wait', '6000'));
+const port = Number(arg('port', '9251'));   // off the lanes' shared 922x range, one browser per port
+// white to move with e4xd5 on the board
+const CAPTURE_FEN = 'rnbqkbnr/ppp1pppp/8/3p4/4P3/8/PPPP1PPP/RNBQKBNR w KQkq - 0 2';
+
+const profile = join(tmpdir(), 'pbp-feel-' + Date.now());
+const edge = spawn(EDGE, [
+  '--headless=new', '--remote-debugging-port=' + port, '--user-data-dir=' + profile,
+  '--window-size=1280,860', '--hide-scrollbars', '--no-first-run', '--no-default-browser-check',
+  '--disable-extensions', '--use-gl=angle', '--use-angle=swiftshader', '--enable-unsafe-swiftshader',
+], { stdio: 'ignore' });
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function target() {
+  for (let i = 0; i < 60; i++) {
+    try {
+      const res = await fetch(`http://127.0.0.1:${port}/json/new?about:blank`, { method: 'PUT' });
+      if (res.ok) return (await res.json()).webSocketDebuggerUrl;
+    } catch { /* browser still starting */ }
+    await sleep(250);
+  }
+  throw new Error('headless msedge did not open a debugging port');
+}
+
+function client(ws) {
+  let id = 0;
+  const pending = new Map();
+  const events = [];
+  ws.addEventListener('message', (ev) => {
+    const msg = JSON.parse(ev.data);
+    if (msg.id && pending.has(msg.id)) { pending.get(msg.id)(msg.result); pending.delete(msg.id); }
+    else if (msg.method) events.push(msg);
+  });
+  return {
+    events,
+    send(method, params = {}) {
+      const n = ++id;
+      ws.send(JSON.stringify({ id: n, method, params }));
+      return new Promise((res) => pending.set(n, res));
+    },
+  };
+}
+
+let cdp = null;
+let failed = false;
+
+async function evalJs(expression) {
+  const r = await cdp.send('Runtime.evaluate', { expression, returnByValue: true, awaitPromise: true });
+  if (r.exceptionDetails) throw new Error(r.exceptionDetails.exception?.description || r.exceptionDetails.text);
+  return r.result?.value;
+}
+
+async function shot(name, clip = null) {
+  const s = await cdp.send('Page.captureScreenshot', clip ? { format: 'png', clip } : { format: 'png' });
+  const path = join(outDir, name);
+  writeFileSync(path, Buffer.from(s.data, 'base64'));
+  return path;
+}
+
+const HIJACK = "window.__pbp = null; (async () => {"
+  + " let q = [];"
+  + " window.requestAnimationFrame = (fn) => { q.push(fn); return q.length; };"
+  + " window.cancelAnimationFrame = () => {};"
+  + " await new Promise((r) => setTimeout(r, 400));"
+  + " let t = performance.now();"
+  + " window.__pbp = { step(ms, n) { for (let i = 0; i < n; i++) { t += ms; const c = q; q = []; for (const fn of c) fn(t); } return q.length; } };"
+  + " return q.length; })()";
+const beat = (ms) => evalJs(`window.__pbp.step(16.667, ${Math.max(1, Math.round(ms / 16.667))})`);
+
+const at = async (sq, height) => JSON.parse(await evalJs(
+  `JSON.stringify(window.PBP.board.projectSquare('${sq}', ${height}))`));
+async function mouse(type, x, y) {
+  return cdp.send('Input.dispatchMouseEvent', {
+    type, x, y, button: 'left', buttons: type === 'mouseReleased' ? 0 : 1, clickCount: 1, pointerType: 'mouse',
+  });
+}
+async function closeUp(sq, height = 0.4) {
+  const p = await at(sq, height);
+  return { x: Math.max(0, p.x - 120), y: Math.max(0, p.y - 120), width: 240, height: 220, scale: 2.5 };
+}
+
+/** Load a page, hand the loop over, and start recording `land`. */
+async function open(pageUrl) {
+  await cdp.send('Page.navigate', { url: pageUrl });
+  await sleep(waitMs);
+  await evalJs('window.PBP.ramp && window.PBP.ramp.setEnabled(false)');
+  await evalJs('window.PBP.board.setWobble(0); window.PBP.board.setCameraSway(0)');
+  await evalJs("window.__land = []; window.PBP.bus.on('land', (p) => window.__land.push(p));");
+  const queued = await evalJs(HIJACK);
+  if (!queued) { console.log('ERROR the frame loop did not hand over'); failed = true; }
+  await beat(200);
+}
+
+async function drag(from, to) {
+  const a = await at(from, 0.45);
+  const b = await at(to, 0);
+  await mouse('mousePressed', a.x, a.y);
+  for (let i = 1; i <= 8; i++) {
+    await mouse('mouseMoved', a.x + (b.x - a.x) * (i / 8), a.y + (b.y - a.y) * (i / 8));
+    await beat(35);
+  }
+  await mouse('mouseReleased', b.x, b.y);
+}
+
+const dust = () => evalJs('JSON.stringify(window.PBP.board.dust && window.PBP.board.dust.stats())').then(JSON.parse);
+const lands = () => evalJs('JSON.stringify(window.__land)').then(JSON.parse);
+
+async function main() {
+  mkdirSync(outDir, { recursive: true });
+  const wsUrl = await target();
+  const ws = new WebSocket(wsUrl);
+  await new Promise((res, rej) => {
+    ws.addEventListener('open', res, { once: true });
+    ws.addEventListener('error', rej, { once: true });
+  });
+  cdp = client(ws);
+  await cdp.send('Runtime.enable');
+  await cdp.send('Log.enable');
+  await cdp.send('Page.enable');
+
+  // --- 1. a plain move: land, then the dust a few frames in -----------------
+  await open(url);
+  await drag('e2', 'e4');
+  await beat(300);            // the slide is 0.30 s
+  await beat(90);             // dust is 90 ms into its half second
+  let d = await dust();
+  let l = await lands();
+  console.log('move landed: ' + JSON.stringify(l[l.length - 1]));
+  console.log('dust after the move: ' + JSON.stringify(d));
+  console.log('  ' + await shot('dust-land.png') + ' ' + await shot('dust-land-near.png', await closeUp('e4')));
+  if (!l.length) { console.log('ERROR no land event'); failed = true; }
+  if (!d || d.bursts < 1 || d.alive < 6) { console.log('ERROR the dust did not burst'); failed = true; }
+  await beat(600);
+  d = await dust();
+  console.log('dust settled: ' + JSON.stringify(d));
+  if (d && d.alive !== 0) { console.log('ERROR motes never die'); failed = true; }
+
+  // --- 2. a refused drop: a shrug of dust, flagged refused -------------------
+  // black to move now, so it is a black pawn that gets told no
+  await drag('d7', 'd3');
+  await beat(400);
+  l = await lands();
+  const refused = l[l.length - 1];
+  console.log('refused landing: ' + JSON.stringify(refused));
+  if (!refused || !refused.refused) { console.log('ERROR the spring-back did not land as refused'); failed = true; }
+
+  // --- 3. a capture: bigger, and the payload says so -------------------------
+  const sep = url.includes('?') ? '&' : '?';
+  await open(url + sep + 'fen=' + encodeURIComponent(CAPTURE_FEN));
+  await drag('e4', 'd5');
+  await beat(300);
+  await beat(70);
+  d = await dust();
+  l = await lands();
+  const take = l[l.length - 1];
+  console.log('capture landed: ' + JSON.stringify(take));
+  console.log('dust after the take: ' + JSON.stringify(d));
+  console.log('  ' + await shot('dust-capture.png') + ' ' + await shot('dust-capture-near.png', await closeUp('d5')));
+  if (!take || !take.capture) { console.log('ERROR the capture did not land as a capture'); failed = true; }
+  await beat(900);
+
+  // --- 4. reduced motion puffs smaller ---------------------------------------
+  await evalJs('window.PBP.reducedMotion = true; window.PBP.board.dust.puff({x:0,y:0,z:0}, 1, "move")');
+  await beat(40);
+  d = await dust();
+  console.log('reduced motion puff: ' + JSON.stringify(d));
+  if (!d.reduced || d.alive > 8 || d.rings > 0) { console.log('ERROR reduced motion did not take'); failed = true; }
+  await evalJs('window.PBP.reducedMotion = false');
+
+  // --- 5. what it costs ------------------------------------------------------
+  const cost = await evalJs(`(() => {
+    const b = window.PBP.board; const v = b.view;
+    for (let i = 0; i < 8; i++) b.dust.puff({x: (i % 8) - 3.5, y: 0, z: 0}, 1, i % 3 ? 'move' : 'capture', 'k');
+    const t = performance.now();
+    for (let i = 0; i < 300; i++) b.dust.update(0.016, v.camera, v.renderer);
+    return JSON.stringify({ updateMs: (performance.now() - t) / 300, alive: b.dust.stats().alive, calls: v.renderer.info.render.calls });
+  })()`);
+  console.log('dust cost: ' + cost);
+
+  const problems = [];
+  for (const ev of cdp.events) {
+    if (ev.method === 'Runtime.exceptionThrown') {
+      const x = ev.params.exceptionDetails;
+      problems.push('exception: ' + (x.exception?.description || x.text));
+    } else if (ev.method === 'Runtime.consoleAPICalled' && ev.params.type === 'error') {
+      problems.push('console.error: ' + ev.params.args.map((a) => a.description || a.value).join(' '));
+    } else if (ev.method === 'Log.entryAdded' && ev.params.entry.level === 'error'
+               && ev.params.entry.source !== 'network') {
+      problems.push('log: ' + ev.params.entry.text);
+    }
+  }
+  ws.close();
+  edge.kill();
+  try { rmSync(profile, { recursive: true, force: true }); } catch { /* disposable */ }
+  if (problems.length || failed) {
+    for (const p of problems) console.log('ERROR ' + p);
+    process.exit(1);
+  }
+  console.log('feel shot done, no console errors');
+}
+
+main().catch((err) => {
+  console.error(err.message || err);
+  edge.kill();
+  process.exit(2);
+});


### PR DESCRIPTION
Lane J, second of three (stacked on #980). A landing pays out: dust, a flash of the square and a ripple, sized to the man and the moment.

## What it does
- `board/anim.js` (my marked hooks): `anim.bindBus(bus, project)` makes the board speak. `land` fires the frame a flight ends, with `{square, piece, side, capture, refused, height, world, screen}`; a refused drop's spring-back lands too, flagged `refused: true`; `sunk` fires when a tumbled man is gone. Emitted from anim.js, so a future Blender capture clip only has to emit `land` at the frame of contact and the dust and the thud keep working. hotseat.js is not touched.
- NEW `board/dust.js`: listens to `land`. 14 motes (cream, pink, and the odd hot-pink one) in a low ring around the base, up and out and down, 0.5 s, plus a soft flash disc on the square (0.14 s) and a ripple ring (0.35 to 0.9 squares, 0.42 s). Capture: 1.6x the motes and a wider ring. Refused drop: a shrug at 0.45x, no ring. King: 8 sparks rising to a crown. Every mote on the board is ONE `THREE.Points` draw over a 256 ring buffer; the shader animates from a spawn time, so the JS per frame is bookkeeping only. Flashes and rings are pooled (4 each). Frozen TUNING at the top.
- Reduced motion (`settings.reducedMotion`, `window.PBP.reducedMotion`, or the media query): 6 motes, half the life, no ring.
- `boot.js`: the same single J block grows by the `bindBus` line and the dust import; the per-frame dt now comes off `view.update` (the loop's own) rather than `performance.now()`, so a stepped harness clock stays true.

## Proof (looked at)
- `C:\Users\PC\Pictures\Screenshots\piecebypiece\j\dust-land-near.png` and `dust-land.png`: e2e4, frame 90 ms after touchdown, flash disc + ring + motes around the pawn.
- `dust-capture-near.png` and `dust-capture.png`: e4xd5, the wider ring, 20 motes.
- NEW `smoke/feel-shot.mjs` (headless msedge on its own port 9251): move lands with `capture:false` and 14 motes alive that all die by 0.6 s; a black pawn dragged d7 to d3 springs back and lands `refused:true`; the take lands `capture:true` at d5 with 20 motes; reduced motion puffs 6 motes and no ring; no console errors.
- Cost: dust.update 0.001 ms/frame with 8 bursts live; 1 extra draw call for the motes, up to 8 more while flashes and rings are visible.
- rules-smoke 43/43 (unchanged rules).

## Not in this PR
Sound (next PR). No change to drag.js, jiggle.js, pieces.js, scene.js, hotseat.js, index.html or styles.css.

## Touches outside my lane
None. The anim.js hooks are the lane's marked block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CQdAN3aDyhnnXWjBtkH1mD
