### PR TITLE
feat(race): the player's own woven spirals reach the road

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
@@ -293,8 +293,11 @@ module's bundled pool to `LEAN_SPIRALS` (sp6.gif 123 KB + sp7.gif 721 KB; the ot
 `start()` covers `?autostart=1`), so a lap never fetches a spiral mid-run. Desktop keeps the full
 pool and the Descent never calls the setter.
 
-On the web there is no account library (the site Loom is anonymous), so the web gets the race book
-only; the desktop hand-off that puts the player's own weaves on the road lands in the next PR.
+On the desktop `raceBoot.js` answers the host's `loom-list` the way `boot.js` does and
+`CaucusHostService` posts it on ready and again on every `DtrhLoomStore.Changed`, so a spiral woven
+in the Boudoir mid-session is on the road at the next pop. An entry with a `params` sidecar is
+woven live; one without is still its gif, so nothing fetches multiple MB mid-lap. On the web there
+is no account library (the site Loom is anonymous), so the web gets the race book only.
 Checks: `race/smoke/loom-book-check.mjs` (the book per room, the seed replay, the mantra),
 `race/smoke/spiral-pool-check.mjs` (the picker mix and the floor under it) and
 `race/smoke/loom-spiral-check.mjs` (the live canvas in the hold, the backing sizes, the
@@ -582,7 +585,7 @@ As built (PR 5 reality notes):
 - `bridge.isHosted` is a BOOLEAN export, not a function. `raceBoot.js` reads it to pick standalone dev mode
   (synthesised `init`, every would-be host message logged as `[race->host]`).
 - `run.js` registers the `pause` and `payout-result` bridge handlers itself; `raceBoot.js` owns `init`,
-  `manifest`, `favorites`, `ping`, `exit-request`, `fullscreen`.
+  `manifest`, `favorites`, `loom-list`, `ping`, `exit-request`, `fullscreen`.
 - Only `video` pops go to the host (`fire-payload {kind:'video', strength 0..100, durationMult}`);
   `payloadFx` never sends it. There is no `audio` bubble kind. Since 2026-09-06 no video bubble spawns
   and the host refuses the message, so this path is dark at both ends.
@@ -777,6 +780,8 @@ and with a track loaded (PR c2): `track-play {name}` (the run started, start the
 
 Host -> page: `init {protocol, settings:{masterVolume, reducedMotion}, modId, modContent}`,
 `manifest {images:[{name,url}], videos, skipped, truncated}`, `favorites {names}`,
+`loom-list {spirals:[{slug, url, params}]}` (the player's own woven spirals; `CaucusHostService`
+posts it on ready and on every `DtrhLoomStore.Changed`),
 `payout-result {baseXp, skillMult, finalXp, sparksEarned, previousBest, dryRun}`, `pause {on}`,
 `ping`, `exit-request`, and the track messages (PR c2): `track-progress {stage, pct, name}`,
 `track-chart {chart, partial}`, `track-clock {t, playing, durationSec}`, `track-ended`,

--- a/ConditioningControlPanel/Resources/web/dtrh/raceBoot.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/raceBoot.js
@@ -22,7 +22,7 @@
  * from the End screen. `?autostart=1` has no menu to leave, so it plays none of
  * it. Reduced motion, as the MENU has it (motionOff()), is one flat fade.
  *
- * Host messages owned here: init, manifest, favorites, ping, exit-request,
+ * Host messages owned here: init, manifest, favorites, loom-list, ping, exit-request,
  * fullscreen, local-media, setting (run.js owns pause + payout-result). Sent
  * here: pong, boot-error, fullscreen-set, exit + exit-done on a host
  * exit-request or a menu surface. A `manifest` that lands AFTER boot is honoured
@@ -100,6 +100,8 @@ import { createHostMediaSource } from './hostMedia.js';
 // The feed's pictures start loading the moment a manifest carrying them lands, so a run built
 // later opens with pictures already on the wall. Imports nothing itself: this is the boot path.
 import { warmWallPosters } from './race/wallWarm.js';
+// THE LOOM: the player's own woven spirals, so a race pop can draw one of theirs.
+import { setLoomSpirals } from './engine/loomSpirals.js';
 
 const INIT_TIMEOUT_MS = 4000, SPLASH_MS = 1000, TRACK_TICK_MS = 250, PERF_LOG_MS = 2000;
 const params = new URLSearchParams(location.search);
@@ -211,6 +213,12 @@ bridge.on('setting', (m) => {
 bridge.on('ping', (m) => host.send({ type: 'pong', t: m && m.t }));
 bridge.on('fullscreen', (m) => host.send({ type: 'fullscreen-set', on: !!(m && m.on) }));
 bridge.on('exit-request', surface);
+// THE LOOM (crafting Part 2): the host's saved-spiral library, the same frame boot.js takes.
+// An entry carrying `params` is woven live by race/loomSpiralFx.js; one without is still its
+// gif. The host pushes this on `ready` and again after every save or delete, so a spiral woven
+// mid-session is on the road the next time one pops. Nothing here reaches into a run: the pool
+// lives in engine/loomSpirals.js and the picker reads it when it draws.
+bridge.on('loom-list', (m) => { try { setLoomSpirals((m && m.spirals) || []); } catch (e) { host.log('loom-list: ' + e); } });
 // ---- track charts (CHART.md host protocol). The run owns the clock; this only relays. ----
 bridge.on('track-chart', (m) => {
   if (!race || !m || !m.chart) return;

--- a/ConditioningControlPanel/Services/Chaos/CaucusHostService.cs
+++ b/ConditioningControlPanel/Services/Chaos/CaucusHostService.cs
@@ -45,6 +45,8 @@ internal static class CaucusHostService
     private static bool _pinged;
     private static bool _runActive;
     private static bool _exiting;
+    // THE LOOM: one DtrhLoomStore.Changed subscription per open page, dropped on teardown.
+    private static bool _loomHooked;
     private static bool _disposing;
     private static bool _videoHooked;
 
@@ -243,6 +245,12 @@ internal static class CaucusHostService
                 if (favorites.Count > 0) _host?.Post(new { type = "favorites", names = favorites });
             }
             catch (Exception ex) { App.Logger?.Debug("RaceHost favorites post failed: {E}", ex.Message); }
+            // THE LOOM: the player's own woven spirals. The race draws them live off the
+            // params sidecar (raceBoot `loom-list` -> engine/loomSpirals.js), so a pop can be
+            // one of theirs instead of a shipped gif. Subscribe once so a spiral woven in the
+            // Boudoir mid-session reaches a race that is already open.
+            PostLoomList();
+            if (!_loomHooked) { DtrhLoomStore.Changed += OnLoomChanged; _loomHooked = true; }
         }
         catch (Exception ex) { App.Logger?.Warning("CaucusHostService.OnPageReady: {E}", ex.Message); }
     }
@@ -560,6 +568,47 @@ internal static class CaucusHostService
     /// <summary>The one funnel every exit reaches: graceful close, watchdogs, the window's own
     /// Closed event, process death. Idempotent - _host.Dispose() closes the window, which
     /// re-raises Closed back into here.</summary>
+    /// <summary>THE LOOM: post the saved-spiral library to the race page, the same frame
+    /// DtrhHostService posts to the descent (slug + ccp.spirals url + the params sidecar). The
+    /// page weaves an entry that has params and falls back to the gif for one that does not.</summary>
+    private static void PostLoomList()
+    {
+        try
+        {
+            _host?.Post(new
+            {
+                type = "loom-list",
+                spirals = DtrhLoomStore.List().Select(s => new
+                {
+                    slug = s.Slug,
+                    url = $"https://ccp.spirals/loom_{s.Slug}.gif",
+                    @params = TryParseLoomParams(s.ParamsJson),
+                }),
+            });
+        }
+        catch (Exception ex) { App.Logger?.Debug("RaceHost.PostLoomList: {E}", ex.Message); }
+    }
+
+    private static JObject? TryParseLoomParams(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json)) return null;
+        try { return JObject.Parse(json); } catch { return null; }
+    }
+
+    /// <summary>A save or delete in the Boudoir: re-post, on the UI thread, only while a race
+    /// page is actually up.</summary>
+    private static void OnLoomChanged()
+    {
+        try
+        {
+            if (_host == null) return;
+            var d = Application.Current?.Dispatcher;
+            if (d == null || d.HasShutdownStarted) return;
+            d.BeginInvoke(new Action(() => { if (_host != null) PostLoomList(); }));
+        }
+        catch (Exception ex) { App.Logger?.Debug("RaceHost.OnLoomChanged: {E}", ex.Message); }
+    }
+
     private static void DisposeAll()
     {
         if (_disposing) return;
@@ -582,6 +631,7 @@ internal static class CaucusHostService
             _devTrackLog = false;
             try { _meta?.FlushSave(); } catch { }
             _runActive = false;
+            if (_loomHooked) { try { DtrhLoomStore.Changed -= OnLoomChanged; } catch { } _loomHooked = false; }
             try { _host?.Dispose(); } catch { }
             _host = null;
             _meta = null;


### PR DESCRIPTION
Third of three, and the half the owner actually asked about: **their own** spirals, not just spirals the race wove.

### what draws now vs before

Before: the saved-spiral library reached the descent only. `boot.js` answered the host's `loom-list`; `raceBoot.js` never registered a handler and `CaucusHostService` never posted one, so `pickSpiral`'s "the player's own ~50% of the time" branch was permanently empty on the race page.

Now: `raceBoot.js` answers `loom-list` the way `boot.js` does and hands it to `engine/loomSpirals.js`, and `CaucusHostService` posts the same frame `DtrhHostService.PostLoomList` posts - `{slug, url, params}`, url on the `ccp.spirals` virtual host, which the race host already mapped. So a `spiral` pop can be a spiral the player wove.

**Params-first.** An entry carrying a `params` sidecar is woven live by the canvas from #1009 - no multi-MB gif fetch mid-lap. One without a sidecar (an older save) is still its gif url, exactly what the picker already promised.

**Live library.** The host subscribes once to `DtrhLoomStore.Changed`, so a spiral woven in the Boudoir while the race is open is on the road at the next pop. The subscription comes off on teardown, the re-post marshals onto the UI thread and no-ops when the page is gone.

### what the web gets

Nothing changes there. The site Loom is anonymous - there is no account library to send - so the web draws the race's own book (#1008) and only that. Noted in CONTRACT.md so nobody goes looking for the missing half.

### perf

One extra host post on page ready and one per save/delete. No new mapping, no new fetch: a woven-live spiral costs the same as a book spiral, and a legacy sidecar-less save costs exactly what a stock gif did.

### how verified

- `dotnet build -c Debug` from `ConditioningControlPanel` - **0 errors** (366 pre-existing warnings, none new).
- the three smokes from the two PRs below still green.
- **not** verified: the real hand-off with a real library. That needs the app running with saved spirals in `%LOCALAPPDATA%/ConditioningControlPanel/Spirals`, which I did not do. The frame is byte-for-byte the one the descent has been posting since crafting Part 2, and the page side is the same handler, so the risk is low - but it is untested end to end.

```
 .../Resources/web/dtrh/race/CONTRACT.md            | 11 +++--
 .../Resources/web/dtrh/raceBoot.js                 | 10 ++++-
 .../Services/Chaos/CaucusHostService.cs            | 50 ++++++++++++++++++++++
 3 files changed, 67 insertions(+), 4 deletions(-)
```

Stack: #1008 -> #1009 -> **this**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013T1bb13w97ndYjNveiFpLz
