### PR TITLE
fix(race): the phone's fullscreen holds run through no filter at all

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/game/payloadFx.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/game/payloadFx.js
@@ -58,8 +58,19 @@ const MAX_CASCADE = 14;
  * With nothing passed the file draws the exact gif backgrounds it always has, so
  * dtrh.html is untouched - and even with it, a `false` from mount() falls straight
  * back onto the gif, so the screen can never go bare.
+ *
+ * `opacityCap` is the THIRD seam (2026-09-10, phone testing: "we still lag a lot on the fullscreen
+ * effects on iphone"). Racing Thoughts caps its sustained holds (spiral 0.78, pink 0.7, drain 0.86,
+ * wash 0.85) so the road stays readable, and it did that in race.css with `filter: opacity()`,
+ * because the intensity is set INLINE here and a stylesheet cannot multiply an inline opacity. On a
+ * phone that filter is the lag: a fullscreen layer with a `filter` is rendered through a filter
+ * pass at device resolution on every composited frame, and these layers change every frame (the
+ * live spiral canvas, the wash's shudder, the glitch's steps). So the cap moves to where the
+ * intensity is set: `opacityCap(kind)` -> 0..1 (or a `{kind: mul}` map), multiplied into every
+ * sustained hold's inline opacity in `holdOn` and `showMelt`. Default null = 1, the Descent's
+ * layers are untouched, and race.css can drop the filter on the tier that cannot afford it.
  */
-export function createPayloadFx({ hud, fx, media, flashBurst, subliminalFx = null, spiralFx = null }) {
+export function createPayloadFx({ hud, fx, media, flashBurst, subliminalFx = null, spiralFx = null, opacityCap = null }) {
   // Two layers: washes/bursts render BEHIND the bubble field (.cf-layer, z6) so
   // bubbles stay crisp and clickable on top of pink/spiral/glitch/braindrain;
   // the video card rides a FRONT layer above the bubbles (in front of the POV).
@@ -72,6 +83,13 @@ export function createPayloadFx({ hud, fx, media, flashBurst, subliminalFx = nul
 
   // sustained overlays: one persistent element per kind, opacity-toggled
   const holds = {};   // kind -> { el, hideTimer }
+  /** The caller's ceiling for a hold kind (see the header): 1 unless it says otherwise. */
+  function capFor(kind) {
+    let c = 1;
+    try { c = typeof opacityCap === 'function' ? opacityCap(kind) : (opacityCap ? opacityCap[kind] : 1); } catch (e) { c = 1; }
+    c = Number(c);
+    return Number.isFinite(c) && c > 0 && c <= 1 ? c : 1;
+  }
   const loops = new Set();   // active rAF loops (cascade / bouncer) for teardown
   const cascades = new Set(); // the gif-rain subset of loops (room arrival cuts these)
   let liveFlash = 0, liveCascade = 0;
@@ -172,7 +190,7 @@ export function createPayloadFx({ hud, fx, media, flashBurst, subliminalFx = nul
   function holdOn(kind, cls, opacity, durMs) {
     const h = ensureHold(kind, cls);
     if (h.hideTimer) { clearTimeout(h.hideTimer); h.hideTimer = 0; }
-    h.el.style.opacity = String(opacity);
+    h.el.style.opacity = String(opacity * capFor(kind));
     h.hideTimer = setTimeout(() => { if (!disposed) h.el.style.opacity = '0'; h.hideTimer = 0; }, durMs);
     return h;
   }
@@ -205,7 +223,7 @@ export function createPayloadFx({ hud, fx, media, flashBurst, subliminalFx = nul
    */
   function showMelt(strength, durMult) {
     const dur = Math.round(scale(2000, 4000, strength) * clamp(durMult, 0.3, 3));
-    const peak = scaleD(0.30, 0.78, strength);
+    const peak = scaleD(0.30, 0.78, strength) * capFor('pink');
     const h = ensureHold('pink', 'sf-pfx-pink');
     if (h.hideTimer) { clearTimeout(h.hideTimer); h.hideTimer = 0; }
     const from = Math.max(0.06, parseFloat(h.el.style.opacity || '0') || 0);   // deepen what is there

--- a/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
@@ -289,6 +289,19 @@ drops layer 2 and the wobble and paces frames at 42 ms. One WebGL context and on
 serve every hold for the manager's life (2026-09-09: a context per pop was the phone's lag - a
 shader compile on every spiral); a hold is only a 2D view over that surface. Reduced motion paints
 one still frame.
+THE PHONE'S LAYERS (2026-09-10: "we still lag a lot on the fullscreen effects on iphone. the glitch
+bubble fullscreen in particular and the spiral"). Every sustained hold is a fullscreen DOM layer over
+the WebGL glass, composited at device resolution (3x on an iPhone), and three things on them cost a
+full-resolution pass on every frame the layer changes: race.css's `filter: opacity()` caps (and the
+MIX crossfade and tint-2 saturate through the same channel), the drain's `backdrop-filter: blur()`,
+and the glitch's `hue-rotate` / `saturate` keyframes. So run.js stamps `#race-root[data-touch="1"]`
+on the touch tier (`isTouchTier`, the same stamp the spiral canvas tiers on) and passes payloadFx
+its third seam, `opacityCap(kind)`: the same 0.78 / 0.7 / 0.86 / 0.85 (0.92 for tint 2) multiplied
+INLINE into the hold's opacity at `holdOn` / `showMelt`, so the intensities are the desktop's and
+race.css can take every filter, the backdrop blur and the colour keyframes off that tier (the
+glitch shudders on transform alone, a heavier fill stands in for the blur, the melt's sag drops its
+saturate). The masks stay: a mask is a composite, not a per-frame filter pass. The desktop rules
+are untouched, the Descent passes no cap. `race/smoke/loom-spiral-check.mjs` section 7b.
 `webglcontextlost`, or no WebGL at all, drops the canvas and paints `href` - the old gif path is the
 floor, not a dead branch. Each mount self-unmounts at `durMs + 700`, so nothing spins behind an
 invisible layer. `gifwash`'s own fallback goes through the same seam, so it gets a weave too.

--- a/ConditioningControlPanel/Resources/web/dtrh/race/race.css
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/race.css
@@ -517,6 +517,49 @@
 #race-root[data-rm="1"] .sf-pfx-pink.is-melting,
 #race-root[data-rm="1"] .sf-pfx-freeze.is-lacquer span { animation: none; }
 
+/* ---- THE PHONE'S LAYERS (run.js stamps data-touch="1" on the touch tier) ----
+   2026-09-10, phone testing: "we still lag a lot on the fullscreen effects on iphone. the glitch
+   bubble fullscreen in particular and the spiral". Every hold above is a fullscreen DOM layer over
+   the WebGL glass, composited at device resolution (3x on an iPhone, ~3 M px). Three things on
+   them cost a full-resolution pass on EVERY frame the layer changes, and these layers change every
+   frame (the live spiral canvas at 24 fps, the wash's shudder, the glitch's 6 Hz steps):
+     - `filter: opacity()` - the cap and the MIX crossfade above, and the tint-2 saturate
+     - `backdrop-filter: blur()` on the drain - a blur of everything under it, re-done on each step
+       of the glitch's translate
+     - the glitch's `hue-rotate` / `saturate` keyframes - a colour filter swapped at 6 Hz
+   So on this tier the cap is applied INLINE by payloadFx (`opacityCap`, run.js passes the same
+   0.78 / 0.7 / 0.86 / 0.85 the rules above hold, and 0.92 for tint 2, so the intensities are the
+   ones the desktop gets) and the filters come off. The road cutout and the wash's feather stay:
+   a mask is a GPU composite, not a per-frame filter pass. What the phone gives up is the drain's
+   blur (a heavier fill stands in for it), the glitch's colour shift (its shudder stays, on
+   transform alone) and the tint-2 saturate. */
+#race-root[data-touch="1"] .sf-pfx-spiral,
+#race-root[data-touch="1"] .sf-pfx-pink,
+#race-root[data-touch="1"] .sf-pfx-drain,
+#race-root[data-touch="1"] .sf-pfx-gifwash { filter: none; transition: opacity 0.45s ease; }
+#race-root[data-touch="1"] .sf-pfx-drain {
+  backdrop-filter: none; -webkit-backdrop-filter: none;
+  background-color: rgba(12, 5, 20, 0.74);   /* the blur's dimming, without the blur */
+}
+#race-root[data-touch="1"] .sf-pfx-drain.sf-pfx-glitching { animation: rhGlitchLite 0.16s steps(2) infinite; }
+@keyframes rhGlitchLite {
+  0%   { transform: translate(0, 0); }
+  50%  { transform: translate(-1.2%, 0); }
+  100% { transform: translate(1.2%, 0); }
+}
+/* the MIX on this tier: the crossfade goes through opacity itself (the inline value is the hold's
+   own, so the replace has to out-rank it), and the tint-2 deepening is payloadFx's inline 0.92 */
+#race-root[data-touch="1"][data-ov="spiral"] .sf-pfx-drain:not(.sf-pfx-glitching) { filter: none; opacity: 0 !important; }
+#race-root[data-touch="1"][data-ov="braindrain"] .sf-pfx-spiral { filter: none; opacity: 0 !important; }
+#race-root[data-touch="1"][data-tint="2"] .sf-pfx-pink { filter: none; }
+/* the melt's sag keeps its sink and wobble and drops the saturate the desktop animates with it */
+#race-root[data-touch="1"] .sf-pfx-pink.is-melting { animation: rhSagLite var(--pfx-sag, 3000ms) ease-in both, sf-pfx-drip 3.6s ease-in-out infinite alternate; }
+@keyframes rhSagLite {
+  from { transform: translateY(-2.5%) scaleY(1); }
+  to   { transform: translateY(1.5%)  scaleY(1.075); }
+}
+#race-root[data-touch="1"][data-rm="1"] .sf-pfx-pink.is-melting { animation: none; }
+
 @media (prefers-reduced-motion: reduce) {
   #race-root .rh-laned { animation: rhFade var(--rh-lane-dur, 2600ms) linear forwards !important; }
   #race-root .sf-pfx-gifwash.is-washing { animation: none; }

--- a/ConditioningControlPanel/Resources/web/dtrh/race/run.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/run.js
@@ -58,7 +58,7 @@ import { createFx } from '../engine/fx.js';
 import { createPayloadFx } from '../game/payloadFx.js';
 import { setBundledSpiralPool, prefetchSpirals, setLoomBook, LEAN_SPIRALS } from '../engine/loomSpirals.js';
 import { createLoomBook } from './loomBook.js';
-import { createLoomSpiralFx } from './loomSpiralFx.js';
+import { createLoomSpiralFx, isTouchTier } from './loomSpiralFx.js';
 import { createScreenShake } from '../game/screenShake.js';
 import { INTENSITY_RAMP_SEC, TREATS_ONLY_SEC, KART_BASE_SPEED, MULT_LADDER, COMBO_HOLD_SEC, makeRng } from './consts.js';
 import { createPace } from './pace.js';
@@ -289,8 +289,22 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1, onExi
   });
   setLoomBook(loomBook.draw);
   const spiralFx = createLoomSpiralFx({ reducedMotion, log: bridge.log });
+  // THE PHONE'S LAYERS (2026-09-10, phone testing: "we still lag a lot on the fullscreen effects
+  // on iphone. the glitch bubble fullscreen in particular and the spiral"). Every sustained hold is
+  // a fullscreen DOM layer over the WebGL glass, composited at device resolution (3x on an iPhone).
+  // race.css capped them with `filter: opacity()` and blurred the drain's backdrop; on a phone each
+  // of those is a full-resolution filter pass on every frame the layer changes, and the spiral
+  // canvas, the wash's shudder and the glitch's steps change it every frame. So on the touch tier
+  // the cap is applied INLINE through payloadFx's `opacityCap` seam (the same numbers race.css
+  // holds for the desktop, so nothing looks different) and `#race-root[data-touch="1"]` takes every
+  // filter and the backdrop blur off. The tint-2 deepening (0.92) rides the same seam; its saturate
+  // is the one thing the phone does not get.
+  const touchTier = isTouchTier();
+  const TOUCH_CAP = { spiral: 0.78, pink: 0.7, braindrain: 0.86, gifwash: 0.85 };
+  const holdCap = (kind) => (kind === 'pink' && root.dataset.tint === '2' ? 0.92 : (TOUCH_CAP[kind] || 1));
   const payloadFx = createPayloadFx({ hud: sfHud, fx: fxProxy, media,
-    subliminalFx: subl ? ({ text }) => subl.show({ text }) : null, spiralFx });
+    subliminalFx: subl ? ({ text }) => subl.show({ text }) : null, spiralFx,
+    opacityCap: touchTier ? holdCap : null });
   // Q.leanSpirals (mobile): the GIF FLOOR under a live spiral (and the wash's own fallback) draws
   // from the two lightest bundled gifs, fetched while the intro plays (warmFx) rather than 2-5 MB
   // mid-lap. With WebGL up nothing here is ever fetched at all; this is what a lost context lands on.
@@ -305,6 +319,8 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1, onExi
   // read a JS flag, so this attribute is the seam: `#race-root[data-rm="1"]` drops the gif wash's
   // shudder exactly the way `prefers-reduced-motion` does for a player who never opened the menu.
   if (reducedMotion) root.dataset.rm = '1'; else root.removeAttribute('data-rm');
+  // the tier, for the same reason: race.css lightens the payload layers under `[data-touch="1"]`
+  if (touchTier) root.dataset.touch = '1'; else root.removeAttribute('data-touch');
   const input = createInput({ root });   // root: the touch layer, on a phone, is built inside its .race-hud
   const audio = createRaceAudio({ bridge, hud, settings, input });
   const speedFx = createSpeedFx({ scene, camera, root, reducedMotion });
@@ -563,8 +579,8 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1, onExi
         if (hud.strobe) hud.strobe(r.charges);
         break;
       case 'tint':
-        fire(p, strength, holdMult);
         root.dataset.tint = String(r.depth); if (hud.setTint) hud.setTint(r.depth);   // race.css deepens the wash and the chrome
+        fire(p, strength, holdMult);   // after the depth is on the root: the phone's inline cap reads it at holdOn
         hud.toast(r.action === 'extend' ? (r.depth >= 2 ? 'pinker' : 'pink, longer') : label, 'effect');
         break;
       case 'overlay':

--- a/ConditioningControlPanel/Resources/web/dtrh/race/smoke/loom-spiral-check.mjs
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/smoke/loom-spiral-check.mjs
@@ -249,6 +249,73 @@ eq(JSON.parse(await ev(HOLD)).canvases, 0, 'every pop after a loss is a gif, wit
 }
 
 /* ============================================================================
+ * 7b. the phone's layers carry no filter (2026-09-10: "we still lag a lot on the
+ *     fullscreen effects on iphone. the glitch bubble fullscreen in particular
+ *     and the spiral"). Every hold is a fullscreen DOM layer over the glass; a
+ *     `filter`, a `backdrop-filter` or a colour keyframe on one is a
+ *     device-resolution pass on every frame it changes. On the touch tier the
+ *     cap is inline (payloadFx `opacityCap`) and race.css takes the filters off.
+ * ==========================================================================*/
+{
+  const run = readFileSync(resolve(RACE, 'run.js'), 'utf8');
+  ok(/opacityCap:\s*touchTier\s*\?/.test(run), 'run.js passes the inline cap on the touch tier only');
+  ok(/dataset\.touch\s*=\s*'1'/.test(run), 'and stamps data-touch on the root for race.css');
+  const LAYER = (sel) => `(() => { const el = document.querySelector('${sel}'); if (!el) return JSON.stringify({ there: false });
+    const cs = getComputedStyle(el); return JSON.stringify({ there: true, filter: cs.filter, bf: cs.backdropFilter || cs.webkitBackdropFilter, anim: cs.animationName, mask: cs.maskImage || cs.webkitMaskImage }); })()`;
+  // the desktop this run is on: the caps and the drain's blur are the filters they always were
+  await ev(`window.__race.race.debugPayload('glitch', { strength: 70 })`);
+  await ev(`window.__race.race.debugPayload('overlay', { overlay: 'spiral', strength: 70 })`);
+  await sleep(200);
+  let d = JSON.parse(await ev(LAYER('.sf-pfx-drain'))), sp = JSON.parse(await ev(LAYER('.sf-pfx-spiral')));
+  // (mid-glitch the keyframe's hue-rotate is the computed filter, over the 0.86 cap: still a filter pass)
+  ok(d.there && d.filter !== 'none', `the desktop drain runs through a filter (${d.filter})`);
+  ok(/blur/.test(d.bf), `and its backdrop blur (${d.bf})`);
+  eq(d.anim, 'sf-pfx-glitch', 'and the glitch shudders with its colour keyframes');
+  ok(/opacity\(0\.78\)/.test(sp.filter), `the desktop spiral keeps its filter cap (${sp.filter})`);
+  // the same page stamped as a phone
+  await ev(`document.getElementById('race-root').dataset.touch = '1'`);
+  await sleep(50);
+  d = JSON.parse(await ev(LAYER('.sf-pfx-drain'))); sp = JSON.parse(await ev(LAYER('.sf-pfx-spiral')));
+  eq(d.filter, 'none', 'on the touch tier the drain carries no filter');
+  eq(d.bf, 'none', 'and no backdrop blur');
+  eq(d.anim, 'rhGlitchLite', 'the glitch shudders on transform alone');
+  ok(/radial-gradient/.test(d.mask), 'the road cutout stays (a mask is a composite, not a filter pass)');
+  eq(sp.filter, 'none', 'the spiral hold carries no filter either');
+  const g = JSON.parse(await ev(LAYER('.sf-pfx-gifwash')));
+  if (g.there) eq(g.filter, 'none', 'nor does the wash');
+  // a spiral takes the slot: the glitch's shudder is over and the drain is the hold that lost
+  await ev(`(() => { const r = document.getElementById('race-root'); r.dataset.ov = 'spiral'; document.querySelector('.sf-pfx-drain').classList.remove('sf-pfx-glitching'); return 1; })()`);
+  await sleep(600);   // the layer's own 0.45 s opacity ease
+  const cross = await ev(`(() => { const cs = getComputedStyle(document.querySelector('.sf-pfx-drain')); return cs.filter + '|' + cs.opacity; })()`);
+  eq(cross, 'none|0', 'the MIX replace crossfades the drain out through opacity, not a filter');
+  await ev(`(() => { const r = document.getElementById('race-root'); delete r.dataset.ov; delete r.dataset.touch; return 1; })()`);
+  // the cap itself: a fresh payloadFx with the seam, the numbers the desktop css holds
+  const cap = await parse(`(async () => {
+    const m = await import('/dtrh/game/payloadFx.js');
+    const hud = document.createElement('div');
+    hud.style.cssText = 'position:fixed;inset:0;pointer-events:none;opacity:0';
+    document.body.appendChild(hud);
+    const asked = [];
+    const pfx = m.createPayloadFx({ hud, fx: { pulseFlash() {} }, media: null, flashBurst: null,
+      opacityCap: (kind) => { asked.push(kind); return kind === 'spiral' ? 0.78 : kind === 'braindrain' ? 0.86 : 1; } });
+    pfx.applyPayload({ payload: { kind: 'overlay', overlay: 'spiral' }, strength: 60 }, {});
+    pfx.applyPayload({ payload: { kind: 'glitch' }, strength: 60 }, {});
+    pfx.applyPayload({ payload: { kind: 'overlay', overlay: 'pink_filter' }, strength: 60 }, {});
+    await new Promise((r) => setTimeout(r, 60));
+    const op = (c) => { const el = hud.querySelector(c); return el ? el.style.opacity : null; };
+    const got = { asked, spiral: op('.sf-pfx-spiral'), drain: op('.sf-pfx-drain'), pink: op('.sf-pfx-pink') };
+    pfx.dispose(); hud.remove();
+    return JSON.stringify(got);
+  })()`);
+  // strength 60: spiral/pink 0.25..0.70 -> 0.52; drain 0.35..0.62 -> 0.512
+  ok(Math.abs(parseFloat(cap.spiral) - 0.52 * 0.78) < 1e-6, `the spiral hold is set inline at 0.52 x 0.78 (${cap.spiral})`);
+  ok(Math.abs(parseFloat(cap.drain) - 0.512 * 0.86) < 1e-6, `the drain at 0.512 x 0.86 (${cap.drain})`);
+  ok(Math.abs(parseFloat(cap.pink) - 0.52) < 1e-6, `and a kind the seam answers 1 for is untouched (${cap.pink})`);
+  ok(cap.asked.includes('spiral') && cap.asked.includes('braindrain') && cap.asked.includes('pink'), 'the seam is asked by hold kind');
+  await sleep(4500);   // let the holds fade before the console tally
+}
+
+/* ============================================================================
  * 8. and nothing said a word about it
  * ==========================================================================*/
 ok(errs.length === 0, 'not one console error in the whole run' + (errs.length ? ':\n    ' + errs.slice(0, 5).join('\n    ') : ''));


### PR DESCRIPTION
The owner, phone testing 2026-09-10, after #1026:

> while its slightly better, we still lag a lot on the fullscreen effects on iphone. The glitch bubble fullscreen in particular and the spiral - we need more optimization, this should be smooth. if the fullscreen is too much we can have it almost fullscreen

## what was actually costing

#1026 fixed the shader compile per pop. What is left is not the spiral's pixels (a phone draws it at 118x256) but the **layer it sits in**. Every sustained hold - spiral, pink, drain, wash - is a fullscreen DOM layer over the WebGL glass, and WebKit composites those at device resolution: 3x on an iPhone, about 3 M px. Three things on them force a full-resolution pass on **every frame the layer changes**, and these layers change every frame (the live spiral canvas at 24 fps, the wash's shudder, the glitch's 6 Hz steps):

| on the layer | where | what it does per frame on a phone |
|---|---|---|
| `filter: opacity(0.78 / 0.7 / 0.86 / 0.85)` | race.css, the overlay cap | renders the whole layer through a filter pass |
| `backdrop-filter: blur(4px)` | race.css, the drain (= the glitch's wash) | blurs everything under it, re-done on every step of the glitch's translate |
| `hue-rotate` / `saturate` keyframes | styles.css `sf-pfx-glitch` | a colour filter swapped at 6 Hz on that same layer |

The cap lived in a `filter` for one reason: payloadFx sets the intensity **inline** and a stylesheet cannot multiply an inline opacity.

## what moved

So the cap moves to where the intensity is set, and the filters come off the tier that cannot afford them.

- **`game/payloadFx.js`** gets its third seam, `opacityCap(kind)` (same shape as `subliminalFx` and `spiralFx`: default null, the Descent passes nothing). `holdOn` and `showMelt` multiply it into the inline opacity.
- **`race/run.js`** stamps `#race-root[data-touch="1"]` on the touch tier (`isTouchTier`, the stamp the spiral canvas already tiers on) and passes the exact numbers race.css holds for the desktop: spiral 0.78, pink 0.7, drain 0.86, wash 0.85, and 0.92 for tint 2. The intensities the phone sees are the desktop's. The tint depth is now stamped on the root **before** the pour so the inline cap reads it.
- **`race/race.css`** under `[data-touch="1"]`: `filter: none` on all four holds, no backdrop blur on the drain (a heavier fill, 0.74, stands in for its dimming), the glitch shudders on a transform-only keyframe, the MIX replace crossfades through `opacity` itself, the melt's sag keeps its sink and drops its saturate. **The masks stay**: the road cutout and the wash's feather are compositor masks, not per-frame filter passes.

Desktop rules are byte-for-byte what they were. What the phone gives up: the drain's blur, the glitch's colour shift (the shudder stays), the tint-2 saturate.

## on "almost fullscreen"

Not taken, on purpose. The cost here was the filter passes, not the area: shrinking the layer 10% would have saved about 10% of a pass we no longer make. If the phone is still not smooth after this, the next levers are the spiral hold's `mix-blend-mode: screen` and then the area - I would rather spend one at a time and know which one paid.

## the bar

`node --check` on every changed file. Six race smokes green:

```
loom-spiral-check: all good      (new section 7b)
spiral-pool-check: all good
subliminal-check: all good
word-flash-check: all good
gifrain-row-check: all good
audio-check: all good
```

Section 7b holds: the desktop drain still runs through a filter and a backdrop blur with the colour keyframes; the same page stamped as a phone has `filter: none` and `backdrop-filter: none` on the drain and the spiral, the transform-only shudder, the road cutout still on; the MIX replace fades the drain to 0 through opacity; a payloadFx given the seam sets the spiral hold inline at 0.52 x 0.78 and the drain at 0.512 x 0.86, and leaves a kind the seam answers 1 for alone.

Not verified on the real phone. 169 changed lines across 5 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015spkaJxek5LPpH1N6rdCru
