### PR TITLE
fix(race): a run the aligner collapsed goes back where it was said

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/race/CHART.md
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/CHART.md
@@ -205,6 +205,18 @@ the pop box. `node race/smoke/coverage-check.mjs` drives the whole shelf through
 refusals and fails under 96 percent on the shelf, under 90 on a track, or on ONE word bubble the
 chart asked for and the field did not lay.
 
+**THE PILE, AND WHY MOST OF THEM ARE NOT ONE.** Twenty-one runs on the shelf have three or more
+words inside `MERGE_SEC` of each other, and nineteen of them are real: "in a completely", "as a
+perfect", "of a trap", said at 0.09 to 0.11 s a word. The other kind is the aligner losing the
+words and dropping the whole run on the last instant it was sure of - seven words at 0.01 s a
+word with 2.7 s of empty road in front of them. So the test is the RATE, `PILE_TIGHT_SEC`
+(0.05 s a word, well under the fastest real run on the shelf), and a run that fails it is spread
+back over the silence beside it at the local speech rate, anchored on the second the aligner DID
+have, never further apart than `PHRASE_GAP_SEC` so it comes back as one line in one lane rather
+than a word per lane. Those bubbles carry `est: true` to the chart event. A run with no silence to
+go back into is left exactly where it is and counted (`coverage.pilesLeft`) - a guess with no room
+is worse than the collision. `node race/smoke/word-sync-check.mjs` holds all of it.
+
 ### `race/run.js` + `raceBoot.js` (PR c2)
 ```js
 race.setTrack(chart | null)        // before start(); null returns to the seeded run

--- a/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
@@ -240,6 +240,11 @@ Combo drops to 0 after `COMBO_HOLD_SEC` with no word DUE: a pop resets that cloc
 missed cannot time the ladder out on two gaps that are each inside the hold. `bank()` moves `score` into `banked` at the
 Tea Garden gate (THE BANK). Events: `{ type:'pop'|'miss'|'combo'|'mult'|'bank'|'jackpot'|'almost', ... }`.
 
+A word event may also carry `est: true`: the second is this build's estimate, not the aligner's,
+because the run it is in was collapsed onto one instant and `race/wordBubbles.js` put it back over
+the silence it was said in. Nothing in the game reads it yet; it is there so a bad transcript is
+visible in the chart rather than only on the road.
+
 ### `race/kart.js` (PR 3)
 ```js
 export function createKart({ scene, layout, reducedMotion }) -> kart

--- a/ConditioningControlPanel/Resources/web/dtrh/race/chart.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/chart.js
@@ -157,6 +157,10 @@ function normalizeEvents(raw, durationSec) {
         // and the LINE it belongs to (race/wordBubbles.js wordEventsFrom). A phrase is what the
         // ladder and the end card count in, so losing this turns a sentence back into loose words.
         if (isFinite(num(e.p, NaN))) ev.p = Math.max(0, Math.round(num(e.p, 0)));
+        // and whether this second is the transcript's or this build's estimate: a run the
+        // aligner collapsed onto one instant is spread back over the silence it was said in
+        // (race/wordBubbles.js unpile), and the bubbles that moved say so.
+        if (e.est === true) ev.est = true;
       }
       if (e.kind === 'chant') { ev.reps = Math.max(1, Math.round(num(e.reps, 3))); ev.period = Math.max(0, num(e.period, 0)); }
       // An author marks the events they placed by hand inside a road, names the cue they

--- a/ConditioningControlPanel/Resources/web/dtrh/race/smoke/word-sync-check.mjs
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/smoke/word-sync-check.mjs
@@ -1,0 +1,184 @@
+/* ============================================================================
+ * race/smoke/word-sync-check.mjs - a word bubble is on the second the word is said.
+ *
+ *   node race/smoke/word-sync-check.mjs   (from Resources/web/dtrh; 0 on pass, 1 with a count)
+ *
+ * Pure: no browser, no network, no audio. The eleven transcripts on the shelf plus a
+ * handful of hand-built fixtures, through race/wordBubbles.js and race/chart.js.
+ *
+ * WHY IT EXISTS. The owner, 2026-09-08: "some words are still isolated and not in sync
+ * (not that often but it's pretty bad) like I get the bubble sinking way before the
+ * words, most are fine."
+ *
+ * Measured, the road's own placement is not the problem: driven headless over a real
+ * chart, the kart met 138 word bubbles a median of 0.022 s from the word's own second,
+ * worst 0.080 s, because race/sync.js keeps a row under its word until the last 0.25 s
+ * (CUE_AHEAD_SEC) whatever the throttle does. Nor is the transcript loose: over 20,923
+ * words there is not one order break and not one overlap.
+ *
+ * What IS wrong is the aligner giving up. Twenty-one runs on the shelf have three or
+ * more words inside MERGE_SEC of each other, and two kinds of thing look like that:
+ *   - fast speech. "in a completely", "as a perfect", "of a trap" at 0.09 to 0.11 s a
+ *     word. Nineteen of the twenty-one. These are real and must not be touched.
+ *   - a COLLAPSE. Seven words at 0.01 s a word, dropped on the last instant the aligner
+ *     was sure of, with 2.7 s of silence in front of them where they were actually
+ *     said. The road used to merge two of them onto that instant and throw the other
+ *     five away: half a phrase, seconds from where the voice says it.
+ *
+ * What it holds:
+ *   1. the line between the two is the RATE, and it is nowhere near the fastest real
+ *      run on the shelf, so no real speech is ever taken apart.
+ *   2. a collapse is put back into the silence beside it, in order, inside that
+ *      silence, at the local rate, anchored on the one second the aligner was sure of.
+ *   3. and it comes back as ONE line in ONE lane, not as a word per lane.
+ *   4. every bubble that moved is marked `est`, all the way through normalizeChart.
+ *   5. the shelf: order, overlap and collapse counts, before and after.
+ *
+ * It never prints a line of a transcript. Everything below is counted.
+ * ==========================================================================*/
+
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import phrasesFrom, { wordEventsFrom, WORD_RULE } from '../wordBubbles.js';
+import { normalizeChart } from '../chart.js';
+
+let fails = 0;
+const ok = (cond, what) => { if (!cond) { console.error('FAIL ' + what); fails++; } else console.log('  ok  ' + what); };
+const eq = (got, want, what) => ok(got === want, what + ' (got ' + JSON.stringify(got) + ', want ' + JSON.stringify(want) + ')');
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const WORDS_DIR = resolve(HERE, '../words');
+const read = (f) => JSON.parse(readFileSync(resolve(WORDS_DIR, f), 'utf8'));
+const SHELF = read('index.json').rows.map((r) => ({ row: r, words: read(r.file) }));
+const rng = () => 0.4;
+const pad = (s, n) => String(s).padEnd(n);
+
+/** Every maximal run of words inside MERGE_SEC of each other, with the rate it runs at. */
+function runsOf(list, min = WORD_RULE.PILE_MIN) {
+  const a = list.slice().sort((x, y) => x.t - y.t);
+  const out = [];
+  for (let i = 0; i < a.length;) {
+    let j = i + 1;
+    while (j < a.length && a[j].t - a[j - 1].t < WORD_RULE.MERGE_SEC) j++;
+    const n = j - i;
+    if (n >= min) out.push({ i, j, n, rate: (a[j - 1].t - a[i].t) / (n - 1), t: a[i].t });
+    i = j;
+  }
+  return out;
+}
+
+console.log('\nword-sync-check\n');
+eq(SHELF.length, 11, 'the shelf has all eleven transcripts on it');
+
+/* ---- 1. the shelf, before and after --------------------------------------- */
+console.log('\n  track                    | words | order | overlap | runs of 3+ | of those a collapse | words put back');
+console.log('  -------------------------+-------+-------+---------+------------+---------------------+---------------');
+let sOrder = 0, sOverlap = 0, sRuns = 0, sTight = 0, sMoved = 0, sLeft = 0, sAfter = 0;
+for (const { row, words } of SHELF) {
+  const a = (words.words || []).slice().sort((x, y) => x.t - y.t);
+  let order = 0, overlap = 0;
+  for (let i = 1; i < a.length; i++) {
+    if (a[i].t < a[i - 1].t) order++;
+    if (a[i].t < a[i - 1].t + (a[i - 1].d || 0) - 1e-6) overlap++;
+  }
+  const runs = runsOf(a);
+  const tight = runs.filter((r) => r.rate <= WORD_RULE.PILE_TIGHT_SEC);
+  const ph = phrasesFrom(words.words, words.hits || [], { rng });
+  const flat = [];
+  for (const p of ph) for (const b of p.words) flat.push(b);
+  const after = runsOf(flat).filter((r) => r.rate <= WORD_RULE.PILE_TIGHT_SEC).length;
+  sOrder += order; sOverlap += overlap; sRuns += runs.length; sTight += tight.length;
+  sMoved += ph.unpiled; sLeft += ph.pilesLeft; sAfter += after;
+  console.log('  ' + pad(row.title, 25) + '| ' + pad(a.length, 6) + '| ' + pad(order, 6) + '| ' + pad(overlap, 8)
+    + '| ' + pad(runs.length, 11) + '| ' + pad(tight.length, 20) + '| ' + ph.unpiled);
+}
+console.log('');
+eq(sOrder, 0, 'not one word on the shelf is out of order');
+eq(sOverlap, 0, 'and not one starts before the word in front of it has finished');
+ok(sRuns >= 20, 'the shelf has runs of three or more inside MERGE_SEC (' + sRuns + ')');
+eq(sTight, 1, 'and exactly one of them is an aligner collapse rather than a fast mouth');
+eq(sMoved, 6, 'so six words go back into the silence they were said in');
+eq(sLeft, 0, 'with no collapse left sitting on one instant');
+eq(sAfter, 0, 'and not one collapse survives into the bubbles');
+
+/* ---- 2. the line between fast speech and a collapse ----------------------- */
+let fastest = Infinity;
+for (const { words } of SHELF) {
+  for (const r of runsOf((words.words || []))) if (r.rate > WORD_RULE.PILE_TIGHT_SEC) fastest = Math.min(fastest, r.rate);
+}
+ok(fastest > WORD_RULE.PILE_TIGHT_SEC * 1.2,
+  'the fastest real run on the shelf is clear of the collapse test (' + fastest.toFixed(3) + ' s a word against ' + WORD_RULE.PILE_TIGHT_SEC + ')');
+ok(WORD_RULE.PILE_TIGHT_SEC < WORD_RULE.MERGE_SEC,
+  'and a collapse is tighter than the merge, so the two rules cannot fight');
+
+/* ---- 3. a collapse goes back where it was said ---------------------------- */
+// eight words dropped on one instant, with two seconds of silence in front of them.
+const pile = [{ t: 0.5, d: 0.2, w: 'and' }, { t: 0.7, d: 0.2, w: 'you' }];
+for (let i = 0; i < 8; i++) pile.push({ t: 3.4 + i * 0.01, d: 0.01, w: 'w' + i });
+pile.push({ t: 3.7, d: 0.2, w: 'after' }, { t: 4.0, d: 0.2, w: 'that' });
+const back = phrasesFrom(pile, [], { rng });
+const bflat = [];
+for (const p of back) for (const b of p.words) bflat.push(b);
+const moved = bflat.filter((b) => b.est);
+eq(back.unpiled, 7, 'a collapse of eight puts seven of them back (the last second was the one the aligner had)');
+ok(moved.length >= 6, 'and the bubbles that moved are marked est (' + moved.length + ')');
+let asc = true, inRoom = true;
+for (let i = 1; i < bflat.length; i++) if (bflat[i].t < bflat[i - 1].t - 1e-9) asc = false;
+for (const b of moved) if (b.t <= 0.9 || b.t > 3.41) inRoom = false;
+ok(asc, 'the words come back in the order they were said');
+ok(inRoom, 'inside the silence and nowhere else: never before the word in front, never past the anchor');
+const anchored = bflat.some((b) => Math.abs(b.t - 3.47) < 0.02 || Math.abs(b.t - 3.4) < 0.02);
+ok(anchored, 'and the one second the aligner was sure of does not move');
+
+/* ---- 4. and it comes back as a LINE, not as a word per lane --------------- */
+const pileLines = back.filter((p) => p.words.some((b) => b.est));
+const lanes = new Set(pileLines.map((p) => p.lane));
+eq(lanes.size, 1, 'every bubble put back sits in one lane');
+eq(pileLines.length, Math.ceil(8 / WORD_RULE.PHRASE_MAX_WORDS),
+  'and the run reads as one line, cut only where a line is always cut');
+let widest = 0;
+for (let i = 1; i < moved.length; i++) widest = Math.max(widest, moved[i].t - moved[i - 1].t);
+ok(widest < WORD_RULE.PHRASE_GAP_SEC, 'no two of them are far enough apart to become separate lines (' + widest.toFixed(3) + ' s)');
+
+/* ---- 5. fast speech is never taken apart ---------------------------------- */
+const fast = [{ t: 1.0, d: 0.3, w: 'stay' },
+  { t: 3.0, d: 0.09, w: 'in' }, { t: 3.09, d: 0.09, w: 'a' }, { t: 3.18, d: 0.4, w: 'completely' },
+  { t: 4.0, d: 0.3, w: 'open' }];
+const kept = phrasesFrom(fast, [], { rng });
+eq(kept.unpiled, 0, 'a real fast run with silence beside it is left exactly where it was');
+const kflat = [];
+for (const p of kept) for (const b of p.words) kflat.push(b);
+eq(kflat.filter((b) => b.est).length, 0, 'and nothing in it is marked est');
+
+/* ---- 6. no silence to go back into --------------------------------------- */
+const boxed = [{ t: 2.85, d: 0.10, w: 'before' }];
+for (let i = 0; i < 4; i++) boxed.push({ t: 3.0 + i * 0.01, d: 0.01, w: 'x' + i });
+boxed.push({ t: 3.16, d: 0.10, w: 'after' });
+const tightRun = phrasesFrom(boxed, [], { rng });
+eq(tightRun.unpiled, 0, 'a collapse with no silence either side is left alone rather than guessed at');
+eq(tightRun.pilesLeft, 1, 'and it is counted, so a transcript that is all collapse is visible');
+
+/* ---- 7. est survives to the chart ---------------------------------------- */
+const evs = wordEventsFrom(pile, [], { rng });
+const estEvents = evs.filter((e) => e.est === true);
+ok(estEvents.length >= 6, 'the moved bubbles come out of wordEventsFrom marked est (' + estEvents.length + ')');
+const chart = normalizeChart({ v: 1, durationSec: 10, name: 'pile', events: evs, words: pile });
+const estKept = chart.events.filter((e) => e.kind === 'word' && e.est === true).length;
+eq(estKept, estEvents.length, 'and normalizeChart keeps every one of them');
+const plain = chart.events.filter((e) => e.kind === 'word' && e.est !== true);
+ok(plain.length > 0 && plain.every((e) => e.est === undefined), 'a word the aligner did find carries no est at all');
+
+/* ---- 8. the un-pile never invents a word --------------------------------- */
+for (const { row, words } of SHELF) {
+  const said = (words.words || []).map((w) => w.w).join(' ');
+  const ph = phrasesFrom(words.words, [], { rng });
+  const out = [];
+  for (const p of ph) for (const b of p.words) out.push(b.w);
+  const same = out.join(' ') === said;
+  if (!same) { ok(false, row.title + ': the words on the road are the words in the file'); break; }
+}
+ok(true, 'with no row of the shelf, the road says exactly the transcript, in order, nothing added or lost');
+
+console.log(fails ? `\nword-sync-check: ${fails} failed\n` : '\nword-sync-check: all good\n');
+process.exit(fails ? 1 : 0);

--- a/ConditioningControlPanel/Resources/web/dtrh/race/wordBubbles.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/wordBubbles.js
@@ -88,6 +88,25 @@ export const WORD_RULE = Object.freeze({
    */
   HIT_GUARD_PRE_SEC: 0.2,
   HIT_GUARD_POST_SEC: 0.1,
+  /**
+   * THE PILE, and the line between it and fast speech. Three or more words inside
+   * MERGE_SEC of each other CAN be real: "in a completely", "as a perfect", "of a trap"
+   * come out of these transcripts at 0.09 to 0.11 s a word and that is simply how a
+   * function word is said. Nineteen of the shelf's twenty-one such runs are that.
+   *
+   * A PILE is the other kind: the aligner losing the words in the audio and dropping the
+   * whole run on the last instant it was sure of. One file has seven words at 0.01 s a
+   * word - "you wear sexy bimbo girl clothes whenever" inside six hundredths of a second -
+   * with 2.7 s of silence in front of them where the voice actually said them. So the
+   * test is the RATE, not the count: at or under PILE_TIGHT_SEC a word, nobody said it.
+   * The floor is set well under the fastest run on the shelf (0.065 s) so real speech is
+   * never taken apart and put back wrong.
+   */
+  PILE_MIN: 3,
+  /** Seconds a word, at or under which a run is the aligner giving up rather than a fast mouth. */
+  PILE_TIGHT_SEC: 0.05,
+  /** The second per word a pile is spread at when the speech around it has no rate of its own. */
+  PILE_RATE_SEC: 0.18,
   /** The silence a line needs before the next one may sit in another lane. */
   LANE_MOVE_SEC: 0.3,
   /** And how many lanes it may move when it does. One. */
@@ -136,6 +155,80 @@ function inGuard(windows, i, t) {
 }
 
 /**
+ * THE RATE THE VOICE IS GOING either side of a pile: the median gap between the words
+ * around it that are neither piled themselves nor across a pause. Used to decide how
+ * far apart the pile's words belong once they are put back.
+ */
+function localRate(list, i, j, R) {
+  const merge = Math.max(0, num(R.MERGE_SEC, WORD_RULE.MERGE_SEC));
+  const gaps = [];
+  for (let k = Math.max(1, i - 12); k < Math.min(list.length, j + 12); k++) {
+    if (k > i && k < j + 1) continue;                       // nothing from inside the pile
+    const g = list[k].t - list[k - 1].t;
+    if (g >= merge && g <= 1) gaps.push(g);
+  }
+  if (!gaps.length) return Math.max(merge, num(R.PILE_RATE_SEC, 0.18));
+  gaps.sort((a, b) => a - b);
+  return Math.max(merge, gaps[gaps.length >> 1]);
+}
+
+/**
+ * UN-PILING, which is the whole of the second bug: "some words are still isolated and
+ * not in sync, like I get the bubble sinking way before the words" - the owner, 2026-09-08.
+ *
+ * A run of PILE_MIN or more words inside MERGE_SEC of each other did not happen. What
+ * happened is that the aligner could not find the words in the audio and dropped them all
+ * on the last instant it was sure of, leaving the silence in front of them empty. The road
+ * then said two of the run in one bubble on one instant and threw the rest away, so the
+ * player read half a phrase seconds away from where the voice says it.
+ *
+ * So the run is put back into the silence beside it: the bigger of the two gaps is where
+ * the speech actually was, and the words are laid back across it at the local rate,
+ * anchored on the end of the pile going backwards or its start going forwards, so the one
+ * timestamp the aligner WAS sure of does not move. A word that moves is marked `est`, which
+ * rides all the way to the chart event. If there is no silence to spread into (the step
+ * would be under MERGE_SEC) the run is left exactly as it was and the merge rule below
+ * handles it: a guess with no room is worse than the collision.
+ *
+ * `list` is mutated in place, which is safe because readWords() built it.
+ */
+function unpile(list, R) {
+  const min = Math.max(3, Math.round(num(R.PILE_MIN, 3)));
+  const merge = Math.max(0, num(R.MERGE_SEC, WORD_RULE.MERGE_SEC));
+  let piles = 0, moved = 0, left = 0;
+  for (let i = 0; i < list.length;) {
+    let j = i + 1;
+    while (j < list.length && list[j].t - list[j - 1].t < merge) j++;
+    const n = j - i;
+    if (n < min) { i = j; continue; }
+    // fast speech or a collapse? the rate the run itself is going says which
+    if ((list[j - 1].t - list[i].t) / (n - 1) > Math.max(0, num(R.PILE_TIGHT_SEC, 0.05))) { i = j; continue; }
+    const prev = list[i - 1], next = list[j];
+    const before = prev ? list[i].t - (prev.t + prev.d) : list[i].t;
+    const after = next ? next.t - (list[j - 1].t + list[j - 1].d) : Infinity;
+    const back = before >= after;
+    const room = Math.max(0, (back ? before : after) - merge);
+    // and never further apart than a line stays a line: PHRASE_GAP_SEC is where the next
+    // bubble becomes a new phrase in a new lane, and a run put back as seven single-word
+    // lines zig-zagging the road is worse than the pile was.
+    const hold = Math.max(merge, num(R.PHRASE_GAP_SEC, WORD_RULE.PHRASE_GAP_SEC) * 0.9);
+    const step = Math.min(Math.min((n - 1) * localRate(list, i, j, R), room) / (n - 1), hold);
+    if (!(step >= merge)) { left++; i = j; continue; }       // no silence to put them in
+    piles++;
+    if (back) {
+      const end = list[j - 1].t;
+      for (let k = 0; k < n - 1; k++) { list[i + k].t = end - (n - 1 - k) * step; list[i + k].est = true; moved++; }
+    } else {
+      const start = list[i].t;
+      for (let k = 1; k < n; k++) { list[i + k].t = start + k * step; list[i + k].est = true; moved++; }
+    }
+    for (let k = i; k < j; k++) list[k].d = Math.min(list[k].d, step);
+    i = j;
+  }
+  return { piles, moved, left };
+}
+
+/**
  * The road's script.
  *
  * @param words  the caption track: [{ t, d, w }], the shape `chart.words` is in
@@ -151,6 +244,7 @@ export function phrasesFrom(words, hits = [], opts = {}) {
   const R = { ...WORD_RULE, ...(opts.rule || {}) };
   const rng = typeof opts.rng === 'function' ? opts.rng : Math.random;
   const list = readWords(words);
+  const pile = unpile(list, R);          // a run the aligner collapsed goes back where it was said
   const windows = guardWindows(hits, R.HIT_GUARD_PRE_SEC, R.HIT_GUARD_POST_SEC);
 
   // ---- 1. the bubbles: guarded words dropped, close words merged ------------
@@ -172,9 +266,10 @@ export function phrasesFrom(words, hits = [], opts = {}) {
       last.n = 2;
       last.d = Math.max(last.d, w.t + w.d - last.t);
       last.cut = CUT_PUNCT.test(w.w);
+      if (w.est) last.est = true;
       continue;
     }
-    bubbles.push({ t: w.t, d: w.d, w: w.w, n: 1, cut: CUT_PUNCT.test(w.w), guarded });
+    bubbles.push({ t: w.t, d: w.d, w: w.w, n: 1, cut: CUT_PUNCT.test(w.w), guarded, est: w.est === true });
     guarded = false;
   }
 
@@ -188,7 +283,9 @@ export function phrasesFrom(words, hits = [], opts = {}) {
       cur = { t: b.t, t1: b.t + b.d, gap: cur ? gap : Infinity, closed: false, words: [] };
       phrases.push(cur);
     }
-    cur.words.push({ t: b.t, d: b.d, w: b.w });
+    const bw = { t: b.t, d: b.d, w: b.w };
+    if (b.est) bw.est = true;             // a second this file guessed, not one the aligner found
+    cur.words.push(bw);
     cur.t1 = Math.max(cur.t1, b.t + b.d);
     cur.closed = b.cut;
   }
@@ -212,6 +309,9 @@ export function phrasesFrom(words, hits = [], opts = {}) {
     delete p.closed;
   }
   phrases.collided = collided;
+  phrases.piles = pile.piles;             // runs the aligner collapsed that went back into a silence
+  phrases.unpiled = pile.moved;           // and the words that moved doing it
+  phrases.pilesLeft = pile.left;          // runs with no silence to go back into
   return phrases;
 }
 
@@ -229,7 +329,11 @@ export function wordEventsFrom(words, hits = [], opts = {}) {
     // rest of the game where one thing said ends and the next begins: race/score.js steps the combo
     // ladder once per phrase taken whole (forty word pops is twenty seconds of a chant and an 8x
     // nobody drove for) and race/chart.js stats() counts a phrase as one thing to take.
-    for (const b of p.words) out.push({ kind: 'word', t: b.t, dur: b.d, label: '', conf: 1, weight: 1, w: b.w, x: p.x, p: n });
+    for (const b of p.words) {
+      const e = { kind: 'word', t: b.t, dur: b.d, label: '', conf: 1, weight: 1, w: b.w, x: p.x, p: n };
+      if (b.est) e.est = true;            // this second is this file's estimate; race/chart.js keeps the flag
+      out.push(e);
+    }
     n++;
   }
   return out;
@@ -287,6 +391,7 @@ export function rateOf(phrases, winSec = 5) {
 export function coverageOf(words, hits = [], events = [], opts = {}) {
   const R = { ...WORD_RULE, ...(opts.rule || {}) };
   const list = readWords(words);
+  const pile = unpile(list, R);          // count what the road counts: phrasesFrom un-piles too
   const windows = guardWindows(hits, R.HIT_GUARD_PRE_SEC, R.HIT_GUARD_POST_SEC);
   const spans = (Array.isArray(hits) ? hits : [])
     .filter((h) => h && isFinite(num(h.t, NaN)))
@@ -320,6 +425,7 @@ export function coverageOf(words, hits = [], events = [], opts = {}) {
   const onRoad = placed + rows;
   const short = Math.max(0, said - onRoad - margin);
   return { said, placed, rows, onRoad, margin, piled: short, lines, singles,
+    unpiled: pile.moved, pilesLeft: pile.left,
     pct: said ? onRoad / said : 1 };
 }
 
@@ -328,7 +434,8 @@ export function coverageLine(name, cov) {
   const pc = (100 * (cov.pct || 0)).toFixed(1);
   return `[race-coverage] ${name || 'track'}: ${pc}% (${cov.onRoad}/${cov.said}) - ${cov.placed} on their own bubble, `
     + `${cov.rows} said by a trigger row; dropped ${cov.said - cov.onRoad}: ${cov.margin} in a row's margin, `
-    + `${cov.piled} piled; ${cov.lines} lines, ${cov.singles} of one word`;
+    + `${cov.piled} piled; ${cov.lines} lines, ${cov.singles} of one word`
+    + (cov.unpiled ? `; ${cov.unpiled} words put back into a silence the aligner collapsed` : '');
 }
 
 export default phrasesFrom;


### PR DESCRIPTION
Stacked on #985 (`feat/race-word-coverage`). Review that one first; this diff is against it.

The owner, on the same road:

> "some words are still isolated and not in sync (not that often but it's pretty bad) like I get the bubble 'sinking' way before the words, most are fine."

## measured before touching anything

**The game is not the problem.** Driven headless over two real charts, reading `syncTrace()` for the frame the kart's depth crossed each word bubble:

| track | word bubbles met | min | p05 | median | p95 | max | more than 0.25 s early |
|---|---|---|---|---|---|---|---|
| Bubble Induction (from 134 s) | 138 | -0.019 | 0.000 | **0.022** | 0.060 | 0.080 | **0** |
| Bambi IQ Lock (from 84 s) | 54 | -0.036 | -0.003 | **0.027** | 0.158 | 0.711* | **0** |

\* the one 0.71 s outlier is an event my harness seeked past (handed at 84.00 for a word at 83.74), not a placement error.

`sync.js` keeps a row under its word and re-places it off the kart's current speed every frame until the last 0.25 s (`CUE_AHEAD_SEC`), so the throttle cannot walk a bubble off its second.

**The transcripts are not loose either.** Over 20,923 words on eleven tracks:

| track | words | order breaks | overlaps | runs of 3+ inside MERGE_SEC | of those, a collapse |
|---|---|---|---|---|---|
| Rapid Induction | 155 | 0 | 0 | 0 | 0 |
| Bubble Induction | 2276 | 0 | 0 | 1 | 0 |
| Bubble Acceptance | 3956 | 0 | 0 | 3 | 0 |
| Bambi Named and Drained | 2025 | 0 | 0 | 2 | 0 |
| Bambi IQ Lock | 1626 | 0 | 0 | 1 | **1** |
| Bambi Body Lock | 2000 | 0 | 0 | 1 | 0 |
| Bambi Attitude Lock | 1703 | 0 | 0 | 2 | 0 |
| Bambi Uniformed | 1956 | 0 | 0 | 2 | 0 |
| Bambi Takeover | 1444 | 0 | 0 | 3 | 0 |
| Bambi Cockslut | 2440 | 0 | 0 | 5 | 0 |
| Bambi Awakens | 1342 | 0 | 0 | 1 | 0 |
| **shelf** | **20923** | **0** | **0** | **21** | **1** |

Compared word for word against the v1 whisper pass (same script, same token count), the only systematic difference is the +0.19 to +0.21 s the v2 aligner already landed. Of the 14 words that sit more than 0.6 s *earlier* than the v1 trend, 13 are v1 collapses that v2 fixed.

## so what was actually wrong

Twenty-one runs on the shelf have three or more words inside `MERGE_SEC` of each other, and **two different things look like that**:

- **fast speech.** "in a completely", "as a perfect", "of a trap", "in the bubble" - 0.09 to 0.11 s a word, which is simply how a function word is said. Nineteen of the twenty-one. Real, and must not be touched.
- **a collapse.** Bambi IQ Lock at 89.36: `you wear sexy bimbo girl clothes whenever`, seven words at **0.01 s a word**, with 2.7 s of silence in front of them. The aligner lost the words in the audio and dropped the whole run on the last instant it was sure of. The road merged two of them onto that instant and threw the other five away, so the player read half a phrase seconds from where the voice says it.

The old code did not tell those apart: it called the third and later word of any such run a collision and dropped it.

## the rule

The test is the **rate**, not the count. `PILE_TIGHT_SEC` = 0.05 s a word, which is well under the fastest real run on the shelf (0.065) and nowhere near the 0.09-0.11 that fast function words actually run at. A run under it is spread back over the silence beside it:

- into the **bigger of the two adjacent gaps** - that is where the speech was
- at the **local speech rate** (median gap of the surrounding words, ignoring gaps inside piles and across pauses)
- **anchored on the one second the aligner did have**, so the timestamp it was sure of does not move
- never further apart than `PHRASE_GAP_SEC`, so it comes back as **one line in one lane** instead of a word per lane, which would have been worse than the pile
- and if the step would land under `MERGE_SEC` there is no silence to go back into, so the run is left exactly where it is and counted in `coverage.pilesLeft`. A guess with no room is worse than the collision.

Every bubble that moves carries `est: true` through `wordEventsFrom` and `normalizeChart`, so a bad transcript is visible in the chart rather than only on the road.

## after

| | before | after |
|---|---|---|
| collapses on the shelf | 1 (5 words dropped, 2 stacked on one instant) | **0** |
| words put back into the silence they were said in | - | **6** |
| real fast runs taken apart | - | **0** |
| collapses left with nowhere to go | - | **0** |
| Bambi IQ Lock coverage | 95.9% (1559/1626) | **96.2% (1564/1626)** |
| shelf coverage | 96.7% (20224/20923) | **96.7% (20229/20923)** |

The line itself, before and after:

```
before   86.48 whenever | 89.36 you | 89.37 wear | 89.38 sexy | 89.39 bimbo
         89.40 girl | 89.41 clothes | 89.42 whenever        <- 7 words in 0.06 s, 5 of them dropped

after    86.48 whenever
         87.80 you | 88.07 wear | 88.34 sexy | 88.61 bimbo   <- one lane
         88.88 girl | 89.15 clothes | 89.42 whenever | 89.70 you
```

## on "isolated"

The bigger half of that sentence was #985: the field was rolling every word bubble against the road-dressing knob, so a four word line came out as one bubble sitting on its own, 44 percent of the time. That is where almost all of the isolated words were coming from. What is left here is the one place where a word genuinely was not where the voice was.

## how it was verified

- `node race/smoke/word-sync-check.mjs` (new): the shelf's order/overlap/collapse table, the margin between fast speech and a collapse, a collapse fixture that must come back in order inside the silence in one lane, a fast-speech fixture that must not be touched, a boxed-in collapse that must be left alone and counted, and `est` surviving `normalizeChart`
- all twelve existing node smokes still green: `words-check`, `words-rate-check`, `lyrics-road-check`, `align-check`, `rows-check`, `wsync-check`, `track-run-check`, `chart-check`, `cloud-chart-check`, `coverage-check`, `word-flash-check`, `gifrain-row-check`
- two headless runs on real charted tracks (the table at the top), zero console errors, zero exceptions

## not done

- the 694 words inside a trigger row's pop-box margin stay dropped. Recovering them means displaying a word up to 0.6 s before it is said, which is the very thing this PR is about.
- no words file is re-aligned: nothing in the data warranted it, so there is no data PR behind this one.

```
 .../Resources/web/dtrh/race/CHART.md               |  12 ++
 .../Resources/web/dtrh/race/CONTRACT.md            |   5 +
 .../Resources/web/dtrh/race/chart.js               |   4 +
 .../web/dtrh/race/smoke/word-sync-check.mjs        | 184 +++++++++++++++++++++
 .../Resources/web/dtrh/race/wordBubbles.js         | 115 ++++++++++++-
 5 files changed, 316 insertions(+), 4 deletions(-)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013T1bb13w97ndYjNveiFpLz
