### PR TITLE
feat(pbp): hold the man where you grabbed him, mark his moves

### DIFF
--- a/ConditioningControlPanel/Resources/web/piecebypiece/board/drag.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/board/drag.js
@@ -1,109 +1,189 @@
 /* ============================================================================
  * board/drag.js - picking a man up and putting him down.
  *
- * Pointer down raycasts the men, the held piece follows the cursor a beat
- * behind and hangs above the board, the squares it may legally land on glow,
- * and a drop either snaps home or springs back with a wobble. The screen
- * position of the held piece goes out on the bus every frame so the effects
- * layer can draw over it.
+ * Pointer down raycasts the men, and the spot on his body the ray struck is
+ * remembered: from then on that spot rides under the cursor, so a held man is
+ * in your hand rather than floating over it. He is lifted just enough to skim
+ * the tops of the others, his base tells you which square he would land on,
+ * and board/markers.js draws a dot on every square he may reach and a red ring
+ * around every man he may take. A drop either plays the move or springs back
+ * with a wobble. The screen position of the held piece goes out on the bus
+ * every frame so the effects layer can draw over it.
  * ==========================================================================*/
 
 import * as THREE from 'three';
-import { worldToSquare } from './scene.js';
+import { worldToSquare, squareToWorld } from './scene.js';
+import { createMarkers } from './markers.js';
 
-const LIFT = 1.15;      // how high above the board a held piece rides
+const LIFT = 0.52;      // how high above the board a held man rides
 const LAG = 11;         // follow stiffness; lower is lazier
 const TILT = 0.22;      // how far it leans into the direction of travel
+const GRAB_MAX = 0.75;  // highest point on a man the hand is allowed to hold
+const GRAB_MID = 0.45;  // where the hand lands when the square, not the man, was hit
 
 export function createDrag({ view, pieces, anim, bus, game, jiggle = null }) {
   const canvas = view.renderer.domElement;
   const ray = new THREE.Raycaster();
   const ndc = new THREE.Vector2();
-  const plane = new THREE.Plane(new THREE.Vector3(0, 1, 0), 0);
+  const ground = new THREE.Plane(new THREE.Vector3(0, 1, 0), 0);
+  const holdPlane = new THREE.Plane(new THREE.Vector3(0, 1, 0), 0);
   const hit = new THREE.Vector3();
   const target = new THREE.Vector3();
+  const grab = new THREE.Vector2();   // piece origin minus the grabbed point, in x/z
+
+  const markers = createMarkers({ group: view.boardGroup });
+  if (view.setHighlightSink) view.setHighlightSink(markers.show);
 
   let held = null;        // the piece object under the cursor
   let from = null;        // the square it was picked up from
-  let legal = [];
+  let legal = [];         // every square it may land on
+  let takes = new Set();  // the ones holding a man it may take
   let hover = null;
+  let holdY = LIFT;       // world height of the plane the cursor drags along
+  const at = { x: 0, y: 0 };   // last pointer position, in client pixels
 
   function toNdc(ev) {
+    if (ev) { at.x = ev.clientX; at.y = ev.clientY; }
     const r = canvas.getBoundingClientRect();
-    ndc.set(((ev.clientX - r.left) / r.width) * 2 - 1, -((ev.clientY - r.top) / r.height) * 2 + 1);
+    ndc.set(((at.x - r.left) / r.width) * 2 - 1, -((at.y - r.top) / r.height) * 2 + 1);
     ray.setFromCamera(ndc, view.camera);
   }
 
   /** Where the cursor meets the board, as a square name (or null, off board). */
   function squareUnder(ev) {
     toNdc(ev);
-    if (!ray.ray.intersectPlane(plane, hit)) return null;
+    if (!ray.ray.intersectPlane(ground, hit)) return null;
     return worldToSquare(hit.x, hit.z);
   }
 
+  /** The man under the cursor, and the point on him the ray landed on. */
   function pieceUnder(ev) {
     toNdc(ev);
     const hits = ray.intersectObjects(view.pieceGroup.children, true);
     for (const h of hits) {
       let node = h.object;
       while (node && node.parent !== view.pieceGroup) node = node.parent;
-      if (node && node.userData.square) return node;
+      if (node && node.userData.square) return { piece: node, point: h.point };
     }
     return null;
   }
 
-  function glow() {
-    view.setHighlights(legal.map((sq) => ({
+  /**
+   * Aim the held man at the cursor. The ray is cut with a horizontal plane at
+   * the height of the spot that was grabbed, not with the board, so that spot
+   * stays under the cursor whatever angle the camera sits at. The man hangs off
+   * it by the offset the grab recorded, which leaves his base over the square
+   * the markers say he is going to. Called with no event it re-uses the last
+   * pointer position, which is how the camera can sway under a still cursor
+   * without the man sliding out of your hand.
+   */
+  function aim(ev) {
+    toNdc(ev);
+    holdPlane.constant = -holdY;
+    if (!ray.ray.intersectPlane(holdPlane, hit)) return false;
+    target.set(hit.x + grab.x, LIFT, hit.z + grab.y);
+    return true;
+  }
+
+  /** The square the held man is standing over right now. */
+  function overSquare() {
+    return worldToSquare(target.x, target.z);
+  }
+
+  function paint() {
+    const list = legal.map((sq) => ({
       square: sq,
-      color: sq === hover ? 0xFFFFFF : 0xFF3FA4,
-      glow: sq === hover ? 0.85 : 0.42,
-    })));
+      kind: takes.has(sq) ? 'capture' : 'move',
+      hover: sq === hover,
+    }));
+    if (from) list.push({ square: from, kind: 'origin' });
+    markers.show(list);
+  }
+
+  /**
+   * chess.js hands back a flag string per move: 'c' is a capture and 'e' is en
+   * passant, which takes a man standing on a square the pawn does not land on.
+   * Castling ('k' and 'q') takes nothing, so it stays a plain dot.
+   */
+  function readMoves(sq) {
+    const rules = game.rules;
+    const verbose = rules && rules.movesFrom ? rules.movesFrom(sq) : [];
+    if (!verbose.length) return { squares: game.legalTargets(sq), captures: new Set() };
+    const captures = new Set();
+    for (const m of verbose) {
+      const flags = String(m.flags || '');
+      if (m.captured || flags.includes('c') || flags.includes('e')) captures.add(m.to);
+    }
+    return { squares: verbose.map((m) => m.to), captures };
   }
 
   function onDown(ev) {
     if (held || ev.button > 0) return;
-    const square = squareUnder(ev);
-    const piece = pieceUnder(ev) || (square ? pieces.pieceAt(square) : null);
+    const found = pieceUnder(ev);
+    const square = found ? null : squareUnder(ev);
+    const piece = found ? found.piece : (square ? pieces.pieceAt(square) : null);
     if (!piece || !piece.userData.square) return;
     const sq = piece.userData.square;
     if (!game.canPick(sq)) return;
 
     held = piece;
     from = sq;
-    legal = game.legalTargets(sq);
+    const moves = readMoves(sq);
+    legal = moves.squares;
+    takes = moves.captures;
     hover = null;
     held.userData.held = true;
     held.userData.busy = true;
     if (jiggle) jiggle.grab(held);   // lifted off the board, so the tip sags
+
+    // Hold him where he was actually grabbed. A hit on the body gives the exact
+    // spot; the square fallback (a click that slipped past the mesh) takes him
+    // around the middle. The height is capped, so grabbing a king by his crown
+    // does not swing his base half a board away from the cursor.
+    const base = squareToWorld(sq, 0);
+    if (found) {
+      grab.set(base.x - found.point.x, base.z - found.point.z);
+      holdY = LIFT + THREE.MathUtils.clamp(found.point.y - piece.position.y, 0.04, GRAB_MAX);
+    } else {
+      grab.set(0, 0);
+      holdY = LIFT + Math.min(GRAB_MAX, GRAB_MID * (piece.userData.scaleBase || 1));
+    }
     target.copy(held.position);
-    glow();
-    canvas.setPointerCapture?.(ev.pointerId);
+    aim(ev);                     // so he lifts on the click, not on the first move
+    const on = overSquare();
+    hover = legal.includes(on) ? on : null;
+    paint();
+    // A synthetic pointer (the smoke harness, some remote-control paths) has no
+    // capture to take, and asking for one throws.
+    try { canvas.setPointerCapture(ev.pointerId); } catch { /* nothing to hold */ }
     bus.emit('grab', { square: sq, piece: piece.userData.type, screen: view.projectPoint(held.position) });
     ev.preventDefault();
   }
 
   function onMove(ev) {
     if (!held) return;
-    toNdc(ev);
-    if (ray.ray.intersectPlane(plane, hit)) target.set(hit.x, LIFT, hit.z);
-    const next = worldToSquare(hit.x, hit.z);
-    if (next !== hover) { hover = legal.includes(next) ? next : null; glow(); }
+    if (!aim(ev)) return;
+    const next = overSquare();
+    const want = legal.includes(next) ? next : null;
+    if (want !== hover) { hover = want; paint(); }
   }
 
   function onUp(ev) {
     if (!held) return;
     const piece = held;
     const start = from;
-    const to = squareUnder(ev);
+    aim(ev);
+    const to = overSquare();
     held = null;
     from = null;
     hover = null;
     legal = [];
-    view.setHighlights([]);
+    takes = new Set();
+    markers.clear();
     piece.userData.held = false;
     piece.rotation.x = 0;
     piece.rotation.z = 0;
-    canvas.releasePointerCapture?.(ev.pointerId);
+    try { canvas.releasePointerCapture(ev.pointerId); } catch { /* never taken */ }
 
     // A legal drop is played by the game, which moves the man and lets anim.js
     // fly it down from where it was being held.
@@ -119,8 +199,8 @@ export function createDrag({ view, pieces, anim, bus, game, jiggle = null }) {
   function onCancel() {
     if (!held) return;
     const piece = held;
-    held = null; from = null; hover = null; legal = [];
-    view.setHighlights([]);
+    held = null; from = null; hover = null; legal = []; takes = new Set();
+    markers.clear();
     piece.userData.held = false;
     piece.rotation.x = 0;
     piece.rotation.z = 0;
@@ -130,7 +210,15 @@ export function createDrag({ view, pieces, anim, bus, game, jiggle = null }) {
 
   /** Lagged follow, a lean into the travel, and the per-frame screen ping. */
   function update(dt) {
+    markers.update(dt);
     if (!held) return;
+    // The camera sways, so where the cursor points moves even when it does not.
+    const was = hover;
+    if (aim(null)) {
+      const next = overSquare();
+      hover = legal.includes(next) ? next : null;
+      if (hover !== was) paint();
+    }
     const k = 1 - Math.exp(-LAG * dt);
     const dx = target.x - held.position.x;
     const dz = target.z - held.position.z;
@@ -152,13 +240,20 @@ export function createDrag({ view, pieces, anim, bus, game, jiggle = null }) {
 
   return {
     update,
+    markers,
     isDragging: () => !!held,
+    // The height of the plane the cursor is dragging along. The screenshot
+    // harness aims its release with this, because board level is no longer
+    // where the held man is.
+    holdHeight: () => (held ? holdY : 0),
     dispose() {
       canvas.removeEventListener('pointerdown', onDown);
       canvas.removeEventListener('pointermove', onMove);
       canvas.removeEventListener('pointerup', onUp);
       canvas.removeEventListener('pointercancel', onCancel);
       window.removeEventListener('blur', onCancel);
+      if (view.setHighlightSink) view.setHighlightSink(null);
+      markers.dispose();
     },
   };
 }

--- a/ConditioningControlPanel/Resources/web/piecebypiece/board/markers.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/board/markers.js
@@ -1,0 +1,210 @@
+/* ============================================================================
+ * board/markers.js - where the man in your hand may land.
+ *
+ * The old hint was an emissive tint on the square itself, which is invisible on
+ * a board made of pink and cream. These are objects instead: a soft dot resting
+ * over every empty square the held man may move to, and a red ring drawn around
+ * any man he may take (en passant counts, and its ring sits on the square the
+ * victim actually stands on). The square he was picked up from gets a faint
+ * outline, so it is clear where putting him back means.
+ *
+ * Wiring:
+ *   drag.js   builds one of these, calls show() on pick up and on hover, and
+ *             pumps update(dt) from its own frame step
+ *   scene.js  setHighlights() forwards here through setHighlightSink(), so a
+ *             caller that only holds the view still lights squares up
+ *
+ * Markers never take a raycast (drag.js picks men, and a marker lying over a
+ * square must not shadow the man standing on it) and they neither cast nor
+ * receive shadows. Everything is unlit MeshBasicMaterial, so a marker reads the
+ * same under the key light and out in the rim light's shade.
+ * ==========================================================================*/
+
+import * as THREE from 'three';
+import { squareToWorld } from './scene.js';
+
+/** Every number that decides how a hint looks. One place, on purpose. */
+export const TUNING = Object.freeze({
+  y: 0.012,            // a hair over the board top, which is y = 0
+  popIn: 0.12,         // s, how long a marker takes to arrive
+  fadeOut: 0.16,       // s, and how long it takes to leave
+  overshoot: 1.7,      // back-ease on the pop; 0 would be a plain ease
+  hoverEase: 16,       // per second, how fast a marker reacts to the cursor
+  hoverScale: 1.34,    // how much bigger the one under the cursor gets
+  hoverGlow: 1.55,     // and how much brighter
+  pulseAmp: 0.035,     // idle breathe, so a live hint never looks like a decal
+  pulseFreq: 1.5,
+  dotRadius: 0.15,
+  glowSize: 0.92,      // the soft halo plane under a dot or a ring
+  ringInner: 0.33,
+  ringOuter: 0.425,
+  originInner: 0.40,
+  originOuter: 0.435,
+  moveColor: 0xFFF1DA,     // cream core
+  moveGlow: 0xFF8FCB,      // pink halo
+  moveOpacity: 0.92,
+  moveGlowOpacity: 0.5,
+  captureColor: 0xFF2E4F,  // the ring around a man you may take
+  captureGlow: 0xFF1F44,
+  captureOpacity: 0.95,
+  captureGlowOpacity: 0.42,
+  originColor: 0xF7E7CC,
+  originOpacity: 0.3,
+});
+
+const T = TUNING;
+const NOPE = () => {};      // markers are not pickable, ever
+
+function reducedMotion() {
+  if (typeof window === 'undefined') return false;
+  const pbp = window.PBP;
+  if (pbp && (pbp.reducedMotion || (pbp.settings && pbp.settings.reducedMotion))) return true;
+  try { return !!window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches; }
+  catch { return false; }
+}
+
+/** Back-ease: a marker arrives a touch too big and settles. */
+function pop(t) {
+  const c = T.overshoot;
+  const u = t - 1;
+  return 1 + (c + 1) * u * u * u + c * u * u;
+}
+
+/** A radial gradient, so the halo has no edge to give itself away. */
+function glowTexture() {
+  const size = 64;
+  const cv = document.createElement('canvas');
+  cv.width = size;
+  cv.height = size;
+  const ctx = cv.getContext('2d');
+  const g = ctx.createRadialGradient(size / 2, size / 2, 0, size / 2, size / 2, size / 2);
+  g.addColorStop(0, 'rgba(255,255,255,1)');
+  g.addColorStop(0.45, 'rgba(255,255,255,0.55)');
+  g.addColorStop(1, 'rgba(255,255,255,0)');
+  ctx.fillStyle = g;
+  ctx.fillRect(0, 0, size, size);
+  const tex = new THREE.CanvasTexture(cv);
+  tex.colorSpace = THREE.SRGBColorSpace;
+  return tex;
+}
+
+export function createMarkers({ group }) {
+  const root = new THREE.Group();
+  root.name = 'pbp-markers';
+  group.add(root);
+
+  const tex = glowTexture();
+  const geo = {
+    dot: new THREE.CircleGeometry(T.dotRadius, 28).rotateX(-Math.PI / 2),
+    glow: new THREE.PlaneGeometry(T.glowSize, T.glowSize).rotateX(-Math.PI / 2),
+    ring: new THREE.RingGeometry(T.ringInner, T.ringOuter, 44).rotateX(-Math.PI / 2),
+    origin: new THREE.RingGeometry(T.originInner, T.originOuter, 44).rotateX(-Math.PI / 2),
+  };
+
+  const live = new Map();   // square -> marker
+  const dying = [];
+  let clock = 0;
+
+  function layer(marker, key, color, opacity, mapped) {
+    const material = new THREE.MeshBasicMaterial({
+      color, transparent: true, opacity, depthWrite: false, fog: false,
+      toneMapped: false, side: THREE.DoubleSide, map: mapped ? tex : null,
+    });
+    const mesh = new THREE.Mesh(geo[key], material);
+    mesh.raycast = NOPE;
+    mesh.castShadow = false;
+    mesh.receiveShadow = false;
+    mesh.renderOrder = 3;
+    marker.node.add(mesh);
+    marker.parts.push({ material, base: opacity });
+  }
+
+  function build(square, kind) {
+    const still = reducedMotion();
+    const m = {
+      square, kind, node: new THREE.Group(), parts: [],
+      t: still ? 1 : 0, hover: 0, want: 0, phase: Math.random() * 6.283,
+    };
+    m.node.raycast = NOPE;
+    if (kind === 'capture') {
+      layer(m, 'glow', T.captureGlow, T.captureGlowOpacity, true);
+      layer(m, 'ring', T.captureColor, T.captureOpacity, false);
+    } else if (kind === 'origin') {
+      layer(m, 'origin', T.originColor, T.originOpacity, false);
+    } else {
+      layer(m, 'glow', T.moveGlow, T.moveGlowOpacity, true);
+      layer(m, 'dot', T.moveColor, T.moveOpacity, false);
+    }
+    m.node.position.copy(squareToWorld(square, T.y));
+    m.node.scale.setScalar(still ? 1 : 0.001);
+    root.add(m.node);
+    return m;
+  }
+
+  function drop(m) {
+    for (const part of m.parts) part.material.dispose();
+    root.remove(m.node);
+  }
+
+  /**
+   * Set the whole hint layer at once. `list` is
+   *   [{ square, kind: 'move' | 'capture' | 'origin', hover: boolean }]
+   * A square that is already showing the same kind stays put and keeps its pop,
+   * so moving the cursor does not restart every animation. `kind` is optional
+   * and falls back to a plain move, which is what an older caller passes.
+   */
+  function show(list = []) {
+    const want = new Map();
+    for (const hint of list) {
+      if (hint && hint.square) want.set(hint.square, hint);
+    }
+    for (const [square, m] of [...live]) {
+      const hint = want.get(square);
+      if (hint && (hint.kind || 'move') === m.kind) continue;
+      live.delete(square);
+      if (reducedMotion()) drop(m); else dying.push(m);
+    }
+    for (const [square, hint] of want) {
+      let m = live.get(square);
+      if (!m) { m = build(square, hint.kind || 'move'); live.set(square, m); }
+      m.want = hint.hover ? 1 : 0;
+      if (reducedMotion()) m.hover = m.want;
+    }
+  }
+
+  function clear() { show([]); }
+
+  function update(dt) {
+    clock += dt;
+    const still = reducedMotion();
+    const k = still ? 1 : 1 - Math.exp(-T.hoverEase * dt);
+    for (const m of live.values()) {
+      if (m.t < 1) m.t = still ? 1 : Math.min(1, m.t + dt / T.popIn);
+      m.hover += (m.want - m.hover) * k;
+      const breathe = still ? 1 : 1 + Math.sin(clock * T.pulseFreq * 6.283 + m.phase) * T.pulseAmp;
+      const grow = 1 + m.hover * (T.hoverScale - 1);
+      m.node.scale.setScalar(Math.max(0.001, pop(m.t) * grow * breathe));
+      const lift = 1 + m.hover * (T.hoverGlow - 1);
+      for (const part of m.parts) part.material.opacity = Math.min(1, part.base * m.t * lift);
+    }
+    for (let i = dying.length - 1; i >= 0; i--) {
+      const m = dying[i];
+      m.t -= dt / T.fadeOut;
+      if (m.t <= 0) { drop(m); dying.splice(i, 1); continue; }
+      m.node.scale.setScalar(Math.max(0.001, m.t));
+      for (const part of m.parts) part.material.opacity = part.base * m.t;
+    }
+  }
+
+  function dispose() {
+    for (const m of live.values()) drop(m);
+    for (const m of dying) drop(m);
+    live.clear();
+    dying.length = 0;
+    for (const key of Object.keys(geo)) geo[key].dispose();
+    tex.dispose();
+    if (root.parent) root.parent.remove(root);
+  }
+
+  return { show, clear, update, dispose, root, count: () => live.size };
+}

--- a/ConditioningControlPanel/Resources/web/piecebypiece/board/scene.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/board/scene.js
@@ -91,21 +91,22 @@ export function createScene({ canvas }) {
     }
   }
 
-  /** Tint squares for legal-move hints. `list` is [{square, color, glow}]. */
-  const tinted = new Set();
+  /**
+   * Legal-move hints. `list` is [{square, kind, hover}]; the hints themselves
+   * are objects standing on the board, drawn by board/markers.js, because an
+   * emissive tint on a pink or cream square cannot be seen. drag.js owns the
+   * markers and installs them here, so a caller holding only the view (the
+   * effects layer, through board.setHighlights) still lights squares up.
+   */
+  let markerSink = null;
+  let waiting = null;
   function setHighlights(list = []) {
-    for (const name of tinted) {
-      const m = squares.get(name);
-      if (m) m.material.emissive.setHex(0x000000);
-    }
-    tinted.clear();
-    for (const hit of list) {
-      const m = squares.get(hit.square);
-      if (!m) continue;
-      m.material.emissive.setHex(hit.color ?? 0xFF3FA4);
-      m.material.emissiveIntensity = hit.glow ?? 0.45;
-      tinted.add(hit.square);
-    }
+    if (markerSink) markerSink(list);
+    else waiting = list;          // asked before the markers existed; keep it
+  }
+  function setHighlightSink(fn) {
+    markerSink = fn || null;
+    if (markerSink && waiting) { markerSink(waiting); waiting = null; }
   }
 
   // --- camera rig -----------------------------------------------------------
@@ -181,7 +182,7 @@ export function createScene({ canvas }) {
   return {
     renderer, scene, camera, boardGroup, pieceGroup, squares,
     update, render, resize, dispose,
-    setSide, setHighlights, projectPoint, projectSquare,
+    setSide, setHighlights, setHighlightSink, projectPoint, projectSquare,
     setCameraSway(v) { sway = Math.max(0, Math.min(1, Number(v) || 0)); },
   };
 }

--- a/ConditioningControlPanel/Resources/web/piecebypiece/smoke/jiggle-shot.mjs
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/smoke/jiggle-shot.mjs
@@ -178,8 +178,11 @@ async function main() {
 
   // --- 2. a drag, held then dropped ----------------------------------------
   const a = await at('e2', 0.45);
-  const b = await at('e4', 0);
   await mouse('mousePressed', a.x, a.y);
+  // The held man rides under the cursor at the height he was grabbed at, so
+  // the release is aimed at that height over e4 rather than at board level.
+  const b = await at('e4', Number(await evalJs(
+    'window.PBP.board.drag && window.PBP.board.drag.holdHeight ? window.PBP.board.drag.holdHeight() : 0')) || 0);
   for (let i = 1; i <= 8; i++) {
     await mouse('mouseMoved', a.x + (b.x - a.x) * (i / 8), a.y + (b.y - a.y) * (i / 8));
     await beat(35);

--- a/ConditioningControlPanel/Resources/web/piecebypiece/smoke/shot.mjs
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/smoke/shot.mjs
@@ -106,11 +106,17 @@ async function dragPiece(cdp, spec) {
   await cdp.send('Runtime.evaluate', { expression:
     `window.__ev = []; for (const t of ['grab','dragmove','drop','turn']) window.PBP.bus.on(t, (p) => window.__ev.push(t + (p && p.ok === false ? ':refused' : '')));` });
   const a = await at(fromSq, 0.45);
-  const b = await at(toSq, 0);
   const mouse = (type, x, y) => cdp.send('Input.dispatchMouseEvent', {
     type, x, y, button: 'left', buttons: type === 'mouseReleased' ? 0 : 1, clickCount: 1, pointerType: 'mouse',
   });
   await mouse('mousePressed', a.x, a.y);
+  // The man now hangs under the cursor at the height he was grabbed at, so the
+  // release is aimed at that height over the target square, not at board level.
+  const held = await cdp.send('Runtime.evaluate', {
+    expression: 'window.PBP.board.drag && window.PBP.board.drag.holdHeight ? window.PBP.board.drag.holdHeight() : 0',
+    returnByValue: true,
+  });
+  const b = await at(toSq, Number(held.result.value) || 0);
   for (let i = 1; i <= 8; i++) {
     await mouse('mouseMoved', a.x + (b.x - a.x) * (i / 8), a.y + (b.y - a.y) * (i / 8));
     await sleep(40);


### PR DESCRIPTION
Lane G of the polish wave: the hitbox complaint and the placement help.

## 1. "It's like I am holding onto the air"

`board/drag.js` cut the pointer ray with the board plane at y=0 and then parked
the held man at `LIFT = 1.15` above that point. From a camera 40 degrees up, a
point 1.15 high renders far above the ground point under the cursor, so the man
floated well clear of the hand that was supposedly holding him.

Now the grab records the world point the ray actually struck on his body plus
the offset from his origin, and every drag move cuts the ray with a horizontal
plane at that height, so the grabbed spot stays under the cursor from any angle.
`LIFT` drops to 0.52, enough to skim over the men he passes. The grab height is
capped at 0.75, so a king taken by his crown does not swing his base half a
board away. The aim is recomputed every frame from the last pointer position,
which means the camera can sway under a still cursor without the man sliding out
of your hand.

His base is what tells you the square now (it is where he would stand), and the
markers under him agree with it.

Untouched on purpose: the follow lag, the tilt into travel, `jiggle.grab` and
`jiggle.lag`, `anim.springBack`, and every `grab` / `dragmove` / `drop` emit the
effects layer listens for.

## 2. "Only highlight the available tiles, and in red the captures"

The old hint was an emissive tint on the square itself, which on a board made of
pink and cream is invisible. New file `board/markers.js` draws objects instead:

- a soft cream dot with a pink halo over every empty square he may reach
- a red ring around every man he may take; en passant counts (chess.js flag
  `e`), so the ring appears on an empty square when that is the take, while
  castling (`k` / `q`) stays a plain dot
- a faint outline on the square he was picked up from
- the marker under the cursor grows 1.34x and brightens; an illegal square does
  nothing

They pop in over 120 ms with a small overshoot and fade out over 160 ms, and
under `reducedMotion` (or `prefers-reduced-motion`) they simply appear and
disappear with no pop and no breathe. Every marker mesh has `raycast = () => {}`
and casts and receives no shadows, so it can never shadow the man standing on
its square. Captures come from `game.rules.movesFrom(sq)`, which already returns
verbose moves with flags, so no new helper was needed in the rules or the
hotseat.

`scene.js setHighlights` stays as the API (boot's `board.setHighlights` still
works) but now forwards to the markers through a sink that drag.js installs.

## How it was proved

Screenshots in `C:\Users\PC\Pictures\Screenshots\piecebypiece\g\`, all with a
green crosshair drawn at the exact pointer coordinates the harness used:

- `05-pawn-held.png` / `-near.png` - held pawn, dots on e3 and e4, e4 hovered
  and brighter, origin ring on e2, cursor on the man
- `06-knight-held.png` / `-near.png` - knight on d4 held: four dots, two red
  rings on the black men it may take, origin ring under it
- `07-hover-capture-near.png` - hovering a capture: the ring grows and brightens
- `08-en-passant-near.png` - the en passant target f6 gets a red ring although
  the square is empty
- `09-far-corner.png`, `10-near-corner.png` - the man carried to the far and
  near edges, cursor still on him
- `11-reduced-motion-near.png` - the same markers with motion turned down
- `01-start.png` - a clean start board, no stray markers

Numbers, with the camera held still (`shot.mjs --eval`, pointer moved to the
projection of six squares, distance from the cursor to the held man measured in
pixels at 1280x860):

    aimed at  a3   h3   a6   h6   d5   e4
    cursor to man   6   10    8   11    5    3  px
    standing over  a3   h3   a6   h6   d5   e4

Picking a tall man: pressing at 15%, 50%, 80% and 97% of the height of the king,
queen, rook, bishop, both knights and a pawn picks that man in every case where
he is the one visible at that pixel. The two exceptions in the sweep are honest
occlusion, not a bad hitbox: a pixel low on e2 is where the e1 king stands in
front of it, and the pixel at the queen's very tip has the d2 pawn behind it.

Smokes:

- `rules-smoke.mjs` 43 checks passed
- `ramp-smoke.mjs` 111 checks passed
- `jiggle-shot.mjs` full strip, mid-drag and landing frames, no console errors;
  the landing spring reads on e4, so the drag still lands where it aimed
- `shot.mjs --drag e2:e4`, `--drag e7:e5` from the swung black camera, and
  `--drag d4:c6` for a capture all play the move and emit grab / dragmove /
  turn / drop

## Touches outside my lane

`smoke/shot.mjs` and `smoke/jiggle-shot.mjs`, two lines each. Both aimed their
release at `projectSquare(to, 0)`, board level, which is no longer where a held
man is; they now ask `board.drag.holdHeight()` after the press and aim there.
Without it every harness drag would land a rank short. `drag.holdHeight()` is
the only API added for them.

Note for whoever runs the harness next: `--drag` presses at the projection of
the from-square, so a slow boot (the page needs about 10 s under swiftshader
with a `fen=` position) or the camera sway can move that pixel off the man. It
is not new, but it bit this run twice: use `--wait 12000` and an `--eval` that
turns the ramp and the sway off when a drag has to be deterministic.

## Not in this PR

No change to lights, the camera rig, piece art, the ramp or boot.js (nothing was
needed there, so the boot.js block is empty). Promotion still auto-queens.
Markers are not shown for a man you may not pick up yet, and there is no hint
layer outside a drag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CQdAN3aDyhnnXWjBtkH1mD
