### PR TITLE
feat(race): gold is the jackpot, not the filler

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
@@ -175,14 +175,24 @@ Pop event: `{ id, kind, payload, strength, points, placement, x, d, eventId, wor
 where relevant (`spiral | braindrain | pink_filter`). `strength` is 0..1.
 
 Bubble kinds (mirror `game/variants.js` and `engine/bubbles.js`; sprites from
-`/dtrh/assets/bubbles/effects/*.png` and `https://ccp.art/bubbles/*.png`):
+`/dtrh/assets/bubbles/effects/*.png` and `https://ccp.art/bubbles/*.png`).
+GOLD IS THE JACKPOT, NOT THE FILLER (2026-09-08): every effect is colour coded, so a coloured
+bubble has to mean "something happens here". The three gold rows are rare and pay like it, and
+the frequency they gave up went to the effect kinds. Measured over five 3-minute seeded runs,
+gold went 13.0% -> 2.2% of what is laid and effects 21.8% -> 30.9%; over the track cues it went
+44.4% -> 5.2% gold and 35.8% -> 57.5% effects. Every gold source in the game is in that count:
+the roll's weights, the room `bubbleBias` leans, the air line (which favours EFFECTS now), the
+chunk-end marker on a transcript road, and the cue tables in `race/cues.js` - a peak rains the
+room's own colour with at most ONE gold on the end, a hard drop's rings are the room's effect
+with one gold at the top of the climb, a countdown golds only its last ring, and a chant golds
+one bubble in twelve, so only the longest chant carries one at all:
 
 | id | kind | payload | points | notes |
 |----|------|---------|--------|-------|
-| treat | treat | null | 10 | the common bubble, plain sprite |
-| golden | treat | null | 50 | rare, JACKPOT chime |
-| lucky | treat | null | 25 | a plain 25 point treat, nothing else |
-| prism | treat | null | 30 | rainbow, pops neighbours |
+| treat | treat | null | 10 | the common bubble, plain sprite; the filler, and nothing but |
+| golden | treat | null | 300 | THE JACKPOT: weight 0.16, the rarest thing on the road, biggest burst, its own chime stack and a `jackpot +N` toast |
+| lucky | treat | null | 150 | weight 0.22, a smaller gold take with a toast of its own |
+| prism | treat | null | 180 | weight 0.3, rainbow, pops neighbours |
 | flash | effect | flash | 15 | DARK since 2026-09-08, never spawns; the WORD carries the flash now (see below) |
 | subliminal | effect | subliminal | 15 | |
 | pink | effect | overlay/pink_filter | 20 | |

--- a/ConditioningControlPanel/Resources/web/dtrh/race/audio.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/audio.js
@@ -493,7 +493,16 @@ export function createRaceAudio({ bridge, hud, settings = {}, input } = {}) {
     const semis = pitchSemis(combo()), pan = panOf(p.x);
     const asEffect = p.kind === 'effect' && (!scored || scored.kindId !== 'treat');
     if (asEffect) { play('pop', { level: LEVELS.effect, semis: semis - 5, pan, lowpass: 1100 }); synth({ kind: 'sine', f0: 140, f1: 50, sec: 0.16, level: 0.28 }); return; }
-    if (p.id === 'golden') { play('pop3', { level: LEVELS.pop, semis: semis + 2, pan }); play('chime3', { level: LEVELS.chime * 0.8, semis: 7, pan, at: 0.05 }); play('chime3', { level: LEVELS.chime * 0.6, semis: 12, pan, at: 0.14 }); return; }
+    // the jackpot: the gold bubble is rare now, so its take is the biggest sound on the road - the
+    // pop, a chime stack that keeps climbing, and a low knock under it.
+    if (p.id === 'golden') {
+      play('pop3', { level: LEVELS.pop, semis: semis + 2, pan });
+      play('chime3', { level: LEVELS.chime * 0.8, semis: 7, pan, at: 0.05 });
+      play('chime3', { level: LEVELS.chime * 0.7, semis: 12, pan, at: 0.14 });
+      play('chime3', { level: LEVELS.chime * 0.5, semis: 19, pan, at: 0.24 });
+      synth({ kind: 'sine', f0: 96, f1: 42, sec: 0.28, level: 0.26 });
+      return;
+    }
     if (p.id === 'prism') { play('pop2', { level: LEVELS.pop, semis: 3 + semis, pan }); play('chime1', { level: LEVELS.chime * 0.45, semis: 5 + semis, pan, at: 0.04 }); return; }
     if (p.id === 'lucky') { play('pop2', { level: LEVELS.pop, semis, pan }); play('chime1', { level: LEVELS.chime * 0.5, semis: 5, pan, at: 0.05 }); return; }
     play(POPS[popRR++ % POPS.length], { level: LEVELS.pop, semis, pan });

--- a/ConditioningControlPanel/Resources/web/dtrh/race/bubbleKinds.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/bubbleKinds.js
@@ -16,6 +16,11 @@
 const SPRITE_BASE = '/dtrh/assets/bubbles/effects/';
 const PLAIN_SPRITE = '/dtrh/assets/bubbles/bubble.png';   // the classic soap bubble
 
+// GOLD IS THE JACKPOT, NOT THE FILLER (2026-09-08). Every effect is colour coded, so a player
+// reads a coloured bubble as "something happens here" - and gold was landing often enough to
+// teach them the opposite. The three gold rows (golden, lucky, prism) are now the rarest thing
+// on the road and pay like it, and the frequency they gave up went to the effect kinds, so the
+// reason to watch the road is that most coloured bubbles really do do something.
 // kind: 'treat' pops for points only; 'effect' also fires a payloadFx spec.
 // payload / overlayKind are the game/payloadFx.js applyPayload names.
 // strength: the base 0..1 power of the effect (intensity nudges it up at pop).
@@ -33,30 +38,30 @@ const PLAIN_SPRITE = '/dtrh/assets/bubbles/bubble.png';   // the classic soap bu
 //   when a flash arrives from a `flash-pulse` trigger row, a burst or a recipe.
 export const BUBBLE_KINDS = [
   { id: 'treat',      label: '',  kind: 'treat',  payload: null,         overlayKind: null,  category: null,
-    strength: 0,    points: 10, weight: 22,  minIntensity: 0,    tint: 'rgb(184,222,255)', sprite: PLAIN_SPRITE },
+    strength: 0,    points: 10, weight: 20,  minIntensity: 0,    tint: 'rgb(184,222,255)', sprite: PLAIN_SPRITE },
   { id: 'golden',     label: '🍀', kind: 'treat',  payload: null,         overlayKind: null,  category: null,
-    strength: 0,    points: 50, weight: 1.2, minIntensity: 0,    tint: 'rgb(255,215,0)',   sprite: SPRITE_BASE + 'golden.png' },
+    strength: 0,    points: 300, weight: 0.16, minIntensity: 0,  tint: 'rgb(255,215,0)',   sprite: SPRITE_BASE + 'golden.png' },
   { id: 'lucky',      label: '✧', kind: 'treat',  payload: null,         overlayKind: null,  category: null,
-    strength: 0,    points: 25, weight: 1.6, minIntensity: 0,    tint: 'rgb(255,215,0)',   sprite: SPRITE_BASE + 'gold_droplet.png' },
+    strength: 0,    points: 150, weight: 0.22, minIntensity: 0,  tint: 'rgb(255,215,0)',   sprite: SPRITE_BASE + 'gold_droplet.png' },
   { id: 'prism',      label: '❂', kind: 'treat',  payload: null,         overlayKind: null,  category: null,
-    strength: 0,    points: 30, weight: 1.4, minIntensity: 0.1,  tint: 'rgb(200,168,255)', sprite: SPRITE_BASE + 'prism.png' },
+    strength: 0,    points: 180, weight: 0.3, minIntensity: 0.1, tint: 'rgb(200,168,255)', sprite: SPRITE_BASE + 'prism.png' },
   { id: 'flash',      label: '',  kind: 'effect', payload: 'flash',      overlayKind: null,  category: 'strobe',
     spawn: false,   // dark since 2026-09-08, see the header; the word bubbles carry the flash now
     strength: 0.45, points: 15, weight: 6,   minIntensity: 0,    tint: 'rgb(255,208,232)', sprite: SPRITE_BASE + 'flash.png' },
   { id: 'subliminal', label: '♥', kind: 'effect', payload: 'subliminal', overlayKind: null,  category: 'cards',
-    strength: 0.45, points: 15, weight: 5,   minIntensity: 0,    tint: 'rgb(176,128,255)', sprite: SPRITE_BASE + 'subliminal.png' },
+    strength: 0.45, points: 15, weight: 7,   minIntensity: 0,    tint: 'rgb(176,128,255)', sprite: SPRITE_BASE + 'subliminal.png' },
   { id: 'pink',       label: '◑', kind: 'effect', payload: 'overlay',    overlayKind: 'pink_filter',  category: 'tint',
-    strength: 0.5,  points: 20, weight: 4,   minIntensity: 0.1,  tint: 'rgb(255,61,165)',  sprite: SPRITE_BASE + 'pinkfilter.png' },
+    strength: 0.5,  points: 20, weight: 6,   minIntensity: 0.1,  tint: 'rgb(255,61,165)',  sprite: SPRITE_BASE + 'pinkfilter.png' },
   { id: 'spiral',     label: '◎', kind: 'effect', payload: 'overlay',    overlayKind: 'spiral',  category: 'overlay',
-    strength: 0.5,  points: 20, weight: 4,   minIntensity: 0.15, tint: 'rgb(64,208,192)',  sprite: SPRITE_BASE + 'spiral.png' },
+    strength: 0.5,  points: 20, weight: 6,   minIntensity: 0.15, tint: 'rgb(64,208,192)',  sprite: SPRITE_BASE + 'spiral.png' },
   { id: 'braindrain', label: '☁', kind: 'effect', payload: 'overlay',    overlayKind: 'braindrain',  category: 'overlay',
-    strength: 0.55, points: 25, weight: 2.4, minIntensity: 0.4,  tint: 'rgb(64,96,192)',   sprite: SPRITE_BASE + 'braindrain.png' },
+    strength: 0.55, points: 25, weight: 3.2, minIntensity: 0.4,  tint: 'rgb(64,96,192)',   sprite: SPRITE_BASE + 'braindrain.png' },
   { id: 'glitch',     label: '▚', kind: 'effect', payload: 'glitch',     overlayKind: null,  category: 'corruption',
-    strength: 0.5,  points: 20, weight: 3,   minIntensity: 0.2,  tint: 'rgb(120,255,190)', sprite: SPRITE_BASE + 'glitch.png' },
+    strength: 0.5,  points: 20, weight: 4.5, minIntensity: 0.2,  tint: 'rgb(120,255,190)', sprite: SPRITE_BASE + 'glitch.png' },
   { id: 'freeze',     label: '❄', kind: 'effect', payload: 'bambiFreeze', overlayKind: null,  category: 'freeze',
-    strength: 0.6,  points: 25, weight: 1,   minIntensity: 0.15, tint: 'rgb(138,230,255)', sprite: SPRITE_BASE + 'bambifreeze.png' },
+    strength: 0.6,  points: 25, weight: 2.2, minIntensity: 0.15, tint: 'rgb(138,230,255)', sprite: SPRITE_BASE + 'bambifreeze.png' },
   { id: 'gifrain',    label: '▼', kind: 'effect', payload: 'gifCascade', overlayKind: null,  category: 'cards',
-    strength: 0.6,  points: 25, weight: 1.2, minIntensity: 0.45, tint: 'rgb(255,200,61)',  sprite: SPRITE_BASE + 'htlink.png' },
+    strength: 0.6,  points: 25, weight: 1.4, minIntensity: 0.45, tint: 'rgb(255,200,61)',  sprite: SPRITE_BASE + 'htlink.png' },
   { id: 'video',      label: '▶', kind: 'effect', payload: 'video',      overlayKind: null,  category: 'video',
     spawn: false,   // dark since 2026-09-06, see the header; the row stays for a later use
     strength: 0.7,  points: 40, weight: 0.35, minIntensity: 0.45, tint: 'rgb(224,64,77)',  sprite: SPRITE_BASE + 'video.png' },

--- a/ConditioningControlPanel/Resources/web/dtrh/race/bubbles.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/bubbles.js
@@ -172,7 +172,7 @@ export function createBubbleField({ scene, layout, media, getIntensity, getRoom,
       if (k.kind === 'effect' && gate < 1) { if (gate <= 0) return 0; return gate * (placement === 'rain' ? 0.5 : 1); }
       if (k.id === 'video' && liveOf('video') > 0) return 0;      // one video on the road at a time
       if (k.id === 'freeze' && liveOf('freeze') > 1) return 0;
-      if (placement === 'air' && k.id === 'golden') return 3;     // gold favours the air line
+      if (placement === 'air' && k.kind === 'effect') return 1.6;  // the air line is where the effects live
       if (placement === 'rain' && k.kind === 'effect') return 0.5;
       return 1;
     };
@@ -242,8 +242,8 @@ export function createBubbleField({ scene, layout, media, getIntensity, getRoom,
     seeded.add(chunk.id);
     chunkRecs.push({ id: chunk.id, d0: chunk.d0, d1: chunk.d1 });
     const len = Math.max(0, chunk.d1 - chunk.d0);
-    if (sparse) {   // the file dresses this road, not us: one golden to say where the chunk ended, nothing else
-      if (chunk.kind !== 'gate' && len > 8) place('golden', 'lane', chunk.d1 - 2.5, 0, LANE_H);
+    if (sparse) {   // the file dresses this road, not us: one bubble to say where the chunk ended, nothing else
+      if (chunk.kind !== 'gate' && len > 8) place(roll('lane'), 'lane', chunk.d1 - 2.5, 0, LANE_H);
       return;
     }
     if (chunk.id === 1 && chunk.room === 'teagarden' && chunk.kind === 'straight') seedStartStraight(chunk);
@@ -357,14 +357,14 @@ export function createBubbleField({ scene, layout, media, getIntensity, getRoom,
     const f = layout.frameAtDepth(s.d);
     const dirs = dirRing[dirNext]; dirNext = (dirNext + 1) % DIR_RING;
     dirs.r.copy(f.right); dirs.u.copy(f.up);
-    const n = golden ? 12 : 7;
+    const n = golden ? 16 : 7;
     for (let i = 0; i < n; i++) {
       // next free shard scanning from where the last burst stopped; a full ring steals the oldest slot
       let sh = null;
       for (let j = 0; j < SHARD_CAP; j++) { const c = shards[(shardNext + j) % SHARD_CAP]; if (!c.alive) { sh = c; shardNext = (shardNext + j + 1) % SHARD_CAP; break; } }
       if (!sh) { sh = shards[shardNext]; shardNext = (shardNext + 1) % SHARD_CAP; }
       const ang = (Math.PI * 2 * i) / n + rand(-0.35, 0.35);
-      const v = rand(2.2, 4.6) * (golden ? 1.3 : 1);
+      const v = rand(2.2, 4.6) * (golden ? 1.5 : 1);
       sh.alive = true; sh.age = 0; sh.life = rand(0.35, 0.6);
       sh.p0.copy(s.sprite.position); sh.r = dirs.r; sh.u = dirs.u;
       sh.vr = Math.cos(ang) * v; sh.vu = Math.sin(ang) * v + 1.2;
@@ -379,7 +379,7 @@ export function createBubbleField({ scene, layout, media, getIntensity, getRoom,
     const k = KIND_BY_ID[s.kindId];
     s.popT = 0;
     spendRow(s.rowId);              // one of the row is the row: the rest may not be missed behind it
-    const golden = k.id === 'golden';
+    const golden = k.id === 'golden' || k.id === 'lucky' || k.id === 'prism';   // a gold take is the loud one now
     burst(s, golden);
     const strength = k.strength > 0 ? clamp(k.strength + 0.35 * intensity() + Math.random() * 0.1, 0, 1) : 0;
     emit(popCbs, { id: k.id, kind: k.kind, payload: k.payload, overlayKind: k.overlayKind, strength,

--- a/ConditioningControlPanel/Resources/web/dtrh/race/cues.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/cues.js
@@ -66,10 +66,14 @@ const FALLBACK_TRIGGER = 'pink';
  *  of "nothing here fights you" anyway and keeps the room off the pink the Toybox already wears. */
 const ROOM_TRIGGER = {
   teagarden: 'subliminal', undertow: 'spiral', toybox: 'pink', chapel: 'spiral',
-  mirrors: 'glitch', greyward: 'freeze', coronation: 'prism', casino: 'lucky',
+  mirrors: 'glitch', greyward: 'freeze', coronation: 'braindrain', casino: 'pink',
 };
-/** What a peak rains per room; anywhere else it is plain treats. */
-const ROOM_RAIN = { casino: 'lucky', coronation: 'golden', chapel: 'prism', mirrors: 'prism' };
+/** What a peak rains per room; anywhere else it is plain treats. Effect kinds, all of them: the
+ *  peak is the loudest second in the file and every colour on it should mean something. */
+const ROOM_RAIN = { casino: 'pink', coronation: 'subliminal', chapel: 'spiral', mirrors: 'glitch' };
+/** ONE gold in a peak, at most, and only in the two rooms that are about it: it falls last, so
+ *  the room pours its colour and the jackpot lands on the end of it. */
+const PEAK_GOLD = { casino: 'lucky', coronation: 'golden' };
 /** Below this the spotter was guessing: the trigger is a treat, not its effect, and no word on the chrome. */
 const TRIGGER_SURE = 0.55;
 /** Below this a structure word is nothing; a guess must never cost the player a miss. */
@@ -109,8 +113,9 @@ const PEAK_MIN = 4, PEAK_MAX = 8, PEAK_GAP = 0.25;
 const PEAK_LYRIC_MULT = 0.5;
 /** The chant's two lanes, and the fallback beat when the analyzer sent no period. */
 const CHANT_X = 1.2, CHANT_PERIOD = 1.2, CHANT_MAX = 16;
-/** Every this-many chant treats, one is gold. */
-const CHANT_GOLD_EVERY = 4;
+/** Every this-many chant treats, one is gold. At CHANT_MAX (16) that is one gold in the longest
+ *  chant the road will lay and none at all in a short one, which is what a jackpot should be. */
+const CHANT_GOLD_EVERY = 12;
 /** A build hands over at most this many seconds of boost. */
 const BOOST_CAP = 4;
 /** THE WORD FLASH (2026-09-08). The flash bubble is dark: the flash is a beat on a WORD now.
@@ -255,21 +260,23 @@ export function cueFor(event, ctx = {}) {
       break;
     }
 
-    // a number inside a countdown: a golden ring in the air that sinks toward the road as the count
-    // runs down (n is the spoken number, of the run length: ten hangs high, one skims the road; a
-    // count going up climbs instead), the number on the chrome, and the last one braces her and
-    // throws the kart at it
+    // a number inside a countdown: a ring in the air that sinks toward the road as the count runs
+    // down (n is the spoken number, of the run length: ten hangs high, one skims the road; a count
+    // going up climbs instead), the number on the chrome, and the last one braces her and throws
+    // the kart at it. Only THAT last ring is gold: a count of ten used to hand out ten jackpots.
     case 'count': {
       const of = Math.max(1, Number(event.of) || 1), n = clamp(Number(event.n) || 1, 1, of);
       const sink = of > 1 ? 1 - (n - 1) / (of - 1) : 1;
-      cue.spawn.push({ kindId: 'golden', placement: 'air', x: laneX(rng) * 0.5, h: AIR_H - (AIR_H - LANE_H - 0.6) * sink, at: 0 });
+      cue.spawn.push({ kindId: event.last ? 'golden' : 'treat', placement: 'air', x: laneX(rng) * 0.5, h: AIR_H - (AIR_H - LANE_H - 0.6) * sink, at: 0 });
       if (label) cue.toast = { text: label, kind: event.last ? 'item' : 'pop' };
       if (event.last) { cue.jump = 6; cue.pose = 'clamp'; }
       break;
     }
 
-    // the drop: a jump, a spiral over the world, and golden rings climbing away from the word. A
-    // soft drop (a dip in the voice, not the fall) is a lower jump, two rings and no spiral.
+    // the drop: a jump, a spiral over the world, and rings climbing away from the word - the room's
+    // own effect, with ONE gold at the top of the climb on a hard drop, because a fall is where a
+    // jackpot belongs and three of them in a row is just wallpaper. A soft drop (a dip in the
+    // voice, not the fall) is a lower jump, two rings, no spiral and no gold.
     case 'drop': {
       const strength = Number.isFinite(Number(event.strength)) ? clamp(Number(event.strength), 0, 1) : 1;
       const hard = strength >= DROP_SOFT;
@@ -278,14 +285,17 @@ export function cueFor(event, ctx = {}) {
       cue.mood = 'streamed';
       cue.toast = { text: label || 'drop', kind: hard ? 'jackpot' : 'effect' };
       const rings = hard ? DROP_AT.length : 2;
+      const ringKind = ROOM_TRIGGER[roomId(ctx)] || FALLBACK_TRIGGER;
       for (let i = 0; i < rings; i++) {
-        cue.spawn.push({ kindId: 'golden', placement: 'air', x: DROP_X[i], h: AIR_H + i * AIR_RISE, at: DROP_AT[i] });
+        const apex = hard && i === rings - 1;
+        cue.spawn.push({ kindId: apex ? 'golden' : ringKind, placement: 'air', x: DROP_X[i], h: AIR_H + i * AIR_RISE, at: DROP_AT[i] });
       }
       break;
     }
 
-    // the same phrase over and over: a lane of treats in the chant's own rhythm, side to side, every
-    // fourth one gold, the phrase on the chrome and a cheer. A light chant is a shorter lane.
+    // the same phrase over and over: a lane of treats in the chant's own rhythm, side to side, the
+    // phrase on the chrome and a cheer. A long chant carries ONE gold; a light one is a shorter
+    // lane and carries none.
     case 'chant': {
       const reps = clamp(Math.round((Number(event.reps) || 3) * Math.max(0.5, weight01(event))), 1, CHANT_MAX);
       const period = Number(event.period) > 0 ? Number(event.period) : CHANT_PERIOD;
@@ -311,8 +321,10 @@ export function cueFor(event, ctx = {}) {
       const lyric = ctx.lyrics ? PEAK_LYRIC_MULT : 1;
       const n = Math.max(1, Math.round((PEAK_MIN + (PEAK_MAX - PEAK_MIN) * intensity) * lyric));
       const kindId = ROOM_RAIN[roomId(ctx)] || 'treat';
+      const gold = PEAK_GOLD[roomId(ctx)] || null;
       for (let i = 0; i < n; i++) {
-        cue.spawn.push({ kindId, placement: 'rain', x: spread(rng), h: CEILING_H, at: i * PEAK_GAP });
+        const last = gold && i === n - 1;
+        cue.spawn.push({ kindId: last ? gold : kindId, placement: 'rain', x: spread(rng), h: CEILING_H, at: i * PEAK_GAP });
       }
       cue.pose = 'cheer';
       cue.mood = intensity > 0.7 ? 'smug' : 'streamed';

--- a/ConditioningControlPanel/Resources/web/dtrh/race/rooms.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/rooms.js
@@ -39,7 +39,7 @@ export const ROOMS = [
   { id: 'teagarden', name: 'The Tea Garden', tagline: 'nothing here fights you', biome: 'mirrorlake',
     colors: { road: 0x2f6e50, edge: 0xf6e7c8, prop: 0xffb6d9, fog: 0x12261f, banner: 0x5fa98a },
     propKind: 'teacup', loud: false,
-    bubbleBias: { treat: 1.4, golden: 0.8, lucky: 1.2, subliminal: 0.5, video: 0 },
+    bubbleBias: { treat: 1.4, subliminal: 0.5, video: 0 },
     ambient: { kind: 'petals', colors: [[255, 182, 217], [191, 235, 216], [246, 231, 200]] } },
   { id: 'toybox', name: 'The Toybox', tagline: 'the floor bounces. so do you', biome: 'toybox',
     colors: { road: 0x33307f, edge: 0xffd23f, prop: 0xffd23f, fog: 0x14103a, banner: 0x6c63d8 },
@@ -49,7 +49,7 @@ export const ROOMS = [
   { id: 'casino', name: "The Fool's Casino", tagline: 'the wheel always pays. eventually', biome: 'casino',
     colors: { road: 0x5c1128, edge: 0xf2c14e, prop: 0xf2c14e, fog: 0x0b0508, banner: 0xa3122e },
     propKind: 'chip', loud: true, propAlt: [0xa3122e],
-    bubbleBias: { golden: 2.0, lucky: 2.0, glitch: 1.3, treat: 0.9 },
+    bubbleBias: { golden: 2.5, lucky: 2.5, glitch: 1.4, pink: 1.2, treat: 0.9 },
     ambient: { kind: 'coins', colors: [[242, 193, 78], [255, 240, 160]] } },
   { id: 'undertow', name: 'The Undertow', tagline: 'the lane drifts. let it', biome: 'undertow',
     colors: { road: 0x15446c, edge: 0x7fe7f0, prop: 0x1fa9b5, fog: 0x06202a, banner: 0x2a8fa8 },
@@ -74,7 +74,7 @@ export const ROOMS = [
   { id: 'coronation', name: 'The Coronation', tagline: 'the run remembers. so will you', biome: 'coronation',
     colors: { road: 0x661838, edge: 0xf2c14e, prop: 0xf2c14e, fog: 0x3a0716, banner: 0x7a0f2b },
     propKind: 'crown', loud: true,
-    bubbleBias: { golden: 1.5, video: 1.6, gifrain: 1.4, pink: 1.2 },
+    bubbleBias: { golden: 2.0, video: 1.6, gifrain: 1.6, pink: 1.4, spiral: 1.2 },
     ambient: { kind: 'goldleaf', colors: [[242, 193, 78], [255, 105, 180]] } },
 ];
 const ROOM_BY_ID = Object.fromEntries(ROOMS.map((r) => [r.id, r]));

--- a/ConditioningControlPanel/Resources/web/dtrh/race/run.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/run.js
@@ -363,11 +363,19 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1, onExi
   }
 
   // ---- pops ----
+  /** THE TAKE the jackpot toast is owed: gold is rare and pays like it now, so the rail says what
+   *  the bubble AND its bonus were worth, not just the bonus. A jackpot off a combo rung leaves
+   *  this at 0 and reads exactly as it always did. */
+  let goldTake = 0;
   function treat(w, p, word) {
-    w.score.pop(p.points, p.id, word ? { combo: false } : undefined);   // a word is worth its treat and no rung
+    const gain = w.score.pop(p.points, p.id, word ? { combo: false } : undefined);   // a word is worth its treat and no rung
     if (p.id === 'golden') {
+      goldTake = gain;
       w.score.jackpot(S.jackpotBias > 1 ? 'major' : 'minor');
-      sfx('golden_pop', 0.9); shake.shake(0.35, 240); poke('jackpot', 1.4); w.kart.pose('cheer');
+      sfx('golden_pop', 0.9); shake.shake(0.55, 320); poke('jackpot', 1.6); w.kart.pose('cheer');
+    } else if (p.id === 'lucky' || p.id === 'prism') {
+      hud.toast(`${p.id} +${gain}`, 'jackpot');
+      shake.shake(0.3, 220); poke('smug', 1.2);
     }
   }
   /**
@@ -533,7 +541,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1, onExi
       case 'miss': hud.setCombo(0, e.mult); break;
       case 'almost': hud.setScore(e.score); hud.toast(`almost +${e.gain}`, 'almost'); break;
       case 'bank': hud.setBank(e.banked); hud.setScore(0); hud.toast(`kept +${e.amount}`, 'bank'); break;
-      case 'jackpot': hud.setScore(e.score); hud.toast(`jackpot +${e.gain}`, 'jackpot'); break;
+      case 'jackpot': hud.setScore(e.score); hud.toast(`jackpot +${e.gain + goldTake}`, 'jackpot'); goldTake = 0; break;
     }
   }
   // ---- THE PICKUPS (race/pickups.js): passive, taken by driving through them ----

--- a/ConditioningControlPanel/Resources/web/dtrh/race/smoke/track-run-check.mjs
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/smoke/track-run-check.mjs
@@ -145,6 +145,11 @@ function chartEnergy(t) {
   const dr = cueFor({ kind: 'drop', strength: 1 }, ctx);
   ok(dr.jump === 7 && dr.mix === 'spiral' && dr.mood === 'streamed' && dr.spawn.length === 3, 'a drop is jump 7, a spiral and three rings');
   ok(dr.spawn.map((s) => s.at).join() === '0.2,0.5,0.8', 'the three land at 0.2, 0.5, 0.8');
+  // GOLD IS THE JACKPOT (2026-09-08): one at the top of a hard drop's climb, none on a dip.
+  ok(dr.spawn.filter((x) => x.kindId === 'golden').length === 1 && dr.spawn[2].kindId === 'golden',
+    'and only the top ring of the climb is gold');
+  ok(dr.spawn.slice(0, 2).every((x) => KIND_BY_ID[x.kindId] && KIND_BY_ID[x.kindId].kind === 'effect'),
+    'the rings under it are the room\'s own effect');
   const ch = cueFor({ kind: 'chant', label: 'good girl', reps: 5, period: 2.4 }, ctx);
   ok(ch.spawn.length === 5 && ch.spawn.every((s, i) => Math.abs(s.at - i * 2.4) < 1e-9), 'a chant is one treat per rep on the chant beat');
   ok(new Set(ch.spawn.map((s) => s.x)).size === 2, 'alternating between two lanes');
@@ -168,15 +173,20 @@ function chartEnergy(t) {
   const fl = cueFor({ kind: 'word', label: 'float' }, ctx);
   ok(fl.spawn[0].placement === 'air' && fl.spawn[0].h > LANE_H, 'a lifting word hangs in the air');
   ok(cueFor({ kind: 'trigger', label: 'never analysed' }, { ...ctx, room: { id: 'chapel' } }).spawn[0].kindId === 'spiral', 'an unmapped phrase in the chapel wears the spiral');
-  ok(cueFor({ kind: 'peak' }, { ...ctx, room: { id: 'casino' } }).spawn.every((s) => s.kindId === 'lucky'), 'a peak in the casino rains lucky bubbles');
+  const pk = cueFor({ kind: 'peak' }, { ...ctx, room: { id: 'casino' } }).spawn;
+  ok(pk.slice(0, -1).every((s) => s.kindId === 'pink') && pk[pk.length - 1].kindId === 'lucky',
+    'a peak in the casino rains the room\'s own colour with ONE gold on the end of it');
   ok(cueFor({ kind: 'peak' }, { ...ctx, intensity: 1 }).spawn.length === 8 && cueFor({ kind: 'peak' }, { ...ctx, intensity: 0 }).spawn.length === 4, 'and rains more the louder the file is');
   const soft = cueFor({ kind: 'drop', strength: 0.4, label: 'sink' }, ctx);
   ok(soft.jump === 5 && soft.mix === null && soft.spawn.length === 2 && soft.toast.text === 'sink', 'a soft drop is a lower jump, two rings, no spiral, its word on the chrome');
+  ok(soft.spawn.every((x) => x.kindId !== 'golden'), 'and no gold at all: a dip is not a fall');
   ok(dr.toast && dr.toast.kind === 'jackpot', 'a hard drop puts its word up in gold');
   const c5 = cueFor({ kind: 'count', label: 'five', n: 5, of: 10 }, ctx), c10 = cueFor({ kind: 'count', label: 'ten', n: 10, of: 10 }, ctx);
   ok(c5.toast.text === 'five' && c5.spawn[0].h < c10.spawn[0].h && c.spawn[0].h < c5.spawn[0].h, 'a countdown sinks its rings toward the road as it runs down');
   ok(c.pose === 'clamp' && c.toast.kind === 'item', 'and she braces on the last one');
-  ok(ch.spawn.filter((s) => s.kindId === 'golden').length === 1 && ch.pose === 'cheer', 'every fourth chant treat is gold, and she cheers the chant');
+  ok(ch.spawn.every((s) => s.kindId !== 'golden') && ch.pose === 'cheer', 'a short chant carries no gold, and she cheers the chant');
+  ok(cueFor({ kind: 'chant', label: 'x', reps: 16 }, ctx).spawn.filter((s) => s.kindId === 'golden').length === 1,
+    'the longest chant the road will lay carries exactly one');
   ok(cueFor({ kind: 'chant', label: 'x', reps: 8, weight: 0.5 }, ctx).spawn.length === 4, 'a light chant is a shorter lane');
   ok(resultTag(0, 0) === null && resultTag(9, 9) === 'every word' && resultTag(8, 10) === 'good girl' && resultTag(5, 10) === 'half of her' && resultTag(2, 10) === 'she noticed' && resultTag(0, 10) === 'you were not listening', 'the end card tag reads the ratio');
 }


### PR DESCRIPTION
> "we have too many gold bubbles and those are actually counter intuitive, since every effect is
> colour coded we expect an effect there, lets make those rare and give waaaaay more so there is
> actually another reason to pay attention."

Stacked on #987 (`feat/race-slope-lift`) - review that one first.

## what the road was actually laying

Measured with the real spine, the real bubble field and run.js's own seed / spawn / rain cadence,
five 3-minute runs, plus every event of a demo chart through `cueFor` in all eight rooms:

| | gold | effect | treat |
|---|---|---|---|
| seeded road, before | **13.0%** | 21.8% | 65.2% |
| seeded road, after | **2.2%** | **30.9%** | 66.9% |
| track cues, before | **44.4%** (29.6% plain golden) | 35.8% | 19.8% |
| track cues, after | **5.2%** | **57.5%** | 37.3% |

Per kind, seeded road (before -> after, share of everything laid):

| kind | before | after | | kind | before | after |
|---|---|---|---|---|---|---|
| golden | 4.5% | 0.7% | | subliminal | 5.6% | 7.7% |
| lucky | 5.4% | 0.7% | | pink | 5.6% | 7.8% |
| prism | 3.1% | 0.8% | | spiral | 5.0% | 7.2% |
| treat | 65.2% | 66.9% | | glitch | 3.5% | 4.9% |
| | | | | freeze | 1.0% | 1.8% |
| | | | | braindrain | 1.0% | 1.2% |

## the rules chosen

**Rare, and worth chasing.** golden 50 -> **300** points at weight 1.2 -> **0.16**; lucky 25 ->
**150** at 1.6 -> 0.22; prism 30 -> **180** at 1.4 -> 0.3. The freed weight went to the effect
kinds (subliminal 5 -> 7, pink and spiral 4 -> 6, glitch 3 -> 4.5, braindrain 2.4 -> 3.2, freeze
1 -> 2.2, gifrain 1.2 -> 1.4); treat drops 22 -> 20 and stays the filler.

**Every source, not just the roll:**

- `bubbles.js` - the air line favoured golden x3; it favours EFFECTS x1.6 now. The chunk-end
  marker on a transcript road was a golden every chunk; it is a rolled bubble.
- `rooms.js` - the Tea Garden's golden/lucky leans are gone; the casino and the coronation keep
  theirs (2.5 / 2.0 on a weight of 0.16, so they are still measurably the gold rooms) and gained
  effect leans.
- `cues.js` - a peak rains the room's own **effect** colour with at most **one** gold on the end
  (casino and coronation only); a hard drop's rings are the room's effect with **one** gold at the
  apex and a soft drop gets none; a countdown golds **only its last ring** (a count of ten used to
  hand out ten jackpots); `CHANT_GOLD_EVERY` 4 -> 12, so only the longest chant carries one at all;
  the unmapped-trigger fallbacks `coronation: 'prism'` and `casino: 'lucky'` are effects now
  (braindrain, pink).
- the rabbit foot is untouched: it is an earned item, and leaning the road gold for 12 seconds is
  exactly what it is for.

**A take you can feel.** 16 shards instead of 12 and 1.5x faster (lucky and prism get that burst
now too), a chime stack that keeps climbing with a low knock under it, shake 0.35 -> 0.55, EMI's
cheer, and the toast reads the WHOLE take - `jackpot +800` is the bubble *and* its bonus, where it
used to show the 100-point bonus alone.

**score.js is untouched.** No ladder, multiplier or bonus maths moved, so a gold take is a spike
inside the run's own economy and cannot dwarf it. Gold still carries ~27% of the points laid on the
road (down from 29.7%) - far fewer bubbles, nearly the same pot, which is what "jackpot" means. The
end card is unaffected: `resultTier` is relative to the player's own best and `resultTag` counts
words, so neither has an absolute threshold to drift past.

## how it was verified

- the mix numbers above come from a measuring harness driving the real placement and cue code (not
  shipped; the smoke that ships is the one below).
- all 16 node smokes green, including the new `slope-check` from #987. `track-run-check.mjs` gained
  the new rules as assertions: only the top ring of a hard drop is gold, the rings under it are the
  room's own effect, a dip carries none, a casino peak rains the room's colour with one gold on the
  end, a short chant has no gold and the longest has exactly one.
- headless Chrome, 1280x720, a real unattended run: a frame a minute in with effects firing on the
  road, and the jackpot frame shot the moment a **real** gold take landed - `jackpot +800`, the gold
  shards still in the air. (The shot script tells a gold take from a combo-rung jackpot by the
  number: a take is 400 x a ladder rung, a rung is 250 x one, and the two sets never collide.)
- zero console errors in both runs.

```
 .../Resources/web/dtrh/race/CONTRACT.md            | 20 +++++++---
 .../Resources/web/dtrh/race/audio.js               | 11 +++++-
 .../Resources/web/dtrh/race/bubbleKinds.js         | 27 +++++++------
 .../Resources/web/dtrh/race/bubbles.js             | 12 +++---
 .../Resources/web/dtrh/race/cues.js                | 44 ++++++++++++++--------
 .../Resources/web/dtrh/race/rooms.js               |  6 +--
 .../Resources/web/dtrh/race/run.js                 | 14 +++++--
 .../web/dtrh/race/smoke/track-run-check.mjs        | 14 ++++++-
 8 files changed, 101 insertions(+), 47 deletions(-)
```

Not verified: nobody has played this on a phone or in WebView2 yet, and the average-run figure is a
stand-in player (takes 70% of what is laid, same seeds and same rule on both builds): 21316 ->
19391, about 9% down. Whether 300 is the right number for a jackpot is a feel call that wants one
real run from the owner - it is one constant in `bubbleKinds.js` if it should be bigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013T1bb13w97ndYjNveiFpLz
