### PR TITLE
fix(race): the script is not dressing - every word of a line goes down

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/race/CHART.md
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/CHART.md
@@ -175,8 +175,8 @@ A loaded track ducks the room OST to `TRACK_DUCK` (0.12) and the bed to silence 
 
 ### `race/bubbles.js` additions (PR c2)
 ```js
-field.spawnAt({ kindId, placement, d, x, h, eventId })   // an explicit placement; returns the slot id or -1 when the pool is full
-field.spawnRow({ kindId, placement, d, h, xs, eventId }) // a whole row at one depth (PR L4); returns how many went down, 0 for none
+field.spawnAt({ kindId, placement, d, x, h, eventId, script })   // an explicit placement; the slot id, or -1 when it was refused
+field.spawnRow({ kindId, placement, d, h, xs, eventId, script }) // a whole row at one depth (PR L4); how many went down, 0 for none
 field.setDensity(mult)                                  // already in CONTRACT.md; with a track this scales only the cue spawns
 field.setSparse(on)                                     // the loaded road came out of a transcript (PR L4): seedChunk stands down
 ```
@@ -188,6 +188,22 @@ also SPENDS as one thing: the first of its bubbles to pop or to slip past settle
 bubbles are one `taken` on the scheduler (`takenIds` is a set) and at worst one broken combo. With
 `setSparse(true)` `seedChunk` lays only the chunk's own golden and no lanes or ramp lines,
 so what the player drives through is the lyric. Too many bubbles is no bubbles.
+
+**THE SCRIPT IS NOT DRESSING** (2026-09-08). `script: true` marks a spawn the FILE asked for -
+`cues.js` puts it on the word bubbles (`case 'word'`) and on the trigger rows (`case 'trigger'`) -
+and neither refusal above may touch one: no density roll, and a full pool recycles the bubble
+farthest from the kart rather than dropping the line. `density` thins the road's DRESSING, and it
+is turned down to 0.6 on every `release` and to 0 through a `silence`; rolling each word bubble
+against it separately was taking 22 percent of the shelf's words and leaving 44 percent of the
+lines short, which is the owner's "i see maybe 1 word out of a phrase".
+
+**THE COVERAGE CHECK.** `wordedRoad` counts itself as it finishes (`wordBubbles.js coverageOf`),
+stamps `analysis.coverage` (kept by `normalizeChart`, so the cache and `window.__race` both have
+it) and says one `[race-coverage]` line to the host log. A word is on the road when it wears a
+bubble or when it is inside a trigger row's own span; what is left is the guard margin, which is
+the pop box. `node race/smoke/coverage-check.mjs` drives the whole shelf through the field's own
+refusals and fails under 96 percent on the shelf, under 90 on a track, or on ONE word bubble the
+chart asked for and the field did not lay.
 
 ### `race/run.js` + `raceBoot.js` (PR c2)
 ```js

--- a/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
@@ -153,7 +153,9 @@ field.update(dt, t, kart)               // kart = { d, x, h, speed }; runs motio
 field.onPop(cb)                         // cb(popEvent)
 field.onMiss(cb)                        // cb({ id, points, d, x, h }) when a treat passes behind the kart unpopped
 field.setDensity(mult)
-field.spawnAt({ kindId, placement, d, x, h, eventId })   // PR c2: an explicit placement from a track cue; the slot id, or -1 when the pool is full
+field.spawnAt({ kindId, placement, d, x, h, eventId, script })   // PR c2: an explicit placement from a track cue; the slot id, or -1 when it was refused
+                                        // `script: true` is a spawn the FILE asked for (a word bubble, a trigger row): no density roll, and a
+                                        // full pool recycles the farthest bubble rather than refusing the line (see CHART.md, 2026-09-08)
 field.setTracked(on)                    // PR c2: a track is loaded, so setDensity gates the CUE spawns and leaves the seeded lanes alone
 field.dispose()
 ```

--- a/ConditioningControlPanel/Resources/web/dtrh/race/bubbles.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/bubbles.js
@@ -261,13 +261,15 @@ export function createBubbleField({ scene, layout, media, getIntensity, getRoom,
   }
   /** An explicit placement from a track cue (CHART.md): the run has already worked the depth out at
    *  the kart's speed, so nothing is rolled or gated by intensity here. Returns the slot id, -1 when
-   *  the pool is full (a cue never steals a live bubble), when the kind is dark (bubbleKinds.js
-   *  spawn:false), or when density has gated this one out.
-   *  Over 1, density is the chance of a second bubble beside the first. */
-  function spawnAt({ kindId, placement = 'lane', d, x = 0, h, eventId = null, w = '', ink = null, big = false } = {}) {
-    if (liveCount >= CAP) return -1;
+   *  the pool is full (a decorative cue never steals a live bubble), when the kind is dark
+   *  (bubbleKinds.js spawn:false), or when density has gated this one out.
+   *  Over 1, density is the chance of a second bubble beside the first.
+   *  `script` is THE ROAD'S OWN SCRIPT (race/cues.js marks the word bubbles and the trigger rows):
+   *  see spawnRow below for why it goes down whatever the density knob is saying. */
+  function spawnAt({ kindId, placement = 'lane', d, x = 0, h, eventId = null, w = '', ink = null, big = false, script = false } = {}) {
+    if (liveCount >= CAP && !script) return -1;
     if (KIND_BY_ID[kindId] && KIND_BY_ID[kindId].spawn === false) return -1;   // a dark kind: no chart may place one
-    if (tracked) {
+    if (tracked && !script) {
       if (density <= 0) return -1;
       if (density < 1 && Math.random() >= density) return -1;
     }
@@ -285,13 +287,26 @@ export function createBubbleField({ scene, layout, media, getIntensity, getRoom,
    *  not laid at all (a row with a hole in it is a row the kart drives through), the density gate is
    *  rolled ONCE for the whole line rather than per bubble, and density over 1 never doubles it,
    *  because a doubled row is just a thicker wall and the wall was already unavoidable.
+   *
+   *  THE SCRIPT IS NOT DECORATION (2026-09-08). `script` marks a row the FILE asked for - a word
+   *  bubble off the transcript, a trigger row - and neither of the two refusals above may touch one.
+   *  `density` is the road-dressing knob: race/cues.js turns it down to 0.6 on a release and to 0
+   *  through a silence, and until now every word bubble was rolled against it one at a time. On a
+   *  worded road that is the road losing three words of a four word line at random and leaving one
+   *  bubble sitting on its own, which is exactly what the owner saw ("I see maybe 1 word out of a
+   *  phrase"): 22 percent of every word on the shelf, 44 percent of the lines thinned, 353 lines
+   *  gone altogether. A line the voice is saying is not the road being busy, so a script row skips
+   *  the density roll and, when the pool is full, RECYCLES the bubble farthest from the kart
+   *  (takeSlot already does, and 60 m of road behind the kart is a cheaper thing to lose than the
+   *  word she is saying) instead of refusing to lay the line at all.
    *  Returns how many went down, 0 for a row that was gated out. */
-  function spawnRow({ kindId, kindIds = null, placement = 'lane', d, h, xs, eventId = null, w = '', ink = null, big = false } = {}) {
+  function spawnRow({ kindId, kindIds = null, placement = 'lane', d, h, xs, eventId = null, w = '', ink = null, big = false, script = false } = {}) {
     const list = Array.isArray(xs) ? xs.filter((x) => Number.isFinite(Number(x))) : [];
     if (!list.length) return 0;
     if (KIND_BY_ID[kindId] && KIND_BY_ID[kindId].spawn === false) return 0;   // a dark kind: no chart may place one
-    if (liveCount + list.length > CAP) return 0;
-    if (tracked) {
+    // a script row may evict, but never more than half the pool: a line longer than that is not a line
+    if (liveCount + list.length > CAP && !(script && list.length * 2 <= CAP)) return 0;
+    if (tracked && !script) {
       if (density <= 0) return 0;
       if (density < 1 && Math.random() >= density) return 0;
     }

--- a/ConditioningControlPanel/Resources/web/dtrh/race/chart.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/chart.js
@@ -81,6 +81,10 @@ export function normalizeChart(json) {
     analysis: Object.freeze({
       energy: str(an.energy, ''), words: str(an.words, 'none'), generatedAt: str(an.generatedAt, ''), partial: an.partial === true, offsetSec: num(an.offsetSec, 0),
       lexicon: Object.freeze((Array.isArray(an.lexicon) ? an.lexicon : []).filter((w) => typeof w === 'string')),
+      // how much of the transcript reached the road (race/wordBubbles.js coverageOf), stamped by
+      // cloudChart.js wordedRoad and kept here so the cache, the host log and window.__race read
+      // the same number. null on a road with no transcript under it.
+      coverage: (an.coverage && typeof an.coverage === 'object') ? Object.freeze({ ...an.coverage }) : null,
     }),
     // THE TRANSCRIPT (race/words.js, CHART.md `chart.words`). The lines the voice says, with
     // the second each word lands on: it is what the captions layer reads and what tells the

--- a/ConditioningControlPanel/Resources/web/dtrh/race/cloudChart.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/cloudChart.js
@@ -47,7 +47,7 @@ import { loadWords, loadWordsRow } from './words.js';
 import { shiftRoad, readNudge } from './wordSync.js';
 import { TRIGGER_SETS } from '../chart/editor/triggerSets.js';
 import { detect } from '../chart/maker/triggers.js';
-import { wordEventsFrom } from './wordBubbles.js';
+import { wordEventsFrom, coverageOf, coverageLine } from './wordBubbles.js';
 import { themeFor } from './triggerTheme.js';
 
 /**
@@ -387,11 +387,15 @@ export function wordedRoad({ peaks, perSec = PEAKS_PER_SEC, durationSec, name = 
     .sort((a, b) => a.t - b.t)
     .map((e, i) => ({ ...e, id: 'g' + i }));
   const lexicon = [...new Set(events.filter((e) => e.kind === 'trigger').map((e) => e.label))].sort();
+  // THE COVERAGE CHECK (2026-09-08, the owner's "recheck after generating the track that actually
+  // all the words gets displayed"). Counted here, where the road is finished and the transcript is
+  // still in hand, and carried on the chart so the cache keeps it and window.__race can read it back.
+  const coverage = coverageOf(caps, triggers, events);
   return {
     version: 1, binSec: WORD_BIN_SEC, energy, events, acts: g.acts,
     words: caps,
     source: { name, hash, durationSec, sampleRate: DECODE_RATE },
-    analysis: { energy: 'web-rms-v1', words: 'script-align-v1', lexicon, generatedAt: g.generatedAt, partial: false },
+    analysis: { energy: 'web-rms-v1', words: 'script-align-v1', lexicon, coverage, generatedAt: g.generatedAt, partial: false },
   };
 }
 
@@ -538,7 +542,10 @@ export function createChartSource({ indexUrl, cache = null, onUpgrade = null, on
     const road = (words && words.words.length)
       ? wordedRoad({ peaks: walked.peaks, perSec: walked.perSec, durationSec: dur, name: title, hash, words })
       : roadFromPeaks({ peaks: walked.peaks, perSec: walked.perSec, durationSec: dur, name: title, hash });
-    if (words && words.words.length) say(`${title}: ${road.words.length} words and ${road.analysis.lexicon.length} triggers on the road`);
+    if (words && words.words.length) {
+      say(`${title}: ${road.words.length} words and ${road.analysis.lexicon.length} triggers on the road`);
+      if (road.analysis.coverage) say(coverageLine(title, road.analysis.coverage));   // the owner's recheck
+    }
     if (hash && cache) await cache.put(hash, road, GENERATOR_ID);   // at offset 0: tuned() shifts on the way out
     return { chart: await tuned(normalizeChart(road), { cloudId, hash, row: words }), door: 'generated' };
   }

--- a/ConditioningControlPanel/Resources/web/dtrh/race/cues.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/cues.js
@@ -219,8 +219,12 @@ export function cueFor(event, ctx = {}) {
       const rain = !gold && !cue.mix && gifRainRow(kindId, intensity, rng);
       for (const x of ROW_X) {
         const mid = Math.abs(x) < 1e-6;
+        // `script: true`: the row is the file talking, not the road being dressed, so race/bubbles.js
+        // lays it whatever the density knob is on. "A trigger row that never lands is the one thing
+        // this road may not do" was already written above the fallback kind; a density of 0 through a
+        // silence used to be able to do exactly that.
         cue.spawn.push({ kindId: mid ? (gold ? 'golden' : (rain ? GIFRAIN_KIND : kindId)) : kindId,
-          placement: 'lane', x, h: LANE_H, at: 0, row: true, w: label || '', ink, big: true });
+          placement: 'lane', x, h: LANE_H, at: 0, row: true, script: true, w: label || '', ink, big: true });
       }
       cue.word = label || null;
       cue.pose = 'grab';
@@ -238,12 +242,15 @@ export function cueFor(event, ctx = {}) {
       // says it whatever the throttle did. A row of one is still a row of one.
       // It carries nothing on the chrome: six hundred words on the toast rail is exactly the noise
       // the owner asked us to take off this road, and the word is read off the bubble's own face.
+      // `script: true` is the other half of what makes it a word rather than dressing: race/bubbles.js
+      // never rolls one against the density knob and never refuses one for a full pool, so a line the
+      // voice is saying cannot come out as one bubble on its own (see spawnRow).
       if (typeof event.w === 'string' && event.w) {
         const x = Number.isFinite(Number(event.x)) ? clamp(Number(event.x), -LANE_X_MAX, LANE_X_MAX) : 0;
         // the face: every word is painted on its bubble, an accent word on a bigger bubble and in
         // the colour of the set this second belongs to (race/cloudChart.js stamps `cue`), else pink.
         const accent = accentOf(event.w);
-        cue.spawn.push({ kindId: 'treat', placement: 'lane', x, h: LANE_H, at: 0, row: true, w: event.w,
+        cue.spawn.push({ kindId: 'treat', placement: 'lane', x, h: LANE_H, at: 0, row: true, script: true, w: event.w,
           big: accent, ink: accent ? tagInk(event) : null });
         break;
       }

--- a/ConditioningControlPanel/Resources/web/dtrh/race/run.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/run.js
@@ -643,7 +643,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1, onExi
     if (row.length) {
       const at = e.t + (row[0].at || 0), d = sync.depthFor(t, ks.d, ks.speed, at);
       const rowId = w.field.spawnRow({ kindId: row[0].kindId, kindIds: row.map((sp) => sp.kindId), placement: row[0].placement, d, h: row[0].h, xs: row.map((sp) => sp.x), eventId: e.id,
-        w: row[0].w || '', ink: row[0].ink || null, big: !!row[0].big });   // the tag, on the middle bubble alone
+        w: row[0].w || '', ink: row[0].ink || null, big: !!row[0].big, script: !!row[0].script });   // the tag, on the middle bubble alone
       if (rowId) sync.trackRow(rowId, e, at, d, t);
       // the word this bubble wears, kept until it is popped or driven past (flashWord spends it).
       // A trigger ROW is not one of these: its word flies at the camera on the plate instead.
@@ -663,7 +663,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1, onExi
       }
     }
     for (const sp of loose) {
-      w.field.spawnAt({ kindId: sp.kindId, placement: sp.placement, d: sync.depthFor(t, ks.d, ks.speed, e.t + (sp.at || 0)), x: sp.x, h: sp.h, eventId: e.id });
+      w.field.spawnAt({ kindId: sp.kindId, placement: sp.placement, d: sync.depthFor(t, ks.d, ks.speed, e.t + (sp.at || 0)), x: sp.x, h: sp.h, eventId: e.id, script: !!sp.script });
     }
     sync.defer(e, cue, t);
   }

--- a/ConditioningControlPanel/Resources/web/dtrh/race/smoke/coverage-check.mjs
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/smoke/coverage-check.mjs
@@ -1,0 +1,241 @@
+/* ============================================================================
+ * race/smoke/coverage-check.mjs - all the words she says get displayed.
+ *
+ *   node race/smoke/coverage-check.mjs   (from Resources/web/dtrh; 0 on pass, 1 with a count)
+ *
+ * Pure: no browser, no network, no audio. The whole shelf of eleven transcripts is
+ * charted with race/cloudChart.js wordedRoad over a synthetic swell (the road's WORDS
+ * are what is under test, and cloud-chart-check.mjs already charts real audio), then
+ * driven through race/chart.js createScheduler, race/cues.js cueFor and a field that
+ * carries race/bubbles.js's own refusals - the pool cap, the density gate, the dark
+ * kind - so what this counts is what the player would actually have seen go down.
+ *
+ * WHY IT EXISTS. The owner, 2026-09-08: "Seems like the words sometimes just get
+ * skipped, like we miss some bubbles, i see maybe 1 word out of a phrase... we should
+ * recheck after generating the track that actually all the words gets displayed."
+ * They were being skipped in the FIELD, not in the chart: `density` is the knob that
+ * thins the road's dressing (0.6 on a release, 0 through a silence) and every word
+ * bubble was being rolled against it one at a time, so a four word line came out as
+ * one bubble sitting on its own. 22 percent of the shelf, 44 percent of the lines.
+ *
+ * What it holds:
+ *   1. the FIELD lays every word bubble the chart asked for. Not most: every one.
+ *      This is the regression guard on the fix - the density knob and the pool cap
+ *      may never touch a bubble the file asked for.
+ *   2. no line is thinned. A line of four goes down as four or the run is broken,
+ *      and no line of two or more is reduced to a single bubble.
+ *   3. and enough of what she SAYS reaches the road, per track and over the shelf:
+ *      a word is on the road when it wears a bubble of its own or when it is inside
+ *      a trigger row's own span (the row of five is a line of faces all saying that
+ *      phrase). What is left is the guard margin, which is the pop box and not taste.
+ *   4. the coverage line the host log gets is the same arithmetic, off the chart's
+ *      own `analysis.coverage` stamp, and it survives normalizeChart.
+ *
+ * It never prints a line of a transcript. Everything below is counted.
+ * ==========================================================================*/
+
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { wordedRoad, PEAKS_PER_SEC } from '../cloudChart.js';
+import { normalizeChart, createScheduler } from '../chart.js';
+import { cueFor } from '../cues.js';
+import { coverageOf, coverageLine } from '../wordBubbles.js';
+import { KIND_BY_ID } from '../bubbleKinds.js';
+import { KART_BASE_SPEED, makeRng } from '../consts.js';
+
+let fails = 0;
+const ok = (cond, what) => { if (!cond) { console.error('FAIL ' + what); fails++; } else console.log('  ok  ' + what); };
+const eq = (got, want, what) => ok(got === want, what + ' (got ' + JSON.stringify(got) + ', want ' + JSON.stringify(want) + ')');
+
+/* ---- the thresholds, and why they are the numbers they are ---------------- *
+ * SHELF/TRACK: what share of every word she says reaches the road. The rest is the
+ * guard margin either side of a trigger row (race/wordBubbles.js WORD_RULE): a word
+ * inside 0.2 s of the wall is inside the same pop box as the wall, so it could never
+ * have been taken on its own. Measured over the shelf that is 3.3 percent, worst on
+ * the opening track (155 words, 19 trigger rows, so the margins eat 9 percent of it),
+ * which is why the per-track floor is lower than the shelf's.
+ * FIELD: the field's own floor is 100 percent and always will be. A word the chart
+ * laid and the field refused is the bug this file was written for. */
+const SHELF_MIN = 0.96, TRACK_MIN = 0.90;
+const STEP = 1 / 30;
+const CAP = 160, MOBILE_CAP = 100;      // shared/quality.js bubbleCap, desktop and the mobile tier
+const DROP_BEHIND = 12;                  // race/bubbles.js: a bubble this far behind the kart is freed
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const WORDS = resolve(HERE, '../words');
+const rows = JSON.parse(readFileSync(resolve(WORDS, 'index.json'), 'utf8')).rows;
+ok(rows.length === 11, 'the shelf has all eleven transcripts on it (' + rows.length + ')');
+
+/** A curve shaped like a spoken track: a speaking level throughout, swelling every 40 s.
+ *  The swell is what puts build/peak/release on the road, and `release` is the event that
+ *  turns the density knob down - so the thing that used to eat the words is in every run below. */
+function swell(durationSec, perSec = PEAKS_PER_SEC) {
+  const n = Math.ceil(durationSec * perSec);
+  const peaks = new Float32Array(n * 2);
+  for (let i = 0; i < n; i++) {
+    const t = i / perSec;
+    const a = 0.22 + 0.5 * Math.max(0, Math.sin((t / 40) * Math.PI * 2)) ** 2;
+    peaks[i * 2] = -a; peaks[i * 2 + 1] = a;
+  }
+  return peaks;
+}
+
+/**
+ * The road driven at KART_BASE_SPEED into a field that refuses exactly what
+ * race/bubbles.js refuses. Returns what went down, per word event and per line.
+ */
+function drive(chart, cap) {
+  const sched = createScheduler(chart);
+  const rng = makeRng(7);
+  const dur = chart.source.durationSec;
+  const live = [];                       // { d, n }
+  let liveCount = 0, density = 1, hold = 0, holdFrom = 0, kartD = 0;
+  const held = [];                       // the visible half of a cue, fired on its own second
+  const placed = new Set(), refused = new Map();
+  const spawnRow = (n, script) => {
+    if (liveCount + n > cap && !(script && n * 2 <= cap)) return 'cap';
+    if (!script) {                       // the density knob is the road's dressing, never the file's words
+      if (density <= 0) return 'density';
+      if (density < 1 && Math.random() >= density) return 'density';
+    }
+    liveCount += n;
+    return null;
+  };
+  for (let t = 0; t <= dur; t += STEP) {
+    if (hold > 0 && (t >= hold || t < holdFrom)) { hold = 0; density = 1; }
+    for (const due of sched.update(t, kartD, KART_BASE_SPEED)) {
+      const e = due.event;
+      const cue = cueFor(e, { intensity: 0.5, rng, act: { kind: 'triggers', room: 'toybox' },
+        room: { id: 'toybox' }, triggerKinds: new Map(), lyrics: true, gold: () => false });
+      if (!cue) continue;
+      const row = cue.spawn.filter((sp) => sp.row);
+      if (row.length) {
+        const why = spawnRow(row.length, !!row[0].script);
+        if (!why) live.push({ d: due.d, n: row.length });
+        if (e.kind === 'word') {
+          if (why) refused.set(e.id, why); else placed.add(e.id);
+        }
+      }
+      for (const sp of cue.spawn) {
+        if (sp.row) continue;
+        if (liveCount >= cap && !sp.script) continue;
+        if (KIND_BY_ID[sp.kindId] && KIND_BY_ID[sp.kindId].spawn === false) continue;
+        liveCount++; live.push({ d: due.d, n: 1 });
+      }
+      held.push({ at: e.t, cue });
+    }
+    for (let i = held.length - 1; i >= 0; i--) {
+      if (held[i].at > t) continue;
+      const { cue, at } = held[i];
+      if (cue.density != null) density = cue.density;
+      if (cue.holdSec > 0) { holdFrom = at; hold = at + cue.holdSec; }
+      held.splice(i, 1);
+    }
+    kartD += KART_BASE_SPEED * STEP;
+    for (let i = live.length - 1; i >= 0; i--) if (live[i].d < kartD - DROP_BEHIND) { liveCount -= live[i].n; live.splice(i, 1); }
+  }
+  return { placed, refused };
+}
+
+/* ---- the shelf ----------------------------------------------------------- */
+const table = [];
+let shelfSaid = 0, shelfRoad = 0, shelfEvents = 0, shelfPlaced = 0, thinned = 0, emptied = 0, singled = 0;
+
+for (const row of rows) {
+  // read the way race/words.js hands a transcript to the road: the file, wearing the aligner stamp
+  // off its index row, so cloudChart.js captionWords keeps every word of a script-aligned one.
+  const file = { ...JSON.parse(readFileSync(resolve(WORDS, row.file), 'utf8')), engine: row.engine };
+  const dur = Number(file.durationSec) || 0;
+  const road = wordedRoad({ peaks: swell(dur), durationSec: dur, name: row.title, hash: row.hash, words: file });
+  const chart = normalizeChart(road);
+  const words = chart.events.filter((e) => e.kind === 'word' && e.w);
+  const wordsIn = (e) => String(e.w).trim().split(/\s+/).length;
+  const asked = words.reduce((n, e) => n + wordsIn(e), 0);
+
+  const { placed, refused } = drive(chart, CAP);
+  const got = words.filter((e) => placed.has(e.id)).reduce((n, e) => n + wordsIn(e), 0);
+
+  // per LINE: a phrase goes down whole or the road is thinning it
+  const line = new Map();
+  for (const e of words) {
+    const key = e.p == null ? 'e' + e.id : 'p' + e.p;
+    const rec = line.get(key) || { want: 0, got: 0 };
+    rec.want++; rec.got += placed.has(e.id) ? 1 : 0;
+    line.set(key, rec);
+  }
+  let thin = 0, empty = 0, single = 0;
+  for (const rec of line.values()) {
+    if (rec.got < rec.want) thin++;
+    if (rec.got === 0) empty++;
+    if (rec.want >= 2 && rec.got === 1) single++;
+  }
+  thinned += thin; emptied += empty; singled += single;
+
+  const cov = chart.analysis.coverage;
+  shelfSaid += cov.said; shelfRoad += cov.onRoad; shelfEvents += asked; shelfPlaced += got;
+  table.push({ title: String(row.title).slice(0, 24), cov, asked, got, lines: line.size, thin, empty, single,
+    why: [...refused.values()] });
+}
+
+console.log('\n  track                    |  said | on road |  pct  | asked | placed | lines | thinned | emptied | 1 of many');
+console.log('  -------------------------+-------+---------+-------+-------+--------+-------+---------+---------+----------');
+for (const r of table) {
+  console.log('  ' + r.title.padEnd(24) + ' | ' + String(r.cov.said).padStart(5) + ' | ' + String(r.cov.onRoad).padStart(7)
+    + ' | ' + (100 * r.cov.pct).toFixed(1).padStart(5) + ' | ' + String(r.asked).padStart(5) + ' | ' + String(r.got).padStart(6)
+    + ' | ' + String(r.lines).padStart(5) + ' | ' + String(r.thin).padStart(7) + ' | ' + String(r.empty).padStart(7)
+    + ' | ' + String(r.single).padStart(8));
+}
+console.log('');
+
+/* ---- 1. the field lays every word bubble the chart asked for --------------- */
+eq(shelfPlaced, shelfEvents, 'the field lays every one of the shelf\'s word bubbles');
+for (const r of table) {
+  if (r.got !== r.asked) ok(false, r.title + ': the field refused ' + (r.asked - r.got) + ' words (' + [...new Set(r.why)].join(', ') + ')');
+}
+ok(table.every((r) => r.got === r.asked), 'and not one of the eleven tracks loses a bubble to the density knob or the pool');
+
+/* ---- 2. no line is thinned ------------------------------------------------ */
+eq(thinned, 0, 'no line of the road goes down short of a word');
+eq(emptied, 0, 'not one line vanishes');
+eq(singled, 0, 'and no line of two or more comes out as a single bubble');
+
+/* ---- 2b. the mobile pool is smaller, and still lays the script ------------- */
+{
+  const file = { ...JSON.parse(readFileSync(resolve(WORDS, rows[2].file), 'utf8')), engine: rows[2].engine };
+  const dur = Number(file.durationSec) || 0;
+  const chart = normalizeChart(wordedRoad({ peaks: swell(dur), durationSec: dur, name: rows[2].title, hash: rows[2].hash, words: file }));
+  const words = chart.events.filter((e) => e.kind === 'word' && e.w);
+  const { placed } = drive(chart, MOBILE_CAP);
+  eq(words.filter((e) => !placed.has(e.id)).length, 0, 'the busiest track lays every word on the mobile pool too (cap ' + MOBILE_CAP + ')');
+}
+
+/* ---- 3. enough of what she says reaches the road --------------------------- */
+const worst = table.reduce((a, b) => (a.cov.pct <= b.cov.pct ? a : b));
+ok(shelfRoad / shelfSaid >= SHELF_MIN,
+  (100 * shelfRoad / shelfSaid).toFixed(1) + ' percent of every word on the shelf is on the road ('
+  + shelfRoad + ' of ' + shelfSaid + ', floor ' + (100 * SHELF_MIN).toFixed(0) + ')');
+ok(worst.cov.pct >= TRACK_MIN, 'and the thinnest track is ' + worst.title + ' at '
+  + (100 * worst.cov.pct).toFixed(1) + ' percent (floor ' + (100 * TRACK_MIN).toFixed(0) + ')');
+{
+  const margin = table.reduce((n, r) => n + r.cov.margin, 0), piled = table.reduce((n, r) => n + r.cov.piled, 0);
+  ok(margin + piled === shelfSaid - shelfRoad,
+    'every word not on the road is accounted for: ' + margin + ' in a trigger row\'s margin, ' + piled + ' piled onto one instant');
+}
+
+/* ---- 4. the stamp, and the line the host log gets -------------------------- */
+{
+  const r = table[1];
+  const again = coverageOf([], [], []);
+  eq(again.said, 0, 'coverageOf of nothing is a clean zero, not a NaN');
+  eq(again.pct, 1, 'and reads as full rather than empty');
+  ok(typeof r.cov.said === 'number' && typeof r.cov.placed === 'number' && typeof r.cov.pct === 'number',
+    'normalizeChart keeps analysis.coverage on the road (' + r.title + ')');
+  const line = coverageLine(r.title, r.cov);
+  ok(line.startsWith('[race-coverage] '), 'the host log line is stamped [race-coverage]');
+  ok(line.includes('(' + r.cov.onRoad + '/' + r.cov.said + ')'), 'and carries the count the table above prints');
+  console.log('  --  ' + line);
+}
+
+console.log(fails ? '\ncoverage-check: ' + fails + ' failed' : '\ncoverage-check: all good');
+process.exit(fails ? 1 : 0);

--- a/ConditioningControlPanel/Resources/web/dtrh/race/wordBubbles.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/wordBubbles.js
@@ -261,6 +261,77 @@ export function rateOf(phrases, winSec = 5) {
     perPhrase: phrases.length ? flat.length / phrases.length : 0 };
 }
 
+/* ---- THE COVERAGE CHECK -------------------------------------------------- *
+ * "we should recheck after generating the track that actually all the words gets
+ * displayed" - the owner, 2026-09-08. So every road built off a transcript counts
+ * itself as it leaves race/cloudChart.js wordedRoad, stamps the count on
+ * `analysis.coverage`, and says one line to the host log.
+ *
+ * A word is ON THE ROAD if it is either wearing a bubble of its own (`placed`) or
+ * inside a trigger row's own span (`rows`), because the row of five is a line of
+ * faces all saying that phrase - the words of a `good girl` hit are not missing, they
+ * are what the whole width of the road says for those seconds.
+ *
+ * A word is DROPPED three ways, and the line names each so nobody has to guess:
+ *   margin - inside HIT_GUARD_PRE/POST_SEC of a row but not in its span. This is the
+ *            pop box, not taste: two bubbles under 2 x POP_HIT_D of road apart sit in
+ *            the box together and one pass takes both, so a word this close to the
+ *            wall could not be taken separately anyway. 3.3 percent of the shelf.
+ *   piled  - three or more words the aligner collapsed onto one instant (see
+ *            MERGE_SEC). Physically impossible speech; race/wordBubbles.js un-piles
+ *            what it can and merges the rest.
+ *   short  - anything else, which should be nothing.
+ */
+
+/** The one number: how much of what she said the player can read, and what took the rest. */
+export function coverageOf(words, hits = [], events = [], opts = {}) {
+  const R = { ...WORD_RULE, ...(opts.rule || {}) };
+  const list = readWords(words);
+  const windows = guardWindows(hits, R.HIT_GUARD_PRE_SEC, R.HIT_GUARD_POST_SEC);
+  const spans = (Array.isArray(hits) ? hits : [])
+    .filter((h) => h && isFinite(num(h.t, NaN)))
+    .map((h) => ({ t0: num(h.t, 0), t1: num(h.t, 0) + Math.max(0, num(h.dur, 0)) }));
+
+  let placed = 0, lines = 0, singles = 0;
+  const seen = new Set();
+  for (const e of Array.isArray(events) ? events : []) {
+    if (!e || e.kind !== 'word' || typeof e.w !== 'string' || !e.w) continue;
+    placed += e.w.trim().split(/\s+/).length;
+    const key = e.p == null ? 'e' + e.t : 'p' + e.p;
+    if (!seen.has(key)) { seen.add(key); lines++; }
+  }
+  // a line of ONE bubble: the thing the owner saw when the field was thinning them
+  const perLine = new Map();
+  for (const e of Array.isArray(events) ? events : []) {
+    if (!e || e.kind !== 'word' || typeof e.w !== 'string' || !e.w) continue;
+    const key = e.p == null ? 'e' + e.t : 'p' + e.p;
+    perLine.set(key, (perLine.get(key) || 0) + 1);
+  }
+  for (const n of perLine.values()) if (n === 1) singles++;
+
+  let rows = 0, margin = 0, gi = 0;
+  for (const w of list) {
+    const g = inGuard(windows, gi, w.t);
+    gi = g.i;
+    if (!g.hit) continue;
+    if (spans.some((s) => w.t >= s.t0 && w.t <= s.t1)) rows++; else margin++;
+  }
+  const said = list.length;
+  const onRoad = placed + rows;
+  const short = Math.max(0, said - onRoad - margin);
+  return { said, placed, rows, onRoad, margin, piled: short, lines, singles,
+    pct: said ? onRoad / said : 1 };
+}
+
+/** The line the host log gets, and the one race/smoke/coverage-check.mjs prints. Never quotes a word. */
+export function coverageLine(name, cov) {
+  const pc = (100 * (cov.pct || 0)).toFixed(1);
+  return `[race-coverage] ${name || 'track'}: ${pc}% (${cov.onRoad}/${cov.said}) - ${cov.placed} on their own bubble, `
+    + `${cov.rows} said by a trigger row; dropped ${cov.said - cov.onRoad}: ${cov.margin} in a row's margin, `
+    + `${cov.piled} piled; ${cov.lines} lines, ${cov.singles} of one word`;
+}
+
 export default phrasesFrom;
 
-// self-check: node race/smoke/words-rate-check.mjs holds all eleven transcripts against WORD_RULE.
+// self-check: node race/smoke/words-rate-check.mjs holds all eleven transcripts against WORD_RULE,
+// and node race/smoke/coverage-check.mjs drives the whole shelf through the field's own refusals.


### PR DESCRIPTION
The owner, on the word road:

> "Seems like the words sometimes just get skipped, like we miss some bubbles, i see maybe 1 word out of a phrase. This doesn't happen often tho its still pretty bad, we should recheck after generating the track that actually all the words gets displayed."

He is right, and it happens on every track, all the time.

## the cause

`bubbles.js` rolled **every word bubble** against `density` - the road-*dressing* knob. `cues.js` sets it to 1.6 on a build, **0.6 on a release**, **0 through a silence**, and it only ever goes back to 1 when a hold expires. So for long stretches of every track a word bubble had a 40 percent chance of simply not being laid, and through a silence no chance at all. A four word line under a 0.6 coin flip comes out as one word about one time in six. That is the owner's sentence, exactly.

A trigger row was already exempt ("a trigger row that never lands is the one thing this road may not do"). Word bubbles now say the same thing: `spawnAt`/`spawnRow` take `script`, and a script bubble skips the density gate. A script row may also evict from a full pool, but never more than half of it - a line longer than that is not a line. Nothing else about density changes: the dressing still breathes with the track.

## the loss table

Measured by replaying the real scheduler and `cueFor` into a field carrying `bubbles.js`'s own refusal rules. `said` = words in the transcript, `asked` = word bubbles the chart asks the field for, `placed` = word bubbles that reach the road.

**before**

| track | said | asked | placed | placed % | lines | lines short | lines emptied |
|---|---|---|---|---|---|---|---|
| Rapid Induction | 155 | 120 | 97 | 62.6 | 38 | 17 | 3 |
| Bubble Induction | 2276 | 2083 | 1560 | 68.5 | 672 | 306 | 51 |
| Bubble Acceptance | 3956 | 3532 | 2699 | 68.2 | 1139 | 485 | 80 |
| Bambi Named and Drained | 2025 | 1806 | 1369 | 67.6 | 586 | 255 | 36 |
| Bambi IQ Lock | 1626 | 1468 | 1137 | 69.9 | 467 | 205 | 31 |
| Bambi Body Lock | 2000 | 1919 | 1470 | 73.5 | 594 | 266 | 28 |
| Bambi Attitude Lock | 1703 | 1595 | 1201 | 70.5 | 519 | 224 | 31 |
| Bambi Uniformed | 1956 | 1850 | 1446 | 73.9 | 553 | 236 | 31 |
| Bambi Takeover | 1444 | 1347 | 1008 | 69.8 | 418 | 200 | 24 |
| Bambi Cockslut | 2440 | 2260 | 1738 | 71.2 | 708 | 325 | 43 |
| Bambi Awakens | 1342 | 1220 | 931 | 69.4 | 379 | 175 | 26 |
| **shelf** | **20923** | **19200** | **14656** | **70.0** | **6073** | **2694** | **384** |

4544 word bubbles thrown away. 353 lines that never made it to the road at all (384 counting single word lines). At the mobile pool (cap 100) the number was 14604 - the pool cap was never the problem, the knob was 100 percent of it.

**after**

| track | said | on road | % | asked | placed | lines | lines short | lines emptied | 1 of many |
|---|---|---|---|---|---|---|---|---|---|
| Rapid Induction | 155 | 143 | 92.3 | 120 | 120 | 38 | 0 | 0 | 0 |
| Bubble Induction | 2276 | 2209 | 97.1 | 2083 | 2083 | 672 | 0 | 0 | 0 |
| Bubble Acceptance | 3956 | 3778 | 95.5 | 3532 | 3532 | 1139 | 0 | 0 | 0 |
| Bambi Named and Drained | 2025 | 1944 | 96.0 | 1806 | 1806 | 586 | 0 | 0 | 0 |
| Bambi IQ Lock | 1626 | 1559 | 95.9 | 1468 | 1468 | 467 | 0 | 0 | 0 |
| Bambi Body Lock | 2000 | 1960 | 98.0 | 1919 | 1919 | 594 | 0 | 0 | 0 |
| Bambi Attitude Lock | 1703 | 1665 | 97.8 | 1595 | 1595 | 519 | 0 | 0 | 0 |
| Bambi Uniformed | 1956 | 1910 | 97.6 | 1850 | 1850 | 553 | 0 | 0 | 0 |
| Bambi Takeover | 1444 | 1399 | 96.9 | 1347 | 1347 | 418 | 0 | 0 | 0 |
| Bambi Cockslut | 2440 | 2371 | 97.2 | 2260 | 2260 | 708 | 0 | 0 | 0 |
| Bambi Awakens | 1342 | 1286 | 95.8 | 1220 | 1220 | 379 | 0 | 0 | 0 |
| **shelf** | **20923** | **20224** | **96.7** | **19200** | **19200** | **6073** | **0** | **0** | **0** |

The field now lays every single bubble the chart asks for, on the desktop pool and on the mobile one.

## where the remaining 699 words are

They are not lost in the field, they are spoken by something else or never separable:

- **694 inside a trigger row's own pop box.** A trigger row is a line of five across the road wearing the phrase; `HIT_GUARD_PRE_SEC` 0.2 / `POST` 0.1 keeps a word bubble out of the box so the row can be hit cleanly. At the slowest cruise 0.2 s is 3.08 m and two bubbles need 2.8 m, so this is physics, not policy. 1019 of these words are literally on the row's own face.
- **5 piled onto one instant** by the aligner (a CTC collapse - seven words at 0.01 s spacing). That is data, and it is what the next PR in this stack handles.

Recovering the margin words would mean showing them up to 0.6 s early, which makes the owner's *other* complaint worse, so they stay where they are.

## the recheck he asked for

`coverageOf()` in `wordBubbles.js` does the arithmetic at generate time, `cloudChart` stamps it on `analysis.coverage` (kept through `normalizeChart`), and the host log gets a line:

```
[race-coverage] Bubble Induction: 97.1% (2209/2276) - 2083 on their own bubble, 126 said by a trigger row; dropped 67: 67 in a row's margin, 0 piled; 672 lines, 101 of one word
```

It also rides on `window.__race.race.track.chart.analysis.coverage`.

`node race/smoke/coverage-check.mjs` drives all eleven tracks through the field's real refusal rules and fails if a word is lost to the knob or the pool, if any line goes down short of a word, if a line of two or more comes out as one bubble, if the shelf falls under 96 percent or any single track under 90 percent (Rapid Induction is 92.3 - it is 155 words long and 38 of them ride trigger rows).

## how it was verified

- all twelve node smokes green: `words-check`, `words-rate-check`, `lyrics-road-check`, `align-check`, `rows-check`, `wsync-check`, `track-run-check`, `chart-check`, `cloud-chart-check`, `word-flash-check`, `gifrain-row-check`, and the new `coverage-check`
- headless Chrome on two real charted tracks, seeking into a stretch the knob used to thin (density 0.6):
  - Bubble Induction, 40.1 s of track from 134.4: chart asked for 90 word bubbles, the field showed 106, **never seen: 0**, console errors 0
  - Bubble Acceptance, 40.3 s of track from 254.4: chart asked for 73, the field showed 96, **never seen: 0**, console errors 0
- a previously thinned line, whole, on the road at t=147.9 of Bubble Induction: `quietly to the sound of my voice`

```
 .../Resources/web/dtrh/race/CHART.md               |  20 +-
 .../Resources/web/dtrh/race/CONTRACT.md            |   4 +-
 .../Resources/web/dtrh/race/bubbles.js             |  33 ++-
 .../Resources/web/dtrh/race/chart.js               |   4 +
 .../Resources/web/dtrh/race/cloudChart.js          |  13 +-
 .../Resources/web/dtrh/race/cues.js                |  11 +-
 .../Resources/web/dtrh/race/run.js                 |   4 +-
 .../web/dtrh/race/smoke/coverage-check.mjs         | 241 +++++++++++++++++++++
 .../Resources/web/dtrh/race/wordBubbles.js         |  73 ++++++-
 9 files changed, 383 insertions(+), 20 deletions(-)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013T1bb13w97ndYjNveiFpLz
