### PR TITLE
feat(pbp): choose your queen

### DIFF
--- a/ConditioningControlPanel/Resources/web/piecebypiece/board/drag.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/board/drag.js
@@ -98,6 +98,8 @@ export function createDrag({ view, pieces, anim, bus, game, jiggle = null }) {
   let press = null;            // { x, y, t } of the pointer that is down
   let pending = false;         // this press could still turn out to be a click
   let toggledOff = null;       // the square this press let go of, so it cannot re-take it
+  let moveHook = null;         // something that may take a move over (see play)
+  let suspended = false;       // the board stands down while a picker is up
   let selected = null;         // the man waiting for his square
   let selSquare = null;
   let selLegal = [];
@@ -291,15 +293,25 @@ export function createDrag({ view, pieces, anim, bus, game, jiggle = null }) {
     if (repaint) paint();
   }
 
+  /**
+   * Play a move, unless something wants it first. The promotion picker takes a
+   * pawn's last step over this way: it answers true, the move waits on the
+   * board, and it plays the move itself once the player has chosen.
+   */
+  function play(from, to) {
+    if (moveHook && moveHook(from, to)) return { deferred: true };
+    return game.tryMove(from, to);
+  }
+
   /** A click on a legal square: the man waiting on his own flies over. */
   function playSelected(to) {
     const start = selSquare;
     clearSelection();
-    return game.tryMove(start, to);
+    return play(start, to);
   }
 
   function onDown(ev) {
-    if (held || ev.button > 0) return;
+    if (held || suspended || ev.button > 0) return;
     pointerIn = true;
     const found = pieceUnder(ev);
     const square = found ? null : squareUnder(ev);
@@ -412,7 +424,7 @@ export function createDrag({ view, pieces, anim, bus, game, jiggle = null }) {
 
     // A legal drop is played by the game, which moves the man and lets anim.js
     // fly it down from where it was being held.
-    const played = to && to !== start ? game.tryMove(start, to) : null;
+    const played = to && to !== start ? play(start, to) : null;
     if (played) {
       bus.emit('drop', { ok: true });
     } else {
@@ -453,7 +465,7 @@ export function createDrag({ view, pieces, anim, bus, game, jiggle = null }) {
   }
 
   function onKey(ev) {
-    if (ev.ctrlKey || ev.altKey || ev.metaKey || typing()) return;
+    if (ev.ctrlKey || ev.altKey || ev.metaKey || typing() || suspended) return;
     // Take the last ply back, with nothing in hand. Backspace is the one every
     // player tries first; z is there for the hand that never leaves the board.
     if (!held && (ev.key === 'Backspace' || ev.key === 'z' || ev.key === 'Z')) {
@@ -476,7 +488,7 @@ export function createDrag({ view, pieces, anim, bus, game, jiggle = null }) {
     markers.update(dt);
     updateLifts(dt);
     if (!held) {
-      if (pointerMoved || cameraMoved()) { look(); pointerMoved = false; }
+      if (!suspended && (pointerMoved || cameraMoved())) { look(); pointerMoved = false; }
       return;
     }
     if (pending && press && performance.now() - press.t > T.tapMs) pending = false;
@@ -515,6 +527,21 @@ export function createDrag({ view, pieces, anim, bus, game, jiggle = null }) {
     update,
     markers,
     /** A man in hand OR a man waiting on his square: the board is busy either way. */
+    /**
+     * Let something else answer a move first. The hook is called with the two
+     * squares and returns true when it has taken the move over.
+     */
+    setMoveHook(fn) { moveHook = typeof fn === 'function' ? fn : null; },
+    /** Stand the board down while a picker is up: no hover, no grab, no keys. */
+    suspend(on) {
+      suspended = !!on;
+      if (!suspended) { pointerMoved = true; return; }
+      onCancel();
+      clearSelection();
+      if (hoverPiece) { hoverPiece.userData.hover = false; wantLift(hoverPiece, 0); hoverPiece = null; }
+      setCursor('default');
+    },
+    isSuspended: () => suspended,
     isDragging: () => !!held || !!selected,
     /** The narrower question: is one actually in the hand right now? */
     isHolding: () => !!held,

--- a/ConditioningControlPanel/Resources/web/piecebypiece/board/promote.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/board/promote.js
@@ -1,0 +1,288 @@
+/* ============================================================================
+ * board/promote.js - what he comes up as.
+ *
+ * A pawn that reaches the eighth used to become a queen and that was that.
+ * Now the move waits: the pawn walks onto the square, stretches up, and four
+ * ghosts rise out of the square in a fan, queen, rook, bishop and knight. The
+ * one under the cursor brightens. Click one and the move is played with him.
+ *
+ * The house rules that shape it:
+ *   - a choice must never cost you the clock. Under 20 s on the mover's clock
+ *     the fan does not open at all and he comes up a queen, and even with time
+ *     in hand the fan queens itself after 4 s
+ *   - anything you can click, you can leave: Esc, or a click off the fan, is
+ *     the queen everybody wanted anyway
+ *   - the new man arrives, he does not appear. He drops onto the square through
+ *     anim, so the landing dust and the thud play as they do for any move
+ *
+ * The ghosts are Sprites with a CanvasTexture of the classic glyph, the same
+ * trick board/glyphs.js uses, because there is no toy for "a queen you have
+ * not chosen yet" and a flat figure reads as an offer rather than a man.
+ *
+ * Wiring: boot.js builds one, hands it to drag.js as the move hook (so every
+ * path that plays a move comes through here and none of them has to know about
+ * promotion) and pumps update(dt) off the loop's own dt, which keeps the four
+ * second offer honest under a harness that steps the clock by hand.
+ * ==========================================================================*/
+
+import * as THREE from 'three';
+import { squareToWorld } from './scene.js';
+
+/** Every number the offer is made of. One place, on purpose. */
+export const TUNING = Object.freeze({
+  size: 0.62,          // sprite size in world units; a square is 1.0
+  rise: 0.55,          // how far the fan climbs out of the square
+  base: 0.34,          // and where it starts, over the board
+  spread: 0.92,        // how wide the fan opens, in squares
+  arc: 0.34,           // how much the outer two sit higher than the inner two
+  riseSec: 0.22,       // how long the fan takes to come up
+  hoverScale: 1.22,    // the one under the cursor
+  hoverDim: 0.62,      // ... and how far the others fall back
+  ease: 14,            // per second, the chase on both of those
+  autoSec: 4,          // queen after this long with no answer
+  hurryMs: 20000,      // under this much clock, do not even ask
+  dropFrom: 0.95,      // the new man falls in from here
+  stretch: -1.9,       // the pawn holds himself tall while you decide
+  stretchEvery: 0.5,   // s, topped up so the hold does not sag
+  px: 128,
+  ink: '#241A3B',
+  white: '#F5E6C8',
+  black: '#AB90FF',
+});
+
+const T = TUNING;
+const KINDS = ['q', 'r', 'b', 'n'];
+const WHITE = { q: '♕', r: '♖', b: '♗', n: '♘' };
+const BLACK = { q: '♛', r: '♜', b: '♝', n: '♞' };
+const LETTER = { q: 'Q', r: 'R', b: 'B', n: 'N' };
+const FONT = '"Segoe UI Symbol", "Segoe UI", "DejaVu Sans", "Arial Unicode MS", system-ui, sans-serif';
+
+function reducedMotion() {
+  if (typeof window === 'undefined') return false;
+  const pbp = window.PBP;
+  if (pbp && (pbp.reducedMotion || (pbp.settings && pbp.settings.reducedMotion))) return true;
+  try { return !!window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches; }
+  catch { return false; }
+}
+
+/** Is this figure in the fonts we asked for? A missing one is drawn as a box. */
+function has(ctx, ch) {
+  const tofu = ctx.measureText('\u{10FFFF}').width;
+  const w = ctx.measureText(ch).width;
+  return w > 0 && Math.abs(w - tofu) > 0.1;
+}
+
+function glyphTexture(kind, side) {
+  const px = T.px;
+  const canvas = document.createElement('canvas');
+  canvas.width = px; canvas.height = px;
+  const ctx = canvas.getContext('2d');
+  ctx.font = Math.round(px * 0.72) + 'px ' + FONT;
+  const wanted = (side === 'w' ? WHITE : BLACK)[kind];
+  const ch = has(ctx, wanted) ? wanted : LETTER[kind];
+  if (ch !== wanted) ctx.font = '700 ' + Math.round(px * 0.58) + 'px ' + FONT;
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  ctx.lineJoin = 'round';
+  ctx.shadowColor = 'rgba(20, 14, 40, 0.55)';
+  ctx.shadowBlur = px * 0.10;
+  ctx.shadowOffsetY = px * 0.03;
+  ctx.lineWidth = px * 0.085;
+  ctx.strokeStyle = T.ink;
+  ctx.strokeText(ch, px / 2, px * 0.53);
+  ctx.shadowColor = 'transparent';
+  ctx.fillStyle = side === 'w' ? T.white : T.black;
+  ctx.fillText(ch, px / 2, px * 0.53);
+  const tex = new THREE.CanvasTexture(canvas);
+  tex.colorSpace = THREE.SRGBColorSpace;
+  tex.anisotropy = 2;
+  return tex;
+}
+
+/**
+ * @param view    what createScene handed back
+ * @param pieces  what createPieces handed back
+ * @param anim    for the new man's landing
+ * @param game    the hotseat: rules, clocks and tryMove
+ * @param drag    so the board can be stood down while the fan is open
+ */
+export function createPromote({ view, pieces, anim, bus, game, drag = null, jiggle = null }) {
+  const canvas = view.renderer.domElement;
+  const group = new THREE.Group();
+  group.name = 'promote';
+  group.renderOrder = 950;
+  view.scene.add(group);
+
+  const textures = new Map();       // "kind:side" -> CanvasTexture
+  const ghosts = [];                // { kind, sprite, want, live }
+  const ray = new THREE.Raycaster();
+  const ndc = new THREE.Vector2();
+  let open = null;                  // { from, to, side, at, t, pawn }
+  let hoverKind = null;
+  let stretchIn = 0;
+
+  function textureFor(kind, side) {
+    const key = kind + ':' + side;
+    if (!textures.has(key)) textures.set(key, glyphTexture(kind, side));
+    return textures.get(key);
+  }
+
+  function ghostFor(kind, side) {
+    const sprite = new THREE.Sprite(new THREE.SpriteMaterial({
+      map: textureFor(kind, side), transparent: true, depthTest: false,
+      depthWrite: false, fog: false, sizeAttenuation: true, opacity: 0,
+    }));
+    sprite.renderOrder = 950;
+    sprite.userData.promoteKind = kind;
+    group.add(sprite);
+    return sprite;
+  }
+
+  /** Where ghost i sits over the square, fully out. */
+  function seat(i, at) {
+    const t = (i - (KINDS.length - 1) / 2) / ((KINDS.length - 1) / 2);   // -1 .. 1
+    return {
+      x: at.x + t * T.spread * 0.5,
+      y: T.base + T.rise - Math.abs(t) * T.arc,
+      z: at.z,
+    };
+  }
+
+  /**
+   * Is this move a promotion, and does it get to ask? Returns true when the
+   * fan has taken the move over, which is the caller's cue to do nothing.
+   */
+  function intercept(from, to) {
+    if (open) return true;                      // one offer at a time
+    const move = game.rules.legalMove(from, to);
+    if (!move || !String(move.flags || '').includes('p')) return false;
+    const side = game.rules.turn();
+    // A clock this low is not a place to be asked a question.
+    const left = game.clock ? game.clock.remaining(side) : Infinity;
+    if (left < T.hurryMs) { game.tryMove(from, to, 'q'); return true; }
+
+    // He walks up first: the choice is made standing on the square.
+    const pawn = pieces.pieceAt(from);
+    pieces.move(from, to);
+    const at = squareToWorld(to, 0);
+    open = { from, to, side, at, t: 0, pawn: pieces.pieceAt(to) || pawn };
+    hoverKind = null;
+    stretchIn = 0;
+    if (drag && drag.suspend) drag.suspend(true);
+    for (const kind of KINDS) ghosts.push({ kind, sprite: ghostFor(kind, side), want: 1, live: 0 });
+    bus.emit('promote', { from, to, side, choosing: true });
+    return true;
+  }
+
+  /** Play the move with the man that was picked, and let him land. */
+  function choose(kind) {
+    if (!open) return null;
+    const { from, to } = open;
+    close();
+    const played = game.tryMove(from, to, kind);
+    if (!played) return null;
+    // He arrives rather than appearing: a short drop, so the dust and the thud
+    // fire off the same land event every other move uses.
+    const man = pieces.pieceAt(to);
+    if (man && anim && anim.slide) {
+      const dest = man.position.clone();
+      const above = dest.clone();
+      above.y += reducedMotion() ? 0.2 : T.dropFrom;
+      anim.slide(man, above, dest, 0);
+    }
+    return played;
+  }
+
+  function close() {
+    if (!open) return;
+    for (const g of ghosts) {
+      group.remove(g.sprite);
+      g.sprite.material.dispose();
+    }
+    ghosts.length = 0;
+    open = null;
+    hoverKind = null;
+    if (drag && drag.suspend) drag.suspend(false);
+  }
+
+  function aim(ev) {
+    if (!open) return null;
+    const r = canvas.getBoundingClientRect();
+    ndc.set(((ev.clientX - r.left) / r.width) * 2 - 1, -((ev.clientY - r.top) / r.height) * 2 + 1);
+    ray.setFromCamera(ndc, view.camera);
+    const hit = ray.intersectObjects(ghosts.map((g) => g.sprite), false)[0];
+    return hit ? hit.object.userData.promoteKind : null;
+  }
+
+  function onMove(ev) {
+    if (!open) return;
+    hoverKind = aim(ev);
+    canvas.style.cursor = hoverKind ? 'pointer' : 'default';
+  }
+
+  function onDown(ev) {
+    if (!open || ev.button > 0) return;
+    ev.preventDefault();
+    ev.stopPropagation();
+    choose(aim(ev) || 'q');       // off the fan is the queen everybody wanted
+  }
+
+  function onKey(ev) {
+    if (!open) return;
+    if (ev.key === 'Escape') { ev.preventDefault(); ev.stopPropagation(); choose('q'); return; }
+    const k = ev.key.toLowerCase();
+    if (KINDS.includes(k)) { ev.preventDefault(); ev.stopPropagation(); choose(k); }
+  }
+
+  function update(dt) {
+    if (!open) return;
+    open.t += dt;
+    const still = reducedMotion();
+    const up = still ? 1 : Math.min(1, open.t / T.riseSec);
+    const k = still ? 1 : 1 - Math.exp(-T.ease * dt);
+    for (let i = 0; i < ghosts.length; i++) {
+      const g = ghosts[i];
+      const s = seat(i, open.at);
+      g.sprite.position.set(s.x, T.base + (s.y - T.base) * up, s.z);
+      const want = hoverKind && g.kind !== hoverKind ? T.hoverDim : 1;
+      g.live += (want - g.live) * k;
+      g.sprite.material.opacity = up * g.live;
+      g.sprite.scale.setScalar(T.size * (g.kind === hoverKind ? T.hoverScale : 1));
+    }
+    // He holds himself tall while you decide, topped up so the hold does not sag.
+    if (!still && jiggle && open.pawn) {
+      stretchIn -= dt;
+      if (stretchIn <= 0) { stretchIn = T.stretchEvery; jiggle.impulse(open.pawn, { squash: T.stretch }); }
+    }
+    if (open.t >= T.autoSec) choose('q');
+  }
+
+  canvas.addEventListener('pointermove', onMove, true);
+  canvas.addEventListener('pointerdown', onDown, true);
+  window.addEventListener('keydown', onKey, true);
+
+  return {
+    intercept, choose, close, update,
+    isOpen: () => !!open,
+    /** For the harness: what is on offer and which one the cursor is on. */
+    debug() {
+      return {
+        open: open ? open.to : null,
+        side: open ? open.side : null,
+        kinds: ghosts.map((g) => g.kind),
+        hover: hoverKind,
+        rise: open ? Number((ghosts[0] ? ghosts[0].sprite.position.y : 0).toFixed(3)) : 0,
+        held: open ? Number(open.t.toFixed(2)) : 0,
+      };
+    },
+    dispose() {
+      close();
+      canvas.removeEventListener('pointermove', onMove, true);
+      canvas.removeEventListener('pointerdown', onDown, true);
+      window.removeEventListener('keydown', onKey, true);
+      for (const tex of textures.values()) tex.dispose();
+      textures.clear();
+      view.scene.remove(group);
+    },
+  };
+}

--- a/ConditioningControlPanel/Resources/web/piecebypiece/boot.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/boot.js
@@ -162,6 +162,16 @@ function main() {
   // in the way of the camera: one finger may still orbit around him, and only a
   // real grab stands the rig off.
   view.cameraRig.setDragGuard(() => drag.isHolding());
+  // A pawn on the eighth is asked what he comes up as. Loaded late and guarded,
+  // so a board without the module simply queens him the way it always did.
+  import('./board/promote.js').then((m) => {
+    board.promote = m.createPromote({ view, pieces, anim, bus, game, drag, jiggle });
+    drag.setMoveHook((from, to) => board.promote.intercept(from, to));
+    // On the loop's own dt, so the four second offer counts game time and a
+    // harness that steps the clock by hand sees it run out.
+    const base = view.update;
+    view.update = (dt) => { base(dt); board.promote.update(dt); };
+  }).catch((e) => console.warn('[pbp] the promotion picker is missing', e));
   // --- end M ---
 
   // --- N: the theatre (parade, poses, bloom, the room watches) ---

--- a/ConditioningControlPanel/Resources/web/piecebypiece/smoke/hand-shot.mjs
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/smoke/hand-shot.mjs
@@ -199,19 +199,9 @@ async function artSettled(ms = 20000) {
   return false;
 }
 
-async function main() {
-  mkdirSync(outDir, { recursive: true });
-  const wsUrl = await target();
-  const ws = new WebSocket(wsUrl);
-  await new Promise((res, rej) => {
-    ws.addEventListener('open', res, { once: true });
-    ws.addEventListener('error', rej, { once: true });
-  });
-  cdp = client(ws);
-  await cdp.send('Runtime.enable');
-  await cdp.send('Log.enable');
-  await cdp.send('Page.enable');
-  await cdp.send('Page.navigate', { url });
+/** Open a board and take its frame loop over, ready to be driven. */
+async function load(where) {
+  await cdp.send('Page.navigate', { url: where });
   await sleep(waitMs);
   await evalJs('window.PBP.ramp && window.PBP.ramp.setEnabled(false)');
   await evalJs('window.PBP.board.setWobble(0); window.PBP.board.setCameraSway(0)');
@@ -224,6 +214,21 @@ async function main() {
   await beat(200);
   await artSettled();
   await beat(200);
+}
+
+async function main() {
+  mkdirSync(outDir, { recursive: true });
+  const wsUrl = await target();
+  const ws = new WebSocket(wsUrl);
+  await new Promise((res, rej) => {
+    ws.addEventListener('open', res, { once: true });
+    ws.addEventListener('error', rej, { once: true });
+  });
+  cdp = client(ws);
+  await cdp.send('Runtime.enable');
+  await cdp.send('Log.enable');
+  await cdp.send('Page.enable');
+  await load(url);
 
   // --- 1. hover: his own man lifts, the other side does not ------------------
   await evalJs("window.__pt(20, 20, 'pointermove')");   // nothing under him
@@ -322,6 +327,56 @@ async function main() {
   const empty = await fen();
   console.log('nothing left to take back: ' + empty.split(' ').slice(0, 2).join(' '));
   if (empty.split(' ')[0] !== 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR') bad('an empty history still changed the board');
+
+  // --- 8. promotion: he is asked what he comes up as -------------------------
+  const promoUrl = url + '&fen=' + encodeURIComponent('8/P7/8/8/8/8/8/k6K w - - 0 1');
+  await load(promoUrl);
+  const fan = () => evalJs('JSON.stringify(window.PBP.board.promote.debug())').then(JSON.parse);
+  await click('a7');
+  await click('a8', { man: false });
+  await beat(400);
+  let f = await fan();
+  console.log('the fan: ' + JSON.stringify(f) + ' ' + (await fen()).split(' ').slice(0, 2).join(' '));
+  if (f.open !== 'a8') bad('the fan did not open on the eighth');
+  if (f.kinds.join('') !== 'qrbn') bad('the fan is not queen rook bishop knight');
+  if ((await fen()).split(' ')[1] !== 'w') bad('the move was played before he had chosen');
+  // Put the cursor on the knight and let the fan say so.
+  const at = await evalJs(`(() => {
+    const g = window.PBP.board.view.scene.getObjectByName('promote');
+    const s = g.children[3];
+    const p = window.PBP.board.view.projectPoint(s.position.clone());
+    window.__mark(p.x, p.y);
+    window.__pt(p.x, p.y, 'pointermove');
+    return JSON.stringify({ x: Math.round(p.x), y: Math.round(p.y) });
+  })()`);
+  await beat(120);
+  f = await fan();
+  console.log('the cursor on the knight at ' + at + ': ' + JSON.stringify(f));
+  console.log('  ' + await shot('promo-fan.png'));
+  if (f.hover !== 'n') bad('the fan did not brighten the one under the cursor');
+  // And take him.
+  const { x, y } = JSON.parse(at);
+  await evalJs(`window.__pt(${x}, ${y}, 'pointerdown'); window.__pt(${x}, ${y}, 'pointerup');`);
+  await beat(160);
+  console.log('  ' + await shot('promo-flight.png'));
+  await beat(700);
+  const promoted = await fen();
+  console.log('promoted: ' + promoted.split(' ').slice(0, 2).join(' ') + ' fan open: ' + (await fan()).open);
+  console.log('  ' + await shot('promo-landed.png'));
+  if (promoted.split(' ')[0] !== 'N7/8/8/8/8/8/8/k6K') bad('the knight he picked is not on the eighth');
+  if ((await fan()).open) bad('the fan stayed up after he chose');
+  if (await evalJs('window.PBP.board.drag.isSuspended()')) bad('the board was left standing down');
+
+  // Auto queen: no answer inside the four seconds, and he comes up a queen.
+  await load(promoUrl);
+  await click('a7');
+  await click('a8', { man: false });
+  await beat(300);
+  if (!(await fan()).open) bad('the second fan did not open');
+  await beat(4200);
+  const queened = await fen();
+  console.log('left alone for four seconds: ' + queened.split(' ').slice(0, 2).join(' '));
+  if (queened.split(' ')[0] !== 'Q7/8/8/8/8/8/8/k6K') bad('an unanswered fan did not queen him');
 
   const problems = [];
   for (const ev of cdp.events) {


### PR DESCRIPTION
Stacked on #1005 (`feat/pbp-m2`), which is stacked on #1003.

## what it does

A pawn on the eighth used to become a queen and that was that. Now the move waits.

- he walks onto the square first, so the choice is made standing there, and he holds himself tall while you decide (jiggle, negative squash, topped up so the hold does not sag)
- four ghosts rise out of the square in a fan: queen, rook, bishop, knight, in the classic glyphs, the same CanvasTexture sprite trick `glyphs.js` uses, because there is no toy for "a queen you have not chosen yet"
- the one under the cursor brightens and grows, the others fall back
- a click plays the move with him, and the new man **drops in** through anim, so the landing dust and the thud fire the way they do for any move
- Esc, or a click off the fan, is the queen everybody wanted anyway. So is four seconds of silence. The keys q, r, b and n work too
- under 20 s on the mover's clock the fan never opens: a choice must not cost you the clock
- reduced motion: the fan is simply there, no rise, no stretch

`board/promote.js` is new and owns all of it. `drag.js` gains the two calls that make it possible:

- `setMoveHook(fn)` - every path that plays a move (a drag, a click) asks first, and the hook answering true means the move has been taken over
- `suspend(on)` - the board stands down while the fan is up: no hover, no grab, no keys, so nothing can be picked up behind it

## how it was proved

`node smoke/hand-shot.mjs`, new section 8, on `?fen=8/P7/8/8/8/8/8/k6K w - - 0 1`:

```
the fan: {"open":"a8","side":"w","kinds":["q","r","b","n"],"hover":null,"rise":0.55,"held":0.27} 8/P7/8/8/8/8/8/k6K w
the cursor on the knight at {"x":407,"y":209}: {... "hover":"n" ...}
promoted: N7/8/8/8/8/8/8/k6K b fan open: null
left alone for four seconds: Q7/8/8/8/8/8/8/k6K b
hand shot done, no console errors
```

which checks, in order: the fan opens on the eighth with the four men, the move is **not** played while it is open, the cursor brightens the right one, clicking the knight leaves a knight on a8 with the fan gone and the board no longer stood down, and a second fan left alone queens him.

Screenshots, both looked at:

- `Pictures/Screenshots/piecebypiece/m/promo-fan.png` - the four ghosts up over a8, the knight brightened under the ring, the pawn still standing there and the move unplayed
- `.../promo-landed.png` - the knight on a8

Regression: `node smoke/rules-smoke.mjs` still **71 checks passed**, `smoke/shot.mjs --drag e2:e4` still reports `grab dragmove turn drop`, and the whole PR 1 and PR 2 harness (hover, click to move, Esc, take back) passes in the same run with no console errors.

## what is NOT in it

The sparkle ring the feel note asks for on the pop. The drop, the dust and the chime carry the beat as it is; a ring belongs with the dust lane's own effects rather than in the picker.

## touches outside my lane

None new. `board/drag.js` and `boot.js` are mine, `board/outline.js` (PR 1) and `game/clock.js` (PR 2) are declared on those.

## my boot.js block

```js
  // --- M: the hand ---
  // A man waiting on his square counts as being in hand for Esc, but he is not
  // in the way of the camera: one finger may still orbit around him, and only a
  // real grab stands the rig off.
  view.cameraRig.setDragGuard(() => drag.isHolding());
  // A pawn on the eighth is asked what he comes up as. Loaded late and guarded,
  // so a board without the module simply queens him the way it always did.
  import('./board/promote.js').then((m) => {
    board.promote = m.createPromote({ view, pieces, anim, bus, game, drag, jiggle });
    drag.setMoveHook((from, to) => board.promote.intercept(from, to));
    // On the loop's own dt, so the four second offer counts game time and a
    // harness that steps the clock by hand sees it run out.
    const base = view.update;
    view.update = (dt) => { base(dt); board.promote.update(dt); };
  }).catch((e) => console.warn('[pbp] the promotion picker is missing', e));
  // --- end M ---
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CQdAN3aDyhnnXWjBtkH1mD
