### PR TITLE
fix(spiral): the nav-rail chip stops fighting the flyout, and shows a spiral

### DIFF
--- a/ConditioningControlPanel/Controls/SpiralRailHost.cs
+++ b/ConditioningControlPanel/Controls/SpiralRailHost.cs
@@ -8,51 +8,65 @@ using ConditioningControlPanel.Services.Descent;
 namespace ConditioningControlPanel.Controls
 {
     /// <summary>
-    /// THE SPIRAL RAIL — the 80px miniature docked in the nav rail (CONTRACTS §9),
-    /// with the static stage badge it falls back to.
+    /// THE SPIRAL RAIL - the miniature docked in the nav rail (CONTRACTS §9).
     ///
-    /// TWO LAYERS, ONE ALWAYS PRESENT:
-    ///   • the BADGE — a plain WPF Border/TextBlock pair showing the stage numeral. It
-    ///     is composited like everything else on the rail, costs nothing, and is what a
-    ///     machine with no WebView2 runtime sees. §9's rule is "never an empty hole",
-    ///     and the badge is how that is kept.
-    ///   • the EMBED — <see cref="SpiralEmbedView"/> at ?mode=mini, created lazily and
-    ///     only when the flag is on. It sits ON TOP of the badge and hides it once the
-    ///     canvas is ready; any failure disposes it and the badge is simply uncovered.
+    /// ONE LAYER, NATIVE WPF. The chip is a 40px medallion holding a
+    /// <see cref="SpiralGlyph"/>: the same vector arm, travelling dot and stage numeral that
+    /// the Trainer Card plate and the account menu row already wear. It costs no process, no
+    /// HWND and no request, it paints on the frame it is asked to, and there is no state in
+    /// which the circle is empty.
     ///
     /// ON BY DEFAULT since 6.9.3 (AppSettings.DescentSpiralRailEnabled, no editor; a
     /// hand-edited false in settings.json makes <see cref="Arm"/> return before it touches
-    /// anything and this control stays Collapsed — zero pixels, zero HWNDs, zero requests).
-    /// If the embed route ever 404s, the fallback path above is the one that runs, which
-    /// is exactly the path this had to prove before the route existed.
+    /// anything and this control stays Collapsed, zero pixels and zero requests).
     ///
-    /// THE AIRSPACE MITIGATION, AND THE OPEN QUESTION BEHIND IT. DECISIONS.md
-    /// (2026-08-10) amended the "one web canvas" law with "rail MINI = native WPF
-    /// Canvas/Path — a rail-docked WebView2 HWND would sit over every tab transition";
-    /// CONTRACTS-0812-FINISH §9 and Master Doc v2.1 §9 (both newer, both frozen) say the
-    /// mini IS the shared canvas hosted via WebView2. This class implements the contract
-    /// and mitigates the amendment's objection: the embed is shown ONLY while the rail is
-    /// wide enough to hold it and is torn down whenever the rail collapses or the control
-    /// leaves the screen (<see cref="OnSizeChanged"/> / <see cref="OnIsVisibleChanged"/>),
-    /// so a native HWND never sits in the middle of the flyout's width animation. It is a
-    /// mitigation, not a proof — whether the mini stays WebView2 or reverts to native WPF
-    /// is an owner/coordinator call, and nothing downstream of this file depends on which
-    /// way it goes.
+    /// <para><b>IT USED TO BE A WEBVIEW2, and that is the bug this file was rewritten to
+    /// fix (2026-09-09).</b> The chip hosted <see cref="SpiralEmbedView"/> at ?mode=mini,
+    /// shown only while the rail was wide enough to hold it and torn down on collapse. Both
+    /// halves of that arrangement misbehaved on the owner's machine.</para>
+    ///
+    /// <para>THE FLICKER. A WebView2 is a native child HWND, so a pointer moving onto it
+    /// leaves the WPF visual tree and NavSidebar raises MouseLeave. MainWindow.NavRail.cs
+    /// collapses the rail on MouseLeave with no timer in front of it, the rail's width then
+    /// dropped under the embed's 72px minimum, the old EvaluateEmbed tore the browser down,
+    /// the pointer was over plain WPF again, MouseEnter fired, the rail reopened and rebuilt
+    /// the embed. A closed loop, running at animation rate, reachable from no other row on
+    /// the rail because no other row owned an HWND.</para>
+    ///
+    /// <para>THE EMPTY CIRCLE. The old host hid its stage badge the moment the canvas posted
+    /// 'spiral:ready' and had nothing else to draw, so a mini canvas that painted only its
+    /// own opaque background left a hole where the spiral should be. Uncovered, the badge
+    /// drew a Roman numeral: it never drew a spiral at all, at any point in its life.</para>
+    ///
+    /// <para>DECISIONS.md (2026-08-10) had already amended the "one web canvas" law with
+    /// "rail MINI = native WPF Canvas/Path, a rail-docked WebView2 HWND would sit over every
+    /// tab transition", and this file's previous revision called the disagreement with
+    /// CONTRACTS-0812-FINISH §9 an open owner call that nothing downstream depended on. The
+    /// owner's bug report is that call. The embed keeps §9's other host, the SPIRAL ROOM at
+    /// ?mode=map (Views/Tabs/SpiralTabView.xaml.cs), where the browser gets a stable slab
+    /// and has no rail animation to fight.</para>
     /// </summary>
     public sealed class SpiralRailHost : Grid
     {
-        /// <summary>Below this width the embed is not shown — see the airspace note above.</summary>
-        private const double MinEmbedWidth = 72;
+        /// <summary>Door rhythm: the rail's medallion column is 56 wide, so the chip lands on
+        /// the same centre line as every row above it and leaves no dead gap where the 80px
+        /// embed slab used to sit.</summary>
+        private const double ChipHeight = 56;
+
+        /// <summary>The medallion, on the ring size the fuse chip uses one row below.</summary>
+        private const double BadgeSize = 40;
+
+        /// <summary>The arm inside the medallion. Above <see cref="SpiralGlyph.NumeralMinWidth"/>,
+        /// so the stage numeral still reads in the middle of it.</summary>
+        private const double GlyphSize = 32;
 
         private readonly Border _badge;
-        private readonly TextBlock _badgeText;
-        private SpiralEmbedView? _embed;
+        private readonly SpiralGlyph _glyph;
         private bool _wired;
-        private bool _embedGaveUp;
 
         public SpiralRailHost()
         {
-            Height = 80;
+            Height = ChipHeight;
             Margin = new Thickness(0, 6, 0, 2);
             Cursor = Cursors.Hand;
             // The rail is dark and nothing here has a flag on: stay out of the layout
@@ -60,32 +74,29 @@ namespace ConditioningControlPanel.Controls
             // this control were not in the tree.
             Visibility = Visibility.Collapsed;
 
-            _badgeText = new TextBlock
+            _glyph = new SpiralGlyph
             {
+                Width = GlyphSize,
+                Height = GlyphSize,
                 HorizontalAlignment = HorizontalAlignment.Center,
                 VerticalAlignment = VerticalAlignment.Center,
-                FontSize = 15,
-                FontWeight = FontWeights.SemiBold,
-                Foreground = new SolidColorBrush(Color.FromRgb(0xFF, 0x8F, 0xAF)),
             };
 
             _badge = new Border
             {
-                Width = 40,
-                Height = 40,
-                CornerRadius = new CornerRadius(20),
+                Width = BadgeSize,
+                Height = BadgeSize,
+                CornerRadius = new CornerRadius(BadgeSize / 2),
                 BorderThickness = new Thickness(1.5),
                 BorderBrush = new SolidColorBrush(Color.FromArgb(0x66, 0xFF, 0x69, 0xB4)),
                 Background = new SolidColorBrush(Color.FromRgb(0x25, 0x25, 0x42)),
                 HorizontalAlignment = HorizontalAlignment.Center,
                 VerticalAlignment = VerticalAlignment.Center,
-                Child = _badgeText,
+                Child = _glyph,
             };
             Children.Add(_badge);
 
             MouseLeftButtonUp += (_, _) => OpenMap();
-            SizeChanged += OnSizeChanged;
-            IsVisibleChanged += OnIsVisibleChanged;
             // SELF-WIRING. The host window adds this control and nothing else: no init
             // call in MainWindow, no line in the startup sequence, no partial to keep in
             // step. A Collapsed element still raises Loaded, so the flag-off case reaches
@@ -105,14 +116,14 @@ namespace ConditioningControlPanel.Controls
         /// the control Collapsed.
         ///
         /// Called on every block change, so an account whose key lights up mid-session
-        /// gets the rail without a restart — and one whose key is withdrawn loses it.
+        /// gets the rail without a restart, and one whose key is withdrawn loses it.
         ///
         /// THE WITHHOLD (CONTRACT-FUSE-0816 §2.4) is the fourth gate and the newest: at
         /// zero the server's block dial promotes to 'all' on the same sync that offers a
         /// veteran the migration ceremony, so block presence alone would light this rail
         /// up while the question is still on screen. DescentMigrationService raises
-        /// BlockChanged when the withhold flips, which is why re-reading it here — in the
-        /// method that already re-runs on every block change — is the entire wiring.
+        /// BlockChanged when the withhold flips, which is why re-reading it here, in the
+        /// method that already re-runs on every block change, is the entire wiring.
         /// </summary>
         public void Arm()
         {
@@ -124,13 +135,11 @@ namespace ConditioningControlPanel.Controls
                 if (!allowed)
                 {
                     Visibility = Visibility.Collapsed;
-                    TeardownEmbed();
                     return;
                 }
 
                 Visibility = Visibility.Visible;
                 ApplyBlock(App.Descent?.Current);
-                EvaluateEmbed();
             }
             catch (Exception ex) { App.Logger?.Debug("[Spiral] Arm: {E}", ex.Message); }
         }
@@ -138,7 +147,7 @@ namespace ConditioningControlPanel.Controls
         /// <summary>
         /// Subscribe to the descent block. Idempotent; call once from the host window.
         /// The rail feeds off the SAME service the Trainer Card's vat does and issues no
-        /// request of its own — one reader, one cadence, one 10s floor.
+        /// request of its own: one reader, one cadence, one 10s floor.
         /// </summary>
         public void Wire()
         {
@@ -152,35 +161,44 @@ namespace ConditioningControlPanel.Controls
             catch (Exception ex) { App.Logger?.Debug("[Spiral] Wire: {E}", ex.Message); }
         }
 
-        // ============================== the badge ==============================
+        /// <summary>
+        /// Re-evaluate the glyph's ambient breath. There is no app-wide motion-level event,
+        /// so this rides the same choke point every other ambient loop does; MainWindow's
+        /// RefreshSpiralGlyphMotion calls it alongside the two profile glyphs.
+        /// </summary>
+        public void RefreshGlyphMotion() => _glyph.RefreshMotion();
+
+        // ============================== the medallion ==============================
 
         private void ApplyBlock(DescentBlock? block)
         {
-            int n = block?.Stage?.N ?? 0;
-            _badgeText.Text = StageNumeral(n);
+            _glyph.Apply(block);
 
             // THE NAME LIVES IN THE TOOLTIP, because that is the only place on this
-            // control where a word actually fits. The badge is a 40px circle sized for
-            // one glyph, so the numeral stays where it is and the hover says what the
-            // rung is called and what it feels like - which is the whole reason the
-            // names were locked. A block that has not arrived leaves the tooltip alone
+            // control where a word actually fits. The medallion is a 40px circle sized for
+            // the arm and one glyph, so the numeral stays where it is and the hover says
+            // what the rung is called and what it feels like - which is the whole reason
+            // the names were locked. A block that has not arrived leaves the tooltip alone
             // rather than hovering "The Edge" over a rail that is about to light up.
+            int n = block?.Stage?.N ?? 0;
             ToolTip = block is null
                 ? null
                 : DescentStageCopy.Name(n) + "\n" + DescentStageCopy.Flavor(n);
-
-            _embed?.PostState(block);
         }
 
         /// <summary>
-        /// Stage as a Roman numeral, which is the only stage copy the BADGE ships. The
-        /// stage names were an open owner decision when this was written; they were
-        /// locked on 2026-08-11 and now live in <see cref="DescentStageCopy"/> with
+        /// Stage as a Roman numeral, which is the only stage copy a medallion this size can
+        /// carry. The stage names were an open owner decision when this was written; they
+        /// were locked on 2026-08-11 and now live in <see cref="DescentStageCopy"/> with
         /// localization keys behind them, so the reason the numeral stays is no longer
         /// "we have no copy" - it is that a 40px circle has room for a glyph and not for
         /// "Crush Depth". The name rides the tooltip instead (see
         /// <see cref="ApplyBlock"/>), and every surface with room for a word uses one.
         /// n = 0 is the real pre-begin rung and reads as a dot.
+        ///
+        /// <para>Still the single source for it: <see cref="SpiralGlyph"/> calls straight
+        /// into here for the numeral it draws, so the rail chip, the Trainer Card plate and
+        /// the account menu row cannot drift apart.</para>
         /// </summary>
         internal static string StageNumeral(int n) => n switch
         {
@@ -195,65 +213,11 @@ namespace ConditioningControlPanel.Controls
             _ => n > 8 ? n.ToString(System.Globalization.CultureInfo.InvariantCulture) : "·",
         };
 
-        // ============================== the embed ==============================
-
         /// <summary>
-        /// Create or tear down the embed to match the space available. The width test is
-        /// the airspace mitigation: a collapsed 56px rail gets the badge, and the native
-        /// HWND only exists while there is a stable slab wide enough to hold it.
-        /// </summary>
-        private void EvaluateEmbed()
-        {
-            if (_embedGaveUp) return;                      // one failure is permanent for the session
-            if (!FlagEnabled) { TeardownEmbed(); return; }
-
-            bool room = IsVisible && ActualWidth >= MinEmbedWidth;
-            if (!room) { TeardownEmbed(); return; }
-            if (_embed != null) return;
-
-            var embed = new SpiralEmbedView("mini");
-            embed.Failed += (_, _) =>
-            {
-                // The badge is already underneath — uncovering it IS the fallback.
-                _embedGaveUp = true;
-                TeardownEmbed();
-            };
-            embed.Ready += (_, _) => _badge.Visibility = Visibility.Hidden;
-            _embed = embed;
-            Children.Add(embed);
-            embed.Start();
-            embed.PostState(App.Descent?.Current);
-        }
-
-        private void TeardownEmbed()
-        {
-            if (_embed == null) return;
-            try
-            {
-                Children.Remove(_embed);
-                _embed.Dispose();
-            }
-            catch (Exception ex) { App.Logger?.Debug("[Spiral] TeardownEmbed: {E}", ex.Message); }
-            _embed = null;
-            _badge.Visibility = Visibility.Visible;
-        }
-
-        private void OnSizeChanged(object sender, SizeChangedEventArgs e)
-        {
-            if (Visibility == Visibility.Visible) EvaluateEmbed();
-        }
-
-        private void OnIsVisibleChanged(object sender, DependencyPropertyChangedEventArgs e)
-        {
-            if (IsVisible) EvaluateEmbed();
-            else TeardownEmbed();
-        }
-
-        /// <summary>
-        /// Click-to-expand: the same canvas at ?mode=map, in the SPIRAL ROOM.
+        /// Click-to-expand: the shared canvas at ?mode=map, in the SPIRAL ROOM.
         ///
         /// <para><b>It used to be a window</b> (<c>SpiralMapWindow</c>), on the reasoning that a
-        /// separate top-level HWND has no airspace problem at all. True — but it also meant the one
+        /// separate top-level HWND has no airspace problem at all. True, but it also meant the one
         /// moment this feature was built for opened a second window over the app instead of opening
         /// a room in it, so the window retired on 2026-08-16 and the tab took over. The airspace
         /// problem is solved there by NOT BUILDING the browser except while that tab is the one on

--- a/ConditioningControlPanel/MainWindow/MainWindow.ProfileSpiral.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.ProfileSpiral.cs
@@ -108,6 +108,9 @@ namespace ConditioningControlPanel
             {
                 DiscordTab?.ProfileSpiralGlyph?.RefreshMotion();
                 ProfileMenuSpiralGlyph?.RefreshMotion();
+                // The nav-rail chip wears the same glyph since it stopped being a WebView2
+                // (Controls/SpiralRailHost.cs), so it re-arms from the same choke point.
+                SpiralRail?.RefreshGlyphMotion();
             }
             catch (Exception ex) { App.Logger?.Debug("RefreshSpiralGlyphMotion: {E}", ex.Message); }
         }

--- a/ConditioningControlPanel/MainWindow/MainWindow.xaml
+++ b/ConditioningControlPanel/MainWindow/MainWindow.xaml
@@ -1338,7 +1338,10 @@
                          (AppSettings.DescentSpiralRailEnabled, no editor), and the control still
                          stays collapsed until the server ships this account a descent block. Collapsed measures as zero, so the rail's
                          layout is identical to the build before this element existed.
-                         See Controls/SpiralRailHost.cs - especially the airspace note. -->
+                         Native WPF (a SpiralGlyph in a medallion) since 2026-09-09: the WebView2
+                         it used to host was a native child HWND, and an HWND on the rail stole
+                         the pointer from NavSidebar and made the flyout open and shut on a loop.
+                         See Controls/SpiralRailHost.cs. -->
                     <controls:SpiralRailHost x:Name="SpiralRail"/>
                     <Border Height="1" Background="{DynamicResource PanelAccentBrush}" Margin="10,8,10,6"/>
                     <!-- THE FUSE RAIL CHIP (CONTRACT-FUSE-0816 2.2). A gold clock that appears

--- a/Tests/ConditioningControlPanel.Tests/SpiralGlyphProgressTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/SpiralGlyphProgressTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.IO;
 using ConditioningControlPanel.Controls;
 using Xunit;
@@ -171,4 +171,49 @@ public class SpiralGlyphProgressTests
         // The gate that IS there: a real block, on your own card.
         Assert.Contains("block is not null && _profileViewingSelf", code, StringComparison.Ordinal);
     }
+
+    /// <summary>
+    /// THE NAV-RAIL CHIP IS NATIVE, and this is the assertion that keeps it that way.
+    ///
+    /// <para>It hosted a <c>SpiralEmbedView</c> at ?mode=mini until 2026-09-09. A WebView2 is a
+    /// native child HWND, so the pointer arriving on it left the WPF visual tree, NavSidebar
+    /// raised MouseLeave, MainWindow.NavRail.cs collapsed the rail on the spot, the rail's width
+    /// fell under the embed's minimum, the host tore the browser down, the pointer was over plain
+    /// WPF again and the rail reopened. The owner saw the flyout open and shut on a loop, on that
+    /// one row and no other, because that was the only row on the rail owning an HWND.</para>
+    ///
+    /// <para>Comment lines are stripped: the file EXPLAINS the browser it no longer builds, and
+    /// the explanation must not be what fails the assertion.</para>
+    /// </summary>
+    [Fact]
+    public void TheRailChipOwnsNoBrowser()
+    {
+        var code = CodeOf("Controls", "SpiralRailHost.cs");
+
+        Assert.DoesNotContain("SpiralEmbedView", code, StringComparison.Ordinal);
+        Assert.DoesNotContain("WebView", code, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// AND IT IS NEVER AN EMPTY CIRCLE. The old chip drew a Roman numeral under the browser and
+    /// hid even that the moment the canvas posted 'spiral:ready', so a mini canvas that painted
+    /// nothing but its own background left a hole where the spiral should be. The chip now wears
+    /// the same <see cref="SpiralGlyph"/> the Trainer Card plate and the account menu row do, and
+    /// a vector arm has no state in which it fails to arrive.
+    /// </summary>
+    [Fact]
+    public void TheRailChipWearsTheSameGlyphAsTheProfileSurfaces()
+    {
+        var code = CodeOf("Controls", "SpiralRailHost.cs");
+
+        Assert.Contains("new SpiralGlyph", code, StringComparison.Ordinal);
+        Assert.Contains("_glyph.Apply(block)", code, StringComparison.Ordinal);
+    }
+
+    /// <summary>Source with every comment line removed, so a file that documents a thing cannot
+    /// be mistaken for a file that does it.</summary>
+    private static string CodeOf(params string[] parts)
+        => string.Join(" ", Array.FindAll(
+            AppFile(parts).Split('\n'),
+            l => !l.TrimStart().StartsWith("//", StringComparison.Ordinal)));
 }


### PR DESCRIPTION
## The bug

Owner: *"when I hover over the spiral on the side menu it tends to glitch (closes and opens the menu rapidly). This doesn't happen to the other items on the menu. Also the little circle there on the menu should show a small spiral, rn its empty."*

Two symptoms, one cause: the Spiral chip was the only row on the nav rail that owned a native window.

## Root cause 1: the flicker

`SpiralRailHost` built a `SpiralEmbedView` (WebView2, `?mode=mini`) whenever the rail was at least 72px wide, and tore it down again below that, from `SizeChanged`:

- `Controls/SpiralRailHost.cs:45` `MinEmbedWidth = 72`
- `Controls/SpiralRailHost.cs:270` `bool room = IsVisible && ActualWidth >= MinEmbedWidth;`
- `Controls/SpiralRailHost.cs:293` `OnSizeChanged` calling `EvaluateEmbed()` on every frame of the rail's width animation
- `MainWindow/MainWindow.NavRail.cs:297` `NavSidebar.MouseLeave += ... SetNavRailExpanded(false);` with the debounce timer deliberately removed on 2026-08-13

A WebView2 is a native child HWND. The pointer arriving on it leaves the WPF visual tree, so `NavSidebar` raises `MouseLeave`. The rail collapses on the spot, its width drops to 56, `EvaluateEmbed` destroys the browser, the pointer is over plain WPF again, `MouseEnter` / `MouseMove` fires, the rail reopens, the embed is rebuilt, and round it goes. A closed loop running at animation rate, unreachable from any other row because no other row on the rail has an HWND.

## Root cause 2: the empty circle

- `Controls/SpiralRailHost.cs:281` `embed.Ready += (_, _) => _badge.Visibility = Visibility.Hidden;`

The stage badge was the only thing in the chip that drew anything, and it was hidden the moment the canvas posted `spiral:ready`. A mini canvas that renders nothing but its own opaque background therefore leaves a hole. And even uncovered, the badge drew a Roman numeral from `StageNumeral` (`·` at stage 0), never a spiral, at any point in its life.

The owner's screenshot confirms the embed was live: the rail chip's rectangle is a flat `#1C1C36`, which is exactly `SpiralEmbedView`'s constructor background, and it reaches roughly 196px across, far past the 56px collapsed rail and out over the page. That is the airspace hole this HWND was always going to cut.

## The fix

The rail miniature becomes native WPF, which is what `DECISIONS.md` (2026-08-10) had already amended the "one web canvas" law to require, and which the previous revision of this file itself called an open owner call that nothing downstream depended on. The bug report is that call.

- The chip is a 40px medallion holding a `SpiralGlyph`: the same vector arm, travelling dot and stage numeral the Trainer Card plate and the account menu row already wear. No process, no HWND, no request, nothing to build or destroy mid-animation, and no state in which the circle is empty.
- The whole embed lifecycle (`MinEmbedWidth`, `EvaluateEmbed`, `TeardownEmbed`, `OnSizeChanged`, `OnIsVisibleChanged`, `_embedGaveUp`) is gone, which also removes the width-driven build/teardown churn during the flyout animation.
- The chip drops from 80px to 56px, the rail's medallion rhythm, now that it is not reserving room for a browser. That closes the dead gap above the divider.
- `MainWindow.RefreshSpiralGlyphMotion` re-arms the rail glyph's ambient breath alongside the two profile glyphs, since it is the same control now.
- `SpiralEmbedView` is untouched and keeps §9's other host, the Spiral Room at `?mode=map`, where the browser has a stable slab and no rail animation to fight. `StageNumeral` stays the single source of the numeral (`SpiralGlyph` calls into it).

## Verification

- `dotnet build ConditioningControlPanel/ConditioningControlPanel.csproj` : 0 errors, warning count unchanged from main.
- Full suite `dotnet test Tests/ConditioningControlPanel.Tests` : **5364 passed, 3 failed**. The 3 failures are `VatFillCoordinatorTests` (`DeltaBelowTheThreshold_EasesSilently`, `ACapChangeWithNoEarn_NeverPours`, `ThresholdFollowsTheCap_SoTheSameGrantReadsDifferentlyAtDepth`) and they fail identically on the unmodified tree at `b9f579c5a`, confirmed by stashing this change and re-running. Nothing to do with the rail.
- Spiral / rail / nav / descent filter: 740 passed, 0 failed. The test from e593ee57a (`SpiralRail_IsOnByDefault_Since693`) still passes, as do `SpiralRail_StageBadge_NeverInventsStageCopy`, `SpiralEmbed_UrlCarriesTheMode_AndOnlyTheEmbedOrigin`, `EveryDoorIntoTheSpiralGoesThroughShowTab`, `TheWebDoorSitsAboveSettingsInThePinnedCluster` and `NeitherSurfaceGatesOnTheRailFlag`.
- Two new source-read regression tests in `SpiralGlyphProgressTests`: `TheRailChipOwnsNoBrowser` (comment lines stripped, so the file may keep explaining the browser it no longer builds) and `TheRailChipWearsTheSameGlyphAsTheProfileSurfaces`.

**Not verified:** I cannot run the WPF app in this environment, so the hover behaviour and the rendered chip were reasoned from the source and from pixel measurements of the owner's screenshot, not observed. Worth one pass on the owner's machine: hover the chip and confirm the rail holds open, and confirm the medallion draws the arm plus the stage numeral at 40px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KFgABkHD2mKXdDiJC3Gx34
