### PR TITLE
feat(pbp): the hand knows before it grabs

### DIFF
--- a/ConditioningControlPanel/Resources/web/piecebypiece/board/drag.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/board/drag.js
@@ -9,17 +9,61 @@
  * around every man he may take. A drop either plays the move or springs back
  * with a wobble. The screen position of the held piece goes out on the bus
  * every frame so the effects layer can draw over it.
+ *
+ * The hand knows two more things than it used to:
+ *
+ *   hover    with nothing held, the man under the cursor lifts a hair and is
+ *            flagged `userData.hover` for the outline, and the canvas cursor
+ *            says whether he can be picked up at all. Only the side to move
+ *            answers. The raycast runs at most once a frame, and only when the
+ *            pointer or the camera has actually moved.
+ *   a click  a press and a release on the same man, quick and still, is a click
+ *            and not a drag: he stays lifted, his legal squares stay lit, and
+ *            the next click on one of them plays the move. A click elsewhere
+ *            lets him go, a click on another of your men moves the selection
+ *            over, and Esc drops it. A man waiting like that still counts as a
+ *            man in hand for isDragging(), so whoever owns Esc reads the same
+ *            "not now" a drag gives them; isHolding() is the narrower question,
+ *            which is what the camera's touch guard wants.
  * ==========================================================================*/
 
 import * as THREE from 'three';
 import { worldToSquare, squareToWorld } from './scene.js';
 import { createMarkers } from './markers.js';
 
-const LIFT = 0.52;      // how high above the board a held man rides
-const LAG = 11;         // follow stiffness; lower is lazier
-const TILT = 0.22;      // how far it leans into the direction of travel
-const GRAB_MAX = 0.75;  // highest point on a man the hand is allowed to hold
-const GRAB_MID = 0.45;  // where the hand lands when the square, not the man, was hit
+/** Every number the hand is made of. One place, on purpose. */
+export const TUNING = Object.freeze({
+  lift: 0.52,        // how high above the board a held man rides
+  lag: 11,           // follow stiffness; lower is lazier
+  tilt: 0.22,        // how far he leans into the direction of travel
+  grabMax: 0.75,     // highest point on a man the hand is allowed to hold
+  grabMid: 0.45,     // where the hand lands when the square, not the man, was hit
+  hoverLift: 0.04,   // a hair off the board, so the cursor has some weight
+  hoverRise: 0.06,   // e-fold seconds up ...
+  hoverFall: 0.12,   // ... and back down when the cursor leaves
+  selectLift: 0.11,  // where a clicked man waits for his square
+  tapMs: 250,        // a press shorter than this ...
+  tapPx: 6,          // ... and stiller than this is a click, not a drag
+});
+
+const T = TUNING;
+
+function reducedMotion() {
+  if (typeof window === 'undefined') return false;
+  const pbp = window.PBP;
+  if (pbp && (pbp.reducedMotion || (pbp.settings && pbp.settings.reducedMotion))) return true;
+  try { return !!window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches; }
+  catch { return false; }
+}
+
+/** Keys belong to whoever is not filling in a form. */
+function typing() {
+  if (typeof document === 'undefined') return false;
+  const el = document.activeElement;
+  if (!el) return false;
+  const tag = el.tagName;
+  return el.isContentEditable || tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT';
+}
 
 export function createDrag({ view, pieces, anim, bus, game, jiggle = null }) {
   const canvas = view.renderer.domElement;
@@ -39,8 +83,26 @@ export function createDrag({ view, pieces, anim, bus, game, jiggle = null }) {
   let legal = [];         // every square it may land on
   let takes = new Set();  // the ones holding a man it may take
   let hover = null;
-  let holdY = LIFT;       // world height of the plane the cursor drags along
+  let holdY = T.lift;     // world height of the plane the cursor drags along
   const at = { x: 0, y: 0 };   // last pointer position, in client pixels
+
+  // --- the hand with nothing in it -------------------------------------------
+  let hoverPiece = null;       // the man under the cursor, when he is yours
+  let pointerIn = false;
+  let pointerMoved = true;
+  let cursor = '';
+  const camAt = new THREE.Vector3(Infinity, 0, 0);
+  const lifts = new Map();     // piece -> { cur, want } height off his own square
+
+  // --- a click instead of a drag ---------------------------------------------
+  let press = null;            // { x, y, t } of the pointer that is down
+  let pending = false;         // this press could still turn out to be a click
+  let toggledOff = null;       // the square this press let go of, so it cannot re-take it
+  let selected = null;         // the man waiting for his square
+  let selSquare = null;
+  let selLegal = [];
+  let selTakes = new Set();
+  let selHover = null;
 
   function toNdc(ev) {
     if (ev) { at.x = ev.clientX; at.y = ev.clientY; }
@@ -76,12 +138,25 @@ export function createDrag({ view, pieces, anim, bus, game, jiggle = null }) {
    * the markers say he is going to. Called with no event it re-uses the last
    * pointer position, which is how the camera can sway under a still cursor
    * without the man sliding out of your hand.
+   *
+   * While the press could still turn out to be a click he does not follow the
+   * cursor at all: he lifts straight up off his own square, to the height a
+   * waiting man sits at. That is what makes a click a click. A man hanging at
+   * hold height stands over a square nearer the camera than the one he came
+   * from, so a press that took him there and let go would read as a move; and
+   * it means a click never yanks him into the air to put him straight back
+   * down. The moment the press becomes a drag he flies to the hand.
    */
   function aim(ev) {
     toNdc(ev);
+    if (pending && held && held.userData.home) {
+      const home = held.userData.home;
+      target.set(home.x, T.selectLift, home.z);
+      return true;
+    }
     holdPlane.constant = -holdY;
     if (!ray.ray.intersectPlane(holdPlane, hit)) return false;
-    target.set(hit.x + grab.x, LIFT, hit.z + grab.y);
+    target.set(hit.x + grab.x, T.lift, hit.z + grab.y);
     return true;
   }
 
@@ -90,14 +165,22 @@ export function createDrag({ view, pieces, anim, bus, game, jiggle = null }) {
     return worldToSquare(target.x, target.z);
   }
 
+  /**
+   * The hint layer, for whichever man the hand is thinking about: the one in
+   * the hand, or the one waiting on his square. It goes out through
+   * view.setHighlights, so a lane holding only the view sees the same list.
+   */
   function paint() {
-    const list = legal.map((sq) => ({
+    const src = held ? { at: from, list: legal, take: takes, hot: hover }
+      : (selected ? { at: selSquare, list: selLegal, take: selTakes, hot: selHover } : null);
+    if (!src) { view.setHighlights([]); return; }
+    const out = src.list.map((sq) => ({
       square: sq,
-      kind: takes.has(sq) ? 'capture' : 'move',
-      hover: sq === hover,
+      kind: src.take.has(sq) ? 'capture' : 'move',
+      hover: sq === src.hot,
     }));
-    if (from) list.push({ square: from, kind: 'origin' });
-    markers.show(list);
+    if (src.at) out.push({ square: src.at, kind: 'origin' });
+    view.setHighlights(out);
   }
 
   /**
@@ -117,17 +200,132 @@ export function createDrag({ view, pieces, anim, bus, game, jiggle = null }) {
     return { squares: verbose.map((m) => m.to), captures };
   }
 
+  // --- lift -------------------------------------------------------------------
+  // A hovered or waiting man rides a little off his square. It is written on his
+  // root position, and drag.update runs after pieces.update, so it sits over the
+  // idle sway instead of fighting the flex, which is the mesh's own business.
+  function wantLift(piece, y) {
+    if (!piece) return;
+    const s = lifts.get(piece) || { cur: piece.position.y || 0, want: 0 };
+    s.want = y;
+    lifts.set(piece, s);
+  }
+
+  function updateLifts(dt) {
+    const still = reducedMotion();
+    for (const [piece, s] of [...lifts]) {
+      // A man in hand, in flight, or off the board is not ours to place.
+      if (!piece.parent || piece.userData.held || piece.userData.busy) { lifts.delete(piece); continue; }
+      const tau = Math.max(0.001, s.want > s.cur ? T.hoverRise : T.hoverFall);
+      s.cur = still ? s.want : s.cur + (s.want - s.cur) * (1 - Math.exp(-dt / tau));
+      if (s.want <= 0 && s.cur < 0.0006) { piece.position.y = 0; lifts.delete(piece); continue; }
+      piece.position.y = s.cur;
+    }
+  }
+
+  function setCursor(name) {
+    if (cursor === name) return;
+    cursor = name;
+    canvas.style.cursor = name;
+  }
+
+  /** Has the camera moved since the last look? A still cursor still needs one. */
+  function cameraMoved() {
+    if (camAt.distanceToSquared(view.camera.position) < 1e-8) return false;
+    camAt.copy(view.camera.position);
+    return true;
+  }
+
+  /** One raycast a frame: who is under the cursor, and what the cursor says. */
+  function look() {
+    let piece = null;
+    if (pointerIn) {
+      const found = pieceUnder(null);
+      const sq = found && found.piece.userData.square;
+      if (sq && game.canPick(sq)) piece = found.piece;
+    }
+    if (piece !== hoverPiece) {
+      if (hoverPiece) {
+        hoverPiece.userData.hover = false;
+        if (hoverPiece !== selected) wantLift(hoverPiece, 0);
+      }
+      hoverPiece = piece;
+      if (piece) {
+        piece.userData.hover = true;
+        if (piece !== selected && !reducedMotion()) wantLift(piece, T.hoverLift);
+      }
+    }
+    // With a man waiting, the square he could land on answers too.
+    let want = piece ? 'grab' : 'default';
+    if (selected) {
+      const sq = piece ? piece.userData.square : (pointerIn ? squareUnder(null) : null);
+      const hot = sq && sq !== selSquare && selLegal.includes(sq) ? sq : null;
+      if (hot) want = 'pointer';
+      if (hot !== selHover) { selHover = hot; paint(); }
+    }
+    setCursor(want);
+  }
+
+  // --- the man who waits -------------------------------------------------------
+  function select(piece, square) {
+    if (selected && selected !== piece) clearSelection(false);
+    selected = piece;
+    selSquare = square;
+    const moves = readMoves(square);
+    selLegal = moves.squares;
+    selTakes = moves.captures;
+    selHover = null;
+    const home = piece.userData.home;
+    if (home) { piece.position.x = home.x; piece.position.z = home.z; }
+    piece.rotation.x = 0;
+    piece.rotation.z = 0;
+    wantLift(piece, T.selectLift);
+    paint();
+  }
+
+  function clearSelection(repaint = true) {
+    if (!selected) return;
+    const piece = selected;
+    selected = null; selSquare = null; selLegal = []; selTakes = new Set(); selHover = null;
+    wantLift(piece, piece === hoverPiece && !reducedMotion() ? T.hoverLift : 0);
+    if (repaint) paint();
+  }
+
+  /** A click on a legal square: the man waiting on his own flies over. */
+  function playSelected(to) {
+    const start = selSquare;
+    clearSelection();
+    return game.tryMove(start, to);
+  }
+
   function onDown(ev) {
     if (held || ev.button > 0) return;
+    pointerIn = true;
     const found = pieceUnder(ev);
     const square = found ? null : squareUnder(ev);
+    const under = found ? found.piece.userData.square : square;
     const piece = found ? found.piece : (square ? pieces.pieceAt(square) : null);
+
+    // A man is already waiting: this click either sends him somewhere or lets
+    // him go. Sending him is the whole gesture, so nothing is picked up after.
+    toggledOff = null;
+    if (selected) {
+      if (under && under !== selSquare && selLegal.includes(under)) {
+        playSelected(under);
+        ev.preventDefault();
+        return;
+      }
+      toggledOff = selSquare;
+      clearSelection();
+    }
+
     if (!piece || !piece.userData.square) return;
     const sq = piece.userData.square;
     if (!game.canPick(sq)) return;
 
     held = piece;
     from = sq;
+    lifts.delete(piece);
     const moves = readMoves(sq);
     legal = moves.squares;
     takes = moves.captures;
@@ -135,6 +333,8 @@ export function createDrag({ view, pieces, anim, bus, game, jiggle = null }) {
     held.userData.held = true;
     held.userData.busy = true;
     if (jiggle) jiggle.grab(held);   // lifted off the board, so the tip sags
+    press = { x: ev.clientX, y: ev.clientY, t: performance.now() };
+    pending = true;                  // ... until he travels, or outstays a click
 
     // Hold him where he was actually grabbed. A hit on the body gives the exact
     // spot; the square fallback (a click that slipped past the mesh) takes him
@@ -143,16 +343,17 @@ export function createDrag({ view, pieces, anim, bus, game, jiggle = null }) {
     const base = squareToWorld(sq, 0);
     if (found) {
       grab.set(base.x - found.point.x, base.z - found.point.z);
-      holdY = LIFT + THREE.MathUtils.clamp(found.point.y - piece.position.y, 0.04, GRAB_MAX);
+      holdY = T.lift + THREE.MathUtils.clamp(found.point.y - piece.position.y, 0.04, T.grabMax);
     } else {
       grab.set(0, 0);
-      holdY = LIFT + Math.min(GRAB_MAX, GRAB_MID * (piece.userData.scaleBase || 1));
+      holdY = T.lift + Math.min(T.grabMax, T.grabMid * (piece.userData.scaleBase || 1));
     }
     target.copy(held.position);
     aim(ev);                     // so he lifts on the click, not on the first move
     const on = overSquare();
     hover = legal.includes(on) ? on : null;
     paint();
+    setCursor('grabbing');
     // A synthetic pointer (the smoke harness, some remote-control paths) has no
     // capture to take, and asking for one throws.
     try { canvas.setPointerCapture(ev.pointerId); } catch { /* nothing to hold */ }
@@ -161,7 +362,12 @@ export function createDrag({ view, pieces, anim, bus, game, jiggle = null }) {
   }
 
   function onMove(ev) {
+    at.x = ev.clientX;
+    at.y = ev.clientY;
+    pointerIn = true;
+    pointerMoved = true;
     if (!held) return;
+    if (pending && press && Math.hypot(ev.clientX - press.x, ev.clientY - press.y) > T.tapPx) pending = false;
     if (!aim(ev)) return;
     const next = overSquare();
     const want = legal.includes(next) ? next : null;
@@ -174,16 +380,35 @@ export function createDrag({ view, pieces, anim, bus, game, jiggle = null }) {
     const start = from;
     aim(ev);
     const to = overSquare();
+    const tap = pending && press
+      && performance.now() - press.t <= T.tapMs
+      && Math.hypot(ev.clientX - press.x, ev.clientY - press.y) <= T.tapPx;
     held = null;
     from = null;
     hover = null;
     legal = [];
     takes = new Set();
+    pending = false;
+    press = null;
     markers.clear();
     piece.userData.held = false;
+    piece.userData.busy = false;
     piece.rotation.x = 0;
     piece.rotation.z = 0;
+    setCursor('grab');
     try { canvas.releasePointerCapture(ev.pointerId); } catch { /* never taken */ }
+
+    // He never left his square and the press was quick: that was a click, not a
+    // drag. He waits where he is with his squares lit, instead of being told no.
+    if (tap && (!to || to === start)) {
+      const again = toggledOff === start;
+      toggledOff = null;
+      if (again) wantLift(piece, 0);      // the same click that let him go
+      else select(piece, start);
+      bus.emit('drop', { ok: true, select: !again, square: start });
+      return;
+    }
+    toggledOff = null;
 
     // A legal drop is played by the game, which moves the man and lets anim.js
     // fly it down from where it was being held.
@@ -200,6 +425,7 @@ export function createDrag({ view, pieces, anim, bus, game, jiggle = null }) {
     if (!held) return;
     const piece = held;
     held = null; from = null; hover = null; legal = []; takes = new Set();
+    pending = false; press = null;
     markers.clear();
     piece.userData.held = false;
     piece.rotation.x = 0;
@@ -208,10 +434,37 @@ export function createDrag({ view, pieces, anim, bus, game, jiggle = null }) {
     bus.emit('drop', { ok: false });
   }
 
+  function onLeave() {
+    pointerIn = false;
+    pointerMoved = true;
+  }
+
+  function onBlur() {
+    onCancel();
+    clearSelection();
+    onLeave();
+    setCursor('default');
+  }
+
+  function onKey(ev) {
+    if (ev.ctrlKey || ev.altKey || ev.metaKey || typing()) return;
+    if (ev.key !== 'Escape' || !selected) return;
+    // Esc belongs to whoever wants to leave the board as well, and they ask
+    // isDragging() inside this same event: the man is only let go once the
+    // whole event is over. A microtask would not do, because the browser runs
+    // one of those between two listeners on the same key.
+    setTimeout(() => clearSelection(), 0);
+  }
+
   /** Lagged follow, a lean into the travel, and the per-frame screen ping. */
   function update(dt) {
     markers.update(dt);
-    if (!held) return;
+    updateLifts(dt);
+    if (!held) {
+      if (pointerMoved || cameraMoved()) { look(); pointerMoved = false; }
+      return;
+    }
+    if (pending && press && performance.now() - press.t > T.tapMs) pending = false;
     // The camera sways, so where the cursor points moves even when it does not.
     const was = hover;
     if (aim(null)) {
@@ -219,14 +472,14 @@ export function createDrag({ view, pieces, anim, bus, game, jiggle = null }) {
       hover = legal.includes(next) ? next : null;
       if (hover !== was) paint();
     }
-    const k = 1 - Math.exp(-LAG * dt);
+    const k = 1 - Math.exp(-T.lag * dt);
     const dx = target.x - held.position.x;
     const dz = target.z - held.position.z;
     held.position.x += dx * k;
     held.position.y += (target.y - held.position.y) * k;
     held.position.z += dz * k;
-    held.rotation.z = THREE.MathUtils.clamp(-dx * TILT, -0.35, 0.35);
-    held.rotation.x = THREE.MathUtils.clamp(dz * TILT, -0.35, 0.35);
+    held.rotation.z = THREE.MathUtils.clamp(-dx * T.tilt, -0.35, 0.35);
+    held.rotation.x = THREE.MathUtils.clamp(dz * T.tilt, -0.35, 0.35);
     // Whatever the body just covered, the soft top has yet to catch up on.
     if (jiggle) jiggle.lag(held, dx * k, dz * k);
     bus.emit('dragmove', { screen: view.projectPoint(held.position) });
@@ -236,23 +489,53 @@ export function createDrag({ view, pieces, anim, bus, game, jiggle = null }) {
   canvas.addEventListener('pointermove', onMove);
   canvas.addEventListener('pointerup', onUp);
   canvas.addEventListener('pointercancel', onCancel);
-  window.addEventListener('blur', onCancel);
+  canvas.addEventListener('pointerleave', onLeave);
+  window.addEventListener('keydown', onKey);
+  window.addEventListener('blur', onBlur);
+  // A move played by anyone (a drag, a click, the demo) ends the wait.
+  const offTurn = bus.on('turn', () => { clearSelection(); pointerMoved = true; });
+  const offOver = bus.on('gameover', () => clearSelection());
 
   return {
     update,
     markers,
-    isDragging: () => !!held,
+    /** A man in hand OR a man waiting on his square: the board is busy either way. */
+    isDragging: () => !!held || !!selected,
+    /** The narrower question: is one actually in the hand right now? */
+    isHolding: () => !!held,
+    /** The square of the man waiting for his, or null. */
+    selection: () => selSquare,
+    /** Let go of him, from anywhere. */
+    deselect: () => clearSelection(),
     // The height of the plane the cursor is dragging along. The screenshot
     // harness aims its release with this, because board level is no longer
     // where the held man is.
     holdHeight: () => (held ? holdY : 0),
+    /** What the hand is doing, for the smoke harness. */
+    debug() {
+      return {
+        held: held ? held.userData.square : null,
+        selected: selSquare,
+        hover: hoverPiece ? hoverPiece.userData.square : null,
+        over: selHover,          // the legal square under the cursor, while one waits
+        cursor,
+        hoverLift: hoverPiece ? Number(hoverPiece.position.y.toFixed(4)) : 0,
+        selectLift: selected ? Number(selected.position.y.toFixed(4)) : 0,
+        markers: markers.count(),
+      };
+    },
     dispose() {
       canvas.removeEventListener('pointerdown', onDown);
       canvas.removeEventListener('pointermove', onMove);
       canvas.removeEventListener('pointerup', onUp);
       canvas.removeEventListener('pointercancel', onCancel);
-      window.removeEventListener('blur', onCancel);
+      canvas.removeEventListener('pointerleave', onLeave);
+      window.removeEventListener('keydown', onKey);
+      window.removeEventListener('blur', onBlur);
+      offTurn();
+      offOver();
       if (view.setHighlightSink) view.setHighlightSink(null);
+      lifts.clear();
       markers.dispose();
     },
   };

--- a/ConditioningControlPanel/Resources/web/piecebypiece/board/outline.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/board/outline.js
@@ -167,7 +167,11 @@ export function createOutline({ group, bus = null }) {
     const mats = [];
     const skins = [];
     const sources = [];
-    piece.traverse((o) => { if (o.isMesh && o.geometry && !o.userData.pbpHull) sources.push(o); });
+    // The contact patch is a picture of shade lying on the board, not a part of
+    // the man: it stays welded to the board while he rises, and a hull pinned to
+    // his root would ride up with him and show as a flat square of line colour.
+    const patch = piece.userData.contact || null;
+    piece.traverse((o) => { if (o.isMesh && o.geometry && !o.userData.pbpHull && o !== patch) sources.push(o); });
     for (const src of sources) {
       const mat = hullMaterial(u, base, insideOut(src.geometry));
       const hull = new THREE.Mesh(src.geometry, mat);

--- a/ConditioningControlPanel/Resources/web/piecebypiece/boot.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/boot.js
@@ -157,6 +157,12 @@ function main() {
     board.hud = hudL;
   }).catch((e) => console.warn('[pbp] hud missing', e));
   // --- end L ---
+  // --- M: the hand ---
+  // A man waiting on his square counts as being in hand for Esc, but he is not
+  // in the way of the camera: one finger may still orbit around him, and only a
+  // real grab stands the rig off.
+  view.cameraRig.setDragGuard(() => drag.isHolding());
+  // --- end M ---
 
   let last = performance.now();
   function frame(now) {

--- a/ConditioningControlPanel/Resources/web/piecebypiece/smoke/hand-shot.mjs
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/smoke/hand-shot.mjs
@@ -1,0 +1,318 @@
+/* ============================================================================
+ * smoke/hand-shot.mjs - proof that the hand knows what it is over.
+ *
+ * Loads the board in headless msedge, takes the frame loop over (the same rAF
+ * hand-over jiggle-shot and feel-shot use, so a screenshot never costs game
+ * time) and drives the pointer the way a player would: hover a man, click him,
+ * click his square. Every step prints what drag.debug() says, and a small ring
+ * is drawn into the page at the pointer position so a still frame shows where
+ * the cursor was standing.
+ *
+ *   node smoke/hand-shot.mjs [--url <page url>] [--out <dir>] [--wait <ms>]
+ *                            [--port <debug port>]
+ *
+ * Needs a static server on the web root, for example:
+ *   python -m http.server 8830   (run from Resources/web)
+ * Exits non-zero when the page logged an error, when a hover did not lift, or
+ * when a click did not select or did not play its move.
+ * ==========================================================================*/
+
+import { spawn } from 'node:child_process';
+import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const EDGE = process.env.PBP_EDGE
+  || 'C:/Program Files (x86)/Microsoft/Edge/Application/msedge.exe';
+
+function arg(name, fallback) {
+  const i = process.argv.indexOf('--' + name);
+  return i > -1 && process.argv[i + 1] ? process.argv[i + 1] : fallback;
+}
+
+const url = arg('url', 'http://localhost:8830/piecebypiece/index.html?hotseat=1');
+const outDir = arg('out', 'C:/Users/PC/Pictures/Screenshots/piecebypiece/m');
+const waitMs = Number(arg('wait', '12000'));
+const port = Number(arg('port', '9272'));
+
+const profile = join(tmpdir(), 'pbp-hand-' + Date.now());
+const edge = spawn(EDGE, [
+  '--headless=new', '--remote-debugging-port=' + port, '--user-data-dir=' + profile,
+  '--window-size=1280,860', '--hide-scrollbars', '--no-first-run', '--no-default-browser-check',
+  '--disable-extensions', '--use-gl=angle', '--use-angle=swiftshader', '--enable-unsafe-swiftshader',
+], { stdio: 'ignore' });
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function target() {
+  for (let i = 0; i < 60; i++) {
+    try {
+      const res = await fetch(`http://127.0.0.1:${port}/json/new?about:blank`, { method: 'PUT' });
+      if (res.ok) return (await res.json()).webSocketDebuggerUrl;
+    } catch { /* browser still starting */ }
+    await sleep(250);
+  }
+  throw new Error('headless msedge did not open a debugging port');
+}
+
+function client(ws) {
+  let id = 0;
+  const pending = new Map();
+  const events = [];
+  ws.addEventListener('message', (ev) => {
+    const msg = JSON.parse(ev.data);
+    if (msg.id && pending.has(msg.id)) { pending.get(msg.id)(msg.result); pending.delete(msg.id); }
+    else if (msg.method) events.push(msg);
+  });
+  return {
+    events,
+    send(method, params = {}) {
+      const n = ++id;
+      ws.send(JSON.stringify({ id: n, method, params }));
+      return new Promise((res) => pending.set(n, res));
+    },
+  };
+}
+
+let cdp = null;
+let failed = false;
+function bad(what) { console.log('ERROR ' + what); failed = true; }
+
+async function evalJs(expression) {
+  const r = await cdp.send('Runtime.evaluate', { expression, returnByValue: true, awaitPromise: true });
+  if (r.exceptionDetails) throw new Error(r.exceptionDetails.exception?.description || r.exceptionDetails.text);
+  return r.result?.value;
+}
+
+async function shot(name, clip = null) {
+  const s = await cdp.send('Page.captureScreenshot', clip ? { format: 'png', clip } : { format: 'png' });
+  const path = join(outDir, name);
+  writeFileSync(path, Buffer.from(s.data, 'base64'));
+  return path;
+}
+
+const HIJACK = "window.__pbp = null; (async () => {"
+  + " let q = [];"
+  + " window.requestAnimationFrame = (fn) => { q.push(fn); return q.length; };"
+  + " window.cancelAnimationFrame = () => {};"
+  + " await new Promise((r) => setTimeout(r, 900));"
+  + " let t = performance.now();"
+  + " window.__pbp = { step(ms, n) { for (let i = 0; i < n; i++) { t += ms; const c = q; q = []; for (const fn of c) fn(t); } return q.length; } };"
+  + " return q.length; })()";
+const beat = (ms) => evalJs(`window.__pbp.step(16.667, ${Math.max(1, Math.round(ms / 16.667))})`);
+
+// A headless screenshot has no pointer in it, so the page is told to draw one.
+const MARK = `window.__mark = (x, y) => {
+  let d = document.getElementById('hand-cursor');
+  if (!d) {
+    d = document.createElement('div');
+    d.id = 'hand-cursor';
+    d.style.cssText = 'position:fixed;width:26px;height:26px;margin:-13px 0 0 -13px;border:2px solid #FF3E8F;'
+      + 'border-radius:50%;box-shadow:0 0 0 2px rgba(255,255,255,.75);pointer-events:none;z-index:99;';
+    document.body.appendChild(d);
+  }
+  d.style.left = x + 'px';
+  d.style.top = y + 'px';
+}`;
+
+/**
+ * The pointer, dispatched from inside the page. A press and a release that
+ * count as a click have to be under 250 ms apart, and one CDP input round trip
+ * through headless swiftshader is slower than that on its own, so the events
+ * are made in the page where the gap is a single turn of the event loop. They
+ * are the same PointerEvents the canvas listens for; the real CDP input path is
+ * what shot.mjs and feel-shot drive, and both still drag.
+ */
+const POINTER = `window.__pt = (x, y, type) => {
+  const c = document.getElementById('board-canvas');
+  c.dispatchEvent(new PointerEvent(type, { clientX: x, clientY: y, button: 0,
+    buttons: type === 'pointerup' ? 0 : 1, bubbles: true, cancelable: true,
+    pointerId: 1, pointerType: 'mouse', isPrimary: true }));
+};
+window.__pointAt = (sq, h) => { const p = window.PBP.board.projectSquare(sq, h); window.__mark(p.x, p.y); return p; };`;
+
+const hand = () => evalJs('JSON.stringify(window.PBP.board.drag.debug())').then(JSON.parse);
+const fen = () => evalJs('window.PBP.game.rules.fen()');
+
+/**
+ * Put the cursor on something and let the hand confirm it. A man standing in
+ * front of the one you want can be in the way of the ray at one height and out
+ * of it at another, so the heights are tried until the hand reports the thing
+ * that was asked for: a man by his square, an empty square by the legal target
+ * under the cursor. Returns the height that worked, or null.
+ */
+const MAN_HEIGHTS = [0.45, 0.62, 0.34, 0.78, 0.24];
+const SQUARE_HEIGHTS = [0, 0.14, 0.3, 0.45];
+
+async function hover(sq, { man = true } = {}) {
+  for (const h of (man ? MAN_HEIGHTS : SQUARE_HEIGHTS)) {
+    await evalJs(`(() => { const p = window.__pointAt('${sq}', ${h}); window.__pt(p.x, p.y, 'pointermove'); })()`);
+    await beat(120);
+    const d = await hand();
+    if (man ? d.hover === sq : d.over === sq) return h;
+  }
+  return null;
+}
+
+/** Press and release on the same spot, in one turn: a click, not a drag. */
+async function click(sq, opts = {}) {
+  const h = await hover(sq, opts);
+  if (h === null && !opts.anyway) bad(`the cursor could not be put on ${sq}`);
+  const gap = await evalJs(`(() => {
+    const p = window.__pointAt('${sq}', ${h === null ? 0.45 : h});
+    window.__pt(p.x, p.y, 'pointermove');
+    const t = performance.now();
+    window.__pt(p.x, p.y, 'pointerdown');
+    window.__pt(p.x, p.y, 'pointerup');
+    return Math.round(performance.now() - t);
+  })()`);
+  await beat(120);
+  const d = await hand();
+  console.log(`  click ${sq} at ${h}: ${gap} ms of the 250 ms window -> `
+    + JSON.stringify(d) + ' ' + (await fen()).split(' ').slice(0, 2).join(' '));
+  return d;
+}
+
+/**
+ * The toys arrive over the network, and each one that lands rebuilds every man
+ * of that type, so a shot taken too early is a shot of the stand-in shapes
+ * pieces.js lathes while it waits. Nothing on the frame clock brings them in.
+ * A man wearing his glb stands at scale 1; a lathe is scaled to its type
+ * height, so counting the men who are still not 1 says how many are waiting.
+ */
+async function artSettled(ms = 20000) {
+  const left = "[...window.PBP.board.pieces.pieces.values()].filter((p) => p.scale.x !== 1).length";
+  const t0 = Date.now();
+  while (Date.now() - t0 < ms) {
+    if ((await evalJs(left)) === 0) return true;
+    await sleep(250);
+  }
+  console.log('  (some men are still in their stand-in shapes; the shots use what landed)');
+  return false;
+}
+
+async function main() {
+  mkdirSync(outDir, { recursive: true });
+  const wsUrl = await target();
+  const ws = new WebSocket(wsUrl);
+  await new Promise((res, rej) => {
+    ws.addEventListener('open', res, { once: true });
+    ws.addEventListener('error', rej, { once: true });
+  });
+  cdp = client(ws);
+  await cdp.send('Runtime.enable');
+  await cdp.send('Log.enable');
+  await cdp.send('Page.enable');
+  await cdp.send('Page.navigate', { url });
+  await sleep(waitMs);
+  await evalJs('window.PBP.ramp && window.PBP.ramp.setEnabled(false)');
+  await evalJs('window.PBP.board.setWobble(0); window.PBP.board.setCameraSway(0)');
+  await evalJs(MARK);
+  await evalJs(POINTER);
+  // The first pointerdown anywhere builds the AudioContext, which costs whole
+  // seconds under swiftshader: spend that on the document, not on a click.
+  await evalJs("document.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, pointerId: 9, clientX: 4, clientY: 4 }));");
+  if (!(await evalJs(HIJACK))) bad('the frame loop did not hand over');
+  await beat(200);
+  await artSettled();
+  await beat(200);
+
+  // --- 1. hover: his own man lifts, the other side does not ------------------
+  await evalJs("window.__pt(20, 20, 'pointermove')");   // nothing under him
+  await beat(200);
+  console.log('  ' + await shot('rest.png'));           // the same camera, no hover
+  await hover('e2');
+  await beat(400);                                      // the lift has settled
+  let h = await hand();
+  console.log('hover a white pawn: ' + JSON.stringify(h));
+  console.log('  ' + await shot('hover.png'));
+  if (h.hover !== 'e2') bad('the man under the cursor was not hovered');
+  if (h.cursor !== 'grab') bad('the cursor did not offer a grab');
+  if (!(h.hoverLift > 0.02)) bad('the hovered man did not lift');
+
+  await hover('e7');   // no height finds him: he is not the side to move
+  h = await hand();
+  console.log('hover a black pawn (not his turn): ' + JSON.stringify(h));
+  if (h.hover || h.cursor !== 'default') bad('the other side answered the cursor');
+
+  // --- 2. a click leaves him waiting, with his squares lit --------------------
+  await click('e2');
+  h = await hand();
+  console.log('clicked: ' + JSON.stringify(h));
+  console.log('  ' + await shot('selected.png'));
+  if (h.selected !== 'e2') bad('the click did not leave him waiting');
+  if (h.markers < 3) bad('the waiting man got no markers');   // e3, e4, and his own square
+  if (!(h.selectLift > 0.05)) bad('the waiting man is not lifted');
+
+  // --- 3. Esc lets him go, and reads as busy while it does -------------------
+  await evalJs("window.__esc = null; window.addEventListener('keydown', () => "
+    + '{ window.__esc = window.PBP.board.drag.isDragging(); });');
+  await cdp.send('Input.dispatchKeyEvent', { type: 'keyDown', key: 'Escape', code: 'Escape', windowsVirtualKeyCode: 27 });
+  await cdp.send('Input.dispatchKeyEvent', { type: 'keyUp', key: 'Escape', code: 'Escape', windowsVirtualKeyCode: 27 });
+  await beat(60);
+  const escBusy = await evalJs('window.__esc');
+  h = await hand();
+  console.log('after esc: ' + JSON.stringify(h) + ' (the board read busy during the key: ' + escBusy + ')');
+  if (h.selected) bad('esc did not let him go');
+  if (escBusy !== true) bad('esc read the board as free, so leaving would fire mid selection');
+
+  // --- 4. click him, click his square: the move plays -------------------------
+  const before = await fen();
+  await click('e2');
+  await click('e4', { man: false });
+  await beat(150);
+  console.log('  ' + await shot('click-move-flight.png'));
+  await beat(400);
+  const after = await fen();
+  h = await hand();
+  console.log('click to move: ' + before.split(' ')[0] + ' -> ' + after.split(' ')[0]);
+  console.log('  ' + await shot('click-move-landed.png'));
+  if (before === after) bad('the click on a legal square played nothing');
+  if (h.selected) bad('the man was still waiting after his move');
+
+  // --- 5. clicking him twice puts him down -----------------------------------
+  await beat(1400);                       // the camera has swung round to black
+  await click('e7');                      // black to move now
+  if ((await hand()).selected !== 'e7') bad('black could not be clicked on his own turn');
+  await click('e7');
+  h = await hand();
+  console.log('clicked twice: ' + JSON.stringify(h));
+  if (h.selected) bad('the second click did not put him down');
+
+  // --- 6. reduced motion: the cursor still answers, the lift does not --------
+  await evalJs('window.PBP.reducedMotion = true');
+  await hover('a7');
+  await beat(300);
+  h = await hand();
+  console.log('reduced motion hover: ' + JSON.stringify(h));
+  if (h.cursor !== 'grab') bad('reduced motion lost the cursor');
+  if (h.hoverLift > 0.005) bad('reduced motion still lifted him');
+  await evalJs('window.PBP.reducedMotion = false');
+
+  const problems = [];
+  for (const ev of cdp.events) {
+    if (ev.method === 'Runtime.exceptionThrown') {
+      const x = ev.params.exceptionDetails;
+      problems.push('exception: ' + (x.exception?.description || x.text));
+    } else if (ev.method === 'Runtime.consoleAPICalled' && ev.params.type === 'error') {
+      problems.push('console.error: ' + ev.params.args.map((a) => a.description || a.value).join(' '));
+    } else if (ev.method === 'Log.entryAdded' && ev.params.entry.level === 'error'
+               && ev.params.entry.source !== 'network') {
+      problems.push('log: ' + ev.params.entry.text);
+    }
+  }
+  ws.close();
+  edge.kill();
+  try { rmSync(profile, { recursive: true, force: true }); } catch { /* disposable */ }
+  if (problems.length || failed) {
+    for (const p of problems) console.log('ERROR ' + p);
+    process.exit(1);
+  }
+  console.log('hand shot done, no console errors');
+}
+
+main().catch((err) => {
+  console.error(err.message || err);
+  edge.kill();
+  process.exit(2);
+});


### PR DESCRIPTION
## what it does

The board used to answer only a full drag. Now it answers the cursor, and it answers a click.

**hover before the grab.** One raycast a frame (only when the pointer or the camera has moved) says who is under the cursor. If he is yours to pick up:

- he lifts 0.04 off his square, eased in over 60 ms and dropped back over 120 ms, written on his root position in `drag.update`, which runs after `pieces.update` so it sits over the idle sway instead of fighting the flex
- he is marked `userData.hover = true`, so the line lane can brighten him. This sets the flag, it does not draw anything
- the canvas cursor becomes `grab` over a man you may pick, `grabbing` while he is held, `pointer` over a square a waiting man may land on, `default` everywhere else

The other side's men never answer the cursor. Under reduced motion the cursor still changes and nothing lifts.

**click to move.** A press and a release on the same man, inside 250 ms and 6 px, leaves him waiting:

- he stays lifted a little higher than a hover (0.11) and his legal squares light up through the same `view.setHighlights` call the drag uses, so the markers lane sees one kind of list
- the next click on a legal square plays the move through `game.tryMove`
- a click anywhere else puts him down, a click on another of your own men switches to him, a second click on him puts him down
- `Esc` lets him go. While a man waits `isDragging()` reads true, so boot.js's hold-Esc-to-leave does not fire in the middle of a selection, and the release is deferred one turn of the event loop because the browser runs a microtask checkpoint between two listeners of the same key
- the camera rig now asks the new `isHolding()` instead, so one finger can still orbit around a waiting man; only a real grab stands the rig off
- a drag that starts on a waiting man still drags. Touch goes down the same path, it is all pointer events

While a press could still turn out to be a click, the man does not follow the cursor at all: he rises straight off his own square. That is what stops a click from reading as a move, because a man hanging at hold height stands over a square nearer the camera than the one he came from.

## how it was proved

New harness `smoke/hand-shot.mjs` (headless msedge on its own debug port, the same rAF hand-over jiggle-shot uses, pointer events made inside the page because a CDP round trip is slower than the 250 ms click window). Last run, all green, no console errors:

- hover a white pawn: `hover e2, cursor grab, hoverLift 0.04`
- hover a black pawn on white's turn: `hover null, cursor default`
- click e2: `selected e2, markers 3, selectLift 0.099`, 7 ms of the 250 ms window
- Esc: `selected null`, and the board read busy during the key: `true`
- click e2 then e4: `rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR` to `rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR`
- click e7 twice on black's turn: waiting, then down
- reduced motion: `cursor grab, hoverLift 0`

Screenshots, all looked at:

- `Pictures/Screenshots/piecebypiece/m/rest.png` and `hover.png` - the same camera, the cursor drawn as a ring, the man up 0.04 in the second
- `.../selected.png` - waiting, origin ring on his square and dots on e3 and e4
- `.../click-move-flight.png` and `click-move-landed.png` - the move he was clicked into
- `.../hold-after.png`, `board-after.png` - `smoke/shot.mjs --drag e2:e4 --hold` still drags: `grab dragmove turn drop`, clean boot

## what is NOT in it

Take back and the promotion picker. They are PR 2 of this stack.

## touches outside my lane

One line in `board/outline.js`, `attach()`: the contact patch is skipped when the hulls are built.

The patch is a picture of shade welded to the board (`pieces.js` holds it at board level while the man rises), but its hull was pinned to the man's root, so any lift carried it up and it drew as a flat square of line colour on the board. Found with the hover shot, and it was there for a held man too. Diff is the guard plus a three line comment.

## my boot.js block

```js
  // --- M: the hand ---
  // A man waiting on his square counts as being in hand for Esc, but he is not
  // in the way of the camera: one finger may still orbit around him, and only a
  // real grab stands the rig off.
  view.cameraRig.setDragGuard(() => drag.isHolding());
  // --- end M ---
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CQdAN3aDyhnnXWjBtkH1mD
