### PR TITLE
feat(pbp): thick silicone, not a shell

### DIFF
--- a/ConditioningControlPanel/Resources/web/piecebypiece/board/jiggle.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/board/jiggle.js
@@ -151,8 +151,12 @@ export function createJiggle() {
     hook.pbpJiggle = true;
     material.onBeforeCompile = hook;
     // Every jiggling material compiles the same program, so they share one
-    // cache entry; without a key of our own three would key them apart.
-    material.customProgramCacheKey = () => key;
+    // cache entry; without a key of our own three would key them apart. The
+    // patch tag is part of the key because a material can carry a hook of its
+    // own (the silicone's fake subsurface): a jewel must never be handed the
+    // silicone's compiled program just because both of them jiggle.
+    const tag = (material.userData && material.userData.pbpPatch) || '';
+    material.customProgramCacheKey = () => key + tag;
     material.needsUpdate = true;
   }
 

--- a/ConditioningControlPanel/Resources/web/piecebypiece/board/pieces.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/board/pieces.js
@@ -61,19 +61,127 @@ function lathe(points, segments = 40) {
   return geo;
 }
 
+/** Every number the silicone and its contact patch are made of. */
+export const SKIN_TUNING = Object.freeze({
+  roughness: 0.33,
+  clearcoat: 0.42,          // was 0.6: a hard gloss over a dark body is a shell
+  clearcoatRoughness: 0.28,
+  sheen: 0.72,
+  sheenRoughness: 0.52,
+  // Fake subsurface. Not transmission and not thickness: those two are what
+  // make a soft body read as glass, which is the hollow look we are getting
+  // rid of. This is the two things a thick soft body actually does. It never
+  // goes to black in its own shade, because light that went in came back out,
+  // and it lights up along an edge where the body is thin.
+  fillFloor: 0.16,          // how much of its own colour a shaded face keeps
+  fillKnee: 0.30,           // the light level that floor has faded out by
+  rimGain: 0.16,            // how bright a thin edge gets
+  rimPower: 2.4,            // how tight to the edge that is
+  rimMix: 0.5,              // how far the rim leans off the body colour
+  // The contact patch: a disc of shade under the man, so he sits ON the board.
+  contactSpread: 2.15,      // disc width, in widths of the man's own footprint
+  contactAlpha: 0.46,
+  contactLiftFade: 0.62,    // world units of lift the patch fades out over
+  contactLiftGrow: 0.45,    // and how far it spreads while it goes
+  contactLean: 0.55,        // how far it slides under a leaning man
+  contactSquash: 0.7,       // and how far it spreads under a squatting one
+  contactUpright: 0.72,     // below this much "up" (a tumble) it is gone
+});
+
+const SK = SKIN_TUNING;
+const n2 = (v) => v.toFixed(4);
+
+// Fake subsurface, injected after <opaque_fragment> so it lands on the lit
+// colour and before the tone mapping. Everything it reads (outgoingLight,
+// diffuseColor, geometryNormal, geometryViewDir) is in scope there in
+// meshphysical_frag; diffuseColor already carries the vertex colours, so a
+// purple man is lifted by purple and a pink one by pink.
+const SKIN_PRELUDE = `
+uniform vec3 uSkinTint;
+`;
+const SKIN_FRAGMENT = `#include <opaque_fragment>
+{
+  float pbpLum = dot(outgoingLight, vec3(0.2126, 0.7152, 0.0722));
+  float pbpShade = 1.0 - smoothstep(0.0, ${n2(SK.fillKnee)}, pbpLum);
+  gl_FragColor.rgb += diffuseColor.rgb * (${n2(SK.fillFloor)} * pbpShade);
+  float pbpFres = pow(1.0 - clamp(dot(geometryNormal, geometryViewDir), 0.0, 1.0), ${n2(SK.rimPower)});
+  gl_FragColor.rgb += mix(diffuseColor.rgb, uSkinTint, ${n2(SK.rimMix)}) * (pbpFres * ${n2(SK.rimGain)});
+}`;
+
 /**
  * The silicone. `painted` is a piece whose geometry brings its own COLOR_0: the
  * base colour goes white and the vertex colours do the tinting, but the sheen,
  * the clearcoat and the emissive the buzz drives are the side's either way.
+ *
+ * The patch is left on onBeforeCompile for jiggle.js to chain the flex onto,
+ * and `userData.pbpPatch` tells jiggle to key this program apart from a plain
+ * material's, so a jewel can never be handed the silicone's shader.
  */
 function material(side, painted = false) {
   const skin = SKIN[side] || SKIN.w;
-  return new THREE.MeshPhysicalMaterial({
+  const mat = new THREE.MeshPhysicalMaterial({
     color: painted ? 0xFFFFFF : skin.color, vertexColors: painted,
-    roughness: 0.35, clearcoat: 0.6, clearcoatRoughness: 0.22, metalness: 0.0,
-    sheen: 0.5, sheenColor: new THREE.Color(skin.sheen), sheenRoughness: 0.6,
+    roughness: SK.roughness, clearcoat: SK.clearcoat,
+    clearcoatRoughness: SK.clearcoatRoughness, metalness: 0.0,
+    sheen: SK.sheen, sheenColor: new THREE.Color(skin.sheen), sheenRoughness: SK.sheenRoughness,
     emissive: new THREE.Color(skin.sheen), emissiveIntensity: 0,
   });
+  const uSkinTint = { value: new THREE.Color(skin.sheen) };
+  mat.userData.pbpPatch = 'skin';
+  mat.onBeforeCompile = (shader) => {
+    shader.uniforms.uSkinTint = uSkinTint;
+    shader.fragmentShader = SKIN_PRELUDE + shader.fragmentShader
+      .replace('#include <opaque_fragment>', SKIN_FRAGMENT);
+  };
+  return mat;
+}
+
+// --- the contact patch ------------------------------------------------------
+// One radial gradient, drawn once into a canvas and shared by every man. It is
+// a picture of shade, not a shadow map: it casts nothing, receives nothing, and
+// its raycast is stubbed out so it can never be the thing a pointer picks up.
+let contactTex = null;
+let contactGeo = null;
+
+function contactTexture() {
+  if (contactTex) return contactTex;
+  const N = 128;
+  const cv = document.createElement('canvas');
+  cv.width = N; cv.height = N;
+  const g = cv.getContext('2d');
+  const grad = g.createRadialGradient(N / 2, N / 2, 0, N / 2, N / 2, N / 2);
+  grad.addColorStop(0.00, 'rgba(0,0,0,1)');
+  grad.addColorStop(0.34, 'rgba(0,0,0,0.78)');
+  grad.addColorStop(0.68, 'rgba(0,0,0,0.24)');
+  grad.addColorStop(1.00, 'rgba(0,0,0,0)');
+  g.fillStyle = grad;
+  g.fillRect(0, 0, N, N);
+  contactTex = new THREE.CanvasTexture(cv);
+  contactTex.colorSpace = THREE.SRGBColorSpace;
+  return contactTex;
+}
+
+/** The disc that goes under one man. `foot` is his own width in local units. */
+function contactPatch(foot) {
+  if (!contactGeo) {
+    contactGeo = new THREE.PlaneGeometry(1, 1);
+    contactGeo.rotateX(-Math.PI / 2);
+  }
+  const mat = new THREE.MeshBasicMaterial({
+    map: contactTexture(), transparent: true, opacity: SK.contactAlpha,
+    depthWrite: false, toneMapped: false, fog: false,
+  });
+  const disc = new THREE.Mesh(contactGeo, mat);
+  disc.position.y = 0.005;
+  // No renderOrder of its own: it has to draw in the transparent pass, AFTER
+  // the board. Drawn early with depthWrite off, the squares simply paint over
+  // it and the patch is never seen.
+  disc.castShadow = false;
+  disc.receiveShadow = false;
+  disc.raycast = () => {};        // never the thing a pointer picks up
+  disc.userData.foot = Math.max(0.12, foot) * SK.contactSpread;
+  disc.scale.setScalar(disc.userData.foot);
+  return disc;
 }
 
 /** Extra bits a lathe cannot turn, also in normalised space. */
@@ -168,6 +276,16 @@ export function createPieces({ group, assetsBase = './assets/pieces/', hooks = {
       phase: Math.random() * Math.PI * 2,
     };
     if (jiggle) jiggle.attach(root);
+    // The contact patch goes on AFTER the flex, on purpose: it must not be
+    // handed the vertex shader or a depth material, because it is a picture of
+    // shade lying on the board and not a part of the man. It is kept out of
+    // userData.materials for the same reason, so the capture fade and the buzz
+    // never touch it.
+    body.geometry.computeBoundingBox();
+    const bb = body.geometry.boundingBox;
+    const disc = contactPatch(Math.max(bb.max.x - bb.min.x, bb.max.z - bb.min.z));
+    root.add(disc);
+    root.userData.contact = disc;
     return root;
   }
 
@@ -224,8 +342,40 @@ export function createPieces({ group, assetsBase = './assets/pieces/', hooks = {
     return piece || null;
   }
 
+  // The contact patches. Every man on the board, every frame, because a patch
+  // has to follow a drag and a drag happens with the wobble turned all the way
+  // down. It stays welded to the board while the man goes up, fades over the
+  // first two thirds of a square of lift, spreads as it fades, and slides and
+  // widens with whatever the spring is doing to him.
+  const upVec = new THREE.Vector3();
+  function updateContacts() {
+    for (const piece of group.children) {
+      const disc = piece.userData && piece.userData.contact;
+      if (!disc) continue;
+      const scale = piece.scale.y || 1;
+      const lift = Math.abs(piece.position.y);
+      const t = Math.min(1, lift / SK.contactLiftFade);
+      upVec.set(0, 1, 0).applyQuaternion(piece.quaternion);
+      const upright = THREE.MathUtils.smoothstep(upVec.y, SK.contactUpright, 1);
+      const body = piece.userData.material;
+      const fade = body && body.transparent ? body.opacity : 1;
+      const j = piece.userData.jiggleUniforms;
+      const bendX = j ? j.uBend.value.x : 0;
+      const bendZ = j ? j.uBend.value.y : 0;
+      const squash = j ? j.uSquash.value : 0;
+      disc.material.opacity = SK.contactAlpha * (1 - t) * upright * fade;
+      disc.visible = disc.material.opacity > 0.002;
+      if (!disc.visible) continue;
+      disc.scale.setScalar(disc.userData.foot * (1 + t * SK.contactLiftGrow) * (1 + squash * SK.contactSquash));
+      disc.position.set(bendX * SK.contactLean, 0.005 - piece.position.y / scale, bendZ * SK.contactLean);
+      // Flat on the board whatever the man is doing above it.
+      disc.quaternion.copy(piece.quaternion).invert();
+    }
+  }
+
   function update(dt) {
     clock += dt;
+    updateContacts();
     if (wobble <= 0.001) return;
     for (const piece of bySquare.values()) {
       if (piece.userData.held || piece.userData.busy) continue;

--- a/ConditioningControlPanel/Resources/web/piecebypiece/board/scene.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/board/scene.js
@@ -21,6 +21,15 @@ export const LIGHT = Object.freeze({
   shadowHalfExtent: 5.2,    // the frustum, in squares from the middle out
   shadowBias: -0.0006,      // pulls the comparison off the surface it came from
   shadowNormalBias: 0.02,   // and walks the lookup out along the normal
+  skyColor: 0x9E93E8,       // the room over the board
+  groundColor: 0x4A3A5E,    // and the bounce off the plinth, warmer than it was
+  hemi: 0.72,
+  keyColor: 0xFFF3E4,
+  key: 2.05,
+  fillColor: 0xCBB9FF,      // cool lavender, opposite the key
+  fill: 0.58,               // low: it is there to stop a flank going black
+  rimColor: 0xFF69B4,
+  rim: 1.15,
 });
 
 /** Square name ("e4") to the world position of its centre. */
@@ -55,9 +64,14 @@ export function createScene({ canvas }) {
 
   const camera = new THREE.PerspectiveCamera(40, 1, 0.1, 120);
 
-  // --- lights: one soft key over the board, one pink rim from behind ---------
-  scene.add(new THREE.HemisphereLight(0x8f86d6, 0x141433, 0.55));
-  const key = new THREE.DirectionalLight(0xFFF3E4, 2.1);
+  // --- lights: a soft key over the board, a fill facing it, a pink rim behind -
+  // A body this thick has no truly black side. The hemisphere is warmer and
+  // brighter at the ground than it was, so an underside picks up the plinth
+  // instead of the void, and the fill stands opposite the key at about a
+  // quarter of its strength: enough to find the far edge of a man, not enough
+  // to flatten the modelling the key is doing. The fill casts nothing.
+  scene.add(new THREE.HemisphereLight(LIGHT.skyColor, LIGHT.groundColor, LIGHT.hemi));
+  const key = new THREE.DirectionalLight(LIGHT.keyColor, LIGHT.key);
   key.position.set(4.5, 9.5, 5.5);
   key.castShadow = true;
   // 2048 over a frustum drawn to the board, instead of 1024 over one with three
@@ -76,7 +90,11 @@ export function createScene({ canvas }) {
   cam.left = -half; cam.right = half; cam.top = half; cam.bottom = -half;
   cam.near = 1; cam.far = 26;
   scene.add(key, key.target);
-  const rim = new THREE.DirectionalLight(PINK, 1.15);
+  const fill = new THREE.DirectionalLight(LIGHT.fillColor, LIGHT.fill);
+  fill.position.set(-5.0, 4.0, 4.5);
+  fill.castShadow = false;
+  scene.add(fill, fill.target);
+  const rim = new THREE.DirectionalLight(LIGHT.rimColor, LIGHT.rim);
   rim.position.set(-5.5, 3.2, -6.5);
   scene.add(rim, rim.target);
 


### PR DESCRIPTION
Lane H, second of two. Stacked on #988.

The complaint was that the men look hollow. I looked at the screenshot before
touching anything, and the first thing to say is that half of it was not the
material at all: it was self-shadowing, and #988 under this one deals with that.
This PR is the other half, the part that makes them read as thick.

No `transmission` and no `thickness` anywhere. Those two are what turn a soft
body into glass, and glass is the hollow look.

## Lights

The hemisphere is warmer and brighter at the ground (`0x4A3A5E` at 0.72 instead
of `0x141433` at 0.55) so an underside picks up the plinth instead of the void.
A fill light stands opposite the key at about a quarter of its strength, cool
lavender, `castShadow = false`: enough to find the far edge of a man, not enough
to flatten the modelling the key is doing. Every number is in the frozen `LIGHT`
object. ACES and the 1.06 exposure are untouched.

## Fake subsurface

Patched into `meshphysical_frag` after `<opaque_fragment>`, which is where
`outgoingLight`, `diffuseColor`, `geometryNormal` and `geometryViewDir` are all
in scope. Two things a thick soft body actually does:

- it never goes to black in its own shade, because light that went in came back
  out: a floor of the body's own colour, gated on how dark the lit result
  already is;
- it lights up along an edge where the body is thin: a fresnel rim leaning half
  way from the body colour to the side's sheen.

`diffuseColor` already carries the vertex colours, so a purple man is lifted by
purple and a pink one by pink, with no per-side branch. Clearcoat came down from
0.6 to 0.42 in the same pass, because a hard gloss over a dark body is most of
what "shell" looks like. Tunables in a frozen `SKIN_TUNING`.

The patch sits on `onBeforeCompile` and jiggle chains the flex on top of it (it
already keeps a prior hook); jiggle's program cache key now carries the
material's patch tag, so a jewel can never be handed the silicone's program.
Crowns and tiaras are still the metal they were exported with, and
`piece.userData.materials` is unchanged, so the capture fade and the buzz still
find what they iterate.

## Contact patches

A radial-gradient `CanvasTexture` disc under every man: parented to his root at
y 0.005, casts nothing, receives nothing, `raycast` stubbed out so a pointer can
never pick it up, deliberately kept OUT of `userData.materials`, and added AFTER
`jiggle.attach` so it gets neither the flex shader nor a depth material. It
stays welded to the board while he goes up, fades over two thirds of a square of
lift, spreads as it fades, slides under him with `uBend` and widens with
`uSquash`, and goes to nothing if he tumbles past 0.72 of upright.

One thing worth knowing if you touch it: it must NOT have a `renderOrder` of its
own. Drawn early with `depthWrite` off, the opaque squares simply paint over it
and the patch is never seen. I shipped that bug to myself first.

## Proof (same camera, same frames)

- board: `Screenshots/piecebypiece/h/before/01-board.png` vs `after3/01-board.png`
- pink close: `before/02-pink.png` vs `after3/02-pink.png`
- purple close: `before/03-purple.png` vs `after3/03-purple.png`
- lifted man, no patch under him, patches still under everyone else in the same
  frame: `after3/04-lifted.png`
- bent man, bent shadow, patch slid under the lean: `after3/07b-shadow-bent-away.png`

`rules-smoke` 43/43, `ramp-smoke` 111/111, `jiggle-shot` clean (peak bend 0.155,
reduced motion poke 0.056, no console errors).

Cost: flex 0.0040 ms per frame over 32 pieces, unchanged. Draw calls 137 -> 169
(one per patch), triangles 538,356 -> 538,420. CPU-side `renderer.render` came
in at 1.09 ms under swiftshader, in the same band as before the change.

## One thing this cannot fix

`pawn_purple.glb` is painted almost black. Its COLOR_0 averages linear
(0.012, 0.012, 0.047); the purple rook, for comparison, averages
(0.112, 0.046, 0.228). That is why the purple pawns still read as black plugs
next to a properly purple back rank. Nothing in a material can lift a black
albedo without lying about every other piece, so this wants a re-export at the
rook's purple. The pinks are exactly right: (1.000, 0.141, 0.463) is linear of
`#FF69B4`, which matches the approved Blender lineup.

Normals were checked too, and they are fine: winding agrees with the normal
5088 to 0, and radial normals point away from the axis 2304 to 144 (the 144 are
cap faces, which is correct). No flip needed.

## Touches outside my lane

`pieces.js` `update()`: one call to `updateContacts()` and the function it calls,
added above the `wobble <= 0.001` early return, because a patch has to follow a
drag and a drag happens with the wobble turned all the way down. Nothing else in
that function changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CQdAN3aDyhnnXWjBtkH1mD
