### PR TITLE
feat(pbp): take it back

### DIFF
--- a/ConditioningControlPanel/Resources/web/piecebypiece/board/drag.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/board/drag.js
@@ -446,8 +446,23 @@ export function createDrag({ view, pieces, anim, bus, game, jiggle = null }) {
     setCursor('default');
   }
 
+  /** The house sound, if the sound lane is loaded. It is optional, always. */
+  function cue(name) {
+    const sfx = window.PBP && window.PBP.board && window.PBP.board.sfx;
+    if (sfx && sfx.play) sfx.play(name);
+  }
+
   function onKey(ev) {
     if (ev.ctrlKey || ev.altKey || ev.metaKey || typing()) return;
+    // Take the last ply back, with nothing in hand. Backspace is the one every
+    // player tries first; z is there for the hand that never leaves the board.
+    if (!held && (ev.key === 'Backspace' || ev.key === 'z' || ev.key === 'Z')) {
+      ev.preventDefault();
+      if (!game.takeBack) return;
+      clearSelection();
+      if (!game.takeBack()) cue('boing');   // nothing to take back, or too soon
+      return;
+    }
     if (ev.key !== 'Escape' || !selected) return;
     // Esc belongs to whoever wants to leave the board as well, and they ask
     // isDragging() inside this same event: the man is only let go once the

--- a/ConditioningControlPanel/Resources/web/piecebypiece/game/clock.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/game/clock.js
@@ -71,6 +71,16 @@ export function createClock({ perSideMs = DEFAULT_MS, onTick, onFlag, now = () =
     remaining(side) { drain(); return left[side]; },
     flagged: () => flagged,
     isRunning: () => active !== null,
+    /**
+     * Give time back, for a ply that was taken back. It is the only way time
+     * ever goes up, and a side that has already flagged keeps its flag: the
+     * game is over by then and nothing is owed.
+     */
+    credit(side, ms) {
+      if (flagged || !(ms > 0)) return;
+      drain();
+      left[side] = Math.min(perSideMs, left[side] + ms);
+    },
     /** Only for tests: charge a side without waiting in real time. */
     debit(side, ms) {
       drain();

--- a/ConditioningControlPanel/Resources/web/piecebypiece/game/hotseat.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/game/hotseat.js
@@ -16,6 +16,11 @@ export function createHotseat({ bus, board, hud = null, clockMs = DEFAULT_MS, fe
   let over = null;
   let autoLeft = Math.max(0, Number(auto) || 0);
   let autoWait = 0.6;
+  // One entry a ply, so a take-back can put the clocks back where they
+  // stood before it. Nothing else reads it.
+  const history = [];
+  let lastBack = 0;
+  const TAKEBACK_GAP_MS = 400;   // two in a row need a breath between them
 
   const clock = createClock({
     perSideMs: clockMs,
@@ -70,8 +75,10 @@ export function createHotseat({ bus, board, hud = null, clockMs = DEFAULT_MS, fe
 
   function tryMove(from, to, promotion = 'q') {
     if (over) return null;
+    const before = { w: clock.remaining('w'), b: clock.remaining('b') };
     const played = rules.move(from, to, promotion);
     if (!played) return null;
+    history.push({ from: played.from, to: played.to, side: played.side, before });
 
     // The men follow the referee.
     if (played.capturedSquare && played.capturedSquare !== to) pieces.remove(played.capturedSquare);
@@ -105,6 +112,48 @@ export function createHotseat({ bus, board, hud = null, clockMs = DEFAULT_MS, fe
     return played;
   }
 
+  /**
+   * Take the last ply back. Hotseat only, and only while the game is on: after
+   * a result there is nothing to undo, the board is a record.
+   *
+   * The referee goes back a ply, the mover slides home through anim (so the
+   * landing dust and the thud play as they would for any move), and whatever
+   * else the ply did - a man taken, a rook that castled, a pawn that came back
+   * a pawn - is put right by rebuilding from the position. The clocks go back
+   * to what they read before the ply, so a take-back costs the mover nothing
+   * but the time he spends thinking again.
+   */
+  function takeBack(now = Date.now()) {
+    if (over) return null;
+    if (now - lastBack < TAKEBACK_GAP_MS) return null;
+    const record = history[history.length - 1] || null;
+    const back = rules.undo();
+    if (!back) return null;
+    history.pop();
+    lastBack = now;
+
+    // A promotion undo swaps the man for a pawn, so there is nothing to slide:
+    // the rebuild below stands him back on his square.
+    if (!back.promotion) {
+      pieces.move(back.to, back.from);
+      const hop = rules.rookHop(back);
+      if (hop) pieces.move(hop.to, hop.from);
+    }
+    pieces.setPosition(rules.position());
+
+    const side = rules.turn();          // the side that moved has the move again
+    if (record) {
+      clock.credit('w', record.before.w - clock.remaining('w'));
+      clock.credit('b', record.before.b - clock.remaining('b'));
+    }
+    clock.press(side);
+    board.setSide(side);
+    bus.emit('takeback', { from: back.from, to: back.to, ply: rules.ply() });
+    bus.emit('turn', { side, ply: rules.ply(), clocks: clocks(), total: clockMs });
+    paint();
+    return back;
+  }
+
   function resign(side) {
     finish({ result: 'resign', winner: side === 'w' ? 'b' : 'w', reason: 'resignation' });
   }
@@ -131,7 +180,8 @@ export function createHotseat({ bus, board, hud = null, clockMs = DEFAULT_MS, fe
   }
 
   return {
-    rules, clock, start, update, tryMove, canPick, legalTargets, resign,
+    rules, clock, start, update, tryMove, takeBack, canPick, legalTargets, resign,
+    plies: () => history.length,
     turn: () => rules.turn(),
     isOver: () => !!over,
     result: () => over,

--- a/ConditioningControlPanel/Resources/web/piecebypiece/game/rules.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/game/rules.js
@@ -84,6 +84,33 @@ export function createRules(fen) {
     };
   }
 
+  /**
+   * Take the last ply back. Returns the same shape `move` does for the ply that
+   * came off, or null when there is nothing to take back. The board is not
+   * touched here: the caller puts the men where the new position says.
+   */
+  function undo() {
+    let back = null;
+    try { back = chess.undo(); } catch { return null; }
+    if (!back) return null;
+    const side = back.color;
+    const flags = String(back.flags || '');
+    const enPassant = flags.includes('e');
+    return {
+      from: back.from,
+      to: back.to,
+      san: back.san,
+      piece: back.piece,
+      side,
+      captured: back.captured || null,
+      capturedSide: back.captured ? (side === 'w' ? 'b' : 'w') : null,
+      promotion: back.promotion || null,
+      enPassant,
+      castle: flags.includes('k') ? 'k' : (flags.includes('q') ? 'q' : null),
+      turn: chess.turn(),
+    };
+  }
+
   /** A castling king move drags the rook with it. Returns {from,to} or null. */
   function rookHop(played) {
     if (!played || !played.castle) return null;
@@ -103,7 +130,7 @@ export function createRules(fen) {
 
   return {
     chess,
-    position, movesFrom, targets, legalMove, move, rookHop, randomMove,
+    position, movesFrom, targets, legalMove, move, undo, rookHop, randomMove,
     turn: () => chess.turn(),
     inCheck: () => chess.isCheck(),
     isOver: () => chess.isGameOver(),

--- a/ConditioningControlPanel/Resources/web/piecebypiece/smoke/hand-shot.mjs
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/smoke/hand-shot.mjs
@@ -131,6 +131,14 @@ const POINTER = `window.__pt = (x, y, type) => {
 };
 window.__pointAt = (sq, h) => { const p = window.PBP.board.projectSquare(sq, h); window.__mark(p.x, p.y); return p; };`;
 
+/** One key press, through the real input path: no page-side shortcut needed. */
+async function key(name) {
+  const code = name === 'Backspace' ? 8 : name.toUpperCase().charCodeAt(0);
+  const p = { key: name, code: name === 'Backspace' ? 'Backspace' : 'Key' + name.toUpperCase(), windowsVirtualKeyCode: code };
+  await cdp.send('Input.dispatchKeyEvent', Object.assign({ type: 'keyDown' }, p));
+  await cdp.send('Input.dispatchKeyEvent', Object.assign({ type: 'keyUp' }, p));
+}
+
 const hand = () => evalJs('JSON.stringify(window.PBP.board.drag.debug())').then(JSON.parse);
 const fen = () => evalJs('window.PBP.game.rules.fen()');
 
@@ -288,6 +296,32 @@ async function main() {
   if (h.cursor !== 'grab') bad('reduced motion lost the cursor');
   if (h.hoverLift > 0.005) bad('reduced motion still lifted him');
   await evalJs('window.PBP.reducedMotion = false');
+
+  // --- 7. take back: the last ply comes home ---------------------------------
+  await evalJs("window.__back = []; window.PBP.bus.on('takeback', (p) => window.__back.push(p));");
+  const beforeBack = await fen();
+  await key('Backspace');
+  await beat(90);
+  console.log('  ' + await shot('takeback-slide.png'));    // he is on his way home
+  await beat(900);
+  const afterBack = await fen();
+  const backs = await evalJs('JSON.stringify(window.__back)');
+  console.log('take back: ' + beforeBack.split(' ').slice(0, 2).join(' ') + ' -> '
+    + afterBack.split(' ').slice(0, 2).join(' ') + ' ' + backs);
+  console.log('  ' + await shot('takeback-done.png'));
+  if (afterBack.split(' ')[0] !== 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR') bad('the ply did not come back');
+  if (afterBack.split(' ')[1] !== 'w') bad('the side that moved did not get the move back');
+  if (!JSON.parse(backs).length) bad('nothing said a ply had been taken back');
+  // The gap between two of them, and then an empty history.
+  await key('z');
+  await beat(60);
+  if ((await fen()).split(' ')[1] !== 'w') bad('a take-back inside the 400 ms gap went through');
+  await beat(700);
+  await key('z');
+  await beat(120);
+  const empty = await fen();
+  console.log('nothing left to take back: ' + empty.split(' ').slice(0, 2).join(' '));
+  if (empty.split(' ')[0] !== 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR') bad('an empty history still changed the board');
 
   const problems = [];
   for (const ev of cdp.events) {

--- a/ConditioningControlPanel/Resources/web/piecebypiece/smoke/rules-smoke.mjs
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/smoke/rules-smoke.mjs
@@ -157,6 +157,91 @@ eq('the clock reads like a clock', [formatClock(DEFAULT_MS), formatClock(64000),
   ok('auto play left a legal position behind', game.rules.ply() > 0 && game.rules.ply() <= 6);
 }
 
+// --- taking it back --------------------------------------------------------
+{
+  const r = createRules();
+  ok('nothing to take back at the start', r.undo() === null);
+  r.move('e2', 'e4');
+  const back = r.undo();
+  eq('the ply that came off', [back.from, back.to, back.side], ['e2', 'e4', 'w']);
+  eq('the position is the one before it', r.fen().split(' ')[0], 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR');
+  eq('and white has the move again', r.turn(), 'w');
+}
+{
+  // A capture, taken back, puts the man that came off back on the board.
+  const r = createRules();
+  r.move('e2', 'e4'); r.move('d7', 'd5'); r.move('e4', 'd5');
+  eq('the pawn was taken', Object.keys(r.position()).length, 31);
+  const back = r.undo();
+  eq('the take-back names the man that came off', back.captured, 'p');
+  eq('and he is back on the board', Object.keys(r.position()).length, 32);
+  eq('standing where he stood', r.pieceAt('d5'), { type: 'p', color: 'b' });
+}
+{
+  // A promotion, taken back, is a pawn again.
+  const r = createRules('8/P7/8/8/8/8/8/k6K w - - 0 1');
+  r.move('a7', 'a8', 'q');
+  eq('he came up a queen', r.pieceAt('a8').type, 'q');
+  const back = r.undo();
+  eq('the take-back knows it was a promotion', back.promotion, 'q');
+  eq('and he is a pawn on his own square again', r.pieceAt('a7'), { type: 'p', color: 'w' });
+  ok('with nothing left on the eighth', r.pieceAt('a8') === null);
+}
+{
+  // Castling, taken back, brings the rook home too.
+  const r = createRules('r3k2r/8/8/8/8/8/8/R3K2R w KQkq - 0 1');
+  r.move('e1', 'g1');
+  eq('the rook castled with him', r.pieceAt('f1').type, 'r');
+  r.undo();
+  eq('the king is home', r.pieceAt('e1').type, 'k');
+  eq('and so is the rook', r.pieceAt('h1').type, 'r');
+  ok('with nothing left on f1', r.pieceAt('f1') === null);
+}
+{
+  const bus = createBus();
+  const board = stubBoard();
+  const game = createHotseat({ bus, board, clockMs: 60000 });
+  game.start();
+  let turns = [];
+  let backs = [];
+  bus.on('turn', (p) => turns.push(p.side));
+  bus.on('takeback', (p) => backs.push(p));
+  game.tryMove('e2', 'e4');
+  eq('black to move after the ply', game.turn(), 'b');
+  const undone = game.takeBack(1000);
+  ok('the ply came back', !!undone);
+  eq('white has the move again', game.turn(), 'w');
+  eq('the takeback event names the ply', backs, [{ from: 'e2', to: 'e4', ply: 0 }]);
+  eq('and the turn event says who moves', turns[turns.length - 1], 'w');
+  eq('the man slid home', board.moves[board.moves.length - 1], ['e4', 'e2']);
+  ok('a second take-back inside the gap is refused', game.takeBack(1200) === null);
+  ok('and with no ply left there is nothing to take', game.takeBack(3000) === null);
+}
+{
+  // The clocks go back to what they read before the ply.
+  const bus = createBus();
+  const board = stubBoard();
+  const game = createHotseat({ bus, board, clockMs: 60000 });
+  game.start();
+  game.clock.debit('w', 9000);
+  const before = game.clock.remaining('w');
+  game.tryMove('e2', 'e4');
+  game.clock.debit('b', 4000);
+  game.takeBack(1000);
+  ok('white got his thinking time back', Math.abs(game.clock.remaining('w') - before) < 200);
+  ok('and black is not charged for a ply he never had', Math.abs(game.clock.remaining('b') - 60000) < 200);
+}
+{
+  // A finished game is a record, not a board.
+  const bus = createBus();
+  const board = stubBoard();
+  const game = createHotseat({ bus, board, clockMs: 60000 });
+  game.start();
+  game.tryMove('f2', 'f3'); game.tryMove('e7', 'e5'); game.tryMove('g2', 'g4'); game.tryMove('d8', 'h4');
+  ok('mate ended it', game.isOver());
+  ok('and there is no taking that back', game.takeBack(9000) === null);
+}
+
 // --- report ----------------------------------------------------------------
 function stubBoard() {
   const moves = [];


### PR DESCRIPTION
Stacked on #1003 (`feat/pbp-m1`).

## what it does

**take back.** Backspace, or `z`, with nothing in hand.

- `rules.undo()` is new: it takes the referee back a ply and hands back the same record `move` does, so the caller knows what came off
- `game.takeBack()` puts the board right: the man slides home through anim, so the landing dust and the thud play as they would for any move, and the position is then rebuilt, which brings back a man that was taken, walks a castled rook home, and turns a promoted man back into a pawn
- the clocks go back to what they read before the ply, both sides. A take-back costs the mover nothing but the time he spends thinking again
- `takeback` `{from, to, ply}` goes out on the bus for the markers lane to clear on, then `turn` with the side that has the move again, and the camera swings back to him
- refused when the game is over, when there is no ply, and inside 400 ms of the last one, so a held key cannot walk the whole game backwards. A refusal plays the small boing, guarded, so a board with no sound lane is silent and fine

## how it was proved

`node smoke/rules-smoke.mjs`: **71 checks passed** (43 before). New cases:

- the referee: nothing to take back at the start; a plain ply; a capture puts the man back on his square (31 men to 32); a promotion is a pawn on the seventh again with nothing on the eighth; castling brings the rook home
- the game: `takeback` fires `{from: 'e2', to: 'e4', ply: 0}`, `turn` says white, the board was told to slide `['e4','e2']`, a second take-back inside the gap is refused, an empty history is refused
- the clocks: white gets his thinking time back to within 200 ms, black is not charged for a ply he never had
- a mate: `takeBack` returns null, a finished game is a record

`node smoke/hand-shot.mjs`, new section 7, pressing the real key in the browser:

```
take back: rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b
        -> rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w  [{"from":"e2","to":"e4","ply":0}]
nothing left to take back: rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w
hand shot done, no console errors
```

Screenshots, both looked at:

- `Pictures/Screenshots/piecebypiece/m/takeback-slide.png` - the pawn out over the middle of the board on his way home, camera already swinging back to white
- `.../takeback-done.png` - he is back on e2, the rank is whole again

The whole PR 1 harness still passes in the same run: hover, the other side ignored, click to select, Esc, click to move, click twice, reduced motion.

## what is NOT in it

The promotion picker. Auto-queen is still what a pawn does on the eighth. `rules.undo()` already handles a promotion coming back, so the picker sits on top of this without changing it.

## touches outside my lane

`game/clock.js` gains `credit(side, ms)`: the only way time ever goes up, capped at the starting time, and a side that has already flagged keeps its flag. Ten lines with the comment.

## my boot.js block

Unchanged from #1003:

```js
  // --- M: the hand ---
  // A man waiting on his square counts as being in hand for Esc, but he is not
  // in the way of the camera: one finger may still orbit around him, and only a
  // real grab stands the rig off.
  view.cameraRig.setDragGuard(() => drag.isHolding());
  // --- end M ---
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CQdAN3aDyhnnXWjBtkH1mD
