### PR TITLE
test(descent): the vat fixtures parse on a machine that writes 40,98

### DIFF
--- a/Tests/ConditioningControlPanel.Tests/VatFillCoordinatorTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/VatFillCoordinatorTests.cs
@@ -1,4 +1,4 @@
-using ConditioningControlPanel.Services.Descent;
+﻿using ConditioningControlPanel.Services.Descent;
 using Newtonsoft.Json.Linq;
 using Xunit;
 
@@ -17,9 +17,10 @@ namespace ConditioningControlPanel.Tests;
 public class VatFillCoordinatorTests
 {
     private static DescentBlock? BlockWith(int cap, int todayXp, double fillPct, double lipPct = 120)
-        => DescentReader.Parse(DescentReader.ParseWire(
-            $"{{ \"devotion_days\": 10, \"vat\": {{ \"cap\": {cap}, \"today_xp\": {todayXp}, " +
-            $"\"fill_pct\": {fillPct}, \"fill_lip_pct\": {lipPct} }} }}"));
+        // Invariant on purpose: a plain interpolation writes 40,98 on an it-IT machine and the wire
+        // JSON stops parsing, which reads as Ignored and fails every fractional case below.
+        => DescentReader.Parse(DescentReader.ParseWire(System.FormattableString.Invariant(
+            $"{{ \"devotion_days\": 10, \"vat\": {{ \"cap\": {cap}, \"today_xp\": {todayXp}, \"fill_pct\": {fillPct}, \"fill_lip_pct\": {lipPct} }} }}")));
 
     // ------------------------------------------------------------- the threshold
 


### PR DESCRIPTION
Three `VatFillCoordinatorTests` fail on any machine whose locale writes decimals with a comma (this dev box is it-IT) and pass on CI's en-US runners.

`BlockWith` builds its wire JSON with a plain interpolated string, so `"fill_pct": 40.98` goes out as `40,98`. `ParseWire` swallows the exception and returns null, the coordinator reads null as `Ignored`, and the three cases with a fractional percentage (`40.98`, `0.2`, `44.4`) assert `Silent` against `Ignored`.

Fix is `FormattableString.Invariant` on the one helper. 23/23 green locally under it-IT afterwards; behaviour on en-US unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ldko9omyL6QeyzjdAjySjp