### PR TITLE
fix(race): one spiral context for the run, the wash a touch lighter, and the sound stops with the screen

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/race/AUDIO.md
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/AUDIO.md
@@ -32,6 +32,11 @@ per-frame edges (airborne, boost, drift, the Big Wheel span, the room).
 - Autoplay: the run starts on a key, so the context is unlocked; if `play()` still rejects
   (`?autostart=1`), the track retries on the next pointer/key. A missing file marks the track dead,
   re-rolls that room from what is left, and never throws.
+- The screen goes dark (2026-09-09, phone testing: "the audio seems to keep going while screen is
+  off"): audio.js watches `visibilitychange` itself. Hidden pauses the music element and suspends
+  the context (the bed's loops with it); visible resumes the context and plays the same element
+  back if it was the one playing, with the usual gesture retry if `play()` rejects. It covers the
+  menu theme too. The loaded file is run.js's: hidden brakes the run, which posts `track-pause`.
 
 ## The speed bed
 

--- a/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
@@ -215,8 +215,11 @@ is the glitch bubble's wash off the leash: no backdrop blur, no dark luminosity 
 ceiling, so the picture is the thing on the glass. Opacity `0.55-0.8` by strength, hold `1.5-3 s`
 stretched by strength and `durationMult`, a light `is-washing` scale shudder, and a soft mask
 (`styles.css .sf-pfx-gifwash`) that both feathers the edges and lands its falloff over the lower
-centre so the road stays drivable - the race's `filter: opacity()` overlay cap is deliberately NOT
-extended to it. The url comes from `pickWashUrl()`, which draws up to four times from the DOM-safe
+centre so the road stays drivable - the spiral's 0.78 `filter: opacity()` cap is deliberately NOT
+extended to it; what the race does put on the hold is a flat `opacity(0.85)` (2026-09-09, phone
+testing: "15% less opacity on the fullscreen gifs"), so the ramp lands at `0.47-0.68` and the live
+Loom canvas, which inherits the hold's filter, sits at the same weight as a gif. The url comes from
+`pickWashUrl()`, which draws up to four times from the DOM-safe
 pool and takes the first entry whose name or url says `.gif`/`.webp`, keeping the last draw if none
 do; with an empty pool it takes a BUNDLED SPIRAL (`pickSpiralUrl()`, all animated) rather than one
 of the still png `FALLBACK_SPRITES`. It has its OWN MIX slot, `wash` (`cocktail.js CATEGORIES`,
@@ -281,8 +284,11 @@ that word in the centrepiece as a `mantra` - the spiral says what the voice said
 same shape as `subliminalFx`); when a weave is picked it mounts a canvas inside the `sf-pfx-spiral`
 hold rather than setting a background-image, inheriting the hold's opacity fade so intensity stays
 one channel, and neutralises only the css the canvas replaces (the 14 s spin, the 1.6 overscan). The
-canvas backing store is capped at 512 px on the long side, 320 px on the touch tier, where it also
-drops layer 2 and the wobble and paces frames at 33 ms. Reduced motion paints one still frame.
+canvas backing store is capped at 512 px on the long side, 256 px on the touch tier, where it also
+drops layer 2 and the wobble and paces frames at 42 ms. One WebGL context and one compiled shader
+serve every hold for the manager's life (2026-09-09: a context per pop was the phone's lag - a
+shader compile on every spiral); a hold is only a 2D view over that surface. Reduced motion paints
+one still frame.
 `webglcontextlost`, or no WebGL at all, drops the canvas and paints `href` - the old gif path is the
 floor, not a dead branch. Each mount self-unmounts at `durMs + 700`, so nothing spins behind an
 invisible layer. `gifwash`'s own fallback goes through the same seam, so it gets a weave too.

--- a/ConditioningControlPanel/Resources/web/dtrh/race/audio.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/audio.js
@@ -14,6 +14,17 @@
  *   audio.toggleMute() -> bool   M key; shared with the dive's master mute (shared/audioMute.js)
  *   audio.dispose()
  *
+ * THE SCREEN GOES DARK (2026-09-09, phone testing: "the audio seems to keep going while
+ * screen is off"). A phone that locks, or a tab that goes to the back, hides the document;
+ * the run's rAF stops with it, but an <audio> element plays on and a WebAudio graph keeps
+ * its loops (the bed) and its session alive. So this module listens to visibilitychange
+ * itself - it covers the menu theme as well as the run - and on hidden it pauses the music
+ * element and suspends the context; on visible it resumes the context and plays the same
+ * element back if it was the one playing. A rejected play() on the way back arms the usual
+ * pointer/key retry (startEl -> armGesture), and engine/audioBus's own gesture hooks resume
+ * the context on the first tap regardless. The loaded track (CHART.md) is not this module's:
+ * run.js brakes the run on hidden, which posts track-pause the way the Brake always has.
+ *
  * Resident music: at most TWO <audio> elements live at once, the room's track and
  * the next room's (residentTracks, prefetched at the gate so it is buffered by the
  * time its room comes). Every other track is released after its crossfade (element
@@ -644,11 +655,36 @@ export function createRaceAudio({ bridge, hud, settings = {}, input } = {}) {
   if (input && input.onAction) input.onAction((a) => { if (a === 'mute') toggleMute(); });
   if (isMuted() && hud && hud.toast) setTimeout(() => { try { hud.toast('muted. m to unmute', 'item'); } catch (e) { /* hud gone */ } }, 800);
 
+  // ---- the screen goes dark (see the header) ----
+  let heldByDark = null;   // the track the lock paused, so only that one comes back
+  function onVisibility() {
+    if (disposed) return;
+    let hid = false;
+    try { hid = document.hidden === true; } catch (e) { return; }
+    if (hid) {
+      heldByDark = null;
+      const cur = music.cur;
+      for (const t of tracks.values()) {
+        let playing = false;
+        try { playing = !t.el.paused; t.el.pause(); } catch (e) { /* ignore */ }
+        if (playing && t === cur) heldByDark = t;
+      }
+      if (ctx && ctx.state === 'running') { try { const p = ctx.suspend(); if (p && p.catch) p.catch(() => {}); } catch (e) { /* ignore */ } }
+      log('screen off: ' + (heldByDark ? heldByDark.name + ' held' : 'no music playing') + ', graph suspended');
+    } else {
+      if (ctx && ctx.state === 'suspended') { try { const p = ctx.resume(); if (p && p.catch) p.catch(() => {}); } catch (e) { /* ignore */ } }
+      const t = heldByDark; heldByDark = null;
+      if (t && music.cur === t && tracks.get(t.name) === t && !t.failed) { startEl(t); log('screen on: ' + t.name + ' back'); }
+    }
+  }
+  try { document.addEventListener('visibilitychange', onVisibility); } catch (e) { /* no document */ }
+
   function dispose() {
     if (disposed) return;
     disposed = true;
     offMute();
     setDucked(false);
+    try { document.removeEventListener('visibilitychange', onVisibility); } catch (e) { /* ignore */ }
     for (const v of voices.splice(0)) { try { v.src.stop(); } catch (e) { /* ignore */ } }
     stopMusic(); stopBed();
     try { master && master.disconnect(); } catch (e) { /* ignore */ }

--- a/ConditioningControlPanel/Resources/web/dtrh/race/loomSpiralFx.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/loomSpiralFx.js
@@ -42,11 +42,18 @@
  * exactly as before the moment it takes the element back.
  *
  * PERF (measured knobs, all in here):
- *   - backing store 512 long side on desktop, 320 on the mobile tier / a coarse
+ *   - ONE WebGL context and ONE compiled shader for the manager's whole life
+ *     (2026-09-09, the owner: "the spirals make the phone version laggy"). The
+ *     first cut built a fresh context per hold - a shader compile + program link
+ *     on every pop, which on a phone is the frame-long stall the player felt as
+ *     lag. Now every hold is a 2D view over the same field surface; a hold costs
+ *     a canvas element and nothing else. The context is torn down on dispose
+ *     (the run's end) and on loss, never between pops.
+ *   - backing store 512 long side on desktop, 256 on the mobile tier / a coarse
  *     pointer, CSS-upscaled to the viewport. The field is analytically
  *     antialiased (u_px in loomField's shader), so it stays crisp anyway - this
  *     is the whole reason a canvas beats a 5 MB gif on a phone.
- *   - 30 fps cap under touch, paced through a timeout so the compositor idles
+ *   - 24 fps cap under touch, paced through a timeout so the compositor idles
  *     between paints (a bare rAF re-arm keeps a display-rate heartbeat alive).
  *   - layer2 off and wobble flattened under touch: two uniforms the phone does
  *     not owe. The params are COPIED first - the book's id means "this spiral
@@ -64,11 +71,11 @@
 import { createFieldRenderer, normalizeParams2, loopMs2, composeFrame } from '../shared/loomField.js';
 import { Q } from '../shared/quality.js';
 
-/** Backing-store long side, by tier. A phone draws under a third of the desktop's pixels. */
+/** Backing-store long side, by tier. A phone draws a quarter of the desktop's pixels. */
 export const BACK_LONG = 512;
-export const BACK_LONG_TOUCH = 320;
-/** 30 fps under touch; the desktop runs at display rate. */
-export const TOUCH_FRAME_MS = 33;
+export const BACK_LONG_TOUCH = 256;
+/** 24 fps under touch; the desktop runs at display rate. */
+export const TOUCH_FRAME_MS = 42;
 /** payloadFx's `.sf-pfx-layer` fade is 0.45 s; the canvas outlives the hold by that plus a breath. */
 export const FADE_MS = 700;
 
@@ -115,8 +122,11 @@ export function backingFor(w, h, touch) {
  */
 export function createLoomSpiralFx({ reducedMotion = false, log = null } = {}) {
   const say = typeof log === 'function' ? log : () => {};
-  /** el -> { el, view, ctx, gl canvas, field, q, loop, kind, timer, id, onLost } */
+  /** el -> { el, view, ctx, q, loop, kind, timer, id, onLost } - the 2D view over the shared field */
   const live = new Map();
+  /** THE ONE FIELD. A GL canvas (never in the DOM) and loomField's renderer over it, built on the
+   *  first mount and kept until dispose or a context loss: every hold draws off this surface. */
+  let glc = null, field = null, onContextLost = null;
   let touch = isTouchTier();
   let lost = false;          // WebGL refused or a context was lost - latched for the run
   let disposed = false;
@@ -135,9 +145,9 @@ export function createLoomSpiralFx({ reducedMotion = false, log = null } = {}) {
   }
   function sizeRec(rec) {
     const b = viewport();
+    if (glc && (glc.width !== b.w || glc.height !== b.h)) { glc.width = b.w; glc.height = b.h; }
     if (rec.view.width !== b.w || rec.view.height !== b.h) {
       rec.view.width = b.w; rec.view.height = b.h;
-      rec.gl.width = b.w; rec.gl.height = b.h;
       return true;
     }
     return false;
@@ -166,7 +176,7 @@ export function createLoomSpiralFx({ reducedMotion = false, log = null } = {}) {
     rafId = raf(frame);
   }
   function drawOne(rec, phase) {
-    try { composeFrame(rec.ctx, rec.field, rec.q, phase, rec.view.width, rec.view.height); stats.frames++; return true; }
+    try { composeFrame(rec.ctx, field, rec.q, phase, rec.view.width, rec.view.height); stats.frames++; return true; }
     catch (e) { say('race loom render threw (' + ((e && e.message) || e) + ') - the gif takes the layer'); fail(rec); return false; }
   }
   function frame(now) {
@@ -182,13 +192,18 @@ export function createLoomSpiralFx({ reducedMotion = false, log = null } = {}) {
     rafId = raf(frame);
   }
 
-  /** Context lost, or a render threw: latch, tear this hold down, tell the caller. */
+  /** Context lost, or a render threw: latch, tear EVERY hold down (they all drew off the one
+   *  surface), tell each caller. `rec` is the hold that saw it first, or null from the context. */
   function fail(rec) {
     lost = true;
-    const back = rec && rec.onLost;
-    dropRec(rec);
-    stats.floors++;
-    if (typeof back === 'function') { try { back(); } catch (e) { /* ignore */ } }
+    const recs = rec ? [rec, ...[...live.values()].filter((r) => r !== rec)] : [...live.values()];
+    for (const r of recs) {
+      const back = r.onLost;
+      dropRec(r);
+      stats.floors++;
+      if (typeof back === 'function') { try { back(); } catch (e) { /* ignore */ } }
+    }
+    dropField();
   }
 
   function applyOverrides(el, kind) {
@@ -200,24 +215,49 @@ export function createLoomSpiralFx({ reducedMotion = false, log = null } = {}) {
     for (const k of Object.keys(map)) { try { el.style[k] = ''; } catch (e) { /* ignore */ } }
   }
 
-  /** Take one hold's canvas off: free the context, remove the node, give the element back. */
+  /** Take one hold's view off: remove the node, give the element back. The field stays for the next pop. */
   function dropRec(rec) {
     if (!rec || !live.has(rec.el)) return;
     if (rec.timer) { clearTimeout(rec.timer); rec.timer = 0; }
     live.delete(rec.el);
-    try {
-      const g = rec.field && rec.field.gl;
-      const ext = g && g.getExtension ? g.getExtension('WEBGL_lose_context') : null;
-      if (ext && typeof ext.loseContext === 'function') ext.loseContext();
-    } catch (e) { /* ignore */ }
-    try { rec.gl.removeEventListener('webglcontextlost', rec.onContextLost); } catch (e) { /* ignore */ }
     try { rec.view.remove(); } catch (e) { /* ignore */ }
     restoreOverrides(rec.el, rec.kind);
     stats.drops++;
     if (!live.size) halt();
   }
 
-  /** Build the pair of canvases for one hold, or null if WebGL will not have us. */
+  /** The shared field: built once, or null (and `lost` latched) if WebGL will not have us. */
+  function ensureField() {
+    if (field) return field;
+    if (lost) return null;
+    const gl = document.createElement('canvas');     // the field's own surface, never in the DOM
+    const b = viewport();
+    gl.width = b.w; gl.height = b.h;
+    let f = null;
+    try { f = createFieldRenderer(gl); } catch (e) { say('race loom shader failed (' + ((e && e.message) || e) + ') - the gif takes the layer'); f = null; }
+    if (!f) { lost = true; return null; }
+    onContextLost = (ev) => {
+      try { if (ev && typeof ev.preventDefault === 'function') ev.preventDefault(); } catch (e) { /* ignore */ }
+      say('race loom: webgl context lost - the gif takes the layer');
+      fail(null);
+    };
+    gl.addEventListener('webglcontextlost', onContextLost, false);
+    glc = gl; field = f;
+    return field;
+  }
+  /** Free the one context: on dispose, and on loss (where it is already gone). */
+  function dropField() {
+    if (!glc) return;
+    try {
+      const g = field && field.gl;
+      const ext = g && g.getExtension ? g.getExtension('WEBGL_lose_context') : null;
+      if (ext && typeof ext.loseContext === 'function') ext.loseContext();
+    } catch (e) { /* ignore */ }
+    try { glc.removeEventListener('webglcontextlost', onContextLost); } catch (e) { /* ignore */ }
+    glc = null; field = null; onContextLost = null;
+  }
+
+  /** Build the 2D view for one hold, or null if the page has no 2D canvas. */
   function makeRec(el, kind) {
     const view = document.createElement('canvas');
     view.className = 'rh-loom-spiral';
@@ -225,19 +265,10 @@ export function createLoomSpiralFx({ reducedMotion = false, log = null } = {}) {
     s.position = 'absolute'; s.left = '0'; s.top = '0';
     s.width = '100%'; s.height = '100%';
     s.display = 'block'; s.pointerEvents = 'none';
-    const gl = document.createElement('canvas');     // the field's own surface, never in the DOM
-    const rec = { el, view, gl, ctx: null, field: null, kind, q: null, loop: 3600, timer: 0, id: '', onLost: null, onContextLost: null };
+    const rec = { el, view, ctx: null, kind, q: null, loop: 3600, timer: 0, id: '', onLost: null };
     sizeRec(rec);
     rec.ctx = view.getContext('2d');
     if (!rec.ctx) return null;
-    rec.field = createFieldRenderer(gl);
-    if (!rec.field) return null;
-    rec.onContextLost = (ev) => {
-      try { if (ev && typeof ev.preventDefault === 'function') ev.preventDefault(); } catch (e) { /* ignore */ }
-      say('race loom: webgl context lost - the gif takes the layer');
-      fail(rec);
-    };
-    gl.addEventListener('webglcontextlost', rec.onContextLost, false);
     return rec;
   }
 
@@ -264,6 +295,7 @@ export function createLoomSpiralFx({ reducedMotion = false, log = null } = {}) {
       if (rec && rec.kind !== kind) { dropRec(rec); rec = null; }
       if (!rec) {
         try {
+          if (!ensureField()) { stats.floors++; return false; }
           rec = makeRec(el, kind);
           if (!rec) { lost = true; stats.floors++; return false; }
           el.appendChild(rec.view);
@@ -304,21 +336,21 @@ export function createLoomSpiralFx({ reducedMotion = false, log = null } = {}) {
       if (disposed) return;
       disposed = true;
       for (const rec of [...live.values()]) dropRec(rec);
+      dropField();
       halt();
       if (resizeWired) { try { window.removeEventListener('resize', onResize); } catch (e) { /* ignore */ } resizeWired = false; }
       if (visWired) { try { document.removeEventListener('visibilitychange', onVisibility); } catch (e) { /* ignore */ } visWired = false; }
     },
 
-    /** SMOKE / RIG ONLY. Pretend the context went on every live hold: the same path a real
-     *  `webglcontextlost` takes, so race/smoke/loom-spiral-check.mjs can prove the gif floor
-     *  without a driver reset. Returns how many holds were dropped. */
+    /** SMOKE / RIG ONLY. Pretend the one context went: the same path a real `webglcontextlost`
+     *  takes, so race/smoke/loom-spiral-check.mjs can prove the gif floor without a driver
+     *  reset. Returns how many holds were dropped. */
     loseContext() {
-      const recs = [...live.values()];
-      for (const rec of recs) {
-        try { rec.gl.dispatchEvent(new Event('webglcontextlost')); }
-        catch (e) { fail(rec); }
-      }
-      return recs.length;
+      const n = live.size;
+      if (!glc) return 0;
+      try { glc.dispatchEvent(new Event('webglcontextlost')); }
+      catch (e) { fail(null); }
+      return n;
     },
 
     /** race/smoke/loom-spiral-check.mjs + the shot harness: what is on the glass. */
@@ -328,7 +360,7 @@ export function createLoomSpiralFx({ reducedMotion = false, log = null } = {}) {
         backing: r.view.width + 'x' + r.view.height,
         mounted: r.view.parentNode === r.el,
       }));
-      return { holds, touch, lost, disposed, still: !!reducedMotion, ...stats };
+      return { holds, touch, lost, disposed, still: !!reducedMotion, field: !!field, ...stats };
     },
   };
   return api;

--- a/ConditioningControlPanel/Resources/web/dtrh/race/race.css
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/race.css
@@ -498,12 +498,17 @@
 #race-root[data-ov="spiral"] .sf-pfx-drain:not(.sf-pfx-glitching) { filter: opacity(0); }
 #race-root[data-ov="braindrain"] .sf-pfx-spiral { filter: opacity(0); }
 /* THE WASH AND THE BLACK (bubbleKinds.js `gifwash` / `blackout`, drawn by game/payloadFx.js).
-   The overlay cap above is deliberately NOT extended to .sf-pfx-gifwash. The whole of the
+   The spiral's 0.78 cap above is deliberately NOT extended to .sf-pfx-gifwash. The whole of the
    owner's ask is that it read as a gif taking the screen rather than the drain's faint bruise,
-   and styles.css already keeps the road open with a soft mask instead of a ceiling. The one
-   thing the race adds is the motion switch: `data-rm` is run.js's own reducedMotion (the race
+   and styles.css already keeps the road open with a soft mask instead of a ceiling. What the
+   race does add (2026-09-09, phone testing: "15% less opacity on the fullscreen gifs") is a
+   flat 0.85 on the hold, so payloadFx's own 0.55-0.80 strength ramp lands at 0.47-0.68: still
+   the picture that took the road, a little more road through it. The live Loom canvas inherits
+   it (loomSpiralFx's layering contract), so a woven wash and a gif wash sit at the same weight.
+   The other thing is the motion switch: `data-rm` is run.js's own reducedMotion (the race
    menu's toggle), and the media query answers a browser whose player never opened that menu.
    A blackout only ever fades, so it has nothing to take away. */
+#race-root .sf-pfx-gifwash { filter: opacity(0.85); }
 #race-root[data-rm="1"] .sf-pfx-gifwash.is-washing { animation: none; }
 /* THE MELT AND THE DOLL (bubbleKinds.js `melt` / `lock`). Reduced motion keeps the COLOUR and the
    words, which is the effect, and drops the movement: the melt stops sinking and wobbling but its

--- a/ConditioningControlPanel/Resources/web/dtrh/race/run.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/run.js
@@ -1097,7 +1097,18 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1, onExi
     else if (a === 'nudgeUp' || a === 'nudgeDown') nudge((a === 'nudgeUp' ? 1 : -1) * (shift ? NUDGE_BIG_SEC : NUDGE_SEC));
     else if (a === 'export') exportSync();
   });
-  const onVis = () => { last = 0; };
+  // THE SCREEN GOES DARK (2026-09-09, phone testing: "the audio seems to keep going while screen is
+  // off"). The rAF already stops with the document, so the world freezes on its own - but the loaded
+  // file (CHART.md: the file is the clock) played on under a locked phone, and the run would leap
+  // to wherever it had got to when the screen came back. So hidden IS the Brake: same duck, same
+  // track-pause to the host or race/cloud.js, same card waiting when the player returns. The music
+  // and the bed are audio.js's own (its visibilitychange hold), so the menu is covered too.
+  const onVis = () => {
+    last = 0;
+    let hid = false;
+    try { hid = document.hidden === true; } catch (e) { /* no document */ }
+    if (hid && W && S.running && !S.paused && !S.ended && !S.hostPaused) brake();
+  };
   document.addEventListener('visibilitychange', onVis);
 
   function start() {

--- a/ConditioningControlPanel/Resources/web/dtrh/race/smoke/loom-spiral-check.mjs
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/smoke/loom-spiral-check.mjs
@@ -244,8 +244,8 @@ eq(JSON.parse(await ev(HOLD)).canvases, 0, 'every pop after a loss is a gif, wit
     return JSON.stringify({ desk: m.backingFor(1280, 720, false), touch: m.backingFor(390, 844, true), cap: m.TOUCH_FRAME_MS });
   })()`);
   ok(Math.max(phone.desk.w, phone.desk.h) === 512, `a 1280x720 desktop draws ${phone.desk.w}x${phone.desk.h}`);
-  ok(Math.max(phone.touch.w, phone.touch.h) === 320, `a 390x844 phone draws ${phone.touch.w}x${phone.touch.h}`);
-  eq(phone.cap, 33, 'and paces itself at 30 fps under touch');
+  ok(Math.max(phone.touch.w, phone.touch.h) === 256, `a 390x844 phone draws ${phone.touch.w}x${phone.touch.h}`);
+  eq(phone.cap, 42, 'and paces itself at 24 fps under touch');
 }
 
 /* ============================================================================


### PR DESCRIPTION
The owner, phone testing 2026-09-09, three reports in a row:

> the spirals make the phone version laggy

> 15% less opacity on the fullscreen gifs

> the audio seems to keep going while screen is off

## the lag

Every pop built a **fresh WebGL context and compiled the loom shader again**. On a desktop that is a hiccup; on a phone a shader compile plus program link is a frame-long stall, and it landed on exactly the frame the player felt best, the pop. `loomSpiralFx.js` now keeps ONE context and ONE compiled program for the manager's whole life. A hold is a 2D view over that shared surface, so a pop costs a canvas element and nothing else. The context goes on dispose (the run's end) and on loss, never between pops.

A loss now tears every hold down, since they all drew off the one surface, and each caller gets its gif floor the way it always did. The touch tier also draws a little less: 256 long side (was 320) at 24 fps (was 30). The field is analytically antialiased so it stays crisp; a phone now draws a quarter of the desktop's pixels.

## the wash

`race.css` puts a flat `opacity(0.85)` on the `.sf-pfx-gifwash` hold. payloadFx's own 0.55-0.80 strength ramp lands at 0.47-0.68: still the picture that took the road, a little more road through it. The live Loom canvas inherits it through the layering contract, so a woven wash and a gif wash sit at the same weight.

## the screen goes dark

A locked phone hides the document. The run's rAF stops with it, but an `<audio>` element plays on and the WebAudio graph keeps its loops alive, and the loaded file (the file IS the clock, CHART.md) played on underneath, so the run leapt forward when the screen came back.

- `audio.js` owns a `visibilitychange` hold: on hidden it pauses the music element and suspends the context; on visible it resumes the context and plays the same element back if it was the one playing. It lives in the audio module so the **menu theme** is covered too, not just the run. A rejected play() on the way back arms the usual first-tap retry.
- `run.js` treats hidden as the Brake: same duck, same `track-pause` to the host or cloud.js, same card waiting when the player returns. Guarded on running, not paused, not ended, not host-paused.

## what moved

| file | what |
|---|---|
| `race/loomSpiralFx.js` | `ensureField` / `dropField`, one `glc` + `field` per manager, `fail(null)` from the context, `BACK_LONG_TOUCH` 256, `TOUCH_FRAME_MS` 42 |
| `race/audio.js` | `onVisibility` hold, `heldByDark`, wired at create and unwired at dispose |
| `race/run.js` | `onVis` brakes on hidden |
| `race/race.css` | `#race-root .sf-pfx-gifwash { filter: opacity(0.85) }` |
| `race/smoke/loom-spiral-check.mjs` | the phone tier numbers |
| `race/AUDIO.md`, `race/CONTRACT.md` | the contracts say the same |

## the bar

`node --check` on every changed file. Both smokes green:

```
audio-check: all good
loom-spiral-check: all good
```

Not yet verified on the real phone. The thing to watch for: the OST comes back on the first tap after unlock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015spkaJxek5LPpH1N6rdCru
