### PR TITLE
feat(race): pixel block off on glass, smallest step on a mouse

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
@@ -695,7 +695,9 @@ resultTier(total, best, personalBest) -> 0..4 (the face index)
   `--rm-scrim-b` to the band's complement and `is-band` on `.rm-root`: menu.css draws those two scrims
   instead of its one sheet, so no dark plate and no verb ever lies over her.
 - Options persist under the single localStorage key `race.options` (`pixel, music, sfx, motion, seed, seedValue`), not in
-  `engine/settings.js`. Precedence for the block: `?pixel` > `race.options.pixel` > host `settings.pixel` > `PIXEL_DEFAULT`.
+  `engine/settings.js`. Precedence for the block: `?pixel` > `race.options.pixel` > host `settings.pixel` > `pixelDefault()`,
+  which answers 0 (off) on a coarse pointer and `PIXEL_MIN` on a fine one. A stored value equal to the old fixed default
+  (`PIXEL_LEGACY_DEFAULT`, 3) is read by `loadOptions` as "never chosen" and takes that per-device default instead.
   The seed rule (daily / random / custom) sets `settings.seedLock`, which `again` honours; a change in the menu calls `reseed`.
 - Music / sfx sliders store their values and call `audio.setLevels({ music, sfx })` when audio.js grows one; until then
   the rows are dimmed with a note. Reduced motion from the menu drives the stage and the intro at once, the run on the next launch.

--- a/ConditioningControlPanel/Resources/web/dtrh/race/menu.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/menu.js
@@ -93,7 +93,7 @@ import * as THREE from 'three';
 import { wantsTouch } from './touch.js';
 import { loadPack, preparePixel, toInstanceGeometry, flattenRig, setFace, FACES } from './gltf.js';
 import { snapshotRest } from './emiPoses.js';
-import { PIXEL_STEPS, PIXEL_DEFAULT, normalizeBlock } from './pixel.js';
+import { PIXEL_STEPS, PIXEL_LEGACY_DEFAULT, pixelDefault, normalizeBlock } from './pixel.js';
 import { createMenuFlashes } from './menuFlashes.js';
 import { vFovForAspect, bindViewportResize } from './viewport.js';
 import { createFeedGroup } from './feedGroup.js';
@@ -107,7 +107,9 @@ export const ROSTER = [
     clips: { idle: 'idle', wave: 'wave', hop: 'hop', peek: 'peek', drum: 'drum' },
     faces: { idle: 0, wave: 1, hop: 2, peek: 3, drum: 4, starry: 5, spiral: 6 } },
 ];
-const DEFAULTS = { pixel: PIXEL_DEFAULT, music: 0.8, sfx: 0.8, motion: 'system', seed: 'daily', seedValue: 7 };
+// `pixel` is the one default that reads the device: off on a coarse pointer, the smallest block on a
+// fine one (race/pixel.js pixelDefault). loadOptions below migrates the old fixed default onto it.
+const DEFAULTS = { pixel: pixelDefault(), music: 0.8, sfx: 0.8, motion: 'system', seed: 'daily', seedValue: 7 };
 const MOTIONS = ['system', 'on', 'off'], SEEDS = ['daily', 'random', 'custom'];
 const GLASS = 'EMI_glass', FADE = 0.3, ONE_SHOTS = ['wave', 'hop', 'drum'];
 const BEAT_MIN = 3, BEAT_MAX = 6, PEEK_GAP = 6;
@@ -178,7 +180,13 @@ export function loadOptions() {
   try {
     const raw = JSON.parse(localStorage.getItem(OPTIONS_KEY) || 'null');
     if (raw && typeof raw === 'object') {
-      if (typeof raw.pixel === 'number') o.pixel = normalizeBlock(raw.pixel);
+      // THE PIXEL MIGRATION. The menu saves the WHOLE options table, so everyone who ever opened
+      // the menu has a `pixel` written down whether or not they ever pressed that row: a saved
+      // value equal to the old default (PIXEL_LEGACY_DEFAULT, 3) is therefore read as "never
+      // chosen" and takes the new per-device default instead (off on glass, the smallest block on
+      // a mouse). A player who deliberately sat on 3 pays for it once and sets it again; every
+      // other number they picked is kept exactly as it is.
+      if (typeof raw.pixel === 'number' && normalizeBlock(raw.pixel) !== PIXEL_LEGACY_DEFAULT) o.pixel = normalizeBlock(raw.pixel);
       for (const k of ['music', 'sfx']) if (typeof raw[k] === 'number' && isFinite(raw[k])) o[k] = clamp(raw[k], 0, 1);
       if (MOTIONS.includes(raw.motion)) o.motion = raw.motion;
       if (SEEDS.includes(raw.seed)) o.seed = raw.seed;

--- a/ConditioningControlPanel/Resources/web/dtrh/race/pixel.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/pixel.js
@@ -22,7 +22,9 @@
  *     { block, setBlock(n), cycle(), resize(w, h), render(scene, camera),
  *       filterTexture(tex), retexture(scene), label(), stats, dispose() }
  *
- * PIXEL_STEPS is the P-key cycle: off, 2, 3, 4, 6 screen pixels per block.
+ * PIXEL_STEPS is the P-key cycle: off, 2, 3, 4, 6 screen pixels per block, and
+ * pixelDefault() is where a player who never touched the option starts: off on
+ * glass, the smallest block on a mouse.
  * Put an object on the crisp layer with `obj.layers.set(CRISP_LAYER)`.
  * `stats` is last frame's draw calls + triangles summed over the passes plus
  * the frame time (avg + p95 ms over the last FRAME_WIN frames); with `log`
@@ -35,7 +37,15 @@ import * as THREE from 'three';
 import { Q } from '../shared/quality.js';
 
 export const PIXEL_STEPS = [0, 2, 3, 4, 6];
-export const PIXEL_DEFAULT = 3;
+/** The smallest block there is, `off` aside. This is the default a mouse gets. */
+export const PIXEL_MIN = PIXEL_STEPS[1];
+/**
+ * THE OLD DEFAULT, kept for one job: the migration in race/menu.js loadOptions. Everybody who never
+ * opened the option still has this number written into `race.options` (the menu saves the whole
+ * table whatever the player touched), so a saved 3 is read there as "never chosen" and takes the new
+ * default instead. Nothing else may read it: what a fresh page gets is pixelDefault() below.
+ */
+export const PIXEL_LEGACY_DEFAULT = 3;
 export const CRISP_LAYER = 1;
 const WORLD_MASK = 1 << 0, CRISP_MASK = 1 << CRISP_LAYER, ALL_MASK = WORLD_MASK | CRISP_MASK;
 const MAP_KEYS = ['map', 'emissiveMap', 'alphaMap', 'normalMap', 'roughnessMap', 'metalnessMap', 'aoMap'];
@@ -43,6 +53,30 @@ const FAR_FADE = [42, 80];     // metres: the world pass fades to the fog colour
 const PERF_LOG_SEC = 5;
 const FRAME_WIN = 300;         // frames kept for the avg / p95
 const SLOW_MS = 24, FAST_MS = 13;   // governor thresholds on the avg frame (about 42 and 77 fps)
+
+/**
+ * THE DEFAULT BLOCK, which is not one number any more. On glass the big pixels cost the most and
+ * read the worst: a phone panel is already tiny, and a 3 px block on it turned the road to mush
+ * (the owner, phone testing 2026-09-09). So a COARSE POINTER starts with the look OFF and a fine
+ * one starts at PIXEL_MIN, the gentlest block on the cycle. The option row still walks the whole
+ * range either way: this decides where a player who never touched it begins, nothing more.
+ *
+ * The test is `(pointer: coarse)` and only that - a Windows laptop with a touchscreen has a mouse
+ * as well, reads as fine, and is a pc. `?coarse=1` / `?coarse=0` force the answer for a headless
+ * check (race/smoke/popped-check.mjs), the way race/touch.js takes `?touch=`.
+ */
+export function pixelDefault(win) {
+  const w = win || (typeof window !== 'undefined' ? window : null);
+  if (!w) return PIXEL_MIN;
+  try {
+    const q = new URLSearchParams(w.location.search).get('coarse');
+    if (q === '1' || q === 'on') return 0;
+    if (q === '0' || q === 'off') return PIXEL_MIN;
+  } catch (e) { /* no location, or a page that hides it: fall through to the device test */ }
+  try { if (typeof w.matchMedia === 'function' && w.matchMedia('(pointer: coarse)').matches) return 0; }
+  catch (e) { /* no matchMedia: a mouse is the safer guess */ }
+  return PIXEL_MIN;
+}
 
 /** Snap any input to a step: 0 (off) or the nearest listed block size. */
 export function normalizeBlock(n) {
@@ -80,7 +114,7 @@ const BLIT_FRAG = `
     #include <colorspace_fragment>
   }`;
 
-export function createPixelizer({ renderer, canvas, block = PIXEL_DEFAULT, log = null }) {
+export function createPixelizer({ renderer, canvas, block = pixelDefault(), log = null }) {
   let cur = normalizeBlock(block);
   let w = 1, h = 1;
   let dprCap = Infinity;         // the governor's lid on the device pixel ratio (1 while slow)

--- a/ConditioningControlPanel/Resources/web/dtrh/race/run.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/run.js
@@ -81,7 +81,7 @@ import { createSubliminal, ECHO_SEC } from './subliminal.js';
 import { createMediaLane } from './mediaLane.js';
 import { createInput } from './input.js';
 import { createPickups, TUNE as PICK } from './pickups.js';
-import { createPixelizer, PIXEL_DEFAULT } from './pixel.js';
+import { createPixelizer, pixelDefault } from './pixel.js';
 import { createSpeedFx } from './speed.js';
 import { vFovForAspect, bindViewportResize } from './viewport.js';
 import { createRaceAudio } from './audio.js';
@@ -122,7 +122,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1, onExi
   const renderer = new THREE.WebGLRenderer({ canvas, antialias: Q.antialias, alpha: false, powerPreference: 'high-performance' });
   // the big-pixel look: the world at low resolution, bubbles + wall media crisp on top (race/pixel.js);
   // host settings.pixel / ?pixel=N override, 0 = off; draw-call stats go to the host log every ~5 s
-  const pixel = createPixelizer({ renderer, canvas, block: settings.pixel == null ? PIXEL_DEFAULT : settings.pixel, log: (m) => { if (bridge.log) bridge.log(m); } });
+  const pixel = createPixelizer({ renderer, canvas, block: settings.pixel == null ? pixelDefault() : settings.pixel, log: (m) => { if (bridge.log) bridge.log(m); } });
   if ('outputColorSpace' in renderer) renderer.outputColorSpace = THREE.SRGBColorSpace;
   const scene = new THREE.Scene();
   scene.background = new THREE.Color(0x12261f);

--- a/ConditioningControlPanel/Resources/web/dtrh/race/smoke/pixel-default-check.mjs
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/smoke/pixel-default-check.mjs
@@ -1,0 +1,161 @@
+/* ============================================================================
+ * race/smoke/pixel-default-check.mjs - headless self-check for THE PIXEL
+ * DEFAULT (race/pixel.js pixelDefault + race/menu.js loadOptions), driven
+ * through the REAL page.
+ *
+ *   node race/smoke/pixel-default-check.mjs      (exits 0 on pass, 1 with a count)
+ *
+ * Why it exists: the big-pixel look used to start at 3 for everybody, which on a
+ * phone panel is mush (the owner, phone testing 2026-09-09). Now a COARSE
+ * pointer starts OFF and a fine one starts at the smallest block, and the old
+ * fixed default that every player already has written into `race.options` is
+ * read as "never chosen" so they get the new one too.
+ *
+ * Headless Chrome has a FINE pointer, so `?coarse=1` / `?coarse=0` force the
+ * answer (race/pixel.js pixelDefault, the way race/touch.js takes `?touch=`).
+ *
+ * What it holds:
+ *   1. a fresh page on a mouse starts at the smallest non-zero step
+ *   2. a fresh page on glass starts with the look off
+ *   3. the migration: a saved 3 (the old default) is not a choice, so both
+ *      devices get their new default instead
+ *   4. a value the player actually picked is kept, on both devices
+ *   5. `?pixel=N` still beats all of it
+ *
+ * CHROME: `CHROME_PATH` if it is set, else the usual Windows install. Nothing is
+ * installed by this file and the profile it makes is deleted on the way out.
+ * ==========================================================================*/
+
+import { spawn } from 'node:child_process';
+import { createServer } from 'node:http';
+import { readFile } from 'node:fs/promises';
+import { mkdtempSync, rmSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, extname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+let fails = 0;
+const ok = (cond, what) => { if (!cond) { console.error('FAIL ' + what); fails++; } else console.log('  ok  ' + what); };
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const HERE = resolve(fileURLToPath(import.meta.url), '..');
+const WEB = resolve(HERE, '../../..');          // Resources/web
+const PORT = 8869;
+const CHROME = process.env.CHROME_PATH || 'C:/Program Files/Google/Chrome/Application/chrome.exe';
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.mjs': 'text/javascript', '.css': 'text/css', '.json': 'application/json', '.glb': 'model/gltf-binary', '.png': 'image/png', '.webp': 'image/webp', '.jpg': 'image/jpeg', '.mp3': 'audio/mpeg', '.wav': 'audio/wav', '.svg': 'image/svg+xml', '.woff2': 'font/woff2' };
+
+const server = createServer(async (req, res) => {
+  const path = decodeURIComponent(new URL(req.url, 'http://x').pathname);
+  if (path.indexOf('..') >= 0) { res.writeHead(400); return res.end(); }
+  try {
+    const body = await readFile(join(WEB, path));
+    res.writeHead(200, { 'content-type': MIME[extname(path).toLowerCase()] || 'application/octet-stream' });
+    res.end(body);
+  } catch (e) { res.writeHead(404, { 'content-type': 'text/plain' }); res.end('no'); }
+});
+
+if (!existsSync(CHROME)) {
+  console.error('FAIL no chrome at ' + CHROME + ' (set CHROME_PATH)');
+  process.exit(1);
+}
+await new Promise((r) => server.listen(PORT, '127.0.0.1', r));
+
+const prof = mkdtempSync(join(tmpdir(), 'race-pixel-'));
+const chrome = spawn(CHROME, [
+  '--headless=new', '--remote-debugging-port=9341', `--user-data-dir=${prof}`,
+  '--no-first-run', '--no-default-browser-check', '--disable-gpu', '--mute-audio',
+  '--enable-unsafe-swiftshader', '--autoplay-policy=no-user-gesture-required',
+  '--window-size=900,700', 'about:blank',
+], { stdio: 'ignore' });
+
+let page = null;
+for (let i = 0; i < 60 && !page; i++) {
+  await sleep(250);
+  try { page = (await (await fetch('http://127.0.0.1:9341/json/list')).json()).find((t) => t.type === 'page'); } catch (e) { /* not up */ }
+}
+if (!page) { console.error('FAIL chrome never answered on the debug port'); await done(1); }
+
+const ws = new WebSocket(page.webSocketDebuggerUrl);
+await new Promise((r) => { ws.onopen = r; });
+let msgId = 0;
+const waits = new Map();
+ws.onmessage = (e) => {
+  const m = JSON.parse(e.data);
+  if (m.id && waits.has(m.id)) { waits.get(m.id)(m); waits.delete(m.id); }
+};
+const cdp = (method, params) => new Promise((res) => { const i = ++msgId; waits.set(i, res); ws.send(JSON.stringify({ id: i, method, params })); });
+const ev = async (x) => (await cdp('Runtime.evaluate', { expression: x, returnByValue: true, awaitPromise: true })).result?.result?.value;
+const json = async (x) => JSON.parse(await ev(`JSON.stringify(${x})`));
+
+const site = `http://127.0.0.1:${PORT}`;
+const url = (q) => `${site}/dtrh/race.html?intro=0&cards=0&${q}`;
+
+async function bootAt(u) {
+  await cdp('Page.navigate', { url: u });
+  for (let i = 0; i < 80; i++) {
+    await sleep(250);
+    const up = await ev(`!!(window.__race && window.__race.menu && window.__race.race)`);
+    if (up) { await sleep(200); return true; }
+  }
+  return false;
+}
+/** What the run and the option row agree the block is. */
+const block = () => json(`({ pixel: window.__race.race.pixel.block, option: window.__race.menu.options.pixel,
+  row: [...document.querySelectorAll('.rm-options .rm-row')].filter(r=>r.dataset.id==='pixel').map(r=>r.querySelector('.rm-row-val').textContent)[0] })`);
+/** Wipe the saved options, or write one, then come back on the given device. */
+async function withOptions(saved, q) {
+  await bootAt(url('coarse=0'));
+  await ev(saved === null
+    ? `localStorage.removeItem('race.options'), 1`
+    : `localStorage.setItem('race.options', ${JSON.stringify(JSON.stringify(saved))}), 1`);
+  return bootAt(url(q));
+}
+
+await cdp('Runtime.enable'); await cdp('Page.enable');
+
+/* ---- 1. a fresh page on a mouse ----------------------------------------- */
+ok(await withOptions(null, 'coarse=0'), 'the page boots with nothing saved, on a fine pointer');
+{
+  const b = await block();
+  ok(b.pixel === 2, `a mouse starts at the smallest block (${b.pixel})`);
+  ok(b.option === 2 && b.row === '2 px', `and the option row says so: "${b.row}"`);
+}
+
+/* ---- 2. a fresh page on glass -------------------------------------------- */
+ok(await withOptions(null, 'coarse=1'), 'the page boots with nothing saved, on a coarse pointer');
+{
+  const b = await block();
+  ok(b.pixel === 0, `glass starts with the look OFF (${b.pixel})`);
+  ok(b.option === 0 && b.row === 'off', `and the option row reads "${b.row}"`);
+}
+
+/* ---- 3. the migration: the old default is not a choice -------------------- */
+const OLD = { pixel: 3, music: 0.8, sfx: 0.8, motion: 'system', seed: 'daily', seedValue: 7 };
+ok(await withOptions(OLD, 'coarse=1'), 'a player carrying the old default (3) opens the race on glass');
+ok((await block()).pixel === 0, 'and gets the new default, off, rather than the 3 nobody picked');
+ok(await withOptions(OLD, 'coarse=0'), 'the same saved 3 on a mouse');
+ok((await block()).pixel === 2, 'takes the smallest block, the new default there');
+
+/* ---- 4. a value the player actually picked is theirs ---------------------- */
+const PICKED = { ...OLD, pixel: 6 };
+ok(await withOptions(PICKED, 'coarse=1'), 'a player who chose 6 opens the race on glass');
+ok((await block()).pixel === 6, 'and keeps their 6');
+ok(await withOptions(PICKED, 'coarse=0'), 'and on a mouse');
+ok((await block()).pixel === 6, 'they keep it there too');
+
+/* ---- 5. ?pixel still beats everything ------------------------------------- */
+ok(await withOptions(null, 'coarse=1&pixel=4'), '?pixel=4 on glass, with nothing saved');
+ok((await block()).pixel === 4, 'the query string still wins over the device default');
+
+await done(fails ? 1 : 0);
+
+async function done(code) {
+  try { ws && ws.close(); } catch (e) { /* never opened */ }
+  try { chrome.kill(); } catch (e) { /* already gone */ }
+  await new Promise((r) => server.close(r));
+  await sleep(300);
+  try { rmSync(prof, { recursive: true, force: true }); } catch (e) { /* chrome still has a lock */ }
+  if (code) console.error(`\n${fails} failure${fails === 1 ? '' : 's'}`);
+  else console.log('\npixel-default-check: all good');
+  process.exit(code);
+}

--- a/ConditioningControlPanel/Resources/web/dtrh/raceBoot.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/raceBoot.js
@@ -53,7 +53,10 @@
  * either they show once, gated on localStorage `race.cards`), and `?card=N`
  * opens them on card N (1..4, a screenshot aid the way `?hold=` is one);
  * `?pixel=N` (0 = off) beats `race.options` which beats `settings.pixel` from
- * the host init; `?pickup=<id>` stands that pickup up on the next spot ahead
+ * the host init, and with none of the three the block is race/pixel.js's own
+ * pixelDefault(): off on a coarse pointer, the smallest step on a mouse
+ * (`?coarse=1` / `?coarse=0` force that answer for a check);
+ * `?pickup=<id>` stands that pickup up on the next spot ahead
  * once the run is up, a screenshot aid for it (race/pickups.js);
  * `?panel=howto` opens the menu on the key card (race/menu.js).
  *


### PR DESCRIPTION
Phone testing, 2026-09-09: "we might wanna make the pixellation off from mobile and default to the min on pc (rn the 3 px block is kinda bad)".

The big-pixel look started at 3 for everyone. On a phone panel that is mush, and on a desktop 3 is a heavier look than anybody opted into.

## What changed

**`race/pixel.js`** grows `pixelDefault(win)`: a **coarse pointer starts with the look off (0)**, a fine one starts at `PIXEL_MIN` (2, the smallest block on the cycle). The test is `(pointer: coarse)` and only that, so a Windows laptop with a touchscreen and a mouse still reads as a pc. `PIXEL_DEFAULT` is gone; `PIXEL_LEGACY_DEFAULT` (3) survives for the migration below and nothing else.

**`race/menu.js`** `loadOptions` migrates: the menu saves the whole options table whether or not a row was ever pressed, so everybody who ever opened the menu carries `pixel: 3` already. A saved value equal to the old fixed default is therefore read as **"never chosen"** and takes the new per-device default; any other saved number is a real choice and is kept as it is. A player who deliberately sat on 3 sets it once more, which is the honest price of the migration and is documented in the code.

**`race/run.js`** two lines: the import and the `settings.pixel == null` fallback now read `pixelDefault()`.

**`raceBoot.js` / `race/CONTRACT.md`** the precedence line says what the bottom of the ladder is now. `?pixel=N` still beats everything above it.

The option row still cycles the full range on both devices. `?coarse=1` / `?coarse=0` force the device answer for a headless check, the way `race/touch.js` takes `?touch=`.

## The check

New `race/smoke/pixel-default-check.mjs` drives the real page: a fresh mouse starts at 2, fresh glass starts at off, a saved 3 takes the new default on both, a saved 6 is kept on both, and `?pixel=4` still wins.

```
pixel-default-check: all good
levels-check: all good
menu-return-check: all good
track-run-check: all good
```

(all four were green on the baseline before this branch too)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PEeoJ93JCmhpWTQnwbPHc1
