### PR TITLE
feat(pbp): the room watches

### DIFF
--- a/ConditioningControlPanel/Resources/web/piecebypiece/audio/sfx.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/audio/sfx.js
@@ -21,6 +21,14 @@
  *   promote    a rising chime              `turn` after a promotion
  *   cardOpen/cardClose  a soft whoosh when the ramp's video card comes and
  *              goes (a MutationObserver on the fx root; the ramp emits nothing)
+ *   whisper    a breathy sigh, quiet     board/watch.js, when a man is held
+ *              too long
+ *
+ * The room (sfx.setMeter, driven by board.setMeter): a feedback delay sits
+ * beside the master and its wet level follows the meter, nothing at 0.25 and
+ * 0.35 at 1.0; past 0.55 every new voice is detuned, down to two semitones
+ * flat at 1.0. Both stay dry while the mover's clock is under 30 s (the
+ * clock ticks must stay crisp) and under reduced motion.
  *
  * sfx.play(name, opts) plays any cue by hand; sfx.log() is the last cues with
  * the context state, so a harness can prove each one scheduled. A `context`
@@ -40,8 +48,22 @@ export const TUNING = Object.freeze({
   clock: { hz: 1200, sharpHz: 1900, sec: 0.015, gain: 0.07, sharpGain: 0.11, underMs: 30000, sharpMs: 10000 },
   promote: { hz: [523, 659, 784, 1047], step: 0.06, sec: 0.28, gain: 0.12 },
   whoosh: { lowHz: 200, highHz: 4000, sec: 0.26, gain: 0.1 },
+  whisper: { from: 1100, to: 380, sec: 0.6, gain: 0.05, attack: 0.18 },
+  room: {
+    delaySec: 0.21, feedback: 0.32,      // the echo and how much of it comes back
+    wetFrom: 0.25, wetAt1: 0.35,         // wet level: 0 at wetFrom, wetAt1 at meter 1
+    driftFrom: 0.55, driftCents: 200,    // detune: 0 at driftFrom, this flat at 1
+    lowClockMs: 30000,                   // dry while the mover has less than this
+  },
   logSize: 32,
 });
+
+function reducedMotion(win) {
+  const s = win && win.PBP && win.PBP.settings;
+  if ((s && s.reducedMotion) || (win && win.PBP && win.PBP.reducedMotion)) return true;
+  try { return !!(win && win.matchMedia) && win.matchMedia('(prefers-reduced-motion: reduce)').matches; }
+  catch { return false; }
+}
 
 const clamp01 = (v) => Math.max(0, Math.min(1, Number(v) || 0));
 
@@ -53,6 +75,11 @@ export function createSfx({ bus, game = null, group = null, squareOf = null, roo
   let master = null;
   let noise = null;
   let disposed = false;
+  let wet = null;            // the delay's return, beside the master
+  let meter = 0;
+  let wetLevel = 0;          // what the wet gain was last asked for
+  let drift = 0;             // cents, applied to every new voice
+  let lowClock = false;      // the mover is under lowClockMs
   const log = [];
   const settings = () => (win && win.PBP && win.PBP.settings) || {};
   const volume = () => {
@@ -71,6 +98,20 @@ export function createSfx({ bus, game = null, group = null, squareOf = null, roo
     master = ctx.createGain();
     master.gain.value = doc && doc.hidden ? 0 : volume();
     master.connect(ctx.destination);
+    // The room: master -> delay -> (feedback -> delay) and delay -> wet -> out.
+    if (typeof ctx.createDelay === 'function') {
+      const R = TUNING.room;
+      const delay = ctx.createDelay(1.0);
+      delay.delayTime.value = R.delaySec;
+      const back = ctx.createGain();
+      back.gain.value = R.feedback;
+      wet = ctx.createGain();
+      wet.gain.value = 0;
+      master.connect(delay);
+      delay.connect(back); back.connect(delay);
+      delay.connect(wet); wet.connect(ctx.destination);
+      applyRoom();
+    }
     const seconds = 1;
     const buf = ctx.createBuffer(1, Math.max(1, Math.floor(ctx.sampleRate * seconds)), ctx.sampleRate);
     const data = buf.getChannelData(0);
@@ -88,6 +129,21 @@ export function createSfx({ bus, game = null, group = null, squareOf = null, roo
     try { master.gain.setTargetAtTime(to, ctx.currentTime, 0.02); } catch { master.gain.value = to; }
   }
 
+  // --- the room --------------------------------------------------------------
+  const lerp01 = (m, from) => (m <= from ? 0 : Math.min(1, (m - from) / (1 - from)));
+  /** Work out the wet level and the drift from the meter, and set the wet gain. */
+  function applyRoom() {
+    const R = TUNING.room;
+    const dry = lowClock || reducedMotion(win);
+    wetLevel = dry ? 0 : R.wetAt1 * lerp01(meter, R.wetFrom);
+    drift = dry ? 0 : -R.driftCents * lerp01(meter, R.driftFrom);
+    if (wet && ctx) {
+      try { wet.gain.setTargetAtTime(wetLevel, ctx.currentTime, 0.15); } catch { wet.gain.value = wetLevel; }
+    }
+  }
+  function setMeter(m) { meter = clamp01(m); applyRoom(); }
+  const tune = (node) => { if (drift && node.detune) { try { node.detune.value = drift; } catch { /* a source without detune */ } } };
+
   // --- the palette ------------------------------------------------------------
   /** An oscillator with a gain envelope: attack straight up, decay to zero. */
   function tone(type, hz, sec, gain, { at = 0, slideTo = null, filterHz = null } = {}) {
@@ -95,6 +151,7 @@ export function createSfx({ bus, game = null, group = null, squareOf = null, roo
     const osc = ctx.createOscillator();
     const env = ctx.createGain();
     osc.type = type;
+    tune(osc);
     osc.frequency.setValueAtTime(hz, t0);
     if (slideTo) osc.frequency.exponentialRampToValueAtTime(Math.max(1, slideTo), t0 + sec);
     env.gain.setValueAtTime(0.0001, t0);
@@ -114,17 +171,18 @@ export function createSfx({ bus, game = null, group = null, squareOf = null, roo
     osc.stop(t0 + sec + 0.02);
   }
   /** Filtered noise with a sweep, for taps and whooshes. */
-  function hiss(sec, gain, { at = 0, from = 1000, to = 1000, type = 'bandpass' } = {}) {
+  function hiss(sec, gain, { at = 0, from = 1000, to = 1000, type = 'bandpass', attack = null } = {}) {
     const t0 = ctx.currentTime + at;
     const src = ctx.createBufferSource();
     src.buffer = noise;
+    tune(src);
     const f = ctx.createBiquadFilter();
     f.type = type;
     f.frequency.setValueAtTime(from, t0);
     if (to !== from) f.frequency.exponentialRampToValueAtTime(to, t0 + sec);
     const env = ctx.createGain();
     env.gain.setValueAtTime(0.0001, t0);
-    env.gain.exponentialRampToValueAtTime(gain, t0 + Math.min(0.03, sec * 0.3));
+    env.gain.exponentialRampToValueAtTime(gain, t0 + (attack != null ? Math.min(attack, sec * 0.5) : Math.min(0.03, sec * 0.3)));
     env.gain.exponentialRampToValueAtTime(0.0001, t0 + sec);
     src.connect(f); f.connect(env); env.connect(master);
     src.start(t0);
@@ -157,6 +215,7 @@ export function createSfx({ bus, game = null, group = null, squareOf = null, roo
       const osc = ctx.createOscillator();
       const env = ctx.createGain();
       osc.type = 'triangle';
+      tune(osc);
       osc.frequency.setValueAtTime(B.hz[0], t0);
       for (let i = 1; i < B.hz.length; i++) osc.frequency.exponentialRampToValueAtTime(B.hz[i], t0 + B.sec * (i / (B.hz.length - 1)));
       env.gain.setValueAtTime(B.gain, t0);
@@ -174,6 +233,7 @@ export function createSfx({ bus, game = null, group = null, squareOf = null, roo
     promote() { const P = TUNING.promote; P.hz.forEach((hz, i) => tone('sine', hz, P.sec, P.gain, { at: i * P.step })); },
     cardOpen() { const W = TUNING.whoosh; hiss(W.sec, W.gain, { from: W.lowHz, to: W.highHz, type: 'lowpass' }); },
     cardClose() { const W = TUNING.whoosh; hiss(W.sec, W.gain, { from: W.highHz, to: W.lowHz, type: 'lowpass' }); },
+    whisper() { const W = TUNING.whisper; hiss(W.sec, W.gain, { from: W.from, to: W.to, type: 'bandpass', attack: W.attack }); },
   };
 
   function play(name, opts = {}) {
@@ -248,6 +308,8 @@ export function createSfx({ bus, game = null, group = null, squareOf = null, roo
   on('clock', (s) => {
     if (over || !s || !s.active) return;
     const ms = s[s.active];
+    const low = ms < TUNING.room.lowClockMs;
+    if (low !== lowClock) { lowClock = low; applyRoom(); }
     if (!(ms < TUNING.clock.underMs) || ms <= 0) return;
     const second = Math.ceil(ms / 1000);
     if (second === lastSecond) return;
@@ -286,7 +348,11 @@ export function createSfx({ bus, game = null, group = null, squareOf = null, roo
     wake,
     log: () => log.slice(),
     ready: () => !!ctx,
-    state: () => ({ context: ctx ? ctx.state : 'none', volume: master ? master.gain.value : 0, pulsing: !!checkTimer, over, hover }),
+    state: () => ({
+      context: ctx ? ctx.state : 'none', volume: master ? master.gain.value : 0, pulsing: !!checkTimer, over, hover,
+      meter, wet: +wetLevel.toFixed(3), drift: Math.round(drift), lowClock, room: !!wet,
+    }),
+    setMeter,
     setVolume(v) { settings().sfxVolume = clamp01(v); if (master) master.gain.value = doc && doc.hidden ? 0 : clamp01(v); },
     dispose() {
       disposed = true;
@@ -299,7 +365,7 @@ export function createSfx({ bus, game = null, group = null, squareOf = null, roo
         doc.removeEventListener('visibilitychange', onVisibility);
       }
       if (ctx && ctx.close) { try { ctx.close(); } catch { /* already */ } }
-      ctx = null; master = null;
+      ctx = null; master = null; wet = null;
     },
   };
 }

--- a/ConditioningControlPanel/Resources/web/piecebypiece/board/bloom.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/board/bloom.js
@@ -1,0 +1,160 @@
+/* ============================================================================
+ * board/bloom.js - the room glows when the meter is high.
+ *
+ * Past meter 0.5 the picture goes through a composer: the scene is drawn
+ * into a float target (with MSAA, so nothing gets jaggier than before), an
+ * UnrealBloomPass lifts the pink out of it, and one output pass does the
+ * tone mapping and the sRGB conversion that three.js only does on its own
+ * when drawing straight to the screen. Below 0.5 the composer is skipped
+ * entirely and the frame costs what it always cost.
+ *
+ * What glows: the pink squares (their lit faces and their emissive when the
+ * poses warm them), the move markers, the held man's line. Not the cream
+ * squares, which are the brightest thing on the board by luminance, so the
+ * stock luminosity threshold cannot be used: the high pass is keyed on how
+ * pink a texel is (red minus green, in linear light) instead. The uniform
+ * names are kept, so `threshold` still means what UnrealBloomPass says.
+ *
+ * Strength eases toward its target, so the meter crossing 0.5 and the
+ * ramp's pushToBoard(0) at game over fade the glow in and out.
+ *
+ * Gate: window.PBP.settings.bloom (default true). board.setMeter drives it.
+ * ==========================================================================*/
+
+import * as THREE from 'three';
+import { EffectComposer } from 'three/addons/postprocessing/EffectComposer.js';
+import { ShaderPass } from 'three/addons/postprocessing/ShaderPass.js';
+import { UnrealBloomPass } from 'three/addons/postprocessing/UnrealBloomPass.js';
+
+/** Every number the glow is made of. */
+export const TUNING = Object.freeze({
+  meterOn: 0.5,          // below this the composer is off
+  strengthAt1: 0.55,     // bloom strength at meter 1.0 (linear from meterOn)
+  radius: 0.35,
+  threshold: 0.62,       // red minus green, linear, where the glow starts
+  smooth: 0.35,          // and how wide the ramp in is
+  ease: 3.0,             // per-second pull of strength toward its target
+  samples: 4,            // MSAA on the scene target
+  offBelow: 0.01,        // strength under this: plain render again
+});
+
+const pinkHighPass = /* glsl */`
+  uniform sampler2D tDiffuse;
+  uniform vec3 defaultColor;
+  uniform float defaultOpacity;
+  uniform float luminosityThreshold;
+  uniform float smoothWidth;
+  varying vec2 vUv;
+  void main() {
+    vec4 texel = texture2D(tDiffuse, vUv);
+    float pink = texel.r - texel.g;
+    float alpha = smoothstep(luminosityThreshold, luminosityThreshold + smoothWidth, pink);
+    gl_FragColor = mix(vec4(defaultColor.rgb, defaultOpacity), texel, alpha);
+  }`;
+
+// The renderer's own tone mapping and output encoding only run when it draws
+// to the screen, so the composer's last pass does both by hand. toneMapped is
+// off on this material, or the renderer would prepend the same chunk and the
+// shader would not compile.
+const outputShader = {
+  uniforms: { tDiffuse: { value: null }, toneMappingExposure: { value: 1 } },
+  vertexShader: /* glsl */`
+    varying vec2 vUv;
+    void main() { vUv = uv; gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0); }`,
+  fragmentShader: /* glsl */`
+    #include <common>
+    #include <tonemapping_pars_fragment>
+    uniform sampler2D tDiffuse;
+    varying vec2 vUv;
+    void main() {
+      vec4 texel = texture2D(tDiffuse, vUv);
+      gl_FragColor = vec4(ACESFilmicToneMapping(texel.rgb), texel.a);
+      gl_FragColor = linearToOutputTexel(gl_FragColor);
+    }`,
+};
+
+function bloomOn() {
+  const s = (typeof window !== 'undefined' && window.PBP && window.PBP.settings) || {};
+  return s.bloom !== false;
+}
+
+/**
+ * `view` is board/scene.js. Wraps view.render (after whoever wrapped it
+ * before, so their per-frame work still runs inside the composer's draw).
+ */
+export function createBloom({ view }) {
+  const T = TUNING;
+  const renderer = view.renderer;
+  const size = new THREE.Vector2();
+  renderer.getSize(size);
+  const pr = renderer.getPixelRatio();
+  const target = new THREE.WebGLRenderTarget(size.x * pr, size.y * pr, { type: THREE.HalfFloatType, samples: T.samples });
+  const composer = new EffectComposer(renderer, target);
+  composer.renderToScreen = true;
+  const bloom = new UnrealBloomPass(new THREE.Vector2(size.x, size.y), 0, T.radius, T.threshold);
+  bloom.materialHighPassFilter.fragmentShader = pinkHighPass;
+  bloom.materialHighPassFilter.needsUpdate = true;
+  bloom.highPassUniforms.smoothWidth.value = T.smooth;
+  const output = new ShaderPass(outputShader);
+  output.material.toneMapped = false;
+  composer.addPass(bloom);
+  composer.addPass(output);
+
+  let meter = 0;
+  let strength = 0;
+  let live = false;
+  const cost = { on: [], off: [] };
+  const seen = new THREE.Vector2(size.x, size.y);
+
+  function targetStrength() {
+    if (!bloomOn() || meter < T.meterOn) return 0;
+    return T.strengthAt1 * Math.min(1, (meter - T.meterOn) / (1 - T.meterOn));
+  }
+
+  const prev = view.render;
+  view.render = () => {
+    const t0 = performance.now();
+    if (!live) {
+      prev();
+      push(cost.off, performance.now() - t0);
+      return;
+    }
+    renderer.getSize(size);
+    if (size.x !== seen.x || size.y !== seen.y) { seen.copy(size); composer.setSize(size.x, size.y); }
+    bloom.strength = strength;
+    output.uniforms.toneMappingExposure.value = renderer.toneMappingExposure;
+    renderer.setRenderTarget(composer.readBuffer);
+    renderer.clear();
+    prev();                                   // the scene, into the float target
+    renderer.setRenderTarget(null);
+    composer.render();
+    push(cost.on, performance.now() - t0);
+  };
+  function push(list, ms) { list.push(ms); if (list.length > 90) list.shift(); }
+  const avg = (list) => (list.length ? +(list.reduce((a, b) => a + b, 0) / list.length).toFixed(3) : null);
+
+  /** Once a frame, before render. */
+  function update(dt) {
+    const want = targetStrength();
+    const k = 1 - Math.exp(-T.ease * (dt || 0.016));
+    strength += (want - strength) * k;
+    if (want === 0 && strength < T.offBelow) strength = 0;
+    live = strength > 0;
+  }
+
+  return {
+    update,
+    setMeter(m) { meter = Math.max(0, Math.min(1, Number(m) || 0)); },
+    /** For the harness: what the glow is doing and what a frame costs. */
+    stats() {
+      return { meter, strength: +strength.toFixed(3), live, enabled: bloomOn(), msOn: avg(cost.on), msOff: avg(cost.off), size: [seen.x, seen.y] };
+    },
+    /** Jump the ease, for a still frame. */
+    settle() { strength = targetStrength(); live = strength > 0; },
+    dispose() {
+      view.render = prev;
+      composer.dispose();
+      target.dispose();
+    },
+  };
+}

--- a/ConditioningControlPanel/Resources/web/piecebypiece/board/watch.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/board/watch.js
@@ -1,0 +1,106 @@
+/* ============================================================================
+ * board/watch.js - the room watches.
+ *
+ * Past meter 0.4, while a man is held, the other men turn to look at him:
+ * each one's yaw eases toward the held man, capped at twelve degrees off
+ * his own facing (white faces the far side, black the near, and that stays
+ * their base). When he is put down they ease back. Below 0.4, or with
+ * nobody held, the room minds its own business.
+ *
+ * Hesitation: a man held for four seconds gets a half-strength grab
+ * impulse (a little flinch in the hand) and the room whispers, once per
+ * hold.
+ *
+ * Reduced motion (window.PBP.settings.reducedMotion or the media query):
+ * nobody turns, nobody flinches, nobody whispers.
+ * ==========================================================================*/
+
+import * as THREE from 'three';
+import { TUNING as JIGGLE } from './jiggle.js';
+
+/** Every number in the room's attention. */
+export const TUNING = Object.freeze({
+  meterOn: 0.4,          // the room starts watching past this
+  maxTurn: 12 * Math.PI / 180,   // radians off a man's own facing
+  ease: 4.0,             // per-second pull toward the wanted yaw
+  hesitateSec: 4.0,      // held this long: the flinch and the whisper
+  flinch: 0.5,           // of the grab squash
+});
+
+function reduced() {
+  if (typeof window === 'undefined') return false;
+  const s = window.PBP && window.PBP.settings;
+  if ((s && s.reducedMotion) || (window.PBP && window.PBP.reducedMotion)) return true;
+  try { return !!window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches; }
+  catch { return false; }
+}
+
+const wrap = (a) => Math.atan2(Math.sin(a), Math.cos(a));
+const baseYaw = (piece) => (piece.userData.side === 'b' ? Math.PI : 0);
+
+/**
+ * `group` is the piece group; `bus` the game bus (grab / drop / land mark a
+ * hold); `jiggle` the flex system; `sfx` a getter for the sound module.
+ */
+export function createWatch({ group, bus = null, jiggle = null, sfx = null }) {
+  const T = TUNING;
+  let meter = 0;
+  let held = null;
+  let heldFor = 0;
+  let hesitated = false;
+  let turned = 0;
+
+  function findHeld() {
+    for (const p of group.children) if (p.userData && p.userData.held) return p;
+    return null;
+  }
+
+  function update(dt) {
+    const now = findHeld();
+    if (now !== held) { held = now; heldFor = 0; hesitated = false; }
+    const watching = !!held && meter >= T.meterOn && !reduced();
+    if (held) {
+      heldFor += dt;
+      if (watching && !hesitated && heldFor >= T.hesitateSec) {
+        hesitated = true;
+        if (jiggle) jiggle.impulse(held, { squash: JIGGLE.grabSquash * T.flinch });
+        const s = sfx ? sfx() : null;
+        if (s && s.play) s.play('whisper');
+      }
+    }
+    const k = 1 - Math.exp(-T.ease * (dt || 0.016));
+    turned = 0;
+    for (const p of group.children) {
+      if (!p.userData || p === held || p.userData.busy || p.userData.parade || p.userData.pose) continue;
+      const base = baseYaw(p);
+      let want = base;
+      if (watching) {
+        // Facing (-sin y, 0, -cos y) is what rotation.y = y looks along.
+        const dx = held.position.x - p.position.x;
+        const dz = held.position.z - p.position.z;
+        if (dx * dx + dz * dz > 1e-6) {
+          const look = Math.atan2(-dx, -dz);
+          want = base + THREE.MathUtils.clamp(wrap(look - base), -T.maxTurn, T.maxTurn);
+        }
+      }
+      const delta = wrap(want - p.rotation.y);
+      if (Math.abs(delta) < 1e-4) { p.rotation.y = want; continue; }
+      p.rotation.y += delta * k;
+      if (watching) turned++;
+    }
+  }
+
+  return {
+    update,
+    setMeter(m) { meter = Math.max(0, Math.min(1, Number(m) || 0)); },
+    /** For the harness. */
+    stats() {
+      let maxOff = 0;
+      for (const p of group.children) {
+        if (!p.userData || p === held) continue;
+        maxOff = Math.max(maxOff, Math.abs(wrap(p.rotation.y - baseYaw(p))));
+      }
+      return { meter, held: held ? held.userData.type : null, heldFor: +heldFor.toFixed(2), hesitated, turning: turned, maxOffDeg: +(maxOff * 180 / Math.PI).toFixed(2) };
+    },
+  };
+}

--- a/ConditioningControlPanel/Resources/web/piecebypiece/boot.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/boot.js
@@ -164,7 +164,9 @@ function main() {
   view.cameraRig.setDragGuard(() => drag.isHolding());
   // --- end M ---
 
-  // --- N: the theatre (parade, poses; bloom and the room in the next PR) ---
+  // --- N: the theatre (parade, poses, bloom, the room watches) ---
+  window.PBP.settings = Object.assign({ bloom: true }, window.PBP.settings);
+  { const prev = board.setMeter; board.setMeter = (m) => { if (prev) prev(m); if (board.bloom) board.bloom.setMeter(m); if (board.watch) board.watch.setMeter(m); if (board.sfx && board.sfx.setMeter) board.sfx.setMeter(m); }; }
   import('./board/parade.js').then((m) => {
     board.parade = m.createParade({ view, bus, jiggle });
     feelLate.push((dt) => board.parade.update(dt));
@@ -173,6 +175,14 @@ function main() {
     board.poses = m.createPoses({ view, pieces, bus, jiggle, outline: () => board.outline, project: (v) => view.projectPoint(v) });
     feelLate.push((dt) => board.poses.update(dt));
   }).catch((e) => console.warn('[pbp] poses missing', e));
+  import('./board/watch.js').then((m) => {
+    board.watch = m.createWatch({ group: view.pieceGroup, bus, jiggle, sfx: () => board.sfx });
+    feelLate.push((dt) => board.watch.update(dt));
+  }).catch((e) => console.warn('[pbp] watch missing', e));
+  import('./board/bloom.js').then((m) => {
+    board.bloom = m.createBloom({ view });
+    feelLate.push((dt) => board.bloom.update(dt));
+  }).catch((e) => console.warn('[pbp] bloom missing', e));
   // --- end N ---
 
   let last = performance.now();

--- a/ConditioningControlPanel/Resources/web/piecebypiece/smoke/sfx-smoke.mjs
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/smoke/sfx-smoke.mjs
@@ -29,12 +29,13 @@ class FakeNode {
 class FakeContext {
   constructor() {
     this.state = 'suspended'; this.currentTime = 0; this.sampleRate = 48000;
-    this.started = []; this.wires = []; this.destination = { kind: 'destination' };
+    this.started = []; this.wires = []; this.sources = []; this.destination = { kind: 'destination' };
   }
   createGain() { const n = new FakeNode(this, 'gain'); n.gain = new Param(1); return n; }
-  createOscillator() { const n = new FakeNode(this, 'osc'); n.frequency = new Param(440); n.type = 'sine'; return n; }
+  createOscillator() { const n = new FakeNode(this, 'osc'); n.frequency = new Param(440); n.detune = new Param(0); n.type = 'sine'; this.sources.push(n); return n; }
   createBiquadFilter() { const n = new FakeNode(this, 'filter'); n.frequency = new Param(1000); n.type = 'lowpass'; return n; }
-  createBufferSource() { return new FakeNode(this, 'noise'); }
+  createBufferSource() { const n = new FakeNode(this, 'noise'); n.detune = new Param(0); this.sources.push(n); return n; }
+  createDelay() { const n = new FakeNode(this, 'delay'); n.delayTime = new Param(0); return n; }
   createBuffer(ch, len) { return { getChannelData: () => new Float32Array(len) }; }
   resume() { this.state = 'running'; return Promise.resolve(); }
   close() { this.state = 'closed'; return Promise.resolve(); }
@@ -114,6 +115,26 @@ history = [{ from: 'e7', to: 'e8', promotion: 'q' }];
 bus.emit('turn', { side: 'b', ply: 5 });
 expect(names().at(-1) === 'promote', 'a promotion chimes on its turn');
 history = [];
+
+// the room: a delay beside the master whose wet follows the meter, and a drift
+expect(fake.wires.some((w) => w[0] === 'gain' && w[1] === 'delay') && fake.wires.some((w) => w[0] === 'delay' && w[1] === 'gain'), 'the master feeds the delay and the delay comes back through a gain');
+const lastSource = () => fake.sources.at(-1);
+sfx.setMeter(0.2); sfx.play('tick');
+expect(sfx.state().wet === 0 && sfx.state().drift === 0 && lastSource().detune.value === 0, 'meter 0.2: dry, in tune');
+sfx.setMeter(0.55); sfx.play('tick');
+expect(Math.abs(sfx.state().wet - 0.14) < 1e-6 && sfx.state().drift === 0, 'meter 0.55: some wet (0.14), still in tune');
+sfx.setMeter(1.0); sfx.play('tick');
+expect(Math.abs(sfx.state().wet - 0.35) < 1e-9 && sfx.state().drift === -200 && lastSource().detune.value === -200, 'meter 1.0: wet 0.35 and every new voice two semitones flat');
+sfx.play('whisper');
+expect(names().at(-1) === 'whisper' && lastSource().kind === 'noise' && lastSource().detune.value === -200, 'the whisper is a breath of noise, and it drifts too');
+bus.emit('clock', { w: 20000, b: 60000, total: 900000, active: 'w' });
+sfx.play('tick');
+expect(sfx.state().lowClock && sfx.state().wet === 0 && lastSource().detune.value === 0, 'the mover under 30 s: the room goes dry and the ticks stay in tune');
+bus.emit('clock', { w: 60000, b: 20000, total: 900000, active: 'w' });
+expect(!sfx.state().lowClock && Math.abs(sfx.state().wet - 0.35) < 1e-9, 'the other side low does not count; the room comes back');
+win.PBP.settings.reducedMotion = true; sfx.setMeter(1.0);
+expect(sfx.state().wet === 0 && sfx.state().drift === 0, 'reduced motion: dry and in tune at meter 1');
+win.PBP.settings.reducedMotion = false; sfx.setMeter(0);
 
 // the clock: one tick a second under 30 s, sharper under 10 s, only the active side
 n0 = names().length;

--- a/ConditioningControlPanel/Resources/web/piecebypiece/smoke/theatre-shot.mjs
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/smoke/theatre-shot.mjs
@@ -316,6 +316,89 @@ const scenes = {
     console.log('knight take at 450 ms: land=' + JSON.stringify(l[l.length - 1] && l[l.length - 1].p));
     await shot('knight-take-2.png', await closeUp('e5', 0.6, 420, 360));
   },
+  // --- PR 3: the room watches -------------------------------------------------
+  async bloom() {
+    await open();
+    await move('e2', 'e4');
+    await beat(900);
+    const bl = () => json('window.PBP.board.bloom.stats()');
+    const chain = () => json('({ bloom: window.PBP.board.bloom.stats().meter, watch: window.PBP.board.watch.stats().meter, sfx: window.PBP.board.sfx.state().meter })');
+    // The ramp's hook: its tick (a real timer, not the stepped clock) pushes the meter down the chain.
+    await evalJs('window.PBP.ramp.setEnabled(true); window.PBP.ramp.debug().setMeter(0.8)');
+    // The ramp ticks on rAF (ours) against the real clock, so let the clock run and step a frame.
+    for (let i = 0; i < 3; i++) { await sleep(260); await beat(50); }
+    const viaRamp = await chain();
+    console.log('meter via ramp: ' + JSON.stringify(viaRamp));
+    if (Math.abs(viaRamp.bloom - 0.8) > 0.05 || Math.abs(viaRamp.watch - 0.8) > 0.05 || Math.abs(viaRamp.sfx - 0.8) > 0.05) bad('the ramp meter did not reach the chain');
+    await evalJs('window.PBP.ramp.setEnabled(false)');
+    await beat(50);
+    // Off and on, same camera, same position.
+    await evalJs('window.PBP.board.setMeter(0); window.PBP.board.bloom.settle()');
+    await beat(300);
+    const e4off = await at('e4', 0);
+    for (let i = 0; i < 30; i++) await beat(16);
+    const off = await bl();
+    await shot('bloom-off.png');
+    await shot('bloom-off-near.png', await closeUp('e4', 0.4, 640, 420));
+    await evalJs('window.PBP.board.setMeter(0.8); window.PBP.board.bloom.settle()');
+    await beat(300);
+    for (let i = 0; i < 30; i++) await beat(16);
+    const on = await bl();
+    const e4on = await at('e4', 0);
+    await shot('bloom-on-0.8.png');
+    await shot('bloom-on-0.8-near.png', await closeUp('e4', 0.4, 640, 420));
+    console.log('bloom off: ' + JSON.stringify(off) + '\nbloom on:  ' + JSON.stringify(on));
+    console.log('projectSquare e4 off/on: ' + JSON.stringify(e4off) + ' ' + JSON.stringify(e4on));
+    if (!on.live || on.strength < 0.3) bad('bloom did not come on at 0.8');
+    if (off.live) bad('bloom was live at meter 0');
+    if (Math.abs(e4off.x - e4on.x) > 0.5 || Math.abs(e4off.y - e4on.y) > 0.5) bad('projectPoint moved under the composer');
+    console.log('outline: ' + JSON.stringify(await json('window.PBP.board.outline && window.PBP.board.outline.stats()')));
+    await evalJs('window.PBP.board.setMeter(0); window.PBP.board.bloom.settle()');
+  },
+  async watch() {
+    await open();
+    await evalJs('window.PBP.board.setMeter(0.6); window.PBP.board.bloom.settle()');
+    await beat(100);
+    const ws = () => json('window.PBP.board.watch.stats()');
+    const a = await at('e2', 0.45);
+    await mouse('mousePressed', a.x, a.y);
+    await beat(80);
+    const held = Number(await evalJs('window.PBP.board.drag && window.PBP.board.drag.holdHeight ? window.PBP.board.drag.holdHeight() : 0')) || 0;
+    const b = await at('e4', held);
+    for (let i = 1; i <= 8; i++) { await mouse('mouseMoved', a.x + (b.x - a.x) * (i / 8), a.y + (b.y - a.y) * (i / 8)); await beat(35); }
+    await beat(700);
+    const w1 = await ws();
+    console.log('watching at 1.1 s: ' + JSON.stringify(w1));
+    if (!w1.held) bad('nobody is held');
+    if (w1.maxOffDeg > 12.01) bad('a man turned past twelve degrees');
+    if (w1.maxOffDeg < 3) bad('the room did not turn');
+    await shot('watch-held.png');
+    await shot('watch-held-near.png', await closeUp('e4', 0.3, 720, 460));
+    await beat(3500);
+    const w2 = await ws();
+    const whispered = (await json('window.PBP.board.sfx.log()')).some((e) => e.name === 'whisper');
+    console.log('held at 4.6 s: ' + JSON.stringify(w2) + ' whisper=' + whispered);
+    if (!w2.hesitated || !whispered) bad('no hesitation after four seconds');
+    await mouse('mouseReleased', b.x, b.y);
+    await beat(1200);
+    const w3 = await ws();
+    console.log('after the drop: ' + JSON.stringify(w3));
+    if (w3.held || w3.maxOffDeg > 0.5) bad('the room did not turn back');
+    await shot('watch-released.png');
+    // Below the meter nobody looks (it is black's move now, so black's pawn).
+    await evalJs('window.PBP.board.setMeter(0.2)');
+    const c = await at('d7', 0.45);
+    await mouse('mousePressed', c.x, c.y);
+    await beat(80);
+    await mouse('mouseMoved', c.x + 4, c.y + 4);
+    await beat(600);
+    const w4 = await ws();
+    console.log('held at meter 0.2: ' + JSON.stringify(w4));
+    if (!w4.held) bad('the second man was not held');
+    if (w4.maxOffDeg > 0.5) bad('the room looked below the meter');
+    await mouse('mouseReleased', c.x, c.y);
+    await beat(300);
+  },
 };
 
 async function main() {


### PR DESCRIPTION
Piece by Piece wave 3, lane N, PR 3 of 3. Stacked on #999 (`feat/pbp-n2`).

## what changed

**`board/bloom.js` (new): the room glows.** Past meter 0.5 the frame goes through an EffectComposer (scene into a HalfFloat MSAA target, UnrealBloomPass, one output pass that does the ACES tone map and the sRGB conversion three.js only does by itself when drawing straight to the screen). Strength is 0 below 0.5 and eases up to 0.55 at meter 1. The stock luminosity high pass would glow the cream squares (the brightest thing on the board), so the high pass is keyed on how pink a texel is (red minus green in linear light, threshold 0.62, smooth 0.35): the pink squares, the move markers, the held man's line, the poses' warm. Below 0.5 (or with `settings.bloom === false`) `view.render` is the plain path and costs what it always cost. Wraps `view.render` after J's wrapper, so the per-frame feel work still runs inside the composer's draw. `projectPoint`, the shadow map and the outline are untouched (checked below).

**`board/watch.js` (new): the room watches.** Past meter 0.4, while a man is held, every other man's yaw eases toward him, capped at twelve degrees off his own facing (black keeps base PI). When he is put down they ease back; below 0.4 nobody looks. Hesitation: a man held four seconds gets a half-strength grab squash and one `whisper`, once per hold. Reduced motion: nobody turns, flinches or whispers.

**`audio/sfx.js`: the room.** New `whisper` cue (a breath of bandpassed noise, 1100 to 380 Hz, 600 ms, quiet, slow attack). A feedback delay beside the master (210 ms, feedback 0.32) whose wet level follows the meter: 0 at 0.25, 0.35 at 1.0. Past 0.55 every new voice is detuned, down to two semitones flat at 1.0. Both stay dry while the mover's clock is under 30 s (the ticks stay crisp) and under reduced motion. `sfx.setMeter(m)`; `state()` now reports `meter, wet, drift, lowClock, room`.

**`ramp/index.js`:** the one meter line in `pushToBoard`, exactly as the rules file gives it, after the setCameraSway line.

**`boot.js`:** the N block extended (below): `settings.bloom` default true, the `board.setMeter` chain, the two imports.

**`smoke/sfx-smoke.mjs`:** FakeContext grows `createDelay` and `detune` params; ten asserts for the room (wet and drift at 0.2 / 0.55 / 1.0, the whisper, the low clock going dry and only for the mover, reduced motion dry).
**`smoke/theatre-shot.mjs`:** scenes `bloom` (ramp hook proof, off vs on same camera, projectPoint before/after, frame cost) and `watch` (a held man, the turn, the hesitation, the return, and a hold below the meter).

## boot.js block

```js
  // --- N: the theatre (parade, poses, bloom, the room watches) ---
  window.PBP.settings = Object.assign({ bloom: true }, window.PBP.settings);
  { const prev = board.setMeter; board.setMeter = (m) => { if (prev) prev(m); if (board.bloom) board.bloom.setMeter(m); if (board.watch) board.watch.setMeter(m); if (board.sfx && board.sfx.setMeter) board.sfx.setMeter(m); }; }
  import('./board/parade.js').then((m) => {
    board.parade = m.createParade({ view, bus, jiggle });
    feelLate.push((dt) => board.parade.update(dt));
  }).catch((e) => console.warn('[pbp] parade missing', e));
  import('./board/poses.js').then((m) => {
    board.poses = m.createPoses({ view, pieces, bus, jiggle, outline: () => board.outline, project: (v) => view.projectPoint(v) });
    feelLate.push((dt) => board.poses.update(dt));
  }).catch((e) => console.warn('[pbp] poses missing', e));
  import('./board/watch.js').then((m) => {
    board.watch = m.createWatch({ group: view.pieceGroup, bus, jiggle, sfx: () => board.sfx });
    feelLate.push((dt) => board.watch.update(dt));
  }).catch((e) => console.warn('[pbp] watch missing', e));
  import('./board/bloom.js').then((m) => {
    board.bloom = m.createBloom({ view });
    feelLate.push((dt) => board.bloom.update(dt));
  }).catch((e) => console.warn('[pbp] bloom missing', e));
  // --- end N ---
```

## proof (looked at every one)

`C:\Users\PC\Pictures\Screenshots\piecebypiece\n\`

- `bloom-off.png` vs `bloom-on-0.8.png` (+ `-near` pair), same camera, after 1.e4: with the meter at 0.8 the pink squares and the pink men carry a soft glow, the cream squares stay cream, the shadows and the outlines are as before. `bloom.stats()` off: strength 0, live false; on: strength 0.33, live true. `projectSquare('e4')` identical before and after (584.60, 365.57). Outline stats unchanged (32 pieces, 36 meshes).
- Meter through the ramp: `ramp.setEnabled(true); ramp.debug().setMeter(0.8)` puts 0.8 in `bloom.stats().meter`, `watch.stats().meter` and `sfx.state().meter` (the chain works end to end).
- `watch-held.png`, `watch-held-near.png` (meter 0.6, white's e-pawn held over e4): `watch.stats()` = 31 men turning, max 11.82 deg off base (cap 12). Honest note: most of the men are round, so a 12 degree turn is easy to read in the numbers and subtle in a still; the asymmetric ones show it, the plugs do not.
- Held 4.55 s: `hesitated: true`, `whisper` in `sfx.log()`. After the drop: `held: null`, max 0.1 deg (everyone back). A second hold at meter 0.2: `maxOffDeg` 0.01 (nobody looks). `watch-released.png`.
- Frame cost on the harness (swiftshader, no GPU, three other lanes' browsers on the same box, so the numbers are noise-heavy): 90-frame averages of ~326 ms plain vs ~698 ms through the composer in one run, ~397 vs ~300 in another. That is a software rasteriser doing a full-frame blur chain, not a number a real GPU will see, but I cannot claim under 2 ms from here, so the glow is behind `settings.bloom` (default true) and the owner can flip it off in Firefox if his frame rate says so.

## smokes

- rules-smoke 43/43, ramp-smoke 111/111, sfx-smoke ok (with the room asserts)
- feel-shot, jiggle-shot (`--wait 25000`): no console errors
- theatre-shot bloom + watch: no console errors, no failed checks

## notes

- Bloom uses the vendored `postprocessing/{EffectComposer,ShaderPass,UnrealBloomPass}.js` and `shaders/{CopyShader,LuminosityHighPassShader}.js` already in `Resources/web/vendor/three/`; nothing new vendored.
- The output pass reads `renderer.toneMappingExposure` every frame, so the look is the same either side of 0.5.

## touches outside my lane

None in code beyond the one ramp line and the boot.js N block. One stray file: an early `node smoke/shot.mjs --help` (no help flag exists) took a screenshot into lane A's folder, `C:\Users\PC\Pictures\Screenshots\piecebypiece\a\board.png`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CQdAN3aDyhnnXWjBtkH1mD
