### PR TITLE
feat(race): draw the woven spiral live on the glass

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/game/payloadFx.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/game/payloadFx.js
@@ -23,7 +23,7 @@
 
 import { S } from '../engine/settings.js';
 import { isMuted, onMuteChange } from '../shared/audioMute.js';
-import { pickSpiralUrl } from '../engine/loomSpirals.js';
+import { pickSpiralUrl, pickSpiral } from '../engine/loomSpirals.js';
 
 const clamp = (v, lo, hi) => Math.min(hi, Math.max(lo, v));
 const clamp01 = (v) => clamp(v, 0, 1);
@@ -49,8 +49,17 @@ const MAX_CASCADE = 14;
  * nothing, so DtRH's whisper blip is byte-for-byte the card it always was. A race pop
  * calls the override with the phrase already resolved and skips the blip entirely.
  * Anything else that wants its own look adds a seam of its own; never restyle .sf-pfx-sub.
+ *
+ * `spiralFx` is the SECOND seam, and the same shape (2026-09-09). Racing Thoughts is
+ * again the only caller (race/run.js -> race/loomSpiralFx.js): with it, a spiral is
+ * WOVEN LIVE off Loom params on a canvas inside the hold instead of being a stock gif
+ * background, per the owner's law that every game's spirals come out of the Loom. It
+ * needs `mount(el, wrap, {kind, durMs, onLost}) -> bool`, `drop(el)` and `cancel()`.
+ * With nothing passed the file draws the exact gif backgrounds it always has, so
+ * dtrh.html is untouched - and even with it, a `false` from mount() falls straight
+ * back onto the gif, so the screen can never go bare.
  */
-export function createPayloadFx({ hud, fx, media, flashBurst, subliminalFx = null }) {
+export function createPayloadFx({ hud, fx, media, flashBurst, subliminalFx = null, spiralFx = null }) {
   // Two layers: washes/bursts render BEHIND the bubble field (.cf-layer, z6) so
   // bubbles stay crisp and clickable on top of pink/spiral/glitch/braindrain;
   // the video card rides a FRONT layer above the bubbles (in front of the POV).
@@ -102,9 +111,35 @@ export function createPayloadFx({ hud, fx, media, flashBurst, subliminalFx = nul
    *  never by whether a picture moves - so this draws a few times and takes the first entry whose
    *  name or url says gif/webp, keeping whatever it drew last if none of them do. With nothing in
    *  the pool at all it takes a BUNDLED SPIRAL rather than one of the still FALLBACK_SPRITES:
-   *  those are all pngs, and a still png is exactly what this effect is not. */
+   *  those are all pngs, and a still png is exactly what this effect is not.
+   *
+   *  With a `spiralFx` seam that last fallback is a LIVE LOOM SPIRAL instead of a stock gif
+   *  (the owner's law), so this may hand back a params wrapper rather than a url - hence
+   *  `pickWash`, not `pickWashUrl`. The media pool still wins whenever it has a moving
+   *  picture: the wash is meant to be the player's own gif, and the Loom is its floor. */
   const MOVING_RE = /\.(gif|webp)(\?|#|$)/i;
-  async function pickWashUrl(tries = 4) {
+  /** The spiral source for a hold: a `{loom:true,...}` wrapper where the race can draw one,
+   *  and the same url every build has always drawn where it cannot. */
+  const spiralSource = () => (spiralFx && spiralFx.supported() ? pickSpiral() : pickSpiralUrl());
+  /** Paint `src` (a url, or a wrapper) onto a hold. Returns true if a live canvas took it. */
+  function paintSpiral(h, kind, src, durMs) {
+    if (src && typeof src === 'object' && src.loom && spiralFx) {
+      const took = spiralFx.mount(h.el, src, {
+        kind,
+        durMs,
+        // context lost MID-HOLD: the canvas is gone, so the gif takes the element at
+        // once and the screen never goes bare.
+        onLost: () => { if (!disposed && src.href) h.el.style.backgroundImage = `url('${src.href}')`; },
+      });
+      if (took) { h.el.style.backgroundImage = 'none'; return true; }
+    }
+    if (spiralFx) spiralFx.drop(h.el);      // a url is taking this element back
+    const url = src && typeof src === 'object' ? src.href : src;
+    // double quotes: a wash url is a media name, and a media name may carry an apostrophe
+    if (url) h.el.style.backgroundImage = `url("${url}")`;
+    return false;
+  }
+  async function pickWash(tries = 4) {
     let last = null;
     for (let i = 0; i < tries; i++) {
       try {
@@ -118,7 +153,7 @@ export function createPayloadFx({ hud, fx, media, flashBurst, subliminalFx = nul
         if (MOVING_RE.test(String(p.name || '')) || MOVING_RE.test(url)) return url;
       } catch (e) { break; }
     }
-    return last || pickSpiralUrl();
+    return last || spiralSource();
   }
 
   // ---- sustained overlays (spiral / pink / braindrain) -----------------------
@@ -143,11 +178,14 @@ export function createPayloadFx({ hud, fx, media, flashBurst, subliminalFx = nul
   }
 
   function showSpiral(strength, durMult) {
-    const h = holdOn('spiral', 'sf-pfx-spiral', scaleD(0.25, 0.70, strength), scale(1500, 4500, strength) * durMult);
+    const durMs = scale(1500, 4500, strength) * durMult;
+    const h = holdOn('spiral', 'sf-pfx-spiral', scaleD(0.25, 0.70, strength), durMs);
     // Draw from the shared pool (bundled sp1..8 + the player's Loom spirals)
     // instead of the single hardcoded spiral.png in .sf-pfx-spiral - the CSS
     // still owns cover/blend/spin, we only swap the image so in-run spirals vary.
-    h.el.style.backgroundImage = `url('${pickSpiralUrl()}')`;
+    // With a `spiralFx` seam the pick may be a LIVE weave instead of a picture,
+    // and then a canvas takes the element and the CSS spin stands down.
+    paintSpiral(h, 'spiral', spiralSource(), durMs);
   }
   function showPink(strength, durMult) {
     const h = holdOn('pink', 'sf-pfx-pink', scaleD(0.25, 0.70, strength), scale(1500, 4500, strength) * durMult);
@@ -222,17 +260,20 @@ export function createPayloadFx({ hud, fx, media, flashBurst, subliminalFx = nul
   /**
    * THE GIF TAKES THE SCREEN. The same wash `showBraindrain` puts under the glitch, off the leash:
    * NO backdrop blur, NO dark luminosity blend and NO 0.62 ceiling, so the picture is the thing on
-   * the glass rather than a bruise behind one. `pickWashUrl` prefers a moving entry (see above) and
-   * styles.css feathers the edges so the road underneath stays drivable at 0.8.
+   * the glass rather than a bruise behind one. `pickWash` prefers a moving entry (see above) and
+   * styles.css feathers the edges so the road underneath stays drivable at 0.8. With an empty
+   * media pool its floor is a LIVE LOOM SPIRAL where the caller can draw one, and a bundled gif
+   * where it cannot - either way the wash is never a still png.
    *
    * Racing Thoughts is the only caller today (bubbleKinds.js `gifwash`, THE MIX slot 'wash'); the
    * tube deals no bubble that fires it, so nothing dtrh.html draws changes.
    */
   async function showGifWash(strength, durMult) {
-    const h = holdOn('gifwash', 'sf-pfx-gifwash', scaleD(0.55, 0.80, strength), scale(1500, 3000, strength) * durMult);
+    const durMs = scale(1500, 3000, strength) * durMult;
+    const h = holdOn('gifwash', 'sf-pfx-gifwash', scaleD(0.55, 0.80, strength), durMs);
     h.el.classList.add('is-washing');   // the light shudder; race.css drops it under reduced motion
-    const url = await pickWashUrl();
-    if (!disposed && url) h.el.style.backgroundImage = `url("${url}")`;
+    const src = await pickWash();
+    if (!disposed && src) paintSpiral(h, 'gifwash', src, durMs);
   }
 
   /**
@@ -556,6 +597,8 @@ export function createPayloadFx({ hud, fx, media, flashBurst, subliminalFx = nul
     cascades.clear();
     videoCardEl = null;
     videoCardCancel = null;
+    // give every live Loom canvas its GL context back before the holds go with root
+    if (spiralFx) { try { spiralFx.cancel(); } catch (e) { /* best effort */ } }
     root.remove();
     front.remove();
   }

--- a/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
@@ -277,17 +277,28 @@ chapel high-glow log and golden, greyward dim arch, coronation golden and petal.
 `hueCycles: 0` (a race spiral does not rainbow), and, when the road phrase is still echoing, puts
 that word in the centrepiece as a `mantra` - the spiral says what the voice said.
 
+`race/loomSpiralFx.js` mounts it. payloadFx takes an optional `spiralFx` seam (defaults null, the
+same shape as `subliminalFx`); when a weave is picked it mounts a canvas inside the `sf-pfx-spiral`
+hold rather than setting a background-image, inheriting the hold's opacity fade so intensity stays
+one channel, and neutralises only the css the canvas replaces (the 14 s spin, the 1.6 overscan). The
+canvas backing store is capped at 512 px on the long side, 320 px on the touch tier, where it also
+drops layer 2 and the wobble and paces frames at 33 ms. Reduced motion paints one still frame.
+`webglcontextlost`, or no WebGL at all, drops the canvas and paints `href` - the old gif path is the
+floor, not a dead branch. Each mount self-unmounts at `durMs + 700`, so nothing spins behind an
+invisible layer. `gifwash`'s own fallback goes through the same seam, so it gets a weave too.
+
 The bundled gifs still ship as that floor. On the mobile tier `Q.leanSpirals` has run.js narrow the
 module's bundled pool to `LEAN_SPIRALS` (sp6.gif 123 KB + sp7.gif 721 KB; the other five are
 2.2-5.3 MB) with `setBundledSpiralPool` and prefetch both in `prepare()` (while the intro plays;
 `start()` covers `?autostart=1`), so a lap never fetches a spiral mid-run. Desktop keeps the full
 pool and the Descent never calls the setter.
 
-A weave is only params until something draws it; `race/loomSpiralFx.js` and the payloadFx seam
-that mounts it land in the next PR, so until then a picked weave falls to its `href` gif. On the web
-there is no account library (the site Loom is anonymous), so the web gets the race book only. Checks:
-`race/smoke/loom-book-check.mjs` (the book per room, the seed replay, the mantra) and
-`race/smoke/spiral-pool-check.mjs` (the picker mix and the floor under it).
+On the web there is no account library (the site Loom is anonymous), so the web gets the race book
+only; the desktop hand-off that puts the player's own weaves on the road lands in the next PR.
+Checks: `race/smoke/loom-book-check.mjs` (the book per room, the seed replay, the mantra),
+`race/smoke/spiral-pool-check.mjs` (the picker mix and the floor under it) and
+`race/smoke/loom-spiral-check.mjs` (the live canvas in the hold, the backing sizes, the
+lost-context floor, reduced motion, and that a Descent pop is still a url).
 A row may carry `spawn: false`. Video bubbles are dark since 2026-09-06: `rollKind` leaves the row out
 of every pool and `field.spawnAt` returns -1 for it, so no roll, lane line, rain or track cue can put
 one on the road, and `CaucusHostService` refuses a `fire-payload {kind:'video'}` as well. The row, its

--- a/ConditioningControlPanel/Resources/web/dtrh/race/loomSpiralFx.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/loomSpiralFx.js
@@ -1,0 +1,339 @@
+/* ============================================================================
+ * race/loomSpiralFx.js - THE LIVE LOOM ON THE ROAD (race page only).
+ *
+ *   createLoomSpiralFx({ reducedMotion, log }) -> { mount, drop, cancel, dispose, ... }
+ *
+ * WHAT THIS REPLACES. A spiral pop in Racing Thoughts painted one of seven stock
+ * gifs out of assets/bubbles/effects/spirals/ as the background of payloadFx's
+ * `.sf-pfx-spiral` hold - 2-5 MB each, the same seven pictures every run, and
+ * nothing to do with the room the kart was in. The owner's law (2026-08-25):
+ * "on ALL the games the spirals should be generated with the Loom." So the hold
+ * gets a CANVAS instead, and shared/loomField.js draws the spiral live off the
+ * params race/loomBook.js wove for this seed and this room.
+ *
+ * THE PATTERN IS THE ARCADEMY'S, not a new one: arcademy/engine/loomWash.js has
+ * done exactly this inside the spiral wash element since 2026-08-25 (one canvas
+ * child, small backing store, rAF phased by loopMs2, still frame under reduced
+ * motion, gif floor on context loss). This is that manager with the race's own
+ * holds under it - two of them at most (`spiral` and `gifwash`), each with its
+ * own field renderer.
+ *
+ * ONE DIFFERENCE FROM THE WASH, AND IT IS THE POINT. The arcademy mounts the GL
+ * canvas itself, so its spirals can never wear a centrepiece. The race draws
+ * through loomField's own `composeFrame` instead - GL field -> 2D blit ->
+ * centrepiece - because the book puts THE ROAD'S OWN WORD in the middle of the
+ * spiral when the voice has just said one. The cost is one drawImage of a
+ * <=512px surface per frame, which is the same pipeline (and a smaller surface)
+ * than the Loom studio's own live preview.
+ *
+ * THE SEAM. game/payloadFx.js takes an optional `spiralFx` exactly the way it
+ * takes `subliminalFx` (#991), defaulting to null - so the Descent, which
+ * passes nothing, still paints the same gif background it always has and
+ * dtrh.html is byte-for-byte the game it was. race/run.js is the only caller.
+ *
+ * LAYERING CONTRACT (the arcademy law, kept). The canvas gets NO opacity and NO
+ * blend mode of its own: it inherits the HOLD's, so payloadFx's fade stays the
+ * one intensity channel and race.css's `#race-root .sf-pfx-spiral { filter:
+ * opacity(0.78) }`, THE MIX's `data-ov` crossfade and styles.css's
+ * `mix-blend-mode: screen` all land on this layer for free. The spiral hold's
+ * own 14 s CSS spin and its 1.6 overscan are neutralised with INLINE styles
+ * while a canvas is mounted (the shader owns rotation; a CSS spin on top of it
+ * is a second, wrong one) and restored to '' on unmount, so the gif path draws
+ * exactly as before the moment it takes the element back.
+ *
+ * PERF (measured knobs, all in here):
+ *   - backing store 512 long side on desktop, 320 on the mobile tier / a coarse
+ *     pointer, CSS-upscaled to the viewport. The field is analytically
+ *     antialiased (u_px in loomField's shader), so it stays crisp anyway - this
+ *     is the whole reason a canvas beats a 5 MB gif on a phone.
+ *   - 30 fps cap under touch, paced through a timeout so the compositor idles
+ *     between paints (a bare rAF re-arm keeps a display-rate heartbeat alive).
+ *   - layer2 off and wobble flattened under touch: two uniforms the phone does
+ *     not owe. The params are COPIED first - the book's id means "this spiral
+ *     as woven", and must not shift because a phone drew it.
+ *   - the loop stops on document.hidden, and each hold unmounts itself when its
+ *     fade is over (payloadFx hands the hold's duration in), so a spiral that
+ *     is not on the glass costs no GPU at all.
+ *   - REDUCED MOTION draws exactly one frame and never arms the loop.
+ *
+ * THE FLOOR. mount() returns false when WebGL is missing or was lost, and a
+ * context lost mid-hold tears the canvas down and calls back - payloadFx then
+ * paints the wrapper's `href` (a bundled gif) so the screen is never bare.
+ * ==========================================================================*/
+
+import { createFieldRenderer, normalizeParams2, loopMs2, composeFrame } from '../shared/loomField.js';
+import { Q } from '../shared/quality.js';
+
+/** Backing-store long side, by tier. A phone draws under a third of the desktop's pixels. */
+export const BACK_LONG = 512;
+export const BACK_LONG_TOUCH = 320;
+/** 30 fps under touch; the desktop runs at display rate. */
+export const TOUCH_FRAME_MS = 33;
+/** payloadFx's `.sf-pfx-layer` fade is 0.45 s; the canvas outlives the hold by that plus a breath. */
+export const FADE_MS = 700;
+
+/**
+ * The hold styles a live canvas has to neutralise, per payloadFx class. Every
+ * key is restored to '' on unmount, so the element's own CSS takes back over
+ * and the gif path is untouched.
+ *
+ * SPIRAL: styles.css spins the element 14 s per turn and overscans it 1.6x so
+ * the rotation never bares a corner. The shader rotates the field itself and
+ * the canvas is inset:0 - both would be wrong, and the overscan would throw
+ * away a third of the pixels the backing store just paid for.
+ * GIFWASH: only the background. Its `is-washing` shudder is a transform on the
+ * element and reads just as well over a canvas, so it stays.
+ */
+const OVERRIDES = {
+  spiral: { animation: 'none', scale: '1', transform: 'none', backgroundImage: 'none' },
+  gifwash: { backgroundImage: 'none' },
+};
+const DEFAULT_OVERRIDE = { backgroundImage: 'none' };
+
+/** The mobile tier's own stamp, with a coarse pointer as the belt to it. */
+export function isTouchTier() {
+  try { if (Q && Q.tier === 'mobile') return true; } catch (e) { /* fall through */ }
+  try { if (typeof matchMedia === 'function') return !!matchMedia('(pointer: coarse)').matches; } catch (e) { /* fall through */ }
+  return false;
+}
+
+/** The backing store a viewport of w x h wants at this tier: `long` on the long side. */
+export function backingFor(w, h, touch) {
+  const long = touch ? BACK_LONG_TOUCH : BACK_LONG;
+  if (!w || !h) return { w: long, h: long };
+  return w >= h
+    ? { w: long, h: Math.max(64, Math.round((long * h) / w)) }
+    : { w: Math.max(64, Math.round((long * w) / h)), h: long };
+}
+
+/**
+ * One manager for the whole run. `mount` is called by game/payloadFx.js with
+ * the hold element and the wrapper race/loomBook.js (or the player's own saved
+ * sidecar) produced.
+ *
+ * @param {Object} o { reducedMotion?: bool, log?: (msg)=>void }
+ */
+export function createLoomSpiralFx({ reducedMotion = false, log = null } = {}) {
+  const say = typeof log === 'function' ? log : () => {};
+  /** el -> { el, view, ctx, gl canvas, field, q, loop, kind, timer, id, onLost } */
+  const live = new Map();
+  let touch = isTouchTier();
+  let lost = false;          // WebGL refused or a context was lost - latched for the run
+  let disposed = false;
+  let rafId = 0, toId = 0, lastAt = 0;
+  let visWired = false, resizeWired = false;
+  const stats = { mounts: 0, drops: 0, floors: 0, frames: 0 };
+
+  const raf = (fn) => { try { return typeof requestAnimationFrame === 'function' ? requestAnimationFrame(fn) : 0; } catch (e) { return 0; } };
+  const caf = (id) => { try { if (id && typeof cancelAnimationFrame === 'function') cancelAnimationFrame(id); } catch (e) { /* ignore */ } };
+  const hidden = () => { try { return typeof document !== 'undefined' && document.hidden === true; } catch (e) { return false; } };
+
+  function viewport() {
+    let w = 0, h = 0;
+    try { w = Number(window.innerWidth) || 0; h = Number(window.innerHeight) || 0; } catch (e) { /* none */ }
+    return backingFor(w, h, touch);
+  }
+  function sizeRec(rec) {
+    const b = viewport();
+    if (rec.view.width !== b.w || rec.view.height !== b.h) {
+      rec.view.width = b.w; rec.view.height = b.h;
+      rec.gl.width = b.w; rec.gl.height = b.h;
+      return true;
+    }
+    return false;
+  }
+  function onResize() {
+    if (disposed) return;
+    for (const rec of live.values()) { if (sizeRec(rec) && reducedMotion) drawOne(rec, 0); }
+  }
+  function onVisibility() { if (disposed) return; if (hidden()) halt(); else arm(); }
+
+  /** Under touch, the second layer and the wobble come off. The caller's params
+   *  are never mutated: the id was hashed off the spiral AS WOVEN. */
+  function tuneFor(params) {
+    const base = normalizeParams2(params);
+    if (!touch) return base;
+    const t = normalizeParams2(base);     // a fresh deep copy through the normalizer
+    t.layer2.enabled = false;
+    t.wobble.amp = 0;
+    return t;
+  }
+
+  function halt() { caf(rafId); rafId = 0; if (toId) { clearTimeout(toId); toId = 0; } }
+  function arm() {
+    // reduced motion draws its one frame at mount and never loops
+    if (disposed || lost || reducedMotion || rafId || toId || !live.size || hidden()) return;
+    rafId = raf(frame);
+  }
+  function drawOne(rec, phase) {
+    try { composeFrame(rec.ctx, rec.field, rec.q, phase, rec.view.width, rec.view.height); stats.frames++; return true; }
+    catch (e) { say('race loom render threw (' + ((e && e.message) || e) + ') - the gif takes the layer'); fail(rec); return false; }
+  }
+  function frame(now) {
+    rafId = 0;
+    if (disposed || lost || !live.size || hidden()) return;
+    const t = Number.isFinite(now) ? now : Date.now();
+    if (touch && t - lastAt < TOUCH_FRAME_MS - 1) {
+      toId = setTimeout(() => { toId = 0; rafId = raf(frame); }, TOUCH_FRAME_MS);
+      return;
+    }
+    lastAt = t;
+    for (const rec of [...live.values()]) { if (!drawOne(rec, (t % rec.loop) / rec.loop)) return; }
+    rafId = raf(frame);
+  }
+
+  /** Context lost, or a render threw: latch, tear this hold down, tell the caller. */
+  function fail(rec) {
+    lost = true;
+    const back = rec && rec.onLost;
+    dropRec(rec);
+    stats.floors++;
+    if (typeof back === 'function') { try { back(); } catch (e) { /* ignore */ } }
+  }
+
+  function applyOverrides(el, kind) {
+    const map = OVERRIDES[kind] || DEFAULT_OVERRIDE;
+    for (const k of Object.keys(map)) { try { el.style[k] = map[k]; } catch (e) { /* ignore */ } }
+  }
+  function restoreOverrides(el, kind) {
+    const map = OVERRIDES[kind] || DEFAULT_OVERRIDE;
+    for (const k of Object.keys(map)) { try { el.style[k] = ''; } catch (e) { /* ignore */ } }
+  }
+
+  /** Take one hold's canvas off: free the context, remove the node, give the element back. */
+  function dropRec(rec) {
+    if (!rec || !live.has(rec.el)) return;
+    if (rec.timer) { clearTimeout(rec.timer); rec.timer = 0; }
+    live.delete(rec.el);
+    try {
+      const g = rec.field && rec.field.gl;
+      const ext = g && g.getExtension ? g.getExtension('WEBGL_lose_context') : null;
+      if (ext && typeof ext.loseContext === 'function') ext.loseContext();
+    } catch (e) { /* ignore */ }
+    try { rec.gl.removeEventListener('webglcontextlost', rec.onContextLost); } catch (e) { /* ignore */ }
+    try { rec.view.remove(); } catch (e) { /* ignore */ }
+    restoreOverrides(rec.el, rec.kind);
+    stats.drops++;
+    if (!live.size) halt();
+  }
+
+  /** Build the pair of canvases for one hold, or null if WebGL will not have us. */
+  function makeRec(el, kind) {
+    const view = document.createElement('canvas');
+    view.className = 'rh-loom-spiral';
+    const s = view.style;
+    s.position = 'absolute'; s.left = '0'; s.top = '0';
+    s.width = '100%'; s.height = '100%';
+    s.display = 'block'; s.pointerEvents = 'none';
+    const gl = document.createElement('canvas');     // the field's own surface, never in the DOM
+    const rec = { el, view, gl, ctx: null, field: null, kind, q: null, loop: 3600, timer: 0, id: '', onLost: null, onContextLost: null };
+    sizeRec(rec);
+    rec.ctx = view.getContext('2d');
+    if (!rec.ctx) return null;
+    rec.field = createFieldRenderer(gl);
+    if (!rec.field) return null;
+    rec.onContextLost = (ev) => {
+      try { if (ev && typeof ev.preventDefault === 'function') ev.preventDefault(); } catch (e) { /* ignore */ }
+      say('race loom: webgl context lost - the gif takes the layer');
+      fail(rec);
+    };
+    gl.addEventListener('webglcontextlost', rec.onContextLost, false);
+    return rec;
+  }
+
+  const api = {
+    /** False once WebGL has refused or been lost: payloadFx stops asking. */
+    supported() { return !disposed && !lost; },
+
+    /**
+     * Put a live Loom spiral on this hold.
+     * @param {Element} el   the payloadFx hold (`.sf-pfx-spiral` / `.sf-pfx-gifwash`)
+     * @param {Object} wrap  { loom:true, params, id?, href? }
+     * @param {Object} [opt] { kind?: 'spiral'|'gifwash', durMs?: how long the hold is up,
+     *                         onLost?: () => void (paint the gif floor) }
+     * @returns {boolean} true = the canvas has the element; false = paint the gif.
+     */
+    mount(el, wrap, opt = {}) {
+      if (disposed || lost) return false;
+      if (!el || !wrap || !wrap.params) return false;
+      if (typeof document === 'undefined' || !document.createElement) return false;
+      const kind = String(opt.kind || 'spiral');
+      const durMs = Number(opt.durMs) > 0 ? Number(opt.durMs) : 3000;
+      touch = isTouchTier();
+      let rec = live.get(el);
+      if (rec && rec.kind !== kind) { dropRec(rec); rec = null; }
+      if (!rec) {
+        try {
+          rec = makeRec(el, kind);
+          if (!rec) { lost = true; stats.floors++; return false; }
+          el.appendChild(rec.view);
+          live.set(el, rec);
+          if (!resizeWired) { try { window.addEventListener('resize', onResize); resizeWired = true; } catch (e) { /* ignore */ } }
+          if (!visWired) { try { document.addEventListener('visibilitychange', onVisibility); visWired = true; } catch (e) { /* ignore */ } }
+        } catch (e) {
+          say('race loom mount threw (' + ((e && e.message) || e) + ') - the gif takes the layer');
+          lost = true; stats.floors++;
+          return false;
+        }
+      } else {
+        sizeRec(rec);          // a viewport flip between pops
+      }
+      stats.mounts++;
+      rec.onLost = typeof opt.onLost === 'function' ? opt.onLost : null;
+      rec.q = tuneFor(wrap.params);
+      rec.loop = Math.max(400, loopMs2(rec.q));
+      rec.id = String(wrap.id || '');
+      applyOverrides(el, kind);
+      if (!drawOne(rec, 0)) return false;     // the first frame threw and took the hold down
+      // THE HOLD OWNS THE CLOCK. payloadFx fades the layer out after durMs; the
+      // canvas follows it off the element one fade later, so nothing spins
+      // behind an invisible layer and the next pop builds a fresh one.
+      if (rec.timer) clearTimeout(rec.timer);
+      rec.timer = setTimeout(() => { rec.timer = 0; if (!disposed) dropRec(rec); }, durMs + FADE_MS);
+      arm();
+      return true;
+    },
+
+    /** Give this hold back to the gif path (a url was drawn for it). */
+    drop(el) { dropRec(live.get(el)); },
+
+    /** Run end / room arrival: take every canvas off at once (payloadFx cancelHeavy). */
+    cancel() { for (const rec of [...live.values()]) dropRec(rec); },
+
+    dispose() {
+      if (disposed) return;
+      disposed = true;
+      for (const rec of [...live.values()]) dropRec(rec);
+      halt();
+      if (resizeWired) { try { window.removeEventListener('resize', onResize); } catch (e) { /* ignore */ } resizeWired = false; }
+      if (visWired) { try { document.removeEventListener('visibilitychange', onVisibility); } catch (e) { /* ignore */ } visWired = false; }
+    },
+
+    /** SMOKE / RIG ONLY. Pretend the context went on every live hold: the same path a real
+     *  `webglcontextlost` takes, so race/smoke/loom-spiral-check.mjs can prove the gif floor
+     *  without a driver reset. Returns how many holds were dropped. */
+    loseContext() {
+      const recs = [...live.values()];
+      for (const rec of recs) {
+        try { rec.gl.dispatchEvent(new Event('webglcontextlost')); }
+        catch (e) { fail(rec); }
+      }
+      return recs.length;
+    },
+
+    /** race/smoke/loom-spiral-check.mjs + the shot harness: what is on the glass. */
+    diagnostics() {
+      const holds = [...live.values()].map((r) => ({
+        kind: r.kind, id: r.id, loopMs: r.loop,
+        backing: r.view.width + 'x' + r.view.height,
+        mounted: r.view.parentNode === r.el,
+      }));
+      return { holds, touch, lost, disposed, still: !!reducedMotion, ...stats };
+    },
+  };
+  return api;
+}
+
+export default createLoomSpiralFx;
+
+// self-check: node --check is the bar; every line of this touches the DOM or WebGL.

--- a/ConditioningControlPanel/Resources/web/dtrh/race/run.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/run.js
@@ -56,7 +56,9 @@ import { Q } from '../shared/quality.js';
 import { createTunnel, FOG_DENSITY } from '../engine/tunnel.js';
 import { createFx } from '../engine/fx.js';
 import { createPayloadFx } from '../game/payloadFx.js';
-import { setBundledSpiralPool, prefetchSpirals, LEAN_SPIRALS } from '../engine/loomSpirals.js';
+import { setBundledSpiralPool, prefetchSpirals, setLoomBook, LEAN_SPIRALS } from '../engine/loomSpirals.js';
+import { createLoomBook } from './loomBook.js';
+import { createLoomSpiralFx } from './loomSpiralFx.js';
 import { createScreenShake } from '../game/screenShake.js';
 import { INTENSITY_RAMP_SEC, TREATS_ONLY_SEC, KART_BASE_SPEED, MULT_LADDER, COMBO_HOLD_SEC, makeRng } from './consts.js';
 import { createPace } from './pace.js';
@@ -261,10 +263,24 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1, onExi
     return text;
   }
   const fxProxy ={ pulseFlash: (a) => { if (W) W.fx.pulseFlash(a); } };   // fx is rebuilt on "again"
+  // OUR OWN SPIRALS (race/loomBook.js + race/loomSpiralFx.js). The owner's law is that every
+  // game's spirals come out of the Loom, so a spiral pop is WOVEN for this seed and this room
+  // and drawn live on a canvas inside payloadFx's hold - not one of seven stock gifs. The book
+  // reads the live room and the road's last phrase off this closure, so the picker downstream
+  // (engine/loomSpirals.js pickSpiral) never has to know what a room is.
+  const loomBook = createLoomBook({
+    seed,
+    room: () => (S.room && S.room.id) || '',
+    // the phrase the voice just said, while it is still worth echoing - the spiral wears it
+    word: () => (S.elapsed - echoAt <= ECHO_SEC ? echoWord : ''),
+  });
+  setLoomBook(loomBook.draw);
+  const spiralFx = createLoomSpiralFx({ reducedMotion, log: bridge.log });
   const payloadFx = createPayloadFx({ hud: sfHud, fx: fxProxy, media,
-    subliminalFx: subl ? ({ text }) => subl.show({ text }) : null });
-  // Q.leanSpirals (mobile): spiral pops draw from the two lightest bundled gifs, fetched while the intro plays
-  // (warmFx) rather than 2-5 MB mid-lap; the desktop pool and the Loom's own spirals are untouched
+    subliminalFx: subl ? ({ text }) => subl.show({ text }) : null, spiralFx });
+  // Q.leanSpirals (mobile): the GIF FLOOR under a live spiral (and the wash's own fallback) draws
+  // from the two lightest bundled gifs, fetched while the intro plays (warmFx) rather than 2-5 MB
+  // mid-lap. With WebGL up nothing here is ever fetched at all; this is what a lost context lands on.
   setBundledSpiralPool(Q.leanSpirals ? LEAN_SPIRALS : null);
   let fxWarm = false;
   function warmFx() { if (fxWarm || !Q.leanSpirals) return; fxWarm = true; prefetchSpirals(LEAN_SPIRALS); }
@@ -370,6 +386,9 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1, onExi
     mix.reset(); PACE.reset(); S.wobble = 0; clearMixChrome(); sync.reset(); wordOf.clear(); lineGot.clear(); lineDone.clear();
     wordyRows.clear(); lastFlashAt = -1e9; flashStats.pops = 0; flashStats.capped = 0; flashStats.rolls = 0; flashStats.flashes = 0;
     echoWord = ''; echoAt = -1e9; if (subl) subl.clear();   // "again" starts with nothing said and a clear glass
+    // the spiral book is the run's, not the page's: "again" on the same seed weaves the same
+    // spirals in the same order, and a new seed opens a new book (race/loomBook.js)
+    loomBook.reseed(runSeed); spiralFx.cancel();
     fxFired.clear();
     hud.setScore(0); hud.setCombo(0, 1); hud.setBank(0); hud.setSpeed(0); hud.setFraught(0); hud.passiveClear(); TR.gild(0);
   }
@@ -1059,6 +1078,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1, onExi
     teardown();
     audio.dispose();
     input.dispose(); hud.dispose(); if (captions) captions.dispose(); if (subl) subl.dispose(); shutter.dispose(); shake.dispose(); payloadFx.dispose(); speedFx.dispose(); lane.dispose();
+    setLoomBook(null); spiralFx.dispose();   // the page may go back to the menu: leave no weaver and no GL context behind
     pixel.dispose();
     scene.clear(); renderer.dispose();
   }
@@ -1133,6 +1153,15 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1, onExi
     },
     /** race/smoke/subliminal-check.mjs: how many cards were painted and how many the queue held. */
     subliminalStats: () => (subl ? subl.stats() : null),
+    /** race/smoke/loom-spiral-check.mjs + the shot harness: the live Loom canvases, and a way to
+     *  ask the book for one spiral by hand (a named room, a chosen phrase) without a world under it. */
+    loom: {
+      stats: () => spiralFx.diagnostics(),
+      draw: (o) => loomBook.draw(o || {}),
+      count: () => loomBook.count(),
+      /** Pretend the context went: the gif floor takes every hold from here on. */
+      breakGl: () => spiralFx.loseContext(),
+    },
     /** Which half of race/captions.js is driving the band on this build: 'flash' or 'type'. */
     capMode: () => CAP_MODE,
     /** THE SYNC WIN, for race/smoke/wsync-check.mjs: the log rows, the offset, a nudge, the export. */

--- a/ConditioningControlPanel/Resources/web/dtrh/race/smoke/loom-spiral-check.mjs
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/smoke/loom-spiral-check.mjs
@@ -1,0 +1,267 @@
+/* ============================================================================
+ * race/smoke/loom-spiral-check.mjs - OUR OWN SPIRALS, on the glass.
+ *
+ *   node race/smoke/loom-spiral-check.mjs      (from Resources/web/dtrh; 0 on pass)
+ *
+ * The book itself is race/smoke/loom-book-check.mjs, which needs only node.
+ * This one drives a headless browser through a real run, because the things
+ * this change can get wrong that no unit test sees are "the canvas never
+ * reached the hold", "it is a 4K backing store on a phone", "it is still
+ * spinning a minute after the pop", "a lost context leaves the screen bare" and
+ * "reduced motion got an animation anyway". It also fires a DtRH-shaped spiral
+ * on a payloadFx built WITHOUT the seam, which is the guard that the Descent
+ * still paints a gif background and nothing else.
+ *
+ * CHROME: `CHROME_PATH` if it is set, else the usual Windows install.
+ * ==========================================================================*/
+
+import { spawn } from 'node:child_process';
+import { createServer } from 'node:http';
+import { readFile } from 'node:fs/promises';
+import { readFileSync, mkdtempSync, rmSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, extname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = resolve(fileURLToPath(import.meta.url), '..');
+const RACE = resolve(HERE, '..');
+const DTRH = resolve(RACE, '..');
+const WEB = resolve(DTRH, '..');                        // Resources/web
+
+let fails = 0;
+const ok = (cond, what) => { if (!cond) { console.error('FAIL ' + what); fails++; } else console.log('  ok  ' + what); };
+const eq = (got, want, what) => ok(got === want, what + ' (got ' + JSON.stringify(got) + ', want ' + JSON.stringify(want) + ')');
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+{
+  // the seams are the race's alone: nothing in game/ reaches for the race's files
+  const pfx = readFileSync(resolve(DTRH, 'game/payloadFx.js'), 'utf8');
+  const run = readFileSync(resolve(RACE, 'run.js'), 'utf8');
+  ok(/spiralFx\s*=\s*null/.test(pfx), 'payloadFx defaults the seam to null, so the Descent keeps its gif');
+  ok(!/from\s+'\.\.\/race\//.test(pfx), 'and game/payloadFx.js imports nothing out of race/');
+  ok(/spiralFx\s*\}\)/.test(run) || /spiralFx\s*[,}]/.test(run), 'run.js is the caller that passes one');
+  ok(/setLoomBook\(null\)/.test(run), 'and takes the book away again on dispose');
+}
+console.log('');
+console.log('');
+
+/* ============================================================================
+ * the browser
+ * ==========================================================================*/
+const CHROME = process.env.CHROME_PATH || 'C:/Program Files/Google/Chrome/Application/chrome.exe';
+const PORT = 8878, DEBUG_PORT = 9348;
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.mjs': 'text/javascript', '.css': 'text/css', '.json': 'application/json', '.glb': 'model/gltf-binary', '.png': 'image/png', '.webp': 'image/webp', '.jpg': 'image/jpeg', '.gif': 'image/gif', '.mp3': 'audio/mpeg', '.wav': 'audio/wav', '.svg': 'image/svg+xml', '.woff2': 'font/woff2' };
+
+if (!existsSync(CHROME)) { console.error('FAIL no chrome at ' + CHROME + ' (set CHROME_PATH)'); process.exit(1); }
+const server = createServer(async (req, res) => {
+  const path = decodeURIComponent(new URL(req.url, 'http://x').pathname);
+  if (path.indexOf('..') >= 0) { res.writeHead(400); return res.end(); }
+  try {
+    const body = await readFile(join(WEB, path));
+    res.writeHead(200, { 'content-type': MIME[extname(path).toLowerCase()] || 'application/octet-stream' });
+    res.end(req.method === 'HEAD' ? undefined : body);
+  } catch (e) { res.writeHead(404, { 'content-type': 'text/plain' }); res.end('no'); }
+});
+await new Promise((r) => server.listen(PORT, '127.0.0.1', r));
+
+const prof = mkdtempSync(join(tmpdir(), 'race-loom-'));
+const chrome = spawn(CHROME, [
+  '--headless=new', `--remote-debugging-port=${DEBUG_PORT}`, `--user-data-dir=${prof}`,
+  '--no-first-run', '--no-default-browser-check', '--disable-gpu', '--mute-audio',
+  '--enable-unsafe-swiftshader', '--autoplay-policy=no-user-gesture-required',
+  '--window-size=1280,720', 'about:blank',
+], { stdio: 'ignore' });
+
+let page = null;
+for (let i = 0; i < 60 && !page; i++) {
+  await sleep(250);
+  try { page = (await (await fetch(`http://127.0.0.1:${DEBUG_PORT}/json/list`)).json()).find((t) => t.type === 'page'); } catch (e) { /* not up */ }
+}
+if (!page) { console.error('FAIL chrome never answered on the debug port'); await done(1); }
+
+const ws = new WebSocket(page.webSocketDebuggerUrl);
+await new Promise((r) => { ws.onopen = r; });
+let msgId = 0;
+const waits = new Map(), errs = [];
+ws.onmessage = (e) => {
+  const m = JSON.parse(e.data);
+  if (m.id && waits.has(m.id)) { waits.get(m.id)(m); waits.delete(m.id); }
+  if (m.method === 'Runtime.exceptionThrown') errs.push('thrown: ' + (m.params.exceptionDetails?.exception?.description || m.params.exceptionDetails?.text || '?'));
+  if (m.method === 'Runtime.consoleAPICalled' && m.params.type === 'error') errs.push(m.params.args.map((a) => a.value ?? a.description ?? '?').join(' '));
+};
+const cdp = (method, params) => new Promise((res) => { const i = ++msgId; waits.set(i, res); ws.send(JSON.stringify({ id: i, method, params })); });
+const ev = async (x) => (await cdp('Runtime.evaluate', { expression: x, returnByValue: true, awaitPromise: true })).result?.result?.value;
+const json = async (x) => JSON.parse(await ev(`JSON.stringify(${x})`));
+/** For an expression that ALREADY returns a JSON string (the async readers below): a promise
+ *  has to be awaited BEFORE it is stringified, or JSON.stringify just writes "{}". */
+const parse = async (x) => JSON.parse(await ev(x));
+await cdp('Runtime.enable'); await cdp('Page.enable');
+await cdp('Emulation.setDeviceMetricsOverride', { width: 1280, height: 720, deviceScaleFactor: 1, mobile: false });
+
+const site = `http://127.0.0.1:${PORT}`;
+await cdp('Page.navigate', { url: `${site}/dtrh/race.html?autostart=1&intro=0&cards=0` });
+let up = false;
+for (let i = 0; i < 120 && !up; i++) {
+  await sleep(250);
+  up = await ev(`!!(window.__race && window.__race.race && window.__race.race.perf().running)`);
+}
+ok(up, 'the page boots and the run is going');
+if (!up) { if (errs.length) console.error('    said: ' + errs.slice(0, 6).join(' | ')); await done(1); }
+
+/** What is inside the spiral hold right now. */
+const HOLD = `(() => {
+  const el = document.querySelector('.sf-pfx-spiral');
+  if (!el) return JSON.stringify({ there: false });
+  const c = el.querySelector('canvas.rh-loom-spiral');
+  const cs = getComputedStyle(el);
+  return JSON.stringify({ there: true, canvas: !!c, canvases: document.querySelectorAll('canvas.rh-loom-spiral').length,
+    w: c ? c.width : 0, h: c ? c.height : 0, cw: c ? Math.round(c.getBoundingClientRect().width) : 0,
+    bg: cs.backgroundImage, anim: cs.animationName, blend: cs.mixBlendMode,
+    op: cs.opacity, canvasOp: c ? getComputedStyle(c).opacity : null, canvasBlend: c ? getComputedStyle(c).mixBlendMode : null });
+})()`;
+
+/* ============================================================================
+ * 2. a spiral pop mounts a live canvas in the hold
+ * ==========================================================================*/
+ok(await ev(`window.__race.race.debugPayload('overlay', { overlay: 'spiral', strength: 70 })`), 'a spiral payload fires');
+await sleep(300);
+let h = JSON.parse(await ev(HOLD));
+ok(h.there && h.canvas, 'a live Loom canvas is inside .sf-pfx-spiral');
+eq(h.canvases, 1, 'exactly one, ever');
+ok(Math.max(h.w, h.h) <= 512, `the backing store is ${h.w}x${h.h}, at or under the 512 long side`);
+ok(h.cw >= 1200, `and it is CSS-stretched to the full ${h.cw}px of glass`);
+eq(h.bg, 'none', 'the gif background stood down');
+eq(h.anim, 'none', "and so did the element's own 14s CSS spin (the shader owns rotation)");
+eq(h.blend, 'screen', 'the hold keeps its screen blend, which the canvas inherits');
+eq(h.canvasOp, '1', 'the canvas has no opacity of its own: the hold is the one intensity channel');
+eq(h.canvasBlend, 'normal', 'and no blend mode of its own either');
+const diag = await json(`window.__race.race.loom.stats()`);
+ok(diag.holds.length === 1 && /^loom:[0-9a-f]{8}$/.test(diag.holds[0].id), `the hold names the weave it is drawing (${diag.holds[0].id})`);
+ok(diag.frames > 1, `and it is animating (${diag.frames} frames so far)`);
+
+/* ============================================================================
+ * 3. it lets go: the canvas is gone once the hold is over
+ * ==========================================================================*/
+{
+  const before = (await json(`window.__race.race.loom.stats()`)).frames;
+  await sleep(1200);
+  const mid = (await json(`window.__race.race.loom.stats()`)).frames;
+  ok(mid > before, 'it keeps drawing while the hold is up');
+}
+// a strength-70 spiral holds ~3.6 s, plus payloadFx's 0.45 s fade and the manager's breath
+await sleep(4200);
+h = JSON.parse(await ev(HOLD));
+ok(!h.canvas, 'the canvas is off the element once the hold has faded');
+eq(h.canvases, 0, 'nothing is left in the page');
+eq(h.anim, 'sf-pfx-spin', 'and the element has its own CSS spin back for the gif path');
+{
+  const after = (await json(`window.__race.race.loom.stats()`)).frames;
+  await sleep(500);
+  eq((await json(`window.__race.race.loom.stats()`)).frames, after, 'and nothing is still drawing behind an invisible layer');
+}
+
+/* ============================================================================
+ * 4. reduced motion: one frame, no loop
+ * ==========================================================================*/
+{
+  await ev(`window.__race.race.dispose && 0`);   // no-op: keep the run, only the media query changes
+  await cdp('Emulation.setEmulatedMedia', { features: [{ name: 'prefers-reduced-motion', value: 'reduce' }] });
+  // the run built its manager with the run's own reducedMotion, so this half is asserted on a
+  // fresh manager the page makes for us - the same file, the same flag, no second run
+  const rm = await parse(`(async () => {
+    const m = await import('/dtrh/race/loomSpiralFx.js');
+    const b = await import('/dtrh/race/loomBook.js');
+    const fx = m.createLoomSpiralFx({ reducedMotion: true });
+    const el = document.createElement('div');
+    el.className = 'sf-pfx-layer sf-pfx-spiral rh-loom-probe';
+    document.querySelector('.sf-pfx').appendChild(el);
+    const wrap = b.createLoomBook({ seed: 5 }).draw({ room: 'chapel' });
+    const took = fx.mount(el, wrap, { kind: 'spiral', durMs: 4000 });
+    const first = fx.diagnostics().frames;
+    const size = fx.diagnostics().holds[0] ? fx.diagnostics().holds[0].backing : null;
+    await new Promise((r) => setTimeout(r, 600));
+    const later = fx.diagnostics().frames;
+    fx.dispose(); el.remove();
+    return JSON.stringify({ took, first, later, size });
+  })()`);
+  ok(rm.took, 'reduced motion still mounts a canvas');
+  eq(rm.first, 1, 'and draws exactly one frame');
+  eq(rm.later, 1, 'and never arms the loop');
+  ok(rm.size, `at ${rm.size}`);
+  await cdp('Emulation.setEmulatedMedia', { features: [] });
+}
+
+/* ============================================================================
+ * 5. the WebGL floor: a lost context paints a gif
+ * ==========================================================================*/
+await ev(`window.__race.race.debugPayload('overlay', { overlay: 'spiral', strength: 70 })`);
+await sleep(250);
+ok(JSON.parse(await ev(HOLD)).canvas, 'a fresh pop is live again');
+eq(await ev(`window.__race.race.loom.breakGl()`), 1, 'the context goes');
+await sleep(120);
+h = JSON.parse(await ev(HOLD));
+ok(!h.canvas, 'the canvas came off with it');
+ok(/url\(.*(gif|webp)/.test(h.bg), `and the hold is painting a gif instead (${h.bg.slice(0, 70)})`);
+eq(h.anim, 'sf-pfx-spin', 'with the element spinning it, exactly as it always did');
+ok((await json(`window.__race.race.loom.stats()`)).lost === true, 'the manager latched the loss');
+// and it stays on the gif: no more canvases after a loss
+await ev(`window.__race.race.debugPayload('overlay', { overlay: 'spiral', strength: 70 })`);
+await sleep(250);
+eq(JSON.parse(await ev(HOLD)).canvases, 0, 'every pop after a loss is a gif, with no retry storm');
+
+/* ============================================================================
+ * 6. the Descent is untouched: no seam, no canvas, a background url
+ * ==========================================================================*/
+{
+  const tube = await parse(`(async () => {
+    const m = await import('/dtrh/game/payloadFx.js');
+    const hud = document.createElement('div');
+    hud.style.cssText = 'position:fixed;inset:0;pointer-events:none;opacity:0';
+    document.body.appendChild(hud);
+    const pfx = m.createPayloadFx({ hud, fx: { pulseFlash() {} }, media: null, flashBurst: null });
+    pfx.applyPayload({ payload: { kind: 'overlay', overlay: 'spiral' }, strength: 60 }, {});
+    await new Promise((r) => setTimeout(r, 60));
+    const el = hud.querySelector('.sf-pfx-spiral');
+    const cs = el ? getComputedStyle(el) : null;
+    const got = { there: !!el, canvas: el ? !!el.querySelector('canvas') : null,
+      bg: cs ? cs.backgroundImage : null, anim: cs ? cs.animationName : null, scale: cs ? cs.scale : null };
+    pfx.dispose(); hud.remove();
+    return JSON.stringify(got);
+  })()`);
+  ok(tube.there, 'a payloadFx with no seam still makes the spiral hold');
+  eq(tube.canvas, false, 'and puts NO canvas in it');
+  ok(/url\(/.test(String(tube.bg)), `it paints a background url, the way dtrh.html always has (${String(tube.bg).slice(0, 60)})`);
+  eq(tube.anim, 'sf-pfx-spin', "with the element's own spin");
+  eq(tube.scale, '1.6', 'and its own 1.6 overscan');
+}
+
+/* ============================================================================
+ * 7. a phone: the small backing store
+ * ==========================================================================*/
+{
+  const phone = await parse(`(async () => {
+    const m = await import('/dtrh/race/loomSpiralFx.js');
+    return JSON.stringify({ desk: m.backingFor(1280, 720, false), touch: m.backingFor(390, 844, true), cap: m.TOUCH_FRAME_MS });
+  })()`);
+  ok(Math.max(phone.desk.w, phone.desk.h) === 512, `a 1280x720 desktop draws ${phone.desk.w}x${phone.desk.h}`);
+  ok(Math.max(phone.touch.w, phone.touch.h) === 320, `a 390x844 phone draws ${phone.touch.w}x${phone.touch.h}`);
+  eq(phone.cap, 33, 'and paces itself at 30 fps under touch');
+}
+
+/* ============================================================================
+ * 8. and nothing said a word about it
+ * ==========================================================================*/
+ok(errs.length === 0, 'not one console error in the whole run' + (errs.length ? ':\n    ' + errs.slice(0, 5).join('\n    ') : ''));
+
+await done(fails ? 1 : 0);
+
+async function done(code) {
+  try { ws && ws.close(); } catch (e) { /* never opened */ }
+  try { chrome.kill(); } catch (e) { /* already gone */ }
+  await new Promise((r) => server.close(r));
+  await sleep(300);
+  try { rmSync(prof, { recursive: true, force: true }); } catch (e) { /* chrome still has a lock */ }
+  if (code) console.error(`\n${fails} failure${fails === 1 ? '' : 's'}`);
+  else console.log('\nloom-spiral-check: all good');
+  process.exit(code);
+}


### PR DESCRIPTION
Second of three. #1008 built the book; this draws it.

### what draws now vs before

Before: a `spiral` pop set `background-image` on `.sf-pfx-spiral` to a stock gif, and the element's own CSS spun it (`sf-pfx-spin`, 14 s) at `scale 1.6`.

Now, in the race only: the pop mounts a **live Loom canvas** in that same hold and the shader owns the rotation. The player's own weave, or one the race wove for the room they are in, over the road - not a shipped picture.

`game/payloadFx.js` takes an optional `spiralFx` seam, the same shape as the `subliminalFx` one from #991 and defaulting to `null`. No seam, no canvas: the descent paints the same url with the same spin and the same overscan it always has, and the smoke asserts exactly that against a seam-less `payloadFx` built on the same page.

`gifwash`'s own fallback goes through the same seam, so it gets a weave too.

### how it renders (and why not the way the Arcademy does it)

`arcademy/engine/loomWash.js` mounts the GL canvas straight into the wash. The race cannot: `createFieldRenderer`'s shader draws the **field only** - the centrepiece is drawn by `composeFrame`, on a 2D context, after the field. Mounting GL directly would mean the road's popped word could never sit in the middle of the spiral, which is the best thing the book does. So `race/loomSpiralFx.js` keeps a **detached** GL canvas for the field and draws through `composeFrame` onto a small 2D canvas on the glass. The cost is one `drawImage` of a <= 512 px surface per frame.

`shared/loomField.js` is imported directly - nothing is vendored from the Arcademy. (Diffed: `arcademy/engine/loom/loomField.js` is byte-identical to `shared/loomField.js` apart from a four-line vendor header.)

### perf numbers

| tier | canvas backing | fps cap | layers |
|---|---|---|---|
| desktop 1280x720 | **512x288** (512 long side) | rAF, uncapped | field + layer 2 + wobble |
| touch 390x844 | **148x320** (320 long side) | **33 ms** paced (~30 fps) | layer 2 off, wobble 0 |
| reduced motion | same as tier | **one frame**, loop never armed | as tier |

Both measured in the headless check, not guessed. The canvas is CSS-stretched to the full glass, so the backing store is the only thing that scales.

### the floors, and the lifecycle

- the canvas inherits the hold's opacity fade and gets no opacity or blend of its own, so intensity stays one channel.
- only the CSS the canvas replaces is switched off while it is up (the 14 s spin, the 1.6 overscan), restored to `''` after; the gifwash shudder and masks stay.
- `webglcontextlost`, or no WebGL at all, drops the canvas and paints the weave's `href` gif with the element spinning it - the old path is the floor, not a dead branch - and latches, so there is no retry storm on the pops after.
- every mount self-unmounts at `durMs + 700`, so nothing draws behind an invisible layer; `run.js` cancels on run reset and drops the book and the manager on dispose.
- `document.hidden` pauses the loop.

### how verified

- `node race/smoke/loom-spiral-check.mjs` (new, headless chrome through a real run): a pop puts exactly one canvas in `.sf-pfx-spiral`, the backing store is within the cap, the gif background stood down and so did the element's spin, the hold keeps its screen blend, the canvas is gone after the hold and stops drawing, reduced motion draws exactly one frame, a lost context paints a gif and every pop after it is a gif, a seam-less `payloadFx` still paints a url with `sf-pfx-spin` and `scale 1.6`, phone backing and the 33 ms pace, **zero console errors**.
- `loom-book-check.mjs` + `spiral-pool-check.mjs` still green.
- headless shots at 1280x720 and 390x844 of a live weave over the road at peak, a contact sheet of all eight room palettes over the same road, and a descent pop for the before/after.

```
 .../Resources/web/dtrh/game/payloadFx.js           |  67 +++-
 .../Resources/web/dtrh/race/CONTRACT.md            |  21 +-
 .../Resources/web/dtrh/race/loomSpiralFx.js        | 339 +++++++++++++++++++++
 .../Resources/web/dtrh/race/run.js                 |  37 ++-
 .../web/dtrh/race/smoke/loom-spiral-check.mjs      | 267 ++++++++++++++++
 5 files changed, 710 insertions(+), 21 deletions(-)
```

Over the ~600 cap by 110, and 267 of the 710 are the headless check - the code half is 443. Splitting the test off from the thing it tests seemed worse than the overrun; say the word and I will.

Stack: #1008 -> **this** -> `feat/race-loom-library`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013T1bb13w97ndYjNveiFpLz
