### PR TITLE
fix(arcademy): the sort room's wall holds a decode budget, not a gallery

### DIFF
--- a/ConditioningControlPanel/ConditioningControlPanel.csproj
+++ b/ConditioningControlPanel/ConditioningControlPanel.csproj
@@ -529,7 +529,8 @@
       $(MSBuildProjectDirectory)\Resources\web\intake\assets\music\**\*.mp3;
       $(MSBuildProjectDirectory)\Resources\web\dtrh\assets\**\*.mp3
     </ContentPackWebExcludeAbs>
-    <!-- The four arcademy *demo.html browser harnesses. Listed once here and referenced by
+    <!-- The four arcademy *demo.html browser harnesses, plus the games' node smoke
+         checks (games\*\smoke\*.mjs). Listed once here and referenced by
          BOTH the <Content> Exclude below AND the CopyContentAfterPublish WebFiles Exclude,
          which re-globs Resources\web independently - miss the second one and the
          harness pages come straight back into the publish tree (and so the installer). -->
@@ -537,13 +538,15 @@
       Resources\web\arcademy\annex\demo.html;
       Resources\web\arcademy\vn\demo.html;
       Resources\web\arcademy\emi\demo.html;
-      Resources\web\arcademy\shell\recordsroom.demo.html
+      Resources\web\arcademy\shell\recordsroom.demo.html;
+      Resources\web\arcademy\games\**\smoke\**\*
     </ArcademyHarnessExclude>
     <ArcademyHarnessExcludeAbs>
       $(MSBuildProjectDirectory)\Resources\web\arcademy\annex\demo.html;
       $(MSBuildProjectDirectory)\Resources\web\arcademy\vn\demo.html;
       $(MSBuildProjectDirectory)\Resources\web\arcademy\emi\demo.html;
-      $(MSBuildProjectDirectory)\Resources\web\arcademy\shell\recordsroom.demo.html
+      $(MSBuildProjectDirectory)\Resources\web\arcademy\shell\recordsroom.demo.html;
+      $(MSBuildProjectDirectory)\Resources\web\arcademy\games\**\smoke\**\*
     </ArcademyHarnessExcludeAbs>
   </PropertyGroup>
 

--- a/ConditioningControlPanel/Resources/web/arcademy/CLAUDE.md
+++ b/ConditioningControlPanel/Resources/web/arcademy/CLAUDE.md
@@ -1633,6 +1633,19 @@ and it is not a third gate** - see trap 99, `init.devAnnex`.
       once `VIDEO_BUDGET` (6; 2 under `.ae-lite`) is spent. Anything that mints a decoration
       video must come through `mediaEl` and leave through `timers.release`/`kill`, or the
       count leaks and the budget closes for the session.
+    - **AN ANIMATED GIF IS A DECODE TOO, AND IT NEVER STOPS** (ccp-bugs #1197, 2026-09-09).
+      The bullet above was written about `<video>`, so "a gif still animates cheaply" got
+      written into `games/sort/wall.js` and the wall held one live `<img>` per landed card,
+      up to `WALL.CAP` = 120 of them. On a gif-heavy library that is 120 perpetual MAIN-THREAD
+      decodes behind the stack: the class's own 250ms `paintClock` stopped being called (the
+      report was "the timer only updates every few seconds" - a starved tick, never a clock
+      bug) and a fresh tile never got a lane. **A COLLAGE HOLDS A BUDGET, NOT A GALLERY:** the
+      newest `WALL.LIVE_FACES` (3) tiles keep an `<img>`, every older one is FROZEN by one
+      `drawImage` into a `<canvas>` that replaces it, and at most `WALL.DECODE_LANES` (4)
+      urls are ever in flight. **`drawImage` into a canvas you never read back is legal on a
+      CORS-tainted image** - the taint only ever bit `toDataURL`/`getImageData` - so a remote
+      feed freezes exactly like the local library and a freeze needs no `canvasSafe` pool.
+      Proof: `games/sort/smoke/wall-live-check.mjs` (33 assertions, 300 fake gifs).
     **AND A LADDER, NOT A SWITCH:** under a 4x CPU throttle even an all-stills board fell to
     40fps, so the whole frame has to get cheaper, not just the videos. `de_perf`
     (`auto|full|lite`) is the pattern: `lite` = `.g-de-lite` on the game's stage **and

--- a/ConditioningControlPanel/Resources/web/arcademy/games/sort/smoke/wall-live-check.mjs
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/sort/smoke/wall-live-check.mjs
@@ -1,0 +1,248 @@
+/* ============================================================================
+ * games/sort/smoke/wall-live-check.mjs - THE WALL'S LIVE BUDGET (ccp-bugs #1197).
+ *
+ *   node games/sort/smoke/wall-live-check.mjs     (from Resources/web/arcademy; 0 on pass)
+ *
+ * The bug: "The sort room mini-game in The Arcademy begins to lag out from too
+ * many gifs playing in the background to the point the timer starts only
+ * updating at like 1 frame every few seconds and some of the images don't load
+ * in at all." The wall held one live <img> per landed card, up to WALL.CAP of
+ * them, and in a gif-heavy library every one of those is an animated decode
+ * that never stops - on the main thread, next to the class's own 250ms clock.
+ *
+ * This drives the REAL `wall.js` against a DOM double and a fake clock with a
+ * library of 300 gifs, and holds it to the budget the fix put in:
+ *
+ *   - at most WALL.LIVE_FACES tiles hold a live <img>, at every single landing;
+ *   - at most WALL.DECODE_LANES urls are ever in flight;
+ *   - every older tile is a frozen <canvas>, one drawImage and never again;
+ *   - a url that errors is SKIPPED and COUNTED, and leaves no <img> behind;
+ *   - a recycled slot lets go of its old face;
+ *   - destroy() takes every decoder with it.
+ *
+ * There is no test seam in the shipped file: the double is a document, the
+ * clock is globalThis.setTimeout, and wall.js resolves both at call time.
+ * ==========================================================================*/
+
+let fails = 0;
+const ok = (cond, what) => { if (!cond) { console.error('FAIL ' + what); fails++; } else console.log('  ok  ' + what); };
+const eq = (got, want, what) => ok(got === want, what + ' (got ' + JSON.stringify(got) + ', want ' + JSON.stringify(want) + ')');
+const le = (got, want, what) => ok(got <= want, what + ' (got ' + got + ', want <= ' + want + ')');
+
+/* ------------------------------------------------------------ the clock -- */
+const timers = new Map();
+let nextTimer = 1;
+globalThis.setTimeout = (fn, ms) => { const id = nextTimer++; timers.set(id, { fn, ms }); return id; };
+globalThis.clearTimeout = (id) => { timers.delete(id); };
+
+/* -------------------------------------------------------------- the DOM -- */
+const pending = [];          // every <img> whose src was set and has not answered
+
+function makeClassList(node) {
+  const set = new Set();
+  const sync = () => { node.className = [...set].join(' '); };
+  return {
+    add(...c) { c.forEach((x) => set.add(x)); sync(); },
+    remove(...c) { c.forEach((x) => set.delete(x)); sync(); },
+    contains(c) { return set.has(c); },
+  };
+}
+
+function makeNode(tag) {
+  const t = String(tag).toLowerCase();
+  const node = {
+    tagName: t.toUpperCase(),
+    className: '',
+    children: [],
+    parentNode: null,
+    attrs: Object.create(null),
+    listeners: Object.create(null),
+    style: { props: Object.create(null), setProperty(k, v) { this.props[k] = v; } },
+    appendChild(c) {
+      if (c && c.parentNode) c.parentNode.removeChild(c);
+      if (c) c.parentNode = node;
+      node.children.push(c);
+      return c;
+    },
+    insertBefore(c, ref) {
+      if (c && c.parentNode) c.parentNode.removeChild(c);
+      const at = node.children.indexOf(ref);
+      if (c) c.parentNode = node;
+      if (at < 0) node.children.push(c); else node.children.splice(at, 0, c);
+      return c;
+    },
+    removeChild(c) {
+      const at = node.children.indexOf(c);
+      if (at >= 0) node.children.splice(at, 1);
+      if (c) c.parentNode = null;
+      return c;
+    },
+    remove() { if (node.parentNode) node.parentNode.removeChild(node); },
+    setAttribute(k, v) { node.attrs[k] = String(v); },
+    removeAttribute(k) { delete node.attrs[k]; if (k === 'src') node._src = ''; },
+    addEventListener(type, fn) { (node.listeners[type] || (node.listeners[type] = [])).push(fn); },
+    dispatch(type) { (node.listeners[type] || []).slice().forEach((fn) => { try { fn(); } catch (e) { /* noop */ } }); },
+    get textContent() { return ''; },
+    set textContent(v) { if (!v) node.children.slice().forEach((c) => node.removeChild(c)); },
+  };
+  node.classList = makeClassList(node);
+  if (t === 'img') {
+    node._src = '';
+    node.naturalWidth = 64;
+    node.naturalHeight = 48;
+    Object.defineProperty(node, 'src', {
+      get() { return node._src; },
+      set(v) { node._src = String(v); pending.push(node); },
+    });
+  }
+  if (t === 'canvas') {
+    node.width = 0;
+    node.height = 0;
+    node.draws = 0;
+    node.getContext = () => ({ drawImage() { node.draws += 1; } });
+  }
+  return node;
+}
+
+globalThis.document = { createElement: makeNode };
+
+const { createWall, WALL } = await import('../wall.js');
+
+/* ------------------------------------------------------------- counters -- */
+function walk(node, out) {
+  if (!node) return out;
+  out.push(node);
+  (node.children || []).forEach((c) => walk(c, out));
+  return out;
+}
+function liveImgs(root) {
+  return walk(root, []).filter((n) => n.tagName === 'IMG' && n._src);
+}
+function stills(root) {
+  return walk(root, []).filter((n) => n.tagName === 'CANVAS');
+}
+/** Answer every <img> that has been handed a src. */
+function flush(kind) {
+  const batch = pending.splice(0, pending.length);
+  batch.forEach((img) => img.dispatch(kind || 'load'));
+  return batch.length;
+}
+
+const cards = [];
+for (let i = 0; i < 300; i++) cards.push({ i, url: 'https://ccp.assets/lib/gif-' + i + '.gif', mime: 'image/gif', tag: i % 3 === 0 ? 'noise' : 'target' });
+
+/* ================================================== 1. THE LIVE BUDGET === */
+{
+  const mount = makeNode('div');
+  const wall = createWall({ mount, tier: 4, reduced: false, seed: 'smoke' });
+  let worstLive = 0;
+  let worstInFlight = 0;
+  for (const card of cards) {
+    wall.land(card, { wrong: card.i % 7 === 0 });
+    worstInFlight = Math.max(worstInFlight, pending.length);
+    flush('load');
+    worstLive = Math.max(worstLive, liveImgs(wall.el).length);
+  }
+  const d = wall.diagnostics();
+  le(worstLive, WALL.LIVE_FACES, '300 gifs land and the wall never holds more than LIVE_FACES live <img>');
+  le(worstInFlight, WALL.DECODE_LANES, 'never more than DECODE_LANES urls in flight at once');
+  eq(d.live, WALL.LIVE_FACES, 'the live window is full at the end');
+  eq(d.painted, 300, 'every one of the 300 urls painted');
+  eq(d.frozen, 300 - WALL.LIVE_FACES, 'everything older than the window froze');
+  eq(d.skipped, 0, 'nothing was skipped on a clean library');
+  eq(d.stuck, 0, 'no tile refused to freeze');
+  eq(d.queued, 0, 'the queue drained');
+  eq(d.landed, 300, 'the ledger still counts every landing');
+  eq(d.tiles, WALL.CAP, 'the wall recycled at CAP and grew no further');
+  /* the collage is intact: every tile the recycle left alone still shows a face */
+  ok(stills(wall.el).length === 300 - WALL.LIVE_FACES - (300 - WALL.CAP),
+    'a frozen still per surviving tile, minus the live window (got ' + stills(wall.el).length + ')');
+  ok(stills(wall.el).every((c) => c.draws === 1), 'each still was drawn exactly once');
+  ok(stills(wall.el).every((c) => c.width === WALL.STILL_PX && c.height === WALL.STILL_PX),
+    'a still is a square STILL_PX backing store');
+
+  wall.destroy();
+  eq(liveImgs(wall.el).length, 0, 'destroy() lets go of every decoder');
+}
+
+/* ============================================ 2. A SLOW LIBRARY QUEUES === */
+{
+  pending.length = 0;
+  const mount = makeNode('div');
+  const wall = createWall({ mount, tier: 4, reduced: false, seed: 'slow' });
+  for (const card of cards) wall.land(card, {});     // nothing answers
+  const d = wall.diagnostics();
+  le(liveImgs(wall.el).length, WALL.DECODE_LANES,
+    'a library that never answers still has only DECODE_LANES <img> on the wall at once');
+  eq(d.lanes, WALL.DECODE_LANES, 'the lanes are all claimed');
+  eq(d.live, 0, 'nothing is live until something loads');
+  ok(d.queued > 0, 'the rest is queued, not in flight');
+  /* the lane timeout hands a lane back WITHOUT touching the <img>: it is a
+   * concurrency claim, not a deadline, so a slow url may still land. */
+  const armed = [...timers.values()];
+  const held = liveImgs(wall.el).length;
+  ok(armed.length >= WALL.DECODE_LANES, 'each lane armed its LANE_MS timeout');
+  ok(armed.every((t) => t.ms === WALL.LANE_MS), 'the lane timeout is LANE_MS');
+  const queuedBefore = d.queued;
+  armed.forEach((t) => t.fn());
+  const after = wall.diagnostics();
+  ok(after.queued < queuedBefore, 'a timed-out lane goes back to the pool and the queue moves on');
+  ok(liveImgs(wall.el).length > held, 'the next urls started');
+  wall.destroy();
+}
+
+/* ================================================ 3. A DEAD URL SKIPS === */
+{
+  pending.length = 0;
+  timers.clear();
+  const mount = makeNode('div');
+  const wall = createWall({ mount, tier: 4, reduced: false, seed: 'dead' });
+  const some = cards.slice(0, 40);
+  some.forEach((card, i) => {
+    wall.land(card, {});
+    flush(i % 4 === 0 ? 'error' : 'load');
+  });
+  const d = wall.diagnostics();
+  eq(d.skipped, 10, 'every dead url was counted');
+  eq(wall.skipped, 10, 'and the class can read the count off the wall');
+  eq(d.painted, 30, 'the healthy ones still painted');
+  le(liveImgs(wall.el).length, WALL.LIVE_FACES, 'a skip does not leak a live <img>');
+  /* a skipped tile keeps its drawn back and its slot - never a hole */
+  eq(d.landed, 40, 'a skipped card still landed');
+  eq(d.tiles, 40, 'and still owns its slot');
+  wall.destroy();
+}
+
+/* ============================================ 4. THE RECYCLE LETS GO === */
+{
+  pending.length = 0;
+  timers.clear();
+  const mount = makeNode('div');
+  const wall = createWall({ mount, tier: 4, reduced: false, seed: 'recycle' });
+  for (let i = 0; i < WALL.CAP + 5; i++) { wall.land(cards[i % cards.length], {}); flush('load'); }
+  const d = wall.diagnostics();
+  eq(d.tiles, WALL.CAP, 'the wall recycles instead of growing');
+  le(liveImgs(wall.el).length, WALL.LIVE_FACES, 'a recycled slot did not leave its old <img> behind');
+  /* slot 0 was landed twice: exactly one face, the newest */
+  const slot0 = walk(wall.el, []).find((n) => n.attrs && n.attrs['data-slot'] === '0');
+  ok(!!slot0, 'slot 0 exists');
+  le(walk(slot0, []).filter((n) => n.tagName === 'IMG' || n.tagName === 'CANVAS').length, 1,
+    'a recycled tile holds exactly one face');
+  wall.destroy();
+}
+
+/* ===================================== 5. VIDEO STILL GETS NO ELEMENT === */
+{
+  pending.length = 0;
+  timers.clear();
+  const mount = makeNode('div');
+  const wall = createWall({ mount, tier: 4, reduced: false, seed: 'video' });
+  wall.land({ i: 1, url: 'https://ccp.assets/lib/clip.mp4', mime: 'video/mp4' }, {});
+  wall.land({ i: 2, url: 'https://ccp.assets/lib/clip2.webm' }, {});
+  eq(pending.length, 0, 'a video url mints no <img> (owner 2026-08-24, unchanged)');
+  eq(wall.diagnostics().landed, 2, 'but the card still landed');
+  wall.destroy();
+}
+
+console.log(fails ? '\n' + fails + ' FAILED' : '\nall green');
+process.exit(fails ? 1 : 0);

--- a/ConditioningControlPanel/Resources/web/arcademy/games/sort/wall.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/sort/wall.js
@@ -20,9 +20,15 @@
  *
  * DECODER BUDGET. A video card lands as a POSTER, never as a second decode: the
  * wall is dozens of tiles and the stack already owns the budget (ceiling 2).
- * `mediaEl` here mints an <img> for everything - a video url gets a still frame
- * or, failing that, its own seeded card back. Never put a live decode on a wall
- * tile (CLAUDE.md trap 36).
+ * `paint()` here mints an <img> for everything else - a video url gets no
+ * element at all and its seeded card back stands in. Never put a live decode on
+ * a wall tile (CLAUDE.md trap 36).
+ *
+ * ...AND AN ANIMATED GIF IS A LIVE DECODE (ccp-bugs #1197). That was the hole in
+ * the budget: a still is cheap, a gif in an <img> is not, and the wall held up
+ * to CAP of them at once. See THE DECODE RAIL below - the newest few tiles keep
+ * a live <img>, everything older is frozen to a canvas, and at most
+ * `DECODE_LANES` urls are ever in flight.
  * ==========================================================================*/
 
 import { hash01 } from '../../core/rng.js';
@@ -47,6 +53,22 @@ export const WALL = Object.freeze({
   CAP: 120,
   /** Column counts the layout will consider. */
   COLS: Object.freeze([6, 7, 8, 9, 10, 11, 12]),
+  /** THE LIVE BUDGET (ccp-bugs #1197). How many tiles keep an ANIMATED <img>.
+   *  Always the newest ones - the eye is on the landing, never on the corner.
+   *  Every older tile is frozen to a canvas still and costs nothing a frame. */
+  LIVE_FACES: 3,
+  /** How many tile urls may be in flight at once. A tier-4 player commits a
+   *  card a second; with no lane count the wall opens a socket and a decode
+   *  for every one of them and the STACK's own media queues behind them,
+   *  which is how a card "doesn't load in at all". */
+  DECODE_LANES: 4,
+  /** A lane is a concurrency claim, not a deadline: a url that has not
+   *  answered in this long hands its lane back. The <img> is left alone and
+   *  still counts if it lands later. */
+  LANE_MS: 4000,
+  /** The side of a frozen tile's canvas backing store, px. A wall tile is
+   *  never wider than ~180 CSS px, so this is one crisp step above it. */
+  STILL_PX: 224,
   /** The full-bleed hold at the bell. */
   BLEED_MS: 3000,
   /** THE KEN-BURNS period band, in seconds. One seeded draw for the collage. */
@@ -122,6 +144,18 @@ function el(tag, cls) {
   } catch (e) { return null; }
 }
 
+/* The lane timer resolves setTimeout off the GLOBAL at call time, the way
+ * index.js's clock does, so a harness with a fake clock drives the wall too
+ * and the shipped file grows no test seam. */
+function laterFn() {
+  const f = globalThis.setTimeout;
+  return typeof f === 'function' ? f : setTimeout;
+}
+function clearLaterFn() {
+  const f = globalThis.clearTimeout;
+  return typeof f === 'function' ? f : clearTimeout;
+}
+
 /**
  * The wall.
  * @param {Object} o
@@ -188,8 +222,196 @@ export function createWall(o = {}) {
   setAttr(root, 'data-bleed', '0');
   setAttr(root, 'data-flood', '0');
 
-  function paint(tile, card) {
-    if (!tile) return;
+  /* ==================================================== THE DECODE RAIL ====
+   * WHY THIS EXISTS (ccp-bugs #1197, "the sort room begins to lag out from too
+   * many gifs playing in the background... the timer starts only updating at
+   * like 1 frame every few seconds and some of the images don't load in").
+   *
+   * The wall used to mint an <img> the moment a card landed and then leave it
+   * there for the rest of the class. At CAP that is 120 live elements, and in
+   * a gif-heavy library every one of them is an ANIMATED gif, which Chromium
+   * keeps decoding for ever, on the MAIN thread, whether or not anyone is
+   * looking at that corner of the mosaic. Past roughly thirty tiles the
+   * decoder owns the frame: the 250ms clock tick lands seconds late (that is
+   * the reported timer, and it is not a clock bug - `paintClock` reads the
+   * wall clock and is simply never called), and a freshly landed tile never
+   * gets a lane, which is the "doesn't load in at all" half. The line that
+   * used to sit right here - "a gif still animates cheaply" - was the bug.
+   *
+   * So the wall now keeps a BUDGET instead of a gallery:
+   *
+   *   1. AT MOST `WALL.LIVE_FACES` TILES HOLD A LIVE <img>, always the newest.
+   *   2. AN OLDER TILE IS FROZEN: its current frame is drawn once into a
+   *      <canvas> that takes the <img>'s place, and the <img> is dropped, so
+   *      the decoder lets go. The tile looks the same and costs nothing a
+   *      frame. `drawImage` into a canvas we never read back is legal on a
+   *      CORS-TAINTED image, so a remote feed freezes exactly like the local
+   *      library does - the taint only ever bit `toDataURL`/`getImageData`,
+   *      and this rail calls neither.
+   *   3. AT MOST `WALL.DECODE_LANES` URLS ARE IN FLIGHT, so a fast player
+   *      cannot open eighty sockets and starve the STACK's own media.
+   *   4. A URL THAT WILL NOT LOAD IS SKIPPED AND COUNTED, never left as a
+   *      half-decoded hole. `skipped` rides `diagnostics()` so the class can
+   *      say how many the wall dropped.
+   *
+   * The tier dial, the recycle, the wrong-card dimming and the thud are
+   * untouched: this changes what a tile COSTS, never what it shows.
+   * ======================================================================= */
+  let skipped = 0;      // urls that answered with an error and lost their tile
+  let frozenN = 0;      // tiles turned into a canvas still
+  let stuck = 0;        // tiles a freeze could not take (kept live, honestly)
+  let paintedN = 0;     // tiles whose media actually landed
+  const liveFaces = []; // records still holding an <img>, oldest first
+  const bySlot = new Map();
+  const gens = [];      // per-slot generation, bumped on every recycle
+  const queue = [];
+  let lanes = 0;
+  let dead = false;
+
+  function genOf(slot) { return gens[slot] || 0; }
+
+  /** Let go of a decoder. `removeAttribute` and not `src=''`: an empty src is
+   *  a request for the document url in some engines. */
+  function killImg(img) {
+    if (!img) return;
+    try { if (typeof img.removeAttribute === 'function') img.removeAttribute('src'); }
+    catch (e) { /* DOM double */ }
+    try { if (typeof img.remove === 'function') img.remove(); }
+    catch (e) { /* noop */ }
+  }
+
+  function freeLane(rec) {
+    if (!rec) return;
+    if (rec.timer) { try { clearLaterFn()(rec.timer); } catch (e) { /* noop */ } rec.timer = 0; }
+    if (rec.lane) { rec.lane = false; lanes = lanes > 0 ? lanes - 1 : 0; pump(); }
+  }
+
+  /** Drop whatever face a slot is holding. Bumps the slot's generation, so an
+   *  in-flight paint for the card that used to live here lands on the floor
+   *  instead of on the card that replaced it. */
+  function clearSlot(slot) {
+    gens[slot] = genOf(slot) + 1;
+    const rec = bySlot.get(slot);
+    if (!rec) return;
+    bySlot.delete(slot);
+    freeLane(rec);
+    const at = liveFaces.indexOf(rec);
+    if (at >= 0) liveFaces.splice(at, 1);
+    killImg(rec.img);
+    rec.img = null;
+    try { if (rec.canvas && typeof rec.canvas.remove === 'function') rec.canvas.remove(); }
+    catch (e) { /* noop */ }
+    rec.canvas = null;
+  }
+
+  /**
+   * THE FREEZE. One `drawImage` and the tile is a still for good.
+   * The canvas is SQUARE and centre-cropped by hand, which is what
+   * `object-fit:cover` was doing for the <img> in a square tile - done in the
+   * draw so the tile does not depend on object-fit applying to a canvas.
+   */
+  function freeze(rec) {
+    if (!rec || !rec.img) return;
+    if (rec.gen !== genOf(rec.slot)) { killImg(rec.img); rec.img = null; return; }
+    const img = rec.img;
+    let canvas = null;
+    try {
+      const side = Math.max(16, Math.round(WALL.STILL_PX));
+      canvas = el('canvas', 'g-sort-wall-face is-still');
+      const ctx = canvas && typeof canvas.getContext === 'function' ? canvas.getContext('2d') : null;
+      if (!ctx || typeof ctx.drawImage !== 'function') { canvas = null; }
+      else {
+        canvas.width = side;
+        canvas.height = side;
+        const nw = Math.round(Number(img.naturalWidth) || 0);
+        const nh = Math.round(Number(img.naturalHeight) || 0);
+        if (nw > 0 && nh > 0) {
+          const s = Math.min(nw, nh);
+          ctx.drawImage(img, (nw - s) / 2, (nh - s) / 2, s, s, 0, 0, side, side);
+        } else {
+          /* no intrinsic size (an svg, a double) - stretch and move on */
+          ctx.drawImage(img, 0, 0, side, side);
+        }
+      }
+    } catch (e) { canvas = null; }
+    if (!canvas) {
+      /* THE ONE HONEST FAILURE. Nothing to freeze onto, so the tile keeps its
+       * live <img>: a drifting gif is a smaller sin than a hole in the ledger,
+       * and this branch means a decode that broke between load and draw. */
+      stuck += 1;
+      return;
+    }
+    setAttr(canvas, 'aria-hidden', 'true');
+    try { if (rec.tile && rec.tile.appendChild) rec.tile.appendChild(canvas); } catch (e) { /* noop */ }
+    killImg(img);
+    rec.img = null;
+    rec.canvas = canvas;
+    frozenN += 1;
+  }
+
+  /** Hold the live budget: the newest LIVE_FACES keep their <img>, the rest freeze. */
+  function trim() {
+    const cap = Math.max(1, Math.round(WALL.LIVE_FACES));
+    while (liveFaces.length > cap) freeze(liveFaces.shift());
+  }
+
+  function settle(rec, ok) {
+    if (!rec || rec.settled) return;
+    rec.settled = true;
+    freeLane(rec);
+    if (rec.gen !== genOf(rec.slot)) { killImg(rec.img); rec.img = null; return; }
+    if (!ok) {
+      /* SKIP, DO NOT HOLE. A dead url loses its <img> and the tile falls back
+       * to its own drawn back - the same answer the stack gives - and the miss
+       * is counted so the class can report it. */
+      skipped += 1;
+      killImg(rec.img);
+      rec.img = null;
+      if (bySlot.get(rec.slot) === rec) bySlot.delete(rec.slot);
+      return;
+    }
+    paintedN += 1;
+    liveFaces.push(rec);
+    trim();
+  }
+
+  function start(rec) {
+    const img = el('img', 'g-sort-wall-face');
+    if (!img) return;
+    rec.img = img;
+    rec.lane = true;
+    lanes += 1;
+    img.alt = '';
+    setAttr(img, 'draggable', 'false');
+    setAttr(img, 'decoding', 'async');
+    if (typeof img.addEventListener === 'function') {
+      img.addEventListener('load', () => settle(rec, true));
+      img.addEventListener('error', () => settle(rec, false));
+    }
+    try { img.src = rec.url; } catch (e) { settle(rec, false); return; }
+    try { if (rec.tile && rec.tile.appendChild) rec.tile.appendChild(img); } catch (e) { /* noop */ }
+    rec.timer = laterFn()(() => { rec.timer = 0; freeLane(rec); }, Math.max(0, WALL.LANE_MS));
+  }
+
+  /* `pumping` is a re-entrancy guard, not a nicety: a url that throws on
+   * assignment settles inside start(), which frees its lane and pumps again,
+   * and a whole dead queue would otherwise recurse once per row. */
+  let pumping = false;
+  function pump() {
+    if (pumping) return;
+    pumping = true;
+    try {
+      while (!dead && lanes < Math.max(1, WALL.DECODE_LANES) && queue.length) {
+        const rec = queue.shift();
+        if (!rec) continue;
+        if (rec.gen !== genOf(rec.slot)) continue;   // the slot recycled while it waited
+        start(rec);
+      }
+    } finally { pumping = false; }
+  }
+
+  function paint(tile, card, slot) {
+    if (!tile || dead) return;
     /* THE SAME FACE THE STACK SHOWED (0826). `resolve` is the game's own
      * substitute resolution (index.js displaySrcOf): a card whose url is on
      * the blacklist was played as a same-tag substitute, and painting its raw
@@ -199,24 +421,19 @@ export function createWall(o = {}) {
      * an old double) keeps the raw card. */
     const src = resolve(card) || null;
     if (!src || !src.url) return;
-    /* A WALL TILE IS NEVER A LIVE DECODE (trap 36). A loop lands as its own
-     * url in an <img> - a gif still animates cheaply. A VIDEO url gets no <img>
-     * at all (owner 2026-08-24): an mp4 in an <img> paints nothing but still
-     * downloads the whole file, so the drawn card back stands for it instead. */
+    /* A VIDEO URL GETS NO <img> AT ALL (owner 2026-08-24): an mp4 in an <img>
+     * paints nothing but still downloads the whole file, so the drawn card
+     * back stands for it instead. */
     const mime = src.mime;
     if ((mime && /^video\//i.test(String(mime)))
       || /\.(mp4|webm|m4v|mov)(\?|#|$)/i.test(String(src.url))) return;
-    const img = el('img', 'g-sort-wall-face');
-    if (!img) return;
-    img.alt = '';
-    setAttr(img, 'draggable', 'false');
-    setAttr(img, 'decoding', 'async');
-    setAttr(img, 'loading', 'lazy');
-    if (typeof img.addEventListener === 'function') {
-      img.addEventListener('error', () => { try { if (img.parentNode) img.remove(); } catch (e) { /* ignore */ } });
-    }
-    img.src = src.url;
-    tile.appendChild(img);
+    const rec = {
+      slot, gen: genOf(slot), tile, url: String(src.url),
+      img: null, canvas: null, lane: false, settled: false, timer: 0,
+    };
+    bySlot.set(slot, rec);
+    queue.push(rec);
+    pump();
   }
 
   const api = {
@@ -262,6 +479,10 @@ export function createWall(o = {}) {
         tiles[slot] = tile;
         if (grid) grid.appendChild(tile);
       } else {
+        /* THE RECYCLE LETS GO FIRST. `textContent = ''` empties the tile in a
+         * real DOM but says nothing to the rail, so without this the old
+         * record kept a lane and a live <img> the wall could no longer see. */
+        clearSlot(slot);
         try { tile.textContent = ''; } catch (e) { /* noop */ }
       }
       setAttr(tile, 'data-slot', String(slot));
@@ -276,7 +497,7 @@ export function createWall(o = {}) {
         if (!reduced) tile.classList.add('thud');
         if (wrong) tile.classList.add('is-wrong'); else tile.classList.remove('is-wrong');
       }
-      paint(tile, card);
+      paint(tile, card, slot);
       return tile;
     },
 
@@ -324,14 +545,33 @@ export function createWall(o = {}) {
       return bleeding;
     },
 
+    /** Urls the wall gave up on. The class reads it for its own report line. */
+    get skipped() { return skipped; },
+
     diagnostics() {
       return {
         landed, cols, visible, bleeding, flooding, kenBurns, tiles: tiles.length,
         fromRung: fromRungFor(tier), tier,
+        /* the decode rail (ccp-bugs #1197) */
+        live: liveFaces.length, frozen: frozenN, painted: paintedN,
+        skipped, stuck, queued: queue.length, lanes,
+        liveCap: Math.max(1, Math.round(WALL.LIVE_FACES)),
       };
     },
 
     destroy() {
+      dead = true;
+      queue.length = 0;
+      /* EVERY DECODER GOES BACK, not just the ones on screen. A class that
+       * ends mid-flight used to leave its <img> elements attached to a
+       * detached tree with their gifs still spinning until GC noticed. */
+      try {
+        bySlot.forEach((rec) => { freeLane(rec); killImg(rec.img); rec.img = null; });
+      } catch (e) { /* noop */ }
+      bySlot.clear();
+      liveFaces.length = 0;
+      lanes = 0;
+      if (skipped > 0) say('wall: ' + skipped + ' tile url(s) skipped');
       tiles.length = 0;
       try { if (root && root.remove) root.remove(); } catch (e) { say('wall destroy: ' + ((e && e.message) || e)); }
     },


### PR DESCRIPTION
## Bug

ccp-bugs #1197 (`BUG-WP3LCS7X9B`, app 6.9.2, Windows 11 26200, mod `builtin-sissyhypno`):

> The sort room mini-game in The Arcademy begins to lag out from too many gifs playing in the background to the point the timer starts only updating at like 1 frame every few seconds and some of the images don't load in at all.

## Cause

`games/sort/wall.js` — the collage behind the stack — minted one `<img>` per committed card and left it there for the rest of the class, up to `WALL.CAP` = **120** of them. Trap 36's decoder budget was written about `<video>`, so the wall carried the line *"a gif still animates cheaply"* and kept every tile as a live face.

On a gif-heavy library that is 120 perpetual **animated decodes on the main thread**, behind the stack. Past roughly thirty tiles the decoder owns the frame:

* the class's own 250 ms `paintClock` is simply never called. The reported timer is a **starved tick, not a clock bug** — `paintClock` reads the wall clock (`budgetMs - (now() - startedAt)`) and is correct whenever it actually runs;
* a freshly landed tile never gets a socket or a decode slot, which is the *"don't load in at all"* half.

The stack itself was already fine (three cards deep, `DECODER_CEILING` 2, posters over budget). It was only the wall.

## Fix

The wall now keeps a **budget instead of a gallery**:

| | |
|---|---|
| `WALL.LIVE_FACES` = 3 | tiles that hold a live `<img>`, always the newest |
| `WALL.DECODE_LANES` = 4 | urls in flight at once |
| `WALL.LANE_MS` = 4000 | a lane is a concurrency claim, not a deadline — a hung url hands its lane back and is still counted if it lands later |
| `WALL.STILL_PX` = 224 | the square backing store a frozen tile is drawn into |

* **The freeze.** A tile that falls out of the live window is drawn **once** into a `<canvas>` that replaces its `<img>`; the `<img>` is dropped (`removeAttribute('src')`, not `src=''`) so the decoder lets go. `drawImage` into a canvas we never read back is legal on a **CORS-tainted** image — the taint only ever bit `toDataURL`/`getImageData` — so a remote feed freezes exactly like the local library, and no `canvasSafe` pool is needed. The crop is a hand-rolled centre cover, i.e. what `object-fit:cover` was already doing in a square tile.
* **Skip, don't hole.** A url that errors loses its `<img>`, the tile falls back to its own drawn card back (the same answer the stack gives), and the miss is counted: `wall.skipped` and `diagnostics().skipped`, which the class's diag payload already carries.
* **Let go.** A recycled slot bumps a per-slot generation, so an in-flight paint for the card that used to live there lands on the floor instead of on its replacement; `destroy()` releases every decoder and lane instead of leaving gifs spinning in a detached tree.

**Behaviour, scoring and look are unchanged**: the tier dial, the recycle at `CAP`, the wrong-card dimming, the thud, the flood, the bleed and the ken-burns drift are all untouched (the frozen canvas wears the same `.g-sort-wall-face` class, so it drifts with the rest). No CSS change was needed. This changes what a tile *costs*, never what it *shows*. No user-facing string was added or changed.

`games/**/smoke/**` joins `ArcademyHarnessExclude` (both the `<Content>` exclude and the `CopyContentAfterPublish` mirror) so the check does not ship.

## Follow-ups (NOT in this PR)

The same "one live `<img>` per pool item" shape exists elsewhere. Worth noting that **Instant Recall already solved it** — `games/instant-recall/montage.js` has `MONTAGE.LIVE_LOOP_CAP` (12 / 6 lite / 0 reduced) and a `VIDEO_TILE_CAP` — so the fix above is that pattern arriving at the wall, and the rooms below are the ones still without it:

1. **`games/deja-vu/index.js:593`** — every board cell mints a `g-dv-face`. Boards are 6/8/10 pairs (`script.js:150 BOARD_SIZES`), so up to 20 faces, and matched pairs stay revealed for the rest of the board. No live cap, no freeze. The most likely next report.
2. **`games/lost-and-found/board.js:142`** — `g-lf-media` per board tile plus wrap clones; error drops the tile but nothing caps concurrent decodes.
3. **`games/the-deep-end/index.js:769`** — has `FACE_CAP`/`SHALLOW_STILL_MAX_TIER` for *videos* but the `g-de-media` `<img>` path is not counted, so gif tiers are uncapped.
4. **`games/composure/index.js:708,731`** and **`games/echo/index.js:801`** — one media element plus a peek; small, but neither freezes when it leaves the screen.
5. **`shell/` Records Office / capsule (`shell/capsule.js:177`, `shell/scene.js:1004,1017`, `shell/room.js:336`)** — long-lived pages that mint faces and never freeze them; the Records Office is the one a player leaves open.
6. **`games/impulse-control/render.js:162-190`** — two background `<img>` + one bubble, cross-faded and never released between rounds; small but worth a release on swap.
7. **Ken-burns layer count.** `.g-sort-wall.is-kb .g-sort-wall-face` animates a transform on up to `CAP` elements, which is up to 120 composited layers. It runs on the compositor and is *not* the reported bug, but moving it to `.g-sort-wall-grid` (the trick `is-shudder` already uses) would be one layer instead of 120. Left alone here because it is a visual change.

## How to verify

```
cd ConditioningControlPanel/Resources/web/arcademy
node games/sort/smoke/wall-live-check.mjs      # 33 assertions, exit 0
```

The check drives the **real** `wall.js` against a DOM double and a fake clock with 300 fake gif entries and asserts:

* at most `LIVE_FACES` live `<img>` on the wall **at every one of the 300 landings** (worst observed: 3);
* at most `DECODE_LANES` urls in flight, even when nothing ever answers;
* every tile older than the window is a `<canvas>` drawn exactly once, `STILL_PX` square;
* a dead url is counted (`skipped`) and leaves no `<img>`, and the card still lands and keeps its slot;
* a recycled tile holds exactly one face;
* a video url still mints no element (owner 2026-08-24, unchanged);
* `destroy()` drops every decoder.

Build:

```
cd ConditioningControlPanel && dotnet build      # 0 errors, 362 warnings (all pre-existing)
```

Web files still land in the output (`bin/.../Resources/web/arcademy/games/sort/wall.js` present, `.../sort/smoke/` correctly absent).

In-app: open the Arcademy, play The Sorting Room (room 201) at grade tier 3 or 4 with a large gif library so the wall wakes at rung 1-2, and sort for the full 180 s. The clock chip should tick every 250 ms to the bell, and the mosaic should keep filling. `sort.__diag()`'s `wall` block reports `live`, `frozen`, `skipped`, `queued` and `lanes`.

## Not verified

The app was not launched (headless environment) — the live budget, the freeze and the lane cap are proven against the DOM double, not against WebView2. Worth one manual 180 s tier-4 class on a gif-heavy library before release, watching for any visible seam at the moment a tile freezes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BcbxiDEFBZMFLM24nLh8qf
