### PR TITLE
fix(race): bubbles ride the road, not a flat height over it

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
@@ -92,7 +92,9 @@ Returns a `layout` object that is ALSO a valid argument to `engine/tunnel.js cre
 - `chunks` -> ordered array of `{ id, kind, d0, d1, room, features }`.
   `kind` in `straight | bendL | bendR | sCurve | climb | dip | ramp | chicane | loop | gate`.
   `features` is an array of:
-  - `{ type:'ramp', d, airLen, height }` - lip at `d`, air line from `d` to `d + airLen`, apex `height`
+  - `{ type:'ramp', d, airLen, height, vh, airSec }` - lip at `d`, apex `height`; `vh`/`airSec` are
+    the launch speed and the hang time the kart really flies at cruise, and `airLen` is that
+    flight's own length, so the air line ends where the saucer lands
   - `{ type:'boost', d, x }` - boost pad centre
   - `{ type:'loop', d0, d1 }` - the Big Wheel occupies `d0..d1`
   - `{ type:'gate', d, room }` - room boundary; MARQUEE fires here
@@ -100,6 +102,15 @@ Returns a `layout` object that is ALSO a valid argument to `engine/tunnel.js cre
 - `featuresBetween(d0, d1)` -> features whose `d` (or `d0`) falls in the wrapped range.
 - `roomAtDepth(d)` -> room id.
 - `rampAt(d)` -> the ramp feature whose air line covers `d`, else `null`.
+- THE REACHABLE LINE, the one height everything on the road is measured from:
+  - `surfaceH(d)` -> the asphalt at `d`. 0 on open road; over the `RAMP_LEN` metres of wedge in
+    front of a lip it climbs to `RAMP_H` (consts.js owns both, rooms.js draws the wedge to them).
+  - `surfaceSlope(d)` -> that wedge's gradient, 0 elsewhere (kart.js pitches the saucer to it).
+  - `airLineAt(d)` -> `{ ramp, u, h }` inside a flight window, else `null`: the kart's own
+    ballistic arc off the lip at cruise.
+  - `rideH(d)` -> the arc where there is one, else the asphalt. NOTHING may hang at a flat height
+    over a ramp: bubbles.js measures every height off `rideH(d)`, so a bubble is never drawn
+    inside the wedge nor left metres under a kart in the air.
 
 Track shape rules: one Tea Garden start straight, then the rooms in `roomOrder`, each room = 4..7
 chunks, exactly one loop somewhere after the first two rooms, at least one ramp per room, the whole
@@ -222,9 +233,13 @@ since 2026-09-08, having pointed at the dark `video` bubble since that one went 
 `race/smoke/gifrain-row-check.mjs` drives a real run and holds the cascades against the rain
 bubbles that were laid, reading `race.fxStats()` - every payload the mixer has poured.
 
-Placements: `lane` (rests on the road, h ~0.9, bobbing), `air` (along a ramp air line, h rises
-2..5), `spawn` (materialises ahead, wobbles laterally), `rain` (falls from `h = 9` to the road in
-about 4 s, rests 2 s, then fizzles). Collision is pass-through: pop when
+Placements, ALL of them measured off `layout.rideH(d)` (the spine's reachable line) and never off
+the flat road plane: `lane` (rests `LANE_H` over the line, bobbing), `air` (`LANE_H` over the
+flight arc, one every 2 m for the first 10 m of it, the stretch every pace in the band can still
+reach), `spawn` (materialises ahead, wobbles laterally), `rain` (falls from `h = 9` and lands ON
+the line, rests 2 s, then fizzles). A row that walks onto a ramp climbs the wedge with it.
+`race/smoke/slope-check.mjs` walks every chart and seed through the real placement and holds it:
+nothing inside a slope, nothing outside the pop box of the line, at every pace. Collision is pass-through: pop when
 `|dd| < POP_HIT_D && |dx| < POP_HIT_X && |dh| < POP_HIT_H`.
 
 ### `race/score.js` (PR 2)
@@ -266,7 +281,8 @@ lathe cup, its rim torus, the handle tube, the saucer cylinder and its rim are t
 the tea disc, the pink saucer mark, `cupLight`, the seat and `TEA_Y` are shared by both paths.
 Speed: cruise `KART_BASE_SPEED`, cap `KART_MAX_SPEED`, floor `KART_MIN_SPEED`. Ramps: when
 `layout.rampAt(d)` matches the lip, give `vh` an upward impulse scaled by speed; `GRAVITY` pulls
-back; `airborne` while `h > 0.05`. Steering moves `x` with inertia, clamped to `KART_X_MAX` (soft wall,
+back. The saucer RIDES THE WEDGE up to the lip (`layout.surfaceH`) and is airborne while it is
+above it, so the ground under the kart is the same line the bubbles hang off. Steering moves `x` with inertia, clamped to `KART_X_MAX` (soft wall,
 no bounce-off shock): THE KERB HOLDS THE SAUCER, NOT THE CUP, so the limit is measured from the
 saucer's outer rim (`KERB_INNER_W - SAUCER_R_ROAD - KERB_KISS` = 1.775 m) and the dish stops on the
 kerb line instead of hanging a metre and a half past it. Drift = tighter steer + sparks, no penalty. EMI: CRT body seen

--- a/ConditioningControlPanel/Resources/web/dtrh/race/bubbles.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/bubbles.js
@@ -17,6 +17,14 @@
  * (engine/audioBus) and throws a few sparkle shards, the WPF BubbleService way.
  * Sprite textures come from the two locally mapped hosts (never remote media). Every sprite
  * (bubbles and shards) sits on pixel.js's CRISP_LAYER: full resolution over the blocky world.
+ *
+ * EVERY HEIGHT RIDES THE ROAD (2026-09-08). A bubble's `h` is metres above THE REACHABLE LINE
+ * (spine.js rideH: the ramp wedge under the wheels, then the flight arc off its lip), not above the
+ * flat road plane. Hung at a flat LANE_H a lane bubble on a ramp sat inside the wedge and one over
+ * an air line sat metres under the kart - the owner: "some bubbles get placed under the slopes and
+ * we can't get to them". The line is read ONCE, at placement, and kept on the slot as `ride`, so a
+ * bob or a rain landing costs no extra lookup; moveRow re-reads it because the row moved. Only rain
+ * starts absolute: it falls from the tube's own ceiling and lands on the line.
  * ==========================================================================*/
 
 import * as THREE from 'three';
@@ -33,6 +41,11 @@ export { BUBBLE_KINDS };
 // hidden, not freed: every visible sprite is a draw call, and past ~80 m the world has folded into fog anyway)
 // are shared/quality.js knobs read when the field is built: desktop 160 / 64 / 110, the mobile tier 100 / 32 / 76.
 const LANE_STEP = 3.2;        // metres between bubbles in a lane line
+/** Metres between the bubbles of a ramp's air line, and how many of them. The line covers the FIRST
+ *  ten metres of the flight on purpose: every pace from the gentle opening to a boosted lap crosses
+ *  those metres within the pop box of the same arc (race/smoke/slope-check.mjs measures it), where
+ *  the far end of a flight is only ever reachable at exactly one speed. */
+const AIR_STEP = 2.0, AIR_N = 5;
 const MISS_BEHIND = 6;        // a treat this far behind the kart unpopped = miss
 const DROP_BEHIND = 12;       // freed once this far behind
 const PASS_FADE_M = 1.6;      // metres behind the pop box over which a passed bubble fades away (before it balloons into the seat)
@@ -65,6 +78,8 @@ export function createBubbleField({ scene, layout, media, getIntensity, getRoom,
   const T = layout.totalDepth;
   /** Signed depth from `from` to `d`, folded into (-T/2, T/2] so the start line is nothing special. */
   const relD = (d, from) => { let r = (d - from) % T; if (r > T / 2) r -= T; else if (r <= -T / 2) r += T; return r; };
+  /** THE REACHABLE LINE at this depth (spine.js rideH). A layout without one is all road, at 0. */
+  const rideAt = (d) => (typeof layout.rideH === 'function' ? layout.rideH(d) : 0);
   const intensity = () => clamp(getIntensity ? getIntensity() : 0, 0, 1);
   const roomBias = () => { const r = getRoom && getRoom(); return (r && r.bubbleBias) || null; };
   /** 0 while the opening is treats only, then a ramp to 1 over the next minute. */
@@ -107,7 +122,7 @@ export function createBubbleField({ scene, layout, media, getIntensity, getRoom,
     sprite.visible = false; sprite.layers.set(CRISP_LAYER);
     group.add(sprite);
     pool.push({ sprite, mat, slot: i, eventId: null, rowId: 0, alive: false, kindId: 'treat', placement: 'lane', d: 0, x: 0, h: LANE_H,
-      x0: 0, baseH: LANE_H, phase: 0, age: 0, size: 1, scale: 1, popT: -1, missed: false,
+      x0: 0, baseH: LANE_H, ride: 0, phase: 0, age: 0, size: 1, scale: 1, popT: -1, missed: false,
       w: '', ink: null, big: false, rowN: 0 });   // the word painted on this bubble's face (race/wordFace.js)
   }
   const shards = [];
@@ -175,7 +190,10 @@ export function createBubbleField({ scene, layout, media, getIntensity, getRoom,
     const s = takeSlot();
     s.kindId = k.id; s.placement = placement;
     s.d = layout.wrap(d); s.x = clamp(x, -LANE_X_MAX, LANE_X_MAX); s.x0 = s.x;
-    s.h = h; s.baseH = h; s.phase = Math.random() * Math.PI * 2; s.age = 0;
+    // `h` is metres above THE REACHABLE LINE, except rain, which starts at the tube's own ceiling
+    // and falls onto it (update below): a ceiling that rode a 4 m flight arc would be outside the tube.
+    s.ride = rideAt(s.d);
+    s.h = placement === 'rain' ? h : h + s.ride; s.baseH = s.h; s.phase = Math.random() * Math.PI * 2; s.age = 0;
     s.size = sizeOf(k.id); s.scale = placement === 'spawn' ? 0 : 1; s.popT = -1; s.missed = false; s.eventId = null; s.rowId = 0;
     s.w = ''; s.ink = null; s.big = false; s.rowN = 0;
     s.mat.map = texOf[k.id]; s.mat.color.set(k.tint); s.mat.opacity = 1; s.mat.needsUpdate = true;
@@ -244,11 +262,10 @@ export function createBubbleField({ scene, layout, media, getIntensity, getRoom,
     }
     for (const f of chunk.features || []) {
       if (f.type === 'ramp') {
-        const n = 5, x = rand(-0.6, 0.6);
-        for (let i = 0; i < n; i++) {
-          const u = (i + 0.5) / n;
-          place(roll('air'), 'air', f.d + f.airLen * u, x, 2 + 3 * (4 * u * (1 - u)));
-        }
+        // the air line is the kart's own flight now: `h` is above the arc (rideAt), so the line
+        // threads the jump instead of hanging a metre and a half over the top of it
+        const x = rand(-0.6, 0.6);
+        for (let i = 0; i < AIR_N; i++) place(roll('air'), 'air', f.d + AIR_STEP * (i + 1), x, LANE_H);
       }
     }
   }
@@ -316,8 +333,10 @@ export function createBubbleField({ scene, layout, media, getIntensity, getRoom,
   function moveRow(id, d) {
     if (!id || !Number.isFinite(Number(d))) return 0;
     const dd = layout.wrap(Number(d));
+    const ride = rideAt(dd);
     let n = 0;
-    for (const s of pool) if (s.alive && s.rowId === id && s.popT < 0 && !s.missed) { s.d = dd; n++; }
+    // the row moved, so the line under it moved: keep its height above the line, not above 0
+    for (const s of pool) if (s.alive && s.rowId === id && s.popT < 0 && !s.missed) { s.d = dd; s.baseH += ride - s.ride; s.ride = ride; n++; }
     return n;
   }
   /** The row has been settled by one of its own: nobody else in it may report a miss. `missed` is
@@ -396,13 +415,14 @@ export function createBubbleField({ scene, layout, media, getIntensity, getRoom,
           const a = Math.min(1, s.age / 0.45);
           s.scale = 1 - (1 - a) * (1 - a);
           s.x = clamp(s.x0 + 0.55 * Math.sin(t * 1.7 + s.phase), -LANE_X_MAX, LANE_X_MAX);
-          s.h = LANE_H + bob;
+          s.h = s.ride + LANE_H + bob;
         } else if (s.placement === 'rain') {
-          if (s.age < RAIN_FALL) { const k = s.age / RAIN_FALL; s.h = CEILING_H - (CEILING_H - LANE_H) * k * k; }
-          else if (s.age < RAIN_FALL + RAIN_REST) { s.h = LANE_H + bob; }
+          const rest = s.ride + LANE_H;   // it lands ON the line, wherever the line is at its depth
+          if (s.age < RAIN_FALL) { const k = s.age / RAIN_FALL; s.h = CEILING_H - (CEILING_H - rest) * k * k; }
+          else if (s.age < RAIN_FALL + RAIN_REST) { s.h = rest + bob; }
           else {
             const f = (s.age - RAIN_FALL - RAIN_REST) / RAIN_FIZZLE;
-            s.h = LANE_H + bob; s.scale = 1 - 0.4 * f; s.mat.opacity = 1 - f;
+            s.h = rest + bob; s.scale = 1 - 0.4 * f; s.mat.opacity = 1 - f;
             if (f >= 1) { freeSlot(s); continue; }
           }
         }
@@ -472,6 +492,14 @@ export function createBubbleField({ scene, layout, media, getIntensity, getRoom,
     setSweep(on) { sweep = !!on; },
     /** riptide: while on, everything inside PULL_M ahead slides into the kart's lane. */
     setPull(on) { pull = !!on; },
+    /** Every live bubble in track space, as it was placed. Never read by the game: it is what
+     *  race/smoke/slope-check.mjs holds against THE REACHABLE LINE, so the one honest answer to
+     *  "is anything hung inside a slope or under a flight" comes out of the real placement code. */
+    slots() {
+      const out = [];
+      for (const s of pool) if (s.alive) out.push({ kindId: s.kindId, placement: s.placement, d: s.d, x: s.x, h: s.h, baseH: s.baseH, ride: s.ride, rowId: s.rowId });
+      return out;
+    },
     /** What race/smoke/face-check.mjs reads: the face cache, and what every live word bubble
      *  is wearing this frame, nearest the kart first, plus `placed`, every kind this run has put
      *  on the road counted by id. Never read by the game itself. */

--- a/ConditioningControlPanel/Resources/web/dtrh/race/consts.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/consts.js
@@ -50,6 +50,17 @@ export const POP_HIT_H = 1.25;
 /** Height of a lane bubble above the road (bubbles.js), and where the pop ring sits (kart.js). */
 export const LANE_H = 0.9;
 
+// ---- the ramp wedge, and the line the kart rides over it ---------------------------------
+// THE ROAD IS NOT ALWAYS AT h = 0. rooms.js builds a solid wedge on the asphalt in front of every
+// ramp lip, and off its crest the kart flies an arc, so for those metres the surface a player can
+// actually reach sits well above the road plane. Both numbers live here because spine.js measures
+// the reachable line off them (surfaceH / airLineAt / rideH), rooms.js draws the wedge to them and
+// kart.js stands the kart on them: three private copies of one slope is how a bubble ends up buried
+// inside it.
+/** Metres of slope in front of the lip, and the height of the crest the kart launches from. */
+export const RAMP_LEN = 4;
+export const RAMP_H = 0.8;
+
 /** Combo -> score multiplier ladder: [comboAtLeast, mult]. The first rung is three pops away. */
 export const MULT_LADDER = [[0, 1], [3, 2], [8, 3], [15, 4], [25, 6], [40, 8]];
 

--- a/ConditioningControlPanel/Resources/web/dtrh/race/kart.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/kart.js
@@ -167,6 +167,9 @@ export function createKart({ scene, layout, reducedMotion = false, pixel = null 
   let sway = 0, swayTarget = 0, swayPeriod = 2, swayX = 0;   // pocket watch: the pendulum (setSway)
 
   let vx = 0, lean = 0, pitch = 0, elapsed = 0, lastRampD = -1, driftSide = 1, camReady = false, camX = 0, camH = 0;
+  // the surface under the wheels this frame (the ramp wedge; 0 on open road) and the pitch that
+  // lying along it costs, so the clearance cap in place() measures air under the saucer, not h
+  let ground = 0, ridePitch = 0;
   let camBoost = 0, steerS = 0, hopT = 0, scrubSec = 0, sparkAcc = 0, driftWas = false;
   let airWas = false, steerWas = 0, trickArmed = false, trickKind = null, trickDir = 1, trickT = 1;
   let jumpArm = 0, jumpPending = false, jumpBoostD = -1, launchT = -1e4;
@@ -333,16 +336,26 @@ export function createKart({ scene, layout, reducedMotion = false, pixel = null 
       if (!hit && here && Math.abs(here.d - lastRampD) > 0.01) hit = here;
       if (hit) launch(hit);
     }
-    if (state.airborne || state.h > 0) {
+    // THE ROAD IS NOT ALWAYS AT h = 0 (consts.js RAMP_LEN / RAMP_H). The ramp wedge rooms.js
+    // draws is solid, so the wheels stand on it: the kart rides the slope up to the lip and
+    // launches off the crest rather than driving straight through the mesh at h = 0 with the air
+    // line hanging over its head. Everything below measures from `ground` for that reason, and
+    // spine.js hands bubbles.js the same line, so a bubble on a ramp is a bubble you can reach.
+    ground = lay.surfaceH ? lay.surfaceH(state.d) : 0;
+    if (state.airborne || state.h > ground) {
       state.vh -= GRAVITY * dt;
       state.h += state.vh * dt;
-      if (state.h <= 0) {                                              // THUD: land, squash, spring back
+      if (state.h <= ground) {                                         // THUD: land, squash, spring back
         rig.squash(clamp(-state.vh / 12, 0.25, 1));
-        state.h = 0; state.vh = 0; state.airborne = false;
+        state.h = ground; state.vh = 0; state.airborne = false;
       }
-    }
-    state.airborne = state.h > 0.05 || (state.airborne && state.h > 0);
-    const pitchT = state.airborne ? -clamp(state.vh / 12, -1, 1) * 0.35 : 0;
+    } else if (state.h !== ground) state.h = ground;                   // riding the wedge up to the lip
+    state.airborne = state.h > ground + 0.05 || (state.airborne && state.h > ground);
+    // grounded on the slope the cup lies ALONG it (nose up the wedge); in the air the pitch is
+    // the flight's. Both are negative for nose-up, see place().
+    const slope = state.airborne ? 0 : -Math.atan(lay.surfaceSlope ? lay.surfaceSlope(state.d) : 0);
+    ridePitch = Math.abs(slope);
+    const pitchT = state.airborne ? -clamp(state.vh / 12, -1, 1) * 0.35 : slope;
     pitch += (pitchT - pitch) * ease(6, dt);
   }
 
@@ -426,7 +439,9 @@ export function createKart({ scene, layout, reducedMotion = false, pixel = null 
     // kart's, but only as far as the air under the saucer allows: on the road the nose-up left
     // over from a landing would otherwise drive the saucer's back edge sin(pitch) * SAUCER_R_W
     // under the surface, so it is capped at asin(clearance / SAUCER_R_W) and touches down level.
-    const clear = Math.asin(clamp((state.h + Math.max(0, hopH)) / SAUCER_R_W, 0, 1));
+    // the air under the saucer is height above the SURFACE (the wedge included), and lying along
+    // the slope is never a clip, so the cap opens by exactly the slope the wheels are on
+    const clear = ridePitch + Math.asin(clamp((state.h - ground + Math.max(0, hopH)) / SAUCER_R_W, 0, 1));
     group.quaternion.multiply(_q.setFromAxisAngle(AX_X, clamp(pitch, -clear, clear)));
     if (trickT < 1) {                                                  // the trick: one full turn, eased
       const ang = Math.PI * 2 * smooth(trickT);

--- a/ConditioningControlPanel/Resources/web/dtrh/race/rooms.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/rooms.js
@@ -22,7 +22,7 @@
  * ==========================================================================*/
 
 import * as THREE from 'three';
-import { makeRng, CAM_BACK, KERB_INNER_W, KERB_OUTER_W, LANE_H } from './consts.js';
+import { makeRng, CAM_BACK, KERB_INNER_W, KERB_OUTER_W, LANE_H, RAMP_LEN, RAMP_H } from './consts.js';
 import { CRISP_LAYER } from './pixel.js';
 import { Q } from '../shared/quality.js';
 import { biomeById } from '../game/biomes.js';
@@ -258,17 +258,20 @@ export function createRoomDresser({ scene, layout, rooms = ROOMS }) {
   const AIR_DOTS = 10, AIR_X = 2.4;
   const DOT_NEAR = 6, DOT_FAR = 11, DOT_BEHIND = -(CAM_BACK + 2.5);
   const airBase = [], airD = [];   // per dot: its resting matrix and wrapped depth
-  const wedges = new THREE.InstancedMesh(track(wedgeGeometry(KERB_OUT, 4, 0.8)), wedgeMat, Math.max(1, ramps.length));
+  // the wedge's length and crest are consts.js's, because spine.js measures the reachable line off
+  // the same two numbers and kart.js stands the kart on them (see consts.js RAMP_LEN / RAMP_H)
+  const wedges = new THREE.InstancedMesh(track(wedgeGeometry(KERB_OUT, RAMP_LEN, RAMP_H)), wedgeMat, Math.max(1, ramps.length));
   const lips = new THREE.InstancedMesh(track(new THREE.BoxGeometry(KERB_OUT * 2 + 0.1, 0.2, 0.3)), pinkGlow, Math.max(1, ramps.length));
   const airDots = new THREE.InstancedMesh(track(new THREE.BoxGeometry(0.3, 0.3, 0.3)), gold, Math.max(1, ramps.length * AIR_DOTS));
   ramps.forEach((r, i) => {
     wedges.setMatrixAt(i, roadMatrix(r.d, 0, 0.01, 0, 1, _m));
     wedges.setColorAt(i, roomColorAt(r.d, 'road', _c).lerp(_c2.set(0xffffff), 0.45));
-    lips.setMatrixAt(i, roadMatrix(r.d, 0, 0.85, 0, 1, _m));
+    lips.setMatrixAt(i, roadMatrix(r.d, 0, RAMP_H + 0.05, 0, 1, _m));
     for (let k = 0; k < AIR_DOTS; k++) {
       const prog = (Math.floor(k / 2) + 1) / (AIR_DOTS / 2 + 1), side = k & 1 ? AIR_X : -AIR_X;
       const dd = r.d + prog * r.airLen;
-      airDots.setMatrixAt(i * AIR_DOTS + k, roadMatrix(dd, side, 0.5 + r.height * Math.sin(Math.PI * prog), prog * 2, 1, _m));
+      // the dots mark the flight ITSELF (spine.js rideH), which is the line the bubbles ride too
+      airDots.setMatrixAt(i * AIR_DOTS + k, roadMatrix(dd, side, layout.rideH ? layout.rideH(dd) + 0.4 : 0.5 + r.height * Math.sin(Math.PI * prog), prog * 2, 1, _m));
       airBase.push(_m.clone()); airD.push(layout.wrap(dd));
     }
   });

--- a/ConditioningControlPanel/Resources/web/dtrh/race/smoke/slope-check.mjs
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/smoke/slope-check.mjs
@@ -1,0 +1,213 @@
+/* ============================================================================
+ * race/smoke/slope-check.mjs - nothing is hung inside a slope or under a flight.
+ *
+ *   node race/smoke/slope-check.mjs      (from Resources/web/dtrh; 0 on pass, 1 with a count)
+ *
+ * THE BUG THIS HOLDS SHUT. The owner, driving it: "some bubbles get placed under the
+ * slopes and we can't get to them". Track space measures h from the road PLANE, and every
+ * climb, dip and the Big Wheel are baked into the spine, so on open road the plane IS the
+ * surface. A ramp is not: rooms.js stands a solid RAMP_LEN x RAMP_H wedge on the asphalt in
+ * front of the lip and the kart flies an arc off its crest. A bubble hung at a flat LANE_H
+ * through those metres is inside the wedge or a long way under the flight.
+ *
+ * So spine.js now answers where the kart IS - surfaceH / airLineAt / rideH, THE REACHABLE
+ * LINE - and bubbles.js measures every placement off it. This walks the REAL placement code
+ * (the real spine, the real createBubbleField, the real seedChunk / rain / spawnAhead and the
+ * two cue doors) over every chunk of several seeded tracks and counts what is out of reach,
+ * under the old flat rule and under the new one.
+ *
+ * It holds four things:
+ *   1. nothing is BELOW the reachable line at its own depth (nothing inside a wedge, nothing
+ *      buried in the road)
+ *   2. everything a run can put down is inside the pop box of that line: a bubble the kart
+ *      cannot meet is a bubble that should not have been placed
+ *   3. the flat rule it replaces really was leaving bubbles behind (else this smoke is testing
+ *      nothing) and the new rule leaves none
+ *   4. the air line is takeable across the whole pace band - the gentle opening at OPEN_PACE
+ *      through a boosted lap - because a line only one speed can reach is the same bug wearing
+ *      a different height
+ *
+ * three resolves off the local vendor copy the way race/smoke/gltf-smoke.mjs does it, and the
+ * DOM the texture loader reaches for is stubbed: no browser, no network, no renderer.
+ * ==========================================================================*/
+
+import { register } from 'node:module';
+import { pathToFileURL } from 'node:url';
+import path from 'node:path';
+
+const VENDOR = pathToFileURL(path.resolve(import.meta.dirname, '../../vendor/three/') + path.sep).href;
+register('data:text/javascript,' + encodeURIComponent(`
+  export function resolve(spec, ctx, next) {
+    if (spec === 'three') return { url: ${JSON.stringify(VENDOR)} + 'three.module.min.js', shortCircuit: true };
+    if (spec.startsWith('three/addons/')) return { url: ${JSON.stringify(VENDOR)} + 'addons/' + spec.slice('three/addons/'.length), shortCircuit: true };
+    return next(spec, ctx);
+  }`), import.meta.url);
+
+// the TextureLoader reaches for an <img> the moment the field is built, and the face cache for a
+// <canvas>: both are handed something inert, so every sprite keeps its fallback dot and nothing draws.
+const el = () => ({ addEventListener() {}, removeEventListener() {}, style: {}, width: 0, height: 0, getContext: () => null, set src(v) {}, get src() { return ''; } });
+globalThis.document = { createElement: el, createElementNS: el, documentElement: {} };
+
+const THREE = await import('three');
+const { createSpine } = await import('../spine.js');
+const { createBubbleField } = await import('../bubbles.js');
+const { rollRoomOrder } = await import('../rooms.js');
+const { LANE_H, POP_HIT_H, POP_HIT_D, CEILING_H, RAMP_H, RAMP_LEN, GRAVITY, KART_BASE_SPEED, OPEN_PACE, KART_MAX_SPEED } = await import('../consts.js');
+
+let fails = 0;
+const ok = (cond, what) => { if (!cond) { console.error('FAIL ' + what); fails++; } else console.log('  ok  ' + what); };
+const SEEDS = [1, 7, 42, 1234, 90210];
+/** A hair of slack: the placement rounds through wrap() and the line is sampled at the same d. */
+const EPS = 1e-6;
+
+/** The height the OLD flat rule gave this bubble at this depth: lane / spawn / a landed rain all sat
+ *  at LANE_H over the road plane, and the air line hung on a fixed parabola over the ramp's window. */
+function flatH(s, layout) {
+  if (s.placement !== 'air') return LANE_H;
+  const a = layout.airLineAt(s.d);
+  const u = a ? a.u : 0.5;
+  return 2 + 3 * (4 * u * (1 - u));
+}
+/** Where the OLD kart was at this depth: h = 0 all the way along the ground (it drove THROUGH the
+ *  wedge) and a flight launched off the road plane rather than off the crest. This is the line the
+ *  owner was actually driving when the bubbles turned out to be unreachable. */
+function oldRideH(d, layout) {
+  const a = layout.airLineAt(d);
+  if (!a) return 0;
+  const t = (d - a.ramp.d) / KART_BASE_SPEED;
+  return Math.max(0, a.ramp.vh * t - 0.5 * GRAVITY * t * t);
+}
+/** Half a bubble sprite, near enough: a lane bubble whose centre is this close to the wedge is
+ *  drawing inside it, which is the "under the slope" the owner could see. */
+const BUBBLE_R = 0.5;
+/** The resting height of a placed bubble: rain is measured where it LANDS, not mid-fall. */
+const restH = (s) => (s.placement === 'rain' ? s.ride + LANE_H : s.baseH);
+
+/** Every bubble one seeded track puts on the road, through the real field. The pool holds 160, and
+ *  a whole track lays far more than that, so each chunk gets its own field: the point is to walk
+ *  EVERY chunk of every seed, not to watch one pool recycle. */
+function lay(seed) {
+  const layout = createSpine({ seed, roomOrder: rollRoomOrder(seed) });
+  const scene = new THREE.Scene();
+  const newField = () => createBubbleField({ scene, layout, media: null,
+    getIntensity: () => 0.8, getRoom: () => null, getElapsed: () => 999 });
+  const ramps = layout.chunks.flatMap((c) => c.features || []).filter((f) => f.type === 'ramp');
+  const slots = [];
+  const drain = (f) => { slots.push(...f.slots()); f.dispose(); };
+  for (const c of layout.chunks) { const f = newField(); f.seedChunk(c); drain(f); }
+  // the two cue doors, aimed straight at the slopes: a lone spawn and a word row on the wedge, at
+  // the lip, and through the flight, plus the drip and the rain. This is what a run does to a ramp.
+  for (const r of ramps) {
+    const f = newField();
+    for (const off of [-RAMP_LEN, -RAMP_LEN / 2, -0.2, 0, 2, 6, 11]) {
+      f.spawnAt({ kindId: 'treat', placement: 'lane', d: r.d + off, x: 0, h: LANE_H, eventId: 'cue' });
+      f.spawnRow({ kindId: 'treat', placement: 'lane', d: r.d + off + 0.5, xs: [-1.6, 0, 1.6], h: LANE_H, eventId: 'row' });
+    }
+    f.rain(r.d - 20, 6);
+    f.spawnAhead(r.d - 45, 6);
+    drain(f);
+  }
+  return { layout, slots, ramps };
+}
+
+// ---- 1 + 2 + 3: the road, chunk by chunk, seed by seed --------------------------------
+let after = { buried: 0, unreachable: 0 }, before = { buried: 0, unreachable: 0 }, total = 0, onRamp = 0;
+const byPlacement = new Map();   // placement -> [placed, on a slope, buried before, unreachable before]
+for (const seed of SEEDS) {
+  const { layout, slots } = lay(seed);
+  const s0 = { below: 0, unreachable: 0, n: slots.length };
+  for (const s of slots) {
+    total++;
+    const ride = layout.rideH(s.d), surf = layout.surfaceH(s.d);
+    const row = byPlacement.get(s.placement) || [0, 0, 0, 0];
+    row[0]++;
+    if (ride > EPS) { onRamp++; row[1]++; }
+    const h = restH(s);
+    if (h < ride - EPS) { after.unreachable++; s0.below++; }
+    else if (Math.abs(h - ride) > POP_HIT_H) { after.unreachable++; s0.unreachable++; }
+    if (h < surf + BUBBLE_R) after.buried++;
+    // the same bubble under the rule this replaces, held against the kart THAT rule was driving
+    const f = flatH(s, layout);
+    if (f < surf + BUBBLE_R) { before.buried++; row[2]++; }
+    if (Math.abs(f - oldRideH(s.d, layout)) > POP_HIT_H) { before.unreachable++; row[3]++; }
+    byPlacement.set(s.placement, row);
+  }
+  ok(s0.below === 0 && s0.unreachable === 0,
+    `seed ${seed}: ${s0.n} bubbles, ${s0.below} below the line, ${s0.unreachable} out of the pop box`);
+}
+console.log(`  ..  ${total} bubbles over ${SEEDS.length} seeds, ${onRamp} of them on a slope or a flight`);
+console.log(`  ..  the flat rule: ${before.buried} drawn inside a slope, ${before.unreachable} out of the kart's reach`);
+console.log(`  ..  riding the line: ${after.buried} inside a slope, ${after.unreachable} out of reach`);
+for (const [p, [n, ramp, bur, lost]] of [...byPlacement].sort()) console.log(`  ..    ${p}: ${n} placed, ${ramp} on a slope, of those ${bur} were buried and ${lost} unreachable before`);
+ok(after.buried === 0, 'nothing is drawn inside a slope');
+ok(after.unreachable === 0, 'everything placed is inside the pop box of the reachable line');
+ok(before.unreachable > 0 && before.buried > 0, 'the flat rule it replaces really did strand bubbles (this smoke tests something)');
+
+// ---- 4: the air line, across the pace band --------------------------------------------
+// The line is dressed to the cruise. A slow lap lands early and a boosted one flies further, so
+// what matters is that the FIRST stretch - the metres the line actually covers - is crossed at
+// about the same height whatever the throttle did.
+const PACES = [OPEN_PACE, 0.85, 1, 1.15, KART_MAX_SPEED / KART_BASE_SPEED];
+/** kart.js launch(): vh scales with speed, capped, and the flight starts on the wedge crest. */
+function kartH(atD, ramp, speed) {
+  const scale = Math.min(1.3, Math.max(0.7, speed / KART_BASE_SPEED));
+  const vh = Math.sqrt(2 * GRAVITY * ramp.height * scale);
+  const t = (atD - ramp.d) / speed;
+  return Math.max(0, RAMP_H + vh * t - 0.5 * GRAVITY * t * t);
+}
+let airN = 0, airMiss = 0, worst = 0;
+for (const seed of SEEDS) {
+  const { slots, ramps } = lay(seed);
+  for (const s of slots) {
+    if (s.placement !== 'air') continue;
+    const r = ramps.find((f) => { const d = s.d - f.d; return d > -1 && d < f.airLen; });
+    if (!r) continue;
+    airN++;
+    for (const p of PACES) {
+      const gap = Math.abs(restH(s) - kartH(s.d, r, p * KART_BASE_SPEED) - LANE_H);
+      worst = Math.max(worst, gap);
+      if (gap > POP_HIT_H) { airMiss++; break; }
+    }
+  }
+}
+// and the same measure on the air line it replaces: five bubbles spread across the WHOLE window on
+// a fixed 2 + 3*4u(1-u) parabola. Its window was a random 22..30 m that had nothing to do with how
+// far the kart actually flew, so it is measured at both ends of that range and in the middle.
+let oldN = 0, oldMiss = 0;
+for (const len of [22, 26, 30]) {
+  let n = 0, miss = 0;
+  for (const seed of SEEDS) {
+    const { ramps } = lay(seed);
+    for (const r of ramps) for (let i = 0; i < 5; i++) {
+      const u = (i + 0.5) / 5, d = r.d + len * u, h = 2 + 3 * (4 * u * (1 - u));
+      const t = (d - r.d) / KART_BASE_SPEED;
+      n++;
+      if (Math.abs(h - Math.max(0, r.vh * t - 0.5 * GRAVITY * t * t)) > POP_HIT_H) miss++;   // the OLD kart: it left the road, not the crest
+    }
+  }
+  console.log(`  ..  the air line it replaces, over a ${len} m window: ${miss} of ${n} out of the kart's reach at the cruise`);
+  oldN += n; oldMiss += miss;
+}
+console.log(`  ..  ${airN} air-line bubbles, worst gap to the kart over the pace band ${worst.toFixed(2)} m (pop box ${POP_HIT_H})`);
+ok(oldMiss > oldN / 5, `the old air line really was hung over the top of the jump (${oldMiss} of ${oldN})`);
+ok(airN > 0, 'the ramps carry an air line at all');
+ok(airMiss === 0, `every air-line bubble is takeable at every pace (${airMiss} were not)`);
+
+// ---- the line itself: the wedge, the lip, the landing ---------------------------------
+{
+  const { layout, ramps } = lay(SEEDS[0]);
+  const r = ramps[0];
+  ok(Math.abs(layout.surfaceH(r.d) - RAMP_H) < 1e-6, 'the lip is the crest of the wedge');
+  ok(Math.abs(layout.surfaceH(r.d - RAMP_LEN) - 0) < 1e-6 && layout.surfaceH(r.d - RAMP_LEN / 2) > 0.3, 'the wedge slopes up over RAMP_LEN');
+  ok(layout.surfaceH(r.d - RAMP_LEN - 2) === 0 && layout.surfaceH(r.d + 8) === 0, 'open road is flat road');
+  ok(Math.abs(layout.surfaceSlope(r.d - 1) - RAMP_H / RAMP_LEN) < 1e-9 && layout.surfaceSlope(r.d + 8) === 0, 'the gradient is the wedge and nothing else');
+  const air = layout.airLineAt(r.d + r.airLen * 0.5);
+  ok(!!air && air.h > r.height * 0.7, 'the flight arcs over the road between the lip and the landing');
+  ok(layout.airLineAt(r.d + r.airLen + 1) === null && layout.rideH(r.d + r.airLen + 1) === 0, 'past the landing the line is the road again');
+  ok(Math.abs(layout.rideH(r.d + r.airLen - 0.05)) < 0.2, 'the arc comes back down onto the road exactly where the air line ends');
+  ok(r.airLen > POP_HIT_D * 2 && r.airLen < 40, `the air line is the flight's own length (${r.airLen.toFixed(1)} m)`);
+  ok(CEILING_H > layout.rideH(r.d + 4) + LANE_H, 'the rain still has room to fall over a flight');
+}
+
+console.log(fails ? `slope-check: ${fails} FAILED` : 'slope-check: all good');
+process.exit(fails ? 1 : 0);

--- a/ConditioningControlPanel/Resources/web/dtrh/race/spine.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/spine.js
@@ -21,10 +21,24 @@
  * like buildLoopLayout (fx.js calls layout.frameAt(Math.random())) and the frames also
  * carry normal/binormal aliases for up/right. Each room's first chunk is its gate; the
  * Tea Garden gate sits at d = 0 and the start straight follows it.
+ *
+ * THE REACHABLE LINE (2026-09-08). Track space measures h from the road PLANE, and climbs, dips
+ * and the Big Wheel are all baked into the spine, so on open road the plane is the surface. A ramp
+ * is not: rooms.js stands a solid RAMP_LEN by RAMP_H wedge on the asphalt in front of the lip and
+ * the kart flies an arc off its crest. A bubble hung at a flat LANE_H through those metres is
+ * inside the wedge or a long way under the flight - the owner, driving it: "some bubbles get placed
+ * under the slopes and we can't get to them". So the layout now answers where the kart IS:
+ *   surfaceH(d)   the solid furniture under the wheels (the wedge, 0 elsewhere)
+ *   surfaceSlope(d) its gradient, so the cup can lie along the slope
+ *   airLineAt(d)  the flight arc off the lip, or null
+ *   rideH(d)      THE REACHABLE LINE: the arc when there is one, else the surface
+ * Every placement is measured off rideH and the smoke race/smoke/slope-check.mjs holds it there.
+ * A ramp's airLen is the flight's own length now (the cruise off the crest), not a random 22..30,
+ * so the arc lands exactly where the air line ends.
  * ==========================================================================*/
 
 import * as THREE from 'three';
-import { RADIUS, ROAD_DROP, ROOM_IDS, makeRng } from './consts.js';
+import { RADIUS, ROAD_DROP, ROOM_IDS, makeRng, RAMP_LEN, RAMP_H, GRAVITY, KART_BASE_SPEED } from './consts.js';
 
 const FRAME_STEP = 0.5;                 // metres between cached frames
 const CP_STEP = 6;                      // control-point spacing along the ring, metres
@@ -67,6 +81,17 @@ const ROOM_POOLS = {
   coronation: ['ramp', 'climb', 'bendR', 'sCurve', 'straight', 'climb'],
 };
 const BOOST_ODDS = { casino: 0.75, toybox: 0.45, coronation: 0.45 };
+
+/** The nominal flight off a ramp lip: launched from the wedge crest (RAMP_H) at the cruise, under
+ *  kart.js's own GRAVITY. `vh` is the launch speed kart.js gives it at scale 1, `sec` the hang time
+ *  and `len` the metres of road it covers - which is what a ramp's airLen IS, so the arc cannot
+ *  disagree with the air line drawn under it. A faster kart flies further and a slow one lands
+ *  early; this is the line the road is dressed to. */
+function flightOf(height) {
+  const vh = Math.sqrt(2 * GRAVITY * Math.max(0.5, height));
+  const sec = (vh + Math.sqrt(vh * vh + 2 * GRAVITY * RAMP_H)) / GRAVITY;
+  return { vh, sec, len: KART_BASE_SPEED * sec };
+}
 
 const bump = (u) => Math.sin(Math.PI * u) ** 4;                    // 0 -> 1 -> 0, flat ends
 const smooth = (u) => u <= 0 ? 0 : u >= 1 ? 1 : u * u * (3 - 2 * u);
@@ -180,7 +205,9 @@ export function createSpine({ seed = 1, roomOrder } = {}) {
     if (c.kind === 'gate') features.push({ type: 'gate', d: d0 + len * 0.5, room: c.room });
     else if (c.kind === 'loop') features.push({ type: 'loop', d0, d1 });
     else if (c.kind === 'ramp') {
-      features.push({ type: 'ramp', d: d0 + 14, airLen: range(rng, [22, 30]), height: range(rng, [3, 4]) });
+      // the lip is the wedge's crest; the air line is the flight the kart actually makes off it
+      const height = range(rng, [3, 4]), fl = flightOf(height);
+      features.push({ type: 'ramp', d: d0 + 14, airLen: fl.len, height, vh: fl.vh, airSec: fl.sec });
     } else {
       if (rng() < boostOdds) features.push({ type: 'boost', d: d0 + len * 0.5, x: range(rng, [-1.2, 1.2]) });
       if (rng() < 0.5) features.push({ type: 'pickup', d: d0 + len * (rng() < 0.5 ? 0.28 : 0.76), x: range(rng, [-1.8, 1.8]) });
@@ -297,6 +324,38 @@ export function createSpine({ seed = 1, roomOrder } = {}) {
     return null;
   }
 
+  // ---- THE REACHABLE LINE (see the header) ---------------------------------------
+  /** Signed metres from `from` to `d`, folded into (-T/2, T/2] so the start line is nothing special. */
+  const relD = (d, from) => { let r = (d - from) % totalDepth; if (r > totalDepth / 2) r -= totalDepth; else if (r <= -totalDepth / 2) r += totalDepth; return r; };
+  /** Height of the solid road furniture above the road plane at `d`: the ramp wedge, which rises
+   *  over the RAMP_LEN metres in front of its lip, and 0 on open road. */
+  function surfaceH(d) {
+    let h = 0;
+    for (const r of ramps) {
+      const s = relD(d, r.d);                                    // -RAMP_LEN..0 while on the wedge
+      if (s <= 0 && s >= -RAMP_LEN) h = Math.max(h, RAMP_H * (1 + s / RAMP_LEN));
+    }
+    return h;
+  }
+  /** The gradient of that surface, metres of rise per metre of road (kart.js lies the cup on it). */
+  function surfaceSlope(d) {
+    for (const r of ramps) { const s = relD(d, r.d); if (s <= 0 && s >= -RAMP_LEN) return RAMP_H / RAMP_LEN; }
+    return 0;
+  }
+  /** The flight off a lip, when `d` is inside one: `{ ramp, u (0..1 of the air line), h }`, else null. */
+  function airLineAt(d) {
+    for (const r of ramps) {
+      const s = relD(d, r.d);
+      if (s <= 0 || s >= r.airLen) continue;
+      const t = s / KART_BASE_SPEED;
+      return { ramp: r, u: s / r.airLen, h: Math.max(0, RAMP_H + r.vh * t - 0.5 * GRAVITY * t * t) };
+    }
+    return null;
+  }
+  /** Where the kart rides at `d`: its flight arc over a lip, else the surface under its wheels.
+   *  Everything the road hangs on it (bubbles.js) is measured from here, never from h = 0. */
+  function rideH(d) { const a = airLineAt(d); return a ? a.h : surfaceH(d); }
+
   // ---- tunnel.js / fx.js compat (normalized t in 0..1, as buildLoopLayout) ---------
   const wrap01 = (t) => ((t % 1) + 1) % 1;
   const pointAt = (t, out) => spine.getPointAt(wrap01(t), out);
@@ -305,6 +364,7 @@ export function createSpine({ seed = 1, roomOrder } = {}) {
   return {
     RADIUS, totalDepth, loopDepth: totalDepth, spine, pointAt, frameAt,
     frameAtDepth, toWorld, wrap, chunks, featuresBetween, roomAtDepth, rampAt,
+    surfaceH, surfaceSlope, airLineAt, rideH,
     seed, roomOrder: [...new Set(chunks.map((c) => c.room))],
   };
 }


### PR DESCRIPTION
> "some bubbles get placed under the slopes and we can't get to them."

They were, and it was worse than it looked: some were drawn *inside* the ramp, invisible.

## what was wrong

A ramp is two things: a solid wedge on the asphalt (4 m long, 0.8 m at the lip) and a real
ballistic flight off that lip. Bubbles were hung at a fixed height over the flat road plane, and
three different files each kept their own copy of the ramp's shape, so:

- a lane row that walked onto a wedge was drawn **inside** it;
- a row inside a flight window sat on the road while the kart was three metres over it, and the pop
  test is on `|rel|` distances, so flying over one is a miss;
- the air line was a made-up parabola over a rolled 22..30 m window, not the arc the saucer flies;
- the kart itself did not ride the wedge, it drove through it.

## numbers, before and after

Measured by the new smoke over 5 seeds, every chart chunk plus the cue doors (`spawnAt`,
`spawnRow`, `rain`, `spawnAhead`) fired at each ramp: **4151 bubbles placed, 2015 of them on a
slope or inside a flight.**

| kind | placed | on a slope | drawn inside a slope (before) | out of the kart's reach (before) | after |
|---|---|---|---|---|---|
| lane | 3484 | 1380 | 217 | 474 | 0 / 0 |
| air | 205 | 205 | 0 | 178 | 0 / 0 |
| rain | 246 | 246 | 16 | 154 | 0 / 0 |
| spawn | 246 | 187 | 11 | 102 | 0 / 0 |
| **all** | **4151** | **2015** | **247** | **943** | **0 / 0** |

The old air line held against the old kart: 134 of 205 out of reach over a 22 m window, 149 over
26 m, 175 over 30 m. The new one's worst gap over the whole pace band is 1.01 m against a 1.25 m
pop box.

## the rule chosen

`race/spine.js` now owns **the reachable line**, and it is the only copy:

- `surfaceH(d)` - the asphalt: 0 on open road, climbing to `RAMP_H` over the `RAMP_LEN` of wedge;
- `surfaceSlope(d)` - that gradient, for the kart's pitch;
- `airLineAt(d)` - the kart's own arc off the lip at cruise;
- `rideH(d)` - the arc where there is one, the asphalt everywhere else.

`RAMP_LEN` and `RAMP_H` moved to `consts.js`, so spine measures, `rooms.js` draws and `kart.js`
stands on the same slope. A ramp's `airLen` is now the flight's own length (`vh`, `airSec` come
with it), so the air line ends exactly where the saucer lands rather than at a rolled number.

`bubbles.js` adds every lane / spawn / rain height to `rideH(d)`, re-reads it when a row moves, and
keeps rain landing *on* the line. On a flight the lane bubbles follow the arc, not the road: the
reachable line is what matters. The air line is the **first ten metres** of the flight, one bubble
every two - past that no single fixed line is takeable at both the open-road crawl and the cap.

`kart.js` rides the wedge up to the lip and pitches to the slope instead of clipping through it,
which also gets the saucer's ground clearance right on a ramp.

## how it was verified

- new `race/smoke/slope-check.mjs`: every chart chunk and a spread of seeds through the *real*
  placement code (`field.slots()` is a new debug-only reader). It asserts nothing inside a slope,
  nothing outside the pop box of the line, every air bubble takeable at 5 paces from `OPEN_PACE` to
  the cap, plus the wedge/lip/landing geometry, and it fails if the old flat rule *would not* have
  stranded anything (so the smoke tests something).
- all 15 existing node smokes still green.
- headless Chrome at 1280x720, same ramp and seed on this branch and on `origin/main`: before, the
  row is sunk into the wedge and the ones past the lip sit on the road under the flight; after, the
  row climbs the wedge and follows the arc. Zero console errors either side.

```
 .../Resources/web/dtrh/race/CONTRACT.md            |  26 ++-
 .../Resources/web/dtrh/race/bubbles.js             |  52 +++--
 .../Resources/web/dtrh/race/consts.js              |  11 ++
 .../Resources/web/dtrh/race/kart.js                |  29 ++-
 .../Resources/web/dtrh/race/rooms.js               |  11 +-
 .../Resources/web/dtrh/race/smoke/slope-check.mjs  | 213 +++++++++++++++++++++
 .../Resources/web/dtrh/race/spine.js               |  64 ++++++-
 7 files changed, 376 insertions(+), 30 deletions(-)
```

Not verified: nobody has played a ramp on a phone or in WebView2 since the change; the arc is
measured at cruise, so a very slow or very fast run over a *long* ramp is held only by the smoke's
pace band.

The gold economy pass rides on top of this branch as a second PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013T1bb13w97ndYjNveiFpLz
