### PR TITLE
feat(race): the race weaves its own spirals (the book)

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/engine/loomSpirals.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/engine/loomSpirals.js
@@ -8,6 +8,20 @@
  * (bubbles.fireEffect) and the in-run payload fx (payloadFx.showSpiral) - so a
  * woven spiral shows up everywhere from one source of truth. Deliberately dumb:
  * all file authority/validation is C#-side (DtrhLoomStore).
+ *
+ * THE BOOK (2026-09-09). Racing Thoughts does not want a stock gif at all - the
+ * owner's law is "on ALL the games the spirals should be generated with the
+ * Loom". `setLoomBook(fn)` hands this module a weaver (race/loomBook.js), and
+ * `pickSpiral()` - a SECOND picker beside the url one, which is untouched -
+ * answers with a PARAMS WRAPPER `{loom:true, params, id, href}` for a caller
+ * that can draw one live, or a plain url for a caller that cannot. `href` is
+ * always a real gif, so the wrapper carries its own floor.
+ *
+ * A SAVED SPIRAL IS PREFERRED AS PARAMS TOO: loom-list entries carry the `.json`
+ * sidecar, so the player's own weave is redrawn from its params rather than
+ * fetched as a multi-megabyte gif. Only the race sets a book and only the race
+ * passes payloadFx a `spiralFx`, so the Descent still draws exactly the gifs it
+ * always has.
  * ==========================================================================*/
 
 let spirals = [];   // [{ slug, url, params }]
@@ -53,4 +67,50 @@ export function pickSpiralUrl() {
     return spirals[Math.floor(Math.random() * spirals.length)].url;
   }
   return bundledPool[Math.floor(Math.random() * bundledPool.length)];
+}
+
+/* ----------------------------------------------------------------------------
+ * THE BOOK: live-woven spirals (race/loomBook.js)
+ * -------------------------------------------------------------------------- */
+
+/** () => { loom:true, params, id } | null - set by the race, null everywhere else. */
+let book = null;
+
+/** Hand this module a weaver, or null to take it away again (run teardown).
+ *  Only race/run.js calls this; with no book, pickSpiral() is pickSpiralUrl(). */
+export function setLoomBook(fn) { book = typeof fn === 'function' ? fn : null; }
+export function hasLoomBook() { return !!book; }
+
+/** A bundled gif, always: the floor under every wrapper. */
+const anyBundled = () => bundledPool[Math.floor(Math.random() * bundledPool.length)];
+
+/**
+ * ONE SPIRAL, as either a live-Loom wrapper or a url.
+ *
+ * The mix is the same ~50/50 pickSpiralUrl has always drawn: the player's own
+ * woven spirals first when they have any, the race's book otherwise. A saved
+ * spiral that kept its params sidecar comes back as a wrapper too (drawn live,
+ * no gif fetched) with its own gif as the `href` floor; one without params is
+ * still just its url.
+ *
+ * @param {Object} [ctx] passed straight to the book ({ room?, word? }); the
+ *   race's book reads the live room and the road's last phrase on its own, so
+ *   this is only for smokes and shot harnesses.
+ * @returns {{loom:true, params:Object, id:string, href:string}|string}
+ */
+export function pickSpiral(ctx = undefined) {
+  if (spirals.length && Math.random() < 0.5) {
+    const s = spirals[Math.floor(Math.random() * spirals.length)];
+    if (s.params && typeof s.params === 'object') {
+      return { loom: true, params: s.params, id: 'saved:' + (s.slug || '?'), href: s.url, saved: true };
+    }
+    return s.url;
+  }
+  if (book) {
+    try {
+      const drawn = book(ctx);
+      if (drawn && drawn.params) return { loom: true, params: drawn.params, id: String(drawn.id || 'loom:0'), href: anyBundled(), saved: false };
+    } catch (e) { /* a book that throws is a book that is not there */ }
+  }
+  return anyBundled();
 }

--- a/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
@@ -258,12 +258,36 @@ Reduced motion (run.js stamps `#race-root[data-rm="1"]` from the run's own toggl
 answers `prefers-reduced-motion`) keeps every colour and every word and drops only movement: no
 wash shudder, no sag or drip, no breathing on the lacquer card.
 
-Spiral pops (`payloadFx.showSpiral`, untouched) take their url from `engine/loomSpirals.js`
-`pickSpiralUrl()`. On the mobile tier `Q.leanSpirals` has run.js narrow that module's bundled pool
-to `LEAN_SPIRALS` (sp6.gif 123 KB + sp7.gif 721 KB; the other five are 2.2-5.3 MB) with
-`setBundledSpiralPool` and prefetch both in `prepare()` (while the intro plays; `start()` covers
-`?autostart=1`), so a lap never fetches a spiral mid-run. Desktop keeps the full pool and the Descent
-never calls the setter.
+**SPIRALS ARE WOVEN, NOT SHIPPED (2026-09-09).** A race spiral is drawn live by the Loom now, not
+loaded as one of seven stock gifs. `engine/loomSpirals.js` grew a second picker beside the old one:
+`pickSpiral()` returns either a gif url (what the Descent still gets) or a weave
+`{loom:true, params, id, href}`, and `setLoomBook(fn)` is the seam the race fills. The mix is the
+player's own saved spirals ~50% of the time (params-first: a `loom-list` entry with a `params`
+sidecar renders live, one without stays its gif), the race's BOOK otherwise; `href` is always a
+bundled gif, kept only as the floor for a lost GL context. `pickSpiralUrl()` is unchanged, so the
+Descent is byte-identical: it never sets a book and never sees a weave.
+
+THE BOOK (`race/loomBook.js`) is the race's own spiral set, seeded off the run seed so a seed
+replays. `paletteFor(roomId)` reads `rooms.js` `colors.edge/prop/banner` + `propAlt` for the thread
+colours and darkens `colors.fog` for ground and outer, so a ninth room needs no edit here.
+`ROOM_CHARACTER` then hand-tunes style/glow/pulse/wobble/speed/arms per room - tea garden soft log
+and arch, toybox loud petals, casino golden, undertow wobbling ribbon and tunnel, mirrors tunnel,
+chapel high-glow log and golden, greyward dim arch, coronation golden and petal. Every draw snaps
+`turns` to 1.5-4, takes two threads (three one draw in four) rotated off a `lead` index, sets
+`hueCycles: 0` (a race spiral does not rainbow), and, when the road phrase is still echoing, puts
+that word in the centrepiece as a `mantra` - the spiral says what the voice said.
+
+The bundled gifs still ship as that floor. On the mobile tier `Q.leanSpirals` has run.js narrow the
+module's bundled pool to `LEAN_SPIRALS` (sp6.gif 123 KB + sp7.gif 721 KB; the other five are
+2.2-5.3 MB) with `setBundledSpiralPool` and prefetch both in `prepare()` (while the intro plays;
+`start()` covers `?autostart=1`), so a lap never fetches a spiral mid-run. Desktop keeps the full
+pool and the Descent never calls the setter.
+
+A weave is only params until something draws it; `race/loomSpiralFx.js` and the payloadFx seam
+that mounts it land in the next PR, so until then a picked weave falls to its `href` gif. On the web
+there is no account library (the site Loom is anonymous), so the web gets the race book only. Checks:
+`race/smoke/loom-book-check.mjs` (the book per room, the seed replay, the mantra) and
+`race/smoke/spiral-pool-check.mjs` (the picker mix and the floor under it).
 A row may carry `spawn: false`. Video bubbles are dark since 2026-09-06: `rollKind` leaves the row out
 of every pool and `field.spawnAt` returns -1 for it, so no roll, lane line, rain or track cue can put
 one on the road, and `CaucusHostService` refuses a `fire-payload {kind:'video'}` as well. The row, its

--- a/ConditioningControlPanel/Resources/web/dtrh/race/loomBook.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/loomBook.js
@@ -1,0 +1,276 @@
+/* ============================================================================
+ * race/loomBook.js - THE RACE'S OWN SPIRAL BOOK.
+ *
+ * The owner's law (2026-08-25, quoted in arcademy/engine/loomWash.js): "on ALL
+ * the games the spirals should be generated with the Loom." Racing Thoughts drew
+ * seven stock gifs out of assets/bubbles/effects/spirals/ and nothing else. This
+ * file is where a race spiral comes from now: schema-v2 Loom params, minted off
+ * the RUN'S OWN SEED, wearing THE ROOM'S OWN COLOURS.
+ *
+ *   createLoomBook({ seed }) -> { draw({room, word}), reseed(seed), count, seed }
+ *
+ * No DOM, no WebGL, no window - race/loomSpiralFx.js is what DRAWS one of
+ * these; this file only decides what a spiral IS. It reads its palettes out of
+ * race/rooms.js, which imports three.js, so a node caller needs the same
+ * `three` resolve hook race/smoke/slope-check.mjs installs (the smoke does).
+ *
+ * ---------------------------------------------------------------------------
+ * THE PALETTE IS THE ROOM'S, AND IT IS READ, NOT WRITTEN TWICE.
+ * `paletteFor(roomId)` takes the threads straight off race/rooms.js: the kerb
+ * `edge`, the prop tint, the marquee `banner` and any `propAlt`, deduped and in
+ * that order, over a ground made from the room's own `fog`. So a spiral in the
+ * Tea Garden is cream/rose/sage over its green haze and the Fool's Casino is
+ * gold over crimson-black - they can never be the same picture, and adding a
+ * ninth room needs no edit here. A room whose colours collapse to one (they do
+ * not today) is topped up with the house pink so a band always has something
+ * to band against.
+ *
+ * THE CHARACTER TABLE (`ROOM_CHARACTER`) is the one hand-tuned half: which of
+ * the six Loom styles a room is allowed, how hot its glow runs, whether the
+ * field breathes or goes liquid, and how fast it spins. Two styles per room,
+ * both of them hypnotic reads at wash alpha - `ribbon` and `petal` only where
+ * a room already looks like that (the Undertow's kelp, the Toybox's confetti).
+ *
+ * CONSTRAINED, NOT RANDOM. loomField's own `randomParams2` rolls the whole
+ * knob board and can hand back a twelve-arm strobe. The book is narrower on
+ * purpose: 2-6 arms, 1.5-4 turns, a duty that keeps the dark as wide as the
+ * light, `hueCycles: 0` always (the ROOM owns the colour, so nothing may rotate
+ * it away), and a second counter-rotating layer only a third of the time.
+ *
+ * THE ROAD SAYS ITS OWN WORD. When a draw is handed the phrase the voice just
+ * said and it fits the Loom's 12-character mantra, the spiral wears it as its
+ * centrepiece - so the picture says what the voice said. No word, and the
+ * centre is a plain dot or nothing.
+ *
+ * DETERMINISM (the same promise race/spine.js makes). Every draw is
+ * `makeRng(seed ^ room ^ n)` - the run seed, the room, and how many spirals
+ * this run has already drawn. Replay a seed and the same rooms deal the same
+ * weaves in the same order. The WORD is not in the seed on purpose: a bubble
+ * wearing a different phrase must not shift the whole book under it.
+ *
+ * THE ID is 'loom:' + FNV-1a over a stable stringify of the normalized params,
+ * the same shape the Arcademy's ledger uses, so the same params always name the
+ * same spiral. race/smoke/loom-spiral-check.mjs holds it.
+ * ==========================================================================*/
+
+import { normalizeParams2, defaultParams2 } from '../shared/loomField.js';
+import { ROOMS, roomById } from './rooms.js';
+import { makeRng } from './consts.js';
+
+/** The house pink, for a room too monochrome to band against itself. */
+const HOUSE_PINK = '#ff69b4';
+/** A gif the floor can paint when WebGL is gone (loomSpiralFx hands this back). */
+const clamp = (v, lo, hi) => Math.min(hi, Math.max(lo, v));
+const snap = (v, step) => Math.round(v / step) * step;
+const hex6 = (n) => '#' + ((n >>> 0) & 0xffffff).toString(16).padStart(6, '0');
+
+/** Mix a hex toward black by `k` (0 = untouched, 1 = black). The ground only. */
+function darken(h, k) {
+  const n = parseInt(String(h).replace('#', ''), 16) || 0;
+  const f = (v) => Math.max(0, Math.min(255, Math.round(v * (1 - k))));
+  return '#' + [f((n >> 16) & 255), f((n >> 8) & 255), f(n & 255)]
+    .map((v) => v.toString(16).padStart(2, '0')).join('');
+}
+
+/**
+ * The hand-tuned half, per room. `styles` are the Loom styles this room may
+ * weave in; `glow`/`pulse`/`wobble` are [min,max] ranges (a 0 max means the
+ * room never does that at all); `speed` is the Loom's 1-5 spin table.
+ */
+export const ROOM_CHARACTER = Object.freeze({
+  // nothing here fights you: a slow open weave, a soft halo, no distortion
+  teagarden:  { styles: ['log', 'arch'],       glow: [0.20, 0.45], pulse: [0.04, 0.09], wobble: [0, 0],       speed: [2, 3], arms: [2, 5] },
+  // the floor bounces: petals and a fat pulse, the confetti room's own bounce
+  toybox:     { styles: ['petal', 'arch'],     glow: [0.35, 0.70], pulse: [0.08, 0.14], wobble: [0, 0],       speed: [3, 4], arms: [3, 6] },
+  // the wheel always pays: gold growth, the hottest glow, the fastest spin
+  casino:     { styles: ['golden', 'log'],     glow: [0.40, 0.75], pulse: [0.06, 0.12], wobble: [0, 0],       speed: [3, 5], arms: [2, 5] },
+  // the lane drifts: the two liquid styles, and the only room that really wobbles
+  undertow:   { styles: ['ribbon', 'tunnel'],  glow: [0.25, 0.50], pulse: [0.06, 0.11], wobble: [0.10, 0.20], speed: [2, 3], arms: [2, 4] },
+  // the picture flips: the bore, a cold glint, a little liquid
+  mirrors:    { styles: ['tunnel', 'log'],     glow: [0.30, 0.60], pulse: [0.04, 0.08], wobble: [0.06, 0.13], speed: [3, 4], arms: [3, 6] },
+  // the spiral pins itself here: the deepest glow and the widest breath in the game
+  chapel:     { styles: ['log', 'golden'],     glow: [0.45, 0.80], pulse: [0.09, 0.15], wobble: [0, 0],       speed: [2, 4], arms: [2, 5] },
+  // the only pink left is the treats: a dim, tight, joyless weave
+  greyward:   { styles: ['arch', 'log'],       glow: [0.12, 0.32], pulse: [0.03, 0.07], wobble: [0, 0],       speed: [2, 3], arms: [3, 6] },
+  // the run remembers: gold leaf, a heavy pulse, a touch of shimmer
+  coronation: { styles: ['golden', 'petal'],   glow: [0.40, 0.80], pulse: [0.08, 0.14], wobble: [0.04, 0.10], speed: [3, 5], arms: [2, 5] },
+});
+/** What a room the table never named (or no room at all) weaves. */
+export const DEFAULT_CHARACTER = Object.freeze({
+  styles: ['log', 'arch'], glow: [0.25, 0.55], pulse: [0.05, 0.10], wobble: [0, 0], speed: [2, 4], arms: [2, 5],
+});
+
+/** The character row for a room id, never null. */
+export function characterFor(roomId) {
+  return ROOM_CHARACTER[String(roomId || '')] || DEFAULT_CHARACTER;
+}
+
+/**
+ * THE ROOM'S OWN COLOURS, as a Loom palette: `{ threads, ground, outer }`.
+ * Threads come off race/rooms.js in kerb -> prop -> marquee -> alt order,
+ * deduped; the ground is the room's haze, and `outer` is that haze taken most
+ * of the way to black so a radial ground has somewhere to fall off to.
+ */
+export function paletteFor(roomId) {
+  const room = roomById(roomId) || null;
+  const c = (room && room.colors) || null;
+  const raw = c
+    ? [c.edge, c.prop, c.banner, ...(Array.isArray(room.propAlt) ? room.propAlt : [])]
+    : [];
+  const threads = [];
+  for (const n of raw) {
+    const h = hex6(n);
+    if (!threads.includes(h)) threads.push(h);
+  }
+  if (threads.length < 2) threads.push(HOUSE_PINK);
+  const fog = c ? hex6(c.fog) : '#12061a';
+  return { threads, ground: darken(fog, 0.35), outer: darken(fog, 0.8) };
+}
+
+/** Every room has one: race/smoke/loom-spiral-check.mjs walks this list. */
+export const BOOK_ROOMS = ROOMS.map((r) => r.id);
+
+const pickOf = (r, arr) => arr[Math.min(arr.length - 1, Math.floor(r() * arr.length))];
+const between = (r, [lo, hi]) => lo + r() * (hi - lo);
+const intBetween = (r, [lo, hi]) => lo + Math.floor(r() * (hi - lo + 1));
+
+/** The Loom's mantra field is 12 characters; a longer phrase is not a centrepiece. */
+export const MANTRA_MAX = 12;
+/** Can the road's phrase ride the middle of the spiral? Lowercase, house style. */
+export function mantraOf(word) {
+  const s = String(word || '').trim().toLowerCase().replace(/\s+/g, ' ');
+  return s && s.length <= MANTRA_MAX ? s : '';
+}
+
+/**
+ * ONE SPIRAL, woven for a room off a die.
+ * @param {Function} rng  a 0..1 stream (race/consts.js makeRng); REQUIRED for
+ *   determinism - a missing die falls back to Math.random and is for rigs only.
+ * @param {Object} [o] { room?: roomId, word?: the road's phrase }
+ * @returns normalized schema-v2 params (plain JSON, loomField-ready)
+ */
+export function bookParams(rng, o = {}) {
+  const r = typeof rng === 'function' ? rng : Math.random;
+  const ch = characterFor(o.room);
+  const pal = paletteFor(o.room);
+  const d = defaultParams2();
+
+  // THE WEAVE. Two threads is the read the owner asked for ("two-colour bands
+  // from the room palette"); a third joins one draw in four where the room has
+  // one, so a long run in one room does not settle into a single picture.
+  const threads = pal.threads.slice();
+  const nThreads = threads.length > 2 && r() < 0.25 ? 3 : 2;
+  // rotate the room's own order rather than shuffling it: the kerb colour leads
+  // most spirals, which is what makes a room's book read as one room's book
+  const lead = Math.floor(r() * threads.length);
+  const rolled = threads.slice(lead).concat(threads.slice(0, lead));
+
+  d.format = 'square';
+  d.speed = intBetween(r, ch.speed);
+  d.bg = { kind: 'radial', color: pal.ground, outer: pal.outer };
+  d.layer.arms = intBetween(r, ch.arms);
+  d.layer.turns = clamp(snap(1.5 + r() * 2.5, 0.25), 0.5, 6);
+  d.layer.duty = clamp(snap(0.35 + r() * 0.25, 0.05), 0.2, 0.8);
+  d.layer.style = pickOf(r, ch.styles);
+  d.layer.direction = r() < 0.5 ? 1 : -1;
+  d.layer.colors = rolled.slice(0, nThreads);
+  d.layer.bandMode = r() < 0.4 ? 'gradient' : 'hard';
+  d.layer.speedMul = 1;
+
+  // THE SECOND WEAVE, a third of the time, always turning the other way and
+  // always in the room's remaining colour: a counter-rotation reads as depth,
+  // two full palettes read as noise.
+  d.layer2.enabled = r() < 0.34;
+  d.layer2.arms = intBetween(r, [2, 5]);
+  d.layer2.turns = clamp(snap(0.75 + r() * 1.75, 0.25), 0.5, 6);
+  d.layer2.style = d.layer.style;
+  d.layer2.direction = -d.layer.direction;
+  d.layer2.colors = [rolled[(nThreads) % rolled.length] || rolled[0]];
+  d.layer2.duty = clamp(snap(0.3 + r() * 0.2, 0.05), 0.2, 0.8);
+
+  d.glow = between(r, ch.glow);
+  d.pulse = { amp: between(r, ch.pulse), cycles: 1 + (r() < 0.3 ? 1 : 0) };
+  d.wobble = ch.wobble[1] > 0
+    ? { amp: between(r, ch.wobble), freq: intBetween(r, [2, 4]), cycles: 1 }
+    : { amp: 0, freq: 2, cycles: 1 };
+  // NEVER. The room owns the colour; a hue rotation would walk the spiral out
+  // of the room it was woven for, halfway through its own loop.
+  d.hueCycles = 0;
+
+  // THE CENTRE. The road's own phrase where it fits, else a quiet dot, else
+  // nothing at all - the field is the effect and the middle is not a logo.
+  const mantra = mantraOf(o.word);
+  if (mantra) {
+    d.centerpiece = { kind: 'mantra', color: rolled[0], sizeFrac: 0.22, text: mantra, flashCycles: 1 + (r() < 0.5 ? 1 : 0) };
+  } else if (r() < 0.3) {
+    d.centerpiece = { kind: 'dot', color: rolled[0], sizeFrac: 0.08 + r() * 0.05, text: '', flashCycles: 0 };
+  }
+  return normalizeParams2(d);
+}
+
+/* ----------------------------------------------------------------------------
+ * THE ID (the Arcademy's shape, so a spiral has one name everywhere)
+ * -------------------------------------------------------------------------- */
+
+/** Deterministic stringify: keys sorted at every depth, arrays in order. */
+export function stableStringify(v) {
+  if (v === null || v === undefined) return 'null';
+  const t = typeof v;
+  if (t === 'number') return Number.isFinite(v) ? String(v) : 'null';
+  if (t === 'boolean') return v ? 'true' : 'false';
+  if (t === 'string') return JSON.stringify(v);
+  if (Array.isArray(v)) return '[' + v.map(stableStringify).join(',') + ']';
+  if (t === 'object') {
+    return '{' + Object.keys(v).sort().map((k) => JSON.stringify(k) + ':' + stableStringify(v[k])).join(',') + '}';
+  }
+  return 'null';
+}
+
+/** FNV-1a 32-bit over a string, 8 lowercase hex chars. */
+function fnv1aHex(s) {
+  let h = 2166136261 >>> 0;
+  for (let i = 0; i < s.length; i++) { h ^= s.charCodeAt(i); h = Math.imul(h, 16777619); }
+  return ('0000000' + ((h >>> 0).toString(16))).slice(-8);
+}
+/** The same params always name the same spiral: 'loom:xxxxxxxx'. */
+export function loomId(params) { return 'loom:' + fnv1aHex(stableStringify(normalizeParams2(params))); }
+export const LOOM_ID_RE = /^loom:[0-9a-f]{8}$/;
+
+/** The room's name folded into 32 bits, so a room's stream is its own. */
+function roomSeed(roomId) {
+  let h = 2166136261 >>> 0;
+  const s = String(roomId || 'none');
+  for (let i = 0; i < s.length; i++) { h ^= s.charCodeAt(i); h = Math.imul(h, 16777619); }
+  return h >>> 0;
+}
+
+/**
+ * THE BOOK for one run. `draw` is what engine/loomSpirals.js calls (through the
+ * `setLoomBook` seam) every time a spiral pop needs a picture.
+ *
+ * @param {Object} o { seed: the run seed, room?: () => roomId, word?: () => phrase }
+ * @returns {{ draw: Function, reseed: Function, count: () => number, seed: () => number }}
+ */
+export function createLoomBook({ seed = 1, room = null, word = null } = {}) {
+  let runSeed = seed >>> 0;
+  let n = 0;
+  /**
+   * One spiral. `o.room` / `o.word` win over the run's own live getters, so a
+   * smoke can ask for a named room without a world under it.
+   * @returns {{ loom: true, params: Object, id: string, room: string, word: string }}
+   */
+  function draw(o = {}) {
+    const roomId = o.room != null ? o.room : (typeof room === 'function' ? room() : '');
+    const phrase = o.word != null ? o.word : (typeof word === 'function' ? word() : '');
+    const rng = makeRng((runSeed ^ roomSeed(roomId) ^ Math.imul(n + 1, 0x9e3779b9)) >>> 0);
+    n++;
+    const params = bookParams(rng, { room: roomId, word: phrase });
+    return { loom: true, params, id: loomId(params), room: String(roomId || ''), word: mantraOf(phrase) };
+  }
+  function reseed(s) { runSeed = (s >>> 0) || 1; n = 0; }
+  return { draw, reseed, count: () => n, seed: () => runSeed };
+}
+
+export default { createLoomBook, bookParams, paletteFor, characterFor, loomId, BOOK_ROOMS };
+
+// self-check: node race/smoke/loom-spiral-check.mjs (the node half walks every room).

--- a/ConditioningControlPanel/Resources/web/dtrh/race/smoke/loom-book-check.mjs
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/smoke/loom-book-check.mjs
@@ -1,0 +1,152 @@
+/* ============================================================================
+ * race/smoke/loom-book-check.mjs - OUR OWN SPIRALS, the pure half.
+ *
+ *   node race/smoke/loom-book-check.mjs      (from Resources/web/dtrh; 0 on pass)
+ *
+ * race/loomBook.js is asked for a spiral in every one of the eight rooms and
+ * held to the promises the book makes - every room has a palette of at least
+ * two of its OWN colours, every draw normalizes into valid schema-v2 params, no
+ * draw rotates its hue away from the room it was woven for, the same seed
+ * replays the same book in the same order, a different seed does not, and the
+ * road's own phrase reaches the centre of the spiral when it fits. Then the
+ * picker seam beside it: with a book every draw is a live weave over a gif
+ * floor, without one it is the Descent's plain url, and the player's own saved
+ * spirals go params-first.
+ *
+ * The canvas that draws all this is race/smoke/loom-spiral-check.mjs, which
+ * needs a browser. This half needs nothing but node.
+ *
+ * three resolves off the local vendor copy (race/rooms.js wants it) exactly the
+ * way race/smoke/slope-check.mjs does it.
+ * ==========================================================================*/
+
+import { register } from 'node:module';
+import { readFile } from 'node:fs/promises';
+import { readFileSync, mkdtempSync, rmSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, extname, resolve, sep } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const HERE = resolve(fileURLToPath(import.meta.url), '..');
+const RACE = resolve(HERE, '..');
+const DTRH = resolve(RACE, '..');
+const WEB = resolve(DTRH, '..');                        // Resources/web
+
+const VENDOR = pathToFileURL(resolve(DTRH, 'vendor/three/') + sep).href;
+register('data:text/javascript,' + encodeURIComponent(`
+  export function resolve(spec, ctx, next) {
+    if (spec === 'three') return { url: ${JSON.stringify(VENDOR)} + 'three.module.min.js', shortCircuit: true };
+    if (spec.startsWith('three/addons/')) return { url: ${JSON.stringify(VENDOR)} + 'addons/' + spec.slice('three/addons/'.length), shortCircuit: true };
+    return next(spec, ctx);
+  }`), import.meta.url);
+
+// three's module build reaches for a document the moment it is imported; nothing here draws.
+const el = () => ({ addEventListener() {}, removeEventListener() {}, style: {}, width: 0, height: 0, getContext: () => null, set src(v) {}, get src() { return ''; } });
+globalThis.document = globalThis.document || { createElement: el, createElementNS: el, documentElement: {} };
+
+const book = await import('../loomBook.js');
+const { normalizeParams2, LOOM_STYLES } = await import('../../shared/loomField.js');
+const spirals = await import('../../engine/loomSpirals.js');
+
+let fails = 0;
+const ok = (cond, what) => { if (!cond) { console.error('FAIL ' + what); fails++; } else console.log('  ok  ' + what); };
+const eq = (got, want, what) => ok(got === want, what + ' (got ' + JSON.stringify(got) + ', want ' + JSON.stringify(want) + ')');
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+/* ============================================================================
+ * 1. the book: every room, its own colours, and the same seed twice
+ * ==========================================================================*/
+eq(book.BOOK_ROOMS.length, 8, 'the book covers all eight rooms');
+const SEED = 90210;
+{
+  const b = book.createLoomBook({ seed: SEED });
+  const seenIds = new Set();
+  for (const room of book.BOOK_ROOMS) {
+    const pal = book.paletteFor(room);
+    ok(pal.threads.length >= 2, `${room}: ${pal.threads.length} threads (${pal.threads.join(' ')})`);
+    ok(pal.threads.every((h) => /^#[0-9a-f]{6}$/.test(h)), `${room}: every thread is a hex colour`);
+    ok(/^#[0-9a-f]{6}$/.test(pal.ground) && /^#[0-9a-f]{6}$/.test(pal.outer), `${room}: the ground is the room's own haze, twice darkened`);
+    const ch = book.characterFor(room);
+    ok(ch.styles.length >= 1 && ch.styles.every((s) => LOOM_STYLES.includes(s)), `${room}: its styles are Loom styles`);
+
+    const d = b.draw({ room, word: 'good girl' });
+    seenIds.add(d.id);
+    ok(d.loom === true && d.params && book.LOOM_ID_RE.test(d.id), `${room}: draws a wrapper with a stable id (${d.id})`);
+    const q = d.params;
+    eq(JSON.stringify(normalizeParams2(q)), JSON.stringify(q), `${room}: the params come out already normalized`);
+    ok(ch.styles.includes(q.layer.style), `${room}: weaves in ${q.layer.style}, one of its own two`);
+    ok(q.layer.colors.every((c) => pal.threads.includes(c)), `${room}: every thread is one of the room's (${q.layer.colors.join(',')})`);
+    ok(q.layer.colors.length >= 2, `${room}: at least two colours to band against each other`);
+    eq(q.hueCycles, 0, `${room}: nothing rotates the room's colour away mid-loop`);
+    ok(q.layer.arms >= 2 && q.layer.arms <= 6, `${room}: ${q.layer.arms} arms, inside the book's 2-6`);
+    ok(q.layer.turns >= 1.5 && q.layer.turns <= 4, `${room}: ${q.layer.turns} turns, inside the book's 1.5-4`);
+    eq(q.centerpiece.kind, 'mantra', `${room}: the road's own phrase is the centrepiece`);
+    eq(q.centerpiece.text, 'good girl', `${room}: and it is the phrase that was said`);
+    ok(q.bg.kind === 'radial' && q.bg.color === pal.ground, `${room}: over the room's own ground`);
+  }
+  ok(seenIds.size === book.BOOK_ROOMS.length, `eight rooms, ${seenIds.size} different spirals - no two rooms share a picture`);
+}
+{
+  // THE PROMISE: replay a seed, get the book back
+  const a = book.createLoomBook({ seed: SEED });
+  const c = book.createLoomBook({ seed: SEED });
+  const A = book.BOOK_ROOMS.map((room) => a.draw({ room, word: 'good girl' }).id);
+  const C = book.BOOK_ROOMS.map((room) => c.draw({ room, word: 'good girl' }).id);
+  eq(C.join(','), A.join(','), 'the same seed weaves the same spirals in the same order');
+  const other = book.createLoomBook({ seed: SEED + 1 });
+  const O = book.BOOK_ROOMS.map((room) => other.draw({ room, word: 'good girl' }).id);
+  ok(O.join(',') !== A.join(','), 'and a different seed opens a different book');
+  // the same room drawn twice in a run is not the same picture: the draw counter is in the die
+  const rep = book.createLoomBook({ seed: SEED });
+  const one = rep.draw({ room: 'chapel' }).id, two = rep.draw({ room: 'chapel' }).id;
+  ok(one !== two, 'two spirals in one room are two spirals');
+  eq(rep.count(), 2, 'and the book counts what it has dealt');
+  rep.reseed(SEED);
+  eq(rep.draw({ room: 'chapel' }).id, one, 'reseed puts the book back to its first page ("again" on the same seed)');
+}
+{
+  // the mantra: only what fits, always lowercase, and gone when there is nothing to say
+  const b = book.createLoomBook({ seed: 7 });
+  eq(book.mantraOf('GOOD GIRL'), 'good girl', 'a phrase is lowercased for the centre');
+  eq(book.mantraOf('every thought you have belongs to the panel'), '', 'and a phrase past 12 characters is not a centrepiece');
+  const quiet = b.draw({ room: 'teagarden' });
+  ok(quiet.params.centerpiece.kind !== 'mantra', 'with nothing said, the middle is not a word');
+  eq(quiet.word, '', 'and the wrapper says so');
+}
+{
+  // the picker: the wrapper, the floor under it, and the Descent's untouched url path
+  spirals.setLoomSpirals([]);
+  spirals.setLoomBook(null);
+  ok(typeof spirals.pickSpiral() === 'string', 'with no book, pickSpiral is pickSpiralUrl');
+  const b = book.createLoomBook({ seed: 3, room: () => 'casino' });
+  spirals.setLoomBook(b.draw);
+  ok(spirals.hasLoomBook(), 'the race hands the picker a book');
+  let wrapped = 0, floored = 0;
+  for (let i = 0; i < 100; i++) {
+    const got = spirals.pickSpiral();
+    if (got && typeof got === 'object') {
+      wrapped++;
+      if (got.href && /\.(gif|webp)$/.test(got.href)) floored++;
+    }
+  }
+  eq(wrapped, 100, 'with a book and no saved spirals, every draw is a live weave');
+  eq(floored, 100, 'and every one of them carries a bundled gif as its floor');
+  // the player's own: params-first, url when there is no sidecar
+  spirals.setLoomSpirals([
+    { slug: 'mine', url: 'https://ccp.spirals/loom_mine.gif', params: { schema: 2, layer: { arms: 3, colors: ['#ff69b4'] } } },
+    { slug: 'plain', url: 'https://ccp.spirals/loom_plain.gif' },
+  ]);
+  let saved = 0, savedLive = 0, plain = 0;
+  for (let i = 0; i < 600; i++) {
+    const got = spirals.pickSpiral();
+    if (got && typeof got === 'object' && got.saved) { saved++; savedLive++; }
+    else if (got === 'https://ccp.spirals/loom_plain.gif') { saved++; plain++; }
+  }
+  ok(saved > 200 && saved < 400, `the player's own spirals still take about half the draws (${saved} of 600)`);
+  ok(savedLive > 0 && plain > 0, `a sidecar is drawn live (${savedLive}) and one without is still its gif (${plain})`);
+  spirals.setLoomSpirals([]);
+  spirals.setLoomBook(null);
+}
+
+if (fails) { console.error(`\nloom-book-check: ${fails} failure(s)`); process.exit(1); }
+console.log('\nloom-book-check: all good');

--- a/ConditioningControlPanel/Resources/web/dtrh/race/smoke/spiral-pool-check.mjs
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/smoke/spiral-pool-check.mjs
@@ -1,12 +1,15 @@
 /* ============================================================================
  * race/smoke/spiral-pool-check.mjs - node self-check for the bundled spiral pool switch in
- * engine/loomSpirals.js (the race narrows it to LEAN_SPIRALS on the mobile tier).
+ * engine/loomSpirals.js (the race narrows it to LEAN_SPIRALS on the mobile tier), plus the
+ * BOOK seam beside it: `setLoomBook` / `pickSpiral`, which is how Racing Thoughts gets a live
+ * Loom weave where the Descent gets a gif url. The weave itself is race/smoke/loom-spiral-check.mjs.
  *
  *   node race/smoke/spiral-pool-check.mjs      (exits 0 on pass, 1 with a count of failures)
  * ==========================================================================*/
 
 import {
   BUNDLED_SPIRALS, LEAN_SPIRALS, setBundledSpiralPool, getBundledSpiralPool, prefetchSpirals, pickSpiralUrl, setLoomSpirals,
+  setLoomBook, hasLoomBook, pickSpiral,
 } from '../../engine/loomSpirals.js';
 
 let fails = 0;
@@ -41,6 +44,68 @@ ok(getBundledSpiralPool() === BUNDLED_SPIRALS, 'null restores the whole set');
 setBundledSpiralPool([]);
 ok(getBundledSpiralPool() === BUNDLED_SPIRALS, 'so does an empty list');
 ok(Array.isArray(prefetchSpirals(LEAN_SPIRALS)) && prefetchSpirals(LEAN_SPIRALS).length === 0, 'prefetch asks for nothing without a DOM and never throws');
+
+/* --- the book seam: pickSpiral() -------------------------------------------------------- */
+
+ok(!hasLoomBook(), 'there is no book until someone sets one (the Descent never does)');
+{
+  const drawn = [];
+  for (let i = 0; i < 100; i++) drawn.push(pickSpiral());
+  ok(drawn.every((d) => typeof d === 'string' && BUNDLED_SPIRALS.includes(d)), 'without a book pickSpiral draws plain gif urls, same as pickSpiralUrl');
+}
+
+let asked = 0;
+setLoomBook(() => { asked++; return { params: { schema: 2, style: 'log' }, id: 'loom:deadbeef' }; });
+ok(hasLoomBook(), 'the race hands the book over on run start');
+{
+  const drawn = [];
+  for (let i = 0; i < 200; i++) drawn.push(pickSpiral());
+  ok(asked === 200 && drawn.every((d) => d && d.loom === true), 'with a book every draw is a live weave, not a gif');
+  ok(drawn.every((d) => d.id === 'loom:deadbeef' && d.params && d.params.schema === 2), 'the weave carries the book params and its id');
+  ok(drawn.every((d) => BUNDLED_SPIRALS.includes(d.href)), 'and a bundled gif rides along as the href floor for a lost context');
+  ok(drawn.every((d) => d.saved === false), 'a book weave is marked as not the player\'s own');
+}
+setBundledSpiralPool(LEAN_SPIRALS);
+ok(pickSpiral().href !== undefined && LEAN_SPIRALS.includes(pickSpiral().href), 'the floor respects the lean pool on the phone tier');
+setBundledSpiralPool(null);
+
+setLoomBook(() => { throw new Error('the book is on fire'); });
+{
+  const drawn = [];
+  for (let i = 0; i < 50; i++) drawn.push(pickSpiral());
+  ok(drawn.every((d) => typeof d === 'string'), 'a book that throws falls through to a gif instead of taking the pop with it');
+}
+
+setLoomBook(() => ({ params: { schema: 2 }, id: 'loom:bookweave' }));
+setLoomSpirals([
+  { slug: 'woven', url: 'https://ccp.spirals/loom_woven.gif', params: { schema: 2, style: 'petal' } },
+]);
+{
+  let live = 0; let fromBook = 0;
+  for (let i = 0; i < 400; i++) {
+    const d = pickSpiral();
+    if (d && d.saved === true) live++;
+    else if (d && d.loom) fromBook++;
+  }
+  ok(live > 100 && live < 300, `the player's own weaves take about half the pops (${live} of 400)`);
+  ok(live + fromBook === 400, 'and the rest come from the race book, never a stock gif while a book is set');
+}
+{
+  const d = pickSpiral();
+  const mine = (() => { for (let i = 0; i < 400; i++) { const x = pickSpiral(); if (x && x.saved) return x; } return null; })();
+  ok(mine && mine.params.style === 'petal' && mine.href === 'https://ccp.spirals/loom_woven.gif' && mine.id === 'saved:woven',
+    'a saved spiral with params renders live from the params, its gif kept only as the floor');
+  ok(d, 'pickSpiral always returns something');
+}
+setLoomSpirals([{ slug: 'old', url: 'https://ccp.spirals/loom_old.gif' }]);
+{
+  let mine = 0;
+  for (let i = 0; i < 400; i++) { const d = pickSpiral(); if (d === 'https://ccp.spirals/loom_old.gif') mine++; }
+  ok(mine > 100 && mine < 300, `a saved spiral with no params sidecar stays a gif url (${mine} of 400)`);
+}
+setLoomSpirals([]);
+setLoomBook(null);
+ok(!hasLoomBook() && typeof pickSpiral() === 'string', 'dropping the book on dispose puts the Descent path back');
 
 if (fails) { console.error(`\nspiral-pool-check: ${fails} failure(s)`); process.exit(1); }
 console.log('\nspiral-pool-check: all good');


### PR DESCRIPTION
Owner, after playing the last wave: *"works amazingly, tho we should have our own spirals (those generated with the loom system) in there."* The house rule since 2026-08-25 says the same thing: on all the games the spirals come off the Loom.

This is the first of three. It builds the book and the seam; the canvas that draws it is the next PR.

### what draws now vs before

Before: a `spiral` pop picked one of seven stock gifs (2-5 MB each, narrowed to the two lean ones on phones). The Loom's own `pickSpiralUrl` would have mixed the player's saved spirals in at 50%, but only as gif urls, and only in the descent.

After this PR: `engine/loomSpirals.js` has a second picker, `pickSpiral()`, which returns **either** a gif url (what the descent still gets, unchanged) **or** a weave `{loom:true, params, id, href}`. `setLoomBook(fn)` is the seam the race fills. Nothing draws a weave yet, so today a picked weave still falls to its `href` gif - PR 2 puts the canvas in.

`pickSpiralUrl()` is untouched, the seam defaults to nothing, and the descent never sets a book, so `dtrh` is byte-identical.

### the book's rules

`race/loomBook.js`. Palette first, character second, both keyed on the room:

- `paletteFor(room)` takes the threads straight out of `race/rooms.js` - `colors.edge`, `colors.prop`, `colors.banner` and every `propAlt` - and darkens `colors.fog` twice into the ground and the outer. Generic, so a ninth room needs no edit here.
- `ROOM_CHARACTER` gives each room its own hand: tea garden soft `log`/`arch` at low glow, toybox loud `petal`, casino `golden`, undertow a wobbling `ribbon`/`tunnel`, mirrors a `tunnel`, chapel high-glow `log`/`golden`, greyward dim `arch`, coronation `golden`/`petal`.
- every draw: `turns` snapped to 1.5-4, `duty` 0.35-0.6, two threads (three one draw in four) rotated off a `lead` index so the same palette does not always lead with the same colour, `layer2` counter-rotating about a third of the time, `hueCycles: 0` **always** (a race spiral never rainbows away from the room it was woven for), a radial ground.
- the centrepiece is the road's own phrase as a `mantra` when the popped word still fits (<= 12 chars, lowercased); otherwise a dot 30% of the time, otherwise nothing. The spiral says what the voice said.
- the die is `makeRng(runSeed ^ roomSeed ^ drawIndex)`, so a seed replays its book in the same order, "again" on the same seed gives the same spirals back, and two spirals in one room are still two spirals.

The mix, once a book is set: the player's own saved spirals ~50% of the time (params-first - a `loom-list` entry with a `params` sidecar comes back live, one without stays its gif), the book otherwise. Every weave carries a bundled gif as `href`, the floor for a machine with no WebGL.

### perf

Nothing renders in this PR. The book is pure params: no fetch, no canvas, no allocation past one params object per pop. The gif floor keeps the existing lean-pool behaviour on phones untouched.

### how verified

- `node race/smoke/loom-book-check.mjs` - every room's palette, valid normalized schema-v2 params, the style/arms/turns bounds, `hueCycles 0`, the mantra, the seed replay, a different seed opening a different book, the picker mix and the gif floor. Green.
- `node race/smoke/spiral-pool-check.mjs` - extended for `pickSpiral`/`setLoomBook`: no book means plain urls, a book means weaves, the floor respects the lean pool, a book that throws falls through to a gif instead of taking the pop with it, dropping the book puts the descent path back. Green.

```
 .../Resources/web/dtrh/engine/loomSpirals.js       |  60 +++++
 .../Resources/web/dtrh/race/CONTRACT.md            |  36 ++-
 .../Resources/web/dtrh/race/loomBook.js            | 276 +++++++++++++++++++++
 .../web/dtrh/race/smoke/loom-book-check.mjs        | 152 ++++++++++++
 .../web/dtrh/race/smoke/spiral-pool-check.mjs      |  67 ++++-
 5 files changed, 584 insertions(+), 7 deletions(-)
```

Stack: **this** -> `feat/race-loom-spirals` (the live canvas) -> `feat/race-loom-library` (the player's own spirals on desktop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013T1bb13w97ndYjNveiFpLz
