### PR TITLE
fix(deeper): stop the fullscreen host stranding an empty, dead window after a video

### DIFF
--- a/ConditioningControlPanel/MainWindow/MainWindow.StartStop.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.StartStop.cs
@@ -532,6 +532,11 @@ namespace ConditioningControlPanel
             // topmost, chrome-less, taskbar-less window, so a session that ends behind one leaves
             // the completion dialog modal and invisible - the reporter had to reboot the machine.
             ExitBrowserFullscreenForTeardown();
+            // Same shape, same list: the Deeper player pops its WebView out into a
+            // borderless topmost host for fullscreen video. Left standing it is a
+            // window with no title bar to drag, no resize grip, and nothing in it
+            // once the video is over (Discord report BUG-J9PPPJT274).
+            Views.Deeper.EnhancementPlayerWindow.ForceExitFullscreenAll();
 
             // Stop ramp timer and reset sliders
             StopRampTimer();

--- a/ConditioningControlPanel/Views/Deeper/EnhancementPlayerWindow.xaml.cs
+++ b/ConditioningControlPanel/Views/Deeper/EnhancementPlayerWindow.xaml.cs
@@ -66,6 +66,11 @@ namespace ConditioningControlPanel.Views.Deeper
         private Window? _videoFullscreenWindow;
         private bool _isVideoFullscreen;
         private bool _fsTransitionInFlight;
+        // An exit request that landed while a fullscreen transition was in flight.
+        // Enter/Exit pump the dispatcher (Invoke at Render priority), so a teardown
+        // can arrive mid-swap; without this it was dropped and the borderless host
+        // stayed up forever.
+        private bool _fsExitPending;
         private bool _isPlayerDualMonitorActive;
 
         public EnhancementPlayerWindow(EnhancementAudioPlayer player, EnhancementHostService host)
@@ -1364,6 +1369,23 @@ namespace ConditioningControlPanel.Views.Deeper
                         }
                     });
 
+                    // ESC from inside the page. The borderless host window's
+                    // WPF KeyDown handler almost never sees a key while the
+                    // WebView2 owns focus (the Chromium HWND eats it), so ESC
+                    // was effectively dead once the page had focus. Post the
+                    // exit message from the page instead - C# force-closes the
+                    // host regardless of page fullscreen state.
+                    function escHandler(e) {
+                        if (!e) return;
+                        var isEsc = e.key === 'Escape' || e.key === 'Esc' || e.keyCode === 27;
+                        if (!isEsc) return;
+                        if (!inAnyFs()) return;
+                        exitLoop(5);
+                        postExit();
+                    }
+                    document.addEventListener('keydown', escHandler, true);
+                    window.addEventListener('keydown', escHandler, true);
+
                     // Ctrl+MouseWheel = page zoom. IsZoomControlEnabled is
                     // false in WebView2 settings so the built-in shortcut is
                     // off and we own the gesture. preventDefault stops the
@@ -1405,7 +1427,7 @@ namespace ConditioningControlPanel.Views.Deeper
                     // the flag, but Close() left the window alive.
                     if (_isVideoFullscreen || _videoFullscreenWindow != null)
                     {
-                        Dispatcher.BeginInvoke(() => { try { ExitVideoFullscreen(); } catch (Exception ex) { Diag.Swallowed(ex); } });
+                        Dispatcher.BeginInvoke(() => ForceExitVideoFullscreen("page requested exit"));
                     }
                 }
                 else if (msg == "ccp_zoom_in")
@@ -1467,6 +1489,19 @@ namespace ConditioningControlPanel.Views.Deeper
                 TxtVideoStatus.Visibility = Visibility.Collapsed;
                 BtnPlayPause.Content = "⏸";
                 TxtStatus.Text = Loc.Get("deeper_player_status_playing");
+
+                // Re-arm the forced-fullscreen flag on the NEW document. It lives
+                // on `window`, so every navigation wipes it — and a video that
+                // ends and rolls into the next page navigates. Without this the
+                // page-side escape hatches (dblclick / ESC / fullscreenchange)
+                // all decide we are not in fullscreen, ESC no-ops, and the
+                // borderless host is left up with nothing in it and no way out
+                // (Discord report BUG-J9PPPJT274).
+                if (_isVideoFullscreen || _videoFullscreenWindow != null)
+                {
+                    try { FireScript("window._ccpForcedFs = true;"); }
+                    catch (Exception ex) { Diag.Swallowed(ex); }
+                }
 
                 ScrollVideoIntoView();
             }
@@ -1650,12 +1685,17 @@ namespace ConditioningControlPanel.Views.Deeper
                         try { App.ScreenMirror?.DisableMirror(); } catch (Exception ex) { Diag.Swallowed(ex); }
                         _isPlayerDualMonitorActive = false;
                     }
-                    ExitVideoFullscreen();
+                    ForceExitVideoFullscreen("page left html5 fullscreen");
                 }
             }
             catch (Exception ex)
             {
                 App.Logger?.Warning(ex, "EnhancementPlayer: fullscreen toggle failed");
+                // A throw on the way INTO fullscreen unwinds inside
+                // EnterVideoFullscreen; a throw on the way out must not leave the
+                // borderless host on screen with no way to reach it.
+                try { ForceExitVideoFullscreen("fullscreen toggle error"); }
+                catch (Exception exIgnored) { Diag.Swallowed(exIgnored); }
             }
         }
 
@@ -1758,10 +1798,13 @@ namespace ConditioningControlPanel.Views.Deeper
                     }
                 };
 
-                System.ComponentModel.CancelEventHandler closingHandler = (_, _) =>
+                // Clear THIS window's content, not whatever _videoFullscreenWindow
+                // happens to point at — a fast exit/re-enter would otherwise blank
+                // the new host while the old one closes.
+                System.ComponentModel.CancelEventHandler closingHandler = (s, _) =>
                 {
-                    if (_videoFullscreenWindow != null)
-                        _videoFullscreenWindow.Content = null;
+                    if (s is Window w) w.Content = null;
+                    else if (built != null) built.Content = null;
                 };
 
                 // TOPMOST IS RENTED, NOT OWNED (#905). A fullscreen video has to sit over the
@@ -1896,6 +1939,7 @@ namespace ConditioningControlPanel.Views.Deeper
                     catch (Exception ex) { Diag.Swallowed(ex); }
                 }
                 _fsTransitionInFlight = false;
+                DrainPendingFullscreenExit();
             }
         }
 
@@ -2001,32 +2045,156 @@ namespace ConditioningControlPanel.Views.Deeper
                     catch (Exception ex) { Diag.Swallowed(ex); }
                 }
                 _fsTransitionInFlight = false;
+                DrainPendingFullscreenExit();
             }
+        }
+
+        /// <summary>
+        /// THE teardown for the borderless fullscreen host. Every end path funnels
+        /// here — ESC/F11, the page's dblclick + ccp_exit_fullscreen message, an
+        /// error mid-playback, and the Player window closing. Idempotent, always
+        /// runs on the UI thread, never throws, and always ends with the host
+        /// window closed and VideoBrowser back in the Player's pane.
+        ///
+        /// Before this existed, exit depended on the PAGE still being in HTML5
+        /// fullscreen. It usually isn't: the reparent drops it, and a video that
+        /// ends and navigates wipes window._ccpForcedFs too. exitFullscreen() then
+        /// no-ops, ContainsFullScreenElementChanged never fires, and the borderless
+        /// host is stranded — empty, un-draggable (WindowStyle.None), un-resizable
+        /// (ResizeMode.NoResize), swallowing input as a topmost window.
+        /// Discord report BUG-J9PPPJT274.
+        /// </summary>
+        private void ForceExitVideoFullscreen(string reason)
+        {
+            if (!Dispatcher.CheckAccess())
+            {
+                try
+                {
+                    if (Application.Current?.Dispatcher?.HasShutdownStarted != true)
+                        Dispatcher.BeginInvoke(() => ForceExitVideoFullscreen(reason));
+                }
+                catch (Exception ex) { Diag.Swallowed(ex); }
+                return;
+            }
+
+            if (!_isVideoFullscreen && _videoFullscreenWindow == null) return;
+
+            // Mid-swap: Enter/Exit pump the dispatcher, so we can land on top of
+            // one. Queue instead of racing it — the transition's finally drains
+            // this via DrainPendingFullscreenExit.
+            if (_fsTransitionInFlight)
+            {
+                _fsExitPending = true;
+                App.Logger?.Information(
+                    "EnhancementPlayer: fullscreen teardown deferred ({Reason}) — transition in flight", reason);
+                return;
+            }
+
+            App.Logger?.Information("EnhancementPlayer: fullscreen teardown ({Reason})", reason);
+
+            // Ordered path first: unsubscribes, clears the page flag, closes.
+            try { ExitVideoFullscreen(); }
+            catch (Exception ex)
+            {
+                App.Logger?.Warning(ex,
+                    "EnhancementPlayer: ordered fullscreen exit failed ({Reason}); forcing the host closed", reason);
+            }
+
+            // Guaranteed path: whatever the ordered attempt did or didn't manage,
+            // the host window does not survive this method.
+            var host = _videoFullscreenWindow;
+            if (host == null && !_isVideoFullscreen) return;
+
+            _fsTransitionInFlight = false;
+            _isVideoFullscreen = false;
+            _videoFullscreenWindow = null;
+
+            if (host != null)
+            {
+                try { App.Overlay?.SetFullscreenBrowserActive(host, false); }
+                catch (Exception ex) { Diag.Swallowed(ex); }
+                try { host.Content = null; }
+                catch (Exception ex) { Diag.Swallowed(ex); }
+                try { host.Close(); }
+                catch (Exception ex)
+                {
+                    App.Logger?.Warning(ex,
+                        "EnhancementPlayer: forced close of the fullscreen host failed ({Reason}); hiding it instead", reason);
+                    // Last resort: a window we cannot close must at least stop
+                    // covering the app and eating input.
+                    try { host.Topmost = false; } catch (Exception exIgnored) { Diag.Swallowed(exIgnored); }
+                    try { host.Hide(); } catch (Exception exIgnored) { Diag.Swallowed(exIgnored); }
+                }
+            }
+
+            // The host's Closed handler normally re-parents the WebView; do it
+            // here too in case that handler was already detached or threw.
+            try { TryDetachFromUiParent(VideoBrowser); } catch (Exception ex) { Diag.Swallowed(ex); }
+            try { SafeRestoreVideoBrowserToPane(); } catch (Exception ex) { Diag.Swallowed(ex); }
+            try { App.Overlay?.RequestForcedZOrderReassert(); } catch (Exception ex) { Diag.Swallowed(ex); }
+        }
+
+        /// <summary>
+        /// Session / panic teardown hook. The Deeper player's forced fullscreen is
+        /// the same shape as the built-in browser's (#952) — topmost, chrome-less,
+        /// taskbar-less — so a panic that leaves it standing hands the user a window
+        /// they cannot move, resize or close. Safe to call unconditionally: it
+        /// early-outs on every player that isn't in fullscreen.
+        /// </summary>
+        internal static void ForceExitFullscreenAll()
+        {
+            try
+            {
+                if (Application.Current == null) return;
+                if (Application.Current.Dispatcher?.HasShutdownStarted == true) return;
+                foreach (var w in Application.Current.Windows
+                                     .OfType<EnhancementPlayerWindow>().ToList())
+                {
+                    try { w.ForceExitVideoFullscreen("session/panic teardown"); }
+                    catch (Exception ex)
+                    {
+                        App.Logger?.Warning(ex, "EnhancementPlayer: teardown fullscreen exit failed");
+                    }
+                }
+            }
+            catch (Exception ex) { Diag.Swallowed(ex); }
+        }
+
+        /// <summary>
+        /// Runs a teardown that arrived while a fullscreen transition held the
+        /// lock. Called from the finally of both Enter and Exit.
+        /// </summary>
+        private void DrainPendingFullscreenExit()
+        {
+            if (!_fsExitPending) return;
+            _fsExitPending = false;
+            if (!_isVideoFullscreen && _videoFullscreenWindow == null) return;
+            try
+            {
+                if (Application.Current?.Dispatcher?.HasShutdownStarted == true) return;
+                Dispatcher.BeginInvoke(() => ForceExitVideoFullscreen("deferred exit"));
+            }
+            catch (Exception ex) { Diag.Swallowed(ex); }
         }
 
         private void ExitFullscreenViaScript()
         {
-            // Driving exitFullscreen from the page side fires
-            // ContainsFullScreenElementChanged again, which routes through
-            // OnVideoFullscreenChanged → ExitVideoFullscreen and keeps the page
-            // and window in sync (vs closing the window first and leaving the
-            // page in fullscreen state).
+            // Ask the page to drop HTML5 fullscreen first so page and window stay
+            // in sync — but never DEPEND on it. When the page isn't in HTML5
+            // fullscreen (the common case after our reparent, and always after the
+            // video ends and the page navigates) this script is a no-op and no
+            // event comes back, which is exactly how the host window got stranded.
             try
             {
                 if (VideoBrowser?.CoreWebView2 != null)
                 {
                     FireScript(
-                        "(function(){if(document.fullscreenElement)document.exitFullscreen();})();");
-                }
-                else
-                {
-                    ExitVideoFullscreen();
+                        "window._ccpForcedFs = false; (function(){if(document.fullscreenElement)document.exitFullscreen();})();");
                 }
             }
-            catch
-            {
-                ExitVideoFullscreen();
-            }
+            catch (Exception ex) { Diag.Swallowed(ex); }
+
+            ForceExitVideoFullscreen("esc/f11");
         }
 
         private void OnHostActionLogged(string line)
@@ -2094,24 +2262,17 @@ namespace ConditioningControlPanel.Views.Deeper
             // Check the window reference too — a partial prior exit can leave
             // the borderless host alive with the flag already cleared, and
             // skipping cleanup here would orphan it past the player's death.
-            try { if (_isVideoFullscreen || _videoFullscreenWindow != null) ExitVideoFullscreen(); } catch (Exception ex) { Diag.Swallowed(ex); }
-
-            // Safety net: ExitVideoFullscreen() early-returns while a fullscreen transition
-            // is in flight (_fsTransitionInFlight) — and EnterVideoFullscreen pumps the
-            // dispatcher at render priority mid-transition, so a close that lands in that
-            // window leaves the borderless host alive as a see-through, un-interactable
-            // ghost AND then disposes VideoBrowser out from under it (#381). Force the host
-            // window closed here regardless of transition state; its Closed handler reparents
-            // VideoBrowser back to the pane before we dispose it below.
-            if (_videoFullscreenWindow != null)
-            {
-                _fsTransitionInFlight = false;
-                try { _videoFullscreenWindow.Close(); }
-                catch (Exception ex) { App.Logger?.Debug("EnhancementPlayer: forced fullscreen window close failed: {Error}", ex.Message); }
-                _videoFullscreenWindow = null;
-                _isVideoFullscreen = false;
-                try { SafeRestoreVideoBrowserToPane(); } catch (Exception ex) { Diag.Swallowed(ex); }
-            }
+            //
+            // ForceExitVideoFullscreen defers when a transition holds the lock,
+            // and there is no "later" once the window is closing — EnterVideoFullscreen
+            // pumps the dispatcher at render priority mid-transition, so a close can
+            // land right inside one and leave the borderless host alive as a
+            // see-through, un-interactable ghost with VideoBrowser disposed out from
+            // under it (#381). Drop the lock first so the teardown runs here and now.
+            _fsTransitionInFlight = false;
+            _fsExitPending = false;
+            try { ForceExitVideoFullscreen("player window closing"); }
+            catch (Exception ex) { Diag.Swallowed(ex); }
 
             try
             {


### PR DESCRIPTION
## Bug

Discord ask-support, 2026-09-08, reporter Nardda (in-app token `BUG-J9PPPJT274`, which never reached ccp-bugs):

> windows border of deeper player do not disappear after watching a video

> It is not possible to interact with it in this state at all (no dragging, re-sizing...)

Their screenshot shows an empty window sitting over the Deeper library after playback ended: the video content is gone, the frame stays, and it takes no input at all.

## Cause

When the Deeper player's embedded video goes fullscreen, `EnhancementPlayerWindow` re-parents its WebView2 into a purpose-built borderless host window: `WindowStyle.None`, `ResizeMode.NoResize`, `ShowInTaskbar = false`, `Topmost = true`. That is the "border" in the screenshot - no title bar to drag, no resize grip, always on top.

Every route back out of that window went through the **page**:

- ESC / F11 called `ExitFullscreenViaScript`, which only ran `document.exitFullscreen()` and relied on the resulting `ContainsFullScreenElementChanged` to close the host.
- The dblclick escape hatch keyed off `window._ccpForcedFs`.

Both assumptions break after a video finishes:

1. The re-parent itself drops HTML5 fullscreen, so `document.fullscreenElement` is already null while our host is up.
2. `window._ccpForcedFs` lives on `window`, so **any navigation wipes it** - and a video ending and rolling on to the next page is exactly that. `OnVideoNavCompleted` never re-armed it.

From that point `exitFullscreen()` is a no-op, no event comes back, `dblclick` decides it is *not* in fullscreen and tries to **enter** instead, and when the page has no video left to enter on it does nothing at all. ESC was doubly dead: the host's WPF `KeyDown` almost never fires while the Chromium HWND owns focus.

Two smaller holes fed the same outcome:

- An exit request that landed while `_fsTransitionInFlight` was set was dropped on the floor. Both transitions pump the dispatcher at `Render` priority, so this is reachable.
- The host's `Closing` handler cleared `_videoFullscreenWindow.Content` rather than its own, so a fast exit/re-enter blanked the wrong window.

## Fix

One idempotent teardown - `ForceExitVideoFullscreen(reason)` - that every end path funnels through: ESC/F11, the page's `ccp_exit_fullscreen` message, the page leaving HTML5 fullscreen, an error in the toggle handler, session/panic stop, and the Player window closing.

It marshals to the Dispatcher, logs at Information, tries the ordered `ExitVideoFullscreen()` first, then closes the host **regardless of what that managed**, re-parents `VideoBrowser` back into the pane, and drops `Topmost` + hides as a last resort if `Close()` itself throws. Failures log at Warning and the window still goes.

Supporting changes:

- Exit requests arriving mid-transition are queued (`_fsExitPending`) and drained from both transitions' `finally`, instead of being dropped.
- `OnVideoNavCompleted` re-arms `window._ccpForcedFs` while the host is up, so the page-side escape hatches survive the navigation a finished video causes.
- An in-page ESC `keydown` listener posts `ccp_exit_fullscreen`, because the host's WPF `KeyDown` does not see keys the WebView2 has focus for.
- `MainWindow` session/panic teardown now calls `EnhancementPlayerWindow.ForceExitFullscreenAll()`, matching the browser's `#952` hook one line above it. A panic could previously leave this window standing too.
- The host's `Closing` handler clears its own `Content` (from `sender`).

No behaviour change while fullscreen is working normally - this only adds guaranteed exits.

## How to verify

1. Deeper tab -> Open Player -> load a video enhancement (or an HT URL).
2. Click the video's fullscreen button. The borderless host appears over everything.
3. **Let the video play to the end** so the page navigates / the player unloads.
4. Press ESC. The host closes and the Player comes back with the video pane populated. Before this change ESC did nothing and the window could not be dragged, resized or closed.
5. Repeat and instead double-click the video after it ends - also exits now.
6. Repeat, and while fullscreen hit the panic key / stop the session - the host tears down with everything else.
7. Repeat, and close the Player window while fullscreen - no orphan window is left behind.
8. `logs/` should carry `EnhancementPlayer: fullscreen teardown (<reason>)` once per exit, and nothing at Warning on the happy path.

Build: `dotnet build` -> 0 errors (366 pre-existing warnings, CA1416/CS8602 style).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BcbxiDEFBZMFLM24nLh8qf
