### PR TITLE
feat(race): the subliminal comes at you

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/game/payloadFx.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/game/payloadFx.js
@@ -43,7 +43,14 @@ const pick = (a) => a[(Math.random() * a.length) | 0];
 const MAX_FLASH = 6;
 const MAX_CASCADE = 14;
 
-export function createPayloadFx({ hud, fx, media, flashBurst }) {
+/**
+ * `subliminalFx` is the ONE presentation seam in this file, and Racing Thoughts is the
+ * only caller that passes it (race/run.js -> race/subliminal.js). The tube hands it
+ * nothing, so DtRH's whisper blip is byte-for-byte the card it always was. A race pop
+ * calls the override with the phrase already resolved and skips the blip entirely.
+ * Anything else that wants its own look adds a seam of its own; never restyle .sf-pfx-sub.
+ */
+export function createPayloadFx({ hud, fx, media, flashBurst, subliminalFx = null }) {
   // Two layers: washes/bursts render BEHIND the bubble field (.cf-layer, z6) so
   // bubbles stay crisp and clickable on top of pink/spiral/glitch/braindrain;
   // the video card rides a FRONT layer above the bubbles (in front of the POV).
@@ -180,7 +187,11 @@ export function createPayloadFx({ hud, fx, media, flashBurst }) {
     }
   }
 
-  async function subliminal(strength) {
+  async function subliminal(strength, text) {
+    // the race's own presentation takes the whole payload, phrase and all (see the seam note above)
+    if (subliminalFx) {
+      try { subliminalFx({ strength, text: String(text || pick(WORDS)) }); return; } catch (e) { /* fall through to the blip */ }
+    }
     const dur = scale(320, 560, strength);   // a quick blip, like FlashSubliminal
     const url = Math.random() < 0.5 ? await pickImageUrl() : null;
     let el;
@@ -394,7 +405,8 @@ export function createPayloadFx({ hud, fx, media, flashBurst }) {
     const p = spec.payload;
     switch (p.kind) {
       case 'flash':        flash(strength, durMult); break;
-      case 'subliminal':   subliminal(strength); break;
+      // p.text: the road's own phrase when the caller has one (race only; the tube never sets it)
+      case 'subliminal':   subliminal(strength, p.text); break;
       case 'overlay':
         if (p.overlay === 'spiral') showSpiral(strength, durMult);
         else if (p.overlay === 'braindrain') showBraindrain(strength, durMult);

--- a/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
@@ -393,6 +393,18 @@ and gates which bubble kinds may appear. Treat pops go to score; effect pops cal
 through the `fire-payload` bridge message exactly like `chaosRun.js` does today. ESC = Brake
 (pause + end screen). Run end sends `run-ended` (below).
 
+**The subliminal payload has a RACE-ONLY presentation.** `payloadFx` takes one optional
+`subliminalFx` seam and run.js is its only caller: the race draws `race/subliminal.js`'s card
+(`.rh-sub-layer` in `.race-hud` at z14, styled in race.css) instead of the tube's `.sf-pfx-sub`
+blip, and dtrh.html - which passes no seam - is unchanged. It is `fitPx`-sized off the viewport
+(176 px at 1280x720, 78 px on a 390 px phone, stepping down by word count so eight words still
+fit), cream on a hot-pink bloom over a dimmed vignette carrying the same road cutout the
+sustained washes carry, and it rushes the POV over 1250 ms (scale 0.62 blurred -> 1.0 by ~330 ms
+-> a ~450 ms readable hold -> 1.7 while it fades). Reduced motion fades it in place at full size.
+One card at a time: a second pop inside `MIN_SHOW_MS` (700 ms) queues at depth one, newest wins.
+The phrase is the popped bubble's own word if it wore one, else the last thing the road said
+inside `ECHO_SEC`, else `payloadFx`'s built-in whisper pool. `race/smoke/subliminal-check.mjs`.
+
 **The End screen's `surface` goes BACK TO THE MENU, it never closes the page.** `onExit` is the way
 home: run.js stops the file, drops the world (`teardown`), resets the run state, re-arms the same
 chart at `t = 0` (so picking that level again replays it) and calls `onExit()`. raceBoot's

--- a/ConditioningControlPanel/Resources/web/dtrh/race/race.css
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/race.css
@@ -745,6 +745,78 @@
 }
 
 /* ============================================================================
+ * THE WHISPER, COMING AT YOU (race/subliminal.js).
+ *
+ * The RACE's subliminal card. game/payloadFx.js still owns the tube's `.sf-pfx-sub`
+ * blip and not one rule below names it, so dtrh.html is untouched; this is a second
+ * presentation the race page alone asks for through payloadFx's `subliminalFx` seam.
+ *
+ * It is built to be the opposite of the chrome in all four ways at once - size, face,
+ * ink and motion - because the owner drove the blip and could not tell a payload from
+ * a HUD label. The size comes from race/subliminal.js (fitPx, written inline in px: an
+ * eight word phrase steps down until its longest word fits 86% of the glass, which is a
+ * cap a `vw` font-size cannot express). Everything else is here.
+ *
+ * z14: over the chrome (z3), the caption band (z4) and all of payloadFx (inside .sf-hud,
+ * z10); under the Brake/End screens (z20), the countdown (z21), the menu (z25) and the
+ * shutter (z40). Click-through, like the rest of the glass.
+ * ==========================================================================*/
+.race-hud .rh-sub-layer {
+  position: fixed; inset: 0; z-index: 14; pointer-events: none; overflow: hidden;
+  display: grid; place-items: center;
+  -webkit-text-size-adjust: 100%; text-size-adjust: 100%;
+}
+.race-hud .rh-sub-layer * { pointer-events: none; }
+.race-hud.is-lobby .rh-sub-layer { display: none; }
+
+/* The room goes dark around it: a payload dims the glass, a label never does. It carries the SAME
+   road cutout the sustained washes above carry, for the same reason - a soft hole over the lower
+   centre so the cup and the cornering line are still there to steer by while the card is up. The
+   card itself rides the middle of the glass, over the hole's soft edge, not inside it. */
+.race-hud .rh-sub-veil {
+  grid-area: 1 / 1; width: 100%; height: 100%; opacity: 0;
+  background: radial-gradient(ellipse 62% 52% at 50% 44%, rgba(26, 6, 28, 0.42), rgba(6, 3, 12, 0.66) 74%, rgba(6, 3, 12, 0.72));
+  -webkit-mask-image: radial-gradient(ellipse 40% 34% at 50% 90%, transparent 0%, rgba(0, 0, 0, 0.5) 58%, #000 100%);
+  mask-image: radial-gradient(ellipse 40% 34% at 50% 90%, transparent 0%, rgba(0, 0, 0, 0.5) 58%, #000 100%);
+  will-change: opacity;
+}
+.race-hud .rh-sub-layer.is-on .rh-sub-veil { animation: rhSubVeil 1250ms linear forwards; }
+
+/* cream, on a hot-pink bloom. 900 with wide tracking is heavy and soft where the chrome
+   is small and tight; the family is the page's own, so nothing is fetched at pop time and
+   a WebView2 with no network draws the same card. */
+.race-hud .rh-sub-card {
+  grid-area: 1 / 1; max-width: 86vw; overflow-wrap: break-word; text-align: center; text-wrap: balance;
+  font-family: var(--rh-font); font-weight: 900; font-style: normal;
+  font-size: 9vmin;   /* the pre-measure fallback only: subliminal.js writes px inline */
+  line-height: 0.98; letter-spacing: 0.055em; text-transform: lowercase;
+  color: #fff3e2; opacity: 0;
+  text-shadow: 0 0 0.34em rgba(255, 32, 150, 0.95), 0 0 0.1em rgba(255, 150, 205, 0.9), 0 0.03em 0.09em rgba(20, 4, 18, 0.85);
+  will-change: transform, opacity, filter;
+}
+/* THE RUSH: small and blurred deep in the scene, at you by ~330 ms, readable through a
+   ~450 ms hold, then past the POV while it lets go. transform / opacity / filter only. */
+.race-hud .rh-sub-layer.is-on .rh-sub-card { animation: rhSubRush 1250ms cubic-bezier(0.14, 0.86, 0.28, 1) forwards; }
+@keyframes rhSubRush {
+  0%   { opacity: 0; transform: scale(0.62); filter: blur(4px); }
+  18%  { opacity: 1; }
+  26%  { transform: scale(1); filter: blur(0px); }
+  62%  { opacity: 1; transform: scale(1.08); filter: blur(0px); }
+  100% { opacity: 0; transform: scale(1.7); filter: blur(2px); }
+}
+@keyframes rhSubVeil { 0% { opacity: 0; } 22%, 62% { opacity: 1; } 100% { opacity: 0; } }
+
+/* REDUCED MOTION (Law VI): nothing comes at you. The card is born at full size and only
+   fades, and the vignette fades with it. `is-still` is the race menu's own motion switch
+   (race/subliminal.js takes run.js's reducedMotion); the media query answers a browser
+   whose player never opened that menu. Both land on the same keyframes. */
+.race-hud .rh-sub-layer.is-on .rh-sub-card.is-still { animation: rhSubHold 1250ms linear forwards; filter: none; }
+@keyframes rhSubHold { 0% { opacity: 0; transform: scale(1); } 12%, 78% { opacity: 1; transform: scale(1); } 100% { opacity: 0; transform: scale(1); } }
+@media (prefers-reduced-motion: reduce) {
+  .race-hud .rh-sub-layer.is-on .rh-sub-card { animation: rhSubHold 1250ms linear forwards; filter: none; }
+}
+
+/* ============================================================================
  * THE SHUTTER (race/shutter.js): two hard-edged panels that close over the
  * screen between the menu, the intro and the run, with one pink line at the
  * seam. It sits above everything the page can put up - the Brake and End

--- a/ConditioningControlPanel/Resources/web/dtrh/race/run.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/run.js
@@ -75,6 +75,7 @@ import { createKart } from './kart.js';
 import { createScore } from './score.js';
 import { createRaceHud } from './hud.js';
 import { createCaptions } from './captions.js';
+import { createSubliminal, ECHO_SEC } from './subliminal.js';
 import { createMediaLane } from './mediaLane.js';
 import { createInput } from './input.js';
 import { createPickups, TUNE as PICK } from './pickups.js';
@@ -156,6 +157,11 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1, onExi
   /** `?words=unread`: a word the kart drove past writes nothing. Ghost is the default. */
   const GHOST_MISSES = flag('words') !== 'unread';
   const captions = hudRoot ? createCaptions(hudRoot, { mode: CAP_MODE }) : null;
+  // THE WHISPER, COMING AT YOU (race/subliminal.js): the RACE's own subliminal card. The tube's
+  // blip is a HUD-sized word in the HUD's own white, which on this page reads as one more label,
+  // so the race hands game/payloadFx.js a presentation of its own through the `subliminalFx` seam
+  // and payloadFx's `.sf-pfx-sub` is left exactly as dtrh.html has always drawn it.
+  const subl = hudRoot ? createSubliminal(hudRoot, { reducedMotion }) : null;
   // THE SHUTTER (race/shutter.js): the seam between the menu, the intro and the run. raceBoot drives
   // the menu side of it through `race.shutter`; in here it is the countdown ending and the way home.
   const shutter = createShutter({ root, reducedMotion, log: bridge.log });
@@ -185,6 +191,20 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1, onExi
   const wordyRows = new Set();
   let lastFlashAt = -1e9;
   const flashStats = { pops: 0, capped: 0, rolls: 0, flashes: 0 };
+  // THE ECHO (race/subliminal.js). A subliminal card would rather say the ROAD's own phrase than a
+  // word out of payloadFx's built-in whisper pool, so the last thing the voice actually said is kept
+  // here with the run clock it was said on. A bubble that wears its own word beats this; nothing
+  // older than ECHO_SEC is used at all, so a quiet stretch falls back to the pool rather than
+  // repeating a line from a minute ago. `S.elapsed` is the RUN's clock: a paused game is not a gap.
+  let echoWord = '', echoAt = -1e9;
+  const echo = (w) => { const s = String(w || '').trim(); if (s) { echoWord = s; echoAt = S.elapsed; } };
+  /** The phrase this subliminal shows: the word the popped bubble wore, else a fresh echo, else ''
+   *  (empty hands it back to payloadFx, which draws from its own pool). */
+  function subText(eventId) {
+    const rec = eventId ? (wordOf.get(eventId) || rowOf.get(eventId)) : null;
+    if (rec && rec.w) return String(rec.w);
+    return S.elapsed - echoAt <= ECHO_SEC ? echoWord : '';
+  }
   const WSYNC = flag('wsync') === '1';
   const ROW_LATE_SEC = 0.6;
   let syncHud = null;
@@ -241,7 +261,8 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1, onExi
     return text;
   }
   const fxProxy ={ pulseFlash: (a) => { if (W) W.fx.pulseFlash(a); } };   // fx is rebuilt on "again"
-  const payloadFx = createPayloadFx({ hud: sfHud, fx: fxProxy, media });
+  const payloadFx = createPayloadFx({ hud: sfHud, fx: fxProxy, media,
+    subliminalFx: subl ? ({ text }) => subl.show({ text }) : null });
   // Q.leanSpirals (mobile): spiral pops draw from the two lightest bundled gifs, fetched while the intro plays
   // (warmFx) rather than 2-5 MB mid-lap; the desktop pool and the Loom's own spirals are untouched
   setBundledSpiralPool(Q.leanSpirals ? LEAN_SPIRALS : null);
@@ -343,6 +364,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1, onExi
     trailClear();
     mix.reset(); PACE.reset(); S.wobble = 0; clearMixChrome(); sync.reset(); wordOf.clear(); lineGot.clear(); lineDone.clear();
     wordyRows.clear(); lastFlashAt = -1e9; flashStats.pops = 0; flashStats.capped = 0; flashStats.rolls = 0; flashStats.flashes = 0;
+    echoWord = ''; echoAt = -1e9; if (subl) subl.clear();   // "again" starts with nothing said and a clear glass
     fxFired.clear();
     hud.setScore(0); hud.setCombo(0, 1); hud.setBank(0); hud.setSpeed(0); hud.setFraught(0); hud.passiveClear(); TR.gild(0);
   }
@@ -381,6 +403,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1, onExi
     const rec = wordOf.get(eventId);
     if (!rec) return;
     wordOf.delete(eventId);                       // one bubble, one flash: it is popped or it is past
+    echo(rec.w);                                  // the voice said it: a subliminal may repeat it back
     logWord(rec, passT == null ? (TR.track ? TR.track.t : 0) : passT, ghost);
     if (captions && (!ghost || GHOST_MISSES)) captions.showWord(rec.w, { ink: rec.ink, accent: rec.accent, ghost: !!ghost });
     if (ghost || rec.p == null || lineDone.has(rec.p)) return;
@@ -415,6 +438,8 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1, onExi
   }
   function onPop(w, p) {
     const word = !!p.eventId && wordOf.has(p.eventId);   // a bubble off the transcript, not a chunk golden
+    // read BEFORE spendWord/rowOf spend the event: a subliminal says the word its own bubble wore
+    const said = p.payload === 'subliminal' ? subText(p.eventId) : '';
     // a plain word face: the transcript's own bubble, or one of a trigger row that wears the phrase
     // without firing an effect. delete() is the row's one-shot: many bubbles, one word, one flash.
     if ((word || (!!p.eventId && wordyRows.delete(p.eventId))) && p.kind === 'treat') wordFlashPop(w);
@@ -422,7 +447,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1, onExi
       const at = passTime(w, p.d);
       TR.taken(p.eventId); platePop(p.eventId); spendWord(w, p.eventId, false, at);
       const row = rowOf.get(p.eventId);   // a trigger row: one log line for the row, on its first pop
-      if (row) { rowOf.delete(p.eventId); logWord(row, at, false); }
+      if (row) { rowOf.delete(p.eventId); echo(row.w); logWord(row, at, false); }
     }
     w.kart.pulseTarget(); w.kart.pose('grab', { side: (p.x == null ? w.kart.state.x : p.x) >= w.kart.state.x ? 1 : -1 });
     if (S.sweep) sfx('chain_pop', 0.5);          // the pump: every pop on the road sounds like the chain
@@ -432,7 +457,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1, onExi
     const r = mix.add(p.id, { durationMult });
     if (r.action === 'held' || r.action === 'ignore') { w.score.pop(p.points, 'treat'); hud.toast('held', 'effect'); return; }
     w.score.pop(p.points, p.id);
-    pour(w, p, r, Math.round(clamp(p.strength, 0, 1) * 100), durationMult);
+    pour(w, p, r, Math.round(clamp(p.strength, 0, 1) * 100), durationMult, said);
     shake.shake(p.payload === 'video' ? 0.9 : 0.5, 300);
     poke('shock', 0.9);
     if (r.recipe) serve(w, r.recipe);
@@ -442,15 +467,17 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1, onExi
   /** Every payload the mixer pours passes through here, so this tally is the whole truth about what
    *  the run fired: race/smoke/gifrain-row-check.mjs reads it to hold a rain row to ONE cascade. */
   const fxFired = new Map();
-  const fire = (p, strength, durationMult) => {
+  const fire = (p, strength, durationMult, text) => {
     fxFired.set(p.payload, (fxFired.get(p.payload) || 0) + 1);
     if (p.payload === 'video') { trackPause(true); send({ type: 'fire-payload', kind: 'video', strength, durationMult }); }
-    else payloadFx.applyPayload({ payload: { kind: p.payload, overlay: p.overlayKind }, strength }, { durationMult });
+    // `text` is the subliminal's phrase and nothing else reads it: the bubble's own word if it wore
+    // one, else the road's last line inside ECHO_SEC, else '' - which hands the pick back to payloadFx.
+    else payloadFx.applyPayload({ payload: { kind: p.payload, overlay: p.overlayKind, text: p.payload === 'subliminal' ? (text || subText(null)) : undefined }, strength }, { durationMult });
   };
   function clearMixChrome() { root.removeAttribute('data-ov'); root.removeAttribute('data-tint'); if (hud.setTint) hud.setTint(0); }
   /** Pour one action. Sustained holds (tint / overlay / corruption) get a durationMult that lands payloadFx's
    *  fade on the mixer's drain, so a tint that was extended stays pink for as long as the rail says it will. */
-  function pour(w, p, r, strength, durationMult) {
+  function pour(w, p, r, strength, durationMult, text) {
     const label = (KIND_BY_ID[p.id] || {}).label || p.id;
     const slot = mix.live(r.category);
     const holdMult = slot && CATEGORIES[r.category].scaled ? clamp(slot.sec / CATEGORIES[r.category].sec, 0.1, 10) : durationMult;
@@ -480,8 +507,8 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1, onExi
         hud.toast(r.action === 'refresh' ? 'more static' : label, 'effect');
         break;
       case 'video': fire(p, strength, durationMult); hud.toast(label, 'effect'); break;
-      default:   // cards, freeze
-        fire(p, strength, durationMult); w.kart.applySlow(0.92, 2.0);
+      default:   // cards (the subliminal lives here, and it is the one kind that carries a phrase), freeze
+        fire(p, strength, durationMult, text); w.kart.applySlow(0.92, 2.0);
         hud.toast(r.charges > 1 ? `${label} x${r.charges}` : label, 'effect');
     }
   }
@@ -879,6 +906,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1, onExi
     S.ended = true; S.running = false; S.paused = false;
     try { payloadFx.cancelHeavy(); } catch (e) { /* nothing heavy */ }
     if (captions) captions.clear();   // nothing of the last phrase is left over the end card
+    if (subl) subl.clear();           // nor a whisper card mid-rush: the End card owns the screen
     const st = w.score.state;
     const summary = { score: st.score, banked: st.banked, bestCombo: st.bestCombo, popped: st.popped, treats: st.treats, effects: st.effects,
       nearMisses: st.nearMisses, laps: w.kart.state.lap, durationSec: Math.round(S.elapsed), seed: S.seed,
@@ -1001,7 +1029,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1, onExi
     if (payoutResolve) payoutResolve(null);
     teardown();
     audio.dispose();
-    input.dispose(); hud.dispose(); if (captions) captions.dispose(); shutter.dispose(); shake.dispose(); payloadFx.dispose(); speedFx.dispose(); lane.dispose();
+    input.dispose(); hud.dispose(); if (captions) captions.dispose(); if (subl) subl.dispose(); shutter.dispose(); shake.dispose(); payloadFx.dispose(); speedFx.dispose(); lane.dispose();
     pixel.dispose();
     scene.clear(); renderer.dispose();
   }
@@ -1065,6 +1093,17 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1, onExi
     fxStats: () => Object.fromEntries(fxFired),
     /** race/smoke/captions-check.mjs: one word at the band, the same call a pop makes. */
     debugWord: (text, o) => (captions ? captions.showWord(text, o || {}) != null : false),
+    /** race/smoke/subliminal-check.mjs and the shot harness: fire ONE payload by hand, rendered
+     *  exactly as a pop of that kind renders it. THE MIX is never touched, so a shot cannot change
+     *  what the run is holding, and an empty `text` falls back to payloadFx's own whisper pool. */
+    debugPayload: (kind, o = {}) => {
+      if (!kind || S.disposed) return false;
+      payloadFx.applyPayload({ payload: { kind: String(kind), overlay: o.overlay || null, text: o.text || '' },
+        strength: o.strength == null ? 45 : o.strength }, { durationMult: o.durationMult == null ? 1 : o.durationMult });
+      return true;
+    },
+    /** race/smoke/subliminal-check.mjs: how many cards were painted and how many the queue held. */
+    subliminalStats: () => (subl ? subl.stats() : null),
     /** Which half of race/captions.js is driving the band on this build: 'flash' or 'type'. */
     capMode: () => CAP_MODE,
     /** THE SYNC WIN, for race/smoke/wsync-check.mjs: the log rows, the offset, a nudge, the export. */

--- a/ConditioningControlPanel/Resources/web/dtrh/race/smoke/subliminal-check.mjs
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/smoke/subliminal-check.mjs
@@ -1,0 +1,249 @@
+/* ============================================================================
+ * race/smoke/subliminal-check.mjs - THE WHISPER, COMING AT YOU.
+ *
+ *   node race/smoke/subliminal-check.mjs        (from Resources/web/dtrh; 0 on pass)
+ *
+ * Two halves, the same shape as word-flash-check.mjs. The first is pure: race/subliminal.js
+ * fitPx is asked for the sizes at the two viewports that matter, and the eight word phrase
+ * on a 390 px phone is held against the width it actually has.
+ *
+ * The second drives a headless browser through a real run, because the four things this
+ * change can get wrong that no unit test sees are "the race card never reached the DOM",
+ * "it is drawn at the HUD's own size after all", "two pops fight over the middle of the
+ * screen" and "it is still there a second after it should have let go". It also builds the
+ * TUBE's own `.sf-pfx-sub` card on the same page and measures it, which is the guard that
+ * race.css never leaks onto dtrh.html: that one must still be 9vmin of white.
+ *
+ * It never prints a line of a transcript; the only phrases below are its own fixtures.
+ *
+ * CHROME: `CHROME_PATH` if it is set, else the usual Windows install.
+ * ==========================================================================*/
+
+import { spawn } from 'node:child_process';
+import { createServer } from 'node:http';
+import { readFile } from 'node:fs/promises';
+import { readFileSync, mkdtempSync, rmSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, extname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { fitPx, LIFE_MS, MIN_SHOW_MS } from '../subliminal.js';
+
+let fails = 0;
+const ok = (cond, what) => { if (!cond) { console.error('FAIL ' + what); fails++; } else console.log('  ok  ' + what); };
+const eq = (got, want, what) => ok(got === want, what + ' (got ' + JSON.stringify(got) + ', want ' + JSON.stringify(want) + ')');
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const HERE = resolve(fileURLToPath(import.meta.url), '..');
+const RACE = resolve(HERE, '..');
+const WEB = resolve(RACE, '../..');                        // Resources/web
+
+/** The tube's card is `font-size: 9vmin` (styles.css .sf-pfx-word) - the size this replaces. */
+const TUBE_PX = (w, h) => 0.09 * Math.min(w, h);
+const SHORT = 'good girl';
+const LONG = 'every thought you have belongs to the panel';   // eight words, the phone's worst case
+
+/* ============================================================================
+ * 1. the sizes, before the browser is ever started
+ * ==========================================================================*/
+const deskShort = fitPx(SHORT, 1280, 720), deskTube = TUBE_PX(1280, 720);
+const phoneShort = fitPx(SHORT, 390, 844), phoneTube = TUBE_PX(390, 844);
+const phoneLong = fitPx(LONG, 390, 844);
+console.log(`  --  1280x720: ${Math.round(deskTube)}px -> ${Math.round(deskShort)}px    390x844: ${Math.round(phoneTube)}px -> ${Math.round(phoneShort)}px (8 words: ${Math.round(phoneLong)}px)`);
+ok(deskShort >= 2.4 * deskTube, `a short phrase on a desktop is ${(deskShort / deskTube).toFixed(1)}x the card it replaces`);
+ok(phoneShort >= 2 * phoneTube, `and ${(phoneShort / phoneTube).toFixed(1)}x on a phone, where the old one was barely a caption`);
+// the eight word cap: its LONGEST word has to sit inside 86% of a 390 px phone, or it goes off both sides
+const longest = LONG.split(' ').reduce((n, s) => Math.max(n, s.length), 0);
+ok(phoneLong * 0.56 * longest <= 390 * 0.87, `an eight word phrase steps down to ${Math.round(phoneLong)}px, which fits "${'x'.repeat(longest)}" across the glass`);
+ok(phoneLong >= 21, 'and never below the floor, so a long phrase is still a payload and not fine print');
+ok(fitPx('', 1280, 720) === 0 && fitPx(null, 1280, 720) === 0, 'no phrase, no size');
+ok(LIFE_MS >= 1100 && LIFE_MS <= 1400, `the whole card is ${LIFE_MS} ms (the rush, the hold, and past the POV)`);
+ok(MIN_SHOW_MS > 0 && MIN_SHOW_MS < LIFE_MS, `and a card cannot be pushed off inside its first ${MIN_SHOW_MS} ms`);
+// the presentation is the RACE's alone: run.js is the only file that passes payloadFx the seam
+const pfx = readFileSync(resolve(RACE, '../game/payloadFx.js'), 'utf8');
+const run = readFileSync(resolve(RACE, 'run.js'), 'utf8');
+const css = readFileSync(resolve(RACE, 'race.css'), 'utf8');
+ok(/subliminalFx\s*=\s*null/.test(pfx), 'payloadFx defaults the seam to null, so the tube passes nothing and keeps the blip');
+ok(/createSubliminal\(hudRoot,\s*\{\s*reducedMotion\s*\}\)/.test(run), 'run.js hands the card the run\'s own reducedMotion');
+// comments stripped first: this file TALKS about the tube's card at length, it just never selects it
+ok(!/sf-pfx-sub|sf-pfx-word/.test(css.replace(/\/\*[\s\S]*?\*\//g, '')),
+  'and no RULE in race.css names the tube\'s card, so dtrh.html cannot be restyled from here');
+
+/* ============================================================================
+ * the browser
+ * ==========================================================================*/
+const CHROME = process.env.CHROME_PATH || 'C:/Program Files/Google/Chrome/Application/chrome.exe';
+const PORT = 8874, DEBUG_PORT = 9344;
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.mjs': 'text/javascript', '.css': 'text/css', '.json': 'application/json', '.glb': 'model/gltf-binary', '.png': 'image/png', '.webp': 'image/webp', '.jpg': 'image/jpeg', '.mp3': 'audio/mpeg', '.wav': 'audio/wav', '.svg': 'image/svg+xml', '.woff2': 'font/woff2' };
+
+if (!existsSync(CHROME)) { console.error('FAIL no chrome at ' + CHROME + ' (set CHROME_PATH)'); process.exit(1); }
+const server = createServer(async (req, res) => {
+  const path = decodeURIComponent(new URL(req.url, 'http://x').pathname);
+  if (path.indexOf('..') >= 0) { res.writeHead(400); return res.end(); }
+  try {
+    const body = await readFile(join(WEB, path));
+    res.writeHead(200, { 'content-type': MIME[extname(path).toLowerCase()] || 'application/octet-stream' });
+    res.end(req.method === 'HEAD' ? undefined : body);
+  } catch (e) { res.writeHead(404, { 'content-type': 'text/plain' }); res.end('no'); }
+});
+await new Promise((r) => server.listen(PORT, '127.0.0.1', r));
+
+const prof = mkdtempSync(join(tmpdir(), 'race-subl-'));
+const chrome = spawn(CHROME, [
+  '--headless=new', `--remote-debugging-port=${DEBUG_PORT}`, `--user-data-dir=${prof}`,
+  '--no-first-run', '--no-default-browser-check', '--disable-gpu', '--mute-audio',
+  '--enable-unsafe-swiftshader', '--autoplay-policy=no-user-gesture-required',
+  '--window-size=1280,720', 'about:blank',
+], { stdio: 'ignore' });
+
+let page = null;
+for (let i = 0; i < 60 && !page; i++) {
+  await sleep(250);
+  try { page = (await (await fetch(`http://127.0.0.1:${DEBUG_PORT}/json/list`)).json()).find((t) => t.type === 'page'); } catch (e) { /* not up */ }
+}
+if (!page) { console.error('FAIL chrome never answered on the debug port'); await done(1); }
+
+const ws = new WebSocket(page.webSocketDebuggerUrl);
+await new Promise((r) => { ws.onopen = r; });
+let msgId = 0;
+const waits = new Map(), errs = [];
+ws.onmessage = (e) => {
+  const m = JSON.parse(e.data);
+  if (m.id && waits.has(m.id)) { waits.get(m.id)(m); waits.delete(m.id); }
+  if (m.method === 'Runtime.exceptionThrown') errs.push('thrown: ' + (m.params.exceptionDetails?.exception?.description || m.params.exceptionDetails?.text || '?'));
+  if (m.method === 'Runtime.consoleAPICalled' && m.params.type === 'error') errs.push(m.params.args.map((a) => a.value ?? a.description ?? '?').join(' '));
+};
+const cdp = (method, params) => new Promise((res) => { const i = ++msgId; waits.set(i, res); ws.send(JSON.stringify({ id: i, method, params })); });
+const ev = async (x) => (await cdp('Runtime.evaluate', { expression: x, returnByValue: true, awaitPromise: true })).result?.result?.value;
+const json = async (x) => JSON.parse(await ev(`JSON.stringify(${x})`));
+/** For an expression that ALREADY returns a JSON string (the readers below). */
+const parse = async (x) => JSON.parse(await ev(x));
+await cdp('Runtime.enable'); await cdp('Page.enable');
+await cdp('Emulation.setDeviceMetricsOverride', { width: 1280, height: 720, deviceScaleFactor: 1, mobile: false });
+
+const site = `http://127.0.0.1:${PORT}`;
+await cdp('Page.navigate', { url: `${site}/dtrh/race.html?autostart=1&intro=0&cards=0` });
+let up = false;
+for (let i = 0; i < 120 && !up; i++) {
+  await sleep(250);
+  up = await ev(`!!(window.__race && window.__race.race && window.__race.race.perf().running)`);
+}
+ok(up, 'the page boots and the run is going');
+if (!up) { if (errs.length) console.error('    said: ' + errs.slice(0, 6).join(' | ')); await done(1); }
+
+/** Read the live card: what it is set in, how big, and which keyframes are moving it. */
+const CARD = `(() => {
+  const el = document.querySelector('.rh-sub-card');
+  const layer = document.querySelector('.rh-sub-layer');
+  if (!el || !layer) return JSON.stringify({ there: false });
+  const cs = getComputedStyle(el), ls = getComputedStyle(layer);
+  const r = el.getBoundingClientRect();
+  return JSON.stringify({ there: true, on: layer.classList.contains('is-on'), text: el.textContent,
+    px: parseFloat(cs.fontSize), weight: cs.fontWeight, color: cs.color, anim: cs.animationName,
+    dur: cs.animationDuration, z: ls.zIndex, w: Math.round(r.width), cards: document.querySelectorAll('.rh-sub-card').length });
+})()`;
+
+/* ============================================================================
+ * 2. one pop: the card is there, it is BIG, and it is the rush and not a label
+ * ==========================================================================*/
+ok(await ev(`window.__race.race.debugPayload('subliminal', { text: ${JSON.stringify(SHORT)} })`), 'a subliminal payload fires');
+await sleep(400);   // the readable hold
+const c = await parse(CARD);
+ok(c.there && c.on, 'the race card is on the glass');
+eq(c.text, SHORT, 'wearing the phrase it was handed');
+eq(c.cards, 1, 'and there is exactly one card element, ever');
+ok(c.px >= 150, `set at ${Math.round(c.px)}px at 1280x720 (the floor this check holds is 150)`);
+ok(Math.abs(c.px - deskShort) < 2, `which is the size race/subliminal.js asked for (${Math.round(deskShort)}px)`);
+ok(c.px >= 2.4 * deskTube, `${(c.px / deskTube).toFixed(1)}x the ${Math.round(deskTube)}px card it replaces`);
+ok(c.w > 1280 * 0.5, `and it fills ${Math.round((c.w / 1280) * 100)}% of the glass, so it is not a caption`);
+eq(c.weight, '900', 'heavy, where the chrome is 700/800');
+ok(c.color !== 'rgb(255, 255, 255)', `and cream rather than the chrome's white (${c.color})`);
+eq(c.anim, 'rhSubRush', 'the motion is the rush at the POV');
+ok(parseFloat(c.dur) * 1000 >= 1100 && parseFloat(c.dur) * 1000 <= 1400, `over ${c.dur}, so it is a beat and not a hold`);
+
+/* ============================================================================
+ * 3. the tube's own card, on this very page: still 9vmin of white
+ * ==========================================================================*/
+const tube = await parse(`(() => {
+  const root = document.querySelector('.sf-pfx') || document.body;
+  const el = document.createElement('div');
+  el.className = 'sf-pfx-sub sf-pfx-word';
+  el.textContent = ${JSON.stringify(SHORT)};
+  root.appendChild(el);
+  const cs = getComputedStyle(el);
+  const got = { px: parseFloat(cs.fontSize), color: cs.color, anim: cs.animationName };
+  el.remove();
+  return JSON.stringify(got);
+})()`);
+ok(Math.abs(tube.px - deskTube) < 0.5, `the tube's .sf-pfx-sub is still ${Math.round(tube.px)}px (9vmin), untouched by race.css`);
+eq(tube.color, 'rgb(255, 255, 255)', 'still white');
+eq(tube.anim, 'sf-pfx-sub', 'and still on its own keyframes');
+
+/* ============================================================================
+ * 4. z: over the payload layers, under the countdown and the shutter
+ * ==========================================================================*/
+const z = await parse(`(() => {
+  const zOf = (sel) => { const e = document.querySelector(sel); return e ? parseInt(getComputedStyle(e).zIndex, 10) : null; };
+  return JSON.stringify({ sub: zOf('.rh-sub-layer'), hud: zOf('.sf-hud'), count: zOf('.rh-count'), shutter: zOf('.rh-shutter'), chrome: zOf('.rh-chrome') });
+})()`);
+console.log('  --  z: ' + JSON.stringify(z));
+ok(z.sub > z.hud, `over every payloadFx layer (.sf-hud is ${z.hud})`);
+ok(z.sub > z.chrome, 'and over the HUD chrome');
+ok(z.count == null || z.sub < z.count, 'under the countdown, which never gets covered');
+ok(z.shutter == null || z.sub < z.shutter, 'and under the shutter');
+
+/* ============================================================================
+ * 5. it lets go: nothing is left on the glass 2 s later
+ * ==========================================================================*/
+await sleep(2000 - 400);
+const after = await parse(CARD);
+ok(!after.on, 'the card has let go of the glass');
+ok(await ev(`getComputedStyle(document.querySelector('.rh-sub-card')).opacity === '0'`), 'and it is drawing nothing at all');
+eq(after.cards, 1, 'still one element: the card is reused, never piled up');
+
+/* ============================================================================
+ * 6. two pops on each other's heels: one queues, they never fight
+ * ==========================================================================*/
+await ev(`window.__race.race.subliminalStats()`);   // the counters carry the run; the deltas are what matter
+const base = await json(`window.__race.race.subliminalStats()`);
+await ev(`(() => { window.__race.race.debugPayload('subliminal', { text: 'sink' }); window.__race.race.debugPayload('subliminal', { text: 'deeper' }); return true; })()`);
+await sleep(200);
+const mid = await parse(CARD);
+eq(mid.cards, 1, 'two pops inside the hold, and still exactly one card on the glass');
+eq(mid.text, 'sink', 'the first one keeps its readable moment');
+const q = await json(`window.__race.race.subliminalStats()`);
+eq(q.queued - base.queued, 1, 'the second is queued, not thrown away');
+await sleep(MIN_SHOW_MS);
+const late = await parse(CARD);
+eq(late.text, 'deeper', 'and it takes the card over once the first has been read');
+eq(late.cards, 1, 'still one');
+eq((await json(`window.__race.race.subliminalStats()`)).shown - base.shown, 2, 'both were shown, one after the other');
+
+/* ============================================================================
+ * 7. reduced motion: nothing comes at you
+ * ==========================================================================*/
+await sleep(LIFE_MS);
+await cdp('Emulation.setEmulatedMedia', { features: [{ name: 'prefers-reduced-motion', value: 'reduce' }] });
+await ev(`window.__race.race.debugPayload('subliminal', { text: ${JSON.stringify(SHORT)} })`);
+await sleep(400);
+const rm = await parse(CARD);
+eq(rm.anim, 'rhSubHold', 'the card fades in place instead of rushing');
+ok(rm.px >= 150, `at the same ${Math.round(rm.px)}px: reduced motion loses the zoom, never the size`);
+await cdp('Emulation.setEmulatedMedia', { features: [] });
+
+/* ============================================================================
+ * 8. and nothing said a word about it
+ * ==========================================================================*/
+ok(errs.length === 0, 'not one console error in the whole run' + (errs.length ? ':\n    ' + errs.slice(0, 5).join('\n    ') : ''));
+
+await done(fails ? 1 : 0);
+
+async function done(code) {
+  try { ws && ws.close(); } catch (e) { /* never opened */ }
+  try { chrome.kill(); } catch (e) { /* already gone */ }
+  await new Promise((r) => server.close(r));
+  await sleep(300);
+  try { rmSync(prof, { recursive: true, force: true }); } catch (e) { /* chrome still has a lock */ }
+  if (code) console.error(`\n${fails} failure${fails === 1 ? '' : 's'}`);
+  else console.log('\nsubliminal-check: all good');
+  process.exit(code);
+}

--- a/ConditioningControlPanel/Resources/web/dtrh/race/subliminal.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/subliminal.js
@@ -1,0 +1,161 @@
+/* ============================================================================
+ * race/subliminal.js - THE WHISPER, COMING AT YOU (race page only).
+ *
+ *   createSubliminal(hudRoot, { reducedMotion }) -> { show, live, clear, dispose }
+ *
+ * WHAT THIS REPLACES. A subliminal pop used to draw game/payloadFx.js's whisper blip:
+ * white Poppins at 9vmin, dead centre, up and gone in 420 ms. On the race page that is
+ * the HUD's own face at the HUD's own size in the HUD's own white, so the owner drove it
+ * and could not tell a PAYLOAD from a label: "the subliminals should be shown BIGGER and
+ * should feel different from the HUD text, maybe they get bigger and go towards the pov
+ * before fading or they have an animation."
+ *
+ * So the race gets its own card and the tube keeps the blip. payloadFx.js has exactly one
+ * seam for this (`subliminalFx`), run.js is the only caller that passes it, and nothing in
+ * game/ or styles.css changes: `.sf-pfx-sub` is untouched and dtrh.html looks the same.
+ *
+ * THE LOOK, and why each half of it is the OPPOSITE of the chrome:
+ *   SIZE   the chrome's labels are 12-24 px and its score reads about 40; the card is sized
+ *          off the viewport (fitPx below) and lands near 175 px on a desktop, so it is not
+ *          a bigger label, it is a different order of thing.
+ *   FACE   the same family as the chrome (nothing new is loaded, and a WebView2 with no
+ *          network still has to draw this) but at 900 with wide tracking and no shadow-box:
+ *          heavy and soft, not the chrome's small tight 800. NEVER a book face.
+ *   INK    cream on a hot-pink bloom over a dark vignette. The chrome is white-on-teal
+ *          plates and pink accents; the card owns the cream and owns the vignette, so a
+ *          payload dims the room and a label never does.
+ *   MOTION it starts small and blurred DEEP in the scene and rushes the POV: 0.62 -> 1.0
+ *          by 320 ms, readable through a ~460 ms hold, then past the camera to 1.7 while
+ *          it lets go. transform / opacity / filter only, on one will-change'd element.
+ *
+ * THE QUEUE. One card, ever. A second pop inside MIN_SHOW_MS is held and painted when the
+ * first has had its readable moment (newest wins, depth one: a wave of pops is one card
+ * after another, never two fighting over the middle of the screen). Past MIN_SHOW_MS the
+ * new phrase simply takes the card over, restarting the rush.
+ *
+ * REDUCED MOTION. The card is BORN at full size and only fades (`is-still`); race.css also
+ * answers `prefers-reduced-motion` for a browser whose player never opened the race menu.
+ *
+ * Z. The layer lives in `.race-hud` at z14: over the canvas (z0), the DOM walls (z1), the
+ * chrome (z3), the caption band (z4) and every payloadFx layer (inside `.sf-hud`, z10), and
+ * UNDER the pause veil (z20), the countdown (z21), the menu and the End card (z25) and the
+ * shutter (z40). It never takes a pointer.
+ * ==========================================================================*/
+
+/** The whole card, in ms: rush in, hold, then past the POV. race.css owns the same number. */
+export const LIFE_MS = 1250;
+/** A card cannot be pushed off before this; a pop inside it is queued instead. */
+export const MIN_SHOW_MS = 700;
+/** How long a phrase stays worth echoing after the voice said it (run.js reads this). */
+export const ECHO_SEC = 7;
+/** The size ladder: how much of the one-or-two-word size a phrase of N words gets. */
+const STEP = [1, 1, 1, 0.78, 0.68, 0.58, 0.54, 0.47, 0.44];
+/** Floor and ceiling in px, so a phone never gets a whisper and a 4K never gets a wall. */
+const MIN_PX = 21, MAX_PX = 210;
+
+/** Words of a phrase, lowercased and squeezed (the house style for UI copy is lowercase). */
+function wordsOf(text) {
+  return String(text || '').toLowerCase().trim().split(/\s+/).filter(Boolean);
+}
+
+/**
+ * The size this phrase gets at this viewport, in px. Two caps, whichever is smaller:
+ *
+ *   the LADDER  a one or two word phrase gets the full base, and a longer one steps down
+ *               the STEP table. PORTRAIT gets a fatter share of its width (0.2 against
+ *               0.145): a phone is narrow, and a short phrase that wraps to two enormous
+ *               lines reads far better there than one timid line that fits.
+ *   the WORD     whatever happens, the LONGEST word sits inside 86% of the glass. 0.56em
+ *               per character is a fair read of this family at 900, and this is the cap
+ *               that keeps an eight word line on a 390 px phone instead of off both sides.
+ *
+ * The card wraps (max-width in race.css), so the ladder only has to be honest about how
+ * much room a phrase wants, not about how many lines it will take.
+ */
+export function fitPx(text, vw, vh) {
+  const w = wordsOf(text);
+  if (!w.length) return 0;
+  const base = Math.min(vw * (vw < vh ? 0.2 : 0.145), vh * 0.245);
+  const step = STEP[Math.min(w.length, STEP.length - 1)];
+  const longest = w.reduce((n, s) => Math.max(n, s.length), 1);
+  const byWord = (vw * 0.86) / (0.56 * longest);
+  return Math.max(MIN_PX, Math.min(MAX_PX, Math.min(base * step, byWord)));
+}
+
+export function createSubliminal(hudRoot, { reducedMotion = false } = {}) {
+  if (!hudRoot) return null;
+  const layer = document.createElement('div');
+  layer.className = 'rh-sub-layer';
+  const veil = document.createElement('div');
+  veil.className = 'rh-sub-veil';
+  const card = document.createElement('div');
+  card.className = 'rh-sub-card';
+  if (reducedMotion) { card.classList.add('is-still'); veil.classList.add('is-still'); }
+  layer.appendChild(veil);
+  layer.appendChild(card);
+  hudRoot.appendChild(layer);
+
+  let shownAt = -1e9, endTimer = 0, queueTimer = 0, pending = null, shown = 0, queued = 0, disposed = false;
+  const now = () => (typeof performance === 'object' && performance.now ? performance.now() : Date.now());
+
+  /** Restart both animations on the SAME frame: strip the class, force a reflow, put it back. */
+  function paint(text) {
+    const w = wordsOf(text);
+    if (!w.length) return false;
+    const vw = window.innerWidth || 1280, vh = window.innerHeight || 720;
+    card.textContent = w.join(' ');
+    card.style.fontSize = Math.round(fitPx(text, vw, vh)) + 'px';
+    layer.classList.remove('is-on');
+    void layer.offsetWidth;            // the reflow that makes a re-fire actually re-fire
+    layer.classList.add('is-on');
+    shownAt = now(); shown++;
+    if (endTimer) clearTimeout(endTimer);
+    endTimer = setTimeout(() => {
+      endTimer = 0;
+      if (!disposed) layer.classList.remove('is-on');
+    }, LIFE_MS);
+    return true;
+  }
+
+  /** Fire one. `{ text }` is the phrase run.js resolved; strength is taken but not used yet. */
+  function show({ text } = {}) {
+    if (disposed) return false;
+    const w = wordsOf(text);
+    if (!w.length) return false;
+    const since = now() - shownAt;
+    if (layer.classList.contains('is-on') && since < MIN_SHOW_MS) {
+      pending = w.join(' '); queued++;   // depth one, newest wins
+      if (!queueTimer) queueTimer = setTimeout(() => {
+        queueTimer = 0;
+        const next = pending; pending = null;
+        if (!disposed && next) paint(next);
+      }, Math.max(16, MIN_SHOW_MS - since));
+      return true;
+    }
+    return paint(w.join(' '));
+  }
+
+  /** True while a card is on the glass (the run's own book-keeping; nothing reads it yet). */
+  const live = () => layer.classList.contains('is-on');
+
+  /** Take the glass back at once: the run ended, or the page went home. */
+  function clear() {
+    pending = null;
+    if (queueTimer) { clearTimeout(queueTimer); queueTimer = 0; }
+    if (endTimer) { clearTimeout(endTimer); endTimer = 0; }
+    layer.classList.remove('is-on');
+  }
+
+  function dispose() {
+    disposed = true;
+    clear();
+    layer.remove();
+  }
+
+  return {
+    show, live, clear, dispose,
+    /** race/smoke/subliminal-check.mjs: how many were painted and how many the queue held. */
+    stats: () => ({ shown, queued }),
+    el: card,
+  };
+}


### PR DESCRIPTION
> "the subliminals should be shown BIGGER and should feel different from the HUD text, maybe they get bigger and go towards the pov before fading or they have an animation."

Today a subliminal pop draws `game/payloadFx.js`'s whisper blip: 9vmin of the HUD's own white, in the HUD's own face, dead centre, up and gone in 420 ms. On the race page that is a HUD label, so a payload and a label look the same.

The race gets a card of its own. The tube keeps the blip.

## Before / after

**Before, 1280x720** (`shots/before-1280x720.png`): "good girl" at **64.8 px**, `#fff`, Poppins 900, dead centre, one `translate(-50%,-50%) scale(0.96 -> 1.02)` over 440 ms. It reads at the same weight as the "the tea garden" room plate two inches to its left.

**After, 1280x720** (`shots/after-1280x720.png`): **176 px** of cream (`#fff3e2`) on a hot-pink bloom, 69% of the glass wide, over a dimmed vignette that leaves the road and the cup lit. The chrome is still readable underneath; the card is plainly not part of it.

**Before, 390x844** (`shots/before-390x844.png`): **35.1 px**, one line, smaller than the score.
**After, 390x844** (`shots/after-390x844.png`): **78 px** over two lines.
**After, 8 words on a phone** (`shots/after-390x844-8word.png`): "every thought you have belongs to the panel" steps down to **34 px** and lands in three lines inside the glass.

**DtRH** (`shots/dtrh-subliminal-unchanged.png`): the tube's `.sf-pfx-sub` on `dtrh/index.html` measures 64.8 px, `rgb(255,255,255)`, animation `sf-pfx-sub`, same text-shadow - byte for byte what it drew before. The smoke asserts this on the race page too, so race.css can never leak onto it.

## The numbers

| | HUD label | old card | new card |
|---|---|---|---|
| 1280x720 | 12-24 px (chrome), ~40 px (score) | 64.8 px | **176 px** (2.7x the old card, 7-14x a label) |
| 390x844 | 11-19 px | 35.1 px | **78 px** (2.2x) |
| 390x844, 8 words | - | 35.1 px (off both sides) | **34 px**, 3 lines, fits |

Size is computed in `race/subliminal.js` `fitPx()` rather than a `vw` unit, because the cap that actually matters is the longest word inside 86% of the glass - that is what keeps an eight-word phrase on a phone. Portrait gets a fatter share of its width (0.2 vs 0.145), so a short phrase wraps big instead of sitting timid on one line.

## The curve

`rhSubRush`, 1250 ms, `cubic-bezier(0.14, 0.86, 0.28, 1)`, `transform` / `opacity` / `filter` only, one `will-change`d element:

```
  0%   opacity 0    scale 0.62   blur 4px     deep in the scene
 18%   opacity 1
 26%   (~330 ms)    scale 1.0    blur 0       at the POV, readable
 62%   (~775 ms)    scale 1.08   blur 0       the ~450 ms hold, drifting closer
100%   opacity 0    scale 1.7    blur 2px     past the camera
```

The vignette runs `rhSubVeil` on the same clock (0 -> 1 at 22% -> out from 62%) and carries the **same road cutout** the sustained washes carry (`race.css` ROAD CUTOUT), so the cornering line stays visible.

Reduced motion -> `rhSubHold`: same size, same colour, plain fade, no zoom and no blur. Wired both ways - `is-still` from the race menu's own motion switch via `run.js`'s `reducedMotion`, and a `prefers-reduced-motion` media query for a browser whose player never opened that menu.

## How it is race-only

`createPayloadFx` grows one optional `subliminalFx` seam, defaulting to `null`. `race/run.js` is the only caller that passes it. DtRH passes nothing and falls straight into the blip it always drew. No rule in `race.css` names `.sf-pfx-sub` or `.sf-pfx-word` (the smoke greps for it, comments stripped).

## Stacking

One card element, ever. A second pop inside `MIN_SHOW_MS` (700 ms) is queued at depth one (newest wins) and painted when the first has had its readable moment; past that it simply takes the card over and restarts the rush. payloadFx itself has no dedup for the subliminal - it appended a fresh element per pop - so the queue is new.

## z

14: over the canvas (0), the DOM walls (1), the chrome (3), the caption band (4) and every payloadFx layer (`.sf-hud`, 10); under the Brake/End screens (20), the countdown (21), the menu (25) and the shutter (40). Click-through. Asserted in the smoke against the live computed values.

## The phrase

The road's, when the road has one: the word the popped bubble wore (`wordOf` / `rowOf`, read before `spendWord` spends the event), else the last thing the voice said inside `ECHO_SEC` (7 s of run clock, so a pause is not a gap), else `payloadFx`'s built-in whisper pool exactly as today. Lowercase, per house style.

## How verified

- **New:** `race/smoke/subliminal-check.mjs` - 42 assertions, all green. Sizes at both viewports and the eight-word cap; the card is on the glass at >= 150 px wearing the phrase it was handed, weight 900, cream not white, on `rhSubRush` over 1.25 s; the tube's `.sf-pfx-sub` measured on the same page is still 9 vmin of white on `sf-pfx-sub`; the z ladder; the card has let go and is drawing nothing 2 s later; two pops on each other's heels -> one card, first keeps its moment, second queues then takes over; reduced motion lands on `rhSubHold` at the same size; zero console errors.
- **Existing race smokes, all green:** `captions-check`, `word-flash-check`, `gifrain-row-check`, `pickups-check`, `track-run-check`, `menu-return-check`, `sync-check`, `rows-check`, `touch-check`, `levels-check`, `face-check`.
- **Shots** at 1280x720 and 390x844 (plus the 8-word phone case and the DtRH card), taken mid-animation on the readable hold of a live headless run.
- `node --check` on every touched .js.

## Not verified

Not driven on real hardware or in WebView2 - headless Chrome only. Nothing new is fetched at pop time (the card uses the page's own `--rh-font`), so an offline WebView2 draws the same card, but a human pass on the desktop build and a phone is still owed.

```
 .../Resources/web/dtrh/game/payloadFx.js           |  18 +-
 .../Resources/web/dtrh/race/CONTRACT.md            |  12 +
 .../Resources/web/dtrh/race/race.css               |  72 ++++++
 .../Resources/web/dtrh/race/run.js                 |  57 ++++-
 .../web/dtrh/race/smoke/subliminal-check.mjs       | 249 +++++++++++++++++++++
 .../Resources/web/dtrh/race/subliminal.js          | 161 +++++++++++++
 6 files changed, 557 insertions(+), 12 deletions(-)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013T1bb13w97ndYjNveiFpLz
