### PR TITLE
feat(race): main menu status lines, tap-to-main track flow, media back fix

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/race/feedGroup.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/feedGroup.js
@@ -162,6 +162,9 @@ export function createFeedGroup({ slot, settings = {}, post, ui = null }) {
     rows,
     els,
     paint,
+    /** What the menu's status line reads: the same consent and picks the rows paint, never a
+     *  pending ask. Labels, lower case, in catalog order. */
+    get state() { return { consent, niches: catalog.filter((c) => picked.has(c.id)).map((c) => c.label) }; },
     /**
      * The host's `setting` echo. Returns true when this group owned the key, so
      * the menu knows not to hand it on to the pickers' own pending paint.

--- a/ConditioningControlPanel/Resources/web/dtrh/race/levels.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/levels.js
@@ -250,7 +250,9 @@ export function createLevels({ settings = {}, sets = [], cloud = null, index = n
   }
 
   /* ---- the presses ------------------------------------------------------- */
-  /** A tap on a level. One track, one run. On a desktop it is a door, not a download. */
+  /** A tap on a level. One track, one run. On a desktop it is a door, not a download.
+   *  The tap is the whole visit: the panel closes behind it and the main list takes over,
+   *  where the menu's plate shows the load and the first verb becomes `start · <name>`. */
   function tap(lv) {
     remember(lv.id);
     pickedId = lv.id; prog = null;   // the row itself is the answer from here on
@@ -259,11 +261,13 @@ export function createLevels({ settings = {}, sets = [], cloud = null, index = n
       call('toast', OVER_THERE_LINE);
       say(lv.title + ': handed to the desktop');
       paint();
+      if (onClose) onClose();
       return;
     }
     say('level ' + lv.n + ': ' + lv.title);
     call('play', [entry(lv)]);
     paint();
+    if (onClose) onClose();
   }
 
   /** The whole set, in order. The rollover between them is lane W1's, unchanged. */
@@ -274,6 +278,7 @@ export function createLevels({ settings = {}, sets = [], cloud = null, index = n
     say(set.title + ': all ' + levels.length);
     call('play', levels.map(entry));
     paint();
+    if (onClose) onClose();
   }
 
   function togglePaste() {
@@ -393,7 +398,8 @@ export function createLevels({ settings = {}, sets = [], cloud = null, index = n
     setStage(id, word) { stageId = String(id || ''); stageWord = String(word || ''); paint(); },
     /**
      * The state the menu's track plate would have shown. TRUE when this panel painted it on a
-     * picked row instead, which is raceBoot's whole rule for hiding the plate.
+     * picked row too, which is the menu's rule for keeping the plate down WHILE THIS PANEL IS OPEN
+     * (on the main list the plate shows regardless: a tap lands there).
      *   picking  a file dialog: not a level at all, so the pick is dropped and the plate takes it
      *   null     nothing loaded any more: the row goes back to being a row
      * A state with no picked row under it (a pasted link, a file) is never claimed.

--- a/ConditioningControlPanel/Resources/web/dtrh/race/menu.css
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/menu.css
@@ -198,6 +198,16 @@
 #race-root .rm-cloud-btn.is-off .rm-cloud-label, #race-root .rm-cloud-btn.is-off .rm-cloud-val { opacity: 0.5; }
 #race-root .rm-cloud-btn.is-on .rm-cloud-label { color: #fff; }
 
+/* ---- the status lines under the verbs: the track and the media the next run is made of ---- */
+#race-root .rm-status { display: flex; flex-direction: column; gap: 2px; margin-top: 10px; font-size: 12px; color: rgba(255, 214, 234, 0.72); letter-spacing: 0.02em; }
+#race-root .rm-status[hidden] { display: none; }
+#race-root .rm-status-line { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+#race-root .rm-status-line[hidden] { display: none; }
+/* the media line can name a feed AND a pile: it may take a second line, never a third */
+#race-root .rm-status-media { white-space: normal; display: -webkit-box; -webkit-box-orient: vertical; -webkit-line-clamp: 2; }
+/* `start · <a long track name>` never wraps a verb: it is cut with an ellipsis instead */
+#race-root .rm-list .rm-btn { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+
 /* ---- the track plate: a file in hand, or the host still reading it ---- */
 #race-root .rm-track {
   margin-top: 14px; padding: 10px 14px; background: rgba(18, 11, 36, 0.82);
@@ -376,6 +386,7 @@
   #race-root .rm-sub { font-size: 10px; margin: 4px 0 0; }
   #race-root .rm-panel { gap: 4px; }
   #race-root .rm-track { margin-top: 8px; padding: 6px 12px; }
+  #race-root .rm-status { margin-top: 4px; font-size: 10px; }
   #race-root .rm-plate { bottom: calc(10px + var(--rm-sa-b)); }
   #race-root .rc-deck { min-height: 0; }
   #race-root .rc-card { gap: 8px; }

--- a/ConditioningControlPanel/Resources/web/dtrh/race/menu.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/menu.js
@@ -1,15 +1,23 @@
 /* ============================================================================
  * race/menu.js - the main menu and the character stage of Racing Thoughts.
  *
- *   createMenu({ root, renderer, pixel, audio, settings, log, send }) ->
+ *   createMenu({ root, renderer, pixel, audio, settings, log, send, levels, media }) ->
  *     { show(), hide(), onPick(cb), options, stage: { update(dt), render(), dispose() }, dispose() }
  *   onPick yields 'race' | 'track' | 'clear' | 'story' | 'surface'; setTrack(state | null, onRow) drives the
  *   track plate (CHART.md: the host's track-progress and the chart that lands) - `onRow` is the levels
- *   panel saying it painted that state on the picked row itself, so only the verbs follow it and the
- *   plate stays down (a pasted link and a picked file still get the plate). refreshView() parks
+ *   panel saying it painted that state on the picked row itself, so the plate stands down only while
+ *   THAT panel is open; on the main list the plate is the status and always shows. refreshView() parks
  *   the stage where the column would park it even while the menu is hidden (race/cards.js borrows it).
  *   setLocalMedia(frame) and settingEcho(frame) feed the media panel below; `send` is the only way out
- *   to the host from in here, and only that panel uses it.
+ *   to the host from in here, and only that panel uses it. `media` is dtrh/hostMedia.js's pool, read
+ *   (stats() only) for the STATUS LINES under the verbs on a host with no media panel of its own.
+ *
+ * THE STATUS LINES. Two short lines under the verbs say what the next run is made of, so nobody has
+ * to open a panel to find out: `track · <name>` or `track · just the road`, and `media · online feed
+ * (niches)`, `media · your files (counts)`, `media · your library (counts)` on the desktop, or
+ * `media · no assets, the walls stay bare`. While a track is in hand the plate carries its name and
+ * its bar, so the track line stands down for it. When the chart is ready the first verb reads
+ * `start · <name>`.
  *
  * YOUR MEDIA (web only). `settings.mediaControls === true` adds a `your media` verb and a panel of
  * pickers: the browser host has no library of its own to enumerate, so the player hands it one. Each
@@ -482,7 +490,7 @@ export function createStage({ renderer, pixel, reducedMotion = false, log = null
 }
 
 // ---- the menu ------------------------------------------------------------------------------------
-export function createMenu({ root, renderer, pixel, audio, settings = {}, log = null, send = null, levels = null }) {
+export function createMenu({ root, renderer, pixel, audio, settings = {}, log = null, send = null, levels = null, media = null }) {
   const options = loadOptions();
   const systemReduced = !!(typeof matchMedia === 'function' && matchMedia('(prefers-reduced-motion: reduce)').matches);
   const reduced = () => wantsReducedMotion(options, settings.reducedMotion != null ? settings.reducedMotion : systemReduced);
@@ -513,6 +521,10 @@ export function createMenu({ root, renderer, pixel, audio, settings = {}, log = 
   const trackCap = el('div', 'rm-track-cap', trackEl, '');
   // shown only for a chart a person wrote (host: track-chart authored:true)
   const trackMark = el('div', 'rm-track-mark', trackEl, 'hand-tuned'); trackMark.hidden = true;
+  // ---- the status lines: what the next run is made of, under the verbs (header: THE STATUS LINES) ----
+  const statusEl = el('div', 'rm-status', col); statusEl.setAttribute('aria-live', 'polite');
+  const statTrack = el('div', 'rm-status-line rm-status-track', statusEl, '');
+  const statMedia = el('div', 'rm-status-line rm-status-media', statusEl, '');
   el('div', 'rm-foot', col, 'arrows move · enter picks · esc back · p pixels · m mute');
   const stageEl = el('div', 'rm-stage', layer);
   const plate = el('div', 'rm-plate', stageEl);
@@ -580,11 +592,17 @@ export function createMenu({ root, renderer, pixel, audio, settings = {}, log = 
   if (webMedia) {
     el('h3', 'rm-h', mediaPanel, 'your media');
     countEl = el('div', 'rm-media-count rh-num', mediaPanel, mediaLine()); countEl.setAttribute('aria-live', 'polite');
-    mediaEls = MEDIA_ROWS.map((r, i) => {
+    // The index is read off the LIVE list at event time, never captured at build: the online feed's
+    // rows are spliced in above `back` further down, and a captured index for `back` then landed on
+    // the feed's consent row, so a thumb leaving the panel switched the feed off instead.
+    const wireMedia = (b) => {
+      b.addEventListener('click', (e) => { e.stopPropagation(); idx.media = mediaEls.indexOf(b); act('press'); });
+      b.addEventListener('pointerenter', () => { idx.media = mediaEls.indexOf(b); ui('tick'); refresh(); });
+    };
+    mediaEls = MEDIA_ROWS.map((r) => {
       const b = el('button', 'rm-btn rm-media-btn', mediaPanel, r.label); b.type = 'button';
       b.dataset.id = r.id; b.setAttribute('role', 'menuitem');
-      b.addEventListener('click', (e) => { e.stopPropagation(); idx.media = i; act('press'); });
-      b.addEventListener('pointerenter', () => { idx.media = i; ui('tick'); refresh(); });
+      wireMedia(b);
       return b;
     });
     el('div', 'rm-hint', mediaPanel, 'nothing is uploaded. your files stay in this tab and go when you close it.');
@@ -600,11 +618,7 @@ export function createMenu({ root, renderer, pixel, audio, settings = {}, log = 
       const at = Math.max(0, MEDIA_ROWS.length - 1);
       MEDIA_ROWS.splice(at, 0, ...feed.rows);
       mediaEls.splice(at, 0, ...feed.els);
-      feed.els.forEach((b, i) => {
-        const at2 = at + i;
-        b.addEventListener('click', (e) => { e.stopPropagation(); idx.media = at2; act('press'); });
-        b.addEventListener('pointerenter', () => { idx.media = at2; ui('tick'); refresh(); });
-      });
+      feed.els.forEach(wireMedia);
     }
     mediaPanel.appendChild(mediaEls[mediaEls.length - 1]);   // `back` was built with the rest: put it last again
   }
@@ -677,7 +691,41 @@ export function createMenu({ root, renderer, pixel, audio, settings = {}, log = 
     return from;
   };
   const STAGE_CAP = { picking: 'pick a file', opening: 'over to bambicloud', fetching: 'pulling the audio down', decode: 'reading the file', energy: 'feeling the pulse', words: 'listening for the words', cancelled: '', error: '' };
-  let trackState = null;
+  let trackState = null, trackOnRow = false;
+  function paintPlate() {
+    const st = trackState;
+    trackEl.hidden = !st || st.stage === 'cancelled' || (trackOnRow && panel === CLOUD_VERB);
+  }
+  /** The two lines under the verbs (header: THE STATUS LINES). `known` is false on a host that
+   *  gave the menu no way to count anything, and then the media line is not shown at all. */
+  function statusLines() {
+    const st = trackState, name = st && st.stage !== 'cancelled' ? String(st.name || '') : '';
+    const counts = (im, vd) => [im ? plural(im, 'image') : '', vd ? plural(vd, 'video') : ''].filter(Boolean).join(', ');
+    const parts = [];
+    if (feed) {
+      const f = feed.state;
+      if (f.consent) parts.push(`online feed (${f.niches.length ? f.niches.join(', ') : 'nothing picked yet'})`);
+    }
+    let known = webMedia;
+    if (webMedia) { if (pile.images || pile.videos) parts.push(`your files (${counts(pile.images, pile.videos)})`); }
+    else if (media && typeof media.stats === 'function') {
+      let c = null; try { c = media.stats(); } catch (e) { c = null; }
+      if (c) { known = true; if (c.images || c.videos) parts.push(`your library (${counts(c.images | 0, c.videos | 0)})`); }
+    }
+    return {
+      track: name ? `track · ${name}` : 'track · just the road',
+      media: parts.length ? `media · ${parts.join(' and ')}` : 'media · no assets, the walls stay bare',
+      known,
+    };
+  }
+  function paintStatus() {
+    const s = statusLines();
+    statusEl.hidden = panel !== 'main';
+    statTrack.hidden = !trackEl.hidden;   // the plate carries the name and the bar while a track is in hand
+    if (statTrack.textContent !== s.track) statTrack.textContent = s.track;
+    statMedia.hidden = !s.known;
+    if (statMedia.textContent !== s.media) statMedia.textContent = s.media;
+  }
   /**
    * setTrack(state | null): the plate and the verbs follow the host. state = { stage, pct, name,
    * durationSec, countable, partial, authored, message }; stage 'ready' is a chart in hand (partial
@@ -685,13 +733,14 @@ export function createMenu({ root, renderer, pixel, audio, settings = {}, log = 
    * Null clears the plate and the verbs read as the seeded run again.
    *
    * `onRow` is raceBoot saying the LEVELS panel already painted this state on the picked row
-   * (race/levels.js): the verbs still follow it - `race the track` is the whole point of knowing -
-   * but the plate stays down, because two places saying the same thing is one place too many.
+   * (race/levels.js). Two places saying the same thing is one place too many, so the plate stands
+   * down while THAT panel is open; back on the main list (where a tap on a level lands, levels.js
+   * tap()) the plate is the status and shows, bar and all. paintPlate() re-reads that on open().
    */
   function setTrack(state, onRow) {
-    trackState = state && state.stage ? state : null;
+    trackState = state && state.stage ? state : null; trackOnRow = !!onRow;
     const st = trackState, ready = !!st && st.stage === 'ready';
-    trackEl.hidden = !st || st.stage === 'cancelled' || !!onRow;
+    paintPlate();
     trackEl.classList.toggle('is-ready', ready); trackEl.classList.toggle('is-error', !!st && st.stage === 'error');
     trackEl.classList.toggle('is-busy', !!st && !ready && st.stage !== 'error');
     if (st) {
@@ -705,7 +754,7 @@ export function createMenu({ root, renderer, pixel, audio, settings = {}, log = 
       } else trackCap.textContent = st.stage === 'error' ? (st.message || 'the track would not load') : (STAGE_CAP[st.stage] || st.stage);
     }
     trackMark.hidden = !(ready && st && st.authored);
-    verbEl('race').textContent = ready ? 'race the track' : 'race';
+    verbEl('race').textContent = ready ? `start · ${st.name || 'the track'}` : 'race';
     verbEl('track').textContent = ready ? 'another track' : 'load a track';
     verbEl('clear').hidden = !ready;
     if (verbEls[idx.main].hidden) idx.main = stepVerb(idx.main, 1);
@@ -718,7 +767,7 @@ export function createMenu({ root, renderer, pixel, audio, settings = {}, log = 
   if (canCloud) {
     cloudUi = levels.buildPanel({
       slot: cloudPanel,
-      pick: (i) => { idx.cloud = i; act('press'); },
+      pick: (i) => { if (panel !== CLOUD_VERB) return; idx.cloud = i; act('press'); },
       close: () => open('main'),
       refresh: () => { const n = cloudRows().length; idx.cloud = n ? clamp(idx.cloud, 0, n - 1) : 0; refresh(); },
     });
@@ -728,6 +777,7 @@ export function createMenu({ root, renderer, pixel, audio, settings = {}, log = 
     panel = p; list.hidden = p !== 'main'; optPanel.hidden = p !== 'options'; mediaPanel.hidden = p !== 'media'; howPanel.hidden = p !== 'how';
     cloudPanel.hidden = p !== CLOUD_VERB;
     if (p === 'options') idx.options = 0; if (p === 'media') idx.media = 0; if (p === CLOUD_VERB) idx.cloud = 0;
+    paintPlate();
     refresh(); if (p !== 'options') seedIn.blur(); onResize();
   }
   function focusRow(i) { idx.options = clamp(i, 0, ROWS.length - 1); ui('tick'); refresh(); }
@@ -737,6 +787,7 @@ export function createMenu({ root, renderer, pixel, audio, settings = {}, log = 
     mediaEls.forEach((b, i) => b.classList.toggle('is-focus', panel === 'media' && i === idx.media));
     cloudEls().forEach((b, i) => b.classList.toggle('is-focus', panel === CLOUD_VERB && i === idx.cloud));
     if (feed) feed.paint();   // equality-guarded, like the options rows above
+    paintStatus();            // same guard; the feed's echo and the pile both land here
     // The feed's niche rows make this panel taller than the column, which scrolls (menu.css
     // .rm-col). A pad or an arrow walking past the fold has to bring the row with it; `nearest` is
     // a no-op while the row is already on screen, so a finger scrolling by hand is left alone.
@@ -872,6 +923,7 @@ export function createMenu({ root, renderer, pixel, audio, settings = {}, log = 
       for (const k of ['images', 'videos', 'skipped']) if (typeof m[k] === 'number') pile[k] = m[k] | 0;
       pile.active = !!m.active;
       if (countEl) countEl.textContent = mediaLine();
+      paintStatus();
     },
     /** The host's `setting` echo. Contract law: only this takes the pending paint back off. The
      *  online feed owns two of the keys and its rows paint their own pending, so it gets first

--- a/ConditioningControlPanel/Resources/web/dtrh/race/smoke/levels-check.mjs
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/smoke/levels-check.mjs
@@ -23,11 +23,13 @@
  *   3. the marks: `hand-tuned` where the index has a row, `road` where it does
  *      not, and neither of them cost a request
  *   4. a tap is a ONE TRACK run: that track and nothing else, and the run's
- *      clock is the file's clock
- *  4b. the tapped row IS the status: it alone is `is-picked`, it alone grows a
- *      progress bar, a road in hand fills that bar and reads `loaded`, the old
- *      bottom plate stays down for a listed level, and `back` is pinned to the
- *      bottom of the column (still the last row the arrows walk)
+ *      clock is the file's clock. The tap closes the panel: the main list is
+ *      back with the plate up, its name on it, the status line stood down for
+ *      the plate, and the first verb reading `start · <name>`
+ *  4b. the tapped row IS the status inside the panel: it alone is `is-picked`,
+ *      it alone grows a progress bar, a road in hand fills that bar and reads
+ *      `loaded`, the plate stays down while the panel is open, and `back` is
+ *      pinned to the bottom of the column (still the last row the arrows walk)
  *   5. `again` lands on the last level played, and it survives a reload
  *   6. `play the set` is the whole list in order, the first one is the authored
  *      chart, and the end of a file rolls the lap on to the next level
@@ -229,9 +231,15 @@ await sleep(3000);
   ok(st.list.length === 1 && st.list[0].id === 'stub-two', 'a tap plays that level and NOTHING else: ' + JSON.stringify(st.list.map((e) => e.id)));
   ok(st.at === 0 && st.busy === false, 'and it is the track in hand');
   ok(await ev(`document.querySelector('.rm-track-name').textContent`) === 'The Second One', 'the plate names it');
+  ok(await ev(`document.querySelector('.rm-cloud').hidden === true && !document.querySelector('.rm-list').hidden`), 'the tap closed the panel: the main list is back');
+  ok(await ev(`document.querySelector('.rm-track').hidden === false`), 'and the plate is UP on the main list, bar and all');
+  ok(await ev(`document.querySelector('.rm-status-track').hidden === true`), 'the track status line stands down for the plate');
+  ok(await ev(`document.querySelector('.rm-list .rm-btn[data-id=race]').textContent`) === 'start · The Second One', 'and the first verb reads `start · The Second One`');
 }
 
 /* ---- 4b. the picked row IS the status, and `back` never leaves the screen ---- */
+await click('.rm-list .rm-btn[data-id=cloud]');
+await sleep(300);
 {
   const rows = await json(`[...document.querySelectorAll('.rm-levels .rm-level-btn')].map(b=>({
     id: b.dataset.id, picked: b.classList.contains('is-picked'), loaded: b.classList.contains('is-loaded'),
@@ -244,8 +252,8 @@ await sleep(3000);
   ok(two.bar === 'block' && one.bar === 'none', 'the picked row grew its own progress bar and no other row has one');
   ok(two.fill === '100%' && two.loaded, `the road is in hand, so the bar is full and the row reads loaded (${two.fill}, mark "${two.mark}")`);
   ok(await ev(`window.__race.levels.state.picked`) === 'stub-two', 'and the panel names that level as the picked one');
-  // the plate under the list is exactly what the picked row replaces: it stays down for a level
-  ok(await ev(`document.querySelector('.rm-track').hidden === true`), 'the old bottom row (the track plate) is NOT shown for a listed level');
+  // inside the panel the picked row is the plate: two places saying the same thing is one too many
+  ok(await ev(`document.querySelector('.rm-track').hidden === true`), 'the track plate stays down while the panel is open');
   const back = await json(`(()=>{const col=document.querySelector('.rm-col'); col.scrollTop = 99999;
     const b=document.querySelector('.rm-levels-foot .rm-btn[data-id=back]'), f=document.querySelector('.rm-levels-foot'), r=b.getBoundingClientRect();
     return { pos: getComputedStyle(f).position, top: Math.round(r.top), bottom: Math.round(r.bottom), h: innerHeight, last: b === [...document.querySelectorAll('.rm-cloud [role=menuitem]')].pop() };})()`);
@@ -283,8 +291,8 @@ await sleep(3000);
   ok(st.at === 0 && st.list[0].id === 'stub-one', 'starting at the first level');
   const held = await json(`(()=>{const t=window.__race.race.track; return { name: t ? t.name : null, hand: t ? t.chart.hand : null };})()`);
   ok(held.hand === true, 'and the authored chart won for it, off the index alone: ' + JSON.stringify(held));
+  ok(await ev(`document.querySelector('.rm-cloud').hidden === true`), 'and `play the set` closed the panel like a tap does');
 }
-await click('.rm-levels-foot .rm-btn[data-id=back]');
 await click('.rm-list .rm-btn[data-id=race]');
 for (let i = 0; i < 60; i++) {
   const st = await json(`window.__race.cloud.state`);

--- a/ConditioningControlPanel/Resources/web/dtrh/raceBoot.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/raceBoot.js
@@ -220,7 +220,11 @@ if (mode.hardBlock || !mode.canTry3d) {
 
 // ---- host wiring ----
 bridge.on('init', (m) => { initMsg = m; maybeBoot(); });
-bridge.on('manifest', (m) => { try { media.setManifest(m); warmWallPosters(media); } catch (e) { host.log('manifest: ' + e); } haveManifest = true; maybeBoot(); });
+bridge.on('manifest', (m) => {
+  try { media.setManifest(m); warmWallPosters(media); } catch (e) { host.log('manifest: ' + e); }
+  haveManifest = true; maybeBoot();
+  if (menu) { try { menu.refresh(); } catch (e) { /* the status line reads the pool on its next paint */ } }
+});
 bridge.on('favorites', (m) => { try { media.setFavorites(m && m.names || []); } catch (e) { host.log('favorites: ' + e); } });
 // The media panel's two frames (race/menu.js "YOUR MEDIA"). Both can land before the menu exists -
 // the pickers are only reachable from the menu, but the host pushes the pile it already holds on
@@ -268,7 +272,9 @@ bridge.on('track-progress', (m) => {
 /**
  * Where a track's progress goes while the menu is up (the run has the toast instead). The LEVELS
  * panel gets first refusal: a state that belongs to a row picked in there is painted ON that row,
- * bar and all, and the plate stays down. Anything the panel does not claim - a pasted link, a file
+ * bar and all, and the menu keeps its plate down while that panel is open. On the main list (where a
+ * tap on a level lands) the plate shows the same state, bar and all, and the first verb reads
+ * `start · <name>` once the chart is in. Anything the panel does not claim - a pasted link, a file
  * the host picked, the seeded road - is the plate's, exactly as it always was.
  */
 function plate(state) {
@@ -375,7 +381,7 @@ async function boot() {
     if (params.get('autostart') === '1') { startRun(false); debugPickup(); return; }
     if (hudRoot) hudRoot.classList.add('is-lobby');   // the run's chrome stays out of the menu and the intro
     levels = await makeLevels();
-    menu = createMenu({ root, renderer: race.renderer, pixel: race.pixel, audio: race.audio, settings, log: host.log, send: host.send, levels });
+    menu = createMenu({ root, renderer: race.renderer, pixel: race.pixel, audio: race.audio, settings, log: host.log, send: host.send, levels, media });
     if (localMedia) { try { menu.setLocalMedia(localMedia); } catch (e) { host.log('local-media: ' + e); } }
     while (settingEchoes.length) { try { menu.settingEcho(settingEchoes.shift()); } catch (e) { host.log('setting: ' + e); } }
     // Nowhere to surface to: no host and no `?back=`, or a host that says outright it cannot take


### PR DESCRIPTION
Three menu changes from the owner's iPhone test (2026-09-09). Race web files only, 6 files, ~150 lines.

## 1. `back` in `your media` switched the feed off (bug)
The media buttons captured their build-time index; the online feed rows are spliced in above `back` afterwards, so `back` pointed at the consent row and toggled it. The index is now read off the live list at event time for click and pointerenter (`wireMedia`). The levels panel's `pick` is also guarded so a press only counts while that panel is open.

## 2. Status lines on the main menu
Two small lines under the verbs:
- `track · <name>` or `track · just the road`
- `media · online feed (hypno, sph) and your files (3 images, 2 videos)` / `media · your library (…)` on the desktop host / `media · no assets, the walls stay bare`

`feedGroup` gets a `state` getter (same consent + picks the rows paint). `raceBoot` passes the media pool to `createMenu` and calls `menu.refresh()` when a manifest lands. The lines repaint on every `refresh()`, on `setLocalMedia` and on the setting echo. While a track is in hand the plate carries the name and bar, so the track line stands down for it.

## 3. Tap a level, land on the main menu
`levels.tap()` and `playSet()` close the panel after the pick. The plate is no longer hidden when the levels row painted the state; it hides only while the levels panel itself is open (`paintPlate()` on `open()`). Once the chart is ready the first verb reads `start · <name>` (id stays `race`, raceBoot untouched). Verbs never wrap: CSS ellipsis on `.rm-list .rm-btn`.

## Verified
- `node --check` on all changed files
- `levels-check.mjs` (extended: tap closes the panel, plate up on main, verb `start · The Second One`, plate down while the panel is open), `remote-feed-check.mjs`, `menu-return-check.mjs`: all green
- Playwright WebKit iPhone 14 harness with a faked `chrome.webview` host (feed on, two niches, a local pile): `back` posts NO `set-setting` and the feed still reads `on`; hover + enter on `back` likewise; status lines follow the consent echo, the niches echo and the pile; `track-progress` shows the plate with the bar on main; a `track-chart` flips the verb to `start · Bambi Sleep Tenderly Extended Mix`, clipped not wrapped; column fits a 390x844 viewport without scrolling

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PEeoJ93JCmhpWTQnwbPHc1
