### PR TITLE
feat(race): count the thoughts popped, and keep the best on each finished track

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
@@ -602,6 +602,14 @@ As built (PR 5 reality notes):
   renderer's programs, and `start()` builds it if nothing did (`?autostart=1`). `reseed` on a world that was
   never built only resets state, so the menu changing the seed rule costs nothing until `race`.
 - Extra `run-ended` fields: `nearMisses`, `personalBest`. `exit` is followed by `exit-done` once torn down.
+- THE THOUGHTS COUNT (`race/popped.js`). A thought is one word bubble: one `word` event of the chart, one
+  bubble on the road. The total is read off the chart when it loads (never off what spawned) and a trigger
+  row is not in it. The HUD carries `popped N / M` under the kept line while a track is in hand, the End card
+  adds a `thoughts` row, and `run-ended` grows `thoughts`, `thoughtsTotal` and, on a run that reached the end
+  of the chart, `thoughtsBest` / `thoughtsRecord`. Only a COMPLETED run files a best, into localStorage
+  `race.popped` keyed by `source.hash` (or `cid:<cloudId>` where there is no hash); a best is beaten on the
+  count alone. race/menu.js paints it on the track plate and the `track ·` status line, race/levels.js on the
+  level's own row (by cloud id, because a row knows a url and not a hash).
 - Boot and reduced motion: `raceBoot.js` calls `detectMode({ reducedIs3d: true })`, so `prefers-reduced-motion: reduce`
   boots the 3D race and only turns motion down through `settings.reducedMotion`; a boot error is reserved for a real
   hard wall (no WebGL, no import maps).

--- a/ConditioningControlPanel/Resources/web/dtrh/race/hud.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/hud.js
@@ -30,6 +30,7 @@
  * ==========================================================================*/
 
 import { COMBO_HOLD_SEC, MULT_LADDER, KART_MAX_SPEED, KART_BASE_SPEED } from './consts.js';
+import { poppedLine } from './popped.js';
 
 const FLICK_MS = 450;
 /**
@@ -98,6 +99,11 @@ export function createRaceHud(root) {
   const comboN = el('rh-num', comboRow, 'combo 0');
   const nextEl = el('rh-next rh-num', scoreWrap, '');
   const bankEl = el('rh-bank rh-num', scoreWrap, 'kept 0');
+  // THE THOUGHTS LINE (race/popped.js): how many word bubbles of this track have been taken, of
+  // every word the file says. A run with no track carries no line at all, so the seeded road and
+  // its plate are exactly what they were.
+  const poppedEl = el('rh-popped rh-num', scoreWrap, '');
+  poppedEl.hidden = true;
 
   // ---- the rung ladder: consts by default, swappable via setLadder ----
   let ladder = okLadder(MULT_LADDER) ? MULT_LADDER : NEW_LADDER;
@@ -310,6 +316,12 @@ export function createRaceHud(root) {
       if (hot !== speedHot) { speedHot = hot; speed.classList.toggle('is-boost', hot); }
     },
     setBank(n) { bankTarget = Math.max(0, n || 0); wake(); },
+    /** THE THOUGHTS LINE: `popped 12 / 560` under the kept line. No total is no line (race/popped.js). */
+    setPopped(n, total) {
+      const line = poppedLine(n, total);
+      poppedEl.hidden = !line;
+      if (line && poppedEl.textContent !== line) poppedEl.textContent = line;
+    },
     banner(name, tagline, colorHex) {
       if (colorHex) chrome.style.setProperty('--rh-room', colorHex);
       bannerName.textContent = (name || '').toLowerCase();
@@ -481,6 +493,9 @@ export function createRaceHud(root) {
       if (s.trackName) {   // a charted run: the file, and how many of its words the player met
         line('track', String(s.trackName).replace(/\.[a-z0-9]{2,4}$/i, '').slice(0, 28));
         if (s.countable > 0) line('taken', `${fmt(s.taken || 0)} of ${fmt(s.countable)}`);
+        // the word bubbles, counted one for one (race/popped.js). `taken` above folds a whole line
+        // of them into one thing to take; this is the raw count of the words the player popped.
+        if (s.thoughtsTotal > 0) line('thoughts', `${fmt(s.thoughts || 0)} of ${fmt(s.thoughtsTotal)}`);
       }
       if (endResolve) settleEnd('exit');
       end.classList.add('is-on');

--- a/ConditioningControlPanel/Resources/web/dtrh/race/levels.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/levels.js
@@ -26,6 +26,12 @@
  *            `cloud-open { url }` and says to press play over there. This page
  *            never loads a byte of audio in that mode.
  *
+ * THE BEST ON A ROW. A level driven to its end at least once carries
+ * `popped 345 / 560 thoughts` under its title: the word bubbles taken on the best
+ * run of that file, of every word in it (race/popped.js). It costs no network and
+ * no chart - the store is keyed by the cloud id off the url - and a level nobody
+ * has finished simply has no line.
+ *
  * THE MARK ON A ROW. `hand-tuned` when race/charts/index.json has a row for that
  * track, `road` when it does not, `again` on the last one played. Deciding it
  * costs NO NETWORK: the index is same-origin and already fetched, and the key is
@@ -54,6 +60,7 @@
  * ==========================================================================*/
 
 import { cloudIdFrom, findAuthored } from './chartSource.js';
+import { readBests, bestFor, bestLine } from './popped.js';
 
 /** The panel key. Kept as `cloud` so the menu, `?panel=cloud` and the smokes all still name it. */
 export const VERB_ID = 'cloud';
@@ -195,6 +202,12 @@ export function createLevels({ settings = {}, sets = [], cloud = null, index = n
 
   /** The `hand-tuned` mark, decided with no network at all: the index is same origin. */
   const authored = (lv) => !!findAuthored(index, { cloudId: cloudIdFrom(lv.url), hash: lv.hash });
+  // THE BEST ON A ROW (race/popped.js): `popped 345 / 560 thoughts` under the title of every level
+  // that has been driven to the end at least once. A level is known here by its URL and never by
+  // its file hash, so the lookup is by cloud id; the whole map is read once per paint rather than
+  // once per row, and a store that throws (a private window) simply has no bests in it.
+  let bests = readBests(mem);
+  const bestOf = (lv) => bestFor(bests, { hash: lv.hash, cloudId: cloudIdFrom(lv.url) });
   /** What race/cloud.js is handed for a level. `bytes` saves it a HEAD the cdn will not answer. */
   const entry = (lv) => ({ id: lv.id, url: lv.url, title: lv.title, bytes: lv.bytes, locked: false });
 
@@ -306,10 +319,16 @@ export function createLevels({ settings = {}, sets = [], cloud = null, index = n
   function paint() {
     if (!slotEl || disposed) return;
     const picked = pickedLevel();
+    bests = readBests(mem);   // a run that just ended wrote one: the panel is painted after it
     for (let i = 0; i < levels.length; i++) {
       const b = levelEls[i]; if (!b) continue;
       const lv = levels[i], mark = markOf(lv), m = b.querySelector('.rm-level-mark');
       if (m && m.textContent !== mark) m.textContent = mark;
+      const bestEl = b.querySelector('.rm-level-best'), bLine = bestLine(bestOf(lv));
+      if (bestEl) {
+        bestEl.hidden = !bLine;
+        if (bLine && bestEl.textContent !== bLine) bestEl.textContent = bLine;
+      }
       b.classList.toggle('is-on', !!playerState(lv));
       b.classList.toggle('is-hand', authored(lv));
       // the picked row IS the status: it lights, and the bar under its title is the load
@@ -350,6 +369,8 @@ export function createLevels({ settings = {}, sets = [], cloud = null, index = n
       elm('span', 'rm-level-title', b, lv.title);
       elm('span', 'rm-level-len', b, mmss(lv.durationSec));
       elm('span', 'rm-level-mark', b, '');
+      // the best on this level, on the row itself: hidden until the track has been finished once
+      const best = elm('span', 'rm-level-best', b, ''); best.hidden = true;
       // the bar lives IN the row, under the title, and only the picked row ever shows it
       const bar = elm('i', 'rm-level-bar', b); elm('i', '', bar);
       b.addEventListener('click', (ev) => { ev.stopPropagation(); if (onPick) onPick(i); });

--- a/ConditioningControlPanel/Resources/web/dtrh/race/menu.css
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/menu.css
@@ -140,7 +140,7 @@
 #race-root .rm-levels { display: flex; flex-direction: column; gap: 4px; }
 #race-root .rm-levels-set { margin-top: 0; margin-bottom: 6px; color: #ffd6ea; letter-spacing: 0.08em; text-transform: uppercase; }
 #race-root .rm-level-btn {
-  display: grid; grid-template-columns: 2.4em 1fr auto; grid-template-areas: 'n title len' 'n bar bar' 'n mark mark';
+  display: grid; grid-template-columns: 2.4em 1fr auto; grid-template-areas: 'n title len' 'n bar bar' 'n mark best';
   gap: 0 10px; align-items: center; width: 100%; min-height: 48px; text-align: left;
   padding: 7px 14px 7px 28px; font-size: 16px;
 }
@@ -148,6 +148,9 @@
 #race-root .rm-level-title { grid-area: title; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 #race-root .rm-level-len { grid-area: len; color: rgba(255, 214, 234, 0.75); font-variant-numeric: tabular-nums; }
 #race-root .rm-level-mark { grid-area: mark; font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: rgba(255, 214, 234, 0.55); }
+/* the best on this level, on the same line as the mark and hard against the right edge */
+#race-root .rm-level-best { grid-area: best; justify-self: end; font-size: 11px; letter-spacing: 0.04em; color: rgba(255, 214, 234, 0.6); font-variant-numeric: tabular-nums; }
+#race-root .rm-level-best[hidden] { display: none; }
 /* a hand-made road is the one thing on this list worth pointing at, so it is the one thing lit */
 #race-root .rm-level-btn.is-hand .rm-level-mark { color: var(--pink, #ff69b4); }
 #race-root .rm-level-btn.is-on .rm-level-title { color: #fff; }
@@ -223,6 +226,9 @@
 #race-root .rm-track.is-error .rm-track-bar { display: none; }
 #race-root .rm-track-cap { font-size: 12px; color: rgba(255, 214, 234, 0.75); }
 #race-root .rm-track.is-busy .rm-track-cap::after { content: '…'; animation: rmDots 1.2s steps(3, end) infinite; }
+/* The best on this track: a count, so it reads quieter than the caption above it. */
+#race-root .rm-track-best { font-size: 11px; letter-spacing: 0.04em; color: rgba(255, 214, 234, 0.6); }
+#race-root .rm-track-best[hidden] { display: none; }
 /* The authored mark: a chart a person wrote, not one the analysis found. */
 #race-root .rm-track-mark { display: inline-block; margin-top: 6px; padding: 1px 6px; font-size: 10px; font-weight: 800; letter-spacing: 0.12em; color: #0d0a14; background: #5be7d8; }
 #race-root .rm-track-mark[hidden] { display: none; }
@@ -377,6 +383,7 @@
   /* the rows keep their 48 px: a short screen scrolls the column, it does not shrink the target */
   #race-root .rm-level-btn { font-size: 15px; padding: 5px 14px 5px 28px; }
   #race-root .rm-level-mark { font-size: 10px; }
+  #race-root .rm-level-best { font-size: 10px; }
   #race-root .rm-level-bar { height: 4px; margin: 3px 0 2px; }
   #race-root .rm-levels-foot { margin-top: 4px; padding: 4px 0 2px; }
   #race-root .rm-h { margin-bottom: 2px; font-size: 16px; }

--- a/ConditioningControlPanel/Resources/web/dtrh/race/menu.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/menu.js
@@ -19,6 +19,12 @@
  * its bar, so the track line stands down for it. When the chart is ready the first verb reads
  * `start · <name>`.
  *
+ * THE BEST ON THIS TRACK (race/popped.js). A file that has been driven to its end at least once
+ * carries `popped 345 / 560 thoughts`: the word bubbles taken on the best run of it, of every word
+ * the file says. It rides the plate while the plate is up and the `track ·` line when it is not, so
+ * the number is under the player's eye wherever the name of the track is. No record is no line, and
+ * the seeded road never has one.
+ *
  * YOUR MEDIA (web only). `settings.mediaControls === true` adds a `your media` verb and a panel of
  * pickers: the browser host has no library of its own to enumerate, so the player hands it one. Each
  * button posts `set-setting {key:'media.pickLocal' | 'media.clearLocal', value}` INSIDE the click's
@@ -94,6 +100,7 @@ import { wantsTouch } from './touch.js';
 import { loadPack, preparePixel, toInstanceGeometry, flattenRig, setFace, FACES } from './gltf.js';
 import { snapshotRest } from './emiPoses.js';
 import { PIXEL_STEPS, PIXEL_LEGACY_DEFAULT, pixelDefault, normalizeBlock } from './pixel.js';
+import { readBests, bestFor, bestLine } from './popped.js';
 import { createMenuFlashes } from './menuFlashes.js';
 import { vFovForAspect, bindViewportResize } from './viewport.js';
 import { createFeedGroup } from './feedGroup.js';
@@ -527,6 +534,9 @@ export function createMenu({ root, renderer, pixel, audio, settings = {}, log = 
   const trackName = el('div', 'rm-track-name', trackEl, '');
   const trackBar = el('div', 'rm-track-bar', trackEl); const trackFill = el('i', '', trackBar);
   const trackCap = el('div', 'rm-track-cap', trackEl, '');
+  // THE BEST ON THIS TRACK (race/popped.js): `popped 345 / 560 thoughts`, off the last completed
+  // run of this same file. No record is no line, and a track nobody finished never grows one.
+  const trackBest = el('div', 'rm-track-best', trackEl, ''); trackBest.hidden = true;
   // shown only for a chart a person wrote (host: track-chart authored:true)
   const trackMark = el('div', 'rm-track-mark', trackEl, 'hand-tuned'); trackMark.hidden = true;
   // ---- the status lines: what the next run is made of, under the verbs (header: THE STATUS LINES) ----
@@ -700,6 +710,8 @@ export function createMenu({ root, renderer, pixel, audio, settings = {}, log = 
   };
   const STAGE_CAP = { picking: 'pick a file', opening: 'over to bambicloud', fetching: 'pulling the audio down', decode: 'reading the file', energy: 'feeling the pulse', words: 'listening for the words', cancelled: '', error: '' };
   let trackState = null, trackOnRow = false;
+  /** The stored best for the track in hand, read ONCE per setTrack: the paints below run every frame. */
+  let trackBestRec = null;
   function paintPlate() {
     const st = trackState;
     trackEl.hidden = !st || st.stage === 'cancelled' || (trackOnRow && panel === CLOUD_VERB);
@@ -720,8 +732,10 @@ export function createMenu({ root, renderer, pixel, audio, settings = {}, log = 
       let c = null; try { c = media.stats(); } catch (e) { c = null; }
       if (c) { known = true; if (c.images || c.videos) parts.push(`your library (${counts(c.images | 0, c.videos | 0)})`); }
     }
+    // the best on this track rides the track line when the plate is not up to carry it (paintStatus)
+    const best = name ? bestLine(trackBestRec) : '';
     return {
-      track: name ? `track · ${name}` : 'track · just the road',
+      track: name ? `track · ${name}${best ? ` · ${best}` : ''}` : 'track · just the road',
       media: parts.length ? `media · ${parts.join(' and ')}` : 'media · no assets, the walls stay bare',
       known,
     };
@@ -762,6 +776,12 @@ export function createMenu({ root, renderer, pixel, audio, settings = {}, log = 
       } else trackCap.textContent = st.stage === 'error' ? (st.message || 'the track would not load') : (STAGE_CAP[st.stage] || st.stage);
     }
     trackMark.hidden = !(ready && st && st.authored);
+    // the best on THIS file, keyed the way race/popped.js keys it (the hash, or the cloud id when
+    // the file was never hashed). Read here and nowhere else: the paints below run every frame.
+    trackBestRec = ready ? bestFor(readBests(), { hash: st.hash, cloudId: st.cloudId }) : null;
+    const bLine = bestLine(trackBestRec);
+    trackBest.hidden = !bLine;
+    if (bLine && trackBest.textContent !== bLine) trackBest.textContent = bLine;
     verbEl('race').textContent = ready ? `start · ${st.name || 'the track'}` : 'race';
     verbEl('track').textContent = ready ? 'another track' : 'load a track';
     verbEl('clear').hidden = !ready;

--- a/ConditioningControlPanel/Resources/web/dtrh/race/popped.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/popped.js
@@ -1,0 +1,132 @@
+/* ============================================================================
+ * race/popped.js - HOW MANY THOUGHTS YOU TOOK, AND THE BEST YOU EVER DID.
+ *
+ *   readBests(store)                       -> { key: record }
+ *   bestFor(bests, { hash, cloudId })      -> record | null
+ *   saveBest(store, run)                   -> { rec, wrote }
+ *   bestLine(rec)                          -> 'popped 345 / 560 thoughts'
+ *   poppedLine(popped, total)              -> 'popped 12 / 560'
+ *
+ * WHAT A THOUGHT IS. One word bubble: one `word` event of the chart (CHART.md),
+ * which race/cues.js lays on the road as exactly one bubble wearing exactly one
+ * word. That is the whole count and it is deliberately the simple one:
+ *
+ *   - the TOTAL is read off the chart the moment it loads, so the number on the
+ *     screen is knowable before the first metre and never depends on what the
+ *     road happened to spawn or on how far the player got;
+ *   - a TRIGGER ROW is not in it. A row is five faces of one trigger and it is
+ *     one thing to take, not five thoughts to pop, so counting it would make the
+ *     total a number nobody could check against the words they heard.
+ *
+ * That leaves `popped N / M thoughts` meaning exactly "the words of this file I
+ * took off the road, of all the words in it". The end card's older `taken N of M`
+ * is a different and finer thing (a LINE of bubbles counts once there, and drops
+ * and rows count too): both are true, they answer different questions.
+ *
+ * THE STORE is one localStorage key, `race.popped`, holding a map of records:
+ *
+ *   { "<hash>": { popped, total, name, cloudId, at } }
+ *
+ * keyed by the chart's file hash (CHART.md `source.hash`) where there is one and
+ * by `cid:<cloudId>` where there is not, so a track that was never hashed still
+ * remembers. Every record carries its cloudId too, because the LEVELS panel
+ * knows a level by its url and never by its hash, so a row looks a best up by
+ * cloudId (race/levels.js). Only a run that reached the END of the chart writes:
+ * a quit is not a score.
+ *
+ * A best is beaten on the count alone (`popped`), never on the fraction: a
+ * longer version of a file is not a worse run.
+ *
+ * Pure but for the store, which is handed in (localStorage by default, and every
+ * touch of it is wrapped: a private window throws on read and on write and
+ * nothing here may care). No DOM, no clock but Date.now, no fetch.
+ * ==========================================================================*/
+
+/** The one key. */
+export const POPPED_KEY = 'race.popped';
+/** How many tracks the map keeps. Past this the oldest records go, oldest by when they were written. */
+export const MAX_TRACKS = 240;
+
+const num = (v) => { const n = Number(v); return isFinite(n) && n > 0 ? Math.floor(n) : 0; };
+const str = (v, max) => String(v == null ? '' : v).slice(0, max);
+const memStore = () => { try { return typeof localStorage !== 'undefined' ? localStorage : null; } catch (e) { return null; } };
+
+/** The key a track files its record under: the hash if it has one, else its cloud id, else ''. */
+export function keyFor({ hash = '', cloudId = '' } = {}) {
+  const h = str(hash, 64).trim();
+  if (h) return h;
+  const c = str(cloudId, 64).trim().toLowerCase();
+  return c ? 'cid:' + c : '';
+}
+
+/** One stored record, or null for anything that is not one. Everything is re-read, nothing trusted. */
+function record(raw) {
+  if (!raw || typeof raw !== 'object') return null;
+  const popped = num(raw.popped), total = num(raw.total);
+  if (!total || popped > total) return null;
+  return { popped, total, name: str(raw.name, 60), cloudId: str(raw.cloudId, 64).toLowerCase(), at: num(raw.at) };
+}
+
+/** The whole map, or an empty one. A private window, a cleared store and a corrupt value are all `{}`. */
+export function readBests(store = undefined) {
+  const mem = store !== undefined ? store : memStore();
+  let raw = null;
+  try { raw = mem ? JSON.parse(mem.getItem(POPPED_KEY) || 'null') : null; } catch (e) { return {}; }
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return {};
+  const out = {};
+  for (const k of Object.keys(raw)) { const r = record(raw[k]); if (r) out[k] = r; }
+  return out;
+}
+
+/**
+ * The record for a track, by hash first and by cloud id second. The LEVELS panel only ever knows
+ * the second one (it reads a url, not a file), so the scan is the whole point of this function.
+ */
+export function bestFor(bests, { hash = '', cloudId = '' } = {}) {
+  if (!bests || typeof bests !== 'object') return null;
+  const k = keyFor({ hash, cloudId });
+  if (k && bests[k]) return bests[k];
+  const c = str(cloudId, 64).trim().toLowerCase();
+  if (!c) return null;
+  for (const key of Object.keys(bests)) if (bests[key].cloudId === c) return bests[key];
+  return null;
+}
+
+/**
+ * File a completed run. Writes only when it beat what was there (or when nothing was), and answers
+ * `{ rec, wrote }` with the record that stands either way. Call it only for a run that reached the
+ * end of the chart: a quit is not a score.
+ */
+export function saveBest(store = undefined, run = {}) {
+  const mem = store !== undefined ? store : memStore();
+  const key = keyFor(run);
+  const fresh = record({ popped: run.popped, total: run.total, name: run.name, cloudId: run.cloudId, at: run.at || Date.now() });
+  if (!key || !fresh) return { rec: null, wrote: false };
+  const bests = readBests(mem);
+  const had = bests[key] || null;
+  if (had && had.popped >= fresh.popped) return { rec: had, wrote: false };
+  bests[key] = fresh;
+  const keys = Object.keys(bests);
+  if (keys.length > MAX_TRACKS) {
+    keys.sort((a, b) => (bests[a].at || 0) - (bests[b].at || 0));
+    for (const k of keys.slice(0, keys.length - MAX_TRACKS)) delete bests[k];
+  }
+  try { if (mem) mem.setItem(POPPED_KEY, JSON.stringify(bests)); } catch (e) { /* a private window, and nothing is lost */ }
+  return { rec: fresh, wrote: true };
+}
+
+/** The live line: `popped 12 / 560`. Lower case, house style, no total means no line. */
+export function poppedLine(popped, total) {
+  const t = num(total);
+  if (!t) return '';
+  return `popped ${Math.min(num(popped), t)} / ${t}`;
+}
+
+/** The menu's line: `popped 345 / 560 thoughts`. '' for no record at all. */
+export function bestLine(rec) {
+  if (!rec) return '';
+  const line = poppedLine(rec.popped, rec.total);
+  return line ? line + ' thoughts' : '';
+}
+
+// self-check: node --check is the bar; race/smoke/popped-check.mjs drives the whole thing through the page.

--- a/ConditioningControlPanel/Resources/web/dtrh/race/race.css
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/race.css
@@ -86,6 +86,9 @@
 .race-hud .rh-next.is-top { color: #fff0b8; }
 .race-hud .rh-bank { font-size: 0.78rem; color: #ffe082; opacity: 0.85; }
 .race-hud .rh-bank.is-pop { animation: rhThud 0.34s cubic-bezier(0.2, 1.6, 0.4, 1); }
+/* the thoughts line: quieter than the kept line, because it is a count and not a prize */
+.race-hud .rh-popped { font-size: 0.72rem; letter-spacing: 0.06em; color: rgba(255, 214, 234, 0.72); }
+.race-hud .rh-popped[hidden] { display: none; }
 
 /* ---- MARQUEE: the room banner as a LEFT RIBBON under the score block.
    It used to sit top-centre, which is exactly where payload cards land and

--- a/ConditioningControlPanel/Resources/web/dtrh/race/run.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/run.js
@@ -82,6 +82,7 @@ import { createMediaLane } from './mediaLane.js';
 import { createInput } from './input.js';
 import { createPickups, TUNE as PICK } from './pickups.js';
 import { createPixelizer, pixelDefault } from './pixel.js';
+import { saveBest } from './popped.js';
 import { createSpeedFx } from './speed.js';
 import { vFovForAspect, bindViewportResize } from './viewport.js';
 import { createRaceAudio } from './audio.js';
@@ -176,6 +177,17 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1, onExi
   // track), `lineGot` how many of them the kart has taken this run, and the pop that finishes one
   // calls race/score.js chain(). A phrase left half-taken simply never pays.
   const lineN = new Map(), lineGot = new Map(), lineDone = new Set();
+  // THE THOUGHTS COUNT (race/popped.js). `total` is every `word` event of the chart, counted the
+  // moment it loads, so the number on the HUD is knowable before the first metre; `popped` is how
+  // many of those bubbles the kart has taken this run. A trigger row is one trigger, not five
+  // thoughts, so it is not in either. A completed run files this as a per-track best.
+  const TH = { popped: 0, total: 0 };
+  const thoughtsIn = (chart) => {
+    let n = 0;
+    for (const e of (chart && Array.isArray(chart.events) ? chart.events : [])) if (e.kind === 'word') n++;
+    return n;
+  };
+  const paintThoughts = () => { try { if (hud && hud.setPopped) hud.setPopped(TH.popped, TH.total); } catch (e) { /* no hud yet */ } };
   // THE SYNC WIN (race/wordSync.js). Every word bubble and every trigger row popped or driven past
   // writes how far from its second it landed into a ring in localStorage; `[` `]` move this track's
   // offset; `\` copies the numbers. `rowOf` is the trigger rows still on the road (a row is not in
@@ -386,6 +398,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1, onExi
     mix.reset(); PACE.reset(); S.wobble = 0; clearMixChrome(); sync.reset(); wordOf.clear(); lineGot.clear(); lineDone.clear();
     wordyRows.clear(); lastFlashAt = -1e9; flashStats.pops = 0; flashStats.capped = 0; flashStats.rolls = 0; flashStats.flashes = 0;
     echoWord = ''; echoAt = -1e9; if (subl) subl.clear();   // "again" starts with nothing said and a clear glass
+    TH.popped = 0; paintThoughts();   // the same road again is the same total and a fresh count
     // the spiral book is the run's, not the page's: "again" on the same seed weaves the same
     // spirals in the same order, and a new seed opens a new book (race/loomBook.js)
     loomBook.reseed(runSeed); spiralFx.cancel();
@@ -436,6 +449,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1, onExi
     if (!rec) return;
     wordOf.delete(eventId);                       // one bubble, one flash: it is popped or it is past
     echo(rec.w);                                  // the voice said it: a subliminal may repeat it back
+    if (!ghost) { TH.popped++; paintThoughts(); }  // a thought taken off the road (race/popped.js)
     logWord(rec, passT == null ? (TR.track ? TR.track.t : 0) : passT, ghost);
     if (captions && (!ghost || GHOST_MISSES)) captions.showWord(rec.w, { ink: rec.ink, accent: rec.accent, ghost: !!ghost });
     if (ghost || rec.p == null || lineDone.has(rec.p)) return;
@@ -671,6 +685,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1, onExi
     for (const e of (t && t.chart && Array.isArray(t.chart.events) ? t.chart.events : [])) {
       if (e.kind === 'word' && e.p != null) lineN.set(e.p, (lineN.get(e.p) || 0) + 1);
     }
+    TH.total = t ? thoughtsIn(t.chart) : 0; TH.popped = 0; paintThoughts();   // the total, off the chart, before the first metre
     if (W) { W.field.setTracked(!!t); W.field.setSparse(TR.lyrics); W.field.setDensity(1); if (!t) applyFog(W, 0); }
     if (captions) captions.setTrack(t ? t.chart : null);
     audio.duck(!!t, 'track');   // the file is the soundtrack: the room OST sits under it until it is cleared
@@ -680,6 +695,8 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1, onExi
   /** The words pass landing live, or a nudge: keep the clock, adopt only what is still ahead (track.js replace). */
   function replaceTrack(chart) {
     TR.replace(chart); audio.setRoute(routeOf(TR.track));
+    // the words pass is what a partial road was waiting for: the total it carries is the real one now
+    TH.total = TR.track ? thoughtsIn(TR.track.chart) : 0; paintThoughts();
     if (W) W.field.setSparse(TR.lyrics);
     if (captions) captions.setTrack(TR.track ? TR.track.chart : null);
     refreshSync();
@@ -961,6 +978,19 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1, onExi
       personalBest: st.banked + st.score > S.bestAtStart && st.banked + st.score > 0 };
     const track = TR.summary();   // "you took N of M" on a charted run (the results screen is PR c7)
     if (track) Object.assign(summary, { taken: track.taken, countable: track.countable, trackName: track.name });
+    // THE THOUGHTS (race/popped.js): the word bubbles of the file taken, of every word in it. Only a
+    // run that reached the END of the chart files a best - a quit is not a score - and the best is
+    // beaten on the count alone, so a longer cut of a file never reads as a worse run.
+    if (track && TH.total > 0) {
+      Object.assign(summary, { thoughts: TH.popped, thoughtsTotal: TH.total });
+      if (TR.ended) {
+        const src = (TR.track && TR.track.chart && TR.track.chart.source) || {};
+        const filed = saveBest(undefined, { hash: track.hash, cloudId: src.cloudId, name: track.name, popped: TH.popped, total: TH.total });
+        summary.thoughtsBest = filed.rec ? filed.rec.popped : 0;
+        summary.thoughtsRecord = filed.wrote;
+        if (bridge.log) bridge.log(`race popped: ${TH.popped} of ${TH.total} thoughts${filed.wrote ? ', a new best' : ''}`);
+      }
+    }
     send({ type: 'run-ended', ...summary, ...(track ? { track } : {}) });
     trackSend('track-stop');
     sfx('surface', 0.8);
@@ -1133,6 +1163,8 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1, onExi
     // trackClock for the host's 250 ms tick, trackEnded when the file runs out at the host's end
     setTrack, replaceTrack, trackClock: (t, playing) => TR.clock(t, playing),
     trackEnded: () => { TR.end(); if (TR.track && S.running) endRun(); }, trackStats: () => TR.stats(), syncTrace: () => sync.trace(), debugPickup,
+    /** THE THOUGHTS COUNT: { popped, total } word bubbles this run (race/popped.js). The check's window on it. */
+    thoughts: () => ({ ...TH }),
     /** What race/smoke/face-check.mjs reads: the word faces on the road this frame. */
     wordFaces: () => (W ? W.field.faceReport() : null),
     /** THE WORD FLASH, for race/smoke/word-flash-check.mjs: word pops, the ones the 250 ms cap ate,

--- a/ConditioningControlPanel/Resources/web/dtrh/race/smoke/popped-check.mjs
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/smoke/popped-check.mjs
@@ -1,0 +1,292 @@
+/* ============================================================================
+ * race/smoke/popped-check.mjs - THE THOUGHTS COUNT and the per-track best
+ * (race/popped.js), pure first and then driven through the REAL page.
+ *
+ *   node race/smoke/popped-check.mjs      (exits 0 on pass, 1 with a count)
+ *
+ * A thought is one word bubble: one `word` event of the chart. The owner's ask,
+ * phone testing 2026-09-09: "lets have the ui actually track how many bubbles out
+ * of the total they got and show in the main menu the personal best on each
+ * completed track (eg Popped 345/560 thoughts)".
+ *
+ * NOTHING LEAVES THIS MACHINE. The road is generated here out of a transcript
+ * that ships with the game (race/words), served at /fixture.json, and the levels
+ * list is a stub of two rows whose files are never fetched: no page in here taps
+ * a level, so not one byte of audio is asked for.
+ *
+ * What it holds:
+ *   1. the store, pure: what a key is, what beats a best, what a private window
+ *      does to all of it, and the two lines it writes
+ *   2. THE TOTAL IS KNOWN AT START: the run reads it off the chart before the
+ *      first metre, and the HUD says `popped 0 / M` there and then
+ *   3. the count goes up as the kart takes words, and the HUD follows it
+ *   4. a run still going files NOTHING
+ *   5. the end of the chart files the best, and the End card carries the row
+ *   6. the menu: the track plate and the `track ·` status line carry the best
+ *   7. the levels panel: the level's own row carries it, looked up with no chart
+ *      and no network at all
+ *
+ * CHROME: `CHROME_PATH` if it is set, else the usual Windows install. Nothing is
+ * installed by this file and the profile it makes is deleted on the way out.
+ * ==========================================================================*/
+
+import { spawn } from 'node:child_process';
+import { createServer } from 'node:http';
+import { readFile } from 'node:fs/promises';
+import { readFileSync, mkdtempSync, rmSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, extname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { POPPED_KEY, keyFor, readBests, bestFor, saveBest, bestLine, poppedLine } from '../popped.js';
+import { wordedRoad, PEAKS_PER_SEC } from '../cloudChart.js';
+
+let fails = 0;
+const ok = (cond, what) => { if (!cond) { console.error('FAIL ' + what); fails++; } else console.log('  ok  ' + what); };
+const eq = (got, want, what) => ok(got === want, what + ' (got ' + JSON.stringify(got) + ', want ' + JSON.stringify(want) + ')');
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const HERE = resolve(fileURLToPath(import.meta.url), '..');
+const RACE = resolve(HERE, '..');
+const WEB = resolve(RACE, '../..');                        // Resources/web
+const read = (rel) => JSON.parse(readFileSync(resolve(RACE, rel), 'utf8'));
+
+/* ============================================================================
+ * 1. the store, pure
+ * ==========================================================================*/
+/** localStorage's shape, in a Map, so the store can be driven without a browser. */
+function fakeStore(seed = null) {
+  const m = new Map(seed ? [[POPPED_KEY, JSON.stringify(seed)]] : []);
+  return { getItem: (k) => (m.has(k) ? m.get(k) : null), setItem: (k, v) => m.set(k, String(v)), _map: m };
+}
+/** A store that throws on every touch: a private window, or site data turned off. */
+const deadStore = { getItem() { throw new Error('nope'); }, setItem() { throw new Error('nope'); } };
+
+eq(keyFor({ hash: 'abc' }), 'abc', 'a track with a hash files under it');
+eq(keyFor({ cloudId: 'AbC' }), 'cid:abc', 'a track with no hash files under its cloud id, lower cased');
+eq(keyFor({}), '', 'and a track with neither has nowhere to file');
+{
+  const s = fakeStore();
+  const a = saveBest(s, { hash: 'h1', cloudId: 'c1', name: 'one', popped: 300, total: 560 });
+  ok(a.wrote && a.rec.popped === 300, 'the first completed run is the best there is');
+  const b = saveBest(s, { hash: 'h1', cloudId: 'c1', name: 'one', popped: 210, total: 560 });
+  ok(!b.wrote && b.rec.popped === 300, 'a worse run does not overwrite it');
+  const c = saveBest(s, { hash: 'h1', cloudId: 'c1', name: 'one', popped: 345, total: 560 });
+  ok(c.wrote && c.rec.popped === 345, 'and a better one does');
+  const bests = readBests(s);
+  ok(bestFor(bests, { hash: 'h1' }).popped === 345, 'the record comes back by hash');
+  ok(bestFor(bests, { cloudId: 'c1' }).popped === 345, 'and by cloud id, which is all a levels row knows');
+  ok(bestFor(bests, { hash: 'nope', cloudId: 'nope' }) === null, 'a track nobody finished has no record');
+  eq(bestLine(bests.h1), 'popped 345 / 560 thoughts', 'the menu line reads');
+  eq(poppedLine(12, 560), 'popped 12 / 560', 'and the hud line reads');
+  eq(bestLine(null), '', 'no record is no line');
+  eq(poppedLine(4, 0), '', 'and no total is no line');
+}
+{
+  const s = fakeStore({ h1: { popped: 12, total: 0 }, h2: { popped: 900, total: 100 }, h3: 'rubbish' });
+  eq(Object.keys(readBests(s)).length, 0, 'a corrupt record is dropped rather than believed');
+  eq(Object.keys(readBests(deadStore)).length, 0, 'a store that throws reads as an empty map');
+  ok(saveBest(deadStore, { hash: 'h', popped: 5, total: 9 }).wrote === true, 'and a write into one is swallowed, not thrown');
+  ok(saveBest(fakeStore(), { hash: '', cloudId: '', popped: 5, total: 9 }).wrote === false, 'a track with no key files nothing');
+}
+
+/* ============================================================================
+ * the browser: the web folder, one generated road, and a stub levels list
+ * ==========================================================================*/
+const ROW = read('words/index.json').rows[0];              // the opening level, whole and shipped
+const WORDS = { ...read('words/' + ROW.file), engine: ROW.engine };
+/** A curve shaped like a spoken track (the swell lyrics-road-check.mjs uses). */
+function swell(durationSec, perSec = PEAKS_PER_SEC) {
+  const n = Math.ceil(durationSec * perSec);
+  const peaks = new Float32Array(n * 2);
+  for (let i = 0; i < n; i++) {
+    const a = 0.22 + 0.5 * Math.max(0, Math.sin(((i / perSec) / 40) * Math.PI * 2)) ** 2;
+    peaks[i * 2] = -a; peaks[i * 2 + 1] = a;
+  }
+  return peaks;
+}
+const road = wordedRoad({ peaks: swell(WORDS.durationSec), durationSec: WORDS.durationSec, name: ROW.title, hash: ROW.hash, words: WORDS });
+const FIXTURE = JSON.stringify(road);
+/** The number the whole feature is about: every `word` event of the chart, counted here. */
+const TOTAL = road.events.filter((e) => e.kind === 'word').length;
+ok(TOTAL > 50, `the fixture road carries ${TOTAL} word bubbles to take`);
+
+const CHROME = process.env.CHROME_PATH || 'C:/Program Files/Google/Chrome/Application/chrome.exe';
+const PORT = 8873, DEBUG_PORT = 9345;
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.mjs': 'text/javascript', '.css': 'text/css', '.json': 'application/json', '.glb': 'model/gltf-binary', '.png': 'image/png', '.webp': 'image/webp', '.jpg': 'image/jpeg', '.mp3': 'audio/mpeg', '.wav': 'audio/wav', '.svg': 'image/svg+xml', '.woff2': 'font/woff2' };
+/** Two rows. The first IS the fixture track (same hash), the second is a file nobody has driven. */
+const LEVELS = {
+  version: 1,
+  sets: [{
+    id: 'stub-set', title: 'A Stub Set', source: 'stub', playlistId: 'stub', playlistUrl: 'https://bambicloud.com/playlist/stub',
+    levels: [
+      { n: 1, id: 'stub-one', title: ROW.title, url: `http://127.0.0.1:${PORT}/stub/one.wav`, durationSec: Math.round(WORDS.durationSec), bytes: 1024, hash: ROW.hash, trackNum: 0 },
+      { n: 2, id: 'stub-two', title: 'The Second One', url: `http://127.0.0.1:${PORT}/stub/two.wav`, durationSec: 90, bytes: 1024, hash: 'nothing-has-this-hash', trackNum: 1 },
+    ],
+  }],
+};
+
+if (!existsSync(CHROME)) { console.error('FAIL no chrome at ' + CHROME + ' (set CHROME_PATH)'); process.exit(1); }
+const asked = [];
+const server = createServer(async (req, res) => {
+  const path = decodeURIComponent(new URL(req.url, 'http://x').pathname);
+  if (path === '/fixture.json') { res.writeHead(200, { 'content-type': 'application/json' }); return res.end(FIXTURE); }
+  if (path === '/stub/levels.json') { res.writeHead(200, { 'content-type': 'application/json' }); return res.end(JSON.stringify(LEVELS)); }
+  if (path.indexOf('/stub/') === 0) { asked.push(path); res.writeHead(404); return res.end('no'); }
+  if (path.indexOf('..') >= 0) { res.writeHead(400); return res.end(); }
+  try {
+    const body = await readFile(join(WEB, path));
+    res.writeHead(200, { 'content-type': MIME[extname(path).toLowerCase()] || 'application/octet-stream' });
+    res.end(body);
+  } catch (e) { res.writeHead(404, { 'content-type': 'text/plain' }); res.end('no'); }
+});
+await new Promise((r) => server.listen(PORT, '127.0.0.1', r));
+
+const prof = mkdtempSync(join(tmpdir(), 'race-popped-'));
+const chrome = spawn(CHROME, [
+  '--headless=new', `--remote-debugging-port=${DEBUG_PORT}`, `--user-data-dir=${prof}`,
+  '--no-first-run', '--no-default-browser-check', '--disable-gpu', '--mute-audio',
+  '--enable-unsafe-swiftshader', '--autoplay-policy=no-user-gesture-required',
+  '--window-size=1280,720', 'about:blank',
+], { stdio: 'ignore' });
+
+let page = null;
+for (let i = 0; i < 60 && !page; i++) {
+  await sleep(250);
+  try { page = (await (await fetch(`http://127.0.0.1:${DEBUG_PORT}/json/list`)).json()).find((t) => t.type === 'page'); } catch (e) { /* not up */ }
+}
+if (!page) { console.error('FAIL chrome never answered on the debug port'); await done(1); }
+
+const ws = new WebSocket(page.webSocketDebuggerUrl);
+await new Promise((r) => { ws.onopen = r; });
+let msgId = 0;
+const waits = new Map(), errs = [];
+ws.onmessage = (e) => {
+  const m = JSON.parse(e.data);
+  if (m.id && waits.has(m.id)) { waits.get(m.id)(m); waits.delete(m.id); }
+  if (m.method === 'Runtime.exceptionThrown') errs.push('thrown: ' + (m.params.exceptionDetails?.exception?.description || m.params.exceptionDetails?.text || '?'));
+};
+const cdp = (method, params) => new Promise((res) => { const i = ++msgId; waits.set(i, res); ws.send(JSON.stringify({ id: i, method, params })); });
+const ev = async (x) => (await cdp('Runtime.evaluate', { expression: x, returnByValue: true, awaitPromise: true })).result?.result?.value;
+const json = async (x) => JSON.parse(await ev(`JSON.stringify(${x})`));
+const text = async (sel) => ev(`(()=>{const n=document.querySelector(${JSON.stringify(sel)}); return n ? (n.hidden ? '(hidden) ' : '') + n.textContent : null;})()`);
+const click = (sel) => ev(`(()=>{const b=document.querySelector(${JSON.stringify(sel)}); if(!b) return 0; b.click(); return 1;})()`);
+await cdp('Runtime.enable'); await cdp('Page.enable');
+
+const site = `http://127.0.0.1:${PORT}`;
+const CHART = `chart=${encodeURIComponent(`${site}/fixture.json`)}`;
+
+/* ============================================================================
+ * 2. the total is known at start
+ * ==========================================================================*/
+await cdp('Page.navigate', { url: `${site}/dtrh/race.html?autostart=1&intro=0&cards=0&${CHART}` });
+let up = false;
+for (let i = 0; i < 120 && !up; i++) {
+  await sleep(250);
+  up = await ev(`!!(window.__race && window.__race.race && window.__race.race.track && window.__race.race.perf().running)`);
+}
+ok(up, 'the page boots the worded fixture road and the run is going');
+if (!up) { if (errs.length) console.error('    said: ' + errs.slice(0, 6).join(' | ')); await done(1); }
+{
+  const th = await json(`window.__race.race.thoughts()`);
+  eq(th.total, TOTAL, 'the run knows the whole total off the chart, before anybody pops anything');
+  eq(th.popped, 0, 'and nothing is popped yet');
+  eq(await text('.rh-popped'), `popped 0 / ${TOTAL}`, 'the hud says so in the house style');
+}
+
+/* ============================================================================
+ * 3. the count goes up, and the hud follows
+ *
+ * The pump is the honest way to make a headless run TAKE the words: nobody is
+ * steering, and a word bubble sits in the lane its phrase was given.
+ * ==========================================================================*/
+const WANT = 20;
+let th = { popped: 0, total: TOTAL };
+// The words of a spoken file do not start at second zero, so this waits the way
+// word-flash-check.mjs waits: a pump every half second until the count climbs.
+for (let i = 0; i < 240 && th.popped < WANT; i++) {
+  await ev(`window.__race.race.debugPickup('the_pump')`);
+  await sleep(500);
+  th = await json(`window.__race.race.thoughts()`);
+}
+ok(th.popped >= WANT, `the run took ${th.popped} word bubbles of ${th.total} without anyone steering`);
+eq(th.total, TOTAL, 'and the total never moved under it');
+eq(await text('.rh-popped'), `popped ${th.popped} / ${TOTAL}`, 'the hud line is the count, live');
+
+/* ============================================================================
+ * 4. a run still going files nothing
+ * ==========================================================================*/
+eq(await ev(`localStorage.getItem('race.popped')`), null, 'a run in progress has filed no best: the end of the chart is what counts');
+
+/* ============================================================================
+ * 5. the end of the chart files it, and the End card carries the row
+ * ==========================================================================*/
+const RUN = (await json(`window.__race.race.thoughts()`)).popped;
+await ev(`window.__race.race.trackEnded()`);
+await sleep(3500);                                   // the payout wait, then the card
+{
+  const bests = await json(`JSON.parse(localStorage.getItem('race.popped') || 'null')`);
+  const keys = bests ? Object.keys(bests) : [];
+  eq(keys.length, 1, 'the completed run filed one record');
+  const rec = bests ? bests[keys[0]] : null;
+  eq(keys[0], ROW.hash, 'under the chart\'s own file hash');
+  ok(rec && rec.popped === RUN && rec.total === TOTAL, `and it is the run that just happened: ${JSON.stringify(rec && [rec.popped, rec.total])} of ${[RUN, TOTAL]}`);
+  const rows = await json(`(()=>{const d=[...document.querySelectorAll('.rh-rows > *')].map(n=>n.textContent);
+    const o={}; for(let i=0;i+1<d.length;i+=2) o[d[i]]=d[i+1]; return o;})()`);
+  ok(!!rows.thoughts, 'the End card grew a `thoughts` row: ' + JSON.stringify(rows.thoughts || null));
+  eq(rows.thoughts, `${RUN.toLocaleString('en-US')} of ${TOTAL.toLocaleString('en-US')}`, 'reading the run against the whole file');
+  ok(!!rows.taken, 'and the older `taken` row, which counts a whole line as one thing, is still beside it: ' + rows.taken);
+}
+const LINE = `popped ${RUN} / ${TOTAL} thoughts`;
+
+/* ============================================================================
+ * 6. the menu: the plate and the status line carry it
+ * ==========================================================================*/
+await cdp('Page.navigate', { url: `${site}/dtrh/race.html?intro=0&cards=0&${CHART}` });
+up = false;
+for (let i = 0; i < 120 && !up; i++) {
+  await sleep(250);
+  up = await ev(`!!(window.__race && window.__race.menu) && !!document.querySelector('.rm-track') && document.querySelector('.rm-track').hidden === false`);
+}
+ok(up, 'the same road comes back to the menu with its plate up');
+eq(await text('.rm-track-best'), LINE, 'the track plate carries the best on this file');
+eq(await text('.rm-status-track'), `(hidden) track · ${ROW.title} · ${LINE}`,
+  'and the `track ·` status line carries it too, standing down only because the plate is up');
+
+/* ============================================================================
+ * 7. the levels panel: the row itself, with no chart and no network
+ * ==========================================================================*/
+await cdp('Page.navigate', { url: `${site}/dtrh/race.html?cloud=1&intro=0&cards=0&levels=${encodeURIComponent('/stub/levels.json')}` });
+up = false;
+for (let i = 0; i < 120 && !up; i++) {
+  await sleep(250);
+  up = await ev(`!!(window.__race && window.__race.menu) && !!document.querySelector('.rm-root') && !document.querySelector('.rm-root').hidden`);
+}
+ok(up, 'the page boots the levels panel with a stub list');
+await click('.rm-list .rm-btn[data-id=cloud]');
+await sleep(400);
+{
+  const rows = await json(`[...document.querySelectorAll('.rm-levels .rm-level-btn')].map(b=>({
+    id: b.dataset.id, title: b.querySelector('.rm-level-title').textContent,
+    best: b.querySelector('.rm-level-best') ? b.querySelector('.rm-level-best').textContent : null,
+    shown: b.querySelector('.rm-level-best') ? !b.querySelector('.rm-level-best').hidden : false,
+    tall: Math.round(b.getBoundingClientRect().height),
+  }))`);
+  const one = rows.find((r) => r.id === 'lv-1'), two = rows.find((r) => r.id === 'lv-2');
+  ok(one && one.shown && one.best === LINE, `the completed level's own row carries the best: ${JSON.stringify(one && one.best)}`);
+  ok(two && !two.shown, 'and the level nobody has finished carries no line at all');
+  ok(rows.every((r) => r.tall >= 48), `every row is still at least 48 px tall for a thumb (${rows.map((r) => r.tall).join(', ')})`);
+  ok(asked.length === 0, 'and not one byte of a level file was asked for to paint any of it' + (asked.length ? ': ' + asked.join(', ') : ''));
+}
+
+await done(fails ? 1 : 0);
+
+async function done(code) {
+  try { ws && ws.close(); } catch (e) { /* never opened */ }
+  try { chrome.kill(); } catch (e) { /* already gone */ }
+  await new Promise((r) => server.close(r));
+  await sleep(300);
+  try { rmSync(prof, { recursive: true, force: true }); } catch (e) { /* chrome still has a lock */ }
+  if (code) console.error(`\n${fails} failure${fails === 1 ? '' : 's'}`);
+  else console.log('\npopped-check: all good');
+  process.exit(code);
+}

--- a/ConditioningControlPanel/Resources/web/dtrh/raceBoot.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/raceBoot.js
@@ -247,6 +247,16 @@ bridge.on('exit-request', surface);
 // mid-session is on the road the next time one pops. Nothing here reaches into a run: the pool
 // lives in engine/loomSpirals.js and the picker reads it when it draws.
 bridge.on('loom-list', (m) => { try { setLoomSpirals((m && m.spirals) || []); } catch (e) { host.log('loom-list: ' + e); } });
+/**
+ * The two names a chart answers to, carried on every `ready` plate state: race/menu.js looks the
+ * track's popped best up by them (race/popped.js keys by the file hash, and by the cloud id for a
+ * file that was never hashed). Nothing else in the plate reads them.
+ */
+const keysOf = (chart) => {
+  const s = (chart && chart.source) || {};
+  return { hash: String(s.hash || ''), cloudId: String(s.cloudId || '') };
+};
+
 // ---- track charts (CHART.md host protocol). The run owns the clock; this only relays. ----
 bridge.on('track-chart', (m) => {
   if (!race || !m || !m.chart) return;
@@ -255,7 +265,7 @@ bridge.on('track-chart', (m) => {
   const t = race.track, st = race.trackStats ? race.trackStats() : null;
   // `authored` is the host saying a person wrote this chart: the plate marks it, and nothing
   // fuller is coming behind it (an authored chart is never partial and never replaced).
-  trackReady = t ? { stage: 'ready', name: t.name, durationSec: t.durationSec, countable: st ? st.countable : 0, partial: !!m.partial, authored: !!m.authored } : null;
+  trackReady = t ? { stage: 'ready', name: t.name, durationSec: t.durationSec, countable: st ? st.countable : 0, partial: !!m.partial, authored: !!m.authored, ...keysOf(t.chart) } : null;
   plate(trackReady);
 });
 bridge.on('track-clock', (m) => { if (race && m) race.trackClock(Number(m.t) || 0, m.playing !== false); });
@@ -432,7 +442,7 @@ async function standaloneTrack() {
     else chart = mod.normalizeChart(await (await fetch(want)).json());
     race.setTrack(chart);
     const st = race.trackStats ? race.trackStats() : null;
-    trackReady = { stage: 'ready', name: chart.source.name, durationSec: chart.source.durationSec, countable: st ? st.countable : 0, partial: false };
+    trackReady = { stage: 'ready', name: chart.source.name, durationSec: chart.source.durationSec, countable: st ? st.countable : 0, partial: false, ...keysOf(chart) };
   } catch (err) {
     trackError('chart: ' + ((err && err.message) || err));
     return;
@@ -483,7 +493,7 @@ function showTrack(chart) {
   const st = race && race.trackStats ? race.trackStats() : null;
   const partial = !!(chart.analysis && chart.analysis.partial);
   trackReady = { stage: 'ready', name: chart.source.name + cloudWhere, durationSec: chart.source.durationSec,
-    countable: st ? st.countable : 0, partial };
+    countable: st ? st.countable : 0, partial, ...keysOf(chart) };
   plate(trackReady);
 }
 


### PR DESCRIPTION
**Stacked on #1021 (`feat/race-pixel-default`). Base that first, or read the diff against it.**

The owner, phone testing 2026-09-09: *"lets have the ui actually track how many bubbles out of the total they got and show in the main menu the personal best on each completed track (eg Popped 345/560 thoughts)"*.

## what a thought is

One word bubble: one `word` event of the chart. `race/run.js` reads the whole total off the chart the moment a track is set, so the number on screen is the file's own count, not a tally of whatever happened to spawn. A trigger row is one trigger, not five thoughts, so it is not in the total and popping it does not move the count. The older `taken N of M` on the End card folds a whole spoken line into one thing taken; it stays exactly as it was and now sits beside the new row.

## the store

`race/popped.js`, new. One localStorage key, `race.popped`, holding a map of track to best. A record is keyed by the chart's file hash and falls back to `cid:<cloudId>`, and carries its cloud id either way, so a levels row that only knows a url can still find its own record. Every read and write is wrapped: a private window simply has no bests rather than a broken menu, and a corrupt map reads as empty.

Only a run that reaches the end of the chart files a best. A run ended at the Brake files nothing.

## where it shows

- the HUD, live under the score: `popped 12 / 560`
- the End card: a `thoughts` row, `20 of 129`
- the track plate and the `track ·` status line: `popped 345 / 560 thoughts` for the selected file
- every finished level's own row in the levels panel, same line, looked up with no chart fetched and no network at all

Free play has no chart, so it has none of this.

## the check

`race/smoke/popped-check.mjs`, new. Pure over the store first (keys, what beats a best, a store that throws, both lines), then one headless run through the real page:

```
  ok  the fixture road carries 129 word bubbles to take
  ok  the run knows the whole total off the chart, before anybody pops anything (got 129, want 129)
  ok  the hud says so in the house style (got "popped 0 / 129", want "popped 0 / 129")
  ok  the run took 20 word bubbles of 129 without anyone steering
  ok  the hud line is the count, live (got "popped 20 / 129", want "popped 20 / 129")
  ok  a run in progress has filed no best: the end of the chart is what counts (got null, want null)
  ok  the completed run filed one record (got 1, want 1)
  ok  under the chart's own file hash
  ok  the End card grew a `thoughts` row: "20 of 129"
  ok  and the older `taken` row, which counts a whole line as one thing, is still beside it: 4 of 52
  ok  the track plate carries the best on this file (got "popped 20 / 129 thoughts", ...)
  ok  and the `track ·` status line carries it too, standing down only because the plate is up
  ok  the completed level's own row carries the best: "popped 20 / 129 thoughts"
  ok  and the level nobody has finished carries no line at all
  ok  every row is still at least 48 px tall for a thumb (50, 50)
  ok  and not one byte of a level file was asked for to paint any of it

popped-check: all good
```

It generates its road from a transcript that already ships with the game and serves it itself, so nothing leaves the machine and no level audio is ever requested.

Also green, unchanged: `levels-check: all good`, `menu-return-check: all good`, `track-run-check: all good`, `pixel-default-check: all good`.

## files

| file | what |
|---|---|
| `race/popped.js` | new. the store: `keyFor`, `readBests`, `bestFor`, `saveBest`, `poppedLine`, `bestLine` |
| `race/run.js` | additive only: the total off the chart on `setTrack`/`replaceTrack`, the count in `spendWord`, the reset, the file on a completed end, `thoughts()` for the check |
| `race/hud.js` | `setPopped(n, total)` paints the live line; the End card's `thoughts` row |
| `race/race.css` | the HUD line's small lower-case type |
| `race/menu.js` | the best on the track plate and in the `track ·` status line |
| `race/menu.css` | the plate line, and the level row's grid grew a `best` cell |
| `race/levels.js` | each row reads its own best out of the map |
| `raceBoot.js` | the hash and cloud id of the loaded chart reach the menu |
| `race/CONTRACT.md` | the thoughts count written down |
| `race/smoke/popped-check.mjs` | new. the check above |

545 changed lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PEeoJ93JCmhpWTQnwbPHc1
