### PR TITLE
feat(pbp): the board makes sounds

### DIFF
--- a/ConditioningControlPanel/Resources/web/piecebypiece/audio/sfx.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/audio/sfx.js
@@ -1,0 +1,305 @@
+/* ============================================================================
+ * audio/sfx.js - the board makes sounds.
+ *
+ * Every cue is drawn with Web Audio on the spot: a few oscillators, one
+ * shared noise buffer, an envelope. No audio files, no dependencies. The
+ * AudioContext is made lazily on the first pointerdown or keydown (browsers
+ * refuse to start one any other way), muted while the tab is hidden, and the
+ * master gain follows window.PBP.settings.sfxVolume (0.6 when unset).
+ *
+ * What plays, and off which bus event:
+ *   grab       a wet little pop           `grab`
+ *   tick       a dry tick per legal square the held man passes over `dragmove`
+ *   land       a thud pitched by the man's height, the king lowest  `land`
+ *   capture    the thud plus a squelch     `land` with capture
+ *   boing      a sympathetic wobble        `drop` ok:false
+ *   check      a low pulse, beating every 0.9 s while the side to move is in
+ *              check                       `check` .. `turn` / `gameover`
+ *   mate/draw  a sting for the end         `gameover`
+ *   clock      one low tick a second for the side to move under 30 s, sharper
+ *              under 10 s, never once the game is over  `clock`
+ *   promote    a rising chime              `turn` after a promotion
+ *   cardOpen/cardClose  a soft whoosh when the ramp's video card comes and
+ *              goes (a MutationObserver on the fx root; the ramp emits nothing)
+ *
+ * sfx.play(name, opts) plays any cue by hand; sfx.log() is the last cues with
+ * the context state, so a harness can prove each one scheduled. A `context`
+ * factory can be injected for tests (node has no AudioContext).
+ * ==========================================================================*/
+
+export const TUNING = Object.freeze({
+  volume: 0.6,            // default master, settings.sfxVolume overrides
+  pop: { from: 520, to: 260, sec: 0.07, gain: 0.22 },
+  tick: { hz: 1800, sec: 0.02, gain: 0.05 },
+  thud: { pawnHz: 210, kingHz: 95, pawnH: 0.55, kingH: 1.25, sec: 0.18, gain: 0.5, tapGain: 0.12 },
+  squelch: { from: 900, to: 150, sec: 0.18, gain: 0.16 },
+  boing: { hz: [300, 180, 240, 200], sec: 0.25, gain: 0.14 },
+  check: { hz: 58, sec: 0.28, gain: 0.32, everySec: 0.9 },
+  mate: { hz: [392, 311, 233], step: 0.16, sec: 0.5, gain: 0.2 },
+  draw: { hz: [262, 262], step: 0.22, sec: 0.4, gain: 0.16 },
+  clock: { hz: 1200, sharpHz: 1900, sec: 0.015, gain: 0.07, sharpGain: 0.11, underMs: 30000, sharpMs: 10000 },
+  promote: { hz: [523, 659, 784, 1047], step: 0.06, sec: 0.28, gain: 0.12 },
+  whoosh: { lowHz: 200, highHz: 4000, sec: 0.26, gain: 0.1 },
+  logSize: 32,
+});
+
+const clamp01 = (v) => Math.max(0, Math.min(1, Number(v) || 0));
+
+export function createSfx({ bus, game = null, group = null, squareOf = null, root = null,
+                            doc = (typeof document !== 'undefined' ? document : null),
+                            win = (typeof window !== 'undefined' ? window : null),
+                            context = null } = {}) {
+  let ctx = null;
+  let master = null;
+  let noise = null;
+  let disposed = false;
+  const log = [];
+  const settings = () => (win && win.PBP && win.PBP.settings) || {};
+  const volume = () => {
+    const v = settings().sfxVolume;
+    return clamp01(v === undefined ? TUNING.volume : v);
+  };
+
+  // --- the context, made on the first gesture -------------------------------
+  function makeContext() {
+    if (ctx || disposed) return ctx;
+    try {
+      const Ctor = context || (win && (win.AudioContext || win.webkitAudioContext));
+      ctx = typeof Ctor === 'function' && !context ? new Ctor() : (context ? context() : null);
+    } catch (e) { console.warn('[pbp] no audio', e); ctx = null; }
+    if (!ctx) return null;
+    master = ctx.createGain();
+    master.gain.value = doc && doc.hidden ? 0 : volume();
+    master.connect(ctx.destination);
+    const seconds = 1;
+    const buf = ctx.createBuffer(1, Math.max(1, Math.floor(ctx.sampleRate * seconds)), ctx.sampleRate);
+    const data = buf.getChannelData(0);
+    for (let i = 0; i < data.length; i++) data[i] = Math.random() * 2 - 1;
+    noise = buf;
+    return ctx;
+  }
+  function wake() {
+    const c = makeContext();
+    if (c && c.state === 'suspended' && c.resume) { try { c.resume(); } catch { /* not yet */ } }
+  }
+  function onVisibility() {
+    if (!master || !ctx) return;
+    const to = doc && doc.hidden ? 0 : volume();
+    try { master.gain.setTargetAtTime(to, ctx.currentTime, 0.02); } catch { master.gain.value = to; }
+  }
+
+  // --- the palette ------------------------------------------------------------
+  /** An oscillator with a gain envelope: attack straight up, decay to zero. */
+  function tone(type, hz, sec, gain, { at = 0, slideTo = null, filterHz = null } = {}) {
+    const t0 = ctx.currentTime + at;
+    const osc = ctx.createOscillator();
+    const env = ctx.createGain();
+    osc.type = type;
+    osc.frequency.setValueAtTime(hz, t0);
+    if (slideTo) osc.frequency.exponentialRampToValueAtTime(Math.max(1, slideTo), t0 + sec);
+    env.gain.setValueAtTime(0.0001, t0);
+    env.gain.exponentialRampToValueAtTime(gain, t0 + 0.005);
+    env.gain.exponentialRampToValueAtTime(0.0001, t0 + sec);
+    let head = osc;
+    if (filterHz) {
+      const f = ctx.createBiquadFilter();
+      f.type = 'lowpass';
+      f.frequency.value = filterHz;
+      osc.connect(f);
+      head = f;
+    }
+    head.connect(env);
+    env.connect(master);
+    osc.start(t0);
+    osc.stop(t0 + sec + 0.02);
+  }
+  /** Filtered noise with a sweep, for taps and whooshes. */
+  function hiss(sec, gain, { at = 0, from = 1000, to = 1000, type = 'bandpass' } = {}) {
+    const t0 = ctx.currentTime + at;
+    const src = ctx.createBufferSource();
+    src.buffer = noise;
+    const f = ctx.createBiquadFilter();
+    f.type = type;
+    f.frequency.setValueAtTime(from, t0);
+    if (to !== from) f.frequency.exponentialRampToValueAtTime(to, t0 + sec);
+    const env = ctx.createGain();
+    env.gain.setValueAtTime(0.0001, t0);
+    env.gain.exponentialRampToValueAtTime(gain, t0 + Math.min(0.03, sec * 0.3));
+    env.gain.exponentialRampToValueAtTime(0.0001, t0 + sec);
+    src.connect(f); f.connect(env); env.connect(master);
+    src.start(t0);
+    src.stop(t0 + sec + 0.02);
+  }
+  const thudHz = (height) => {
+    const T = TUNING.thud;
+    const k = clamp01((height - T.pawnH) / (T.kingH - T.pawnH));
+    return T.pawnHz + (T.kingHz - T.pawnHz) * k;
+  };
+
+  const cues = {
+    grab() { const P = TUNING.pop; tone('sine', P.from, P.sec, P.gain, { slideTo: P.to }); },
+    tick() { const P = TUNING.tick; tone('triangle', P.hz, P.sec, P.gain); },
+    land({ height = 1 } = {}) {
+      const T = TUNING.thud;
+      const hz = thudHz(height);
+      tone('sine', hz, T.sec, T.gain, { slideTo: hz * 0.6 });
+      hiss(0.04, T.tapGain, { from: 2500, to: 600, type: 'lowpass' });
+    },
+    capture({ height = 1 } = {}) {
+      cues.land({ height });
+      const S = TUNING.squelch;
+      tone('sawtooth', S.from, S.sec, S.gain, { slideTo: S.to, filterHz: 1200, at: 0.02 });
+      hiss(0.12, S.gain * 0.5, { from: 3000, to: 300, at: 0.03 });
+    },
+    boing() {
+      const B = TUNING.boing;
+      const t0 = ctx.currentTime;
+      const osc = ctx.createOscillator();
+      const env = ctx.createGain();
+      osc.type = 'triangle';
+      osc.frequency.setValueAtTime(B.hz[0], t0);
+      for (let i = 1; i < B.hz.length; i++) osc.frequency.exponentialRampToValueAtTime(B.hz[i], t0 + B.sec * (i / (B.hz.length - 1)));
+      env.gain.setValueAtTime(B.gain, t0);
+      env.gain.exponentialRampToValueAtTime(0.0001, t0 + B.sec);
+      osc.connect(env); env.connect(master);
+      osc.start(t0); osc.stop(t0 + B.sec + 0.02);
+    },
+    check() { const C = TUNING.check; tone('sine', C.hz, C.sec, C.gain, { filterHz: 200 }); },
+    mate() { const M = TUNING.mate; M.hz.forEach((hz, i) => tone('sawtooth', hz, M.sec, M.gain, { at: i * M.step, filterHz: 900 })); },
+    draw() { const D = TUNING.draw; D.hz.forEach((hz, i) => tone('triangle', hz, D.sec, D.gain, { at: i * D.step, filterHz: 700 })); },
+    clock({ sharp = false } = {}) {
+      const C = TUNING.clock;
+      tone('square', sharp ? C.sharpHz : C.hz, C.sec, sharp ? C.sharpGain : C.gain, { filterHz: 3000 });
+    },
+    promote() { const P = TUNING.promote; P.hz.forEach((hz, i) => tone('sine', hz, P.sec, P.gain, { at: i * P.step })); },
+    cardOpen() { const W = TUNING.whoosh; hiss(W.sec, W.gain, { from: W.lowHz, to: W.highHz, type: 'lowpass' }); },
+    cardClose() { const W = TUNING.whoosh; hiss(W.sec, W.gain, { from: W.highHz, to: W.lowHz, type: 'lowpass' }); },
+  };
+
+  function play(name, opts = {}) {
+    if (disposed || !cues[name]) return false;
+    if (!ctx && !makeContext()) return false;
+    if (doc && doc.hidden) return false;
+    const v = volume();
+    if (v <= 0) return false;
+    if (master.gain.value !== v) master.gain.value = v;
+    try { cues[name](opts); } catch (e) { console.warn('[pbp] cue failed ' + name, e); return false; }
+    log.push({ name, opts, at: ctx.currentTime, state: ctx.state });
+    if (log.length > TUNING.logSize) log.shift();
+    return true;
+  }
+
+  // --- the bus --------------------------------------------------------------
+  const offs = [];
+  const on = (type, fn) => { if (bus && bus.on) offs.push(bus.on(type, fn)); };
+  let held = null;
+  let legal = [];
+  let hover = null;
+  let checkArmed = false;   // `check` comes before `turn` on the same move
+  let checkTimer = 0;
+  let lastSecond = -1;
+  let over = false;
+
+  function stopPulse() { if (checkTimer) { clearInterval(checkTimer); checkTimer = 0; } }
+  function startPulse() {
+    stopPulse();
+    play('check');
+    checkTimer = setInterval(() => play('check'), TUNING.check.everySec * 1000);
+  }
+
+  on('grab', (p) => {
+    play('grab');
+    held = group ? group.children.find((c) => c.userData && c.userData.held) || null : null;
+    legal = game && game.legalTargets && p && p.square ? game.legalTargets(p.square) : [];
+    hover = p && p.square ? p.square : null;
+  });
+  on('dragmove', () => {
+    if (!held || !squareOf) return;
+    const sq = squareOf(held.position.x, held.position.z);
+    if (sq === hover) return;
+    hover = sq;
+    if (sq && legal.includes(sq)) play('tick');
+  });
+  on('drop', (p) => {
+    held = null; legal = []; hover = null;
+    if (!p || !p.ok) play('boing');
+  });
+  on('land', (p) => {
+    if (!p || p.refused) return;
+    play(p.capture ? 'capture' : 'land', { height: p.height });
+  });
+  on('check', () => { checkArmed = true; startPulse(); });
+  on('turn', () => {
+    lastSecond = -1;
+    if (checkArmed) checkArmed = false; else stopPulse();
+    try {
+      const chess = game && game.rules && game.rules.chess;
+      const hist = chess && chess.history ? chess.history({ verbose: true }) : [];
+      const last = hist[hist.length - 1];
+      if (last && last.promotion) play('promote');
+    } catch { /* the referee keeps its own counsel */ }
+  });
+  on('gameover', (p) => {
+    over = true;
+    stopPulse();
+    const r = p && p.result;
+    play(r === 'stalemate' || r === 'draw' ? 'draw' : 'mate');
+  });
+  on('clock', (s) => {
+    if (over || !s || !s.active) return;
+    const ms = s[s.active];
+    if (!(ms < TUNING.clock.underMs) || ms <= 0) return;
+    const second = Math.ceil(ms / 1000);
+    if (second === lastSecond) return;
+    lastSecond = second;
+    play('clock', { sharp: ms < TUNING.clock.sharpMs });
+  });
+
+  // --- the video card, seen not heard from -----------------------------------
+  let observer = null;
+  const isCard = (n) => n && n.classList && n.classList.contains('pbp-card');
+  if (root && typeof MutationObserver === 'function') {
+    observer = new MutationObserver((records) => {
+      for (const r of records) {
+        if (r.type === 'attributes') {
+          if (isCard(r.target) && r.target.classList.contains('is-out') && !r.target.dataset.pbpClosed) {
+            r.target.dataset.pbpClosed = '1';
+            play('cardClose');
+          }
+          continue;
+        }
+        for (const n of r.addedNodes) if (isCard(n)) play('cardOpen');
+        for (const n of r.removedNodes) if (isCard(n) && !n.dataset.pbpClosed) play('cardClose');
+      }
+    });
+    observer.observe(root, { childList: true, subtree: true, attributes: true, attributeFilter: ['class'] });
+  }
+
+  if (doc) {
+    doc.addEventListener('pointerdown', wake, { capture: true, passive: true });
+    doc.addEventListener('keydown', wake, { capture: true, passive: true });
+    doc.addEventListener('visibilitychange', onVisibility);
+  }
+
+  return {
+    play,
+    wake,
+    log: () => log.slice(),
+    ready: () => !!ctx,
+    state: () => ({ context: ctx ? ctx.state : 'none', volume: master ? master.gain.value : 0, pulsing: !!checkTimer, over, hover }),
+    setVolume(v) { settings().sfxVolume = clamp01(v); if (master) master.gain.value = doc && doc.hidden ? 0 : clamp01(v); },
+    dispose() {
+      disposed = true;
+      stopPulse();
+      for (const off of offs) { try { off(); } catch { /* gone */ } }
+      if (observer) observer.disconnect();
+      if (doc) {
+        doc.removeEventListener('pointerdown', wake, { capture: true });
+        doc.removeEventListener('keydown', wake, { capture: true });
+        doc.removeEventListener('visibilitychange', onVisibility);
+      }
+      if (ctx && ctx.close) { try { ctx.close(); } catch { /* already */ } }
+      ctx = null; master = null;
+    },
+  };
+}

--- a/ConditioningControlPanel/Resources/web/piecebypiece/boot.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/boot.js
@@ -115,6 +115,9 @@ function main() {
     board.dust = m.createDust({ scene: view.scene, bus });
     feelLate.push((dt) => board.dust.update(dt, view.camera, view.renderer));
   }).catch((e) => console.warn('[pbp] dust missing', e));
+  Promise.all([import('./audio/sfx.js'), import('./board/scene.js')]).then(([m, sc]) => {
+    board.sfx = m.createSfx({ bus, game, group: view.pieceGroup, squareOf: sc.worldToSquare, root: dom.fx });
+  }).catch((e) => console.warn('[pbp] sfx missing', e));
   // --- end J ---
 
   let last = performance.now();

--- a/ConditioningControlPanel/Resources/web/piecebypiece/smoke/feel-shot.mjs
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/smoke/feel-shot.mjs
@@ -129,8 +129,12 @@ async function open(pageUrl) {
 
 async function drag(from, to) {
   const a = await at(from, 0.45);
-  const b = await at(to, 0);
   await mouse('mousePressed', a.x, a.y);
+  // The man hangs under the cursor at the height he was grabbed at, so the
+  // release is aimed at that height over the target square, not at the board.
+  const held = Number(await evalJs(
+    'window.PBP.board.drag && window.PBP.board.drag.holdHeight ? window.PBP.board.drag.holdHeight() : 0')) || 0;
+  const b = await at(to, held);
   for (let i = 1; i <= 8; i++) {
     await mouse('mouseMoved', a.x + (b.x - a.x) * (i / 8), a.y + (b.y - a.y) * (i / 8));
     await beat(35);

--- a/ConditioningControlPanel/Resources/web/piecebypiece/smoke/feel-shot.mjs
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/smoke/feel-shot.mjs
@@ -6,7 +6,9 @@
  * drags a pawn and captures the frame right after it lands, dust mid-burst;
  * then loads a position with a take on the board and does it again. Every
  * `land` the bus carries is logged with its payload, the dust reports how many
- * motes are alive, and reduced motion is checked to puff smaller.
+ * motes are alive, the sound module reports which cues it scheduled for the
+ * move (and for a video card poked into the fx root), and reduced motion is
+ * checked to puff smaller.
  *
  *   node smoke/feel-shot.mjs [--url <page url>] [--out <dir>] [--wait <ms>]
  *
@@ -168,6 +170,21 @@ async function main() {
   d = await dust();
   console.log('dust settled: ' + JSON.stringify(d));
   if (d && d.alive !== 0) { console.log('ERROR motes never die'); failed = true; }
+
+  // --- 1b. the board made sounds for that move (a real AudioContext here) ---
+  const sfx = await evalJs(`(async () => {
+    const s = window.PBP.board.sfx; if (!s) return null;
+    const tick = () => new Promise((r) => setTimeout(r, 30));
+    const fx = document.getElementById('fx');
+    const card = document.createElement('div'); card.className = 'pbp-card'; fx.appendChild(card);
+    await tick();
+    card.classList.add('is-out'); await tick(); card.remove(); await tick();
+    return JSON.stringify({ state: s.state(), cues: s.log().map((e) => e.name + '@' + e.state) });
+  })()`).then((v) => (v ? JSON.parse(v) : null));
+  console.log('sound: ' + JSON.stringify(sfx));
+  const cues = sfx ? sfx.cues.map((c) => c.split('@')[0]) : [];
+  if (!cues.includes('grab') || !cues.includes('land')) { console.log('ERROR the move made no sound'); failed = true; }
+  if (!cues.includes('cardOpen') || !cues.includes('cardClose')) { console.log('ERROR the card made no sound'); failed = true; }
 
   // --- 2. a refused drop: a shrug of dust, flagged refused -------------------
   // black to move now, so it is a black pawn that gets told no

--- a/ConditioningControlPanel/Resources/web/piecebypiece/smoke/sfx-smoke.mjs
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/smoke/sfx-smoke.mjs
@@ -1,0 +1,155 @@
+/* ============================================================================
+ * smoke/sfx-smoke.mjs - every cue schedules, in node, with a fake AudioContext.
+ *
+ * Builds the real bus and the real sfx module around a recording stand-in for
+ * the Web Audio graph, walks a game through the bus (grab, hover, refused
+ * drop, land, capture, check, promotion, low clock, mate) and checks that each
+ * cue logged and started at least one node; then checks the tab-hidden mute,
+ * the volume setting, and that dispose stops the check pulse timer.
+ *
+ *   node smoke/sfx-smoke.mjs        (no server, no browser)
+ * ==========================================================================*/
+
+import { createBus } from '../game/events.js';
+import { createSfx, TUNING } from '../audio/sfx.js';
+
+class Param {
+  constructor(v) { this.value = v; }
+  setValueAtTime(v) { this.value = v; return this; }
+  linearRampToValueAtTime() { return this; }
+  exponentialRampToValueAtTime(v) { if (!(v > 0)) throw new Error('exponential ramp to ' + v); return this; }
+  setTargetAtTime(v) { this.value = v; return this; }
+}
+class FakeNode {
+  constructor(ctx, kind) { this.ctx = ctx; this.kind = kind; }
+  connect(to) { this.ctx.wires.push([this.kind, to && to.kind || 'destination']); return to; }
+  start(t) { this.ctx.started.push({ kind: this.kind, at: t }); }
+  stop() { }
+}
+class FakeContext {
+  constructor() {
+    this.state = 'suspended'; this.currentTime = 0; this.sampleRate = 48000;
+    this.started = []; this.wires = []; this.destination = { kind: 'destination' };
+  }
+  createGain() { const n = new FakeNode(this, 'gain'); n.gain = new Param(1); return n; }
+  createOscillator() { const n = new FakeNode(this, 'osc'); n.frequency = new Param(440); n.type = 'sine'; return n; }
+  createBiquadFilter() { const n = new FakeNode(this, 'filter'); n.frequency = new Param(1000); n.type = 'lowpass'; return n; }
+  createBufferSource() { return new FakeNode(this, 'noise'); }
+  createBuffer(ch, len) { return { getChannelData: () => new Float32Array(len) }; }
+  resume() { this.state = 'running'; return Promise.resolve(); }
+  close() { this.state = 'closed'; return Promise.resolve(); }
+}
+
+function fakeDoc() {
+  const listeners = new Map();
+  return {
+    hidden: false,
+    addEventListener(type, fn) { if (!listeners.has(type)) listeners.set(type, new Set()); listeners.get(type).add(fn); },
+    removeEventListener(type, fn) { listeners.get(type)?.delete(fn); },
+    fire(type) { for (const fn of listeners.get(type) || []) fn({ type }); },
+  };
+}
+
+const problems = [];
+const expect = (ok, msg) => { if (!ok) problems.push(msg); console.log((ok ? 'ok   ' : 'FAIL ') + msg); };
+
+const bus = createBus();
+const doc = fakeDoc();
+const win = { PBP: { settings: { sfxVolume: 0.6 } } };
+let fake = null;
+const heldMan = { position: { x: 0.5, y: 0.6, z: 0.5 }, userData: { held: true, type: 'p', side: 'w' } };
+const group = { children: [{ userData: {} }, heldMan] };
+const squareOf = (x, z) => 'abcdefgh'[Math.round(x + 3.5)] + (Math.round(3.5 - z) + 1);
+let history = [];
+const game = {
+  legalTargets: (sq) => (sq === 'e2' ? ['e3', 'e4'] : []),
+  rules: { chess: { history: () => history } },
+};
+
+const sfx = createSfx({
+  bus, game, group, squareOf, doc, win,
+  context: () => { fake = new FakeContext(); return fake; },
+});
+const names = () => sfx.log().map((e) => e.name);
+const startedSince = (n) => fake.started.length - n;
+
+// a grab before any gesture still makes the context (suspended) and logs
+let n0 = 0;
+bus.emit('grab', { square: 'e2', piece: 'p' });
+expect(fake && names().includes('grab'), 'grab pops (context made lazily on the first cue)');
+expect(fake.state === 'suspended', 'context starts suspended before a gesture');
+doc.fire('pointerdown');
+expect(fake.state === 'running', 'the first pointerdown resumes it');
+
+// hover: a tick per legal square passed over, silence elsewhere
+heldMan.position.x = 0.5; heldMan.position.z = 1.5;      // e3
+bus.emit('dragmove', {}); bus.emit('dragmove', {});
+heldMan.position.z = 0.5;                                 // e4
+bus.emit('dragmove', {});
+heldMan.position.x = 1.5;                                 // f4, not legal
+bus.emit('dragmove', {});
+expect(names().filter((x) => x === 'tick').length === 2, 'two legal squares crossed, two ticks, no tick on f4 or on a repeat');
+
+n0 = fake.started.length;
+bus.emit('drop', { ok: false });
+expect(names().at(-1) === 'boing' && startedSince(n0) > 0, 'refused drop boings');
+bus.emit('land', { square: 'e2', piece: 'p', height: 0.55, refused: true });
+expect(names().at(-1) === 'boing', 'a refused landing makes no thud');
+
+n0 = fake.started.length;
+bus.emit('land', { square: 'e4', piece: 'p', height: 0.55, capture: false });
+expect(names().at(-1) === 'land' && startedSince(n0) >= 2, 'a pawn lands: tone plus tap');
+const pawnHz = fake.started.length;
+bus.emit('land', { square: 'd5', piece: 'k', height: 1.25, capture: true });
+expect(names().at(-1) === 'capture' && fake.started.length - pawnHz > 2, 'a capture: thud plus squelch');
+
+// check pulses through the same move's turn and stops on the next
+bus.emit('check', { side: 'b' });
+bus.emit('turn', { side: 'b', ply: 3 });
+expect(sfx.state().pulsing && names().includes('check'), 'check pulses, and the turn that follows it keeps the pulse');
+bus.emit('turn', { side: 'w', ply: 4 });
+expect(!sfx.state().pulsing, 'the next turn stops the pulse');
+
+history = [{ from: 'e7', to: 'e8', promotion: 'q' }];
+bus.emit('turn', { side: 'b', ply: 5 });
+expect(names().at(-1) === 'promote', 'a promotion chimes on its turn');
+history = [];
+
+// the clock: one tick a second under 30 s, sharper under 10 s, only the active side
+n0 = names().length;
+bus.emit('clock', { w: 45000, b: 29500, total: 900000, active: 'w' });
+bus.emit('clock', { w: 29800, b: 29500, total: 900000, active: 'w' });
+bus.emit('clock', { w: 29600, b: 29500, total: 900000, active: 'w' });   // same second
+bus.emit('clock', { w: 28900, b: 29500, total: 900000, active: 'w' });
+bus.emit('clock', { w: 9800, b: 29500, total: 900000, active: 'w' });
+const ticks = sfx.log().slice(n0).filter((e) => e.name === 'clock');
+expect(ticks.length === 3 && !ticks[0].opts.sharp && ticks[2].opts.sharp, 'three seconds under 30 s tick three times, the one under 10 s sharp');
+
+bus.emit('gameover', { result: 'checkmate', winner: 'w' });
+expect(names().at(-1) === 'mate', 'checkmate stings');
+n0 = names().length;
+bus.emit('clock', { w: 5000, b: 29500, total: 900000, active: 'w' });
+expect(names().length === n0, 'no clock tick once the game is over');
+sfx.play('draw');
+expect(names().at(-1) === 'draw', 'draw sting plays by hand');
+expect(sfx.play('cardOpen') && sfx.play('cardClose'), 'card whooshes play by hand');
+
+doc.hidden = true; doc.fire('visibilitychange');
+expect(sfx.state().volume === 0 && !sfx.play('grab'), 'hidden tab: master to 0 and nothing schedules');
+doc.hidden = false; doc.fire('visibilitychange');
+expect(sfx.state().volume === 0.6, 'visible again: master back to the setting');
+win.PBP.settings.sfxVolume = 0.25;
+sfx.play('tick');
+expect(Math.abs(sfx.state().volume - 0.25) < 1e-9, 'settings.sfxVolume is read on play');
+win.PBP.settings.sfxVolume = 0;
+expect(!sfx.play('tick'), 'volume 0 schedules nothing');
+
+expect(Object.isFrozen(TUNING), 'TUNING is frozen');
+expect(fake.wires.some((w) => w[0] === 'gain' && w[1] === 'destination'), 'the master reaches the destination');
+
+bus.emit('check', { side: 'w' });
+sfx.dispose();
+expect(!sfx.state().pulsing && fake.state === 'closed', 'dispose stops the pulse and closes the context');
+
+if (problems.length) { console.log('\n' + problems.length + ' problem(s)'); process.exit(1); }
+console.log('\nsfx smoke: every cue schedules');


### PR DESCRIPTION
Lane J, third of three (stacked on #983). The board makes sounds, all drawn with Web Audio on the spot. No audio files, no dependencies, nothing loads until the first gesture.

## What it does
NEW `audio/sfx.js`, `createSfx({bus, game, group, squareOf, root})`, frozen TUNING at the top. Every cue is a few oscillators or one shared noise buffer with an envelope:
- grab: a wet little pop (520 to 260 Hz, 70 ms) on `grab`.
- hover: a dry tick each time the held man crosses a legal square (derived from his position via `worldToSquare` against `game.legalTargets(from)`; illegal squares stay silent, so the sound is information). Silent on repeats.
- land: a thud pitched by the man's height, pawn about 210 Hz down to the king at 95 Hz, plus a short noise tap, on `land`. A refused spring-back makes no thud.
- capture: the thud plus a sawtooth squelch and a wet hiss.
- boing: a sympathetic wobble on `drop` ok:false (failure gets sympathy, not a buzzer).
- check: a 58 Hz pulse every 0.9 s while the side to move is in check. `check` arrives before `turn` on the same move, so the turn that follows it keeps the pulse and the next turn stops it; gameover stops it too.
- mate sting (checkmate, flag, resign) and draw sting (stalemate, draw) on `gameover`.
- clock: one low tick a second for the side to move under 30 s, sharper under 10 s, never once the game is over.
- promotion: a rising four-note chime, found via `game.rules.chess.history` on the turn.
- video card: soft whoosh open and close. The ramp emits nothing on the bus, so a MutationObserver on the fx root watches `.pbp-card` come, get `is-out`, and go.
- AudioContext is made lazily on the first pointerdown or keydown (document capture, so the grab pop rides the very gesture that made it), resumed if suspended, master gain to 0 while the tab is hidden and back on return, master follows `window.PBP.settings.sfxVolume` (0.6 by default, read on every play; 0 schedules nothing).
- `sfx.play(name, opts)`, `sfx.log()` (last 32 cues with the context state), `sfx.state()`, `setVolume`, `dispose`. A `context` factory can be injected for tests.

`boot.js`: the same J block gains the sfx import (with `worldToSquare` off scene.js), nothing else.

## Proof
- NEW `smoke/sfx-smoke.mjs` (node, no browser): a fake recording AudioContext and the real bus, 23 checks all passing: lazy context, resume on gesture, two ticks for two legal squares crossed and none for an illegal one or a repeat, boing, no thud on a refused landing, pawn thud is tone plus tap, capture adds the squelch, check pulse survives its own turn and stops on the next, promotion chimes, three clock ticks for three seconds under 30 s with the one under 10 s sharp, no tick after gameover, mate and draw stings, card whooshes, hidden tab mutes and nothing schedules, volume read from settings, volume 0 schedules nothing, dispose stops the pulse timer and closes the context.
- `smoke/feel-shot.mjs` now dumps the cues a real drag made on the real page (headless msedge, real AudioContext): `grab, tick, tick, land, cardOpen, cardClose`, context `running`, no console errors.
- rules-smoke 43/43, ramp-smoke 111/111, jiggle-shot on the stack tip clean (flex cost 0.0045 ms/frame, reduced motion right).

## Not in this PR
No ramp-stage sound design (the brainstorm's wet-to-dry idea), no music, no per-cue volume UI. No change to drag.js, jiggle.js, pieces.js, scene.js, hotseat.js, ramp, index.html or styles.css.

## Touches outside my lane
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CQdAN3aDyhnnXWjBtkH1mD
