### PR TITLE
fix(race): the phone's last filters come off, and the governor gets a lower rung

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
@@ -302,6 +302,17 @@ race.css can take every filter, the backdrop blur and the colour keyframes off t
 glitch shudders on transform alone, a heavier fill stands in for the blur, the melt's sag drops its
 saturate). The masks stay: a mask is a composite, not a per-frame filter pass. The desktop rules
 are untouched, the Descent passes no cap. `race/smoke/loom-spiral-check.mjs` section 7b.
+The second pass (2026-09-10, "smoother but still not good enough ... the gifs, pink filter and
+spiral ... the blink shutter effect on the bambi sleep trigger"): under the same stamp the melt's
+drip (an animated background-position, a 3 M px repaint per frame) is gone and only the sag stays;
+the flash bursts and the gif rain swap `filter: drop-shadow()` for a box-shadow; the `pink-blink`
+plate blinks in colour instead of `filter: brightness()`, and the `melt` and `fog` plates let go
+without `filter: blur()`; the doll's lacquer breathes on scale alone; the subliminal card rushes
+without its blur; the strobe edge is the 5 px line without the 40 px inset blur. `shared/quality.js`
+mobile: `bubbleShards` 24 (was 32) and `bubbleViewAhead` 64 m (was 76): every visible sprite is a
+draw call, and 64 m is still 2.9 s ahead at cruise. The governor in `race/pixel.js` has a lower rung
+on a coarse pointer, `TOUCH_DPR_FLOOR` 0.8, read every `GOV_TOUCH_SEC` 2 s, climbing back one rung
+at a time. Section 7c.
 `webglcontextlost`, or no WebGL at all, drops the canvas and paints `href` - the old gif path is the
 floor, not a dead branch. Each mount self-unmounts at `durMs + 700`, so nothing spins behind an
 invisible layer. `gifwash`'s own fallback goes through the same seam, so it gets a weave too.

--- a/ConditioningControlPanel/Resources/web/dtrh/race/pixel.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/pixel.js
@@ -31,6 +31,12 @@
  * given, a line goes out every PERF_LOG_SEC seconds. THE GOVERNOR: on a
  * high-DPI screen an average frame above SLOW_MS drops the canvas to one
  * device pixel per CSS pixel, and one under FAST_MS restores the native ratio.
+ * On a COARSE POINTER (2026-09-10, the owner's phone: "fps drop a lot" under
+ * effects and bubbles) the ladder has one more rung, TOUCH_DPR_FLOOR, and it is
+ * read every GOV_TOUCH_SEC instead of every PERF_LOG_SEC: a phone's fill rate is
+ * the frame, and a hold that drops it needs an answer in two seconds, not five.
+ * It climbs back the same way, one rung at a time, when the average frame is
+ * under FAST_MS again.
  * ==========================================================================*/
 
 import * as THREE from 'three';
@@ -53,6 +59,19 @@ const FAR_FADE = [42, 80];     // metres: the world pass fades to the fog colour
 const PERF_LOG_SEC = 5;
 const FRAME_WIN = 300;         // frames kept for the avg / p95
 const SLOW_MS = 24, FAST_MS = 13;   // governor thresholds on the avg frame (about 42 and 77 fps)
+/** The coarse pointer's lower rung and its faster read (see THE GOVERNOR in the header). */
+export const TOUCH_DPR_FLOOR = 0.8, GOV_TOUCH_SEC = 2;
+/** `(pointer: coarse)` and nothing else, the way pixelDefault reads it - `?coarse=` forces it for a check. */
+export function coarsePointer(win) {
+  const w = win || (typeof window !== 'undefined' ? window : null);
+  if (!w) return false;
+  try {
+    const q = new URLSearchParams(w.location.search).get('coarse');
+    if (q === '1' || q === 'on') return true;
+    if (q === '0' || q === 'off') return false;
+  } catch (e) { /* no location */ }
+  try { return typeof w.matchMedia === 'function' && !!w.matchMedia('(pointer: coarse)').matches; } catch (e) { return false; }
+}
 
 /**
  * THE DEFAULT BLOCK, which is not one number any more. On glass the big pixels cost the most and
@@ -117,7 +136,8 @@ const BLIT_FRAG = `
 export function createPixelizer({ renderer, canvas, block = pixelDefault(), log = null }) {
   let cur = normalizeBlock(block);
   let w = 1, h = 1;
-  let dprCap = Infinity;         // the governor's lid on the device pixel ratio (1 while slow)
+  let dprCap = Infinity;         // the governor's lid on the device pixel ratio (1 while slow, the touch floor while slower)
+  const touch = coarsePointer();
   const screenDpr = () => Math.min(window.devicePixelRatio || 1, Q.maxDpr, 1.5);
   const nativeDpr = () => Math.min(screenDpr(), dprCap);
   const caps = renderer.capabilities || {};
@@ -173,7 +193,7 @@ export function createPixelizer({ renderer, canvas, block = pixelDefault(), log 
   }
 
   // ---- the frame ---------------------------------------------------------------------------
-  const stats = { calls: 0, triangles: 0, passes: 0, frameMs: 0, frameP95: 0 };
+  const stats = { calls: 0, triangles: 0, passes: 0, frameMs: 0, frameP95: 0, dprCap: Infinity, touch };
   let fCalls = 0, fTris = 0, fPasses = 0, perfLast = 0;
   const info = renderer.info;
   function tally() { if (!info || !info.render) return; fCalls += info.render.calls; fTris += info.render.triangles; fPasses++; }
@@ -192,18 +212,25 @@ export function createPixelizer({ renderer, canvas, block = pixelDefault(), log 
     if (gapN < 60) return;
     const native = screenDpr();
     if (avg > SLOW_MS && dprCap > 1 && native > 1) { dprCap = 1; apply(); if (log) log(`[race-perf] governor: dpr 1 (avg frame ${avg.toFixed(1)} ms)`); }
+    else if (avg > SLOW_MS && touch && dprCap > TOUCH_DPR_FLOOR) { dprCap = TOUCH_DPR_FLOOR; apply(); if (log) log(`[race-perf] governor: dpr ${TOUCH_DPR_FLOOR} (avg frame ${avg.toFixed(1)} ms)`); }
+    else if (avg < FAST_MS && dprCap < 1) { dprCap = 1; apply(); if (log) log(`[race-perf] governor: dpr 1, climbing (avg frame ${avg.toFixed(1)} ms)`); }
     else if (avg < FAST_MS && dprCap < native) { dprCap = Infinity; apply(); if (log) log(`[race-perf] governor: dpr native (avg frame ${avg.toFixed(1)} ms)`); }
   }
+  let govLast = 0;
   function closeFrame() {
-    stats.calls = fCalls; stats.triangles = fTris; stats.passes = fPasses;
+    stats.calls = fCalls; stats.triangles = fTris; stats.passes = fPasses; stats.dprCap = dprCap;
     fCalls = fTris = fPasses = 0;
     const nowMs = performance.now();
     if (lastFrameAt) { const g = nowMs - lastFrameAt; if (g < 250) { gaps[gapI] = g; gapI = (gapI + 1) % FRAME_WIN; if (gapN < FRAME_WIN) gapN++; } }
     lastFrameAt = nowMs;
     const now = nowMs / 1000;
     if (!perfLast) perfLast = now;
+    if (touch && now - govLast >= GOV_TOUCH_SEC && now - perfLast < PERF_LOG_SEC) {
+      govLast = now;                       // the phone's faster read, between the log lines
+      govern(frameStats().avg);
+    }
     if (now - perfLast < PERF_LOG_SEC) return;
-    perfLast = now;
+    perfLast = govLast = now;
     const { avg, p95 } = frameStats();
     stats.frameMs = avg; stats.frameP95 = p95;
     govern(avg);

--- a/ConditioningControlPanel/Resources/web/dtrh/race/race.css
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/race.css
@@ -560,6 +560,56 @@
 }
 #race-root[data-touch="1"][data-rm="1"] .sf-pfx-pink.is-melting { animation: none; }
 
+/* ---- THE PHONE'S LAYERS, second pass (2026-09-10: "smoother but still not good enough ... it
+   gets worse on fullscreen effects (the gifs, pink filter and spiral) and the effect like the
+   blink shutter effect we got on the bambi sleep trigger"). The same law as the block above, applied
+   to everything that is still a per-frame filter or a per-frame repaint on this tier:
+     - the melt's drip animated background-position: a 3 M px gradient repainted every frame. The
+       sag (transform) stays, the drip goes.
+     - the flash bursts and the gif rain carried `filter: drop-shadow()` on an element in a transform
+       animation: a filter pass per burst per frame, and a word flash lands every trigger word. A
+       box-shadow paints once.
+     - the plates: `pink-blink` blinked with `filter: brightness()` (the owner's "blink shutter"),
+       `melt` and `fog` blurred out with `filter: blur()`. The blink is two colour steps now, and
+       the two blurs fade on transform and opacity alone.
+     - the doll's lacquer breathed with `filter: brightness()`; it breathes on scale alone.
+     - the subliminal card rushed in through `filter: blur()`; it rushes on transform and opacity.
+     - the strobe edge painted a 40 px inset blur across the whole glass on every charge; on this
+       tier the frame is the 5 px line alone. */
+#race-root[data-touch="1"] .sf-pfx-pink.is-melting { animation: rhSagLite var(--pfx-sag, 3000ms) ease-in both; }
+#race-root[data-touch="1"] .sf-pfx-flash { filter: none; box-shadow: 0 0 26px rgba(255, 105, 180, 0.85); }
+#race-root[data-touch="1"] .sf-pfx-cascade { filter: none; box-shadow: 0 0 14px rgba(255, 105, 180, 0.7); }
+#race-root[data-touch="1"] .sf-pfx-freeze.is-lacquer span { animation: rhLacquerLite 0.9s ease-in-out infinite alternate; }
+@keyframes rhLacquerLite { from { transform: scale(1); } to { transform: scale(1.035); } }
+#race-root[data-touch="1"] .race-hud .rc-plate--blink { animation: rcZoom 1400ms cubic-bezier(0.16, 0.9, 0.3, 1) forwards, rcBlinkLite 1400ms steps(1) forwards; }
+@keyframes rcBlinkLite { 0%, 44% { color: var(--rc-glow, #fff); } 48% { color: #3a0d26; } 52% { color: #fff; } 60% { color: #3a0d26; } 64%, 100% { color: var(--rc-glow, #fff); } }
+#race-root[data-touch="1"] .race-hud .rc-plate--melt { animation: rcMeltLite 1400ms cubic-bezier(0.3, 0.6, 0.2, 1) forwards; }
+@keyframes rcMeltLite {
+  0% { opacity: 0; transform: translate(-50%, -50%) scale(0.15); }
+  8% { opacity: 1; }
+  50% { opacity: 1; transform: translate(-50%, -50%) scale(1.35) skewY(0deg); }
+  78% { opacity: 0.85; transform: translate(-50%, -44%) scale(1.35) skewY(2.5deg); }
+  100% { opacity: 0; transform: translate(-50%, -34%) scale(1.4) skewY(6deg); }
+}
+#race-root[data-touch="1"] .race-hud .rc-plate--fog { animation: rcFogLite 1400ms cubic-bezier(0.25, 0.7, 0.2, 1) forwards; }
+@keyframes rcFogLite {
+  0%   { opacity: 0; letter-spacing: 0.06em; transform: translate(-50%, -50%) scale(0.2); }
+  10%  { opacity: 1; }
+  46%  { opacity: 1; letter-spacing: 0.06em; transform: translate(-50%, -50%) scale(1.24); }
+  76%  { opacity: 0.7; letter-spacing: 0.3em; transform: translate(-50%, -50%) scale(1.3); }
+  100% { opacity: 0; letter-spacing: 0.6em; transform: translate(-50%, -50%) scale(1.34); }
+}
+#race-root[data-touch="1"] .race-hud .rh-sub-card { will-change: transform, opacity; }
+#race-root[data-touch="1"] .race-hud .rh-sub-layer.is-on .rh-sub-card { animation: rhSubRushLite 1250ms cubic-bezier(0.14, 0.86, 0.28, 1) forwards; filter: none; }
+@keyframes rhSubRushLite {
+  0%   { opacity: 0; transform: scale(0.62); }
+  26%  { opacity: 1; transform: scale(1); }
+  62%  { opacity: 1; transform: scale(1.08); }
+  100% { opacity: 0; transform: scale(1.7); }
+}
+#race-root[data-touch="1"] .race-hud .rh-sub-layer.is-on .rh-sub-card.is-still { animation: rhSubHold 1250ms linear forwards; }
+#race-root[data-touch="1"] .race-hud .rh-strobe { box-shadow: inset 0 0 0 5px rgba(255, 255, 255, var(--rh-strobe, 0.6)); }
+
 @media (prefers-reduced-motion: reduce) {
   #race-root .rh-laned { animation: rhFade var(--rh-lane-dur, 2600ms) linear forwards !important; }
   #race-root .sf-pfx-gifwash.is-washing { animation: none; }

--- a/ConditioningControlPanel/Resources/web/dtrh/race/run.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/run.js
@@ -1197,6 +1197,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1, onExi
       frameMs: st.frameMs || 0, programs: info.programs ? info.programs.length : -1,
       geometries: mem.geometries == null ? -1 : mem.geometries, textures: mem.textures == null ? -1 : mem.textures, texMax,
       audio: audio._tracks ? audio._tracks.size : -1, dpr: renderer.getPixelRatio(), block: pixel.block,
+      dprCap: st.dprCap == null ? null : st.dprCap, touch: !!st.touch,   // the governor's lid and its ladder (race/pixel.js)
       world: !!W, stage: !!stage, running: S.running, bubbles: W ? W.field.liveCount : 0,
       // the pace envelope and what the kart actually did with it (race/pace.js, race/smoke/pace-check.mjs)
       speed: W ? W.kart.state.speed : 0, boosting: W ? W.kart.state.boostSec > 0 : false, pace: S.pace ? { ...S.pace } : null,

--- a/ConditioningControlPanel/Resources/web/dtrh/race/smoke/loom-spiral-check.mjs
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/smoke/loom-spiral-check.mjs
@@ -316,6 +316,80 @@ eq(JSON.parse(await ev(HOLD)).canvases, 0, 'every pop after a loss is a gif, wit
 }
 
 /* ============================================================================
+ * 7c. the second pass (2026-09-10: "smoother but still not good enough"): the
+ *     rest of the per-frame filters and repaints come off the touch tier -
+ *     the melt's drip, the flash burst's drop-shadow, the blink / melt / fog
+ *     plates, the lacquer's breath, the subliminal's rush, the strobe's blur.
+ *     And the governor has a lower rung on a coarse pointer.
+ * ==========================================================================*/
+{
+  const CS = (sel) => `(() => { const el = document.querySelector('${sel}'); if (!el) return JSON.stringify({ there: false });
+    const cs = getComputedStyle(el); return JSON.stringify({ there: true, filter: cs.filter, anim: cs.animationName, shadow: cs.boxShadow, bg: cs.backgroundPositionY }); })()`;
+  // probes: one of each kind, stamped as the phone, read, then taken away again
+  const probe = await parse(`(async () => {
+    const r = document.getElementById('race-root'); r.dataset.touch = '1';
+    const hud = r.querySelector('.race-hud') || r;
+    const pfx = r.querySelector('.sf-pfx') || r;
+    const mk = (parent, cls, tag = 'div') => { const e = document.createElement(tag); e.className = cls; parent.appendChild(e); return e; };
+    const els = [
+      mk(pfx, 'sf-pfx-layer sf-pfx-pink is-melting rh-probe'),
+      mk(pfx, 'sf-pfx-flash rh-probe', 'img'),
+      mk(pfx, 'sf-pfx-cascade rh-probe', 'img'),
+      mk(hud, 'rc-plate rc-plate--blink rh-probe'),
+      mk(hud, 'rc-plate rc-plate--melt rh-probe'),
+      mk(hud, 'rc-plate rc-plate--fog rh-probe'),
+      mk(hud, 'rh-strobe rh-probe'),
+    ];
+    const lac = mk(pfx, 'sf-pfx-freeze is-lacquer rh-probe'); const span = document.createElement('span'); span.textContent = 'x'; lac.appendChild(span);
+    const sub = mk(hud, 'rh-sub-layer is-on rh-probe'); const card = mk(sub, 'rh-sub-card');
+    await new Promise((res) => setTimeout(res, 40));
+    const read = (el) => { const cs = getComputedStyle(el); return { filter: cs.filter, anim: cs.animationName, shadow: cs.boxShadow }; };
+    const got = { melt: read(els[0]), flash: read(els[1]), cascade: read(els[2]), blink: read(els[3]), pmelt: read(els[4]), fog: read(els[5]), strobe: read(els[6]), lacquer: read(span), sub: read(card) };
+    for (const e of r.querySelectorAll('.rh-probe')) e.remove();
+    delete r.dataset.touch;
+    return JSON.stringify(got);
+  })()`);
+  eq(probe.melt.anim, 'rhSagLite', 'the melt sags on transform alone, no drip repainting the gradient');
+  eq(probe.flash.filter, 'none', 'a flash burst carries no drop-shadow filter');
+  ok(/rgba?\(/.test(probe.flash.shadow) && probe.flash.shadow !== 'none', `its glow is a box-shadow, painted once (${probe.flash.shadow.slice(0, 40)})`);
+  eq(probe.cascade.filter, 'none', 'nor does a falling gif');
+  eq(probe.blink.anim, 'rcZoom, rcBlinkLite', "the blink plate blinks in colour, not filter: brightness()");
+  eq(probe.blink.filter, 'none', 'and carries no filter');
+  eq(probe.pmelt.anim, 'rcMeltLite', 'the melt plate lets go without a blur');
+  eq(probe.fog.anim, 'rcFogLite', 'so does the fog plate');
+  eq(probe.lacquer.anim, 'rhLacquerLite', 'the doll breathes on scale alone');
+  eq(probe.sub.anim, 'rhSubRushLite', 'the subliminal card rushes without a blur');
+  eq(probe.sub.filter, 'none', 'and carries none at rest');
+  ok(!/40px/.test(probe.strobe.shadow), `the strobe edge is the 5 px line alone (${probe.strobe.shadow.slice(0, 60)})`);
+  // the desktop, untouched: the same probes without the stamp still carry what they always did
+  const desk = await parse(`(async () => {
+    const r = document.getElementById('race-root');
+    const hud = r.querySelector('.race-hud') || r;
+    const p = document.createElement('div'); p.className = 'rc-plate rc-plate--blink rh-probe'; hud.appendChild(p);
+    const f = document.createElement('img'); f.className = 'sf-pfx-flash rh-probe'; r.appendChild(f);
+    await new Promise((res) => setTimeout(res, 40));
+    const got = { blink: getComputedStyle(p).animationName, flash: getComputedStyle(f).filter };
+    p.remove(); f.remove();
+    return JSON.stringify(got);
+  })()`);
+  eq(desk.blink, 'rcZoom, rcBlink', 'the desktop blink plate still blinks with brightness');
+  ok(/drop-shadow/.test(desk.flash), 'and the desktop flash burst keeps its drop-shadow');
+  // the governor's rungs
+  const gov = await parse(`(async () => {
+    const m = await import('/dtrh/race/pixel.js');
+    const q = await import('/dtrh/shared/quality.js');
+    const st = window.__race.race.perf();
+    return JSON.stringify({ floor: m.TOUCH_DPR_FLOOR, sec: m.GOV_TOUCH_SEC,
+      coarseOn: m.coarsePointer({ location: { search: '?coarse=1' } }), coarseOff: m.coarsePointer({ location: { search: '?coarse=0' }, matchMedia: () => ({ matches: true }) }),
+      touch: st ? st.touch : null, cap: st ? st.dprCap : null });
+  })()`);
+  eq(gov.floor, 0.8, 'a coarse pointer can drop to 0.8 device pixels per css pixel');
+  eq(gov.sec, 2, 'and is read every two seconds');
+  ok(gov.coarseOn === true && gov.coarseOff === false, '?coarse= forces the answer either way');
+  eq(gov.touch, false, 'this desktop run is not on the touch ladder');
+}
+
+/* ============================================================================
  * 8. and nothing said a word about it
  * ==========================================================================*/
 ok(errs.length === 0, 'not one console error in the whole run' + (errs.length ? ':\n    ' + errs.slice(0, 5).join('\n    ') : ''));

--- a/ConditioningControlPanel/Resources/web/dtrh/shared/quality.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/shared/quality.js
@@ -53,8 +53,8 @@ export function setQuality(tier) {
     deeperRadial: 14,
     leanLights: true,    // 7 lights -> 3: every lit material's fragment loop shrinks with the light count
     bubbleCap: 100,      // the run holds 46-93 live on desktop's 160; the pool is 100 sprite materials smaller
-    bubbleShards: 32,
-    bubbleViewAhead: 76, // what the fog has already folded away is not drawn (a quarter fewer sprite draw calls)
+    bubbleShards: 24,    // 2026-09-10 (phone: "fps drop a lot ... too many effects or bubbles"): a pop's sparkle is 24 draw calls, not 32
+    bubbleViewAhead: 64, // what the fog has already folded away is not drawn; 64 m is 2.9 s ahead at cruise, still past where a bubble first reads
     leanSpirals: true,   // sp6 + sp7 (0.8 MB together) instead of a 2.2-5.3 MB gif fetched mid-lap
   });
 }


### PR DESCRIPTION
The owner, phone testing 2026-09-10, after #1027:

> Smoother but still not good enough. From phone it is still laggy when we get too many effects or bubbles, fps drops a lot. We need more smoothness and more polish. It gets worse on fullscreen effects (the gifs, pink filter and spiral) and the effect like the blink shutter effect we got on the bambi sleep trigger, etc.

## what was still costing

#1027 took the `filter` and the backdrop blur off the four sustained holds. This pass went through everything else the touch tier still paid for on every frame, and found the same class of thing in nine more places:

| what | where | per frame on a phone |
|---|---|---|
| the melt's drip | styles.css `sf-pfx-drip`, an animated `background-position` | the whole 3 M px gradient repainted, every frame, for the length of the hold |
| the flash bursts and the gif rain | `.sf-pfx-flash` / `.sf-pfx-cascade`, `filter: drop-shadow()` on an element in a transform animation | a filter pass per burst per frame, and a word flash lands on every trigger word |
| the "blink shutter" | the `pink-blink` plate, `rcBlink`: `filter: brightness()` steps | a filter pass on the plate for the whole 1.4 s |
| the melt and fog plates | `rcMelt` / `rcFog`: `filter: blur(0 -> 9px / 12px)` | a blur pass on big text, growing, every frame of the release |
| the doll's lacquer | `sf-pfx-lacquer`: `filter: brightness()` breathing, infinite | a filter pass for as long as the card is up |
| the subliminal card | `rhSubRush`: `filter: blur(4px -> 0 -> 2px)` | a blur pass through the rush |
| the strobe edge | `.rh-strobe`, a 40 px inset blur across the glass | a 3 M px repaint on every charge, and a charge lands on every flash roll |

The shutter itself (race/shutter.js) is clean: `display: none` when open, transform-only when it moves, two panels. The "blink shutter" the owner saw on the sleep trigger is the plate's brightness blink above.

## what moved

- **`race/race.css`** under `#race-root[data-touch="1"]`: the melt keeps its sag (transform) and loses the drip; the flash burst and the falling gif carry a box-shadow instead of a drop-shadow filter (painted once); the blink plate blinks in **colour** (two steps to a dark plum and white, same beats); the melt and fog plates let go on transform and opacity alone; the lacquer breathes on scale alone; the subliminal card rushes without its blur; the strobe frame is the 5 px line alone. Every rule is a twin of the desktop's with the filter taken out; the desktop rules are byte-for-byte what they were.
- **`race/pixel.js`**, the governor. It could only lid the canvas at 1 device pixel per css pixel, and it looked once every 5 s (the perf-log cadence). On a coarse pointer it now has one more rung, `TOUCH_DPR_FLOOR` 0.8, read every `GOV_TOUCH_SEC` 2 s, and it climbs back one rung at a time when the average frame is under 13 ms again. `coarsePointer()` reads `(pointer: coarse)` the way `pixelDefault` does, `?coarse=` forcing it for a check. `perf()` reports the lid and the ladder.
- **`shared/quality.js`** mobile tier: `bubbleShards` 24 (was 32), `bubbleViewAhead` 64 m (was 76). Every visible sprite is a draw call on the crisp pass. 64 m is 2.9 s ahead at cruise, past where a bubble first reads; the cap on live bubbles (100) and the pop box are untouched, so nothing the player can take has changed.

## what the phone gives up

The melt's slow drip down the glass (the sag stays). The blink's brightness flare is a colour flare. The melt and fog plates fade instead of blurring away. The lacquer's brightness pulse. The subliminal's soft entry. A softer strobe frame. Eight fewer sparkle shards per pop, and bubbles first appear 64 m out instead of 76.

## what I did not change, and why

- **`mix-blend-mode: screen`** on the spiral and pink holds. In WebKit that is a compositor blend, not a per-frame filter pass; with the filters gone it should be cheap. Left on, deliberately, so if the phone is still not smooth it is the one lever we know we have not pulled.
- **The loom canvas as the GL canvas itself in the DOM** (skipping the 2D copy). The copy is 118x256 on a phone; not worth the concurrency it would cost (two holds share one context).
- **The wash's gif.** On the phone build there is no host manifest, so `pickWash` falls to the loom canvas, not a gif. Where a gif does land (the floor under a lost context) it is already the lean pool.
- **`bubbleCap`** (100). It decides how many bubbles are on the road; that is gameplay, not paint.
- **kinds-check** fails on `main` too (`with a picture in it`: the wash now paints a loom canvas, and that assertion still expects a url). Pre-existing, not touched here.

## if it is still not smooth, in this order

1. `mix-blend-mode: screen` off the spiral and pink holds on the touch tier (with the loom field drawn transparent so the arms still sit over the road).
2. `bubbleCap` 100 -> 80 on mobile: fewer draw calls per frame, at the cost of a thinner road.
3. Lower `TOUCH_DPR_FLOOR` to 0.7 and let a fullscreen hold pre-empt the governor instead of waiting for the average to say so.
4. The loom canvas at 20 fps under touch (42 ms -> 50 ms).

## the bar

`node --check` on every changed file. Nine race smokes:

```
loom-spiral-check: all good      (new section 7c)
spiral-pool-check: all good
subliminal-check: all good
word-flash-check: all good
captions-check: all good
popped-check: all good
audio-check: all good
pixel-default-check: all good
kinds-check: 1 failure, pre-existing on main (see above)
```

Section 7c stamps the page as a phone and reads every twin: the melt on `rhSagLite` with no drip, the flash burst and the falling gif with `filter: none` and a box-shadow, the blink plate on `rcZoom, rcBlinkLite` with no filter, the melt and fog plates on their lite keyframes, the lacquer on scale alone, the subliminal on its lite rush, the strobe without its 40 px blur. Then the same probes without the stamp: the desktop blink still runs `rcBlink`, the desktop flash still carries its drop-shadow. And the governor: floor 0.8, read every 2 s, `?coarse=` forcing the answer either way, and this desktop run not on the touch ladder.

Not verified on the real phone. 175 changed lines across 6 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015spkaJxek5LPpH1N6rdCru
