### PR TITLE
feat(pbp): the clocks find their corners

### DIFF
--- a/ConditioningControlPanel/Resources/web/piecebypiece/boot.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/boot.js
@@ -146,6 +146,17 @@ function main() {
     bus.on('local', () => { if (marks) marks.setLastMove(null); });
   }
   // --- end K ---
+  // --- L: the HUD (corner clocks, sliding light, tally, meter vignette) ---
+  // The chain never replaces what is already there: another lane may want the
+  // meter too. hudL is filled in when the module lands; until then the meter is
+  // simply dropped, which is what a HUD that has not arrived should do.
+  let hudL = null;
+  { const prev = board.setMeter; board.setMeter = (m) => { if (prev) prev(m); if (hudL) hudL.setMeter(m); }; }
+  import('./hud.js').then((m) => {
+    hudL = m.createHud({ bus, game, board, root: document.getElementById('hud'), params });
+    board.hud = hudL;
+  }).catch((e) => console.warn('[pbp] hud missing', e));
+  // --- end L ---
 
   let last = performance.now();
   function frame(now) {

--- a/ConditioningControlPanel/Resources/web/piecebypiece/hud.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/hud.js
@@ -1,0 +1,306 @@
+/* ============================================================================
+ * hud.js - the screen furniture: two clocks, one status line, the tally, and
+ * the meter drawn as the frame of the screen warming.
+ *
+ * The board is orbitable, so nothing in here may depend on which way the camera
+ * faces: clocks and words live on the screen, anything that belongs to a square
+ * lives on the board itself. The chips sit in the LEFT corners, black on top and
+ * white on the bottom, because the middle and the right are the lane the ramp's
+ * video card rides through.
+ *
+ * This layers on top of hotseat.js rather than rewiring it. hotseat still writes
+ * the two times and the base status line into the ids it was handed; everything
+ * here is driven off the bus (clock, turn, check, gameover, capture, local) and
+ * off game.rules for the material count, so the match code never has to know the
+ * HUD changed shape.
+ *
+ *   createHud({ bus, game, board, root, params }) -> { setMeter, debug, dispose }
+ *
+ * Nothing here may throw at import or at attach time: a missing node, a missing
+ * bus and a missing game all degrade to a quieter HUD, never to a dead board.
+ * ==========================================================================*/
+
+/** Every number the HUD decides with. One place, on purpose. */
+export const TUNING = Object.freeze({
+  slideMs: 260,        // the light moving from one chip to the other
+  gapLine: 6,          // px, chip bottom to the sliding line
+  gapStatus: 14,       // px, chip bottom to the status column
+  lowMs: 30000,        // the mover's clock goes red and the chip shivers
+  panicMs: 10000,      // and the shiver gets sharper
+  hintMs: 3000,        // how long "hold esc to leave the board" stays
+  vigFull: 0.5,        // meter at which the vignette is at full strength
+  vigMax: 0.9,         // and how strong full is
+  vigBreathe: 0.7,     // past this the glow breathes
+  unlocks: Object.freeze([0.25, 0.40, 0.55, 0.70]),   // the debug dot row
+});
+
+const T = TUNING;
+const VALUE = Object.freeze({ p: 1, n: 3, b: 3, r: 5, q: 9 });
+const NAMES = Object.freeze({ p: 'pawn', n: 'knight', b: 'bishop', r: 'rook', q: 'queen' });
+const COUNT = Object.freeze(['one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine', 'ten']);
+
+const clamp01 = (v) => Math.min(1, Math.max(0, Number(v) || 0));
+const other = (s) => (s === 'w' ? 'b' : 'w');
+const sideWord = (s) => (s === 'w' ? 'white' : 'black');
+
+function reducedMotion() {
+  try {
+    if (typeof window === 'undefined') return false;
+    const pbp = window.PBP;
+    if (pbp && pbp.settings && pbp.settings.reducedMotion) return true;
+    return !!(window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches);
+  } catch { return false; }
+}
+
+/**
+ * The material count as one word, from `side`'s point of view.
+ * A clean one-man lead is named ("up a knight"); anything messier falls back to
+ * the point difference ("down two"). Kings are not counted, they never come off.
+ */
+export function tallyWord(position, side = 'w') {
+  const count = { w: {}, b: {} };
+  for (const sq of Object.keys(position || {})) {
+    const man = position[sq];
+    if (!man || man.type === 'k' || !count[man.side]) continue;
+    count[man.side][man.type] = (count[man.side][man.type] || 0) + 1;
+  }
+  let points = 0;
+  const differing = [];
+  for (const type of Object.keys(VALUE)) {
+    const d = (count.w[type] || 0) - (count.b[type] || 0);
+    points += d * VALUE[type];
+    if (d !== 0) differing.push({ type, d });
+  }
+  if (side === 'b') { points = -points; for (const x of differing) x.d = -x.d; }
+  if (points === 0) return 'even';
+  const way = points > 0 ? 'up' : 'down';
+  if (differing.length === 1 && Math.abs(differing[0].d) === 1) {
+    return way + ' a ' + NAMES[differing[0].type];
+  }
+  const n = Math.abs(points);
+  return way + ' ' + (COUNT[n - 1] || String(n));
+}
+
+export function createHud(opts = {}) {
+  const bus = opts.bus && typeof opts.bus.on === 'function' ? opts.bus : null;
+  const game = opts.game || null;
+  const root = opts.root || (typeof document !== 'undefined' ? document.getElementById('hud') : null);
+  if (!root) {
+    return { setMeter() {}, dispose() {}, debug: () => ({ ok: false, why: 'no #hud' }) };
+  }
+  const pick = (id) => root.querySelector('#' + id) || (typeof document !== 'undefined' ? document.getElementById(id) : null);
+  const el = {
+    vig: pick('hud-vig'),
+    line: pick('turn-line'),
+    col: pick('status-col'),
+    status: pick('status'),
+    hint: pick('hud-hint'),
+    dots: pick('hud-dots'),
+    chip: { w: pick('chip-w'), b: pick('chip-b') },
+    tally: { w: pick('tally-w'), b: pick('tally-b') },
+  };
+
+  let active = 'w';         // whose clock is running
+  let over = null;          // the gameover payload, once it lands
+  let meter = 0;
+  let lastSecond = -1;      // so the shiver fires once a second, not every tick
+  let hinted = false;
+  const timers = new Set();
+  const unbind = [];
+
+  const later = (fn, ms) => { const id = setTimeout(() => { timers.delete(id); fn(); }, ms); timers.add(id); return id; };
+  const on = (type, fn) => {
+    if (!bus) return;
+    const safe = (p) => { try { fn(p); } catch (e) { console.warn('[pbp/hud] ' + type + ': ' + (e && e.message)); } };
+    try { unbind.push(bus.on(type, safe)); } catch { /* a bus that will not take listeners is still a bus */ }
+  };
+
+  /* ---- the sliding light -------------------------------------------------- */
+
+  /** Put the line and the status column under whichever chip is on the move. */
+  function place(instant) {
+    const chip = el.chip[active];
+    if (!chip) return;
+    const y = chip.offsetTop + chip.offsetHeight;
+    const set = (node, dy) => {
+      if (!node) return;
+      if (instant) node.style.transition = 'none';
+      node.style.transform = 'translateY(' + Math.round(y + dy) + 'px)';
+      if (instant) { void node.offsetWidth; node.style.transition = ''; }
+    };
+    set(el.line, T.gapLine);
+    set(el.col, T.gapStatus);
+    if (el.line) el.line.classList.toggle('on', !over);
+  }
+
+  function setActive(side, instant) {
+    active = side === 'b' ? 'b' : 'w';
+    for (const s of ['w', 'b']) {
+      if (el.chip[s]) el.chip[s].classList.toggle('on', s === active && !over);
+    }
+    place(instant);
+  }
+
+  /* ---- check, low clock, tally -------------------------------------------- */
+
+  /** The checked side wears the red tinge for exactly as long as the check stands. */
+  function paintCheck() {
+    let checked = null;
+    try { if (game && game.rules && game.rules.inCheck() && !over) checked = game.rules.turn(); } catch { checked = null; }
+    for (const s of ['w', 'b']) {
+      if (el.chip[s]) el.chip[s].classList.toggle('check', s === checked);
+    }
+  }
+
+  function shiver(chip, hard) {
+    if (!chip || reducedMotion()) return;
+    const cls = hard ? 'shiver-hard' : 'shiver';
+    chip.classList.remove('shiver', 'shiver-hard');
+    void chip.offsetWidth;                       // restart the run, do not queue it
+    chip.classList.add(cls);
+    later(() => chip.classList.remove(cls), 220);
+  }
+
+  /** Under 30 s the mover's digits go red; the chip shivers on each tick. */
+  function paintLow(snap) {
+    const left = snap && typeof snap[active] === 'number' ? snap[active] : null;
+    const low = left != null && left < T.lowMs && !over;
+    for (const s of ['w', 'b']) {
+      if (el.chip[s]) el.chip[s].classList.toggle('low', low && s === active);
+    }
+    if (!low) { lastSecond = -1; return; }
+    const second = Math.ceil(left / 1000);
+    if (second === lastSecond) return;
+    lastSecond = second;
+    shiver(el.chip[active], left < T.panicMs);
+  }
+
+  function paintTally() {
+    if (!game || !game.rules) return;
+    let position;
+    try { position = game.rules.position(); } catch { return; }
+    for (const s of ['w', 'b']) {
+      if (el.tally[s]) el.tally[s].textContent = tallyWord(position, s);
+    }
+  }
+
+  /* ---- the meter, as a warm frame ----------------------------------------- */
+
+  function setMeter(v) {
+    meter = clamp01(v);
+    const still = reducedMotion();
+    // the host can turn reduced motion on after boot, so this is re-read rather
+    // than remembered; the class is what stops the light sliding
+    root.classList.toggle('still', still);
+    const strength = clamp01(meter / T.vigFull) * T.vigMax;
+    if (el.vig) {
+      el.vig.style.setProperty('--pbp-vig', strength.toFixed(3));
+      el.vig.classList.toggle('breathe', meter >= T.vigBreathe && !still);
+    }
+    if (el.dots && !el.dots.hidden) {
+      const lit = el.dots.querySelectorAll('i');
+      for (let i = 0; i < lit.length; i++) lit[i].classList.toggle('lit', meter >= T.unlocks[i]);
+    }
+  }
+
+  /* ---- copy --------------------------------------------------------------- */
+
+  /**
+   * hotseat.js already writes "white to move", "check", "checkmate, black wins",
+   * "stalemate, a draw" and "time, white wins" into the same node, in the same
+   * words. The one line it does not have is the kneel, so that is the only line
+   * this overwrites, and it lands after hotseat's own paint.
+   */
+  function endLine(end) {
+    if (!end || end.result !== 'resign' || !end.winner) return null;
+    return sideWord(other(end.winner)) + ' kneels';
+  }
+
+  /* ---- wiring ------------------------------------------------------------- */
+
+  on('clock', (snap) => {
+    if (snap && snap.active && snap.active !== active && !over) setActive(snap.active);
+    paintLow(snap);
+  });
+  on('turn', (p) => {
+    setActive(p && p.side === 'b' ? 'b' : 'w');
+    paintCheck();
+    paintTally();
+  });
+  on('check', () => paintCheck());
+  on('capture', () => paintTally());
+  on('local', () => { paintTally(); place(true); });
+  on('gameover', (p) => {
+    over = p || { result: 'over' };
+    const line = endLine(over);
+    if (line && el.status) el.status.textContent = line;
+    for (const s of ['w', 'b']) {
+      if (!el.chip[s]) continue;
+      el.chip[s].classList.remove('low', 'check', 'shiver', 'shiver-hard');
+    }
+    if (el.line) el.line.classList.remove('on');
+  });
+
+  // The one piece of teaching copy, and it leaves on its own. The first pointer
+  // move means the player has arrived; three seconds later they have read it.
+  function showHint() {
+    if (hinted || !el.hint) return;
+    hinted = true;
+    el.hint.hidden = false;
+    requestAnimationFrame(() => el.hint.classList.add('on'));
+    later(() => {
+      el.hint.classList.remove('on');
+      later(() => { el.hint.hidden = true; }, 360);
+    }, T.hintMs);
+  }
+  const onPointer = () => showHint();
+  try { window.addEventListener('pointermove', onPointer, { once: true, passive: true }); } catch { /* no window */ }
+
+  const onResize = () => place(true);
+  try { window.addEventListener('resize', onResize, { passive: true }); } catch { /* no window */ }
+
+  /* ---- start ------------------------------------------------------------- */
+
+  try {
+    const params = opts.params || new URLSearchParams(location.search);
+    if (el.dots && params.get('debug') === '1') el.dots.hidden = false;
+  } catch { /* no location: the dots stay hidden, which is the default */ }
+
+  setActive(game && game.turn ? game.turn() : 'w', true);
+  paintTally();
+  paintCheck();
+  setMeter(0);
+
+  function dispose() {
+    for (const off of unbind) { try { off(); } catch { /* already gone */ } }
+    unbind.length = 0;
+    for (const id of timers) clearTimeout(id);
+    timers.clear();
+    try { window.removeEventListener('pointermove', onPointer); } catch { /* gone */ }
+    try { window.removeEventListener('resize', onResize); } catch { /* gone */ }
+  }
+
+  return {
+    setMeter,
+    dispose,
+    /** Everything a harness needs to prove a state without reading pixels. */
+    debug() {
+      const cls = (node) => (node ? node.className : null);
+      return {
+        active,
+        over,
+        meter,
+        vig: el.vig ? el.vig.style.getPropertyValue('--pbp-vig') : null,
+        breathing: !!(el.vig && el.vig.classList.contains('breathe')),
+        status: el.status ? el.status.textContent : null,
+        hint: !!(el.hint && el.hint.classList.contains('on')),
+        chips: { w: cls(el.chip.w), b: cls(el.chip.b) },
+        tally: { w: el.tally.w ? el.tally.w.textContent : null, b: el.tally.b ? el.tally.b.textContent : null },
+        line: el.line ? el.line.style.transform : null,
+        reducedMotion: reducedMotion(),
+      };
+    },
+  };
+}
+
+export default createHud;

--- a/ConditioningControlPanel/Resources/web/piecebypiece/index.html
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/index.html
@@ -25,10 +25,34 @@
        is owned entirely by the effects module (ramp/index.js). -->
   <div id="stage"><canvas id="board-canvas"></canvas></div>
 
+  <!-- The HUD. Clocks in the left corners, out of the lane the ramp's video
+       card slides through; the status column rides under whichever clock is on
+       the move. hud.js layers the behaviour on top by listening to the bus, so
+       the three ids hotseat.js writes into (time-w, time-b, status) stay exactly
+       where they were. #hud sits under #fx on purpose: the effects layer washes
+       over it, and the meter vignette lives in here for the same reason. -->
   <div id="hud" class="hud">
-    <div class="chip"><span class="who">black</span><span class="time" id="time-b">15:00</span></div>
-    <p class="status" id="status">white to move</p>
-    <div class="chip"><span class="who">white</span><span class="time" id="time-w">15:00</span></div>
+    <div class="vig" id="hud-vig" aria-hidden="true"></div>
+
+    <div class="chip chip-b" id="chip-b" data-side="b">
+      <span class="who">black</span>
+      <span class="time" id="time-b">15:00</span>
+      <span class="tally" id="tally-b"></span>
+    </div>
+    <div class="chip chip-w" id="chip-w" data-side="w">
+      <span class="who">white</span>
+      <span class="time" id="time-w">15:00</span>
+      <span class="tally" id="tally-w"></span>
+    </div>
+
+    <!-- the light that moves between the chips IS the turn indicator -->
+    <span class="turn-line" id="turn-line" aria-hidden="true"></span>
+
+    <div class="statuscol" id="status-col">
+      <p class="status" id="status">white to move</p>
+      <p class="hint" id="hud-hint" hidden>hold esc to leave the board</p>
+      <div class="dots" id="hud-dots" hidden aria-hidden="true"><i></i><i></i><i></i><i></i></div>
+    </div>
   </div>
 
   <div id="fx"></div>

--- a/ConditioningControlPanel/Resources/web/piecebypiece/ramp/index.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/ramp/index.js
@@ -144,6 +144,7 @@ export function attachRamp(opts = {}) {
       if (!board) return;
       if (typeof board.setWobble === 'function') board.setWobble(clamp01(m * tuning.wobbleScale));
       if (typeof board.setCameraSway === 'function') board.setCameraSway(clamp01(m * tuning.swayScale));
+      if (typeof board.setMeter === 'function') board.setMeter(clamp01(m));
     } catch { /* A's board is optional and may change under us */ }
   }
 

--- a/ConditioningControlPanel/Resources/web/piecebypiece/styles.css
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/styles.css
@@ -18,22 +18,90 @@ html, body {
 #stage { position: fixed; inset: 0; z-index: 1; }
 #stage canvas { display: block; width: 100%; height: 100%; touch-action: none; }
 
-/* Clocks and status. Sits under #fx on purpose, so the effects layer can wash
-   over it as things get busier. */
-.hud {
-  position: fixed; right: 22px; top: 22px; bottom: 22px; z-index: 2;
-  display: flex; flex-direction: column; align-items: flex-end; justify-content: space-between;
-  pointer-events: none; text-align: right;
+/* --- the HUD ---------------------------------------------------------------
+   Clocks in the left corners, so the middle and the right stay clear for the
+   ramp's video card. The chip of the side to move is bright and full size, the
+   waiting one dims and shrinks a step, and a thin pink line slides between them:
+   the light moving is the whole turn indicator. Sits under #fx on purpose, so
+   the effects layer can wash over it. hud.js places the sliding parts by
+   measuring the chips, so nothing here has to know how tall a chip is. */
+.hud { position: fixed; inset: 0; z-index: 2; pointer-events: none; }
+
+/* the meter, as the frame of the screen warming rather than a bar with a
+   number on it. --pbp-vig is written by hud.js, 0 to about 0.9. */
+.vig {
+  position: fixed; inset: 0; pointer-events: none;
+  opacity: var(--pbp-vig, 0);
+  /* closest-side: the last stop lands exactly on the edges of the screen, so
+     the warmth is a frame and never a wash over the board in the middle */
+  background: radial-gradient(ellipse closest-side at 50% 50%,
+    rgba(255, 105, 180, 0) 40%, rgba(255, 105, 180, 0.18) 74%, rgba(255, 74, 150, 0.55) 100%);
+  transition: opacity 520ms ease;
 }
+.vig.breathe { animation: pbp-vig-breathe 3600ms ease-in-out infinite; }
+@keyframes pbp-vig-breathe {
+  0%, 100% { opacity: calc(var(--pbp-vig, 0) * 0.58); }
+  50% { opacity: var(--pbp-vig, 0); }
+}
+
 .chip {
-  display: flex; flex-direction: column; gap: 2px; padding: 10px 16px; border-radius: 12px;
+  position: absolute; left: 22px; width: 140px;
+  display: flex; flex-direction: column; gap: 1px; padding: 9px 14px; border-radius: 12px;
   background: rgba(20, 20, 46, 0.55); border: 1px solid rgba(245, 230, 200, 0.12);
-  backdrop-filter: blur(3px);
+  backdrop-filter: blur(3px); opacity: 0.45;
+  transition: opacity 220ms ease, background-color 300ms ease, border-color 300ms ease;
 }
+.chip-b { top: 22px; }
+.chip-w { bottom: 124px; }   /* room under it for the status column and the .cam- row */
+.chip.on { opacity: 1; }
 .chip .who { font-size: 11px; letter-spacing: 0.18em; text-transform: uppercase; opacity: 0.55; }
-.chip .time { font-size: 26px; font-variant-numeric: tabular-nums; opacity: 0.7; transition: color 200ms ease, opacity 200ms ease; }
-.chip .time.on { color: var(--pbp-pink); opacity: 1; }
-.status { margin: 0; font-size: 13px; letter-spacing: 0.14em; text-transform: lowercase; opacity: 0.6; }
+.chip .time {
+  font-size: 21px; line-height: 1.15; font-variant-numeric: tabular-nums;
+  transition: font-size 200ms ease, color 200ms ease;
+}
+.chip.on .time { font-size: 27px; color: var(--pbp-pink); }
+.chip .tally { min-height: 13px; font-size: 10px; letter-spacing: 0.14em; opacity: 0.5; }
+/* under 30 s on the mover's clock. After .on, so the red wins the tie. */
+.chip.low .time { color: #FF4257; }
+/* the checked side, for as long as the check stands */
+.chip.check { background: rgba(96, 16, 38, 0.6); border-color: rgba(255, 70, 105, 0.5); }
+.chip.shiver { animation: pbp-shiver 120ms steps(4) 1; }
+.chip.shiver-hard { animation: pbp-shiver-hard 110ms steps(5) 1; }
+@keyframes pbp-shiver {
+  0% { transform: translate(0, 0); } 25% { transform: translate(3px, -1px); }
+  50% { transform: translate(-2px, 2px); } 75% { transform: translate(2px, 1px); }
+  100% { transform: translate(0, 0); }
+}
+@keyframes pbp-shiver-hard {
+  0% { transform: translate(0, 0); } 20% { transform: translate(-5px, 2px); }
+  45% { transform: translate(5px, -2px); } 70% { transform: translate(-3px, -3px); }
+  88% { transform: translate(4px, 2px); } 100% { transform: translate(0, 0); }
+}
+
+.turn-line {
+  position: absolute; left: 22px; top: 0; width: 140px; height: 2px; border-radius: 2px;
+  background: var(--pbp-pink); box-shadow: 0 0 10px rgba(255, 105, 180, 0.75);
+  opacity: 0; transform: translateY(0);
+  transition: transform 260ms cubic-bezier(0.4, 0, 0.2, 1), opacity 220ms ease;
+}
+.turn-line.on { opacity: 0.95; }
+/* the host's own reduced-motion switch, which the OS media query cannot see */
+.hud.still .turn-line, .hud.still .statuscol { transition: none; }
+
+.statuscol {
+  position: absolute; left: 22px; top: 0; width: 210px;
+  transform: translateY(0); transition: transform 260ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+.status { margin: 0; font-size: 13px; letter-spacing: 0.14em; text-transform: lowercase; opacity: 0.62; }
+.hint { margin: 6px 0 0; font-size: 11px; letter-spacing: 0.14em; opacity: 0; transition: opacity 320ms ease; }
+.hint.on { opacity: 0.42; }
+.dots { display: flex; gap: 5px; margin-top: 8px; }
+.dots i {
+  width: 6px; height: 6px; border-radius: 50%;
+  background: rgba(245, 230, 200, 0.16); transition: background-color 200ms ease;
+}
+.dots i.lit { background: var(--pbp-pink); }
+/* --- end the HUD ---------------------------------------------------------- */
 
 /* Owned by the effects layer. Never written to by the board code. */
 #fx { position: fixed; inset: 0; z-index: 3; pointer-events: none; overflow: hidden; }
@@ -81,4 +149,11 @@ html, body {
 .nope h1 { margin: 0; font-size: 28px; letter-spacing: 0.16em; color: var(--pbp-pink); }
 .nope p { margin: 0; max-width: 30rem; line-height: 1.5; opacity: 0.8; }
 
-@media (prefers-reduced-motion: reduce) { .loader-ring { animation-duration: 2400ms; } }
+@media (prefers-reduced-motion: reduce) {
+  .loader-ring { animation-duration: 2400ms; }
+  /* the HUD keeps its colour and loses its movement: no shiver, no breathing
+     glow, and the light arrives instead of sliding */
+  .vig.breathe { animation: none; }
+  .chip.shiver, .chip.shiver-hard { animation: none; }
+  .turn-line, .statuscol { transition: none; }
+}


### PR DESCRIPTION
## What it does

The HUD moves out of the right edge, which is the lane the ramp's video card rides
through, and into the left corners.

- **Corner clocks.** Black top-left, white bottom-left. The side to move is bright pink
  with full-size digits; the waiting chip drops to 45 percent and shrinks its digits one
  step. A thin pink line slides from one chip to the other over 260 ms on `turn`: the
  light moving is the whole turn indicator, no arrows and no "your turn".
- **Status column** rides under whichever chip is on the move (the line, the teaching
  hint, and the debug dots travel together). hotseat.js still writes the words it always
  wrote, in the same lowercase house voice; the one line it has no word for, the kneel,
  is written here on `gameover` with `result: 'resign'` ("black kneels").
- **"hold esc to leave the board"** shows for 3 s on the first pointer move and never
  again.
- **Low clock.** Under 30 s on the mover's clock the digits go red (they were already
  tabular) and the chip shivers 3 px for 120 ms once a second; under 10 s the shiver is
  sharper. Reduced motion keeps the colour and drops the shiver.
- **Check.** The checked side's chip takes a red tinge for exactly as long as the check
  stands, read off `game.rules.inCheck()` so it clears itself when the check is answered.
- **Tally.** One word under each clock, from that side's point of view: "up a knight",
  "even", "down a pawn". A clean one-man lead is named, anything messier falls back to
  the point difference ("down two"). No icon lists.
- **The meter as a vignette.** `board.setMeter` chained in the boot block; the frame of
  the screen warms from nothing at 0 to a soft pink glow at the edges by 0.5 and breathes
  past 0.7. Fixed full-screen div, `pointer-events: none`, driven by a CSS custom
  property. `?debug=1` adds the four-dot unlock row under the status line.
- Everything stays in `#hud` at z-index 2, under `#fx`, so the effects layer still washes
  over the HUD.

## How I proved it

`python -m http.server 8829`, headless msedge on debug port 9271, every shot looked at.

| shot | what it shows |
|---|---|
| `C:\Users\PC\Pictures\Screenshots\piecebypiece\l\01-start.png` | white to move: white chip lit and full size, black dimmed, line and status under white, debug dots dark at meter 0 |
| `...\l\02-after-moves.png` | after a real drag of `e2:e4`: the light and the status have slid to the black chip, white has dimmed and shrunk |
| `...\l\03-tally.png` | ten moves in (1.e4 d5 2.exd5 Nf6 3.Nc3 Nbd7 4.d4 Nb6 5.Nf3 Bg4): "up a pawn" under white, "down a pawn" under black |
| `...\l\04-check.png` | `?fen=` with black to move in check: red tinge on the black chip, status "check" |
| `...\l\05-lowclock.png` | `?clock=25` after a wait: white 0:11 in red, black 0:25 normal, `chip chip-w on low` |
| `...\l\06-meter08.png` | meter pinned to 0.8 through the ramp's own override, all four dots lit, full stack |
| `...\l\07-vignette-08-only.png` | the same 0.8 with the ramp's layers off, so the vignette is the only thing on screen |

Smokes: `rules-smoke` 43/43, `ramp-smoke` 111/111, `feel-shot` clean ("feel shot done, no
console errors") on port 9271. Every page load reported "clean boot, no console errors".

## What is NOT in it

- The move list. That is the second PR of this stack.
- The parade of captured men on the plinth edge (the tally is the echo of it, the row
  itself is a later wave).
- The Esc hold-to-leave ring. The hint line names the gesture the feel note settled on,
  but nothing in this branch listens for Esc yet, so that copy is a promise the exit lane
  still has to keep.

## Touches outside my lane

- `ramp/index.js`: the one agreed meter line in `pushToBoard`, character for character as
  the wave rules spell it, so the other lane that wants the meter merges clean:
  `if (typeof board.setMeter === 'function') board.setMeter(clamp01(m));`
- `boot.js`: my one block (below).
- `hotseat.js` is untouched. The HUD listens to `clock`, `turn`, `check`, `capture`,
  `local` and `gameover` and reads the position off `game.rules`, and the three ids
  hotseat writes into (`time-w`, `time-b`, `status`) are still exactly where they were.

## My boot.js block

```js
  // --- L: the HUD (corner clocks, sliding light, tally, meter vignette) ---
  // The chain never replaces what is already there: another lane may want the
  // meter too. hudL is filled in when the module lands; until then the meter is
  // simply dropped, which is what a HUD that has not arrived should do.
  let hudL = null;
  { const prev = board.setMeter; board.setMeter = (m) => { if (prev) prev(m); if (hudL) hudL.setMeter(m); }; }
  import('./hud.js').then((m) => {
    hudL = m.createHud({ bus, game, board, root: document.getElementById('hud'), params });
    board.hud = hudL;
  }).catch((e) => console.warn('[pbp] hud missing', e));
  // --- end L ---
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CQdAN3aDyhnnXWjBtkH1mD
