### PR TITLE
feat(race): word bubbles x1.6, the word kept inside the glass

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/race/bubbles.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/bubbles.js
@@ -60,9 +60,10 @@ const sizeOf = (id) => (id === 'video' || id === 'gifrain') ? 1.5 : id === 'gold
 /** A trigger row's centre bubble, and an accent word, are drawn this much bigger than the rest. */
 const BIG_SCALE = 1.15;
 /** A bubble wearing a word is drawn this much bigger than a plain one of its kind: the owner
- *  could not read the words at speed on the phone (0909), so the glass the word sits on grew
- *  by a quarter. The pop box is unchanged; only the sprite is. */
-const WORD_SCALE = 1.25;
+ *  could not read the words at speed on the phone (0909), so the glass the word sits on grew:
+ *  a quarter first, then to 1.6 once the word was kept inside the glass (the sprite's glass is
+ *  only 72 percent of its canvas, see wordFace.js GLASS_FRAC). The pop box is unchanged. */
+const WORD_SCALE = 1.6;
 
 /** Soft radial dot: the fallback face while a sprite loads, and the shard face. */
 function makeDotTex() {

--- a/ConditioningControlPanel/Resources/web/dtrh/race/smoke/face-check.mjs
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/smoke/face-check.mjs
@@ -62,7 +62,8 @@ const constOf = (name) => Number((src.match(new RegExp(name + ' = ([0-9.]+)')) |
 const CACHE_MAX = constOf('CACHE_MAX');
 eq(CACHE_MAX, 96, 'the face cache holds 96 textures');
 eq(constOf('TEX_PX'), 256, 'each one 256 px square (128 until 0909: too soft once the word grew)');
-eq(constOf('TEXT_FRAC'), 0.8, 'and the word fits inside 80 percent of the diameter');
+eq(constOf('GLASS_FRAC'), 0.72, 'the glass is 72 percent of the sprite canvas');
+ok(constOf('TEXT_FRAC') <= constOf('GLASS_FRAC') * 0.9, `and the word fits inside it with a margin (${constOf('TEXT_FRAC')} of the canvas): no letter past the rim`);
 eq(constOf('MAX_LINES'), 2, 'over at most two lines');
 eq(constOf('OUTLINE_PX'), 6, 'with a 6 px dark outline (and a HALO_PX halo) so it reads on the bubble highlight');
 ok(/--rh-font/.test(src) && /800 \$\{size\}px/.test(src), 'set in the HUD sans at weight 800');

--- a/ConditioningControlPanel/Resources/web/dtrh/race/wordFace.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/wordFace.js
@@ -28,15 +28,20 @@
 
 import * as THREE from 'three';
 
-/** The face canvas, square. A word bubble is about 85 px on a phone (x3 for its pixel ratio)
- *  and 185 on a desktop at the pop point, so 256 keeps the letters crisp on the glass; the
+/** The face canvas, square. A word bubble is about 110 px on a phone (x3 for its pixel ratio)
+ *  and 235 on a desktop at the pop point, so 256 keeps the letters crisp on the glass; the
  *  cache at its cap is 25 MB of texture, which a phone holds fine. */
 export const TEX_PX = 256;
 /** How many faces live at once before the least recently asked for one is disposed. */
 export const CACHE_MAX = 96;
-/** The word fits inside this much of the bubble's diameter: the rest is the bubble's rim.
- *  0.7 until 0909; the owner could not read it at speed, so the word takes more of the glass. */
-export const TEXT_FRAC = 0.8;
+/** The GLASS is only this much of the sprite canvas: the rest is the rim's soft edge and clear
+ *  margin (bubble.png and the effects sprites all measure 0.72 at alpha over 40). */
+export const GLASS_FRAC = 0.72;
+/** The word fits inside this much of the canvas, which is 0.89 of the glass: 0.7 and then 0.8
+ *  let the letters clip past the rim (owner, 0909: "the words kinda clip and go out of the
+ *  bubble"), so the word is kept on the glass and the bubble itself grew instead
+ *  (bubbles.js WORD_SCALE). */
+export const TEXT_FRAC = 0.64;
 /** At most this many lines. A merged two word bubble reads as two; a set label of three or
  *  four words is balanced across the same two rather than shrinking to nothing on one. */
 export const MAX_LINES = 2;


### PR DESCRIPTION
Owner after #1019 (2026-09-09): "make those bubbles bigger since the words kinda clip and go out of the bubble". Race web files only, 3 files, ~20 lines.

The sprite's glass is only 72 percent of its canvas (bubble.png and the effects sprites all measure 0.72 at alpha over 40), so a word set across 80 percent of the canvas ran past the rim.

- `wordFace.js`: `GLASS_FRAC = 0.72` documents the glass; `TEXT_FRAC` 0.8 -> 0.64 (0.89 of the glass), so no letter crosses the rim
- `bubbles.js`: `WORD_SCALE` 1.25 -> 1.6, so the word on screen stays the size #1019 gave it while the glass around it grows; pop box unchanged; rows still clear each other (row gap 2.07 m, glass 1.32 m)
- `face-check.mjs` holds `GLASS_FRAC` and `TEXT_FRAC <= 0.9 * GLASS_FRAC`

## Verified
- `node --check` on all three files
- `face-check.mjs` and `rows-check.mjs` (nearest approach 3.16 m, unchanged) green
- iPhone 14 WebKit face sheet at the pop-point size (109 px now): every word, the two-liners included, sits inside the glass with a margin

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PEeoJ93JCmhpWTQnwbPHc1
