### PR TITLE
Validation only: #493–#495 cumulative candidate on Windows/.NET 8

### DIFF
--- a/.github/scripts/url-dialog-pair.ps1
+++ b/.github/scripts/url-dialog-pair.ps1
@@ -122,7 +122,7 @@ try {
     $commit = Require-Success (Invoke-Owned $git @('-C', $repo, 'cat-file', '-p', 'HEAD') $repo 'commit-object') # Real parents even with shallow checkout.
     Save-Json "$root/identity.json" @{ checkout = $identity; commitObject = $commit; githubSha = $env:GITHUB_SHA; os = [Environment]::OSVersion.VersionString; powershell = "$($PSVersionTable.PSVersion)" }
     # Freeze the reviewed safe Program/App/null-lifetime route and every product dependency.
-    foreach ($entry in @(@('CCP.Avalonia', '93b3a4c7ac3c9c975a38831d7528821022556c47'), @('CCP.Core', '125429304e1d6251f8a5a0c8a5cd87287f8b472f'))) {
+    foreach ($entry in @(@('CCP.Avalonia', 'e40e51f8beff40d98824c2871d9a71df8b7fc663'), @('CCP.Core', '125429304e1d6251f8a5a0c8a5cd87287f8b472f'))) {
         $tree = Require-Success (Invoke-Owned $git @('-C', $repo, 'rev-parse', "HEAD:$($entry[0])") $repo "tree-$($entry[0])")
         if ($tree -ne $entry[1]) { throw "Unreviewed source tree: $($entry[0])" }
     }

--- a/CCP.Avalonia/Views/Controls/Companion/AttentionGaugeView.axaml
+++ b/CCP.Avalonia/Views/Controls/Companion/AttentionGaugeView.axaml
@@ -1,0 +1,190 @@
+<!-- PORTED from ConditioningControlPanel/Views/Controls/Companion/AttentionGaugeView.xaml.
+     Structure, ordering, spacing, comments and every resource key are preserved so the two diff
+     directly. Deviations, all forced by real WPF/Avalonia differences:
+
+       Style="{StaticResource X}"      ->  Theme="{StaticResource X}"
+       <Style x:Key TargetType>        ->  <ControlTheme x:Key TargetType>
+       Style.Triggers / DataTrigger    ->  a class binding + a nested <Style Selector="^.class">
+                                           Avalonia has no triggers; Classes.foo="{Binding Bool}"
+                                           is the supported way to drive one off viewmodel state.
+       ControlTemplate.Triggers        ->  <Style Selector="...:pointerover /template/ ...">
+                                           A ControlTemplate cannot carry a Style, so the upsell
+                                           button's hover rule moved to UserControl.Styles and
+                                           the button had to be named to keep the rule targeted.
+       <ContentPresenter/>             ->  Name="PART_ContentPresenter" + TemplateBindings
+       Visibility=/{CmpBoolToVis}      ->  IsVisible bound straight to the bool
+       ToolTip="..."                   ->  ToolTip.Tip="..."
+       {loc:Str key}                   ->  a binding (LocExtension is a WPF MarkupExtension and
+                                           stays in the head; the strings still come from
+                                           CCP.Core's LocalizationManager, via the viewmodel)
+       <Image {CmpEmojiToImage}>       ->  <TextBlock Text="💗"/>; Avalonia draws colour emoji
+                                           natively, so the Twemoji pipeline is not needed.
+
+     Verified rather than assumed: an Avalonia ColumnDefinition is NOT a StyledElement (its base
+     chain is DefinitionBase -> AvaloniaObject, no DataContext property), so the star-width
+     binding below looked like it could not resolve. It does - measured headless on 12.1.1, the
+     0.72/0.28 pair lands on 288px/112px of a 400px track. The Trainer Card recipe survives the
+     port unchanged; no ActualWidth arithmetic was introduced. -->
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             x:Class="ConditioningControlPanel.Avalonia.Views.Controls.Companion.AttentionGaugeView"
+             xmlns:local="clr-namespace:ConditioningControlPanel.Avalonia.Views.Controls.Companion"
+             x:DataType="local:AttentionGaugeViewModel"
+             mc:Ignorable="d"
+             d:DesignWidth="430" d:DesignHeight="170">
+
+    <!-- ================================================================
+         Z6 — HER ATTENTION (the daily budget meter).
+         Elegant, not scary. Copy rules, non-negotiable:
+           · never the word "tokens" — the ladder is in chats, in her voice
+           · the floor is not mute: barks keep playing, and the card says
+             so OUT LOUD — FloorNote is a resting line, never hover-gated
+           · the Patreon line appears below 40% only, once, quietly
+           · the numeric detail is on demand (hover or click), never resting
+
+         The bar is the Trainer Card recipe: a star-width fill column, no
+         ActualWidth arithmetic. At zero it keeps a 4% sliver so a spent
+         meter reads as empty rather than broken. This XAML knows no
+         numbers at all: the spent styling asks IsSpent and the floor note
+         asks ShowFloorNote, both computed in AttentionCopy where the
+         thresholds live and are unit-tested.
+
+         Thresholds live in AttentionCopy, not here, so they are
+         unit-tested and exist in exactly one place.
+         ================================================================ -->
+
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceInclude Source="avares://CCP.Avalonia/Views/Controls/Companion/Themes/CompanionTheme.axaml"/>
+            </ResourceDictionary.MergedDictionaries>
+
+            <!-- the spent bar: same geometry, no heat. Keyed off IsSpent (intent), never off
+                 BarFraction == 0.04 — the sliver and a real 4% are the same double, and a user
+                 with 4 chats left was getting the "she'll be all yours tomorrow" treatment while
+                 the copy beside it said otherwise. -->
+            <ControlTheme x:Key="CmpZ6AttentionFillStyle" TargetType="Border"
+                          BasedOn="{StaticResource CmpGaugeFillAttentionStyle}">
+                <Style Selector="^.spent">
+                    <Setter Property="BorderThickness" Value="0"/>
+                    <Setter Property="Opacity" Value="0.70"/>
+                </Style>
+            </ControlTheme>
+
+            <!-- detail-on-demand: revealed by the toggle command OR by hovering the card.
+                 The WPF original was two DataTriggers on one style. Only the first survives as a
+                 class here; the second asked an ANCESTOR Button for IsMouseOver, which a nested
+                 style cannot reach, so it lives in UserControl.Styles below as a descendant
+                 selector. Both still resolve to "visible", and the un-hovered, un-toggled state
+                 still falls back to this theme's IsVisible="False". -->
+            <ControlTheme x:Key="CmpZ6DetailLineStyle" TargetType="TextBlock"
+                          BasedOn="{StaticResource CmpFaintTextStyle}">
+                <Setter Property="FontSize" Value="10"/>
+                <Setter Property="Margin" Value="0,4,0,0"/>
+                <Setter Property="IsVisible" Value="False"/>
+                <Style Selector="^.shown">
+                    <Setter Property="IsVisible" Value="True"/>
+                </Style>
+            </ControlTheme>
+        </ResourceDictionary>
+    </UserControl.Resources>
+
+    <UserControl.Styles>
+        <!-- the second half of the detail line's trigger pair: hovering the gauge button.
+             A Style outranks a ControlTheme, so this wins over the theme's IsVisible="False"
+             while the pointer is over the card and releases it again on exit. -->
+        <Style Selector="Button:pointerover TextBlock#Z6DetailLine">
+            <Setter Property="IsVisible" Value="True"/>
+        </Style>
+        <!-- ControlTemplate.Triggers replacement for the upsell link's hover colour. -->
+        <Style Selector="Button#Z6UpsellButton:pointerover /template/ TextBlock#Txt">
+            <Setter Property="Foreground" Value="#FFFF9CCE"/>
+        </Style>
+    </UserControl.Styles>
+
+    <Border Theme="{StaticResource CmpCardStyle}">
+        <StackPanel>
+
+            <!-- ========== header ========== -->
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <StackPanel Grid.Column="0" Orientation="Horizontal">
+                    <TextBlock Text="💗" FontSize="16" Margin="0,0,9,0" VerticalAlignment="Center"/>
+                    <TextBlock Text="{Binding LocTitle}" Theme="{StaticResource CmpSectionTitleStyle}"/>
+                </StackPanel>
+                <Border Grid.Column="2" Theme="{StaticResource CmpTrainTagLiveStyle}">
+                    <TextBlock Text="{Binding LocTagTrain1}" Theme="{StaticResource CmpTrainTagLiveTextStyle}"/>
+                </Border>
+            </Grid>
+
+            <!-- ========== the gauge (the whole block hovers/clicks to reveal the numbers) ========== -->
+            <!-- HorizontalAlignment="Stretch" is NOT in the WPF original and is not decoration:
+                 Avalonia's Fluent Button theme defaults HorizontalAlignment to Left, where WPF's
+                 Button inherits Stretch. Without it the whole gauge collapsed to the natural
+                 width of the state-copy line - 194px inside a 388px card, measured headless. -->
+            <Button Command="{Binding ToggleDetailCommand}" HorizontalContentAlignment="Stretch"
+                    HorizontalAlignment="Stretch"
+                    ToolTip.Tip="{Binding LocDetailTip}" Margin="0,13,0,0">
+                <Button.Template>
+                    <ControlTemplate TargetType="Button">
+                        <Border Background="Transparent" Cursor="Hand">
+                            <ContentPresenter Name="PART_ContentPresenter"
+                                              Content="{TemplateBinding Content}"
+                                              ContentTemplate="{TemplateBinding ContentTemplate}"
+                                              HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"/>
+                        </Border>
+                    </ControlTemplate>
+                </Button.Template>
+
+                <StackPanel>
+                    <Border Theme="{StaticResource CmpGaugeTrackThickStyle}">
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="{Binding BarFraction, Converter={StaticResource CmpFractionToStar}}"/>
+                                <ColumnDefinition Width="{Binding BarFraction, Converter={StaticResource CmpFractionToRemainderStar}}"/>
+                            </Grid.ColumnDefinitions>
+                            <Border Grid.Column="0" Theme="{StaticResource CmpZ6AttentionFillStyle}"
+                                    Classes.spent="{Binding IsSpent}"/>
+                        </Grid>
+                    </Border>
+
+                    <TextBlock Text="{Binding StateCopy}" Margin="0,8,0,0" FontSize="12.5"
+                               Foreground="#FFFFD9EC" TextWrapping="Wrap"/>
+
+                    <!-- the floor promise. ALWAYS visible once she is low — never behind hover.
+                         The numbers are detail-on-demand; "her voice never runs out" is the card
+                         answering the only question a shrinking meter actually raises, and a
+                         drained card that says nothing but "tomorrow~" reads as a ration. -->
+                    <TextBlock Text="{Binding FloorNote}" Margin="0,5,0,0" FontSize="11"
+                               FontStyle="Italic" Foreground="#FFCBA9C4" TextWrapping="Wrap"
+                               IsVisible="{Binding ShowFloorNote}"/>
+
+                    <!-- the numbers, for the curious only -->
+                    <TextBlock x:Name="Z6DetailLine" Text="{Binding DetailLine}"
+                               Theme="{StaticResource CmpZ6DetailLineStyle}"
+                               Classes.shown="{Binding IsDetailShown}"/>
+                </StackPanel>
+            </Button>
+
+            <!-- ========== the one quiet upsell, below 40% only ========== -->
+            <Button x:Name="Z6UpsellButton" Theme="{StaticResource CmpLinkButtonStyle}" Margin="0,8,0,0"
+                    Command="{Binding UpsellCommand}"
+                    IsVisible="{Binding ShowUpsell}">
+                <Button.Template>
+                    <ControlTemplate TargetType="Button">
+                        <Border Background="Transparent" Cursor="Hand" Padding="0,2,0,2">
+                            <TextBlock x:Name="Txt" Text="{Binding UpsellCopy}"
+                                       Theme="{StaticResource CmpFlavorTextStyle}" FontSize="11"/>
+                        </Border>
+                    </ControlTemplate>
+                </Button.Template>
+            </Button>
+        </StackPanel>
+    </Border>
+</UserControl>

--- a/CCP.Avalonia/Views/Controls/Companion/AttentionGaugeView.axaml.cs
+++ b/CCP.Avalonia/Views/Controls/Companion/AttentionGaugeView.axaml.cs
@@ -1,0 +1,119 @@
+using System;
+using System.ComponentModel;
+using System.Windows.Input;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using ConditioningControlPanel.Localization;
+
+namespace ConditioningControlPanel.Avalonia.Views.Controls.Companion
+{
+    /// <summary>
+    /// Z6 — the attention meter. See the XAML header for the visual spec.
+    ///
+    /// <para>Code-free by design: the copy ladder is a pure function of the remaining fraction
+    /// (AttentionCopy), the bar is a star-width column, and detail-on-demand is a command on the
+    /// viewmodel. Nothing here animates.</para>
+    /// </summary>
+    public partial class AttentionGaugeView : UserControl
+    {
+        public AttentionGaugeView()
+        {
+            AvaloniaXamlLoader.Load(this);
+            DataContext = new AttentionGaugeViewModel();
+        }
+
+        /// <summary>Convenience for hosts that hand in a viewmodel rather than setting DataContext.</summary>
+        public AttentionGaugeViewModel? ViewModel
+        {
+            get => DataContext as AttentionGaugeViewModel;
+            set => DataContext = value;
+        }
+    }
+
+    /// <summary>
+    /// Supplies everything the view binds to. The strings come from CCP.Core's <see cref="Loc"/> -
+    /// the same localization runtime and the same JSON files the WPF head reads.
+    ///
+    /// <para>This exists because WPF's <c>{loc:Str key}</c> markup extension (LocExtension)
+    /// cannot cross: it derives from System.Windows.Markup.MarkupExtension and stays in the head.
+    /// The strings do cross; only the binding mechanism differs.</para>
+    ///
+    /// <para><b>Not a port of IAttentionGaugeVm.</b> That interface, MockAttentionGaugeVm and
+    /// AttentionCopy all still live in the WPF head, so the thresholds cannot be reached from
+    /// here and are deliberately NOT re-implemented - a second copy of the ladder is exactly the
+    /// duplication the Core split exists to prevent. The numbers below are the WPF mock's
+    /// artboard state (72% left) hard-coded, and every derived flag is the value AttentionCopy
+    /// returns for it. Wiring the real viewmodel is a separate change from proving the view
+    /// renders.</para>
+    /// </summary>
+    public sealed class AttentionGaugeViewModel : INotifyPropertyChanged
+    {
+        private bool _isDetailShown;
+
+        public AttentionGaugeViewModel()
+        {
+            ToggleDetailCommand = new ToggleCommand(() => IsDetailShown = !IsDetailShown);
+        }
+
+        public string LocTitle => Loc.Get("companion_attention_title");
+        public string LocTagTrain1 => Loc.Get("companion_tag_train1");
+        public string LocDetailTip => Loc.Get("companion_attention_detail_tip");
+
+        /// <summary>The headline copy. AttentionCopy.CopyKeyFor(0.72) is the "plenty" rung.</summary>
+        public string StateCopy => Loc.Get("companion_attention_plenty");
+
+        /// <summary>
+        /// Numeric detail, on demand only. Note what it never says: "tokens".
+        ///
+        /// <para>This is the MOCK's static key. The shipped VM
+        /// (AttentionGaugeRuntimeVm, CompanionDepthRuntimeVms.cs:304-306) formats it instead -
+        /// <c>Loc.GetF("companion_attention_detail_fmt", remaining)</c>, or
+        /// <c>companion_attention_detail_unlimited</c> when she thinks on the user's machine.
+        /// Whoever wires the real chat budget in must switch to those two, not to this.</para>
+        /// </summary>
+        public string DetailLine => Loc.Get("companion_attention_detail_line");
+
+        /// <summary>The barks-only floor promise, at rest, in her voice.</summary>
+        public string FloorNote => Loc.Get("companion_attention_floor_note");
+
+        public string UpsellCopy => Loc.Get("companion_attention_upsell");
+
+        // Placeholder state: the WPF MockAttentionGaugeVm's default artboard, 72% remaining.
+        public double BarFraction => 0.72;
+        public bool IsSpent => false;
+        public bool ShowFloorNote => false;
+        public bool ShowUpsell => false;
+
+        public bool IsDetailShown
+        {
+            get => _isDetailShown;
+            set
+            {
+                if (_isDetailShown == value) return;
+                _isDetailShown = value;
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsDetailShown)));
+            }
+        }
+
+        public ICommand ToggleDetailCommand { get; }
+
+        /// <summary>
+        /// LEFT UNWIRED. The WPF original hands this to the Companion tab, which deep-links to the
+        /// Patreon tab - head-owned navigation with no Avalonia counterpart yet. A null command
+        /// disables the link rather than pretending the click did something.
+        /// </summary>
+        public ICommand? UpsellCommand => null;
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        /// <summary>The one command this view can honour on its own: it only flips local state.</summary>
+        private sealed class ToggleCommand : ICommand
+        {
+            private readonly Action _run;
+            public ToggleCommand(Action run) => _run = run;
+            public bool CanExecute(object? parameter) => true;
+            public void Execute(object? parameter) => _run();
+            public event EventHandler? CanExecuteChanged { add { } remove { } }
+        }
+    }
+}

--- a/CCP.Avalonia/Views/Controls/Companion/CompanionConverters.cs
+++ b/CCP.Avalonia/Views/Controls/Companion/CompanionConverters.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Globalization;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Data;
+using Avalonia.Data.Converters;
+
+namespace ConditioningControlPanel.Avalonia.Views.Controls.Companion
+{
+    // =====================================================================================
+    //  PORTED (PARTIAL) from ConditioningControlPanel/Views/Controls/Companion/CompanionConverters.cs.
+    //
+    //  Only the converters the ported zone controls still need cross. The WPF file also carries
+    //  CompanionBoolToVisibilityConverter, CompanionEmptyToVisibilityConverter and friends -
+    //  those exist to produce a System.Windows.Visibility and have no Avalonia counterpart,
+    //  because Avalonia binds IsVisible to a bool directly.
+    // =====================================================================================
+
+    /// <summary>
+    /// 0..1 fraction to a star <see cref="GridLength"/>. This is the Trainer Card bar recipe:
+    /// the filled part of a gauge is a star-width column, so it needs no ActualWidth maths,
+    /// causes no layout-thrash binding, and survives any resize.
+    /// </summary>
+    public sealed class FractionToStarConverter : IValueConverter
+    {
+        /// <summary>When true the converter returns the *remainder* (1 - fraction).</summary>
+        public bool Invert { get; set; }
+
+        public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+        {
+            double f = ToFraction(value);
+            if (Invert) f = 1.0 - f;
+            return new GridLength(f, GridUnitType.Star);
+        }
+
+        public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+            => BindingOperations.DoNothing;
+
+        /// <summary>Clamps anything sane-looking into 0..1. Never throws, never returns NaN.</summary>
+        internal static double ToFraction(object? value)
+        {
+            double f;
+            switch (value)
+            {
+                case double d: f = d; break;
+                case float ff: f = ff; break;
+                case int i: f = i; break;
+                case long l: f = l; break;
+                case decimal m: f = (double)m; break;
+                default: return 0.0;
+            }
+            if (double.IsNaN(f) || double.IsInfinity(f)) return 0.0;
+            if (f < 0.0) return 0.0;
+            if (f > 1.0) return 1.0;
+            return f;
+        }
+    }
+}

--- a/CCP.Avalonia/Views/Controls/Companion/Themes/CompanionTheme.axaml
+++ b/CCP.Avalonia/Views/Controls/Companion/Themes/CompanionTheme.axaml
@@ -1,0 +1,212 @@
+<!-- PORTED (PARTIAL) from ConditioningControlPanel/Views/Controls/Companion/Themes/CompanionTheme.xaml.
+
+     PARTIAL ON PURPOSE. The WPF original is 1605 lines covering every zone of the Companion tab.
+     Only the keys the ported zone controls actually reach for live here, carrying their original
+     names, values, order and section headings so the two diff cleanly. Ported so far: everything
+     Z6 (AttentionGaugeView) needs. Adding a zone means copying its keys down in the same order,
+     never renaming or "tidying" one.
+
+     Deviations, all forced by real WPF/Avalonia differences:
+
+       <Style x:Key TargetType>          ->  <ControlTheme x:Key TargetType>
+       Style="{StaticResource X}"        ->  Theme="{StaticResource X}"   (at the call site)
+       ControlTemplate.Triggers          ->  nested <Style Selector="^:pointerover">
+       <ContentPresenter/>               ->  Name="PART_ContentPresenter"
+       DropShadowEffect ShadowDepth="0"  ->  OffsetX="0" OffsetY="0"
+       SnapsToDevicePixels="True"        ->  dropped; Avalonia rounds layout by default
+                                             (UseLayoutRounding, on for every Control)
+       cmp:CompanionCapsule.IsCapsule    ->  CornerRadius="999"           (see the tag section)
+       LinearGradientBrush "0,0"/"1,0"   ->  "0%,0%"/"100%,0%"
+                                             Avalonia's StartPoint/EndPoint are RelativePoint and
+                                             BARE NUMBERS ARE ABSOLUTE PIXELS, so the WPF values
+                                             would paint a 1px-wide gradient in the top-left
+                                             corner and flat-fill everything after it.
+
+     Consumers merge this with
+       <ResourceInclude Source="avares://CCP.Avalonia/Views/Controls/Companion/Themes/CompanionTheme.axaml"/>
+     in place of the WPF pack:// URI. -->
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:cmp="clr-namespace:ConditioningControlPanel.Avalonia.Views.Controls.Companion">
+
+    <!-- ============================ 0. converters ============================ -->
+    <cmp:FractionToStarConverter x:Key="CmpFractionToStar"/>
+    <cmp:FractionToStarConverter x:Key="CmpFractionToRemainderStar" Invert="True"/>
+    <!-- CmpBoolToVis and friends are NOT ported: Avalonia binds IsVisible to a bool directly.
+         CmpEmojiToImage is not ported either - Avalonia draws colour emoji natively, so an
+         <Image> through the Twemoji pipeline becomes a plain <TextBlock Text="💗"/>. -->
+
+    <!-- ============================ 1. spacing tokens ============================
+         The mockup's rhythm: 6/8/12/16/22. Cards sit 16 apart, card padding is 18x20,
+         the room breathes 22/26. Use these instead of typing margins by hand. -->
+    <Thickness x:Key="CmpCardPadding">20,18,20,18</Thickness>
+    <Thickness x:Key="CmpCardMargin">0,0,0,16</Thickness>
+
+    <CornerRadius x:Key="CmpRadiusCard">14</CornerRadius>
+
+    <!-- ============================ 2. palette ============================
+         :root of the mockup. Colours are exposed as both Color (for gradient stops and
+         animations) and Brush (for direct use). -->
+    <Color x:Key="CmpPinkColor">#FFFF69B4</Color>
+    <Color x:Key="CmpPinkLightColor">#FFFF8FCB</Color>
+    <Color x:Key="CmpPurpleColor">#FFB478FF</Color>
+    <Color x:Key="CmpLiveColor">#FF6EE7A7</Color>
+
+    <!-- .card background is #1A1A2Eee — 93% opaque over the room. -->
+    <SolidColorBrush x:Key="CmpCardBrush" Color="#EE1A1A2E"/>
+    <SolidColorBrush x:Key="CmpPurpleBrush" Color="{StaticResource CmpPurpleColor}"/>
+    <SolidColorBrush x:Key="CmpLiveBrush" Color="{StaticResource CmpLiveColor}"/>
+
+    <!-- text ramp: the mockup's txt / dim / muted / faint custom properties -->
+    <SolidColorBrush x:Key="CmpTextBrush" Color="#FFFFFFFF"/>
+    <SolidColorBrush x:Key="CmpDimBrush" Color="#FFB8B1CC"/>
+    <SolidColorBrush x:Key="CmpMutedBrush" Color="#FF9A93B8"/>
+    <SolidColorBrush x:Key="CmpFaintBrush" Color="#FF6C6689"/>
+
+    <!-- borders & hairlines -->
+    <SolidColorBrush x:Key="CmpCardBorderBrush" Color="#66FF69B4"/>
+    <SolidColorBrush x:Key="CmpTrackBrush" Color="#22FFFFFF"/>
+    <SolidColorBrush x:Key="CmpTrackSoftBrush" Color="#14FFFFFF"/>
+
+    <!-- gradients -->
+    <LinearGradientBrush x:Key="CmpPinkPurpleBrush" StartPoint="0%,0%" EndPoint="100%,0%">
+        <GradientStop Color="{StaticResource CmpPinkColor}" Offset="0"/>
+        <GradientStop Color="{StaticResource CmpPurpleColor}" Offset="1"/>
+    </LinearGradientBrush>
+
+    <!-- Z6 attention bar: pink → light pink → purple. -->
+    <LinearGradientBrush x:Key="CmpAttentionBrush" StartPoint="0%,0%" EndPoint="100%,0%">
+        <GradientStop Color="{StaticResource CmpPinkColor}" Offset="0"/>
+        <GradientStop Color="{StaticResource CmpPinkLightColor}" Offset="0.5"/>
+        <GradientStop Color="{StaticResource CmpPurpleColor}" Offset="1"/>
+    </LinearGradientBrush>
+
+    <!-- ============================ 3. glows ============================
+         House glow = DropShadowEffect with zero offset. Budget (design §7.4): hero title,
+         portrait ring, active constellation node, section titles. Never on a scrolling item
+         container — fact cards get their emphasis from BorderBrush instead. -->
+    <DropShadowEffect x:Key="CmpSectionGlow" Color="{StaticResource CmpPinkColor}" BlurRadius="14"
+                      OffsetX="0" OffsetY="0" Opacity="0.70"/>
+
+    <!-- ============================ 4. text styles ============================ -->
+    <!-- .card h2 — the zone header. Glow is on the title only, not the whole row. -->
+    <ControlTheme x:Key="CmpSectionTitleStyle" TargetType="TextBlock">
+        <Setter Property="FontSize" Value="16.5"/>
+        <Setter Property="FontWeight" Value="SemiBold"/>
+        <Setter Property="Foreground" Value="{StaticResource CmpTextBrush}"/>
+        <Setter Property="VerticalAlignment" Value="Center"/>
+        <Setter Property="Effect" Value="{StaticResource CmpSectionGlow}"/>
+        <Setter Property="TextTrimming" Value="CharacterEllipsis"/>
+    </ControlTheme>
+
+    <ControlTheme x:Key="CmpFaintTextStyle" TargetType="TextBlock">
+        <Setter Property="FontSize" Value="10.5"/>
+        <Setter Property="Foreground" Value="{StaticResource CmpFaintBrush}"/>
+        <Setter Property="TextWrapping" Value="Wrap"/>
+    </ControlTheme>
+
+    <!-- in-character italic copy: dormant promises, flavor lines, veil sell copy -->
+    <ControlTheme x:Key="CmpFlavorTextStyle" TargetType="TextBlock">
+        <Setter Property="FontSize" Value="12"/>
+        <Setter Property="FontStyle" Value="Italic"/>
+        <Setter Property="Foreground" Value="{StaticResource CmpDimBrush}"/>
+        <Setter Property="TextWrapping" Value="Wrap"/>
+        <Setter Property="LineHeight" Value="18"/>
+    </ControlTheme>
+
+    <!-- quiet expert-door link.
+         NOTE: Text="{TemplateBinding Content}" is the WPF original verbatim. Z6 overrides this
+         template locally (as the WPF view does), so the object->string conversion is not
+         exercised by the ported view; the first zone that DOES use this template should check
+         it renders before trusting it. -->
+    <ControlTheme x:Key="CmpLinkButtonStyle" TargetType="Button">
+        <Setter Property="Background" Value="Transparent"/>
+        <Setter Property="BorderThickness" Value="0"/>
+        <Setter Property="Foreground" Value="{StaticResource CmpMutedBrush}"/>
+        <Setter Property="FontSize" Value="11"/>
+        <Setter Property="Cursor" Value="Hand"/>
+        <Setter Property="Padding" Value="0,2,10,2"/>
+        <Setter Property="HorizontalAlignment" Value="Left"/>
+        <Setter Property="Template">
+            <ControlTemplate TargetType="Button">
+                <TextBlock x:Name="Txt" Text="{TemplateBinding Content}" Margin="{TemplateBinding Padding}"
+                           Foreground="{TemplateBinding Foreground}" FontSize="{TemplateBinding FontSize}"
+                           TextDecorations="Underline" Background="Transparent"/>
+            </ControlTemplate>
+        </Setter>
+        <Style Selector="^:pointerover /template/ TextBlock#Txt">
+            <Setter Property="Foreground" Value="{StaticResource CmpTextBrush}"/>
+        </Style>
+    </ControlTheme>
+
+    <!-- ============================ 5. cards ============================ -->
+    <ControlTheme x:Key="CmpCardStyle" TargetType="Border">
+        <Setter Property="Background" Value="{StaticResource CmpCardBrush}"/>
+        <Setter Property="BorderBrush" Value="{StaticResource CmpCardBorderBrush}"/>
+        <Setter Property="BorderThickness" Value="1"/>
+        <Setter Property="CornerRadius" Value="{StaticResource CmpRadiusCard}"/>
+        <Setter Property="Padding" Value="{StaticResource CmpCardPadding}"/>
+        <Setter Property="Margin" Value="{StaticResource CmpCardMargin}"/>
+    </ControlTheme>
+
+    <!-- ============================ 6. train microtags ============================
+         WPF needed cmp:CompanionCapsule.IsCapsule="True" here because WPF's Border clamps the X
+         and Y corner radii INDEPENDENTLY, so border-radius:999px drew a full ellipse (78% fill,
+         i.e. pi/4, on a 110x26 box) instead of a stadium. Avalonia does not have that bug: it
+         scales the radii proportionally the way CSS does. Measured headless on the same 110x26
+         box, CornerRadius="999" and CornerRadius="13" (an exact half-height capsule) both fill
+         95.1% - so the attached property has no work left to do and is not ported. -->
+    <ControlTheme x:Key="CmpTrainTagStyle" TargetType="Border">
+        <Setter Property="Background" Value="#14B478FF"/>
+        <Setter Property="BorderBrush" Value="#55B478FF"/>
+        <Setter Property="BorderThickness" Value="1"/>
+        <Setter Property="CornerRadius" Value="999"/>
+        <Setter Property="Padding" Value="8,2,8,2"/>
+        <Setter Property="VerticalAlignment" Value="Center"/>
+    </ControlTheme>
+    <ControlTheme x:Key="CmpTrainTagTextStyle" TargetType="TextBlock">
+        <Setter Property="FontSize" Value="9"/>
+        <Setter Property="FontWeight" Value="Bold"/>
+        <Setter Property="Foreground" Value="{StaticResource CmpPurpleBrush}"/>
+    </ControlTheme>
+    <!-- .ttag.live — green, "this is real right now" -->
+    <ControlTheme x:Key="CmpTrainTagLiveStyle" TargetType="Border" BasedOn="{StaticResource CmpTrainTagStyle}">
+        <Setter Property="Background" Value="#126EE7A7"/>
+        <Setter Property="BorderBrush" Value="#556EE7A7"/>
+    </ControlTheme>
+    <ControlTheme x:Key="CmpTrainTagLiveTextStyle" TargetType="TextBlock" BasedOn="{StaticResource CmpTrainTagTextStyle}">
+        <Setter Property="Foreground" Value="{StaticResource CmpLiveBrush}"/>
+    </ControlTheme>
+
+    <!-- ============================ 8. gauge primitives ============================
+         Every bar on this page is the Trainer Card recipe: a rounded track Border with a
+         two-column Grid inside, the fill column bound to a star GridLength. No ActualWidth
+         maths anywhere, so nothing thrashes layout while the page scrolls. -->
+    <ControlTheme x:Key="CmpGaugeTrackStyle" TargetType="Border">
+        <Setter Property="Height" Value="10"/>
+        <Setter Property="CornerRadius" Value="5"/>
+        <Setter Property="Background" Value="{StaticResource CmpTrackBrush}"/>
+        <Setter Property="ClipToBounds" Value="True"/>
+    </ControlTheme>
+    <!-- .att-track — the 12px attention gauge -->
+    <ControlTheme x:Key="CmpGaugeTrackThickStyle" TargetType="Border" BasedOn="{StaticResource CmpGaugeTrackStyle}">
+        <Setter Property="Height" Value="12"/>
+        <Setter Property="CornerRadius" Value="6"/>
+        <Setter Property="Background" Value="{StaticResource CmpTrackSoftBrush}"/>
+    </ControlTheme>
+
+    <!-- The heat used to be a DropShadowEffect on every fill. Gauges live inside PageScroll and
+         there are a dozen of them once the Workshop is open, so the glow is a brush now: a
+         lighter top edge inside the fill reads as "lit" without a bitmap effect. -->
+    <ControlTheme x:Key="CmpGaugeFillStyle" TargetType="Border">
+        <Setter Property="CornerRadius" Value="5"/>
+        <Setter Property="Background" Value="{StaticResource CmpPinkPurpleBrush}"/>
+        <Setter Property="BorderThickness" Value="0,1,0,0"/>
+        <Setter Property="BorderBrush" Value="#59FFB8DC"/>
+    </ControlTheme>
+    <ControlTheme x:Key="CmpGaugeFillAttentionStyle" TargetType="Border" BasedOn="{StaticResource CmpGaugeFillStyle}">
+        <Setter Property="CornerRadius" Value="6"/>
+        <Setter Property="Background" Value="{StaticResource CmpAttentionBrush}"/>
+        <Setter Property="BorderBrush" Value="#66FFD0E6"/>
+    </ControlTheme>
+</ResourceDictionary>


### PR DESCRIPTION
## Validation only — do not merge

Run existing CI against the accepted local cumulative #493–#495 repair candidate. This draft does **not** replace or retarget #493, #494 or #495, and does not claim migration/parity completion.

- Exact base: `cfd7d7a8e7d0c1216a6c39855b7f9a4816622a4b`
- Exact candidate: `982426f409acdd2beef5797504a646d6c406cec0`
- Parent-relative diff: **581 lines** (580 additions / 1 deletion). The base carries the prior local layers; CI checks the cumulative candidate, not just this last-layer diff.
- Existing commits and contributor attribution are preserved. No existing PR head/base was changed; no force-push.

### Existing local evidence

Independent review accepted the #493 localization, keyboard, pulse and theme fixes and fixture lifecycle checks. Final isolated Linux headless run: **111 passed / 0 failed**. URL inverse: **87 passed / 18 expected ordered failures**. All six exact-head classifier `-SelfCheck` runs passed using PowerShell 7.6.5. These are Linux CLR 10.0.11 and synthetic classifier evidence, **not** Windows/.NET 8 proof.

### Requested CI evidence

Existing workflow runs Windows and Linux checks, including the Windows/.NET 8 URL RED/GREEN pair and its export/archive/inverse safeguards. Retain exact checkout/tree identity and artifacts, including failure evidence. No weakening of tests or guards is authorized.

### Explicit limitations

S1 selection-fill was not reproduced at the tested Avalonia public-property seam; this is not visual/native parity. The approved two-answer Escape→No behavior is a documented deviation, while Enter defaults follow WPF. Qualified #494/#495 staged, locale, privacy, budget and NaN findings remain unresolved. Native interaction, WPF visual comparison and performance acceptance remain outstanding even if CI passes.
