### PR TITLE
feat(pbp): the taken stand and watch

### DIFF
--- a/ConditioningControlPanel/Resources/web/piecebypiece/board/outline.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/board/outline.js
@@ -209,6 +209,13 @@ export function createOutline({ group, bus = null }) {
     flickering.push({ piece, t: 0 });
   }
 
+  /** Give one man's line another colour (`null` puts his side's back). The poses use it. */
+  function setBase(piece, hex) {
+    const h = piece && hulls.get(piece);
+    if (!h) return;
+    h.base = hex == null ? (piece.userData.side === 'b' ? T.colorBlack : T.colorWhite) : hex;
+  }
+
   function kingOf(side) {
     for (const p of group.children) {
       if (p.userData && p.userData.type === 'k' && p.userData.side === side) return p;
@@ -267,7 +274,7 @@ export function createOutline({ group, bus = null }) {
   }
 
   return {
-    update, attach, detach, flicker,
+    update, attach, detach, flicker, setBase,
     /** For the harness: how many men are inked and what the line is doing. */
     stats() {
       let held = 0;

--- a/ConditioningControlPanel/Resources/web/piecebypiece/board/parade.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/board/parade.js
@@ -1,0 +1,208 @@
+/* ============================================================================
+ * board/parade.js - the taken stand and watch.
+ *
+ * A captured man does not vanish. Once anim.js has sunk him through the
+ * board he comes back up on the plinth rim on the side of whoever took him,
+ * small (0.6 of himself), facing the board, in the order he was taken. White's
+ * captures line up along white's left edge (the a-file end of his rim),
+ * black's along black's left edge (the h-file end of his). Each new arrival
+ * shuffles the row along; past eight a side starts a second row behind the
+ * first. Fifteen a side is the most chess can take, and the most we stand.
+ *
+ * The man is the very same object: his materials, his flex (jiggle.js keeps
+ * a state as long as he has a parent) and his outline all carry over, so a
+ * parade man breathes and inks like his brothers on the board. He is made
+ * unpickable (no raycast) and marked `parade` so nothing else reads him as a
+ * man in play. Idle wobble already leaves `busy` men alone.
+ *
+ *   bus  'capture' {by, piece, square, victimSide}   a man came off; noted
+ *        'sunk'    {piece, side, object}   he has finished sinking; he stands
+ *        'takeback' {from, to, ply}        the last man to arrive steps down
+ *        'local'                            a new game; the rim is cleared
+ *
+ * Respects window.PBP.settings.reducedMotion (and the media query): the men
+ * appear and shuffle instantly instead of rising and easing.
+ * ==========================================================================*/
+
+import * as THREE from 'three';
+
+/** Every number that decides where the taken stand. */
+export const TUNING = Object.freeze({
+  scale: 0.6,            // of the man's own size
+  perRow: 8,             // men in the first row before a second starts
+  maxPerSide: 15,
+  rimZ: 4.24,            // first row, from the board centre (the plinth edge is 4.7)
+  rowGap: 0.30,          // the second row stands this much further out
+  spacing: 0.56,         // between neighbours along the rim
+  start: 3.85,           // the first man stands this far from the centre line
+  rimY: -0.08,           // the plinth top
+  riseFrom: 0.55,        // a new arrival comes up from this far below the rim
+  riseSec: 0.55,
+  ease: 9,               // per-second pull toward a slot while the row shuffles
+  contactAlpha: 0.32,    // the shade disc under a parade man, fixed
+  arriveSquash: 2.2,     // jiggle squash as he settles
+});
+
+function reduced() {
+  if (typeof window === 'undefined') return false;
+  const s = window.PBP && window.PBP.settings;
+  if ((s && s.reducedMotion) || (window.PBP && window.PBP.reducedMotion)) return true;
+  try { return !!window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches; }
+  catch { return false; }
+}
+
+const easeOut = (p) => 1 - Math.pow(1 - p, 3);
+
+/**
+ * `view` is board/scene.js (boardGroup is where the men stand); `bus` the game
+ * bus; `jiggle` the flex system for the arrival squash (optional).
+ */
+export function createParade({ view, bus = null, jiggle = null }) {
+  const T = TUNING;
+  const rows = { w: [], b: [] };     // taker -> [{ piece, slot, want, t }]
+  let pendingSkip = 0;               // taken back before he finished sinking
+
+  /** World slot for the n-th man on `taker`'s rim. */
+  function slotFor(taker, n) {
+    const row = Math.floor(n / T.perRow);
+    const i = n % T.perRow;
+    const along = T.start - i * T.spacing - (row ? T.spacing * 0.5 : 0);
+    // White's rim is +z and his left is the a-file (-x); black's rim is -z and
+    // his left is the h-file (+x). Both rows run left to right for their owner.
+    const sign = taker === 'w' ? 1 : -1;
+    return {
+      x: -sign * along,
+      z: sign * (T.rimZ + row * T.rowGap),
+      yaw: taker === 'w' ? 0 : Math.PI,   // facing the board from his rim
+    };
+  }
+
+  function dress(piece) {
+    const d = piece.userData;
+    d.parade = true;
+    d.busy = true;
+    d.held = false;
+    d.square = null;
+    d.tookOne = false;
+    if (!d.paradeScale) d.paradeScale = piece.scale.clone();
+    piece.scale.copy(d.paradeScale).multiplyScalar(T.scale);
+    for (const mat of d.materials || (d.material ? [d.material] : [])) {
+      mat.transparent = false;
+      mat.opacity = 1;
+      mat.emissiveIntensity = 0;
+    }
+    piece.traverse((o) => { if (o.isMesh) o.raycast = () => {}; });
+    const disc = d.contact;
+    if (disc) {
+      disc.visible = true;
+      disc.material.opacity = T.contactAlpha;
+      disc.position.set(0, 0.005, 0);
+      disc.quaternion.identity();
+      disc.scale.setScalar(disc.userData.foot || 1);
+    }
+  }
+
+  function relayout(taker) {
+    const row = rows[taker];
+    for (let n = 0; n < row.length; n++) row[n].want = slotFor(taker, n);
+  }
+
+  function stand(piece) {
+    const victim = piece.userData.side === 'b' ? 'b' : 'w';
+    const taker = victim === 'w' ? 'b' : 'w';
+    const row = rows[taker];
+    if (row.length >= T.maxPerSide) return;   // more than chess allows; keep him gone
+    dress(piece);
+    const entry = { piece, want: null, t: 0, rising: !reduced() };
+    row.push(entry);
+    relayout(taker);
+    const w = entry.want;
+    piece.rotation.set(0, w.yaw, 0);
+    piece.position.set(w.x, entry.rising ? T.rimY - T.riseFrom : T.rimY, w.z);
+    view.boardGroup.add(piece);
+    if (!entry.rising && jiggle) jiggle.impulse(piece, { squash: T.arriveSquash * 0.5 });
+  }
+
+  function stepDown(entry) {
+    const piece = entry.piece;
+    view.boardGroup.remove(piece);
+    const d = piece.userData;
+    if (d.paradeScale) piece.scale.copy(d.paradeScale);
+    d.parade = false;
+    d.busy = false;
+  }
+
+  function clear() {
+    for (const side of ['w', 'b']) {
+      for (const e of rows[side]) stepDown(e);
+      rows[side].length = 0;
+    }
+    pendingSkip = 0;
+  }
+
+  /** The last man to arrive leaves the rim (a move was taken back). */
+  function takeback() {
+    let last = null;
+    let side = null;
+    for (const s of ['w', 'b']) {
+      const row = rows[s];
+      const e = row[row.length - 1];
+      if (e && (!last || e.order > last.order)) { last = e; side = s; }
+    }
+    if (!last) { pendingSkip++; return; }   // he is still sinking; skip him when he surfaces
+    rows[side].pop();
+    stepDown(last);
+    relayout(side);
+  }
+
+  let order = 0;
+  const unsubs = [];
+  if (bus && typeof bus.on === 'function') {
+    unsubs.push(bus.on('capture', () => { /* noted; the man arrives on `sunk` */ }));
+    unsubs.push(bus.on('sunk', (p) => {
+      const piece = p && p.object;
+      if (!piece || !piece.userData) return;
+      if (pendingSkip > 0) { pendingSkip--; return; }
+      stand(piece);
+      const row = rows[piece.userData.side === 'b' ? 'w' : 'b'];
+      row[row.length - 1].order = ++order;
+    }));
+    unsubs.push(bus.on('takeback', () => takeback()));
+    unsubs.push(bus.on('local', () => clear()));
+  }
+
+  function update(dt) {
+    const k = reduced() ? 1 : 1 - Math.exp(-T.ease * (dt || 0.016));
+    for (const side of ['w', 'b']) {
+      for (const e of rows[side]) {
+        const piece = e.piece;
+        const w = e.want;
+        piece.position.x += (w.x - piece.position.x) * k;
+        piece.position.z += (w.z - piece.position.z) * k;
+        if (e.rising) {
+          e.t += dt;
+          const p = Math.min(1, e.t / T.riseSec);
+          piece.position.y = T.rimY - T.riseFrom * (1 - easeOut(p));
+          if (p >= 1) {
+            e.rising = false;
+            piece.position.y = T.rimY;
+            if (jiggle) jiggle.impulse(piece, { squash: T.arriveSquash });
+          }
+        }
+      }
+    }
+  }
+
+  return {
+    update,
+    /** For the harness: who stands where. */
+    stats() {
+      const side = (s) => rows[s].map((e) => ({
+        type: e.piece.userData.type, x: +e.piece.position.x.toFixed(2), z: +e.piece.position.z.toFixed(2), rising: e.rising,
+      }));
+      return { w: side('w'), b: side('b'), pendingSkip };
+    },
+    clear,
+    dispose() { for (const u of unsubs) if (typeof u === 'function') u(); clear(); },
+  };
+}

--- a/ConditioningControlPanel/Resources/web/piecebypiece/board/poses.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/board/poses.js
@@ -1,0 +1,220 @@
+/* ============================================================================
+ * board/poses.js - how the board ends.
+ *
+ * The last beat of a game, played by the men themselves:
+ *
+ *   mate    the losing king tips over toward his own side, slowly (1.2 s),
+ *           pivoting on the edge of his base, and stays down. His outline
+ *           fades to grey. The winner's men take one sway together the
+ *           moment he hits, and the pink squares warm for two seconds.
+ *   draw    the two kings lean toward each other over a second, and hold.
+ *   flag / resignation   the mate pose for whoever lost.
+ *
+ * Everything here happens after `gameover`, when nothing else moves a man,
+ * so the posed kings are simply written every frame; `busy` keeps the idle
+ * wobble off them. A new game (`local`) stands them back up before pieces.js
+ * decides whether to keep them.
+ *
+ * Reduced motion (window.PBP.settings.reducedMotion or the media query): the
+ * final pose is set at once, no fall, no sway, no warm.
+ * ==========================================================================*/
+
+import * as THREE from 'three';
+
+/** Every number in the last beat. */
+export const TUNING = Object.freeze({
+  fallSec: 1.2,          // the king takes this long to hit the board
+  fallAngle: Math.PI / 2 - 0.06,   // he rests on his crown, not quite flat
+  bounce: 0.05,          // radians of the little rebound after he hits
+  bounceSec: 0.28,
+  leanSec: 1.0,          // a draw: how long the kings take to lean in
+  leanAngle: 0.30,       // and how far (radians)
+  swayBend: 2.4,         // the winner's men, one bend together, in jiggle units
+  warmSec: 2.0,          // the pink squares
+  warmPeak: 0.9,         // emissive intensity at the top of the warm
+  warmColor: 0xFF3FA4,
+  greyLine: 0x8A8390,    // the fallen king's outline
+});
+
+function reduced() {
+  if (typeof window === 'undefined') return false;
+  const s = window.PBP && window.PBP.settings;
+  if ((s && s.reducedMotion) || (window.PBP && window.PBP.reducedMotion)) return true;
+  try { return !!window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches; }
+  catch { return false; }
+}
+
+const easeIn = (p) => p * p * p;
+const easeOut = (p) => 1 - Math.pow(1 - p, 3);
+const UP = new THREE.Vector3(0, 1, 0);
+const tmpV = new THREE.Vector3();
+const tmpQ = new THREE.Quaternion();
+const baseQ = new THREE.Quaternion();
+
+/** Half the man's footprint in world units, off the body he was built from. */
+function footRadius(piece) {
+  let best = 0.25;
+  piece.traverse((o) => {
+    if (!o.isMesh || o.userData.pbpHull || o === piece.userData.contact || !o.geometry) return;
+    if (!o.geometry.boundingBox) o.geometry.computeBoundingBox();
+    const bb = o.geometry.boundingBox;
+    best = Math.max(best, (bb.max.x - bb.min.x) / 2, (bb.max.z - bb.min.z) / 2);
+  });
+  return best * (piece.scale.x || 1);
+}
+
+/**
+ * `view` is board/scene.js; `pieces` the roster (pieceAt, pieces map); `bus`
+ * the game bus; `jiggle` the flex system; `outline` a getter for the outline
+ * module (it loads separately) with setBase(piece, hex).
+ */
+export function createPoses({ view, pieces, bus = null, jiggle = null, outline = null, project = null }) {
+  const T = TUNING;
+  let scene = null;          // { kind, poses: [...], t, swayed, warmed }
+  const posed = [];          // kings we have written, to stand back up
+
+  function kingOf(side) {
+    for (const p of view.pieceGroup.children) {
+      if (p.userData && p.userData.type === 'k' && p.userData.side === side && !p.userData.parade) return p;
+    }
+    return null;
+  }
+
+  /** Lean `piece` by `angle` toward the unit direction `d`, pivoting on his base edge. */
+  function lean(pose, angle) {
+    const { piece, d, r, home } = pose;
+    tmpV.crossVectors(UP, d).normalize();          // rotates +Y toward d
+    tmpQ.setFromAxisAngle(tmpV, angle);
+    baseQ.setFromAxisAngle(UP, piece.userData.side === 'b' ? Math.PI : 0);
+    piece.quaternion.copy(baseQ).premultiply(tmpQ);
+    // The pivot p = d * r sits on the base edge; keep it where it was.
+    tmpV.copy(d).multiplyScalar(r);
+    const moved = tmpV.clone().applyQuaternion(tmpQ);
+    piece.position.set(home.x + tmpV.x - moved.x, home.y + tmpV.y - moved.y, home.z + tmpV.z - moved.z);
+  }
+
+  function makePose(piece, d) {
+    piece.userData.busy = true;
+    piece.userData.pose = true;
+    if (!posed.includes(piece)) posed.push(piece);
+    return { piece, d: d.clone().normalize(), r: footRadius(piece), home: piece.position.clone() };
+  }
+
+  function standUp() {
+    for (const piece of posed) {
+      piece.rotation.set(0, piece.userData.side === 'b' ? Math.PI : 0, 0);
+      if (piece.userData.home) piece.position.set(piece.userData.home.x, 0, piece.userData.home.z);
+      piece.userData.busy = false;
+      piece.userData.pose = false;
+      const o = outline && outline();
+      if (o && o.setBase) o.setBase(piece, null);
+    }
+    posed.length = 0;
+    coolSquares(0);
+    scene = null;
+  }
+
+  const warmSquares = [];
+  function coolSquares(intensity) {
+    if (!warmSquares.length) {
+      for (const mesh of view.squares.values()) {
+        const b = mesh.userData.base;
+        if (b && b.r > b.g + 0.2) warmSquares.push(mesh);   // the pink ones
+      }
+    }
+    for (const mesh of warmSquares) {
+      const mat = mesh.material;
+      if (intensity <= 0) { mat.emissive.setHex(0x000000); mat.emissiveIntensity = 1; }
+      else { mat.emissive.setHex(T.warmColor); mat.emissiveIntensity = intensity; }
+    }
+  }
+
+  function begin(result, winner) {
+    standUp();
+    const drawn = !winner || result === 'stalemate' || result === 'draw';
+    if (drawn) {
+      const wk = kingOf('w');
+      const bk = kingOf('b');
+      if (!wk || !bk) return;
+      const toward = (a, b) => tmpV.set(b.position.x - a.position.x, 0, b.position.z - a.position.z);
+      const dw = toward(wk, bk).lengthSq() > 1e-6 ? toward(wk, bk).clone() : new THREE.Vector3(0, 0, -1);
+      const db = toward(bk, wk).lengthSq() > 1e-6 ? toward(bk, wk).clone() : new THREE.Vector3(0, 0, 1);
+      scene = { kind: 'draw', t: 0, poses: [makePose(wk, dw), makePose(bk, db)] };
+    } else {
+      const loser = winner === 'w' ? 'b' : 'w';
+      const king = kingOf(loser);
+      if (!king) return;
+      // He falls toward his own side: white's is +z, black's is -z.
+      const d = new THREE.Vector3(0, 0, loser === 'w' ? 1 : -1);
+      scene = { kind: 'mate', t: 0, loser, poses: [makePose(king, d)], hit: false };
+    }
+    if (reduced()) { update(1e6); }
+  }
+
+  function hit(scene) {
+    scene.hit = true;
+    const king = scene.poses[0].piece;
+    const o = outline && outline();
+    if (o && o.setBase) o.setBase(king, T.greyLine);
+    if (reduced()) return;
+    // The winner's men, one sway together, away from the fallen king.
+    const winner = scene.loser === 'w' ? 'b' : 'w';
+    const away = scene.loser === 'w' ? -1 : 1;
+    if (jiggle) {
+      for (const p of view.pieceGroup.children) {
+        if (p.userData && p.userData.side === winner && !p.userData.parade) jiggle.impulse(p, { bend: [0, T.swayBend * away] });
+      }
+    }
+    // The dust and the thud hear him hit.
+    if (bus && typeof bus.emit === 'function') {
+      const world = { x: king.position.x, y: 0, z: king.position.z };
+      bus.emit('land', {
+        square: king.userData.square, piece: 'k', side: scene.loser, capture: false, refused: false, pose: true,
+        height: king.userData.scaleBase || 1, world, screen: project ? project(new THREE.Vector3(world.x, 0, world.z)) : { x: 0, y: 0 },
+      });
+    }
+  }
+
+  function update(dt) {
+    if (!scene) return;
+    scene.t += dt;
+    const t = scene.t;
+    if (scene.kind === 'mate') {
+      const p = Math.min(1, t / T.fallSec);
+      let angle = T.fallAngle * easeIn(p);
+      if (p >= 1) {
+        if (!scene.hit) hit(scene);
+        const b = Math.min(1, (t - T.fallSec) / T.bounceSec);
+        angle = T.fallAngle - Math.sin(b * Math.PI) * T.bounce;
+      }
+      lean(scene.poses[0], angle);
+      if (scene.hit) {
+        const w = Math.min(1, (t - T.fallSec) / T.warmSec);
+        const glow = reduced() ? 0 : Math.sin(w * Math.PI) * T.warmPeak;
+        coolSquares(w >= 1 ? 0 : glow);
+      }
+    } else {
+      const p = Math.min(1, t / T.leanSec);
+      for (const pose of scene.poses) lean(pose, T.leanAngle * easeOut(p));
+    }
+  }
+
+  const unsubs = [];
+  if (bus && typeof bus.on === 'function') {
+    unsubs.push(bus.on('gameover', (p) => begin(p && p.result, p && p.winner)));
+    unsubs.push(bus.on('local', () => standUp()));
+  }
+
+  return {
+    update,
+    /** For the harness. */
+    stats() {
+      if (!scene) return { kind: null, posed: posed.length };
+      return {
+        kind: scene.kind, t: +scene.t.toFixed(3), hit: !!scene.hit,
+        kings: scene.poses.map((q) => ({ side: q.piece.userData.side, y: +q.piece.position.y.toFixed(3), up: +UP.clone().applyQuaternion(q.piece.quaternion).y.toFixed(3) })),
+      };
+    },
+    dispose() { for (const u of unsubs) if (typeof u === 'function') u(); standUp(); },
+  };
+}

--- a/ConditioningControlPanel/Resources/web/piecebypiece/boot.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/boot.js
@@ -164,6 +164,17 @@ function main() {
   view.cameraRig.setDragGuard(() => drag.isHolding());
   // --- end M ---
 
+  // --- N: the theatre (parade, poses; bloom and the room in the next PR) ---
+  import('./board/parade.js').then((m) => {
+    board.parade = m.createParade({ view, bus, jiggle });
+    feelLate.push((dt) => board.parade.update(dt));
+  }).catch((e) => console.warn('[pbp] parade missing', e));
+  import('./board/poses.js').then((m) => {
+    board.poses = m.createPoses({ view, pieces, bus, jiggle, outline: () => board.outline, project: (v) => view.projectPoint(v) });
+    feelLate.push((dt) => board.poses.update(dt));
+  }).catch((e) => console.warn('[pbp] poses missing', e));
+  // --- end N ---
+
   let last = performance.now();
   function frame(now) {
     const dt = Math.min(0.1, (now - last) / 1000);

--- a/ConditioningControlPanel/Resources/web/piecebypiece/smoke/theatre-shot.mjs
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/smoke/theatre-shot.mjs
@@ -43,8 +43,8 @@ const FEN = {
   knightTake: 'rnbqkbnr/pppp1ppp/8/4p3/8/5N2/PPPPPPPP/RNBQKB1R w KQkq - 0 2',
   // white queen and rook vs a lone black king: four takes then a mate
   parade: 'k7/pppp4/8/8/8/8/8/R3Q2K w - - 0 1',
-  mate: '6k1/5ppp/8/8/8/8/8/R5K1 w - - 0 1',           // Ra8 is mate
-  draw: '7k/8/6Q1/8/8/8/8/K7 w - - 0 1',              // Qg7?? no: Qf7 stalemates... use Qg6-> h6? see scene
+  mate: '6k1/5ppp/8/8/8/8/8/R5K1 w - - 0 1',            // Ra8 is mate
+  draw: '7k/8/6K1/8/8/8/8/5Q2 w - - 0 1',           // Qf7 is stalemate
 };
 
 const profile = join(tmpdir(), 'pbp-theatre-' + Date.now());
@@ -109,7 +109,7 @@ const HIJACK = "window.__pbp = null; (async () => {"
   + " let q = [];"
   + " window.requestAnimationFrame = (fn) => { q.push(fn); return q.length; };"
   + " window.cancelAnimationFrame = () => {};"
-  + " await new Promise((r) => setTimeout(r, 400));"
+  + " for (let i = 0; i < 40 && !q.length; i++) await new Promise((r) => setTimeout(r, 100));"
   + " let t = performance.now();"
   + " window.__pbp = { step(ms, n) { for (let i = 0; i < n; i++) { t += ms; const c = q; q = []; for (const fn of c) fn(t); } return q.length; } };"
   + " return q.length; })()";
@@ -229,6 +229,79 @@ const scenes = {
     await shot('capture-side-2-landing.png', await closeUp('d5', 0.5, 520, 360));
     await beat(260);
     await shot('capture-side-3-rolling.png', await closeUp('d5', 0.5, 520, 360));
+  },
+  // --- PR 2: the taken stand and watch ------------------------------------------
+  async parade() {
+    await open();
+    const seq = [['e2', 'e4'], ['d7', 'd5'], ['e4', 'd5'], ['d8', 'd5'], ['b1', 'c3'], ['d5', 'g2'], ['f1', 'g2']];
+    for (const [a, b] of seq) { const r = await move(a, b); await beat(r && r.captured ? 1700 : 450); }
+    await beat(600);
+    const st = await json('window.PBP.board.parade && window.PBP.board.parade.stats()');
+    console.log('parade: ' + JSON.stringify(st));
+    if (!st || st.w.length !== 2 || st.b.length !== 2) bad('the parade does not hold four men');
+    if (st && st.w.concat(st.b).some((e) => e.rising)) bad('a parade man is still rising');
+    const sunk = (await events()).filter((e) => e.t === 'sunk').length;
+    console.log('sunk events: ' + sunk);
+    await shot('parade-normal.png');
+    await shot('parade-white-rim.png', { x: 0, y: 380, width: 1280, height: 480, scale: 1.5 });
+    await shot('parade-black-rim.png', { x: 200, y: 60, width: 900, height: 340, scale: 1.5 });
+    await view('top');
+    await beat(1200);
+    await shot('parade-top.png');
+    // Straight down on each rim: white's is +z (the a-file end holds his first man).
+    const rim = async (name, sq) => { const c = await closeUp(sq, 0, 420, 200); c.y += 55 * (sq[1] === '1' ? 1 : -1); await shot(name, c); };
+    await rim('parade-top-white-rim.png', 'b1');
+    await rim('parade-top-black-rim.png', 'g8');
+    const pick = await json("(() => { const P = window.PBP.board.parade; const g = window.PBP.board.view.boardGroup; return g.children.filter((o) => o.userData && o.userData.parade).map((o) => ({ raycast: o.children.every((c) => !c.isMesh || c.raycast.length === 0 && c.raycast() === undefined), busy: !!o.userData.busy, scale: +o.scale.x.toFixed(3) })); })()");
+    console.log('parade men: ' + JSON.stringify(pick));
+    await evalJs("window.PBP.bus.emit('takeback', { from: 'f1', to: 'g2', ply: 7 })");
+    await beat(400);
+    console.log('after takeback: ' + JSON.stringify(await json('window.PBP.board.parade.stats()')));
+    await evalJs("window.PBP.bus.emit('local', { sides: ['w', 'b'] })");
+    await beat(50);
+    console.log('after local: ' + JSON.stringify(await json('window.PBP.board.parade.stats()')));
+  },
+  async mate() {
+    await open(FEN.mate);
+    await move('a1', 'a8');
+    await beat(2000);
+    let st = await json('window.PBP.board.poses.stats()');
+    console.log('mate at 2.0 s: ' + JSON.stringify(st));
+    if (!st || st.kind !== 'mate' || !st.hit || st.kings[0].up > 0.15) bad('the king did not fall');
+    const l = (await events()).filter((e) => e.t === 'land' && e.p.pose);
+    console.log('pose land events: ' + l.length);
+    await shot('mate-pose.png');
+    await shot('mate-pose-near.png', await closeUp('g8', 0.3, 520, 360));
+    await beat(1200);
+    await shot('mate-pose-settled.png');
+    const ov = await json('window.PBP.board.outline.stats()');
+    console.log('outline: ' + JSON.stringify(ov));
+  },
+  async mateWarm() {
+    await open(FEN.mate);
+    await move('a1', 'a8');
+    await beat(1450);
+    console.log('mate at 1.45 s: ' + JSON.stringify(await json('window.PBP.board.poses.stats()')));
+    await shot('mate-warm.png');
+    await shot('mate-hit-near.png', await closeUp('g8', 0.3, 520, 360));
+  },
+  async draw() {
+    await open(FEN.draw);
+    const r = await move('f1', 'f7');
+    console.log('draw played: ' + JSON.stringify(r && r.san) + ' over=' + await evalJs('JSON.stringify(window.PBP.game.result())'));
+    await beat(1300);
+    const st = await json('window.PBP.board.poses.stats()');
+    console.log('draw at 1.3 s: ' + JSON.stringify(st));
+    if (!st || st.kind !== 'draw') bad('the kings did not lean');
+    await shot('draw-pose.png');
+    await shot('draw-pose-near.png', await closeUp('g7', 0.3, 640, 400));
+  },
+  async resign() {
+    await open();
+    await evalJs("window.PBP.game.resign('w')");
+    await beat(1500);
+    console.log('resign at 1.5 s: ' + JSON.stringify(await json('window.PBP.board.poses.stats()')));
+    await shot('resign-pose.png', await closeUp('e1', 0.3, 640, 400));
   },
   async knightTake() {
     await open(FEN.knightTake);


### PR DESCRIPTION
Piece by Piece wave 3, lane N, PR 2 of 3. Stacked on #996 (`feat/pbp-n1`).

## what changed

**`board/parade.js` (new): the taken stand and watch.** Once anim.js has sunk a captured man (`sunk {piece, side, object}`) he comes back up on the plinth rim on his taker's side at 0.6 of his size, facing the board, in capture order: white's captures along white's left edge (the a-file end of the +z rim), black's along black's left (the h-file end of the -z rim). Each arrival rises out of the rim and squashes as he settles; the row shuffles along to make room; past eight a second row starts behind the first; fifteen a side is the cap. He is the same object (materials, jiggle state and outline all carry over), made unpickable (`raycast` stubbed on every mesh), `busy` so the idle wobble leaves him, `parade: true` so nothing reads him as a man in play. `takeback {from, to, ply}` steps the last arrival down (or skips the next `sunk` if he has not surfaced yet); `local` clears both rims.

**`board/poses.js` (new): how the board ends.** On `gameover`:
- checkmate / flag / resignation: the losing king tips toward his own side over 1.2 s, pivoting on the edge of his base, hits, rebounds a hair, and stays down. On the hit his outline goes grey (`outline.setBase`), the winner's men take one sway together away from him (a unison jiggle bend), a `land` is emitted (`pose: true`) so the dust and the thud hear him hit, and the pink squares warm for 2 s through their emissive (`view.squares`, restored to black after).
- stalemate / draw: the two kings lean toward each other over 1 s and hold.
- reduced motion: the final pose is set at once, no sway, no warm.
`local` stands the kings back up before pieces.js decides whether to keep them.

**`board/outline.js`:** `setBase(piece, hex | null)` to recolour one man's line (the fallen king's goes `0x8A8390`).

**`boot.js`:** the N block (below), right after `// --- end J ---`.

**`smoke/theatre-shot.mjs`:** scenes `parade`, `mate`, `mateWarm`, `draw`, `resign`; the frame hand-over now waits for a queued frame instead of a fixed 400 ms (it was flaky on a loaded machine).

## boot.js block

```js
  // --- N: the theatre (parade, poses; bloom and the room in the next PR) ---
  import('./board/parade.js').then((m) => {
    board.parade = m.createParade({ view, bus, jiggle });
    feelLate.push((dt) => board.parade.update(dt));
  }).catch((e) => console.warn('[pbp] parade missing', e));
  import('./board/poses.js').then((m) => {
    board.poses = m.createPoses({ view, pieces, bus, jiggle, outline: () => board.outline, project: (v) => view.projectPoint(v) });
    feelLate.push((dt) => board.poses.update(dt));
  }).catch((e) => console.warn('[pbp] poses missing', e));
  // --- end N ---
```

## proof (looked at every one)

`C:\Users\PC\Pictures\Screenshots\piecebypiece\n\`

- `parade-normal.png`, `parade-top.png` after 1.e4 d5 2.exd5 Qxd5 3.Nc3 Qxg2 4.Bxg2 (four captures): the two white pawns black took stand at the h-file end of black's rim, the black pawn and queen white took at the a-file end of white's rim. `parade.stats()` = two men a side at x 3.85 / 3.29, none rising; `sunk` events 4; every parade man `raycast` stubbed, `busy`, scale 0.6. A synthetic `takeback` drops white's last arrival (the queen) and `local` clears both rims.
- `mate-pose.png`, `mate-pose-near.png` (2.0 s: black king down on his back over his own rim, `up` 0.06, grey line, pink squares warm), `mate-warm.png` (1.45 s: dust ring where he hit), `mate-pose-settled.png` (3.2 s: squares cooled, king still down). One `land` with `pose: true`.
- `draw-pose.png`, `draw-pose-near.png` (stalemate: both kings leaning in, `up` 0.955).
- `resign-pose.png` (`game.resign('w')`: white king down toward +z, grey line, dust).

## smokes

- rules-smoke 43/43, ramp-smoke 111/111, sfx-smoke ok
- feel-shot: done, no console errors
- theatre-shot: all scenes, no console errors

## notes

- `takeback` is not emitted by anything on this branch yet (the hover / click-to-move lane owns it); the parade listens for `{from, to, ply}` as specified and was proven with a synthetic emit.
- The kings' fall pivots on the base edge (`position = home + p - R p`), so a fallen king lies on the board rather than sinking through it.

## touches outside my lane

None beyond the boot.js N block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CQdAN3aDyhnnXWjBtkH1mD
