### PR TITLE
feat(race): the popped word slides into its slot on the caption line

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/race/captions.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/captions.js
@@ -11,7 +11,19 @@
  * Two layers, one file, because they are one idea: the road says the word, the
  * glass says the word, and the plate says it loudly.
  *
- *   THE FLASH (`mode: 'flash'`, what a worded road runs). The words are on the ROAD
+ *   THE SLOT (`mode: 'slot'`, what a worded road runs). The owner, phone testing
+ *   2026-09-09: "when popped a bubble the word rises and slides into the typewriter
+ *   we got (the missed ones appear as dimmed like now) the words we get go slot
+ *   themselves as visible on the typewriter kind of text we got displayed, except
+ *   triggers that get already shown big and highlighted." So the band is the SCRIPT
+ *   and the pops light it. The phrase the file is on opens with every one of its words
+ *   already in the DOM and DIMMED, the word the kart pops rises out of the bubble's own
+ *   place on the glass and slides into its own slot over SLOT_FLY_MS, and there it
+ *   inks. A word driven past never moves: it stays dim in the slot it already had,
+ *   which is the same faint grey the flash's ghost wore. A sure trigger flies nothing
+ *   into the line - the plate below is its moment, and doubling it is noise.
+ *
+ *   THE FLASH (`mode: 'flash'`, behind `?cap=flash`). The words are on the ROAD
  *   now, one to a bubble (race/wordBubbles.js), so the band is no longer where the
  *   script is read: it is where a POP is answered. The word the kart just took hits
  *   the band whole, holds FLASH_HOLD_MS, fades over FLASH_FADE_MS, and a pop inside
@@ -27,13 +39,19 @@
  *
  *   THE PLATE. A sure trigger flies at the camera from the vanishing point, themed
  *   off race/triggerTheme.js, one at a time, a new one taking the old one's place.
- *   It owns the glass while it flies: the plate clears the band under it.
+ *   It owns the glass while it flies: on the flash band the plate clears the words
+ *   under it, and on the slot band it clears the flights and leaves the script alone,
+ *   because the script is not an answer to anything and has nothing to give way to.
  *
  * EVERYTHING IS A FUNCTION OF THE CLOCK. `update(t)` reads the track second and
  * nothing else: no elapsed frames, no timers of its own. A seek, a pause, a resume
  * and a chart swapped in under the run all land right for free, because there is no
- * state to get out of step. The only thing with a timer is the plate, which is a
- * one shot animation and belongs to no second in particular.
+ * state to get out of step. The slot band keeps that promise the same way: WHICH
+ * phrase is up is the clock's, and which of its words are inked is a set of slots the
+ * player took, so the same second with the same pops behind it always draws the same
+ * line. The only things with timers are the plate and a slot flight, which are one
+ * shot animations and belong to no second in particular - and a seek or a pause lands
+ * every flight in the air at once, so nothing is left moving over a stopped clock.
  *
  * `buildPhrases` is pure and node-clean; the layer wants a DOM.
  * ==========================================================================*/
@@ -63,6 +81,16 @@ export const FLASH_FADE_MS = 300;
 export const FLASH_JOIN_MS = 300;
 /** A word the kart drove past: the ghost's own opacity (race.css `.rc-flash-word.is-ghost`). */
 export const GHOST_ALPHA = 0.35;
+
+/** THE SLOT. The flight from the bubble to its slot, in ms (race.css `rcSlotFly` runs the same). */
+export const SLOT_FLY_MS = 300;
+/** The ink lands this long before the flight ends, so the word arrives on a slot already lit. */
+export const SLOT_LAND_MS = 60;
+/** How far from a word's own second a pop may be and still be that word's slot. A bubble is popped
+ *  a frame either side of the second it was laid on, never a word away from it. */
+export const SLOT_NEAR_SEC = 0.25;
+/** A word nobody has popped yet, on the slot band: the ghost's grey, so the line reads either way. */
+export const SLOT_DIM_ALPHA = GHOST_ALPHA;
 
 /** Two lines and no more. A third is shrunk into the two, never cut off the glass. */
 export const MAX_LINES = 2;
@@ -177,8 +205,10 @@ function phraseAt(phrases, t) {
 export function createCaptions(root, opts = {}) {
   const doc = root && root.ownerDocument;
   if (!doc) return null;
-  /** 'flash' (the pops write the band) or 'type' (the old typewriter, behind `?cap=type`). */
-  const mode = (opts && opts.mode) === 'type' ? 'type' : 'flash';
+  /** 'slot' (the script on the band, the pops light it), 'flash' (the pops WRITE the band, behind
+   *  `?cap=flash`) or 'type' (the old typewriter, behind `?cap=type`). */
+  const want = opts && opts.mode;
+  const mode = want === 'type' ? 'type' : want === 'flash' ? 'flash' : 'slot';
   const reduced = !!(typeof matchMedia === 'function' && matchMedia('(prefers-reduced-motion: reduce)').matches);
   const el = (cls, parent) => { const d = doc.createElement('div'); d.className = cls; parent.appendChild(d); return d; };
 
@@ -188,12 +218,21 @@ export function createCaptions(root, opts = {}) {
   const cap = el('rc-cap', layer);
   const line = el('rc-cap-line', cap);
   cap.hidden = true;
+  if (mode === 'slot') cap.classList.add('is-slot');   // race.css: every word dim until its slot is taken
 
   let phrases = [];
   let shown = -1;              // which phrase is in the DOM
   let inked = -1;              // how many of its words have been inked
   let spans = [];              // the word elements of the phrase in the DOM
   let plate = null, plateTimer = 0, dimTimer = 0;
+  /** THE SLOTS THE PLAYER TOOK, as `phrase:word`. Not the clock's: a pop is a thing the player did
+   *  and it stays done, so a seek back over a line the kart read clean draws it read clean again. */
+  const popped = new Set();
+  /** The flights in the air. Each one is a word on its way from a bubble to its slot. */
+  const flys = [];
+  /** What the pops did to the line, for race/smoke/captions-check.mjs: flights started, pops whose
+   *  slot was in a phrase the clock had already left, and pops that matched no slot at all. */
+  const slotStats = { flew: 0, stale: 0, none: 0 };
 
   // ---- the measured layout: see the header of this function ----
   const win = doc.defaultView || (typeof window === 'object' ? window : null);
@@ -307,6 +346,7 @@ export function createCaptions(root, opts = {}) {
    * @returns the span, or null when this build is not the one that flashes
    */
   function showWord(text, o = {}) {
+    if (mode === 'slot') return slotWord(text, o);
     if (mode !== 'flash') return null;
     const said = String(text == null ? '' : text).trim();
     if (!said) return null;
@@ -340,6 +380,121 @@ export function createCaptions(root, opts = {}) {
     return s;
   }
 
+  // ---- THE SLOT: the script on the band, and the pop that lights its own word ----
+  // The phrase is the CLOCK's (draw / update below, exactly as the typewriter's is). Which of its
+  // words are lit is the PLAYER's, and lives in `popped` rather than in the DOM, so a phrase drawn
+  // again after a seek comes back lit the way the kart left it and no flight has to be replayed.
+  const slotKey = (i, k) => i + ':' + k;
+
+  /**
+   * The slot a popped word belongs to: `{ i, k }`, the phrase and the word inside it.
+   * By the word's own second first, because that is the one thing a bubble and a caption word
+   * certainly share (race/wordBubbles.js lays a bubble on the second race/captions.js cut the
+   * phrase at). With no second to go on - a hand call, a smoke - the text picks the first slot of
+   * the phrase on the band that nobody has taken yet.
+   */
+  function slotFor(at, said) {
+    if (!phrases.length) return null;
+    const t = Number(at);
+    if (!Number.isFinite(t)) {
+      const p = phrases[shown];
+      if (!p) return null;
+      const want = said.toLowerCase();
+      for (let k = 0; k < p.words.length; k++) {
+        if (popped.has(slotKey(shown, k))) continue;
+        if (String(p.words[k].w).trim().toLowerCase() === want) return { i: shown, k };
+      }
+      return null;
+    }
+    // the phrase whose window this second falls in, and its neighbours: a word on a phrase's edge
+    // belongs to whichever of the two actually holds it
+    let lo = 0, hi = phrases.length - 1, near = 0;
+    while (lo <= hi) { const mid = (lo + hi) >> 1; if (phrases[mid].t0 <= t) { near = mid; lo = mid + 1; } else hi = mid - 1; }
+    let best = null, gap = SLOT_NEAR_SEC;
+    for (let i = near - 1; i <= near + 1; i++) {
+      const p = phrases[i];
+      if (!p) continue;
+      for (let k = 0; k < p.words.length; k++) {
+        const d = Math.abs(p.words[k].t - t);
+        if (d <= gap) { best = { i, k }; gap = d; }
+      }
+    }
+    return best;
+  }
+
+  /** A flight is over: the word it carried is off the glass and its slot is lit. */
+  function dropFly(rec) {
+    const at = flys.indexOf(rec);
+    if (at >= 0) flys.splice(at, 1);
+    if (rec.land) { clearTimeout(rec.land); rec.land = 0; }
+    if (rec.gone) { clearTimeout(rec.gone); rec.gone = 0; }
+    rec.el.remove();
+  }
+
+  /** Every flight in the air lands NOW. A seek, a pause or a new phrase leaves nothing moving. */
+  function clearFlys() {
+    while (flys.length) {
+      const rec = flys[0];
+      if (rec.land) rec.ink();     // it never reached its slot: the slot lights anyway
+      dropFly(rec);
+    }
+  }
+
+  /**
+   * The rise and the slide. A copy of the word starts at the bubble's own place on the glass, lifts
+   * out of it and slides into the slot's box, and the slot inks under it just before it gets there.
+   * With no start point, no box or reduced motion the slot simply lights: the ink is the promise,
+   * the flight is the flourish.
+   */
+  function flyTo(span, from) {
+    const ink = () => { span.classList.add('is-said'); };
+    const box = span.getBoundingClientRect ? span.getBoundingClientRect() : null;
+    const x0 = from ? num(from.x, NaN) : NaN, y0 = from ? num(from.y, NaN) : NaN;
+    if (reduced || !box || !(box.width > 0) || !Number.isFinite(x0) || !Number.isFinite(y0)) { ink(); return; }
+    const node = doc.createElement('span');
+    node.className = 'rc-slot-fly';
+    node.textContent = span.textContent;
+    node.style.left = `${Math.round(x0)}px`;
+    node.style.top = `${Math.round(y0)}px`;
+    node.style.setProperty('--rc-fly-dx', `${Math.round(box.left + box.width / 2 - x0)}px`);
+    node.style.setProperty('--rc-fly-dy', `${Math.round(box.top + box.height / 2 - y0)}px`);
+    const tint = span.style.getPropertyValue('--rc-ink');
+    if (tint) node.style.setProperty('--rc-ink', tint);
+    try { if (win) node.style.fontSize = win.getComputedStyle(span).fontSize; } catch (e) { /* no layout */ }
+    layer.appendChild(node);
+    const rec = { el: node, ink, land: 0, gone: 0 };
+    flys.push(rec);
+    rec.land = setTimeout(() => { rec.land = 0; ink(); }, Math.max(0, SLOT_FLY_MS - SLOT_LAND_MS));
+    rec.gone = setTimeout(() => { rec.gone = 0; dropFly(rec); }, SLOT_FLY_MS + 80);
+  }
+
+  /**
+   * One pop, on the slot band.
+   * @param text the word the bubble wore (a merged bubble's two words are one string, and take
+   *             two slots: race/wordBubbles.js merged them, the script never did)
+   * @param o { at, from, ghost }: `at` the word's own second, `from` the bubble's place on the
+   *          glass in viewport pixels, `ghost` a word the kart drove past - which does nothing at
+   *          all here, because its slot is already dim and dim is what a missed word looks like
+   * @returns the slot's span, or null when there was no slot to take
+   */
+  function slotWord(text, o) {
+    const said = String(text == null ? '' : text).trim();
+    if (!said || o.ghost) return null;
+    const hit = slotFor(o.at, said);
+    if (!hit) { slotStats.none++; return null; }
+    if (popped.has(slotKey(hit.i, hit.k))) return null;
+    const p = phrases[hit.i];
+    const n = Math.max(1, said.split(/\s+/).length);
+    for (let k = hit.k; k < Math.min(p.words.length, hit.k + n); k++) popped.add(slotKey(hit.i, k));
+    if (hit.i !== shown) { slotStats.stale++; return null; }   // not the line on the band; draw() inks it
+    const span = spans[hit.k];
+    if (!span) { slotStats.stale++; return null; }
+    for (let k = hit.k + 1; k < Math.min(spans.length, hit.k + n); k++) spans[k].classList.add('is-said');
+    slotStats.flew++;
+    flyTo(span, o.from);
+    return span;
+  }
+
   function draw(i) {
     clearPhrase();
     const p = phrases[i];
@@ -354,6 +509,9 @@ export function createCaptions(root, opts = {}) {
       spans.push(s);
     }
     shown = i; inked = 0;
+    // the slots this phrase was already read out of, lit again with no flight: the line the kart
+    // took clean a minute ago comes back exactly as it left, and a seek costs no animation
+    if (mode === 'slot') for (let k = 0; k < spans.length; k++) if (popped.has(slotKey(i, k))) spans[k].classList.add('is-said');
     cap.hidden = false;
     fit();          // two lines, measured off what the phrase actually drew
     measure();      // and the plate under it goes wherever that left room
@@ -364,27 +522,30 @@ export function createCaptions(root, opts = {}) {
    * needs no telling: the same second always draws the same line.
    */
   function update(t) {
-    if (mode !== 'type') return;   // the flash is answered by the pops, not typed by the second
-    if (!phrases.length) { if (shown >= 0) clearPhrase(); return; }
+    if (mode === 'flash') return;  // the flash is answered by the pops, not opened by the second
+    if (!phrases.length) { if (shown >= 0) { clearFlys(); clearPhrase(); } return; }
     const sec = num(t, 0);
     const i = phraseAt(phrases, sec);
     if (i !== shown) {
+      clearFlys();                 // nothing may be in flight to a line that is no longer up
       if (i < 0) { clearPhrase(); return; }
       draw(i);
     }
     const p = phrases[shown];
     if (!p) return;
-    // ink every word the voice has reached, and un-ink the ones a seek put back in the future
-    let n = 0;
-    while (n < p.words.length && p.words[n].t <= sec) n++;
-    if (n !== inked) {
-      for (let k = 0; k < spans.length; k++) spans[k].classList.toggle('is-said', k < n);
-      inked = n;
-    }
-    // the word being spoken right now carries the light
-    for (let k = 0; k < spans.length; k++) {
-      const w = p.words[k];
-      spans[k].classList.toggle('is-now', sec >= w.t && sec < w.t + Math.max(0.12, w.d));
+    if (mode === 'type') {
+      // ink every word the voice has reached, and un-ink the ones a seek put back in the future
+      let n = 0;
+      while (n < p.words.length && p.words[n].t <= sec) n++;
+      if (n !== inked) {
+        for (let k = 0; k < spans.length; k++) spans[k].classList.toggle('is-said', k < n);
+        inked = n;
+      }
+      // the word being spoken right now carries the light
+      for (let k = 0; k < spans.length; k++) {
+        const w = p.words[k];
+        spans[k].classList.toggle('is-now', sec >= w.t && sec < w.t + Math.max(0.12, w.d));
+      }
     }
     // fleeting: the line lets go over its last second rather than blinking out
     const left = p.tEnd - sec;
@@ -396,7 +557,10 @@ export function createCaptions(root, opts = {}) {
     const row = themeFor(event);
     const text = (event && typeof event.label === 'string' ? event.label : '').trim();
     if (!row || !text) return null;
-    clearFlash();   // the plate owns the glass: the band under it goes quiet for the flight
+    // the plate owns the glass. On the flash band that means the words under it go quiet for the
+    // flight; on the slot band the line IS the script and stays, and only the flights are landed,
+    // so a trigger is never doubled by a word sliding into the line behind it.
+    if (mode === 'flash') clearFlash(); else clearFlys();
     measure();      // it lands in the air the band and the toast rail left, never on either
     if (plateTimer) { clearTimeout(plateTimer); plateTimer = 0; }
     if (plate) plate.remove();
@@ -428,6 +592,7 @@ export function createCaptions(root, opts = {}) {
     /** The loaded chart, or null to go quiet. Reads `words` and the trigger events, nothing else. */
     setTrack(chart) {
       phrases = chart ? paintTriggers(buildPhrases(chart.words), chart.events) : [];
+      clearFlys(); popped.clear();     // a new file is a new script: no slot of the old one is taken
       clearFlash();
       // hud.js reads this: with words on the glass the act ribbon's old spot under the score
       // plate belongs to the caption band, so the ribbon takes the clear air lower down instead
@@ -438,13 +603,31 @@ export function createCaptions(root, opts = {}) {
     update,
     showPlate,
     showWord,
-    /** Which half of this file is driving the band: 'flash' (the pops) or 'type' (the clock). */
+    /** Which third of this file is driving the band: 'slot' (the script, lit by the pops), 'flash'
+     *  (the pops write it) or 'type' (the clock types it). */
     get mode() { return mode; },
     /** How many words the flash line is holding right now. The smoke reads it; the game does not. */
     get flashWords() { return mode === 'flash' ? flashN : 0; },
+    /** THE SLOT, for race/smoke/captions-check.mjs: the line's words, how many of them the player
+     *  has taken, and how many are still in the air. Nothing in the game reads this. */
+    get slots() {
+      let said = 0;
+      for (const s of spans) if (s.classList.contains('is-said')) said++;
+      return { phrase: shown, words: spans.length, said, flying: flys.length, taken: popped.size, ...slotStats };
+    },
+    /** THE SMOKE'S OWN ZERO, and nothing in the game calls it. A check that seeks the clock about
+     *  by hand drags a burst of real bubbles onto the road behind it, and those pops are real pops:
+     *  they take real slots. This forgets them, so the next thing the check does is the only thing
+     *  the count can be about. Never wired to a key, a pause or an "again". */
+    resetSlots() {
+      clearFlys(); popped.clear();
+      for (const s of spans) s.classList.remove('is-said');
+      slotStats.flew = 0; slotStats.stale = 0; slotStats.none = 0;
+    },
     /** The run is over or the file was cleared: nothing of the last one stays on the glass. */
     clear() {
-      clearFlash();
+      clearFlys(); popped.clear();
+      clearFlash();               // which takes the phrase off the band with it, in every mode
       if (plateTimer) { clearTimeout(plateTimer); plateTimer = 0; }
       if (plate) { plate.remove(); plate = null; }
       if (dimTimer) { clearTimeout(dimTimer); dimTimer = 0; }
@@ -464,5 +647,6 @@ export function createCaptions(root, opts = {}) {
   };
 }
 
-// self-check: node race/smoke/captions-check.mjs cuts the real caption track, pops words at the
-// band and drives the typewriter behind ?cap=type.
+// self-check: node race/smoke/captions-check.mjs cuts the real caption track, slots popped words
+// into the script on the band, pops words at the flash band behind ?cap=flash and drives the
+// typewriter behind ?cap=type.

--- a/ConditioningControlPanel/Resources/web/dtrh/race/race.css
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/race.css
@@ -603,6 +603,41 @@
   to { text-shadow: 0 0 16px var(--rc-ink, rgba(255, 105, 180, 0.9)), 0 2px 5px rgba(0, 0, 0, 0.95); }
 }
 
+/* ---- THE SLOT: the script on the band, and the word you popped sliding into it ----
+   The owner, phone testing 2026-09-09: "when popped a bubble the word rises and slides into the
+   typewriter we got (the missed ones appear as dimmed like now) the words we get go slot themselves
+   as visible". So the whole phrase is on the band from the moment the clock opens it, dim, and the
+   pop lights its own word: same band, same box, same two line cap, same measured top. Dim is the
+   ghost's own grey, so a line half taken reads as a line half taken and nothing has to be explained.
+   The flight is one shot and one element, parented to the layer rather than to the line, so it can
+   start anywhere on the glass without ever reflowing the sentence it is on its way into. */
+.race-hud .rc-cap.is-slot .rc-cap-word {
+  opacity: 0.35; color: #d6d0dd; text-shadow: 0 2px 5px rgba(0, 0, 0, 0.95);
+  transition: opacity 0.16s linear, color 0.16s linear, text-shadow 0.16s linear;
+}
+.race-hud .rc-cap.is-slot .rc-cap-word.is-said {
+  opacity: 1; color: var(--rc-ink, #fff);
+  text-shadow: 0 0 16px var(--rc-ink, rgba(255, 105, 180, 0.9)), 0 2px 5px rgba(0, 0, 0, 0.95);
+}
+/* captions.js sets left/top to the bubble's own place on the glass and --rc-fly-dx/dy to the trip
+   from there to the slot's middle. The lift at 55 percent is the RISE the ask asks for: the word
+   comes up out of the road before it slides, rather than skating flat across the screen. */
+.race-hud .rc-slot-fly {
+  position: absolute; left: 0; top: 0; white-space: nowrap; z-index: 1;
+  font-size: 1rem; font-weight: 800; letter-spacing: 0.02em; color: var(--rc-ink, #fff);
+  text-shadow: 0 0 18px var(--rc-ink, rgba(255, 105, 180, 0.9)), 0 2px 5px rgba(0, 0, 0, 0.95);
+  transform: translate(-50%, -50%);
+  animation: rcSlotFly 300ms cubic-bezier(0.3, 0.86, 0.28, 1) both;
+}
+@keyframes rcSlotFly {
+  from { opacity: 0.25; transform: translate(-50%, -50%) scale(1.22); }
+  22% { opacity: 1; }
+  55% {
+    transform: translate(calc(-50% + var(--rc-fly-dx, 0px) * 0.42), calc(-50% + var(--rc-fly-dy, 0px) * 0.42 - 24px)) scale(1.1);
+  }
+  to { opacity: 1; transform: translate(calc(-50% + var(--rc-fly-dx, 0px)), calc(-50% + var(--rc-fly-dy, 0px))) scale(1); }
+}
+
 /* ---- the plate: out of the vanishing point, into your face ---- */
 .race-hud .rc-plates { position: absolute; inset: 0; perspective: 900px; }
 .race-hud .rc-plate {
@@ -814,6 +849,9 @@
   /* the flash fades in place too; the ghost keeps its own faintness, which is a reading and not a motion */
   .race-hud .rc-cap-word.rc-flash-word, .race-hud .rc-flash-word.is-accent,
   .race-hud .rc-flash-word.is-ghost { animation: none; }
+  /* and the slot simply lights: captions.js already flies nothing under reduced motion, so this is
+     the belt to that brace rather than the rule itself */
+  .race-hud .rc-slot-fly { animation: none; opacity: 0; }
   .race-hud .rc-dim.is-on { animation: none; }
 }
 

--- a/ConditioningControlPanel/Resources/web/dtrh/race/run.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/run.js
@@ -152,11 +152,12 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1, onExi
   // ---- the parts that outlive a run ----
   const hud = createRaceHud(hudRoot);
   // the voice on the glass: the band under the chrome and the trigger plate over it.
-  // The band ANSWERS THE POPS now (race/captions.js showWord): the words are on the road, so the
-  // word the kart just took is what lands, and the word it drove past lands as a ghost. The old
-  // word-timed typewriter is one release behind `?cap=type`; a track with no words file had no
-  // caption either way and is untouched.
-  const CAP_MODE = flag('cap') === 'type' ? 'type' : 'flash';
+  // The band is the SCRIPT and the pops LIGHT it (race/captions.js, mode 'slot'): the phrase the
+  // file is on sits there dim, and the word the kart pops rises out of the bubble and slides into
+  // its own slot. The wave 3 flash band, where a pop WROTE the word instead, is one release behind
+  // `?cap=flash`, and the word-timed typewriter two behind `?cap=type`; a track with no words file
+  // had no caption on any of the three and is untouched.
+  const CAP_MODE = flag('cap') === 'type' ? 'type' : flag('cap') === 'flash' ? 'flash' : 'slot';
   /** `?words=unread`: a word the kart drove past writes nothing. Ghost is the default. */
   const GHOST_MISSES = flag('words') !== 'unread';
   const captions = hudRoot ? createCaptions(hudRoot, { mode: CAP_MODE }) : null;
@@ -437,13 +438,29 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1, onExi
       shake.shake(0.3, 220); poke('smug', 1.2);
     }
   }
+  /** THE POP'S PLACE ON THE GLASS. A bubble's world point through the run's own camera, in viewport
+   *  pixels: race/captions.js starts the slot flight there, so the word rises out of the bubble the
+   *  player actually took rather than out of a corner. Null when the point is behind the camera or
+   *  the canvas has no box to speak of yet, and the slot then simply lights where it stands. */
+  const _pop3 = new THREE.Vector3();
+  function screenOf(v) {
+    if (!v || typeof v.x !== 'number') return null;
+    _pop3.set(v.x, v.y, v.z).project(camera);
+    if (!Number.isFinite(_pop3.x) || !Number.isFinite(_pop3.y) || _pop3.z > 1) return null;
+    const b = root.getBoundingClientRect ? root.getBoundingClientRect() : null;
+    const cw = (b && b.width) || root.clientWidth || 0, ch = (b && b.height) || root.clientHeight || 0;
+    if (!(cw > 0) || !(ch > 0)) return null;
+    return { x: (b ? b.left : 0) + (_pop3.x * 0.5 + 0.5) * cw, y: (b ? b.top : 0) + (0.5 - _pop3.y * 0.5) * ch };
+  }
   /**
-   * THE FLASH. The word that bubble wore goes on the band: bright on a pop, a grey ghost on a
-   * word the kart drove past. Pops inside race/captions.js FLASH_JOIN_MS join one line, so a line
-   * of word bubbles taken clean reads back as the sentence the voice said.
+   * THE WORD, ON THE BAND. The default band is the SCRIPT (race/captions.js mode 'slot'): the word
+   * the kart popped rises out of its bubble and slides into its own slot in the line, and a word
+   * driven past stays dim in the slot it already had. Behind `?cap=flash` the same call writes the
+   * word onto the band instead, bright on a pop and a grey ghost on a miss.
    * @param eventId the chart event that spawned the bubble, @param ghost true for a miss
+   * @param from the bubble's world position (the pop payload's `worldPos`), for the slot flight
    */
-  function spendWord(w, eventId, ghost, passT) {
+  function spendWord(w, eventId, ghost, passT, from) {
     if (!eventId) return;
     const rec = wordOf.get(eventId);
     if (!rec) return;
@@ -451,7 +468,8 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1, onExi
     echo(rec.w);                                  // the voice said it: a subliminal may repeat it back
     if (!ghost) { TH.popped++; paintThoughts(); }  // a thought taken off the road (race/popped.js)
     logWord(rec, passT == null ? (TR.track ? TR.track.t : 0) : passT, ghost);
-    if (captions && (!ghost || GHOST_MISSES)) captions.showWord(rec.w, { ink: rec.ink, accent: rec.accent, ghost: !!ghost });
+    if (captions && (!ghost || GHOST_MISSES)) captions.showWord(rec.w,
+      { ink: rec.ink, accent: rec.accent, ghost: !!ghost, at: rec.t, from: ghost ? null : screenOf(from) });
     if (ghost || rec.p == null || lineDone.has(rec.p)) return;
     const n = lineN.get(rec.p) || 0, got = (lineGot.get(rec.p) || 0) + 1;
     lineGot.set(rec.p, got);
@@ -491,7 +509,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1, onExi
     if ((word || (!!p.eventId && wordyRows.delete(p.eventId))) && p.kind === 'treat') wordFlashPop(w);
     if (p.eventId) {
       const at = passTime(w, p.d);
-      TR.taken(p.eventId); platePop(p.eventId); spendWord(w, p.eventId, false, at);
+      TR.taken(p.eventId); platePop(p.eventId); spendWord(w, p.eventId, false, at, p.worldPos);
       const row = rowOf.get(p.eventId);   // a trigger row: one log line for the row, on its first pop
       if (row) { rowOf.delete(p.eventId); echo(row.w); logWord(row, at, false); }
     }
@@ -1172,8 +1190,12 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1, onExi
     wordFlashStats: () => ({ ...flashStats }),
     /** GIF RAIN, for race/smoke/gifrain-row-check.mjs: how many of each payload the mixer poured. */
     fxStats: () => Object.fromEntries(fxFired),
-    /** race/smoke/captions-check.mjs: one word at the band, the same call a pop makes. */
+    /** race/smoke/captions-check.mjs: one word at the band, the same call a pop makes. `o` carries
+     *  the slot band's `at` (the word's own second) and `from` (a point on the glass) untouched. */
     debugWord: (text, o) => (captions ? captions.showWord(text, o || {}) != null : false),
+    /** race/smoke/captions-check.mjs: what the slot line is holding - words, taken, still flying. */
+    capSlots: () => (captions ? captions.slots : null),
+    capSlotsReset: () => { if (captions && captions.resetSlots) captions.resetSlots(); },
     /** race/smoke/subliminal-check.mjs and the shot harness: fire ONE payload by hand, rendered
      *  exactly as a pop of that kind renders it. THE MIX is never touched, so a shot cannot change
      *  what the run is holding, and an empty `text` falls back to payloadFx's own whisper pool. */
@@ -1194,7 +1216,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1, onExi
       /** Pretend the context went: the gif floor takes every hold from here on. */
       breakGl: () => spiralFx.loseContext(),
     },
-    /** Which half of race/captions.js is driving the band on this build: 'flash' or 'type'. */
+    /** Which third of race/captions.js drives the band on this build: 'slot', 'flash' or 'type'. */
     capMode: () => CAP_MODE,
     /** THE SYNC WIN, for race/smoke/wsync-check.mjs: the log rows, the offset, a nudge, the export. */
     wordSync: { rows: () => popLog.rows(trackKey()), size: () => popLog.size, offset: offsetOf, nudge, exportJson: exportSync, overlay: () => (syncHud ? syncHud.el : null) },

--- a/ConditioningControlPanel/Resources/web/dtrh/race/smoke/captions-check.mjs
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/smoke/captions-check.mjs
@@ -2,6 +2,7 @@
  * race/smoke/captions-check.mjs - the voice on the glass.
  *
  *   node race/smoke/captions-check.mjs     (from Resources/web/dtrh; 0 on pass, 1 with a count)
+ *   RACE_SHOTS=1 node race/smoke/captions-check.mjs   (also writes shots/cap-slot-phone.png)
  *
  * Two halves. The first is pure: the real caption track this branch ships for the
  * opening level is cut into phrases and the cut is held against its own rules. The
@@ -9,13 +10,16 @@
  * things this layer can get wrong that no unit test sees are "the caption sits on
  * the score plate" and "the plate never actually reached the DOM".
  *
- * The browser half boots the same fixture TWICE, because the band has two halves of
- * its own now. `?cap=type` is the old word-timed typewriter (sections 2, 3 and 7);
- * the default build is THE FLASH (section 7b), where the words are on the road and
- * the band answers a pop instead of typing the file. The flash section holds the
- * whole rule: within 50 ms of a pop, joined inside 0.3 s, a fresh line after the
- * fade, a ghost at 0.35 for a word driven past, two lines at most, no typewriter,
- * and never a pixel on the score plate, the toast rail or the plate's rest spot.
+ * The browser half boots the same fixture THREE times, because the band has three
+ * halves of its own now. `?cap=type` is the old word-timed typewriter (sections 2, 3
+ * and 7); `?cap=flash` is the wave 3 band, where a pop WROTE the word onto the glass
+ * (section 7b); and the default build is THE SLOT (section 7c), where the script sits
+ * on the band dim and the word the kart pops rises out of its bubble and slides into
+ * its own slot. Between them those two sections hold the whole rule: dim until it is
+ * popped, inked where it lands, a word driven past left exactly as dim as it was, a
+ * seek that redraws with nothing replayed, the trigger's plate never doubled, two
+ * lines at most, and never a pixel on the score plate, the toast rail or the plate's
+ * rest spot.
  *
  * The browser half builds one fixture chart off the real transcript, serves it to
  * `?chart=<url>`, then drives `race.trackClock(t, false)` straight at the seconds
@@ -30,13 +34,14 @@
 
 import { spawn } from 'node:child_process';
 import { createServer } from 'node:http';
-import { readFile } from 'node:fs/promises';
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
 import { readFileSync, mkdtempSync, rmSync, existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, extname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { buildPhrases, paintTriggers, MAX_WORDS, GAP_SEC, HOLD_SEC, PLATE_MS,
-  FLASH_HOLD_MS, FLASH_FADE_MS, FLASH_JOIN_MS, GHOST_ALPHA } from '../captions.js';
+  FLASH_HOLD_MS, FLASH_FADE_MS, FLASH_JOIN_MS, GHOST_ALPHA,
+  SLOT_FLY_MS, SLOT_DIM_ALPHA } from '../captions.js';
 import { THEME_BY_PRESET, themeFor } from '../triggerTheme.js';
 import { wordedRoad, PEAKS_PER_SEC } from '../cloudChart.js';
 
@@ -48,6 +53,8 @@ const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 const HERE = resolve(fileURLToPath(import.meta.url), '..');
 const RACE = resolve(HERE, '..');
 const WEB = resolve(RACE, '../..');                        // Resources/web
+/** `RACE_SHOTS=1`: one 390x844 png of the slot line, half read and half still dim, into shots/. */
+const SHOTS = process.env.RACE_SHOTS === '1' ? resolve(WEB, '../../../shots') : null;
 const read = (rel) => JSON.parse(readFileSync(resolve(RACE, rel), 'utf8'));
 const ROW = read('words/index.json').rows[0];             // the opening level
 // the aligner stamp lives on the index row, not on the race copy of the transcript, and
@@ -357,19 +364,20 @@ ok(!!worst && !hits(worst.cap, worst.score), 'and even the tallest keeps off the
 /* ============================================================================
  * 7b. THE FLASH: the band answers the pops, and nothing types
  *
- * The default build. The words are on the road (race/wordBubbles.js), so the band
- * is where a POP is answered: the word lands whole, holds, joins the line if
- * another pop is inside 0.3 s, and a word the kart drove past still lands as a
- * grey ghost. `race.debugWord` is the same call race/run.js onPop makes, so the
- * timings below are the layer's own and not a re-implementation of them.
+ * The wave 3 band, one release behind `?cap=flash` now that the slot line below is
+ * the default. The words are on the road (race/wordBubbles.js), so the band is where
+ * a POP is answered: the word lands whole, holds, joins the line if another pop is
+ * inside 0.3 s, and a word the kart drove past still lands as a grey ghost.
+ * `race.debugWord` is the same call race/run.js onPop makes, so the timings below
+ * are the layer's own and not a re-implementation of them.
  *
  * It never prints a word of the transcript: everything here is counted, measured
  * or read off a class, and the one word it puts on the glass itself is 'ok'.
  * ==========================================================================*/
-const upFlash = await boot(FIXTURE_URL);
-ok(upFlash, 'the default build boots the same road');
+const upFlash = await boot(`${FIXTURE_URL}&cap=flash`);
+ok(upFlash, 'the flash band boots the same road behind ?cap=flash');
 if (!upFlash) await done(1);
-eq(await ev(`window.__race.race.capMode()`), 'flash', 'and the band is the flash, not the typewriter');
+eq(await ev(`window.__race.race.capMode()`), 'flash', 'and the band is the flash, not the slot line and not the typewriter');
 
 /** What the band is holding right now: the words, their classes, and the boxes around them. */
 const band = () => json(`(()=>{ const cap=document.querySelector('.rc-cap');
@@ -443,7 +451,7 @@ ok(!hitB(chain.cap, chain.score), `it never touches the score plate (band ${chai
 ok(!hitB(chain.cap, chain.rail), 'nor the toast rail');
 ok(chain.plateY > chain.cap.y + chain.cap.h, `and the plate's rest spot is still clear under it (band bottom ${chain.cap.y + chain.cap.h}, plate y ${chain.plateY})`);
 
-// 7. the typewriter really is behind ?cap=type: the clock inside a phrase writes nothing
+// 7. the typewriter really is behind ?cap=type: the clock inside a phrase writes nothing on the flash band
 await sleep(FLASH_HOLD_MS + FLASH_FADE_MS + 250);
 await ev(`window.__race.race.trackClock(${target.words[1].t}, false)`);
 await sleep(300);
@@ -473,6 +481,157 @@ await sleep(6000);
 const live = await json(`({ flash: window.__flash, ghost: window.__ghost, t: window.__race.race.track.t })`);
 ok(live.t > road.words[0].t, `the road rolled through the first spoken words (to ${live.t.toFixed(1)}s)`);
 ok(live.flash > 0, `and ${live.flash} of them reached the band off real pops and passes (${live.ghost} as ghosts)`);
+
+/* ============================================================================
+ * 7c. THE SLOT: the script on the band, and the pop that lights its own word
+ *
+ * The default build. The owner, phone testing 2026-09-09: "when popped a bubble the
+ * word rises and slides into the typewriter we got (the missed ones appear as dimmed
+ * like now) the words we get go slot themselves as visible on the typewriter kind of
+ * text we got displayed, except triggers that get already shown big and highlighted."
+ *
+ * So the whole promise, held here and not described: the phrase the clock is on sits
+ * on the band with every word DIM, a pop puts one word in the air and inks the slot
+ * it lands in, a word driven past stays exactly as dim as it was, a seek away and back
+ * draws the line the way the kart left it with nothing replayed, a sure trigger flies
+ * its plate and slides nothing into the line behind it, and none of it touches the
+ * score plate or the toast rail on a 390x844 phone.
+ *
+ * Same rule as 7b about the transcript: a word of it is handed to the page inside an
+ * evaluate so the layer has a real slot to find, and not one is ever printed.
+ * ==========================================================================*/
+const upSlot = await boot(FIXTURE_URL);
+ok(upSlot, 'the default build boots the same road');
+if (!upSlot) await done(1);
+eq(await ev(`window.__race.race.capMode()`), 'slot', 'and the default band is the slot line');
+
+/**
+ * What the slot line is holding: its words, their ink, what is in the air, and the boxes.
+ *
+ * `zero` runs `capSlotsReset()` first, and `then` runs after it, all inside ONE evaluate. A check
+ * that seeks the clock about by hand drags a burst of real bubbles onto the road behind it, and
+ * those pops are real pops that take real slots. Forgetting them and reading the line back without
+ * ever yielding is the only way a count here can be about the one thing the check just did.
+ */
+const slotBand = (o = {}) => json(`(()=>{ ${o.zero ? 'window.__race.race.capSlotsReset();' : ''} ${o.then || ''}
+  const cap=document.querySelector('.rc-cap');
+  const r=(el)=>{ if(!el) return null; const b=el.getBoundingClientRect(); return { x:Math.round(b.left), y:Math.round(b.top), w:Math.round(b.width), h:Math.round(b.height) }; };
+  const words=[...document.querySelectorAll('.rc-cap-word')], cs=(w)=>getComputedStyle(w);
+  const a=(w)=>Math.round(+cs(w).opacity*100)/100;
+  const fly=[...document.querySelectorAll('.rc-slot-fly')].pop();
+  const tops=new Set(); for(const w of words){ const b=w.getBoundingClientRect(); if(b.height>0) tops.add(Math.round(b.top)); }
+  return { n: words.length, said: words.filter(w=>w.classList.contains('is-said')).length,
+    ink: words.map(w=>w.classList.contains('is-said')?1:0),
+    lit: words.filter(w=>w.classList.contains('is-said')).map(a),
+    dim: words.filter(w=>!w.classList.contains('is-said')).map(a),
+    flying: document.querySelectorAll('.rc-slot-fly').length,
+    flyMs: fly?getComputedStyle(fly).animationDuration:'', flyY: fly?Math.round(fly.getBoundingClientRect().top+fly.getBoundingClientRect().height/2):0,
+    flashWords: document.querySelectorAll('.rc-flash-word').length,
+    slots: window.__race.race.capSlots(),
+    lines: tops.size, hidden: !cap||cap.hidden, cap: cap&&!cap.hidden?r(cap):null,
+    score: r(document.querySelector('.rh-score-wrap')), rail: r(document.querySelector('.rh-toasts')),
+    plateY: parseFloat(getComputedStyle(document.querySelector('.rc-layer')).getPropertyValue('--rc-plate-y'))||0,
+    vw: innerWidth, vh: innerHeight };})()`);
+/** Park the clock on one second, as a pause does, and let the seek's own burst of bubbles drain off
+ *  the road before reading anything: with the clock stopped no cue fires, so the road goes quiet. */
+const park = async (t, o) => { await ev(`window.__race.race.trackClock(${t}, false)`); await sleep(1500); return slotBand(o); };
+
+// 1. the phrase is up whole and DIM: the script is on the band before anything is popped.
+// The zero is its own step here rather than part of the read, because a word going back to dim
+// takes race.css's own 0.16s to do it and a computed opacity mid-transition is the transition's.
+const one = target.words[1];
+const POP = `window.__race.race.debugWord(${JSON.stringify(one.w)}, { at: ${one.t}, from: { x: 195, y: 700 } });`;
+await park(one.t);
+await ev(`window.__race.race.capSlotsReset()`);
+await sleep(320);
+const dim = await slotBand();
+eq(dim.n, target.words.length, `the phrase the clock is on sits on the band with all ${target.words.length} of its words in it`);
+eq(dim.said, 0, 'and not one of them is inked until the kart takes it');
+ok(dim.dim.length > 0 && dim.dim.every((v) => Math.abs(v - SLOT_DIM_ALPHA) < 0.02),
+  `every unread word sits at ${SLOT_DIM_ALPHA}, the faint grey a missed word already wore (got ${dim.dim[0]})`);
+eq(dim.flashWords, 0, 'and nothing writes itself onto the band: the slot line never flashes a word beside the script');
+
+// 2. a pop rises out of the bubble and slides into its own slot
+const flew = await slotBand({ zero: true, then: POP });
+eq(flew.flying, 1, 'a pop puts exactly one word in the air');
+eq(flew.slots.flew, 1, 'and one flight is all the layer thinks it started');
+eq(flew.flyMs, `${SLOT_FLY_MS / 1000}s`, `it flies for ${SLOT_FLY_MS}ms, which keeps up with the road`);
+ok(flew.flyY > 400, `and starts down at the pop rather than up at the band (it left from y ${flew.flyY} of ${dim.vh})`);
+eq(flew.n, dim.n, 'while the line it is on its way into never grew a word or reflowed to take it');
+eq(flew.said, 0, 'and no slot lights the moment the pop happens: the word has to get there first');
+
+await sleep(SLOT_FLY_MS + 220);
+const landed = await json(`(()=>{ const w=document.querySelectorAll('.rc-cap-word')[1], cs=getComputedStyle(w);
+  return { said: w.classList.contains('is-said'), alpha: Math.round(+cs.opacity*100)/100,
+    n: document.querySelectorAll('.rc-cap-word').length, flying: document.querySelectorAll('.rc-slot-fly').length };})()`);
+ok(landed.said, 'the word it carried is inked when it gets there, in its own slot in the line');
+ok(landed.alpha > 0.95, `and reads at full strength (${landed.alpha}) where an unread word sits at ${SLOT_DIM_ALPHA}`);
+eq(landed.flying, 0, 'with the flight over and nothing left moving on the glass');
+eq(landed.n, dim.n, 'and the line still exactly as long as the script said it was');
+
+// the picture the owner asked for: half the line taken, half of it still dim, on the phone
+if (SHOTS) {
+  const two0 = target.words[0];
+  await ev(`window.__race.race.debugWord(${JSON.stringify(two0.w)}, { at: ${two0.t}, from: { x: 120, y: 660 } })`);
+  await sleep(SLOT_FLY_MS + 260);
+  const png = (await cdp('Page.captureScreenshot', { format: 'png' })).result?.data;
+  if (png) {
+    await mkdir(SHOTS, { recursive: true });
+    const at = join(SHOTS, 'cap-slot-phone.png');
+    await writeFile(at, Buffer.from(png, 'base64'));
+    console.log('  --  shot: ' + at);
+  }
+}
+
+// 3. a word driven past stays dim in the slot it already had: no ghost, no flight, no ink
+const two = target.words[Math.min(2, target.words.length - 1)];
+const missed = await slotBand({ zero: true,
+  then: `window.__race.race.debugWord(${JSON.stringify(two.w)}, { at: ${two.t}, ghost: true, from: { x: 195, y: 700 } });` });
+eq(missed.said, 0, 'a word the kart drove past inks nothing: it stays dim in the slot it already had');
+eq(missed.flying, 0, 'and flies nothing');
+eq(missed.flashWords, 0, 'nor writes a ghost of its own beside the line');
+
+// 4. a seek is a redraw off the clock, and the slots the player took come back with it
+await slotBand({ zero: true, then: POP });
+await sleep(SLOT_FLY_MS + 120);
+await park(Math.max(0, target.t0 - 1.2));
+const back = await park(one.t);
+eq(back.ink[1], 1, 'a seek away and back draws the line the way the kart left it: the slot it took is still lit');
+eq(back.flying, 0, 'and re-drawing a line replays no flight, so a stopped clock leaves nothing moving');
+eq(back.n, dim.n, 'with the same words in it either way');
+
+// 5. the phone: two lines at most, and never on the chrome
+ok(back.vw + 'x' + back.vh === '390x844', 'the slot line is being measured on a phone portrait viewport');
+ok(back.lines <= 2, `it draws two lines at most (${back.lines})`);
+ok(!!back.cap && back.cap.y >= 0 && back.cap.y + back.cap.h <= back.vh, 'and the band is whole on the glass');
+ok(!hitB(back.cap, back.score), `it never touches the score plate (band ${back.cap.y}..${back.cap.y + back.cap.h}, plate ${back.score.y}..${back.score.y + back.score.h})`);
+ok(!hitB(back.cap, back.rail), 'nor the toast rail');
+ok(back.plateY > back.cap.y + back.cap.h, `and the plate's rest spot is still clear under it (band bottom ${back.cap.y + back.cap.h}, plate y ${back.plateY})`);
+
+// 6. the trigger keeps the plate and is never doubled by a slot flying in behind it. The count is
+// taken AT the frame the plate reaches the DOM, with a flight deliberately in the air when it does.
+await ev(`(()=>{ window.__atPlate = -1;
+  new MutationObserver((ms)=>{ for (const m of ms) for (const n of m.addedNodes) {
+    if (n.classList && n.classList.contains('rc-plate') && window.__atPlate < 0) window.__atPlate = document.querySelectorAll('.rc-slot-fly').length;
+  } }).observe(document.querySelector('.rc-plates'), { childList: true });
+  window.__race.race.capSlotsReset(); ${POP} window.__race.race.trackClock(${trig.t}, false); })()`);
+await sleep(700);
+eq(await json(`document.querySelectorAll('.rc-plate').length`), 1, 'a sure trigger still flies its plate, big and highlighted');
+eq(await ev(`window.__atPlate`), 0, 'and the frame it reaches the glass has nothing sliding into the line behind it: the plate is that word\'s moment, not a slot\'s');
+
+// 7. THE WIRING: real pops on the real road slot themselves, counted as they land. The clock is
+// seeked onto the first spoken words and given three seconds to shed that seek's own burst of
+// bubbles, and only the six seconds AFTER that are counted: a seek is not a drive.
+await ev(`window.__race.race.trackClock(${Math.max(0, road.words[0].t - 0.7)}, true)`);
+await sleep(3000);
+await ev(`window.__race.race.capSlotsReset()`);
+await sleep(6000);
+const slotLive = await json(`({ s: window.__race.race.capSlots(), t: window.__race.race.track.t })`);
+ok(slotLive.t > road.words[0].t, `the road rolled through the first spoken words (to ${slotLive.t.toFixed(1)}s)`);
+console.log(`  --  six seconds of road: ${slotLive.s.flew} words slid into their slot, ${slotLive.s.stale} landed on a line the clock had already left, ${slotLive.s.none} found no slot at all`);
+ok(slotLive.s.flew > 0, `${slotLive.s.flew} words rose out of a real bubble and slid into a real slot`);
+ok(slotLive.s.flew >= slotLive.s.stale + slotLive.s.none,
+  'and most of what the kart took landed on the line that was up, which is the whole promise of the slot band');
 
 /* ============================================================================
  * 8. the demo road still runs, and nothing shouted


### PR DESCRIPTION
The owner, phone testing 2026-09-09:

> when popped a bubble the word rises and slides into the typewriter we got (the missed ones appear as dimmed like now) the words we get go slot themselves as visible on the typewriter kind of text we got displayed, except triggers that get already shown big and highlighted.

So the band is the **script** again, and the pops **light** it rather than write it.

The phrase the file is on opens with every one of its words in the DOM and dim. The word the kart pops rises out of the bubble's own place on the glass and slides into its own slot over 300 ms, and there it inks at full strength. A word driven past never moves: it stays dim in the slot it already had, which is the same faint grey the flash band's ghost wore, so a line half taken reads as a line half taken and nothing has to be explained. A sure trigger flies its plate and nothing else, because that word's moment is the plate and doubling it is noise.

Here it is on a 390x844 phone, mid-line: "can you" taken, "feel it" not yet.

The png is at `shots/cap-slot-phone.png` in the worktree (untracked), written by `RACE_SHOTS=1 node race/smoke/captions-check.mjs`.

## why it stays a function of the clock

Which phrase is up is the clock's, exactly as the typewriter's always was. Which of its words are lit is a set of slots the player took, kept off the DOM, so a seek back over a line the kart read clean draws it read clean again with no animation replayed. A seek, a pause or a new phrase lands every flight in the air at once, so nothing is ever left moving over a stopped clock. The flight itself is a one shot, like the plate.

The start point is the bubble's world position through the run's own camera (`bubbles.js` already hands `worldPos` to every pop callback), so the word really does come up out of the bubble the player took. With no point, no box or reduced motion the slot simply lights: the ink is the promise, the flight is the flourish.

## what moved

| file | what |
|---|---|
| `race/captions.js` | mode `slot`, now the default. The slot ledger, `slotFor` (by the word's own second, so a merged two word bubble takes two slots), the flight, and `showPlate` leaving the script line alone |
| `race/race.css` | `.rc-cap.is-slot` (dim at 0.35, inked at full) and `rcSlotFly`, which lifts the word 24px out of the road before it slides |
| `race/run.js` | `CAP_MODE` default, `screenOf()` projecting the pop, and the word's own second passed through to the layer. Additive: two new lines in the pop path and one changed call |
| `race/smoke/captions-check.mjs` | section 7b moved behind `?cap=flash`, new section 7c holding the whole slot promise, and `RACE_SHOTS=1` writes the phone png |

The wave 3 flash band, where a pop **wrote** the word onto the glass, is one release behind `?cap=flash` and every rule it ever held is still checked there. The old word-timed typewriter stays behind `?cap=type`.

## the bar

`node --check` on every changed file. All four smokes were green on the baseline and are green now:

```
captions-check: all good
word-flash-check: all good
face-check: all good
words-check: all good
```

Section 7c holds: the phrase up with every word at 0.35, one pop putting exactly one word in the air for 300 ms starting down at the pop and not up at the band, the slot lighting only when the word gets there, a word driven past inking nothing and flying nothing, a seek away and back drawing the line the way the kart left it with nothing replayed, the trigger's plate with no slot sliding in behind it, and two lines at most clear of the score plate, the toast rail and the plate's rest spot on a phone.

The wiring, on six seconds of real road after the seek's own burst has gone by:

```
  --  six seconds of road: 7 words slid into their slot, 0 landed on a line
      the clock had already left, 0 found no slot at all
```

458 insertions, 55 deletions across 4 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PEeoJ93JCmhpWTQnwbPHc1
