### PR TITLE
feat(pbp): a room to reflect, the last move remembered

### DIFF
--- a/ConditioningControlPanel/Resources/web/piecebypiece/board/env.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/board/env.js
@@ -1,0 +1,193 @@
+/* ============================================================================
+ * board/env.js - the room the toys reflect.
+ *
+ * The men are silicone under a clearcoat and the king and queen wear real
+ * metal, and metal with nothing to mirror is flat paint: the crown read as a
+ * dark shape sitting on a head rather than gold. So the board gets a room to
+ * look at. It is not a picture anyone sees, it is a tiny scene rendered once
+ * into a cube map: a dark plum box, a big cream panel standing where the key
+ * light comes from, a pink one opposite it where the rim light is, a soft
+ * ceiling, and a faint warm glow off the floor so an underside has something to
+ * pick up. The two big ones stand at the height of a man rather than hanging
+ * overhead, because a crown is a standing band and mirrors sideways.
+ *
+ * It goes on `scene.environment`, never `scene.background`. The backdrop stays
+ * the flat fog colour the board has always sat in, so nothing about the look of
+ * the page changes; only what the shiny bits have to reflect.
+ *
+ * Wiring: boot.js builds one of these after the scene, and pumps update(dt) so
+ * a man that was rebuilt (a promotion, the glb art arriving) is dressed too.
+ * The reflection strength is per material, because silicone is not chrome: the
+ * body takes a hint of the room and the jewellery takes all of it. The board
+ * and the plinth set their own, in scene.js, where they are built.
+ *
+ * The one sharp edge: three only reads a material's own `envMapIntensity` when
+ * that material owns an `envMap`. A material lit by `scene.environment` alone
+ * has its intensity uniform overwritten with `scene.environmentIntensity`, so
+ * every surface in the game would take the room at exactly the same strength.
+ * That is why dressing hands each material the texture as well as the number.
+ * ==========================================================================*/
+
+import * as THREE from 'three';
+
+/** Every number the room is made of. One place, on purpose. */
+export const ENV = Object.freeze({
+  wall: 0x241833,          // the plum box everything sits inside
+  wallGain: 0.9,
+  creamColor: 0xFFF2E2,    // the big soft panel on the key side
+  creamGain: 2.9,          // above 1 on purpose: this is what makes a highlight
+  creamSize: [10.0, 7.2],
+  creamAt: [4.4, 3.1, 4.6],   // at the height of a man, not up in the ceiling:
+                              // a crown is a standing band and reflects sideways
+  pinkColor: 0xFF7FC2,     // and the one facing it, on the rim light's side
+  pinkGain: 1.6,
+  pinkSize: [8.4, 5.6],
+  pinkAt: [-5.2, 2.5, -5.0],
+  topColor: 0xFFF6EC,      // a soft ceiling, for the top of a crown and a tiara
+  topGain: 1.15,
+  topSize: [13.0, 13.0],
+  topAt: [0.8, 9.0, 1.2],
+  floorColor: 0x8A6BA8,    // the bounce off the plinth, so a flank is never void
+  floorGain: 0.32,
+  floorSize: 14,
+  floorAt: -3.4,
+  blur: 0.035,             // PMREM sigma; the panels want edges, not hard ones
+  skin: 0.48,              // how much room a silicone body takes (subtle)
+  metal: 1.0,              // and how much the crown and the tiara take (all)
+  loose: 0.14,             // anything nobody has dressed, the board included
+  sweep: 0.3,              // s between passes that look for undressed materials
+});
+
+/** One flat panel, aimed at the middle of the board. `gain` may exceed 1. */
+function panel(scene, hex, gain, size, at) {
+  const color = new THREE.Color(hex).multiplyScalar(gain);
+  const mesh = new THREE.Mesh(
+    new THREE.PlaneGeometry(size[0], size[1]),
+    new THREE.MeshBasicMaterial({ color, side: THREE.DoubleSide, toneMapped: false }),
+  );
+  mesh.position.set(at[0], at[1], at[2]);
+  mesh.lookAt(0, 0, 0);
+  scene.add(mesh);
+  return mesh;
+}
+
+/** The scene that only ever gets rendered into a cube map. */
+function buildRoom() {
+  const room = new THREE.Scene();
+  const wall = new THREE.Mesh(
+    new THREE.BoxGeometry(40, 26, 40),
+    new THREE.MeshBasicMaterial({
+      color: new THREE.Color(ENV.wall).multiplyScalar(ENV.wallGain),
+      side: THREE.BackSide, toneMapped: false,
+    }),
+  );
+  room.add(wall);
+  panel(room, ENV.creamColor, ENV.creamGain, ENV.creamSize, ENV.creamAt);
+  panel(room, ENV.pinkColor, ENV.pinkGain, ENV.pinkSize, ENV.pinkAt);
+  panel(room, ENV.topColor, ENV.topGain, ENV.topSize, ENV.topAt);
+  const floor = new THREE.Mesh(
+    new THREE.PlaneGeometry(ENV.floorSize, ENV.floorSize).rotateX(-Math.PI / 2),
+    new THREE.MeshBasicMaterial({
+      color: new THREE.Color(ENV.floorColor).multiplyScalar(ENV.floorGain),
+      side: THREE.DoubleSide, toneMapped: false,
+    }),
+  );
+  floor.position.y = ENV.floorAt;
+  room.add(floor);
+  return room;
+}
+
+function tearDown(room) {
+  room.traverse((o) => {
+    if (o.geometry) o.geometry.dispose();
+    if (o.material) o.material.dispose();
+  });
+}
+
+/**
+ * Build the room, hang it on the scene, and hand back the dresser.
+ *
+ *   createEnv({ renderer, scene }) -> { texture, ms, dress, update, dispose }
+ *
+ * `ms` is what the one-off cost actually was on this machine, so a slow boot
+ * has a number to point at.
+ */
+export function createEnv({ renderer, scene }) {
+  const t0 = (typeof performance !== 'undefined' ? performance.now() : 0);
+  const pmrem = new THREE.PMREMGenerator(renderer);
+  const room = buildRoom();
+  const rt = pmrem.fromScene(room, ENV.blur, 0.1, 80);
+  tearDown(room);
+  pmrem.dispose();
+  scene.environment = rt.texture;
+  scene.environmentIntensity = ENV.loose;
+  const ms = (typeof performance !== 'undefined' ? performance.now() : 0) - t0;
+
+  // A material is dressed once and remembered, so the sweep below is a walk
+  // over about a hundred objects and nothing else.
+  const done = new WeakSet();
+
+  /**
+   * How much room one material takes. The silicone knows itself: pieces.js
+   * stamps `userData.pbpPatch = 'skin'` on the body material so jiggle.js can
+   * tell a body from a jewel, and the same stamp answers this question. Every
+   * other lit material in the piece group is jewellery, which is metal, and
+   * metal takes the room whole.
+   */
+  function gainFor(material) {
+    return material.userData && material.userData.pbpPatch === 'skin' ? ENV.skin : ENV.metal;
+  }
+
+  /**
+   * `own` is a material that already carries the strength it wants, which is
+   * how the board and the plinth work: scene.js sets their numbers where they
+   * are built, and all this hands over is the texture that makes three honour
+   * them. Everything else is a man, and is given both.
+   */
+  function dressOne(material, own) {
+    if (!material || done.has(material)) return false;
+    done.add(material);
+    if (!('envMapIntensity' in material)) return false;   // unlit, nothing to reflect
+    if (!material.envMap) material.envMap = rt.texture;
+    if (!own) material.envMapIntensity = gainFor(material);
+    material.needsUpdate = true;
+    return true;
+  }
+
+  function dressGroup(group, own) {
+    let n = 0;
+    if (!group) return n;
+    group.traverse((o) => {
+      const m = o.material;
+      if (!m) return;
+      if (Array.isArray(m)) { for (const one of m) if (dressOne(one, own)) n++; }
+      else if (dressOne(m, own)) n++;
+    });
+    return n;
+  }
+
+  /** Every man standing right now. Safe to call as often as you like. */
+  function dress(pieceGroup) { return dressGroup(pieceGroup, false); }
+
+  /** The squares and the plinth, once: they keep the strength scene.js set. */
+  function dressBoard(boardGroup) { return dressGroup(boardGroup, true); }
+
+  // The men are rebuilt whenever the art arrives or a pawn promotes, and a new
+  // build brings new materials. Rather than reach into pieces.js for a hook,
+  // this looks for undressed ones a few times a second, which is cheap enough
+  // to be invisible and cannot go stale.
+  let since = ENV.sweep;
+  function update(dt, pieceGroup) {
+    since += dt;
+    if (since < ENV.sweep) return 0;
+    since = 0;
+    return dress(pieceGroup);
+  }
+
+  function dispose() {
+    if (scene.environment === rt.texture) scene.environment = null;
+    rt.dispose();
+  }
+
+  return { texture: rt.texture, ms, dress, dressBoard, update, dispose };
+}

--- a/ConditioningControlPanel/Resources/web/piecebypiece/board/markers.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/board/markers.js
@@ -8,11 +8,18 @@
  * victim actually stands on). The square he was picked up from gets a faint
  * outline, so it is clear where putting him back means.
  *
+ * The board also remembers the move that was just played: setLastMove(from, to)
+ * leaves a thin ring where the man was standing and a soft fill where he came
+ * to rest, faint enough to sit under everything else and kept until the next
+ * move. That memory is deliberately NOT part of the hint layer, which is wiped
+ * every time a man is picked up and put down.
+ *
  * Wiring:
  *   drag.js   builds one of these, calls show() on pick up and on hover, and
  *             pumps update(dt) from its own frame step
  *   scene.js  setHighlights() forwards here through setHighlightSink(), so a
  *             caller that only holds the view still lights squares up
+ *   boot.js   watches the bus for a turn and hands the move over
  *
  * Markers never take a raycast (drag.js picks men, and a marker lying over a
  * square must not shadow the man standing on it) and they neither cast nor
@@ -50,6 +57,17 @@ export const TUNING = Object.freeze({
   captureGlowOpacity: 0.42,
   originColor: 0xF7E7CC,
   originOpacity: 0.3,
+  // The last move, kept until the next one. Lower than the hints and drawn
+  // before them, so a legal dot always sits on top of the memory.
+  lastY: 0.008,
+  lastFade: 0.30,          // s, in and out
+  lastFromColor: 0xFFF1DA, // a thin ring around where he was standing
+  lastFromOpacity: 0.21,
+  lastToColor: 0xFFE6C9,   // and a soft fill where he came to rest
+  lastToOpacity: 0.19,
+  lastToSize: 1.02,
+  lastRingInner: 0.385,
+  lastRingOuter: 0.435,
 });
 
 const T = TUNING;
@@ -99,6 +117,8 @@ export function createMarkers({ group }) {
     glow: new THREE.PlaneGeometry(T.glowSize, T.glowSize).rotateX(-Math.PI / 2),
     ring: new THREE.RingGeometry(T.ringInner, T.ringOuter, 44).rotateX(-Math.PI / 2),
     origin: new THREE.RingGeometry(T.originInner, T.originOuter, 44).rotateX(-Math.PI / 2),
+    lastRing: new THREE.RingGeometry(T.lastRingInner, T.lastRingOuter, 44).rotateX(-Math.PI / 2),
+    lastFill: new THREE.PlaneGeometry(T.lastToSize, T.lastToSize).rotateX(-Math.PI / 2),
   };
 
   const live = new Map();   // square -> marker
@@ -174,8 +194,76 @@ export function createMarkers({ group }) {
 
   function clear() { show([]); }
 
+  // --- the last move ---------------------------------------------------------
+  // A move leaves something behind: a thin cream ring on the square he was
+  // standing on and a soft fill on the one he came to rest on, both faint, both
+  // kept until the next move is played. They live in their own group, so the
+  // show()/clear() cycle the hints go through every time a man is picked up
+  // cannot touch them, and they draw before the hints, so a legal dot landing
+  // on the same square still reads over the top.
+  const lastRoot = new THREE.Group();
+  lastRoot.name = 'pbp-lastmove';
+  lastRoot.raycast = NOPE;
+  root.add(lastRoot);
+  let lastMark = null;      // { key, node, parts, t }
+  const lastDying = [];
+
+  function lastLayer(mark, key, color, opacity, square, mapped) {
+    const material = new THREE.MeshBasicMaterial({
+      color, transparent: true, opacity: 0, depthWrite: false, fog: false,
+      toneMapped: false, side: THREE.DoubleSide, map: mapped ? tex : null,
+    });
+    const mesh = new THREE.Mesh(geo[key], material);
+    mesh.raycast = NOPE;
+    mesh.castShadow = false;
+    mesh.receiveShadow = false;
+    mesh.renderOrder = 2;
+    mesh.position.copy(squareToWorld(square, T.lastY));
+    mark.node.add(mesh);
+    mark.parts.push({ material, base: opacity });
+  }
+
+  function dropLast(mark) {
+    for (const part of mark.parts) part.material.dispose();
+    lastRoot.remove(mark.node);
+  }
+
+  /**
+   * Remember a move. `setLastMove('e2', 'e4')` marks it; `setLastMove()` or
+   * `setLastMove(null)` forgets it, which is what a new game and a take-back
+   * both want. Setting the same move twice is a no-op, so a caller may pump
+   * this on every turn without restarting the fade.
+   */
+  function setLastMove(from = null, to = null) {
+    const key = from || to ? String(from) + '>' + String(to) : '';
+    if ((lastMark ? lastMark.key : '') === key) return;
+    if (lastMark) { lastDying.push(lastMark); lastMark = null; }
+    if (!key) return;
+    const mark = { key, node: new THREE.Group(), parts: [], t: reducedMotion() ? 1 : 0 };
+    mark.node.raycast = NOPE;
+    if (to) lastLayer(mark, 'lastFill', T.lastToColor, T.lastToOpacity, to, true);
+    if (from) lastLayer(mark, 'lastRing', T.lastFromColor, T.lastFromOpacity, from, false);
+    lastRoot.add(mark.node);
+    lastMark = mark;
+  }
+
+  function updateLast(dt) {
+    const still = reducedMotion();
+    if (lastMark) {
+      if (lastMark.t < 1) lastMark.t = still ? 1 : Math.min(1, lastMark.t + dt / T.lastFade);
+      for (const part of lastMark.parts) part.material.opacity = part.base * lastMark.t;
+    }
+    for (let i = lastDying.length - 1; i >= 0; i--) {
+      const m = lastDying[i];
+      m.t = still ? 0 : m.t - dt / T.lastFade;
+      if (m.t <= 0) { dropLast(m); lastDying.splice(i, 1); continue; }
+      for (const part of m.parts) part.material.opacity = part.base * m.t;
+    }
+  }
+
   function update(dt) {
     clock += dt;
+    updateLast(dt);
     const still = reducedMotion();
     const k = still ? 1 : 1 - Math.exp(-T.hoverEase * dt);
     for (const m of live.values()) {
@@ -201,10 +289,17 @@ export function createMarkers({ group }) {
     for (const m of dying) drop(m);
     live.clear();
     dying.length = 0;
+    if (lastMark) { dropLast(lastMark); lastMark = null; }
+    for (const m of lastDying) dropLast(m);
+    lastDying.length = 0;
     for (const key of Object.keys(geo)) geo[key].dispose();
     tex.dispose();
     if (root.parent) root.parent.remove(root);
   }
 
-  return { show, clear, update, dispose, root, count: () => live.size };
+  return {
+    show, clear, update, dispose, root, setLastMove, lastRoot,
+    count: () => live.size,
+    lastMove: () => (lastMark ? lastMark.key : null),
+  };
 }

--- a/ConditioningControlPanel/Resources/web/piecebypiece/board/scene.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/board/scene.js
@@ -31,6 +31,11 @@ export const LIGHT = Object.freeze({
   fill: 0.58,               // low: it is there to stop a flank going black
   rimColor: 0xFF69B4,
   rim: 1.15,
+  // board/env.js hangs a little studio room on scene.environment. The men take
+  // it at their own strength; the board sets its own here, because a square is
+  // paint under a clearcoat and taking the room whole simply washes it out.
+  envSquares: 0.16,        // a hint in the gloss, not a second light
+  envPlinth: 0.55,         // the dark box wants it: it is what gives it an edge
 });
 
 /** Square name ("e4") to the world position of its centre. */
@@ -102,7 +107,9 @@ export function createScene({ canvas }) {
   const pieceGroup = new THREE.Group();
   scene.add(boardGroup, pieceGroup);
 
-  const plinthMat = new THREE.MeshPhysicalMaterial({ color: 0x241F45, roughness: 0.45, clearcoat: 0.35 });
+  const plinthMat = new THREE.MeshPhysicalMaterial({
+    color: 0x241F45, roughness: 0.45, clearcoat: 0.35, envMapIntensity: LIGHT.envPlinth,
+  });
   const plinth = new THREE.Mesh(new THREE.BoxGeometry(9.4, 0.5, 9.4), plinthMat);
   plinth.position.y = -0.33;
   plinth.receiveShadow = true;
@@ -114,7 +121,8 @@ export function createScene({ canvas }) {
     for (let r = 0; r < 8; r++) {
       const light = (f + r) % 2 === 1; // a1 is dark, h1 is light
       const mat = new THREE.MeshPhysicalMaterial({
-        color: light ? CREAM : PINK, roughness: light ? 0.42 : 0.34, clearcoat: 0.5, clearcoatRoughness: 0.3,
+        color: light ? CREAM : PINK, roughness: light ? 0.42 : 0.34, clearcoat: 0.5,
+        clearcoatRoughness: 0.3, envMapIntensity: LIGHT.envSquares,
       });
       const mesh = new THREE.Mesh(squareGeo, mat);
       mesh.position.set((f - 3.5) * SQUARE, -0.08, (3.5 - r) * SQUARE);

--- a/ConditioningControlPanel/Resources/web/piecebypiece/boot.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/boot.js
@@ -119,6 +119,28 @@ function main() {
     board.sfx = m.createSfx({ bus, game, group: view.pieceGroup, squareOf: sc.worldToSquare, root: dom.fx });
   }).catch((e) => console.warn('[pbp] sfx missing', e));
   // --- end J ---
+  // --- K: a room to reflect, and where he just came from ---
+  // The room is rendered once off the live renderer and hung on the scene; the
+  // sweep re-dresses a man who was rebuilt (the art arriving, a promotion).
+  import('./board/env.js').then((m) => {
+    board.env = m.createEnv({ renderer: view.renderer, scene: view.scene });
+    board.env.dressBoard(view.boardGroup);
+    board.env.dress(view.pieceGroup);
+    feelLate.push((dt) => board.env.update(dt, view.pieceGroup));
+  }).catch((e) => console.warn('[pbp] env missing', e));
+  // A turn carries no squares, so the referee is asked which move it was. A new
+  // game forgets, and so does a take-back, when one turns up.
+  {
+    const marks = board.drag && board.drag.markers;
+    const remember = () => {
+      const played = game.rules.chess.history({ verbose: true }).pop();
+      if (marks) marks.setLastMove(played ? played.from : null, played ? played.to : null);
+    };
+    bus.on('turn', remember);
+    bus.on('gameover', remember);
+    bus.on('local', () => { if (marks) marks.setLastMove(null); });
+  }
+  // --- end K ---
 
   let last = performance.now();
   function frame(now) {


### PR DESCRIPTION
The gold crown reflected nothing. It was painted metal in a room with no room in it, and the silicone had a clearcoat with nothing to mirror. And once a man had moved, the board forgot where he came from the moment the legal dots went away.

## a room to reflect

`board/env.js` builds a small studio once at boot and hangs it on `scene.environment`: a dark plum box, a big cream panel at the height of a standing man on the key side, a pink one facing it, a soft ceiling, and a faint bounce off the floor so a flank is never void. It is rendered straight into a PMREM off the live renderer and thrown away; the backdrop is untouched, so the fog colour still owns the frame.

The panels are drawn above white on purpose (`creamGain` 2.9). PMREM renders with tone mapping off, so a colour over 1.0 survives into the map, and that overshoot is the thing that reads as a highlight on a curved band of gold.

Silicone takes 0.48 of the room, the metals take all of it, the squares take 0.16 and the plinth 0.55. Anything nobody has dressed sits at 0.14.

**One three.js trap, written into the file so the next person does not lose an afternoon to it:** a material only gets its own `envMapIntensity` honoured while it owns an `envMap`. With `scene.environment` alone, three overwrites the uniform with `scene.environmentIntensity` and every per-material number is a lie. Proven here by setting the squares from 0.16 to 0.05 and measuring no pixel change at all. So each material is handed the PMREM texture as its own `envMap` when it is dressed.

Dressing is a throttled sweep, 0.3 s apart, guarded by a `WeakSet`: a man rebuilt when his art lands, or a pawn who becomes a queen, is picked up without `pieces.js` needing a hook.

Cost: **290 ms** one-off, measured under headless swiftshader, which is the worst machine this will ever run on.

## the last move remembered

`board/markers.js` keeps a thin cream ring on the square he left and a soft fill on the square he came to, both low alpha, both under the dust, both cleared when the next move lands. They live in their own group under the markers root, drawn before the hints, so a legal dot always sits on top of the memory. They never take a raycast and never cast a shadow.

`turn` carries no squares, so boot asks the referee which move it actually was. `gameover` is listened to as well, because a mating move ends the game without a `turn`. A new game forgets. `setLastMove(null)` is the take-back's handle for whenever one turns up.

## proof

Same camera, before and after, all in `Pictures/Screenshots/piecebypiece/k/`:

- `pair-crown.png`, `pair-crown-wide.png` - the crown was flat dark brown, it has a gold sheen across the band now
- `pair-tiara.png` - silver picks up the cream panel
- `pair-flank.png` - a pink man's flank has a soft sheen instead of falling to void
- `01-before-normal.png` / `04-after-normal.png`, `02-before-top.png`, `03-before-opponent.png`
- `07-lastmove-top.png` - `--drag e2:e4 --wait 12000`, top view: the ring is on e2 and the fill is under the pawn on e4, after the legal markers came and went

`rules-smoke` 43/43, `ramp-smoke` 111/111, `jiggle-shot` on 9270 clean.

## touches outside my lane

`boot.js` only, one contiguous `// --- K:` block right after `// --- end J ---`: it builds the room, dresses the board and the men, pushes the sweep onto `feelLate`, and wires `turn` / `gameover` / `local` to `markers.setLastMove`. Nothing else outside `board/env.js`, `board/markers.js` and the lights block of `board/scene.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CQdAN3aDyhnnXWjBtkH1mD
