### PR TITLE
fix(race): print the boot error on the splash

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/raceBoot.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/raceBoot.js
@@ -169,7 +169,28 @@ function fail(err) {
   const msg = String((err && (err.stack || err.message)) || err || 'unknown').slice(0, 600);
   console.error('[race] boot-error', msg);
   note('something broke. the host has the log.');
+  showDetail(msg);
   host.send({ type: 'boot-error', msg, message: msg });
+}
+/**
+ * The first line of the error, on the splash under the note. A phone has no console and no host
+ * log to open (cclabs-web's race host only console.errors the frame), so without this a boot that
+ * dies on an iPhone is a sad face and nothing to report. Selectable, so it can be copied.
+ */
+function showDetail(msg) {
+  if (!waitEl || !waitEl.parentNode) return;
+  let el = document.getElementById('race-err');
+  if (!el) {
+    el = document.createElement('div');
+    el.id = 'race-err';
+    const s = el.style;
+    s.marginTop = '12px'; s.padding = '0 24px'; s.fontSize = '11px'; s.lineHeight = '1.4';
+    s.fontFamily = 'ui-monospace, Menlo, Consolas, monospace'; s.color = 'rgba(255,255,255,0.45)';
+    s.whiteSpace = 'pre-wrap'; s.wordBreak = 'break-word'; s.userSelect = 'text'; s.webkitUserSelect = 'text';
+    s.maxWidth = '92vw'; s.textAlign = 'center';
+    waitEl.parentNode.insertBefore(el, waitEl.nextSibling);
+  }
+  el.textContent = String(msg || '').split('\n').slice(0, 4).join('\n').slice(0, 320);
 }
 window.addEventListener('error', (e) => {
   const src = e.filename ? ` @ ${String(e.filename).split('/').pop()}:${e.lineno}` : '';


### PR DESCRIPTION
The race splash said "something broke. the host has the log." and nothing else. On an iPhone there is no console and the web host only console.errors the boot-error frame, so the owner's phone test of wave 2 died with nothing to report.

fail() now also writes the first lines of the error under the note (11px, muted, selectable). 21 lines, raceBoot.js only. Verified in Playwright WebKit (iPhone 14 emulation): a forced error shows `TypeError: boom from the harness @ run.js:271` under the note.

Sibling on cclabs-web carries the same hunk to production so the phone can report today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PEeoJ93JCmhpWTQnwbPHc1