### PR TITLE
feat(pbp): the shadow bends with the man

### DIFF
--- a/ConditioningControlPanel/Resources/web/piecebypiece/board/jiggle.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/board/jiggle.js
@@ -8,6 +8,12 @@
  * deformation happens in the vertex shader, normals included, so the lighting
  * follows the bend instead of sitting painted on a rigid shape.
  *
+ * The flex goes on twice: once on the materials you can see, and once on a
+ * MeshDepthMaterial hung on every mesh as its customDepthMaterial, because the
+ * shadow map is drawn through that and not through the surface shader. Both
+ * copies share the same uniform objects, so the man and his shadow bend off
+ * one spring in the same frame.
+ *
  * The spring lives in the piece's LOCAL space. World-space impulses (a slide
  * direction, a drag delta) are rotated into it first, so a black man, who is
  * turned to face down the board, leans the same way a white one does.
@@ -59,6 +65,7 @@ export const TUNING = Object.freeze({
 });
 
 const CACHE_KEY = 'pbp-jiggle-1';
+const DEPTH_KEY = 'pbp-jiggle-depth-1';
 const T = TUNING;
 const f = (n) => (Number.isInteger(n) ? n.toFixed(1) : String(n));
 
@@ -114,22 +121,52 @@ export function createJiggle() {
 
   const gain = () => (prefersReducedMotion() ? T.reducedScale : 1);
 
-  function install(material, u) {
+  /**
+   * Put the flex on one material.
+   *   normals  off for the depth material: its vertex shader only reaches for
+   *            a normal behind #ifdef USE_DISPLACEMENTMAP, so there is nothing
+   *            there to rotate, and injecting into that branch would only
+   *            write dead code into a shader that never asks for it.
+   *   key      the program cache key. Depth and surface are different shaders,
+   *            so they get different keys.
+   * A hook the material already carried (the silicone's own patch) is kept and
+   * runs first; a hook this system installed earlier is dropped instead, so a
+   * cloned material cannot end up with the prelude declared twice.
+   */
+  function install(material, u, { normals = true, key = CACHE_KEY } = {}) {
     material.userData.pbpJiggle = u;
-    material.onBeforeCompile = (shader) => {
+    const prior = material.onBeforeCompile && !material.onBeforeCompile.pbpJiggle
+      ? material.onBeforeCompile : null;
+    const hook = (shader, renderer) => {
+      if (prior) prior(shader, renderer);
       shader.uniforms.uBend = u.uBend;
       shader.uniforms.uSquash = u.uSquash;
       shader.uniforms.uHeight = u.uHeight;
       shader.uniforms.uPhase = u.uPhase;
       shader.uniforms.uTime = u.uTime;
-      shader.vertexShader = PRELUDE + shader.vertexShader
-        .replace('#include <beginnormal_vertex>', BEND_NORMAL)
-        .replace('#include <begin_vertex>', BEND_VERTEX);
+      let vs = PRELUDE + shader.vertexShader;
+      if (normals) vs = vs.replace('#include <beginnormal_vertex>', BEND_NORMAL);
+      shader.vertexShader = vs.replace('#include <begin_vertex>', BEND_VERTEX);
     };
+    hook.pbpJiggle = true;
+    material.onBeforeCompile = hook;
     // Every jiggling material compiles the same program, so they share one
     // cache entry; without a key of our own three would key them apart.
-    material.customProgramCacheKey = () => CACHE_KEY;
+    material.customProgramCacheKey = () => key;
     material.needsUpdate = true;
+  }
+
+  /**
+   * The shadow map is not drawn with the material you can see: three renders it
+   * through a MeshDepthMaterial of its own, which knows nothing about the flex,
+   * so a bending man used to cast a standing shadow. This is that depth pass
+   * given the same prelude and the SAME uniform objects, so one spring drives
+   * the man and his shadow off the same numbers, in the same frame.
+   */
+  function depthMaterialFor(u) {
+    const depth = new THREE.MeshDepthMaterial({ depthPacking: THREE.RGBADepthPacking });
+    install(depth, u, { normals: false, key: DEPTH_KEY });
+    return depth;
   }
 
   /** Give a freshly built piece its spring and hook up every mesh it owns. */
@@ -142,9 +179,13 @@ export function createJiggle() {
       uPhase: { value: Math.random() * Math.PI * 2 },
       uTime: { value: 0 },
     };
+    // One depth material for the whole man: every mesh he owns bends off the
+    // same spring, so they can all cast through the same shader.
+    const depth = depthMaterialFor(u);
     let height = 0;
     piece.traverse((o) => {
       if (!o.isMesh || !o.material) return;
+      o.customDepthMaterial = depth;
       if (o.geometry) {
         if (!o.geometry.boundingBox) o.geometry.computeBoundingBox();
         const bb = o.geometry.boundingBox;
@@ -162,6 +203,10 @@ export function createJiggle() {
       o.material = Array.isArray(o.material) ? next : next[0];
     });
     u.uHeight.value = height > 0.01 ? height : 1;
+    // The live spring, readable by anyone who owns the piece: pieces.js reads
+    // uBend and uSquash off it to keep the contact patch under a leaning man.
+    piece.userData.jiggleUniforms = u;
+    piece.userData.depthMaterial = depth;
     const world = (piece.scale.y || 1) * u.uHeight.value;
     const state = {
       piece, u,

--- a/ConditioningControlPanel/Resources/web/piecebypiece/board/pieces.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/board/pieces.js
@@ -41,6 +41,16 @@ const PROFILE = {
 
 const SKIN = { w: { color: 0xFFF0F5, sheen: 0xFF9EC4 }, b: { color: 0x3B2A63, sheen: 0x7B6CFF } };
 
+// The men cast shadows but do not take one. Their sculpt detail (ribs, suckers,
+// veins) is finer than any shadow texel we can afford, so every crease shadowed
+// the crease beside it and a whole flank of every piece went black: that is the
+// "hollow shell" the board used to read as. Proven by sweep: at 4096 over a
+// frustum drawn to the board it is unchanged, and at normalBias 0.6 (over half
+// a square) it only trades the black flanks for black pits. Their form comes
+// from the lights, the fake subsurface and the contact patch instead. The board
+// still receives, so the shadow a man throws is still there.
+const RECEIVES_SHADOW = false;
+
 // A glb node is allowed a transform of its own; if it has one it is baked into
 // the geometry, because only the geometry travels out of the file.
 const IDENTITY = new THREE.Matrix4();
@@ -123,7 +133,7 @@ export function createPieces({ group, assetsBase = './assets/pieces/', hooks = {
     const mats = [mat];
     const body = new THREE.Mesh(geometryFor(type, side), mat);
     body.castShadow = true;
-    body.receiveShadow = true;
+    body.receiveShadow = RECEIVES_SHADOW;
     root.add(body);
     // Jewellery: every mesh in the glb that is not the body is metal, not
     // silicone, so it keeps the material it was exported with. It shares the
@@ -132,7 +142,7 @@ export function createPieces({ group, assetsBase = './assets/pieces/', hooks = {
     if (art) for (const bit of art.trims) {
       const jewel = new THREE.Mesh(bit.geometry, bit.material ? bit.material.clone() : mat);
       jewel.castShadow = true;
-      jewel.receiveShadow = true;
+      jewel.receiveShadow = RECEIVES_SHADOW;
       root.add(jewel);
       mats.push(jewel.material);
     }

--- a/ConditioningControlPanel/Resources/web/piecebypiece/board/scene.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/board/scene.js
@@ -15,6 +15,14 @@ const CREAM = 0xF5E6C8;
 const PINK = 0xFF69B4;
 const BACKDROP = 0x1A1A3E;
 
+/** Every number the lighting rig is made of. One place, on purpose. */
+export const LIGHT = Object.freeze({
+  shadowMap: 2048,          // texels per side of the key light's shadow map
+  shadowHalfExtent: 5.2,    // the frustum, in squares from the middle out
+  shadowBias: -0.0006,      // pulls the comparison off the surface it came from
+  shadowNormalBias: 0.02,   // and walks the lookup out along the normal
+});
+
 /** Square name ("e4") to the world position of its centre. */
 export function squareToWorld(sq, y = 0, out = new THREE.Vector3()) {
   const f = FILES.indexOf(sq[0]);
@@ -52,10 +60,21 @@ export function createScene({ canvas }) {
   const key = new THREE.DirectionalLight(0xFFF3E4, 2.1);
   key.position.set(4.5, 9.5, 5.5);
   key.castShadow = true;
-  key.shadow.mapSize.set(1024, 1024);
+  // 2048 over a frustum drawn to the board, instead of 1024 over one with three
+  // squares of empty air on every side. A shadow texel is now about 5 mm of a
+  // 1.0 square, so a bent tip casts a bent tip and not a stair.
+  key.shadow.mapSize.set(LIGHT.shadowMap, LIGHT.shadowMap);
   key.shadow.radius = 3;
+  // The men are round and glossy, which is the shape self-shadowing goes wrong
+  // on. Without these the map wrote a whole flank of every piece into its own
+  // shadow and the man read as a black shell; normalBias walks the lookup off
+  // the surface along its normal, which is what a curved caster wants.
+  key.shadow.bias = LIGHT.shadowBias;
+  key.shadow.normalBias = LIGHT.shadowNormalBias;
   const cam = key.shadow.camera;
-  cam.left = -7; cam.right = 7; cam.top = 7; cam.bottom = -7; cam.near = 1; cam.far = 26;
+  const half = LIGHT.shadowHalfExtent;
+  cam.left = -half; cam.right = half; cam.top = half; cam.bottom = -half;
+  cam.near = 1; cam.far = 26;
   scene.add(key, key.target);
   const rim = new THREE.DirectionalLight(PINK, 1.15);
   rim.position.set(-5.5, 3.2, -6.5);


### PR DESCRIPTION
Lane H, first of two. The complaint was "shadows don't wobble": a man bends and
his shadow stays standing up straight.

## Why it did that

The flex lives in `material.onBeforeCompile`, and that only patches the material
you can see. Three renders the shadow map with its OWN material
(`MeshDepthMaterial`), which never got the patch, so the depth pass drew the
undeformed geometry every frame. The shadow was the shape of a man who was not
moving.

## What this does

`jiggle.attach` now builds a second material next to the visible one: a
`MeshDepthMaterial` with `RGBADepthPacking`, patched with the same prelude, the
same `<begin_vertex>` replacement, and the SAME uniform objects, so one spring
drives both. It goes on every mesh of the piece as `customDepthMaterial`, which
is exactly the hook three offers for this. The normals injection is skipped for
the depth pass: `depth_vert` only has a `<beginnormal_vertex>` inside
`#ifdef USE_DISPLACEMENTMAP`, so there is nothing there to rotate. Depth and
surface get different program cache keys.

Shadow quality went up to match: 2048 instead of 1024, over a frustum drawn to
the board (5.2 squares out) instead of one with three squares of empty air on
every side. A shadow texel is now about 5 mm of a 1.0 square, so a bent tip
casts a bent tip and not a stair. The numbers live in one frozen `LIGHT` object.

## The men cast a shadow, they do not take one

While proving the above I found the real reason the board looked like a rack of
black shells: self-shadowing. The sculpt detail (ribs, suckers, veins) is finer
than any shadow texel we can afford, so every crease shadowed the crease beside
it and a whole flank of every man went black. That is not fixable by turning
knobs, and I proved it rather than guessed:

- 4096 over a frustum drawn to the board: identical.
- `normalBias` 0.6 (over half a square): trades the black flanks for black pits.
- `shadowSide` front/double: no effect.

So `receiveShadow` is off on the men. The board still receives, so the shadow a
man throws is still there, and it is now the right shape.

## Proof

Same camera, same frame, forced bend of the same size.

- before: `Screenshots/piecebypiece/h/before/07b-shadow-bent-away.png` - the man
  leans, his shadow is a straight upright pawn silhouette.
- after: `Screenshots/piecebypiece/h/mid2/07b-shadow-bent-away.png` - the shadow
  is a bent lozenge that follows the lean.
- board: `before/01-board.png` vs `mid2/01-board.png` for the shell fix.

`rules-smoke` 43/43, `ramp-smoke` 111/111, `jiggle-shot` clean (peak bend 0.166,
reduced motion honoured).

Flex cost per frame over 32 pieces: 0.0032 ms before, 0.0048 ms after, on a
loaded machine where the same measurement wanders between 0.003 and 0.13 ms
depending on what else is running. The extra work is one more material per mesh
in the depth pass, which the GPU was already drawing.

## Touches outside my lane

None. `jiggle.js` is mine; in `pieces.js` only the two `receiveShadow` lines
inside `build()`; in `scene.js` only the lights block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CQdAN3aDyhnnXWjBtkH1mD
