### PR TITLE
feat(pbp): the moves, written down

### DIFF
--- a/ConditioningControlPanel/Resources/web/piecebypiece/hud.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/hud.js
@@ -266,12 +266,20 @@ export function createHud(opts = {}) {
     if (el.dots && params.get('debug') === '1') el.dots.hidden = false;
   } catch { /* no location: the dots stay hidden, which is the default */ }
 
+  // The list is HUD furniture too, but it is the only part that takes a click,
+  // so it lives in its own file and is loaded late and guarded like the rest.
+  let moves = null;
+  import('./movelist.js').then((m) => {
+    moves = m.createMoveList({ bus, game, board: opts.board || null, root: pick('moves') });
+  }).catch((e) => console.warn('[pbp] move list missing', e));
+
   setActive(game && game.turn ? game.turn() : 'w', true);
   paintTally();
   paintCheck();
   setMeter(0);
 
   function dispose() {
+    if (moves) { try { moves.dispose(); } catch { /* already gone */ } moves = null; }
     for (const off of unbind) { try { off(); } catch { /* already gone */ } }
     unbind.length = 0;
     for (const id of timers) clearTimeout(id);
@@ -298,6 +306,7 @@ export function createHud(opts = {}) {
         tally: { w: el.tally.w ? el.tally.w.textContent : null, b: el.tally.b ? el.tally.b.textContent : null },
         line: el.line ? el.line.style.transform : null,
         reducedMotion: reducedMotion(),
+        moves: moves ? moves.debug() : null,
       };
     },
   };

--- a/ConditioningControlPanel/Resources/web/piecebypiece/index.html
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/index.html
@@ -48,6 +48,17 @@
     <!-- the light that moves between the chips IS the turn indicator -->
     <span class="turn-line" id="turn-line" aria-hidden="true"></span>
 
+    <!-- The moves, written down. Right edge, clear of the middle lane the
+         ramp's card rides down, and the one part of the HUD that takes a
+         click. Hidden until movelist.js takes it, so a missing module leaves
+         nothing half-built on screen. -->
+    <div class="moves closed" id="moves" hidden>
+      <button type="button" class="moves-tab" id="moves-tab" aria-expanded="false" aria-controls="moves-list">
+        <span class="chev" aria-hidden="true"></span><span class="word">moves</span>
+      </button>
+      <ol class="moves-list" id="moves-list"></ol>
+    </div>
+
     <div class="statuscol" id="status-col">
       <p class="status" id="status">white to move</p>
       <p class="hint" id="hud-hint" hidden>hold esc to leave the board</p>

--- a/ConditioningControlPanel/Resources/web/piecebypiece/movelist.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/movelist.js
@@ -1,0 +1,247 @@
+/* ============================================================================
+ * movelist.js - the moves, written down.
+ *
+ * A quiet column on the right edge, one row per move number, white then black,
+ * read straight off the referee's own history. It is the one part of the HUD
+ * that takes a click: tap a move and the two squares it came from and went to
+ * light up on the board for a moment, so a player can ask "where was that?"
+ * without the board replaying anything.
+ *
+ * It stays clear of the ramp's video card on purpose. The card is centred and
+ * min(72vmin, 88vw) wide (ramp.css .pbp-card), so it never reaches the right
+ * edge on a wide screen; on a narrow one the list is closed by default and only
+ * its tab shows. It lives in #hud, under #fx, so the card still rides over it.
+ *
+ *   createMoveList({ bus, game, board, root }) -> { refresh, dispose, debug }
+ *
+ * Nothing here may throw: a missing node, a missing history and a board with no
+ * setHighlights all degrade to a list that simply does less.
+ * ==========================================================================*/
+
+/** Every number and key the list decides with. One place, on purpose. */
+export const TUNING = Object.freeze({
+  litMs: 1200,             // how long a tapped move keeps its squares lit
+  wideAt: 1100,            // px, wider than this and the list opens by default
+  storeKey: 'pbp-movelist',
+});
+
+const T = TUNING;
+
+function reducedMotion() {
+  try {
+    if (typeof window === 'undefined') return false;
+    const pbp = window.PBP;
+    if (pbp && pbp.settings && pbp.settings.reducedMotion) return true;
+    return !!(window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches);
+  } catch { return false; }
+}
+
+function remember(value) {
+  try { window.localStorage.setItem(T.storeKey, value); } catch { /* private window, no memory */ }
+}
+
+function recall() {
+  try { return window.localStorage.getItem(T.storeKey); } catch { return null; }
+}
+
+export function createMoveList(opts = {}) {
+  const bus = opts.bus && typeof opts.bus.on === 'function' ? opts.bus : null;
+  const game = opts.game || null;
+  const board = opts.board || null;
+  const root = opts.root || null;
+  const tab = root ? root.querySelector('#moves-tab') : null;
+  const list = root ? root.querySelector('#moves-list') : null;
+  if (!root || !list) {
+    return { refresh() {}, dispose() {}, debug: () => ({ ok: false, why: 'no #moves' }) };
+  }
+
+  let drawn = 0;            // half-moves currently on screen
+  let lastSan = '';         // so a take-back (same length, different move) redraws
+  let selected = null;      // the ply whose squares are lit
+  let litTimer = 0;
+  const unbind = [];
+
+  const on = (type, fn) => {
+    if (!bus) return;
+    const safe = (p) => { try { fn(p); } catch (e) { console.warn('[pbp/moves] ' + type + ': ' + (e && e.message)); } };
+    try { unbind.push(bus.on(type, safe)); } catch { /* a bus that will not take listeners is still a bus */ }
+  };
+
+  /* ---- open and closed ---------------------------------------------------- */
+
+  function setOpen(open, save) {
+    root.classList.toggle('open', open);
+    root.classList.toggle('closed', !open);
+    if (tab) tab.setAttribute('aria-expanded', open ? 'true' : 'false');
+    if (save) remember(open ? 'open' : 'closed');
+    if (open) scrollToNewest(true);
+  }
+  const isOpen = () => root.classList.contains('open');
+
+  /* ---- the rows ----------------------------------------------------------- */
+
+  function history() {
+    try {
+      const h = game && game.rules && game.rules.chess ? game.rules.chess.history({ verbose: true }) : [];
+      return Array.isArray(h) ? h : [];
+    } catch { return []; }
+  }
+
+  function cell(move, ply) {
+    const span = document.createElement('span');
+    span.className = 'm';
+    if (!move) { span.className = 'm gap'; span.textContent = ''; return span; }
+    span.textContent = move.san || (move.from + move.to);
+    span.dataset.ply = String(ply);
+    span.dataset.from = move.from;
+    span.dataset.to = move.to;
+    return span;
+  }
+
+  function draw() {
+    const moves = history();
+    list.textContent = '';
+    if (moves.length === 0) {
+      const empty = document.createElement('li');
+      empty.className = 'mv empty';
+      empty.textContent = 'no moves yet';
+      list.appendChild(empty);
+    }
+    for (let i = 0; i < moves.length; i += 2) {
+      const row = document.createElement('li');
+      row.className = 'mv';
+      const n = document.createElement('span');
+      n.className = 'n';
+      n.textContent = (i / 2 + 1) + '.';
+      row.appendChild(n);
+      row.appendChild(cell(moves[i], i));
+      row.appendChild(cell(moves[i + 1], i + 1));
+      list.appendChild(row);
+    }
+    drawn = moves.length;
+    lastSan = moves.length ? String(moves[moves.length - 1].san || '') : '';
+    if (selected != null && selected >= moves.length) clearLit();
+    paintSelected();
+    scrollToNewest(false);
+  }
+
+  function refresh() {
+    const moves = history();
+    const tail = moves.length ? String(moves[moves.length - 1].san || '') : '';
+    if (moves.length === drawn && tail === lastSan) return;
+    draw();
+  }
+
+  function scrollToNewest(force) {
+    if (!isOpen()) return;
+    const go = () => {
+      try {
+        if (reducedMotion() || force) list.scrollTop = list.scrollHeight;
+        else list.scrollTo({ top: list.scrollHeight, behavior: 'smooth' });
+      } catch { list.scrollTop = list.scrollHeight; }
+    };
+    try { requestAnimationFrame(go); } catch { go(); }
+  }
+
+  /* ---- lighting a move up on the board ------------------------------------ */
+
+  function paintSelected() {
+    for (const node of list.querySelectorAll('.m')) {
+      node.classList.toggle('sel', selected != null && node.dataset.ply === String(selected));
+    }
+  }
+
+  function highlight(list2) {
+    if (!board || typeof board.setHighlights !== 'function') return;
+    // a man in the hand owns the hints; the list never takes them off him
+    try { if (board.drag && board.drag.isDragging && board.drag.isDragging()) return; } catch { /* no drag yet */ }
+    try { board.setHighlights(list2); } catch { /* the board may not be up */ }
+  }
+
+  function clearLit() {
+    if (litTimer) { clearTimeout(litTimer); litTimer = 0; }
+    selected = null;
+    paintSelected();
+    highlight([]);
+  }
+
+  function lightUp(node) {
+    const ply = Number(node.dataset.ply);
+    if (!Number.isFinite(ply)) return;
+    if (selected === ply) { clearLit(); return; }     // tap the same move again to put it out
+    if (litTimer) { clearTimeout(litTimer); litTimer = 0; }
+    selected = ply;
+    paintSelected();
+    highlight([
+      { square: node.dataset.from, kind: 'origin' },
+      { square: node.dataset.to, kind: 'move' },
+    ]);
+    litTimer = setTimeout(() => { litTimer = 0; clearLit(); }, T.litMs);
+  }
+
+  /* ---- wiring ------------------------------------------------------------- */
+
+  const onClick = (ev) => {
+    const node = ev.target && ev.target.closest ? ev.target.closest('.m[data-ply]') : null;
+    if (!node) return;
+    ev.stopPropagation();
+    lightUp(node);
+  };
+  list.addEventListener('click', onClick);
+
+  // the wheel belongs to the list while the pointer is over it: the canvas
+  // behind it takes the wheel as a camera zoom, and reading the moves is not
+  // a reason to lose your view of the board
+  const onWheel = (ev) => { ev.stopPropagation(); };
+  list.addEventListener('wheel', onWheel, { passive: true });
+
+  const onTab = (ev) => { ev.stopPropagation(); setOpen(!isOpen(), true); };
+  if (tab) tab.addEventListener('click', onTab);
+
+  const onKey = (ev) => { if (ev.key === 'Escape' && selected != null) clearLit(); };
+  try { window.addEventListener('keydown', onKey); } catch { /* no window */ }
+
+  on('turn', () => refresh());
+  on('gameover', () => refresh());
+  on('local', () => refresh());
+
+  /* ---- start -------------------------------------------------------------- */
+
+  const stored = recall();
+  let open;
+  if (stored === 'open') open = true;
+  else if (stored === 'closed') open = false;
+  else open = (typeof window !== 'undefined' ? window.innerWidth : 0) > T.wideAt;
+  root.hidden = false;
+  setOpen(open, false);
+  draw();
+
+  function dispose() {
+    for (const off of unbind) { try { off(); } catch { /* already gone */ } }
+    unbind.length = 0;
+    if (litTimer) { clearTimeout(litTimer); litTimer = 0; }
+    list.removeEventListener('click', onClick);
+    list.removeEventListener('wheel', onWheel);
+    if (tab) tab.removeEventListener('click', onTab);
+    try { window.removeEventListener('keydown', onKey); } catch { /* gone */ }
+  }
+
+  return {
+    refresh,
+    dispose,
+    setOpen: (v) => setOpen(!!v, true),
+    /** Everything a harness needs to prove a state without reading pixels. */
+    debug() {
+      return {
+        open: isOpen(),
+        rows: list.querySelectorAll('.mv').length,
+        plies: drawn,
+        last: lastSan,
+        selected,
+        stored: recall(),
+      };
+    },
+  };
+}
+
+export default createMoveList;

--- a/ConditioningControlPanel/Resources/web/piecebypiece/styles.css
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/styles.css
@@ -101,6 +101,50 @@ html, body {
   background: rgba(245, 230, 200, 0.16); transition: background-color 200ms ease;
 }
 .dots i.lit { background: var(--pbp-pink); }
+/* the move list. Right edge, so it never crosses the ramp's card, which is
+   centred and min(72vmin, 88vw) wide; only the list and its tab take a click,
+   the rest of the HUD stays click-through. */
+.moves {
+  position: absolute; right: 18px; top: 22px; width: 186px;
+  display: flex; flex-direction: column; align-items: flex-end; gap: 6px;
+  max-height: calc(100vh - 150px);
+}
+.moves-tab {
+  pointer-events: auto; cursor: pointer;
+  display: flex; align-items: center; gap: 7px; padding: 5px 10px; border-radius: 10px;
+  font: 10px/1 'Segoe UI', system-ui, sans-serif; letter-spacing: 0.18em; text-transform: uppercase;
+  color: var(--pbp-ink); opacity: 0.5;
+  background: rgba(20, 20, 46, 0.55); border: 1px solid rgba(245, 230, 200, 0.12);
+  backdrop-filter: blur(3px); transition: opacity 160ms ease;
+}
+.moves-tab:hover { opacity: 0.9; }
+.moves-tab:focus-visible { outline: 2px solid var(--pbp-pink); outline-offset: 2px; }
+.moves .chev {
+  width: 0; height: 0; border-top: 4px solid transparent; border-bottom: 4px solid transparent;
+  border-left: 5px solid currentColor; transition: transform 180ms ease;
+}
+.moves.open .chev { transform: rotate(90deg); }
+.moves-list {
+  pointer-events: auto; overflow-y: auto; overscroll-behavior: contain;
+  margin: 0; padding: 6px; list-style: none; width: 100%; min-height: 0;
+  border-radius: 12px; background: rgba(20, 20, 46, 0.55);
+  border: 1px solid rgba(245, 230, 200, 0.12); backdrop-filter: blur(3px);
+  scrollbar-width: thin; scrollbar-color: rgba(255, 105, 180, 0.5) transparent;
+}
+.moves.closed .moves-list { display: none; }
+.mv {
+  display: grid; grid-template-columns: 26px 1fr 1fr; gap: 3px; align-items: baseline;
+  font-size: 12px; letter-spacing: 0.04em;
+}
+.mv .n { opacity: 0.32; font-variant-numeric: tabular-nums; }
+.mv .m {
+  padding: 2px 5px; border-radius: 6px; cursor: pointer; opacity: 0.85;
+  transition: background-color 160ms ease, opacity 160ms ease;
+}
+.mv .m:hover { opacity: 1; background: rgba(245, 230, 200, 0.08); }
+.mv .m.gap { cursor: default; }
+.mv .m.sel { background: rgba(255, 105, 180, 0.34); color: #FFF3FA; opacity: 1; }
+.mv.empty { display: block; padding: 2px 5px; font-size: 11px; letter-spacing: 0.12em; opacity: 0.3; }
 /* --- end the HUD ---------------------------------------------------------- */
 
 /* Owned by the effects layer. Never written to by the board code. */


### PR DESCRIPTION
Second of the lane L stack. Base is `feat/pbp-l1`.

## What it does

The move list: a quiet column on the right edge, one row per move number, white then
black, read straight off `game.rules.chess.history({ verbose: true })` so there is no
second source of truth about what has been played (a take-back redraws it, because a
changed last move redraws even when the length matches).

- **Clear of the card.** The ramp's `.pbp-card` is centred and `min(72vmin, 88vw)` wide,
  so on a wide screen it never reaches the right edge; on a narrow one the list is closed
  by default and only its tab shows. It lives in `#hud` under `#fx`, so the card still
  rides over it.
- **Tap a move** and the from and to squares light through `board.setHighlights` for
  1.2 s: the origin ring on the square it left, the dot on the square it went to. No
  position replay, that is a later wave. Tap the same move again, or press Esc, and the
  light goes out early. A man in the hand owns the hints, so the list checks
  `board.drag.isDragging()` and never takes them off him.
- **The wheel** over the list scrolls the list and stops there (`stopPropagation`), so
  reading the moves never costs you your view of the board.
- **Collapsible** with a small chevron; the choice is remembered in `localStorage` under
  `pbp-movelist`, and with nothing remembered it opens by default only above 1100 px.
- `pointer-events: auto` on the list and its tab only; the rest of the HUD stays
  click-through.
- Reduced motion: the newest move arrives with a plain `scrollTop`, no smooth scroll.
- Empty history reads "no moves yet" rather than an empty box.

## How I proved it

`python -m http.server 8829`, headless msedge on debug port 9271, every shot looked at.

| shot | what it shows |
|---|---|
| `C:\Users\PC\Pictures\Screenshots\piecebypiece\l\08-movelist.png` | ten moves in: five rows, "1. e4 d5 / 2. exd5 Nf6 / 3. Nc3 Nbd7 / 4. d4 Nb6 / 5. Nf3 Bg4", newest visible |
| `...\l\09-movelist-tap.png` | tapping "e4": the cell is selected and e2 and e4 are lit on the board (`selected: 0`) |
| `...\l\10-movelist-collapsed.png` | after the chevron: only the tab, `open: false`, `stored: "closed"` |
| `...\l\11-narrow-1000.png` | a 1000 px window (976 px inner): closed by default with nothing remembered, chips and status still clear of the `.cam-` row |

Smokes: `rules-smoke` 43/43, `ramp-smoke` 111/111, `feel-shot` clean ("feel shot done, no
console errors") on port 9271. Every page load reported "clean boot, no console errors".

## What is NOT in it

- Replaying a position from a row. Tapping lights the squares and nothing more, by
  design; the board never moves backwards this wave.
- Any take-back or promotion UI. The list reads whatever history it is given, so the lane
  that owns take-back in hotseat needs nothing from here.

## Touches outside my lane

None beyond lane L's own files: `index.html` (`#hud` markup), `styles.css`, `hud.js`, and
the new `movelist.js`. `hotseat.js` is untouched. No boot.js change in this PR: the list
is loaded from `hud.js`, so the lane's boot block is still the one in the first PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CQdAN3aDyhnnXWjBtkH1mD
