### PR TITLE
feat(race): the scan is the roll call, the fingerprint is the clock

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/race/cloudChart.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/cloudChart.js
@@ -45,7 +45,7 @@ import { peaksInto, binsPer, binCount } from '../chart/editor/audio.js';
 import { cloudIdFrom, hashUrl, hashBytes, loadIndex, findAuthored, isAuthored } from './chartSource.js';
 import { loadWords, loadWordsRow } from './words.js';
 import { shiftRoad, readNudge } from './wordSync.js';
-import { TRIGGER_SETS } from '../chart/editor/triggerSets.js';
+import { TRIGGER_SETS, rankOf, laysRow, compareHits } from '../chart/editor/triggerSets.js';
 import { detect } from '../chart/maker/triggers.js';
 import { wordEventsFrom, coverageOf, coverageLine } from './wordBubbles.js';
 import { themeFor } from './triggerTheme.js';
@@ -63,8 +63,11 @@ import { themeFor } from './triggerTheme.js';
  * v4 (the word bubbles): the whole script is on the road now, one word a bubble in
  * its phrase's lane (race/wordBubbles.js), so a v3 road carries a few dozen loose
  * treats where the new one carries the lyric and cannot be served in its place.
+ * v5 (the trigger catalogue, 2026-09-08): the catalogue says every trigger and every
+ * alluring word the eleven scripts use, so a v4 road holds a fraction of the rows the
+ * new one does and half of those wear the wrong effect. It has to be laid again.
  */
-export const GENERATOR_ID = 'web-road-v4';
+export const GENERATOR_ID = 'web-road-v5';
 
 /* ---- the knobs, and why each one is what it is --------------------------- */
 /**
@@ -249,7 +252,15 @@ export const SET_BY_ID = new Map(TRIGGER_SETS.map((s) => [s.id, s]));
  * scan (chart/maker/words.js `scan`), in the shape generate.js reads, so a hit here
  * means what a hit means on the Track Maker page.
  *
- * @returns [{ id, t, dur, setId, n }] sorted by t
+ * A set marked `row: false` in the catalogue is skipped: it keeps its id and its place
+ * in the Track Maker, but it is an ACCENT WORD on this road, not a row (triggerSets.js).
+ *
+ * The order is the catalogue's own precedence rule (`compareHits`), not the alphabet:
+ * the thinning below keeps the FIRST hit of a second, so the sort IS which set wins a
+ * second two of them are true of. Each hit carries the two things that rule reads -
+ * `rank` (the set's group) and `nw` (how many words the match covered).
+ *
+ * @returns [{ id, t, dur, setId, n, rank, nw }] in precedence order
  */
 export function scanTriggers(words, durationSec) {
   const list = (words && Array.isArray(words.words)) ? words.words : [];
@@ -266,32 +277,83 @@ export function scanTriggers(words, durationSec) {
   };
   const out = [];
   for (const set of TRIGGER_SETS) {
+    if (!laysRow(set)) continue;
+    const rank = rankOf(set);
     const ms = detect(words, set, [], { durationSec });
     ms.forEach((m, n) => out.push({ id: 'h:' + set.id + ':' + n, t: m.t, dur: r3(Number(m.dur) || 0),
-      setId: set.id, n, conf: conf(m.i0, m.i1) }));
+      setId: set.id, n, conf: conf(m.i0, m.i1), rank, nw: Math.max(1, (m.i1 - m.i0) + 1) }));
   }
-  return out.sort((a, b) => a.t - b.t || a.setId.localeCompare(b.setId));
+  return out.sort(compareHits);
+}
+
+/** How far a scanned hit may be moved onto a fingerprinted second of the same set. The
+ *  fingerprint shifts a phrase by about a quarter second in the median; a whole second is
+ *  room to spare, and still much less than the gap a catalogue set clusters two sayings by,
+ *  so a hit can never be snapped onto the NEXT time she says the same thing. */
+export const FP_SNAP_SEC = 1;
+
+/**
+ * THE FINGERPRINT IS THE CLOCK, THE SCAN IS THE ROLL CALL (2026-09-08).
+ *
+ * `tools/racechart/fingerprint.py` correlates a handful of phrases against the audio
+ * itself and writes the seconds it finds into the words file's `hits`, which are truer
+ * than the aligner's guess and worth keeping. But that list was written against the
+ * catalogue OF THE DAY: every one of the eleven shelf transcripts carries hits for a
+ * dozen or so of the old sets and none at all for the fifty the survey added. Reading
+ * the file's hits INSTEAD of the scan, which is what this did, meant a new set could
+ * never reach the road however plainly the voice says it - the catalogue would grow and
+ * nothing would change, silently.
+ *
+ * So the two are merged, each doing the half it is good at. The live scan says WHICH
+ * phrases are said, over the whole catalogue. Then every scanned hit that has a
+ * fingerprinted hit of its own set within FP_SNAP_SEC takes that second, that length and
+ * that confidence: the phrase keeps the truer clock it had. A fingerprinted hit the scan
+ * does not claim is dropped, because the scan is the roll call and the phrase it was
+ * found for has either moved to another set (the old flat `pink` hits inside "pink
+ * satin") or is not a row any more (`accept`, `relax`, `sleep`).
+ */
+function snapToFingerprint(scan, fp) {
+  const bySet = new Map();
+  for (const h of fp) {
+    if (!bySet.has(h.setId)) bySet.set(h.setId, []);
+    bySet.get(h.setId).push(h);
+  }
+  const used = new Set();
+  return scan.map((s) => {
+    const list = bySet.get(s.setId);
+    if (!list) return s;
+    let best = null, bestD = FP_SNAP_SEC;
+    for (const h of list) {
+      if (used.has(h)) continue;
+      const d = Math.abs((Number(h.t) || 0) - s.t);
+      if (d <= bestD) { bestD = d; best = h; }
+    }
+    if (!best) return s;
+    used.add(best);
+    return { ...s, t: r3(Number(best.t) || 0), dur: r3(Number(best.dur) || s.dur), src: best.src === 'fp' ? 'fp' : 'words',
+      conf: Math.round(clamp01(typeof best.conf === 'number' ? best.conf : s.conf) * 100) / 100 };
+  });
 }
 
 /**
- * The trigger seconds for a transcript: the fingerprinted `hits` the words file
- * carries when tools/racechart/fingerprint.py has been over it (each one's `t` is
- * the correlation peak in the audio itself, a quarter second truer than the
- * aligner's guess in the median), in scanTriggers' shape; the live scan when it
- * has none. A hit for a set the catalogue no longer has is dropped.
+ * The trigger seconds for a transcript: the live scan over the whole catalogue, with
+ * every phrase the words file was fingerprinted for moved onto the second the audio
+ * itself put it (see snapToFingerprint). A file with no `hits` is the scan, exactly.
  */
 export function triggerHits(words, durationSec) {
-  const fp = words && Array.isArray(words.hits) ? words.hits : null;
-  if (!fp || !fp.length) return scanTriggers(words, durationSec);
-  const perSet = new Map(), out = [];
-  for (const h of fp.slice().sort((a, b) => a.t - b.t || a.setId.localeCompare(b.setId))) {
-    if (!SET_BY_ID.has(h.setId) || !(h.t >= 0) || (durationSec > 0 && h.t > durationSec)) continue;
+  const scan = scanTriggers(words, durationSec);
+  const raw = (words && Array.isArray(words.hits)) ? words.hits : null;
+  if (!raw || !raw.length) return scan;
+  const fp = raw.filter((h) => h && typeof h.setId === 'string' && SET_BY_ID.has(h.setId)
+    && laysRow(SET_BY_ID.get(h.setId)) && Number(h.t) >= 0
+    && !(durationSec > 0 && Number(h.t) > durationSec));
+  if (!fp.length) return scan;
+  const perSet = new Map();
+  return snapToFingerprint(scan, fp).sort(compareHits).map((h) => {
     const n = perSet.get(h.setId) || 0;
     perSet.set(h.setId, n + 1);
-    out.push({ id: 'h:' + h.setId + ':' + n, t: r3(h.t), dur: r3(Number(h.dur) || 0), setId: h.setId, n,
-      conf: Math.round(clamp01(typeof h.conf === 'number' ? h.conf : 1) * 100) / 100, src: h.src === 'fp' ? 'fp' : 'words' });
-  }
-  return out.length ? out : scanTriggers(words, durationSec);
+    return { ...h, n, id: 'h:' + h.setId + ':' + n };
+  });
 }
 
 /**
@@ -320,8 +382,14 @@ export function triggersFromHits(events, hits, setById) {
   for (const h of hits) {
     const set = setById.get(h.setId);
     if (!set) continue;
+    // `prev` is a { h, set } pair, so `prev.t` was undefined and `h.t - undefined` is NaN, and
+    // NaN < TRIGGER_GAP is false: the gap has never thinned a single hit (fixed 2026-09-08). It
+    // did not show, because fingerprint.py had already spaced the seconds it wrote into the words
+    // files and the whole catalogue only landed a dozen phrases a track. With the survey's
+    // catalogue on it the live scan finds twelve hundred, and the gap is the only thing between
+    // the player and a wall of rows.
     const prev = kept[kept.length - 1];
-    if (prev && h.t - prev.t < TRIGGER_GAP) continue;
+    if (prev && h.t - prev.h.t < TRIGGER_GAP) continue;
     kept.push({ h, set });
   }
   const triggers = kept.map(({ h, set }) => ({

--- a/ConditioningControlPanel/Resources/web/dtrh/race/smoke/catalogue-check.mjs
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/smoke/catalogue-check.mjs
@@ -13,9 +13,10 @@
  *   2. PRECEDENCE: the rule is a real order, and it is the rule that decides the
  *      seconds two sets both claim
  *   3. the countdown mode finds the two countdowns the shelf actually contains
-
- * The road the catalogue lays is the next PR's to hold: this one is the table, the
- * rule and the matcher, over the eleven real transcripts.
+ *   4. the fingerprint merge: a set the words file was never fingerprinted for
+ *      still reaches the road, and one it was keeps the truer second
+ *   5. the road: how many rows, how many of them wear an effect, and no one kind
+ *      swallowing a track
  *
  * It never prints a line of a transcript. Everything below is counted, never quoted.
  * ==========================================================================*/
@@ -27,6 +28,7 @@ import { TRIGGER_SETS, SET_RANK, rankOf, laysRow, compareHits } from '../../char
 import { findMatches, COUNTDOWN } from '../../chart/maker/triggers.js';
 import { KIND_BY_ID } from '../bubbleKinds.js';
 import { THEME_BY_PRESET, themeFor, kindForPreset } from '../triggerTheme.js';
+import { scanTriggers, triggerHits, wordedRoad, TRIGGER_GAP, FP_SNAP_SEC, PEAKS_PER_SEC } from '../cloudChart.js';
 
 let fails = 0;
 const ok = (cond, what) => { if (!cond) { console.error('FAIL ' + what); fails++; } else console.log('  ok  ' + what); };
@@ -36,7 +38,19 @@ const RACE = resolve(fileURLToPath(import.meta.url), '../..');
 const read = (rel) => JSON.parse(readFileSync(resolve(RACE, rel), 'utf8'));
 const index = read('words/index.json');
 
+/** A curve shaped like a spoken track: a speaking level throughout, swelling every 40 s. */
+function swell(durationSec, perSec = PEAKS_PER_SEC) {
+  const n = Math.ceil(durationSec * perSec);
+  const peaks = new Float32Array(n * 2);
+  for (let i = 0; i < n; i++) {
+    const t = i / perSec;
+    const a = 0.22 + 0.5 * Math.max(0, Math.sin((t / 40) * Math.PI * 2)) ** 2;
+    peaks[i * 2] = -a; peaks[i * 2 + 1] = a;
+  }
+  return peaks;
+}
 const loadWords = (row) => ({ ...read('words/' + row.file), engine: row.engine });
+const durOf = (w) => Number(w.durationSec) || (w.source && Number(w.source.durationSec)) || 0;
 
 /* ---- 1. the catalogue ----------------------------------------------------- */
 {
@@ -126,4 +140,70 @@ const loadWords = (row) => ({ ...read('words/' + row.file), engine: row.engine }
   eq(old, 0, 'and the regex it replaced found none of them, which is why the mode exists');
 }
 
+/* ---- 4. the fingerprint merge --------------------------------------------- */
+{
+  const row = index.rows.find((r) => r.title === 'Bambi Body Lock');
+  const words = loadWords(row), dur = durOf(words);
+  ok(Array.isArray(words.hits) && words.hits.length > 0, row.title + ' carries fingerprinted hits (' + words.hits.length + ')');
+  const fpSets = new Set(words.hits.map((h) => h.setId));
+  const hits = triggerHits(words, dur);
+  const scan = scanTriggers({ ...words, hits: undefined }, dur);
+  eq(hits.length, scan.length, 'the merge lays exactly the scan\'s roll call, no more and no less');
+  const fresh = hits.filter((h) => !fpSets.has(h.setId));
+  ok(fresh.length > 0, 'and ' + fresh.length + ' of them are sets the fingerprint never saw, which used to reach the road never');
+  // a fingerprinted set keeps the truer second: every hit of one lands on a hit in the file
+  const kept = hits.filter((h) => fpSets.has(h.setId));
+  const snapped = kept.filter((h) => words.hits.some((f) => f.setId === h.setId && Math.abs(f.t - h.t) < 1e-6));
+  ok(snapped.length > kept.length * 0.6, 'and ' + snapped.length + ' of ' + kept.length + ' fingerprinted rows sit on the second the audio gave them');
+  ok(hits.every((h) => Math.abs(h.t - (scan.find((s) => s.id === h.id) || h).t) <= FP_SNAP_SEC + 1e-6),
+    'no row was moved further than the snap window (' + FP_SNAP_SEC + ' s)');
+  const bare = { ...words }; delete bare.hits;
+  ok(JSON.stringify(triggerHits(bare, dur)) === JSON.stringify(scan), 'a words file with no hits is the live scan, exactly');
+  eq(triggerHits({ ...bare, hits: [{ setId: 'not-a-set', t: 1, dur: 1, score: 1, src: 'fp' }] }, dur).length, scan.length,
+    'and hits that are all for sets the catalogue lost change nothing');
+}
+
+/* ---- 5. the road ---------------------------------------------------------- */
+/** The general share cap, and the roof for the three tracks that are genuinely one note. */
+const SHARE_CAP = 0.40, ONE_NOTE_CAP = 0.55;
+const ONE_NOTE = new Set(['Bambi IQ Lock', 'Bambi Body Lock', 'Bambi Uniformed']);
+/** Under this many rows a share is not a share, it is a handful. */
+const SHARE_MIN_ROWS = 20;
+/** What the survey asked for, as floors: the road is nearly all effect now. */
+const SHELF_ROWS_MIN = 900, SHELF_EFFECT_MIN = 850;
+
+const table = [];
+for (const row of index.rows) {
+  const words = loadWords(row), dur = durOf(words);
+  const road = wordedRoad({ peaks: swell(dur), durationSec: dur, name: row.title, hash: row.hash, words });
+  const trig = road.events.filter((e) => e.kind === 'trigger');
+  const by = {};
+  let effect = 0, tight = 0;
+  for (let i = 0; i < trig.length; i++) {
+    const k = (themeFor(trig[i]) || {}).kind || 'treat';
+    by[k] = (by[k] || 0) + 1;
+    if (KIND_BY_ID[k] && KIND_BY_ID[k].kind === 'effect') effect++;
+    if (i && trig[i].t - trig[i - 1].t < TRIGGER_GAP - 1e-6) tight++;
+  }
+  table.push({ title: row.title, rows: trig.length, effect, by, tight, sets: new Set(trig.map((e) => e.setId)).size });
+}
+const shelfRows = table.reduce((a, r) => a + r.rows, 0), shelfEffect = table.reduce((a, r) => a + r.effect, 0);
+console.log('  --  ' + table.map((r) => r.title.replace('Bambi ', '') + ' ' + r.effect + '/' + r.rows).join(', '));
+ok(shelfRows >= SHELF_ROWS_MIN, 'the shelf lays ' + shelfRows + ' trigger rows (floor ' + SHELF_ROWS_MIN + ')');
+ok(shelfEffect >= SHELF_EFFECT_MIN, 'and ' + shelfEffect + ' of them wear an effect (floor ' + SHELF_EFFECT_MIN + ')');
+eq(table.reduce((a, r) => a + r.tight, 0), 0, 'no two rows land inside TRIGGER_GAP of each other');
+ok(table.every((r) => r.sets >= 4), 'every track hears at least four different sets');
+{
+  const bi = table.find((r) => r.title === 'Bubble Induction');
+  ok(bi && bi.effect >= 40, 'Bubble Induction wears ' + (bi ? bi.effect : 0) + ' effect rows (floor 40, it had 2)');
+}
+for (const r of table) {
+  if (r.rows < SHARE_MIN_ROWS) continue;
+  const cap = ONE_NOTE.has(r.title) ? ONE_NOTE_CAP : SHARE_CAP;
+  const top = Math.max(...Object.values(r.by)), kind = Object.keys(r.by).find((k) => r.by[k] === top);
+  ok(top / r.rows <= cap, r.title + ': no kind past ' + (100 * cap).toFixed(0) + ' percent (' + kind + ' ' + (100 * top / r.rows).toFixed(0) + ')');
+}
+
+console.log('');
+console.log(fails ? 'catalogue-check: ' + fails + ' failed' : 'catalogue-check: all good');
 process.exit(fails ? 1 : 0);

--- a/ConditioningControlPanel/Resources/web/dtrh/race/smoke/lyrics-road-check.mjs
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/smoke/lyrics-road-check.mjs
@@ -25,8 +25,9 @@ import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { BUBBLE_KINDS, KIND_BY_ID } from '../bubbleKinds.js';
 import { normalizeChart } from '../chart.js';
+import { TRIGGER_SETS, laysRow } from '../../chart/editor/triggerSets.js';
 import { THEME_BY_PRESET, PRESETS_IN_USE, kindForPreset, themeFor, FALLBACK_KIND } from '../triggerTheme.js';
-import { GENERATOR_ID, WORD_BIN_SEC, BIN_SEC, CAPTION_CONF, captionWords, scanTriggers, triggerHits, wordedRoad, roadFromPeaks, PEAKS_PER_SEC } from '../cloudChart.js';
+import { GENERATOR_ID, WORD_BIN_SEC, BIN_SEC, CAPTION_CONF, FP_SNAP_SEC, captionWords, scanTriggers, triggerHits, wordedRoad, roadFromPeaks, PEAKS_PER_SEC } from '../cloudChart.js';
 
 let fails = 0;
 const ok = (cond, what) => { if (!cond) { console.error('FAIL ' + what); fails++; } else console.log('  ok  ' + what); };
@@ -35,6 +36,7 @@ const eq = (got, want, what) => ok(got === want, what + ' (got ' + JSON.stringif
 const RACE = resolve(fileURLToPath(import.meta.url), '../..');
 const read = (rel) => JSON.parse(readFileSync(resolve(RACE, rel), 'utf8'));
 const index = read('words/index.json');
+const TRIGGER_SET_BY_ID = new Map(TRIGGER_SETS.map((t) => [t.id, t]));
 const ROW = index.rows[0];                                  // the opening track: short, and it says the phrase
 // the aligner stamp lives on the index row, not on the race copy of the transcript, and
 // race/words.js loadWords() hands it to the road: the fixture is read the same way here.
@@ -52,6 +54,9 @@ function swell(durationSec, perSec = PEAKS_PER_SEC) {
   }
   return peaks;
 }
+
+/** the seconds a words file carries are rounded to the hundredth, so the fixtures are too. */
+const r2 = (v) => Math.round(v * 100) / 100;
 
 /* ---- 1. the theme table --------------------------------------------------- */
 const rows = Object.entries(THEME_BY_PRESET);
@@ -82,30 +87,49 @@ ok(hits.every((h, i) => i === 0 || h.t >= hits[i - 1].t), 'the hits come out sor
 ok(hits.every((h) => h.setId && h.id && h.t >= 0 && h.t <= DUR), 'every hit names its set and sits inside the file');
 ok(hits.some((h) => h.setId === 'bambi-sleep'), 'and the opening track really does say the phrase the road is built on');
 
-/* ---- 2b. the fingerprinted seconds win over the scan ------------------------ */
+/* ---- 2b. the scan is the roll call, the fingerprint is the clock ------------ */
 {
+  // Until 2026-09-08 a words file that shipped `hits` was taken INSTEAD of the scan, so a
+  // catalogue set the file had never been fingerprinted for could never reach the road: the
+  // catalogue could grow and nothing would change, quietly. Now the scan says WHICH phrases are
+  // said and the fingerprint only moves the ones it recognises onto their truer second.
   const bare = { ...WORDS }; delete bare.hits;
   const scanned = scanTriggers(bare, DUR);
-  eq(JSON.stringify(triggerHits(bare, DUR)), JSON.stringify(scanned), 'a words file with no hits gets the live scan, exactly');
-  const fp = { ...bare, hits: [{ setId: 'bambi-sleep', t: 10, dur: 0.6, score: 0.9, src: 'fp', conf: 0.7 }, { setId: 'good-girl', t: 20.5, dur: 0.5, score: 0.5, src: 'words', conf: 1 },
-    { setId: 'bambi-sleep', t: 30, dur: 0.6, score: 0.95, src: 'fp' }, { setId: 'not-a-set', t: 40, dur: 1, score: 1, src: 'fp' }] };
+  ok(JSON.stringify(triggerHits(bare, DUR)) === JSON.stringify(scanned), 'a words file with no hits gets the live scan, exactly');
+  const sleep0 = scanned.find((h) => h.setId === 'bambi-sleep');
+  const good0 = scanned.find((h) => h.setId === 'good-girl');
+  ok(!!sleep0 && !!good0, 'the transcript says both of the two the merge is tested on');
+  const fp = { ...bare, hits: [
+    { setId: 'bambi-sleep', t: r2(sleep0.t + 0.4), dur: 0.6, score: 0.9, src: 'fp', conf: 0.7 },
+    { setId: 'good-girl', t: r2(good0.t - 0.3), dur: 0.5, score: 0.5, src: 'words', conf: 1 },
+    { setId: 'bambi-sleep', t: r2(sleep0.t + 400), dur: 0.6, score: 0.95, src: 'fp' },
+    { setId: 'not-a-set', t: 40, dur: 1, score: 1, src: 'fp' }] };
   const got = triggerHits(fp, DUR);
-  eq(got.length, 3, 'a words file with hits gets its hits, and a set the catalogue no longer has is dropped');
-  eq(got.map((h) => h.t).join(','), '10,20.5,30', 'in time order, at the fingerprinted seconds, not the scan\'s');
-  eq(got.map((h) => h.id).join(','), 'h:bambi-sleep:0,h:good-girl:0,h:bambi-sleep:1', 'numbered per set in the scan\'s own shape');
-  eq(got[0].conf, 0.7, 'the phrase keeps the confidence the transcript gave it');
-  eq(got[2].conf, 1, 'and a hit with no conf is sure');
-  eq(triggerHits({ ...bare, hits: [{ setId: 'not-a-set', t: 1, dur: 1, score: 1, src: 'fp' }] }, DUR).length, scanned.length, 'hits that are all for unknown sets fall back to the scan');
+  eq(got.length, scanned.length, "the merge lays the scan's roll call, no more and no less");
+  ok(got.every((h, i) => i === 0 || h.t >= got[i - 1].t), 'still in time order after the snap');
+  const moved = got.find((h) => h.setId === 'bambi-sleep' && Math.abs(h.t - (sleep0.t + 0.4)) < 1e-6);
+  ok(!!moved, 'a fingerprinted phrase moves onto the second the audio gave it');
+  eq(moved.conf, 0.7, 'and keeps the confidence the fingerprint gave it');
+  eq(moved.src, 'fp', 'and says where that second came from');
+  ok(got.some((h) => h.setId === 'good-girl' && Math.abs(h.t - (good0.t - 0.3)) < 1e-6), 'in both directions');
+  ok(!got.some((h) => h.t > sleep0.t + 300), 'a fingerprinted second with no phrase anywhere near it is dropped, not laid');
+  ok(got.every((h) => scanned.some((s) => s.setId === h.setId && Math.abs(s.t - h.t) <= FP_SNAP_SEC + 1e-6)), 'no row moved further than the snap window (' + FP_SNAP_SEC + ' s)');
+  eq(triggerHits({ ...bare, hits: [{ setId: 'not-a-set', t: 1, dur: 1, score: 1, src: 'fp' }] }, DUR).length, scanned.length, 'hits that are all for unknown sets change nothing');
   const road2 = wordedRoad({ peaks: swell(DUR), durationSec: DUR, name: ROW.title, hash: ROW.hash, words: fp });
   const tr2 = road2.events.filter((e) => e.kind === 'trigger');
-  ok(tr2.some((e) => e.setId === 'bambi-sleep' && e.t === 10) && tr2.some((e) => e.setId === 'bambi-sleep' && e.t === 30), 'and the worded road lays its triggers at the fingerprinted seconds');
+  ok(tr2.length > 0 && tr2.every((e) => got.some((h) => Math.abs(h.t - e.t) < 1e-6)), 'and the worded road lays its triggers on the merged seconds');
   ok(Array.isArray(WORDS.hits) && WORDS.hits.length > 0, ROW.title + ' ships with ' + (WORDS.hits || []).length + ' fingerprinted hits');
-  // The fingerprint refines the scan, it never invents. Since the 2026-09-08 catalogue wave a hit may
-  // be heard by a DIFFERENT set than the one it was fingerprinted for (the precedence rule hands an
-  // overlap to the longer phrase), and a set that clusters folds several seconds into one span, so
-  // what has to hold is that the second is still heard, not that it is still heard by the same name.
+  // A shipped hit for a set that no longer lays a row (the accent words) is not a miss, it is the
+  // catalogue saying that phrase is said too often to stop the road; and a shipped second the scan
+  // hears nowhere near is dropped by the merge rather than laid on trust.
   const near = (h, sp) => Math.abs(sp.t - h.t) <= 0.6 || (h.t >= sp.t - 0.6 && h.t <= sp.t + sp.dur + 0.6);
-  ok(WORDS.hits.every((h) => scanned.some((sp) => near(h, sp))), 'every shipped hit is a second the scan hears too (the fingerprint refines, it does not invent)');
+  const shipped = WORDS.hits.filter((h) => laysRow(TRIGGER_SET_BY_ID.get(h.setId)));
+  ok(shipped.every((h) => scanned.some((sp) => near(h, sp))), 'every one of the ' + shipped.length + ' shipped row hits is a second the scan hears too (the fingerprint refines, it does not invent)');
+  ok(WORDS.hits.length > shipped.length, 'and the ones it no longer lays are the accent words, on purpose');
+  // the real file, merged: every set the fingerprint never carried still reaches the road
+  const live = triggerHits(WORDS, DUR);
+  const fpSets = new Set(WORDS.hits.map((h) => h.setId));
+  ok(live.filter((h) => !fpSets.has(h.setId)).length > 0, 'and the sets the fingerprint never saw are on the road now, not lost');
 }
 
 /* ---- 3. the worded road --------------------------------------------------- */
@@ -154,7 +178,7 @@ eq(plain.analysis.words, 'none', 'a track with no transcript still gets the road
 eq(plain.binSec, BIN_SEC, 'at the quarter second bin it was tuned to');
 ok(!plain.events.some((e) => e.kind === 'trigger'), 'and it has no triggers on it, because nobody heard one');
 eq(normalizeChart(plain).words.length, 0, 'and no caption track');
-eq(GENERATOR_ID, 'web-road-v4', 'the cache key moved again, so a v3 road (a handful of loose treats where the new one carries the whole script) can never be served');
+eq(GENERATOR_ID, 'web-road-v5', 'the cache key moved again, so a v4 road (a dozen phrases a track where the new one hears the whole catalogue) can never be served');
 
 console.log(fails ? '\nlyrics-road-check: ' + fails + ' failed' : '\nlyrics-road-check: all good');
 process.exit(fails ? 1 : 0);

--- a/ConditioningControlPanel/Resources/web/dtrh/race/smoke/rows-check.mjs
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/smoke/rows-check.mjs
@@ -412,15 +412,24 @@ ok(kept.trace.firedAt != null && kept.trace.firedAt - kept.trace.handedAt > 2, '
       }
       for (const m of [4, 8]) if (at[m] == null && score.state.mult >= m) at[m] = e.t - events[0].t;
     }
-    return { at, released, mult: score.state.mult, lines: done.size, score: score.state.score };
+    return { at, released, mult: score.state.mult, lines: done.size, score: score.state.score,
+      span: events[events.length - 1].t - events[0].t };
   }
 
   const was = drive(0, true), now = drive(0, false);
   ok(was.at[8] != null && was.at[8] < 30, 'a rung per bubble reached x8 in ' + (was.at[8] || 0).toFixed(1) + ' s of the file, which is the thing being fixed');
   ok(now.at[4] != null && was.at[4] != null && now.at[4] > was.at[4] * 2,
     'a rung per line takes ' + now.at[4].toFixed(1) + ' s to reach x4 where a rung per bubble took ' + was.at[4].toFixed(1) + ' s');
-  ok(now.at[8] == null, 'and x8 is not something this opening hands out for reading along: the rows and the goldens on the road are the rest of it');
-  eq(now.mult, 6, 'a clean read of every line in the file is worth x' + now.mult);
+  // 2026-09-08, the catalogue wave: the accent words (accept, relax, sleep) stopped laying trigger
+  // rows, this opening lost ten of them, and the word road got the seconds back - 41 readable lines
+  // where there were under forty. So a FLAWLESS read of the whole file does now touch the top rung,
+  // and the thing worth holding is not that it never comes, it is that it comes at the END: reading
+  // along cannot hand you x8 in the first half and leave the rows and the goldens with nothing to add.
+  ok(now.at[8] == null || now.at[8] > now.span * 0.9,
+    'x8 is not something this opening hands out early for reading along: ' +
+    (now.at[8] == null ? 'it never comes' : 'it comes at ' + now.at[8].toFixed(1) + ' s of ' + now.span.toFixed(1)) +
+    ', and the rows and the goldens on the road are the rest of it');
+  ok(now.mult >= 6, 'a clean read of every line in the file is worth x' + now.mult);
   ok(now.score >= events.length * 10, 'every word still pays its treat (' + now.score + ' points over ' + events.length + ' bubbles)');
 
   const sloppy = drive(3, false);


### PR DESCRIPTION
Stacked on #1000. This is the road half: the chart generator now uses the catalogue it was given.

## the rule

**The scan is the roll call, the fingerprint is the clock.**

`scanTriggers` reads the transcript and finds every phrase the catalogue knows. The audio fingerprint knows *when* a moment lands but not *what* was said. Before this PR the two were an either/or and the fingerprint won, so a phrase the script certainly says was dropped whenever no peak sat on it.

Now `triggerHits` **merges** them: a scanned hit within `FP_SNAP_SEC` (1 s) of a fingerprint snaps to the fingerprint's second, and a scanned hit with no fingerprint near it keeps its own. A fingerprint with no phrase on it is not a trigger and never was.

## what changed

- `race/cloudChart.js`: imports `rankOf` / `laysRow` / `compareHits`; `scanTriggers` skips accent sets, carries `rank` and word count, and sorts hits by `compareHits` so precedence decides overlaps deterministically.
- `snapToFingerprint` + the merge described above.
- **Bug fixed:** `triggersFromHits` read `prev.t` on a wrapped hit that only has `prev.h.t`, so the `TRIGGER_GAP` comparison was always `NaN` and the thinning **never ran**. It runs now.
- `GENERATOR_ID` `web-road-v4` to `web-road-v5` - the id is half the chart cache key, so every cached road is rebuilt.

## the numbers

Trigger rows over the eleven shelf files, through the real generation path:

| | rows | of them wearing an effect |
|---|---|---|
| before (main) | 779 | 260 |
| after (this stack) | 974 | 962 |

Per track, before to after: 00 Rapid Induction 19 to 9, 01 Bubble Induction 80 to 56, 02 Bubble Acceptance 202 to 147, 03 Named and Drained 101 to 133, 04 IQ Lock 72 to 114, 05 Body Lock 34 to 80, 06 Attitude Lock 48 to 75, 07 Uniformed 46 to 96, 08 Takeover 40 to 58, 09 Cockslut 80 to 140, 10 Awakens 57 to 66.

Some tracks go **down**: the three accent sets stopped laying rows for words said a hundred times, and the thinning bug fix now actually thins. That is the point - the count that matters is the effect column, 260 to 962.

Of the 621 hits the road ships, **0** are phrases the scan cannot hear, and 21 were handed to a better set by precedence (`w-pink` to `w-satin` x14, `w-drop` to `drop-for-cock` x7).

## how it was verified

- `catalogue-check.mjs` gains section 4 (the fingerprint merge: real scanned hits shifted plus or minus 0.3 and 0.4 s snap, a hit 400 s away is dropped, the `FP_SNAP_SEC` bound holds) and section 5 (the road: 974 rows, 962 effect, no one kind over 40 percent of a track with 20+ rows, a 55 percent ceiling on the three one-note tracks, Bubble Induction at 40+ effect rows).
- `lyrics-road-check.mjs` section 2b rewritten for the merge contract, and its shipped-hit assertion made span-aware - clustering folds repeats into one span, so a shipped second can sit inside a span rather than at its head.
- `rows-check.mjs`: the x8 rung needs 40 chained lines, and the opening track now has 41 readable lines, so the assertion became "x8 comes at the END" rather than a fixed second. Measured: 129 word bubbles over 41 lines, x8 at 76.1 s of a 78.0 s span.

All pure-node smokes green.

```
 4 files changed, 225 insertions(+), 44 deletions(-)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013T1bb13w97ndYjNveiFpLz
