### PR TITLE
feat(pbp): the room - floor, dome, motes, the light that leans, and the online game holding together

### DIFF
--- a/ConditioningControlPanel/Resources/web/piecebypiece/CAPTURES.md
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/CAPTURES.md
@@ -110,7 +110,7 @@ slide entry; the early shiver is one `delay` on the shiver list.
 
 ## Bishop
 
-### B1 - The Whip (BUILT, `board/whip.js`, `anim.js`) [N]
+### B1 - The Whip (BUILT but GATED OFF by default: `settings.whip` / `?whip=1`; `board/whip.js`, `anim.js`) [N]
 The tentacle takes the man. The bishop stops one stand-off short on the diagonal, drops,
 draws back, cracks across the victim, and strides onto the square while the tentacle rings.
 

--- a/ConditioningControlPanel/Resources/web/piecebypiece/FRONT-DOOR.md
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/FRONT-DOOR.md
@@ -39,7 +39,10 @@ Screens:
   foot says how to leave and who you are at the board.
 - **lobby** - "N at the board - you are visible as <name>", the incoming ask line when there is one,
   QUICK MATCH, then the list: name, how long they have waited, JOIN. Empty state is a sentence and the
-  dot, never a blank.
+  dot, never a blank. Hosted with no signed-in account it is one line, "sign in to play online", with
+  QUICK MATCH off; a hosted page never gets the mock's invented room. The lobby is left when the game
+  deals (`go()`), not when the found screen replaces the lobby screen: the pairing lands through the
+  lobby's poll, and a lobby still entered mid-game would re-advertise the player.
 - **found** - the JACKPOT-shaped beat, kept small: "matched with <name>" lands with THE THUD (scale
   2.1 -> 0.86 -> 1, 340 ms), the side chip, then 3-2-1 at 700 ms a step (CHIME LADDER: each number
   BOUNCEs in, `tick` under it), and the board deals. "tap to start now" is written under it.
@@ -47,9 +50,10 @@ Screens:
   player's seat; "white won" when the seat is unknown), the move count, WATCH.
 - **replay** - the card folds to a strip at the bottom so the board is the subject: to-start, back,
   the move in SAN, forward, play/pause, a scrubber. The last move's squares light up as they do live.
-- **profile** - the name you show as (typed here until the host sends one), then games / wins /
-  losses / draws / streak / taken / favourite piece / time at the board / rating. Rating reads
-  **unrated** until the server rates; the door invents no number.
+- **profile** - the name you show as (typed here in a plain browser; hosted, it is the account's
+  display name off `pbp:identity` and the box is read-only, because that is the name the server
+  lists), then games / wins / losses / draws / streak / taken / favourite piece / time at the board /
+  rating. Rating reads **unrated** until the server rates; the door invents no number.
 - **end** - waits 1400 ms so the board's own end beat lands first, then: the result line with THE THUD
   (a loss adds a SHIVER after it: sympathy, never silence), the tally line, `#door-recap` (empty, the
   XP and recap lane fills it), REMATCH (primary), BACK TO THE DOOR.
@@ -67,15 +71,21 @@ transition is cut, classes still land, so each screen simply is where it should 
   challenge / onChallenge / cancel`) and a mock behind it so every screen works with no host and no
   network. The server lane ships `net/lobbyServer.js` exporting `createServerLobby(opts)` with the same
   shape; `boot.js` prefers it when present, `?lobby=mock` forces the mock.
-- `boot.js` deals the game (`startGame({ mode, match })`, which resets the referee and the clocks in
-  place and emits `local` with the mode); `?hotseat=1`, `?auto=N` and `?door=0` deal at once so every
-  existing shot still photographs a live board. `window.PBP.match` carries the match for the online
-  lane; the door never runs a relay.
+- `boot.js` deals the game (`startGame({ mode, match })`, which puts the hotseat back in the chair if
+  an online seat was there (`game.switchBack()`), resets the referee and the clocks in place and emits
+  `local` with the mode); `?hotseat=1`, `?auto=N` and `?door=0` deal at once so every existing shot
+  still photographs a live board. `window.PBP.match` carries the match for the online lane; the door
+  never runs a relay. BACK TO THE DOOR after an online game switches back the same way, so the menu
+  board is a fresh position and not the mate.
+- `hud.js` owns the two things an online seat can say that are not a move: RESIGN (asks once,
+  "resign? yes / no") and OFFER DRAW, with his offer as an accept / decline line. Bottom right of the
+  HUD, online only, hidden outright in a hotseat.
 - The door does NOT: pay XP, rate anyone, keep games anywhere but the shelf, or touch the referee
   mid-game.
 
 ## Proof
 
-`node smoke/door-shot.mjs --out DIR` serves the web root and photographs ten screens headless through
-`smoke/shot.mjs` (`--eval` levers on `window.PBP.door.debug` and `window.PBP.lobby.debug`), failing on
-any console error.
+`node smoke/door-shot.mjs --out DIR` serves the web root and photographs sixteen screens headless
+through `smoke/shot.mjs` (`--eval` levers on `window.PBP.door.debug` and `window.PBP.lobby.debug`; a
+fake transport through `net/api.js` for the online seat; `door.debug.host` for the hosted states),
+failing on any console error.

--- a/ConditioningControlPanel/Resources/web/piecebypiece/board/anim.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/board/anim.js
@@ -42,6 +42,11 @@
  * its own. Under reduced motion the bishop takes the plain way, like everyone
  * else. The victim's SHIVER (house book) is a forced tremor across the whip
  * line at the crack: no colour, no emissive, a flinch and nothing more.
+ *
+ * Gate: window.PBP.settings.whip (default FALSE). The owner has parked the
+ * capture animations, so the whip is built but off: a bishop takes the plain
+ * way, like a rook, unless the setting is true (boot.js reads ?whip=1 into
+ * it for dev pages and harnesses). whipOn() is the one place that asks.
  * ==========================================================================*/
 
 import * as THREE from 'three';
@@ -75,6 +80,12 @@ function prefersReducedMotion() {
   if ((s && s.reducedMotion) || (window.PBP && window.PBP.reducedMotion)) return true;
   try { return !!window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches; }
   catch { return false; }
+}
+
+/** The whip is parked: off unless the setting says so (bloom.js's bloomOn, inverted default). */
+function whipOn() {
+  const s = (typeof window !== 'undefined' && window.PBP && window.PBP.settings) || {};
+  return s.whip === true;
 }
 
 // A man is not always one material: a modelled king wears a metal crown over
@@ -179,7 +190,8 @@ export function createAnim({ group, jiggle = null }) {
         // The bishop does not land on him. He stops one stand-off short on the
         // diagonal and the whip does the taking; the victim stands and waits
         // for the crack (board/whip.js), then goes over faster and further.
-        if (d.type === 'b' && !refused && !prefersReducedMotion() && dir.lengthSq() > 1e-6) {
+        // Only when the whip is switched on; off, he lands on him like anyone.
+        if (d.type === 'b' && whipOn() && !refused && !prefersReducedMotion() && dir.lengthSq() > 1e-6) {
           const near = dest.clone().addScaledVector(dir, -W.standOff);
           s.to = near;
           s.dur = W.approachSec;

--- a/ConditioningControlPanel/Resources/web/piecebypiece/board/camera.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/board/camera.js
@@ -24,6 +24,7 @@
  * ==========================================================================*/
 
 import * as THREE from 'three';
+import { fitScaleFor } from './frame.js';
 
 const DEG = Math.PI / 180;
 
@@ -93,7 +94,7 @@ export function createCameraRig({ camera, canvas, isDragging = null }) {
 
   const listeners = new Set();
   const notify = () => { for (const fn of listeners) { try { fn(state()); } catch { /* a listener is not the rig's problem */ } } };
-  const state = () => ({ preset, free, theta, phi, radius });
+  const state = () => ({ preset, free, theta, phi, radius, fit: fitScaleFor(camera.aspect, camera.fov), fov: camera.fov });
 
   const sideAngle = (side) => (side === 'b' ? Math.PI : 0);
 
@@ -299,7 +300,10 @@ export function createCameraRig({ camera, canvas, isDragging = null }) {
       if (Math.abs(velTheta) < T.inertiaFloor && Math.abs(velPhi) < T.inertiaFloor) { velTheta = 0; velPhi = 0; }
     }
 
-    const r = radius * dolly;
+    // On a narrow screen every preset stands further back, so the whole
+    // board is in the picture; on the wide window this was tuned on, fit is 1.
+    const fit = fitScaleFor(camera.aspect, camera.fov);
+    const r = radius * dolly * fit;
     const sinPhi = Math.sin(phi);
     camera.position.set(
       target.x + Math.sin(theta) * sinPhi * r + Math.sin(clock * 0.53) * T.swayPos[0] * sway,

--- a/ConditioningControlPanel/Resources/web/piecebypiece/board/frame.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/board/frame.js
@@ -1,0 +1,49 @@
+/* ============================================================================
+ * board/frame.js - keeping the whole board in the picture on any screen.
+ *
+ * The camera presets were tuned on a wide window: radius 12, a 40 degree
+ * lens. Stand a phone up and the picture is half as wide as it is tall, the
+ * horizontal field drops to about 19 degrees, and no preset can see the a
+ * and h files at once. Two pure numbers put that right, and both come out as
+ * exactly 1 (no change at all) on the wide window the game was tuned on:
+ *
+ *   fovForAspect(aspect)          the vertical lens angle: opens on a narrow
+ *                                 screen so the horizontal field never drops
+ *                                 under hfovHalfDeg, capped at fovMax so the
+ *                                 perspective never goes fish-eye;
+ *   fitScaleFor(aspect, fovDeg)   how much further back every preset stands
+ *                                 so a board `reach` wide fits the horizontal
+ *                                 field with a margin, relative to the radius
+ *                                 the presets were tuned at.
+ *
+ * No three in here, so smoke/room-smoke.mjs can pin the numbers.
+ * ==========================================================================*/
+
+const DEG = Math.PI / 180;
+const clamp = (v, lo, hi) => Math.max(lo, Math.min(hi, v));
+
+/** Every number the framing is made of. One place, on purpose. */
+export const FRAME = Object.freeze({
+  reach: 5.9,          // half the board's width as seen corner-on: the plinth
+                       // is 4.75 to its edge, and the rim coordinates sit on it
+  base: 12,            // the radius the presets were tuned at (11.5 .. 12.6)
+  margin: 1.06,        // a little air either side of the a and h files
+  hfovHalfDeg: 24,     // the horizontal half-field the lens will not drop under
+  fovMin: 40,          // the lens the game was tuned with, and its floor
+  fovMax: 62,          // wider than this and the men at the near edge distort
+});
+
+/** The vertical field of view, in degrees, for a viewport `aspect` wide/tall. */
+export function fovForAspect(aspect, F = FRAME) {
+  const a = Math.max(0.2, Number(aspect) || 1);
+  const want = (2 * Math.atan(Math.tan(F.hfovHalfDeg * DEG) / a)) / DEG;
+  return clamp(want, F.fovMin, F.fovMax);
+}
+
+/** The factor every preset radius is multiplied by so the board fits. >= 1. */
+export function fitScaleFor(aspect, fovDeg, F = FRAME) {
+  const a = Math.max(0.2, Number(aspect) || 1);
+  const half = Math.atan(Math.tan((Number(fovDeg) || F.fovMin) * DEG * 0.5) * a);
+  const needed = (F.margin * F.reach) / Math.max(1e-3, Math.tan(half));
+  return Math.max(1, needed / F.base);
+}

--- a/ConditioningControlPanel/Resources/web/piecebypiece/board/motes.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/board/motes.js
@@ -1,0 +1,194 @@
+/* ============================================================================
+ * board/motes.js - dust in the air of the room.
+ *
+ * board/room.js gave the board a floor and a sky; on their own they read as a
+ * gradient. This is the air between: a few hundred motes drifting slowly
+ * around and above the board, catching the light, so the room has depth and
+ * the camera has something to move against. They are scenery under Law III
+ * and never react to the game (board/dust.js is the dust that does - it
+ * puffs when a man lands, and this file is deliberately not that).
+ *
+ * All the motes live in ONE THREE.Points; the vertex shader moves each one
+ * from the clock and its own seed, so a frame costs one draw call and no
+ * attribute upload. A mote is a soft additive disc: it fades out when it
+ * would come too close to the lens (a blob), when it is far enough to be in
+ * the fog, and it twinkles a little on its own clock. Reduced motion freezes
+ * the drift and the twinkle; the motes stay, still.
+ *
+ * Gate: window.PBP.settings.motes (default true).
+ *
+ * Wiring: boot.js builds one after the room and pumps update(dt, camera,
+ * renderer) before render, like dust.js.
+ * ==========================================================================*/
+
+import * as THREE from 'three';
+
+/** Every number the air is made of. One place, on purpose. */
+export const MOTES = Object.freeze({
+  count: 440,
+  box: [11, 6.0, 11],      // half-extents in x, y (from floor up), z
+  floorY: -0.5,            // the lowest a mote floats
+  sizeMin: 0.035,          // world units at distance 1 (see uScale)
+  sizeMax: 0.115,
+  drift: 0.55,             // how far a mote wanders sideways, world units
+  driftRate: 0.09,         // and how fast, cycles per second (slow)
+  rise: 0.06,              // world units per second, straight up, wrapping
+  twinkle: 0.45,           // depth of the flicker, 0..1
+  alpha: 0.58,             // the brightest a mote gets
+  pinkShare: 0.3,          // the rest are cream
+  cream: 0xF5E6C8,
+  pink: 0xFF8FCB,
+  nearFade: [1.2, 3.2],    // gone this close to the lens, full this far
+  renderOrder: 4,          // after the room, before the landing dust
+});
+
+const T = MOTES;
+
+const VERT = /* glsl */`
+attribute float aSeed;
+attribute float aSize;
+attribute vec3 aColor;
+uniform float uTime;
+uniform float uScale;
+uniform float uFogNear;
+uniform float uFogFar;
+uniform float uNear0;
+uniform float uNear1;
+uniform float uDrift;
+uniform float uRate;
+uniform float uRise;
+uniform float uTwinkle;
+uniform float uFloor;
+uniform float uHeight;
+varying float vAlpha;
+varying vec3 vColor;
+void main() {
+  vColor = aColor;
+  float s = aSeed * 6.2831853;
+  float t = uTime;
+  vec3 p = position;
+  // a slow wander: two sines at unrelated rates, phase from the seed
+  p.x += sin(t * uRate * (0.7 + aSeed * 0.6) + s) * uDrift;
+  p.z += cos(t * uRate * (0.5 + aSeed * 0.9) + s * 1.7) * uDrift;
+  // and a slower rise that wraps inside the box, so the air is never empty
+  p.y = uFloor + mod(p.y - uFloor + t * uRise * (0.6 + aSeed * 0.8) + aSeed * uHeight, uHeight);
+  vec4 mv = modelViewMatrix * vec4(p, 1.0);
+  float depth = -mv.z;
+  float near = smoothstep(uNear0, uNear1, depth);
+  float far = 1.0 - smoothstep(uFogNear, uFogFar, depth);
+  float wink = 1.0 - uTwinkle * (0.5 + 0.5 * sin(t * (1.1 + aSeed * 1.7) + s * 2.3));
+  vAlpha = near * far * wink;
+  gl_PointSize = aSize * uScale / max(depth, 0.05);
+  gl_Position = projectionMatrix * mv;
+}`;
+
+const FRAG = /* glsl */`
+uniform float uAlpha;
+varying float vAlpha;
+varying vec3 vColor;
+void main() {
+  float d = length(gl_PointCoord - 0.5) * 2.0;
+  float a = smoothstep(1.0, 0.15, d) * vAlpha * uAlpha;
+  if (a < 0.004) discard;
+  gl_FragColor = vec4(vColor * a, a);
+}`;
+
+function motesOn() {
+  const s = (typeof window !== 'undefined' && window.PBP && window.PBP.settings) || {};
+  return s.motes !== false;
+}
+
+function reduced() {
+  if (typeof window === 'undefined') return false;
+  const s = window.PBP && window.PBP.settings;
+  if (s && s.reducedMotion) return true;
+  try { return !!window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches; }
+  catch { return false; }
+}
+
+/** A small deterministic rng, so a harness photographs the same air twice. */
+function rng(seed = 7) {
+  let x = seed >>> 0 || 1;
+  return () => { x ^= x << 13; x >>>= 0; x ^= x >> 17; x ^= x << 5; x >>>= 0; return x / 4294967296; };
+}
+
+/**
+ * createMotes({ scene, seed }) -> { points, update, stats, dispose }
+ */
+export function createMotes({ scene, seed = 7 }) {
+  const rnd = rng(seed);
+  const N = T.count;
+  const pos = new Float32Array(N * 3);
+  const seeds = new Float32Array(N);
+  const size = new Float32Array(N);
+  const color = new Float32Array(N * 3);
+  const cream = new THREE.Color(T.cream);
+  const pink = new THREE.Color(T.pink);
+  const height = T.box[1];
+  for (let i = 0; i < N; i++) {
+    pos[i * 3] = (rnd() * 2 - 1) * T.box[0];
+    pos[i * 3 + 1] = T.floorY + rnd() * height;
+    pos[i * 3 + 2] = (rnd() * 2 - 1) * T.box[2];
+    seeds[i] = rnd();
+    // more small motes than big ones
+    size[i] = T.sizeMin + (T.sizeMax - T.sizeMin) * Math.pow(rnd(), 2.2);
+    const c = rnd() < T.pinkShare ? pink : cream;
+    color[i * 3] = c.r; color[i * 3 + 1] = c.g; color[i * 3 + 2] = c.b;
+  }
+  const geo = new THREE.BufferGeometry();
+  geo.setAttribute('position', new THREE.BufferAttribute(pos, 3));
+  geo.setAttribute('aSeed', new THREE.BufferAttribute(seeds, 1));
+  geo.setAttribute('aSize', new THREE.BufferAttribute(size, 1));
+  geo.setAttribute('aColor', new THREE.BufferAttribute(color, 3));
+  geo.boundingSphere = new THREE.Sphere(new THREE.Vector3(0, height / 2, 0), 20);
+
+  const uniforms = {
+    uTime: { value: 0 }, uScale: { value: 400 },
+    uFogNear: { value: 12 }, uFogFar: { value: 34 },
+    uNear0: { value: T.nearFade[0] }, uNear1: { value: T.nearFade[1] },
+    uDrift: { value: T.drift }, uRate: { value: T.driftRate * 6.2831853 }, uRise: { value: T.rise },
+    uTwinkle: { value: T.twinkle }, uFloor: { value: T.floorY }, uHeight: { value: height },
+    uAlpha: { value: T.alpha },
+  };
+  const points = new THREE.Points(geo, new THREE.ShaderMaterial({
+    uniforms, vertexShader: VERT, fragmentShader: FRAG,
+    transparent: true, depthWrite: false, depthTest: true,
+    blending: THREE.AdditiveBlending, toneMapped: false,
+  }));
+  points.frustumCulled = false;
+  points.renderOrder = T.renderOrder;
+  points.name = 'pbp-motes';
+  scene.add(points);
+
+  let clock = 0;
+  let still = false;
+  let hpx = 0;
+
+  function update(dt, camera, renderer) {
+    const on = motesOn();
+    points.visible = on;
+    if (!on) return;
+    still = reduced();
+    if (!still) clock += dt;
+    uniforms.uTime.value = clock;
+    if (scene.fog && scene.fog.isFog) { uniforms.uFogNear.value = scene.fog.near; uniforms.uFogFar.value = scene.fog.far; }
+    if (camera && renderer) {
+      const h = renderer.domElement.height || 0;
+      if (h !== hpx) { hpx = h; }
+      // pixels per world unit at distance 1: the same reading dust.js takes
+      uniforms.uScale.value = (hpx * (camera.projectionMatrix.elements[5] || 1)) / 2;
+    }
+  }
+
+  function stats() {
+    return { count: N, visible: points.visible, still, clock: +clock.toFixed(2), scale: +uniforms.uScale.value.toFixed(1) };
+  }
+
+  function dispose() {
+    scene.remove(points);
+    geo.dispose();
+    points.material.dispose();
+  }
+
+  return { points, update, stats, dispose };
+}

--- a/ConditioningControlPanel/Resources/web/piecebypiece/board/room.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/board/room.js
@@ -25,16 +25,53 @@
  *                full on the first frame of the turn and easing to a resting
  *                glow, while the other edge waits dim.
  *
- * Reduced motion (window.PBP.settings.reducedMotion) takes the state and not
- * the travel: the rig and the edges land at once.
+ * Then the room answers the game (layer 2 of the backdrop):
  *
- * Wiring: boot.js builds one after the scene, forwards `turn`, `local` and
- * `gameover` off the bus, and pumps update(dt) before render. env.js dresses
- * the floor with the cube map whichever of the two lands first.
+ *   the DIP      a capture makes the key light flinch: down to dipTo on the
+ *                frame the man comes off, back to full over dipMs. A second
+ *                capture restarts it; nothing stacks and nothing is gated;
+ *   the WARMTH   the ramp's meter (boot.js chains setMeter into here, 0..1
+ *                every 200 ms) turns the room pink past warmFrom: the fog,
+ *                the background and the dome's horizon move TOGETHER toward
+ *                warmHorizon (they must stay one colour, see the dome), the
+ *                haze, the hemisphere and the fill follow, eased over warmMs
+ *                so the steps never show. Past breathAt (the HUD's
+ *                vigBreathe) the warmth breathes on the vignette's own
+ *                3600 ms cycle, so the room and the frame swell as one;
+ *   the DRAIN    game over: key, fill and hemisphere sink to overLevel of
+ *                their base over overMs (the ramp's sigh-out), the rim to
+ *                overRim, and one SpotLight comes up over the winner's king.
+ *                A draw only dims to overDraw and lights no spot. A new game
+ *                brings everything back at once; a take-back that resurrects
+ *                the game brings it back over overBackMs.
+ *
+ * And the room's one piece of air (layer 3):
+ *
+ *   the SHAFT    a faint open cone of light down the key light's axis, riding
+ *                the rig so it always falls from behind the mover. Alpha
+ *                fades along its height (lit up at the light, gone at the
+ *                board) and at its silhouette, peaks at shaftAlpha so it reads
+ *                as air catching light and never a beam, brightens a little
+ *                with the warmth, dims with the drain, and is capped as the
+ *                camera looks straight down, where it would be a disc.
+ *                board/motes.js's dust already drifts through it.
+ *
+ * Every move is a tween off update(dt), so the headless harness's stepped
+ * clock sees all of it. Reduced motion (window.PBP.settings.reducedMotion or
+ * the OS query) takes every state at once and never breathes.
+ *
+ * Wiring: boot.js builds one after the scene with the game, forwards `turn`,
+ * `local`, `capture` and `gameover` off the bus, chains setMeter, and pumps
+ * update(dt) before render. env.js dresses the floor with the cube map
+ * whichever of the two lands first.
  * ==========================================================================*/
 
 import * as THREE from 'three';
-import { ROOM, createTweens, yawFor, glowTargets, easeOutCubic } from './roomMath.js';
+import { squareToWorld } from './scene.js';
+import {
+  ROOM, createTweens, yawFor, glowTargets, easeOutCubic, clamp01,
+  warmthFor, breathFor, overTargets, shaftLevel,
+} from './roomMath.js';
 
 export { ROOM } from './roomMath.js';
 
@@ -167,13 +204,88 @@ function buildEdge(side) {
   return { holder, mat };
 }
 
+// --- the light shaft --------------------------------------------------------
+// An open truncated cone, wide end on the board's centre, narrow end up at
+// the key light, drawn additively with no depth write and no tone mapping so
+// it only ever adds a little light to whatever is behind it. The vertex
+// shader hands down the height (0 at the board, 1 at the light) and the
+// view-space normal; the fragment fades along the height, so the shaft is
+// lit where it is narrow and gone where it would lie across the men, and at
+// the silhouette, where a cone's edge would otherwise draw as a line. Both
+// faces draw (DoubleSide) and add: the core of the projected shape gets a
+// front and a back, the edges get nothing, which is what soft air does. The
+// peak alpha comes down from JS as uLevel (roomMath.shaftLevel), already
+// warmed, drained and capped for a top-down camera.
+const KEY_AT = new THREE.Vector3(4.5, 9.5, 5.5);   // scene.js's key, in rig space
+const UP = new THREE.Vector3(0, 1, 0);
+const shaftVertex = /* glsl */`
+  uniform float uHalf;
+  varying float vH; varying vec3 vN; varying vec3 vV;
+  void main() {
+    vH = (position.y + uHalf) / (2.0 * uHalf);
+    vN = normalize(normalMatrix * normal);
+    vec4 mv = modelViewMatrix * vec4(position, 1.0);
+    vV = normalize(-mv.xyz);
+    gl_Position = projectionMatrix * mv;
+  }`;
+const shaftFragment = /* glsl */`
+  uniform vec3 color; uniform float uLevel;
+  uniform float uRise; uniform float uFadeTip; uniform float uSoft;
+  varying float vH; varying vec3 vN; varying vec3 vV;
+  void main() {
+    float along = smoothstep(0.0, uRise, vH) * (1.0 - smoothstep(uFadeTip, 1.0, vH));
+    float face = smoothstep(0.0, uSoft, abs(dot(normalize(vN), normalize(vV))));
+    float a = along * face * uLevel;
+    if (a < 0.002) discard;
+    gl_FragColor = vec4(color * a, a);
+  }`;
+
+function buildShaft() {
+  const half = T.shaftLength / 2;
+  const mat = new THREE.ShaderMaterial({
+    uniforms: {
+      color: { value: new THREE.Color(T.shaftColor) }, uLevel: { value: T.shaftAlpha },
+      uHalf: { value: half }, uRise: { value: T.shaftRise }, uFadeTip: { value: T.shaftFadeTip }, uSoft: { value: T.shaftSoft },
+    },
+    vertexShader: shaftVertex, fragmentShader: shaftFragment,
+    side: THREE.DoubleSide, transparent: true, depthWrite: false, depthTest: true,
+    blending: THREE.AdditiveBlending, premultipliedAlpha: true, fog: false,
+  });
+  mat.toneMapped = false;
+  const geo = new THREE.CylinderGeometry(T.shaftTip, T.shaftRadius, T.shaftLength, 40, 1, true);
+  const shaft = new THREE.Mesh(geo, mat);
+  // local +Y up the cone; stand it on the board's centre and point it at the key
+  const axis = KEY_AT.clone().normalize();
+  shaft.quaternion.setFromUnitVectors(UP, axis);
+  shaft.position.copy(axis).multiplyScalar(half);
+  shaft.renderOrder = 3;            // after the room and the pool, before the motes
+  shaft.frustumCulled = false;
+  shaft.name = 'pbp-shaft';
+  return shaft;
+}
+
+// --- the spot over the winner's king -----------------------------------------
+// Built once, dark, and aimed when the game ends. It lives on the scene and
+// not the rig: the rig leans to the mover, and the spot has one man to find.
+function buildSpot() {
+  const spot = new THREE.SpotLight(T.spotColor, 0, 0, T.spotAngle, T.spotPenumbra, 2);
+  spot.position.set(0, T.spotHeight, 0);
+  spot.castShadow = false;
+  spot.name = 'pbp-spot';
+  spot.target.name = 'pbp-spot-target';
+  return spot;
+}
+
 /**
- * createRoom({ view, bus, env }) -> { group, update, lean, tell, settle, debug, dispose }
+ * createRoom({ view, bus, game, env })
+ *   -> { group, update, lean, tell, setMeter, settle, debug, dispose }
  *
- * `view` is board/scene.js (its lightRig is what leans); `env` is a getter
- * for board/env.js, which may or may not have landed yet.
+ * `view` is board/scene.js (its lightRig is what leans, and its lights are
+ * what dip, warm and drain); `game` is the referee, asked where the winner's
+ * king stands; `env` is a getter for board/env.js, which may or may not have
+ * landed yet.
  */
-export function createRoom({ view, bus, env = () => null }) {
+export function createRoom({ view, bus, game = null, env = () => null }) {
   const scene = view.scene;
   const group = new THREE.Group();
   group.name = 'pbp-room';
@@ -199,8 +311,38 @@ export function createRoom({ view, bus, env = () => null }) {
 
   const tweens = createTweens();
   const rig = view.lightRig || null;
-  const state = { side: 'w', yaw: 0 };
+  const lights = view.lights || {};
+  const state = { side: 'w', yaw: 0, meter: 0, over: null, spotSquare: null, breathMs: 0, topness: 0 };
   const yaw = { value: 0 };   // tweened, then written onto the rig each frame
+  const dip = { value: 1 };   // the key's share of itself: dipTo on a capture, easing home
+  const warm = { value: 0 };  // the warmth the room has reached (its target is warmthFor(meter))
+  const drain = { key: 1, fill: 1, hemi: 1, rim: 1, spot: 0 };   // shares of base, 1 = live
+  let breath = 0;
+
+  // The lights' base, read once from what scene.js built, so this file never
+  // needs LIGHT and a retuned rig retunes the room with it.
+  const base = {
+    key: lights.key ? lights.key.intensity : 0,
+    fill: lights.fill ? lights.fill.intensity : 0,
+    hemi: lights.hemi ? lights.hemi.intensity : 0,
+    rim: lights.rim ? lights.rim.intensity : 0,
+    sky: lights.hemi ? lights.hemi.color.clone() : new THREE.Color(),
+    ground: lights.hemi ? lights.hemi.groundColor.clone() : new THREE.Color(),
+    fillColor: lights.fill ? lights.fill.color.clone() : new THREE.Color(),
+    horizon: new THREE.Color(T.horizon),
+    haze: new THREE.Color(T.haze),
+  };
+  const warmTo = {
+    horizon: new THREE.Color(T.warmHorizon), haze: new THREE.Color(T.warmHaze),
+    sky: new THREE.Color(T.warmSky), ground: new THREE.Color(T.warmGround), fill: new THREE.Color(T.warmFill),
+  };
+
+  const spot = buildSpot();
+  scene.add(spot, spot.target);
+  const shaft = buildShaft();
+  if (rig) rig.add(shaft);
+  const forward = new THREE.Vector3();
+  const kingAt = new THREE.Vector3();
 
   /** Swing the rig to stand behind `side`. */
   function lean(side, instant = false) {
@@ -220,42 +362,156 @@ export function createRoom({ view, bus, env = () => null }) {
     }
   }
 
+  /** The key flinches: dipTo this frame, home over dipMs. A second one restarts. */
+  function flinch() {
+    dip.value = T.dipTo;
+    tweens.to(dip, 'value', 1, reducedMotion() ? 0 : T.dipMs, easeOutCubic);
+  }
+
+  /** The ramp's meter, 0..1, arriving in steps: the warmth eases toward it. */
+  function setMeter(m) {
+    state.meter = clamp01(m);
+    tweens.to(warm, 'value', warmthFor(state.meter), reducedMotion() ? 0 : T.warmMs, easeOutCubic);
+  }
+
+  /** Where `side`'s king stands, off the referee, or null. */
+  function kingSquare(side) {
+    try {
+      const pos = game && game.rules && game.rules.position ? game.rules.position() : null;
+      if (!pos) return null;
+      for (const sq of Object.keys(pos)) {
+        const man = pos[sq];
+        if (man && man.type === 'k' && man.side === side) return sq;
+      }
+    } catch { /* a referee that cannot say: no spot */ }
+    return null;
+  }
+
+  /** Aim the spot at `sq`: high above, a little toward the camera's side. */
+  function aimSpot(sq) {
+    squareToWorld(sq, 0, kingAt);
+    const cam = view.camera ? view.camera.position : null;
+    const tx = cam ? cam.x : 0;
+    const tz = cam ? cam.z : 1;
+    const len = Math.hypot(tx, tz) || 1;
+    spot.position.set(kingAt.x + (tx / len) * T.spotToward, T.spotHeight, kingAt.z + (tz / len) * T.spotToward);
+    spot.target.position.copy(kingAt);
+    state.spotSquare = sq;
+  }
+
+  /** Game over: the room drains, and the spot finds the winner's king. */
+  function over(result, winner) {
+    state.over = { result: result || 'over', winner: winner || null };
+    const want = overTargets(state.over.result, state.over.winner);
+    const ms = reducedMotion() ? 0 : T.overMs;
+    for (const k of ['key', 'fill', 'hemi', 'rim']) tweens.to(drain, k, want[k], ms, easeOutCubic);
+    const sq = want.spot ? kingSquare(winner) : null;
+    if (sq) aimSpot(sq);
+    tweens.to(drain, 'spot', sq ? 1 : 0, ms, easeOutCubic);
+  }
+
+  /** Back to the live room: at once for a new game, over overBackMs for a take-back. */
+  function restore(instant = false) {
+    state.over = null;
+    state.spotSquare = null;
+    const ms = instant || reducedMotion() ? 0 : T.overBackMs;
+    for (const k of ['key', 'fill', 'hemi', 'rim']) tweens.to(drain, k, 1, ms, easeOutCubic);
+    tweens.to(drain, 'spot', 0, ms, easeOutCubic);
+    if (instant) { tweens.to(dip, 'value', 1, 0); tweens.to(warm, 'value', warmthFor(state.meter), 0); }
+  }
+
   const unsubs = [];
   if (bus && bus.on) {
-    unsubs.push(bus.on('turn', (p) => { const s = p && p.side === 'b' ? 'b' : 'w'; lean(s); tell(s); }));
-    unsubs.push(bus.on('local', () => { lean('w', true); tell(null, true); }));
-    unsubs.push(bus.on('gameover', () => { tell(null); }));
+    unsubs.push(bus.on('turn', (p) => {
+      const s = p && p.side === 'b' ? 'b' : 'w';
+      lean(s); tell(s);
+      if (state.over) restore(false);   // a take-back resurrected the game
+    }));
+    unsubs.push(bus.on('local', () => { lean('w', true); tell(null, true); restore(true); }));
+    unsubs.push(bus.on('capture', () => { flinch(); }));
+    unsubs.push(bus.on('gameover', (p) => { tell(null); over(p && p.result, p && p.winner); }));
   }
 
   function update(dt) {
     tweens.update(dt);
     if (rig) rig.rotation.y = yaw.value;
     state.yaw = yaw.value;
+
+    // the breath runs its own clock only while the meter is over the line and
+    // motion is on; below it the clock resets so the next swell starts at rest
+    const still = reducedMotion();
+    if (state.meter >= T.breathAt && !still) state.breathMs += Math.max(0, dt) * 1000;
+    else state.breathMs = 0;
+    breath = still ? 0 : breathFor(state.meter, state.breathMs);
+    const we = clamp01(warm.value + breath);
+
+    // the lights
+    if (lights.key) lights.key.intensity = base.key * dip.value * drain.key;
+    if (lights.fill) { lights.fill.intensity = base.fill * drain.fill; lights.fill.color.lerpColors(base.fillColor, warmTo.fill, we); }
+    if (lights.hemi) {
+      lights.hemi.intensity = base.hemi * drain.hemi;
+      lights.hemi.color.lerpColors(base.sky, warmTo.sky, we);
+      lights.hemi.groundColor.lerpColors(base.ground, warmTo.ground, we);
+    }
+    if (lights.rim) lights.rim.intensity = base.rim * drain.rim;
+    spot.intensity = T.spotIntensity * drain.spot;
+
+    // the horizon, in all three places at once, and the haze above it
+    const u = dome.material.uniforms;
+    u.horizon.value.lerpColors(base.horizon, warmTo.horizon, we);
+    if (scene.fog) scene.fog.color.copy(u.horizon.value);
+    if (scene.background && scene.background.isColor) scene.background.copy(u.horizon.value);
+    u.haze.value.lerpColors(base.haze, warmTo.haze, we);
+
+    // the shaft: warmed, drained with the key, capped as the camera goes plumb
+    if (view.camera) { view.camera.getWorldDirection(forward); state.topness = clamp01(-forward.y); }
+    shaft.material.uniforms.uLevel.value = shaftLevel({ warmth: we, drain: drain.key, topness: state.topness });
   }
 
   /** Jump every ease to its end, for a still frame. */
   function settle() { tweens.settle(); update(0); }
 
   function debug() {
+    const r3 = (v) => +Number(v).toFixed(3);
     return {
       side: state.side,
       yawDeg: +((yaw.value * 180) / Math.PI).toFixed(1),
-      glow: { w: +edges.w.mat.opacity.toFixed(3), b: +edges.b.mat.opacity.toFixed(3) },
+      glow: { w: r3(edges.w.mat.opacity), b: r3(edges.b.mat.opacity) },
       tweens: tweens.count(),
       pool: !!pool,
       fog: scene.fog ? [scene.fog.near, scene.fog.far] : null,
+      dip: r3(dip.value),
+      key: lights.key ? r3(lights.key.intensity) : null,
+      meter: r3(state.meter),
+      warmth: r3(warm.value),
+      breath: r3(breath),
+      breathing: state.meter >= T.breathAt && !reducedMotion(),
+      horizon: '#' + dome.material.uniforms.horizon.value.getHexString(),
+      over: state.over ? { result: state.over.result, winner: state.over.winner } : null,
+      drain: { key: r3(drain.key), fill: r3(drain.fill), hemi: r3(drain.hemi), rim: r3(drain.rim) },
+      spot: { on: drain.spot > 0.001, square: state.spotSquare, intensity: r3(spot.intensity) },
+      shaft: { level: +shaft.material.uniforms.uLevel.value.toFixed(4), topness: r3(state.topness) },
     };
   }
 
   function dispose() {
     for (const off of unsubs) { try { off(); } catch { /* already gone */ } }
-    scene.remove(group);
+    tweens.settle();
+    scene.remove(group, spot, spot.target);
     group.traverse((o) => {
       if (o.geometry) o.geometry.dispose();
       if (o.material) { if (o.material.map) o.material.map.dispose(); o.material.dispose(); }
     });
-    if (rig) rig.rotation.y = 0;
+    if (rig) { rig.remove(shaft); rig.rotation.y = 0; }
+    shaft.geometry.dispose();
+    shaft.material.dispose();
+    spot.dispose();
+    // the lights back where scene.js left them
+    if (lights.key) lights.key.intensity = base.key;
+    if (lights.fill) { lights.fill.intensity = base.fill; lights.fill.color.copy(base.fillColor); }
+    if (lights.hemi) { lights.hemi.intensity = base.hemi; lights.hemi.color.copy(base.sky); lights.hemi.groundColor.copy(base.ground); }
+    if (lights.rim) lights.rim.intensity = base.rim;
   }
 
-  return { group, dome, floor, pool, edges, update, lean, tell, settle, debug, dispose };
+  return { group, dome, floor, pool, edges, shaft, spot, update, lean, tell, setMeter, settle, debug, dispose };
 }

--- a/ConditioningControlPanel/Resources/web/piecebypiece/board/room.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/board/room.js
@@ -1,0 +1,261 @@
+/* ============================================================================
+ * board/room.js - the room the board stands in, and how it answers the game.
+ *
+ * Until now the board sat in a flat navy void: one background colour and a
+ * fog of the same colour. env.js gave the crowns a studio to reflect, but it
+ * was rendered once into a cube map and nobody could see it. This is the room
+ * the eye gets:
+ *
+ *   the FLOOR    a wide dark glossy plane the plinth stands on, taking the
+ *                same studio room in its gloss that the men take, and melting
+ *                into the horizon under the existing fog;
+ *   the POOL     a soft pool of shade on the floor around the plinth, so the
+ *                box is standing on something and not hovering over it;
+ *   the DOME     a sphere round everything, plum at the horizon, a pink haze
+ *                just above it, black overhead. Drawn by one small shader.
+ *
+ * And the first of the room's reactions, the TURN TELL (PBP-BEATS beat 6):
+ *
+ *   the LEAN     the light rig (key, fill and rim together, scene.js groups
+ *                them) swings round to stand behind whoever is to move, over
+ *                leanMs. From the fixed camera that keeps the light on the
+ *                mover's shoulder as the view swings; from the top or a free
+ *                camera the shadows sweeping round IS the tell;
+ *   the EDGE     a pink line on the bevel of the plinth on the mover's side,
+ *                full on the first frame of the turn and easing to a resting
+ *                glow, while the other edge waits dim.
+ *
+ * Reduced motion (window.PBP.settings.reducedMotion) takes the state and not
+ * the travel: the rig and the edges land at once.
+ *
+ * Wiring: boot.js builds one after the scene, forwards `turn`, `local` and
+ * `gameover` off the bus, and pumps update(dt) before render. env.js dresses
+ * the floor with the cube map whichever of the two lands first.
+ * ==========================================================================*/
+
+import * as THREE from 'three';
+import { ROOM, createTweens, yawFor, glowTargets, easeOutCubic } from './roomMath.js';
+
+export { ROOM } from './roomMath.js';
+
+const T = ROOM;
+
+function reducedMotion() {
+  try {
+    const s = window.PBP && window.PBP.settings;
+    if (s && s.reducedMotion) return true;
+    return !!(window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches);
+  } catch { return false; }
+}
+
+// --- the dome ---------------------------------------------------------------
+// Colours come in as linear THREE.Colors and go out through the renderer's
+// colour space chunk but NOT its tone mapping: three converts the fog colour
+// to the output space and applies it after tone mapping, so a tone-mapped
+// dome could never meet the fully fogged floor at the horizon without a
+// seam. Untouched, the horizon IS the fog colour, on screen and inside
+// bloom.js's composer alike (where neither is tone mapped until the output
+// pass, which then does both the same).
+const domeVertex = /* glsl */`
+  varying vec3 vDir;
+  void main() {
+    vDir = normalize((modelMatrix * vec4(position, 1.0)).xyz);
+    gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+  }`;
+const domeFragment = /* glsl */`
+  #include <common>
+  uniform vec3 horizon; uniform vec3 haze; uniform vec3 zenith; uniform vec3 under;
+  uniform float hazeAt; uniform float zenithAt; uniform float underAt;
+  varying vec3 vDir;
+  void main() {
+    float h = normalize(vDir).y;
+    vec3 c;
+    if (h < 0.0) {
+      c = mix(horizon, under, smoothstep(0.0, underAt, -h));
+    } else {
+      c = mix(horizon, haze, smoothstep(0.0, hazeAt, h));
+      c = mix(c, zenith, smoothstep(hazeAt, zenithAt, h));
+    }
+    gl_FragColor = vec4(c, 1.0);
+    #include <colorspace_fragment>
+  }`;
+
+function buildDome() {
+  const mat = new THREE.ShaderMaterial({
+    uniforms: {
+      horizon: { value: new THREE.Color(T.horizon) },
+      haze: { value: new THREE.Color(T.haze) },
+      zenith: { value: new THREE.Color(T.zenith) },
+      under: { value: new THREE.Color(T.under) },
+      hazeAt: { value: T.hazeAt }, zenithAt: { value: T.zenithAt }, underAt: { value: T.underAt },
+    },
+    vertexShader: domeVertex, fragmentShader: domeFragment,
+    side: THREE.BackSide, depthWrite: false, fog: false,
+  });
+  mat.toneMapped = false;
+  const dome = new THREE.Mesh(new THREE.SphereGeometry(T.domeRadius, 48, 24), mat);
+  dome.name = 'pbp-dome';
+  dome.frustumCulled = false;
+  dome.renderOrder = -10;
+  return dome;
+}
+
+// --- the floor and the pool of shade under the plinth ----------------------
+function buildFloor() {
+  const mat = new THREE.MeshPhysicalMaterial({
+    color: T.floorColor, roughness: T.floorRough, metalness: 0,
+    clearcoat: T.floorClearcoat, clearcoatRoughness: T.floorClearcoatRough,
+    envMapIntensity: T.floorEnv,
+  });
+  const floor = new THREE.Mesh(new THREE.PlaneGeometry(T.floorSize, T.floorSize).rotateX(-Math.PI / 2), mat);
+  floor.position.y = T.floorY;
+  floor.receiveShadow = true;
+  floor.name = 'pbp-floor';
+  return floor;
+}
+
+/** A blurred dark rounded square, drawn once, laid on the floor. */
+function buildPool() {
+  const px = T.poolPx;
+  let texture = null;
+  try {
+    const canvas = document.createElement('canvas');
+    canvas.width = px; canvas.height = px;
+    const ctx = canvas.getContext('2d');
+    const inset = px * T.poolInset;
+    const r = px * 0.06;
+    ctx.shadowColor = 'rgba(0, 0, 0, 1)';
+    ctx.shadowBlur = inset * 0.9;
+    ctx.fillStyle = 'rgba(0, 0, 0, 1)';
+    // three passes stack the blur into a soft falloff instead of one hard-edged smear
+    for (let i = 0; i < 3; i++) {
+      ctx.beginPath();
+      ctx.roundRect(inset, inset, px - inset * 2, px - inset * 2, r);
+      ctx.fill();
+    }
+    texture = new THREE.CanvasTexture(canvas);
+    texture.colorSpace = THREE.SRGBColorSpace;
+  } catch { return null; }   // no 2D canvas (a stripped-down harness): no pool, no harm
+  const mat = new THREE.MeshBasicMaterial({
+    map: texture, alphaMap: texture, color: 0x000000, transparent: true, opacity: T.poolAlpha,
+    depthWrite: false, toneMapped: false,
+  });
+  const pool = new THREE.Mesh(new THREE.PlaneGeometry(T.poolSize, T.poolSize).rotateX(-Math.PI / 2), mat);
+  pool.position.y = T.floorY + 0.004;
+  pool.renderOrder = -5;
+  pool.name = 'pbp-pool';
+  return pool;
+}
+
+// --- the edge glow: one line per side, laid on the plinth's top bevel ------
+// The bevel is 0.05 out and 0.05 down from the lid's edge at 4.7 / -0.08, so
+// its slope is centred at 4.725 / -0.105 and faces up-and-out at 45 degrees.
+// The bar floats a hair off that slope along its normal: on the surface
+// itself it z-fought the plinth and came through in flickers.
+function buildEdge(side) {
+  const holder = new THREE.Group();
+  holder.rotation.y = side === 'b' ? Math.PI : 0;
+  const mat = new THREE.MeshBasicMaterial({
+    color: T.glowColor, transparent: true, opacity: T.glowOff,
+    depthWrite: false, toneMapped: false, side: THREE.DoubleSide,
+  });
+  const bar = new THREE.Mesh(new THREE.PlaneGeometry(T.glowLength, T.glowWidth), mat);
+  bar.position.set(0, -0.105 + T.glowLift, 4.725 + T.glowLift);
+  bar.rotation.x = -Math.PI / 4;
+  bar.name = 'pbp-edge-' + side;
+  holder.add(bar);
+  return { holder, mat };
+}
+
+/**
+ * createRoom({ view, bus, env }) -> { group, update, lean, tell, settle, debug, dispose }
+ *
+ * `view` is board/scene.js (its lightRig is what leans); `env` is a getter
+ * for board/env.js, which may or may not have landed yet.
+ */
+export function createRoom({ view, bus, env = () => null }) {
+  const scene = view.scene;
+  const group = new THREE.Group();
+  group.name = 'pbp-room';
+  const dome = buildDome();
+  const floor = buildFloor();
+  const pool = buildPool();
+  group.add(dome, floor);
+  if (pool) group.add(pool);
+  const edges = { w: buildEdge('w'), b: buildEdge('b') };
+  group.add(edges.w.holder, edges.b.holder);
+  scene.add(group);
+
+  // The fog and the background now belong to the horizon, so the far floor
+  // melts into exactly the colour the dome shows behind it.
+  const horizon = new THREE.Color(T.horizon);
+  scene.background = horizon.clone();
+  scene.fog = new THREE.Fog(horizon.clone(), T.fogNear, T.fogFar);
+
+  // env.js hands the floor the cube map if it is already here; if it lands
+  // later, boot.js asks it to dress this group too.
+  const e = env();
+  if (e && e.dressBoard) e.dressBoard(group);
+
+  const tweens = createTweens();
+  const rig = view.lightRig || null;
+  const state = { side: 'w', yaw: 0 };
+  const yaw = { value: 0 };   // tweened, then written onto the rig each frame
+
+  /** Swing the rig to stand behind `side`. */
+  function lean(side, instant = false) {
+    state.side = side;
+    const want = yawFor(side);
+    tweens.to(yaw, 'value', want, instant || reducedMotion() ? 0 : T.leanMs);
+  }
+
+  /** The mover's edge hits full and settles; the other waits. null = over. */
+  function tell(side, instant = false) {
+    const want = glowTargets(side);
+    const ms = instant || reducedMotion() ? 0 : T.glowMs;
+    for (const s of ['w', 'b']) {
+      const m = edges[s].mat;
+      if (s === side) m.opacity = T.glowHit;   // frame one, before the ease
+      tweens.to(m, 'opacity', want[s], ms, easeOutCubic);
+    }
+  }
+
+  const unsubs = [];
+  if (bus && bus.on) {
+    unsubs.push(bus.on('turn', (p) => { const s = p && p.side === 'b' ? 'b' : 'w'; lean(s); tell(s); }));
+    unsubs.push(bus.on('local', () => { lean('w', true); tell(null, true); }));
+    unsubs.push(bus.on('gameover', () => { tell(null); }));
+  }
+
+  function update(dt) {
+    tweens.update(dt);
+    if (rig) rig.rotation.y = yaw.value;
+    state.yaw = yaw.value;
+  }
+
+  /** Jump every ease to its end, for a still frame. */
+  function settle() { tweens.settle(); update(0); }
+
+  function debug() {
+    return {
+      side: state.side,
+      yawDeg: +((yaw.value * 180) / Math.PI).toFixed(1),
+      glow: { w: +edges.w.mat.opacity.toFixed(3), b: +edges.b.mat.opacity.toFixed(3) },
+      tweens: tweens.count(),
+      pool: !!pool,
+      fog: scene.fog ? [scene.fog.near, scene.fog.far] : null,
+    };
+  }
+
+  function dispose() {
+    for (const off of unsubs) { try { off(); } catch { /* already gone */ } }
+    scene.remove(group);
+    group.traverse((o) => {
+      if (o.geometry) o.geometry.dispose();
+      if (o.material) { if (o.material.map) o.material.map.dispose(); o.material.dispose(); }
+    });
+    if (rig) rig.rotation.y = 0;
+  }
+
+  return { group, dome, floor, pool, edges, update, lean, tell, settle, debug, dispose };
+}

--- a/ConditioningControlPanel/Resources/web/piecebypiece/board/roomMath.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/board/roomMath.js
@@ -2,8 +2,10 @@
  * board/roomMath.js - the numbers and the pure functions behind board/room.js.
  *
  * Kept apart from room.js so a node smoke can pin the dome's gradient, the
- * lean of the light rig and the turn tell's timeline without a renderer, the
- * way smoke/whip-smoke.mjs pins the whip. Nothing in here touches three.
+ * lean of the light rig, the turn tell's timeline, the capture dip, the
+ * ramp's warmth and its breath, the game-over drain and the light shaft's
+ * level without a renderer, the way smoke/whip-smoke.mjs pins the whip.
+ * Nothing in here touches three.
  * ==========================================================================*/
 
 /** Every number the room is made of. One place, on purpose. */
@@ -45,6 +47,44 @@ export const ROOM = Object.freeze({
   glowLength: 9.3,         // along the plinth's edge (the plinth is 9.4 wide)
   glowWidth: 0.09,         // across the bevel, which is 0.07 on the slope
   glowLift: 0.014,         // off the bevel along its normal (out and up), each axis
+  // --- the capture dip: the key light flinches when a man comes off ----------
+  dipTo: 0.55,             // of the key's base, on the frame the capture lands
+  dipMs: 440,              // and back to full, easing out; a second capture restarts it
+  // --- the ramp's warmth: the room goes pink as the meter climbs -------------
+  warmFrom: 0.25,          // meter below which the room stays plum
+  warmMs: 600,             // the ease toward each of the ramp's 200 ms steps
+  warmHorizon: 0x5C2264,   // the horizon at full warmth: fog, background and dome alike
+  warmHaze: 0x9E3E8A,      // the haze just above it
+  warmSky: 0xC49CEC,       // the hemisphere's room, pinker
+  warmGround: 0x6E3C76,    // and its bounce
+  warmFill: 0xE6B8F2,      // the fill, a little toward pink
+  breathAt: 0.7,           // = hud.js vigBreathe: from here the room breathes
+  breathDepth: 0.12,       // of warmth, dipping from the top of the swell
+  breathMs: 3600,          // = the DOM vignette's cycle in styles.css
+  // --- game over: the room drains, and one spot finds the winner's king ------
+  overLevel: 0.12,         // key, fill and hemisphere, as a share of their base
+  overRim: 0.4,            // the rim keeps a little more, so the men keep an edge
+  overDraw: 0.35,          // a draw: dimmer, no spot
+  overMs: 1200,            // = the ramp's sigh-out
+  overBackMs: 600,         // a take-back resurrects the game: the lights come back
+  spotIntensity: 90,       // candela; at spotHeight that is about the key's strength
+  spotColor: 0xFFE9D2,
+  spotAngle: 0.26,         // radians, half-angle: the king and a square around him
+  spotPenumbra: 0.55,
+  spotHeight: 7.5,         // above the king
+  spotToward: 2.2,         // and this far toward the camera's side, so his face is lit
+  // --- the light shaft: air catching the key light, riding the rig -----------
+  shaftAlpha: 0.07,        // the peak, never a beam
+  shaftColor: 0xFFD8E6,
+  shaftLength: 11,         // up along the key light from the board's centre
+  shaftRadius: 3.5,        // the wide end, landing over the board
+  shaftTip: 1.3,           // the narrow end, up at the light
+  shaftRise: 0.72,         // fraction of the length by which it is fully lit (gone at the board)
+  shaftFadeTip: 0.86,      // and from here it fades again, so the open end draws no ring
+  shaftSoft: 0.7,          // silhouette: full alpha needs this much of a face-on normal
+  shaftWarm: 0.3,          // brighter by this share at full warmth
+  shaftTopFade: Object.freeze([0.8, 0.98]),   // -forward.y of the camera: the cap comes in here
+  shaftTopKeep: 0.3,       // and this much is left looking straight down
 });
 
 export const clamp01 = (v) => Math.min(1, Math.max(0, Number.isFinite(v) ? v : 0));
@@ -75,6 +115,47 @@ export function yawFor(side, T = ROOM) {
 export function glowTargets(side, T = ROOM) {
   if (side !== 'w' && side !== 'b') return { w: T.glowOver, b: T.glowOver };
   return { w: side === 'w' ? T.glowRest : T.glowOff, b: side === 'b' ? T.glowRest : T.glowOff };
+}
+
+/** How warm the room wants to be for a ramp meter of `m`: 0 up to warmFrom, 1 at 1. */
+export function warmthFor(m, T = ROOM) {
+  return clamp01((clamp01(m) - T.warmFrom) / (1 - T.warmFrom));
+}
+
+/**
+ * The breath: once the meter has crossed breathAt the warmth dips from its
+ * swell by breathDepth and back, on a cosine (its own ease-in-out) with the
+ * DOM vignette's period, so the room and the frame breathe together. Below
+ * breathAt it is flat. `tMs` is time since the breath began.
+ */
+export function breathFor(m, tMs, T = ROOM) {
+  if (!(m >= T.breathAt)) return 0;
+  const phase = ((tMs % T.breathMs) + T.breathMs) % T.breathMs / T.breathMs;
+  return -T.breathDepth * (0.5 - 0.5 * Math.cos(phase * Math.PI * 2));
+}
+
+/**
+ * What each light drains to once the game is over, as a share of its base,
+ * and whether the spot lights the winner's king. A draw (no winner, or a
+ * stalemate or agreed draw) only dims, and no spot. No result at all is the
+ * live room: everything at 1, no spot.
+ */
+export function overTargets(result, winner, T = ROOM) {
+  if (!result) return { key: 1, fill: 1, hemi: 1, rim: 1, spot: false };
+  const drawn = !winner || result === 'stalemate' || result === 'draw';
+  if (drawn) return { key: T.overDraw, fill: T.overDraw, hemi: T.overDraw, rim: T.overDraw, spot: false };
+  return { key: T.overLevel, fill: T.overLevel, hemi: T.overLevel, rim: T.overRim, spot: true };
+}
+
+/**
+ * The light shaft's peak alpha this frame: the table's peak, up by shaftWarm
+ * at full warmth, down with the key light's drain, and capped as the camera
+ * looks straight down (`topness` is -forward.y, 0 level to 1 plumb), where an
+ * uncapped shaft is a bright disc over the board.
+ */
+export function shaftLevel({ warmth = 0, drain = 1, topness = 0 } = {}, T = ROOM) {
+  const cap = 1 - (1 - T.shaftTopKeep) * smoothstep(T.shaftTopFade[0], T.shaftTopFade[1], clamp01(topness));
+  return T.shaftAlpha * (1 + T.shaftWarm * clamp01(warmth)) * clamp01(drain) * cap;
 }
 
 /**

--- a/ConditioningControlPanel/Resources/web/piecebypiece/board/roomMath.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/board/roomMath.js
@@ -1,0 +1,105 @@
+/* ============================================================================
+ * board/roomMath.js - the numbers and the pure functions behind board/room.js.
+ *
+ * Kept apart from room.js so a node smoke can pin the dome's gradient, the
+ * lean of the light rig and the turn tell's timeline without a renderer, the
+ * way smoke/whip-smoke.mjs pins the whip. Nothing in here touches three.
+ * ==========================================================================*/
+
+/** Every number the room is made of. One place, on purpose. */
+export const ROOM = Object.freeze({
+  // --- the floor: a dark glossy table top the plinth stands on --------------
+  floorSize: 220,          // world units; the fog ends long before the edge
+  floorY: -0.585,          // the plinth's underside is -0.58
+  floorColor: 0x1C1240,    // dark plum, a shade under the plinth walls
+  floorRough: 0.55,        // matte-ish: at a grazing angle a gloss floor went white
+  floorClearcoat: 0,       // (the clearcoat's Fresnel did most of that; off)
+  floorClearcoatRough: 0.4,
+  floorEnv: 0.35,          // how much of env.js's room the sheen picks up
+  // --- the pool of shade under the plinth ----------------------------------
+  poolSize: 14.5,          // the plinth is 9.5 across; the shade reaches past it
+  poolInset: 0.16,         // fraction of the canvas the dark core stops short of
+  poolAlpha: 0.62,
+  poolPx: 256,
+  // --- the dome: plum at the horizon, a pink haze low, black overhead --------
+  domeRadius: 60,          // inside the camera's far plane (120) with room to spare
+  horizon: 0x3A1C58,       // = the fog colour: the far floor melts into exactly this
+  haze: 0x7A3070,
+  zenith: 0x06040C,
+  under: 0x0A0713,         // below the horizon, where only the side view can look
+  hazeAt: 0.18,            // sin(elevation) where the haze peaks
+  zenithAt: 0.62,          // and where the black has taken over
+  underAt: 0.35,
+  fogNear: 12,             // the floor melts into the horizon between these
+  fogFar: 34,
+  // --- the turn tell: the light rig leans to the side to move ----------------
+  leanMs: 480,
+  leanDeg: 180,            // white's rig, swung round to stand behind black
+  // --- and the edge of the plinth on the mover's side lights up --------------
+  glowHit: 1.0,            // full on the first frame of the turn
+  glowRest: 0.42,          // and easing to this
+  glowOff: 0.06,           // the other side's edge, waiting
+  glowOver: 0.12,          // both edges once the game is over
+  glowMs: 480,
+  glowColor: 0xFF69B4,
+  glowLength: 9.3,         // along the plinth's edge (the plinth is 9.4 wide)
+  glowWidth: 0.09,         // across the bevel, which is 0.07 on the slope
+  glowLift: 0.014,         // off the bevel along its normal (out and up), each axis
+});
+
+export const clamp01 = (v) => Math.min(1, Math.max(0, Number.isFinite(v) ? v : 0));
+export const easeOutCubic = (t) => 1 - Math.pow(1 - clamp01(t), 3);
+export const smoothstep = (a, b, x) => { const t = clamp01((x - a) / (b - a)); return t * t * (3 - 2 * t); };
+
+const hexToRgb = (hex) => [((hex >> 16) & 255) / 255, ((hex >> 8) & 255) / 255, (hex & 255) / 255];
+const mix = (a, b, t) => [a[0] + (b[0] - a[0]) * t, a[1] + (b[1] - a[1]) * t, a[2] + (b[2] - a[2]) * t];
+
+/**
+ * The dome's colour at a direction whose sine of elevation is `h` (-1 to 1),
+ * as [r, g, b] in 0..1. The same three mixes as the shader in room.js; the
+ * shader is the one that draws, this is the one the smoke can read.
+ */
+export function domeColorAt(h, T = ROOM) {
+  const horizon = hexToRgb(T.horizon);
+  if (h < 0) return mix(horizon, hexToRgb(T.under), smoothstep(0, T.underAt, -h));
+  const c = mix(horizon, hexToRgb(T.haze), smoothstep(0, T.hazeAt, h));
+  return mix(c, hexToRgb(T.zenith), smoothstep(T.hazeAt, T.zenithAt, h));
+}
+
+/** Where the light rig stands for `side`, in radians about +Y. */
+export function yawFor(side, T = ROOM) {
+  return side === 'b' ? (T.leanDeg * Math.PI) / 180 : 0;
+}
+
+/** What each edge glow eases toward once `side` is to move (null = game over). */
+export function glowTargets(side, T = ROOM) {
+  if (side !== 'w' && side !== 'b') return { w: T.glowOver, b: T.glowOver };
+  return { w: side === 'w' ? T.glowRest : T.glowOff, b: side === 'b' ? T.glowRest : T.glowOff };
+}
+
+/**
+ * A handful of eased tweens, driven by the frame loop's own dt so a stepped
+ * harness clock sees them run. `to` replaces any tween on the same target and
+ * key; a new tween starts from wherever the value is now.
+ */
+export function createTweens() {
+  const live = [];
+  function to(obj, key, value, ms, ease = easeOutCubic) {
+    for (let i = live.length - 1; i >= 0; i--) if (live[i].obj === obj && live[i].key === key) live.splice(i, 1);
+    if (!(ms > 0)) { obj[key] = value; return; }
+    live.push({ obj, key, from: obj[key], to: value, t: 0, ms, ease });
+  }
+  function update(dt) {
+    const ms = Math.max(0, dt) * 1000;
+    for (let i = live.length - 1; i >= 0; i--) {
+      const w = live[i];
+      w.t += ms;
+      const p = w.ease(w.t / w.ms);
+      w.obj[w.key] = w.from + (w.to - w.from) * p;
+      if (w.t >= w.ms) { w.obj[w.key] = w.to; live.splice(i, 1); }
+    }
+  }
+  /** Jump every tween to its end, for a still frame. */
+  function settle() { for (const w of live) w.obj[w.key] = w.to; live.length = 0; }
+  return { to, update, settle, count: () => live.length };
+}

--- a/ConditioningControlPanel/Resources/web/piecebypiece/board/scene.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/board/scene.js
@@ -99,7 +99,8 @@ export function createScene({ canvas }) {
   // instead of the void, and the fill stands opposite the key at about a
   // quarter of its strength: enough to find the far edge of a man, not enough
   // to flatten the modelling the key is doing. The fill casts nothing.
-  scene.add(new THREE.HemisphereLight(LIGHT.skyColor, LIGHT.groundColor, LIGHT.hemi));
+  const hemi = new THREE.HemisphereLight(LIGHT.skyColor, LIGHT.groundColor, LIGHT.hemi);
+  scene.add(hemi);
   const key = new THREE.DirectionalLight(LIGHT.keyColor, LIGHT.key);
   key.position.set(4.5, 9.5, 5.5);
   key.castShadow = true;
@@ -118,14 +119,21 @@ export function createScene({ canvas }) {
   const half = LIGHT.shadowHalfExtent;
   cam.left = -half; cam.right = half; cam.top = half; cam.bottom = -half;
   cam.near = 1; cam.far = 26;
-  scene.add(key, key.target);
+  // The three directionals and their targets ride in ONE group, so the whole
+  // rig can be swung about +Y as a unit: board/room.js turns it to stand
+  // behind whoever is to move, and key, fill and rim keep their places
+  // relative to each other. At rotation 0 nothing about the light has moved.
+  const lightRig = new THREE.Group();
+  lightRig.name = 'pbp-light-rig';
+  lightRig.add(key, key.target);
   const fill = new THREE.DirectionalLight(LIGHT.fillColor, LIGHT.fill);
   fill.position.set(-5.0, 4.0, 4.5);
   fill.castShadow = false;
-  scene.add(fill, fill.target);
+  lightRig.add(fill, fill.target);
   const rim = new THREE.DirectionalLight(LIGHT.rimColor, LIGHT.rim);
   rim.position.set(-5.5, 3.2, -6.5);
-  scene.add(rim, rim.target);
+  lightRig.add(rim, rim.target);
+  scene.add(lightRig);
 
   // --- board ----------------------------------------------------------------
   const boardGroup = new THREE.Group();
@@ -251,6 +259,7 @@ export function createScene({ canvas }) {
 
   return {
     renderer, scene, camera, boardGroup, pieceGroup, squares,
+    lightRig, lights: { hemi, key, fill, rim },
     update, render, resize, dispose,
     setSide, setHighlights, setHighlightSink, projectPoint, projectSquare,
     cameraRig: rig,

--- a/ConditioningControlPanel/Resources/web/piecebypiece/board/scene.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/board/scene.js
@@ -8,6 +8,7 @@
 
 import * as THREE from 'three';
 import { createCameraRig } from './camera.js';
+import { fovForAspect } from './frame.js';
 
 export const SQUARE = 1.0;
 export const FILES = 'abcdefgh';
@@ -225,6 +226,7 @@ export function createScene({ canvas }) {
     const h = canvas.clientHeight || window.innerHeight;
     renderer.setSize(w, h, false);
     camera.aspect = w / Math.max(1, h);
+    camera.fov = fovForAspect(camera.aspect);   // opens up on a phone held upright
     camera.updateProjectionMatrix();
   }
   window.addEventListener('resize', resize);

--- a/ConditioningControlPanel/Resources/web/piecebypiece/board/whip.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/board/whip.js
@@ -26,6 +26,12 @@
  * | wind 100 | snap 80, crack 36 in | stride 100 from the crack. Crack at
  * 336 ms from the move, the bishop stands on the square at 436 ms; the ring
  * dies by 800 ms, the victim is sunk by ~1420 and on the rim by ~1970.
+ *
+ * Gate: window.PBP.settings.whip (default FALSE; ?whip=1 sets it on a dev
+ * page). anim.js asks it once, where the bishop's capture slide would be
+ * marked as a whip; off, the bishop takes the plain capture like every other
+ * man and nothing in this file runs. The functions below are pure and do not
+ * look at the gate, so the node smoke and the phone preview stand as they are.
  * ==========================================================================*/
 
 /** Every number that decides how the whip plays. One place, on purpose. */

--- a/ConditioningControlPanel/Resources/web/piecebypiece/boot.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/boot.js
@@ -195,8 +195,10 @@ function main() {
   // --- end M ---
 
   // --- N: the theatre (parade, poses, bloom, the room watches) ---
-  window.PBP.settings = Object.assign({ bloom: true }, window.PBP.settings);
-  { const prev = board.setMeter; board.setMeter = (m) => { if (prev) prev(m); if (board.bloom) board.bloom.setMeter(m); if (board.watch) board.watch.setMeter(m); if (board.sfx && board.sfx.setMeter) board.sfx.setMeter(m); }; }
+  // The bishop's whip (board/whip.js) is parked: off unless the host says so,
+  // or a dev page asks with ?whip=1. Host-provided settings still win.
+  window.PBP.settings = Object.assign({ bloom: true, whip: params.get('whip') === '1' }, window.PBP.settings);
+  { const prev = board.setMeter; board.setMeter = (m) => { if (prev) prev(m); if (board.bloom) board.bloom.setMeter(m); if (board.watch) board.watch.setMeter(m); if (board.sfx && board.sfx.setMeter) board.sfx.setMeter(m); if (board.room && board.room.setMeter) board.room.setMeter(m); }; }
   import('./board/parade.js').then((m) => {
     board.parade = m.createParade({ view, bus, jiggle });
     feelLate.push((dt) => board.parade.update(dt));
@@ -218,7 +220,7 @@ function main() {
   // Loaded late and guarded like the rest: without it the board sits in the
   // flat navy it always did. The turn tell rides the bus on its own.
   import('./board/room.js').then((m) => {
-    board.room = m.createRoom({ view, bus, env: () => board.env });
+    board.room = m.createRoom({ view, bus, game, env: () => board.env });
     feelLate.push((dt) => board.room.update(dt));
   }).catch((e) => console.warn('[pbp] room missing', e));
   // The air in it: motes drifting round the board, scenery only.

--- a/ConditioningControlPanel/Resources/web/piecebypiece/boot.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/boot.js
@@ -17,7 +17,7 @@ import { createBus } from './game/events.js';
 import { createHotseat } from './game/hotseat.js';
 import { createDriverSwitch, startOnlineMatch } from './net/online.js';
 import { DEFAULT_MS } from './game/clock.js';
-import { postToHost, onHostMessage, signalReady } from './bridge.js';
+import { postToHost, onHostMessage, onIdentity, signalReady } from './bridge.js';
 
 const dom = {
   canvas: document.getElementById('board-canvas'),
@@ -98,6 +98,15 @@ function main() {
     if (m.type !== 'pbp:settings') return;
     const { type, ...values } = m;   // the envelope's own key is not a setting
     Object.assign(window.PBP.settings, values);
+  });
+  // The host names the player from the account (pbp:identity, displayName),
+  // and that is the name the server lists in the lobby - so it is the name the
+  // door has to show, or "you are visible as" says one thing and the room sees
+  // another. Subscribed rather than read: the frame lands after `ready`, which
+  // is after everything below has run, and settings is read fresh here because
+  // the object is merged into a new one twice further down.
+  onIdentity((id) => {
+    if (id && id.displayName) window.PBP.settings.playerName = String(id.displayName);
   });
 
   // --- camera: the rig the player drives ---
@@ -274,6 +283,11 @@ function main() {
     // an online seat is built and switched in by net/online.js; the hotseat's
     // reset-and-start is not what it wants
     if (mode === 'online' && match) { window.PBP.startOnline(match); return; }
+    // A finished online seat may still be in the chair from the last game
+    // (it stays for the end card). Reset-and-start against it would resync
+    // the finished match and fire its gameover a second time, so the hotseat
+    // goes back in first - which also disposes the seat - and is dealt.
+    if (game.switchBack) game.switchBack();
     if (game.reset) game.reset();
     bus.emit('local', { sides: ['w', 'b'], mode, match });
     game.start();

--- a/ConditioningControlPanel/Resources/web/piecebypiece/boot.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/boot.js
@@ -144,6 +144,7 @@ function main() {
   import('./board/env.js').then((m) => {
     board.env = m.createEnv({ renderer: view.renderer, scene: view.scene });
     board.env.dressBoard(view.boardGroup);
+    if (board.room) board.env.dressBoard(board.room.group);   // the floor, if it got here first
     board.env.dress(view.pieceGroup);
     feelLate.push((dt) => board.env.update(dt, view.pieceGroup));
   }).catch((e) => console.warn('[pbp] env missing', e));
@@ -213,6 +214,14 @@ function main() {
     feelLate.push((dt) => board.bloom.update(dt));
   }).catch((e) => console.warn('[pbp] bloom missing', e));
   // --- end N ---
+  // --- T: the room (floor, dome, and the light that leans to the mover) ---
+  // Loaded late and guarded like the rest: without it the board sits in the
+  // flat navy it always did. The turn tell rides the bus on its own.
+  import('./board/room.js').then((m) => {
+    board.room = m.createRoom({ view, bus, env: () => board.env });
+    feelLate.push((dt) => board.room.update(dt));
+  }).catch((e) => console.warn('[pbp] room missing', e));
+  // --- end T ---
   // Esc closes the board - but never mid-drag, where it is "put the piece back".
   window.addEventListener('keydown', (e) => {
     if (e.key === 'Escape' && !drag.isDragging()) postToHost({ type: 'pbp:exit' });

--- a/ConditioningControlPanel/Resources/web/piecebypiece/boot.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/boot.js
@@ -221,6 +221,11 @@ function main() {
     board.room = m.createRoom({ view, bus, env: () => board.env });
     feelLate.push((dt) => board.room.update(dt));
   }).catch((e) => console.warn('[pbp] room missing', e));
+  // The air in it: motes drifting round the board, scenery only.
+  import('./board/motes.js').then((m) => {
+    board.motes = m.createMotes({ scene: view.scene });
+    feelLate.push((dt) => board.motes.update(dt, view.camera, view.renderer));
+  }).catch((e) => console.warn('[pbp] motes missing', e));
   // --- end T ---
   // Esc closes the board - but never mid-drag, where it is "put the piece back".
   window.addEventListener('keydown', (e) => {

--- a/ConditioningControlPanel/Resources/web/piecebypiece/door/door.css
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/door/door.css
@@ -70,6 +70,10 @@
   50% { box-shadow: 0 0 26px rgba(255, 105, 180, 0.6); }
 }
 .door-btn.primary:hover { background: #FF7DBE; border-color: #FF7DBE; }
+/* off (no lobby, or nobody to play as): dim, still, and it does not breathe -
+   a button that glows and does nothing reads as broken */
+.door-btn:disabled, .door-btn.primary:disabled { opacity: 0.4; cursor: default; animation: none; box-shadow: none; transform: none; }
+.door-btn.primary:disabled:hover { background: var(--pbp-pink); border-color: var(--pbp-pink); }
 .door-btn .k { font-size: 10px; opacity: 0.55; letter-spacing: 0.1em; }
 .door-row { display: flex; gap: 10px; }
 .door-row .door-btn { flex: 1; }
@@ -168,6 +172,9 @@
   font: 14px 'Segoe UI', system-ui, sans-serif;
 }
 .door-name input:focus { outline: 2px solid var(--pbp-pink); outline-offset: 1px; }
+/* hosted, the name is the account's and is shown, not typed */
+.door-name input[readonly] { opacity: 0.6; cursor: default; }
+.door-name input[readonly]:focus { outline: none; }
 
 /* --- replay: the card folds down to a strip so the board is the subject --- */
 .door.screen-replay { align-items: flex-end; padding-bottom: 26px; }

--- a/ConditioningControlPanel/Resources/web/piecebypiece/door/door.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/door/door.js
@@ -17,9 +17,24 @@
  *
  * startGame({ mode, match }) is boot's: it deals the game and hides the door.
  * The door never touches the referee mid-game; it reads the record at the end.
+ *
+ * THE LOBBY IS LEFT WHEN THE GAME DEALS, not when the lobby screen goes. The
+ * found screen keeps the lobby entered on purpose (the pairing has to land
+ * through its poll), so the one place the door can stand up is go(): a lobby
+ * still entered during a game keeps re-advertising a player who is mid-game,
+ * and the server would pair a third player against a ghost.
+ *
+ * THE HOST NAMES THE PLAYER. Hosted, the account's display name is what the
+ * server lists and what "you are visible as" has to say (boot.js copies it
+ * into settings.playerName off pbp:identity), so the profile's name box is
+ * read-only there. And a hosted page whose account is signed out cannot play
+ * anybody: the lobby says so in one line, with quick match off, rather than
+ * showing an empty room and a quick match that fails - and never the mock,
+ * whose invented names a desktop player would try to join.
  * ==========================================================================*/
 
 import { Chess } from '../vendor/chess.js';
+import { isHosted, identity, whenIdentity } from '../bridge.js';
 import { listGames, getGame, saveGame, playerName, setPlayerName, profileStats, outcome, fmtDuration, fmtMoves, fmtWhen } from './store.js';
 
 /** Every number the door decides with. */
@@ -53,7 +68,9 @@ function positionOf(chess) {
 export function createDoor(opts = {}) {
   const { bus, game, board, params } = opts;
   const root = opts.root || (typeof document !== 'undefined' ? document.getElementById('door') : null);
-  const lobby = opts.lobby || null;
+  // A hosted page never gets the mock (see the header). No lobby at all reads
+  // as "not available", which is at least true.
+  const lobby = (opts.lobby && !(isHosted && opts.lobby.debug && opts.lobby.debug.isMock)) ? opts.lobby : null;
   const settings = () => (opts.settings ? opts.settings() : ((typeof window !== 'undefined' && window.PBP && window.PBP.settings) || {}));
   const startGame = typeof opts.startGame === 'function' ? opts.startGame : () => {};
   if (!root) return { show() {}, hide() {}, isUp: () => false, debug: () => ({ ok: false, why: 'no #door' }), dispose() {} };
@@ -71,6 +88,30 @@ export function createDoor(opts = {}) {
   let replay = null;            // { moves, positions, marks, i, timer }
   const timers = new Set();
   const unbind = [];
+
+  /**
+   * Who the host says we are, behind one object so a harness can stand in for
+   * the desktop (debug.host). Unhosted, whenIdentity resolves at once with the
+   * empty identity and none of the account states below can happen.
+   */
+  let host = { isHosted, identity, whenIdentity };
+  let signedOut = false;        // hosted, and there is no signed-in account behind the page
+
+  /** Wait for the host's word, then remember whether there is anyone to play as. */
+  async function askHost() {
+    let id = null;
+    try { id = await host.whenIdentity(); } catch { id = null; }
+    if (!id) { try { id = host.identity(); } catch { id = null; } }
+    signedOut = !!host.isHosted && !(id && id.online !== false && id.unifiedId);
+    return id;
+  }
+
+  /** Nothing is asked of the lobby before the host has spoken, and nothing at all for nobody. */
+  async function afterHost(fn) {
+    await askHost();
+    if (signedOut) throw new Error('cancelled');    // the quiet rejection: look() re-renders, no squelch
+    return fn();
+  }
 
   function later(fn, ms) { const t = setTimeout(() => { timers.delete(t); fn(); }, ms); timers.add(t); return t; }
   function hudEl() { return document.getElementById('hud'); }
@@ -107,7 +148,7 @@ export function createDoor(opts = {}) {
     const body = document.createElement('div'); body.className = 'door-body';
     body.innerHTML = ({ menu, lobby: lobbyScreen, found, games, profile, replay: replayScreen, end }[screen] || menu)();
     card.append(body);
-    if (screen === 'profile') { const inp = body.querySelector('input'); if (inp) inp.addEventListener('change', () => setPlayerName(inp.value)); }
+    if (screen === 'profile') { const inp = body.querySelector('input'); if (inp && !inp.readOnly) inp.addEventListener('change', () => setPlayerName(inp.value)); }
     if (screen === 'replay') { const r = body.querySelector('.door-scrub'); if (r) r.addEventListener('input', () => stepReplay(Number(r.value))); }
     const focus = body.querySelector('.door-btn.primary') || body.querySelector('button');
     if (focus && !still()) later(() => { try { focus.focus({ preventScroll: true }); } catch { /* fine */ } }, 60);
@@ -130,6 +171,10 @@ export function createDoor(opts = {}) {
   }
 
   function lobbyScreen() {
+    // Three rooms: the one with people in it, the one with nobody to play as
+    // (hosted, signed out), and the one with no lobby behind it at all. The
+    // last two are one line each and quick match is off, never a dead button.
+    const canPlay = !!lobby && !signedOut;
     const rows = people.map((p) => `
       <li class="door-item" data-id="${esc(p.id)}">
         <span class="who">${esc(p.name)}</span>
@@ -140,12 +185,18 @@ export function createDoor(opts = {}) {
       <div class="door-ask"><span><b>${esc(ask.name)}</b> wants a game</span>
         <button type="button" class="door-pill" data-act="accept">play</button>
         <button type="button" class="door-link" data-act="decline">ignore</button></div>` : '';
+    const sub = signedOut ? 'not signed in'
+      : !lobby ? 'online play is not available right now'
+        : `${people.length ? `<b>${people.length}</b> at the board` : 'nobody else here yet'} - you are visible as <b>${esc(me())}</b>`;
+    const empty = signedOut ? 'sign in to play online'
+      : !lobby ? 'the board here still works - play here from the menu'
+        : '<span class="door-dot"></span>nobody at the board yet - you are first in line';
     return `
       <h1 class="door-title">lobby</h1>
-      <p class="door-sub">${people.length ? `<b>${people.length}</b> at the board` : 'nobody else here yet'} - you are visible as <b>${esc(me())}</b></p>
+      <p class="door-sub">${sub}</p>
       ${askRow}
-      <button type="button" class="door-btn primary" data-act="quick" ${looking ? 'disabled' : ''}>${looking ? 'looking for a game' : 'quick match'} ${looking ? '<span class="door-dot"></span>' : '<span class="k">whoever waited longest</span>'}</button>
-      ${people.length ? `<ul class="door-list">${rows}</ul>` : `<div class="door-empty"><span class="door-dot"></span>nobody at the board yet - you are first in line</div>`}
+      <button type="button" class="door-btn primary" data-act="quick" ${(looking || !canPlay) ? 'disabled' : ''}>${looking ? 'looking for a game' : 'quick match'} ${looking ? '<span class="door-dot"></span>' : '<span class="k">whoever waited longest</span>'}</button>
+      ${people.length && canPlay ? `<ul class="door-list">${rows}</ul>` : `<div class="door-empty">${empty}</div>`}
       <div class="door-foot"><span>esc - back</span>${looking ? '<button type="button" class="door-link" data-act="cancel">stop looking</button>' : ''}</div>`;
   }
 
@@ -182,9 +233,13 @@ export function createDoor(opts = {}) {
   function profile() {
     const s = profileStats();
     const stat = (n, l, pink) => `<div class="door-stat"><span class="n${pink ? ' pink' : ''}">${n}</span><span class="l">${l}</span></div>`;
+    // Hosted, the name is the account's: the server lists it, so it is shown
+    // here and not typed. Unhosted (a plain browser), typed and kept locally.
+    const hosted = !!host.isHosted;
     return `
       <h1 class="door-title">profile</h1>
-      <div class="door-name"><input type="text" maxlength="24" value="${esc(me())}" aria-label="your name at the board" spellcheck="false"></div>
+      <div class="door-name"><input type="text" maxlength="24" value="${esc(me())}" aria-label="your name at the board" spellcheck="false"${hosted ? ' readonly' : ''}></div>
+      ${hosted ? '<p class="door-sub">your name comes from your account</p>' : ''}
       <div class="door-stats">
         ${stat(s.games, 'games')}${stat(s.wins, 'wins', true)}${stat(s.losses, 'losses')}
         ${stat(s.draws, 'draws')}${stat(s.streak, 'streak', s.streak > 1)}${stat(s.captures, 'taken')}
@@ -237,7 +292,10 @@ export function createDoor(opts = {}) {
   // ---------------------------------------------------------------- lobby
   let offList = null, offAsk = null;
   async function enterLobby() {
-    if (!lobby) return;
+    // The host first: a signed-out account has nothing to enter with, and
+    // the screen has to say so rather than sit on an empty list.
+    await askHost();
+    if (signedOut || !lobby) { if (screen === 'lobby') render(); return; }
     try { await lobby.enter({ name: me() }); } catch { /* the door still opens */ }
     if (offList) offList();
     offList = lobby.onList((l) => { people = l || []; if (screen === 'lobby') render(); });
@@ -304,8 +362,31 @@ export function createDoor(opts = {}) {
   function go() {
     if (!current) return;
     if (countTimer) { timers.delete(countTimer); clearTimeout(countTimer); countTimer = null; }
+    const m = current.match;
+    // An accepted challenge is a round trip on a server, and the lobby handed
+    // the door its Match before the answer landed (net/lobbyServer.js,
+    // offer()): the id is filled in behind it, on `ready`. Dealing a match
+    // with no id throws in startOnlineMatch, so the count holds at zero until
+    // the id is there - or until it is not, which is the lobby's way of
+    // saying he is not playing after all.
+    if (current.mode === 'online' && m && !m.id && m.ready && typeof m.ready.then === 'function') {
+      const mine = current;
+      m.ready.then((r) => {
+        if (current !== mine) return;
+        if (r && r.id) { go(); return; }
+        current = null;
+        sfx('squelch');
+        show('lobby');
+      }).catch(() => { if (current === mine) { current = null; show('lobby'); } });
+      return;
+    }
+    // The lobby was kept through the found screen so the pairing could land;
+    // the game has, so stand up (see the header). The next visit to the lobby
+    // screen enters again, because leaveLobby drops the subscription show()
+    // keys the re-entry on.
+    leaveLobby();
     if (screen === 'found') { screen = null; }
-    deal(current.mode, current.match);
+    deal(current.mode, m);
   }
 
   // ---------------------------------------------------------------- the game itself
@@ -322,8 +403,11 @@ export function createDoor(opts = {}) {
     let rec = {};
     try { rec = game.record ? game.record() : {}; } catch { rec = {}; }
     const m = current.match;
+    // the seat off the record when the driver knows it (an online seat may have
+    // been corrected by the server after the deal), else the lobby's word
+    const seat = (rec.me === 'w' || rec.me === 'b') ? rec.me : (m ? m.side : null);
     lastEnd = saveGame({
-      mode: current.mode, me: m ? m.side : null, opponent: m ? m.opponent.name : 'a friend here',
+      mode: current.mode, me: seat, opponent: m ? m.opponent.name : 'a friend here',
       moves: rec.moves || [], plies: rec.plies || 0, result: rec.result || null,
       durationMs: Date.now() - current.startedAt, captures: { ...current.captures }, clocks: rec.clocks || null,
     });
@@ -344,6 +428,11 @@ export function createDoor(opts = {}) {
   }
 
   function toMenu() {
+    // A finished online seat stays in the chair for the end card, so the
+    // board under the card is the finished position. The menu wants the
+    // hotseat's fresh one, and that only exists once the switch has gone
+    // back; reset() on the online seat is a no-op and would leave the mate.
+    try { if (typeof game.switchBack === 'function') game.switchBack(); } catch { /* one driver only */ }
     try { game.reset(); board.pieces.setPosition(game.rules.position()); } catch { /* the board stays as it is */ }
     try { board.setSide('w', true); } catch { /* no rig */ }
     show('menu');
@@ -396,12 +485,14 @@ export function createDoor(opts = {}) {
   // ---------------------------------------------------------------- input
   function act(name, id) {
     switch (name) {
-      case 'quick': if (screen !== 'lobby') show('lobby'); if (lobby) look(lobby.quickMatch()); break;
+      // the lobby is asked only once the host has said who we are, and not at
+      // all for nobody (afterHost); look() reads the quiet rejection as a re-render
+      case 'quick': if (screen !== 'lobby') show('lobby'); if (lobby) look(afterHost(() => lobby.quickMatch())); break;
       case 'hotseat': deal('hotseat'); break;
       case 'lobby': show('lobby'); break;
       case 'games': show('games'); break;
       case 'profile': show('profile'); break;
-      case 'challenge': if (lobby) look(lobby.challenge(id)); break;
+      case 'challenge': if (lobby) look(afterHost(() => lobby.challenge(id))); break;
       case 'cancel': try { if (lobby) lobby.cancel(); } catch { /* fine */ } break;
       // accepting is a round trip on a server; the mock answers at once and
       // Promise.resolve makes both read the same
@@ -455,11 +546,22 @@ export function createDoor(opts = {}) {
     screen: () => screen,
     /** For the harness: the door's state, and levers to pull. */
     debug: {
-      state: () => ({ screen, looking, ask: ask ? ask.name : null, people: people.length, current: current ? current.mode : null, replay: replay ? replay.i : null, games: listGames().length }),
+      state: () => ({ screen, looking, ask: ask ? ask.name : null, people: people.length, current: current ? current.mode : null, replay: replay ? replay.i : null, games: listGames().length, signedOut, hosted: !!host.isHosted, inLobby: !!offList }),
       act,
       openReplay,
       matched,
       shelf: { save: saveGame, list: listGames },
+      /**
+       * Stand in for the desktop host: { isHosted, identity(), whenIdentity() },
+       * any subset. What lets a plain browser photograph the hosted states
+       * (a read-only name, a signed-out lobby) that only a host can put it in.
+       */
+      host(fake) {
+        host = Object.assign({}, host, fake || {});
+        signedOut = false;
+        if (offList) leaveLobby();
+        if (screen) render();
+      },
     },
     dispose() {
       card.removeEventListener('click', onClick);

--- a/ConditioningControlPanel/Resources/web/piecebypiece/hud.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/hud.js
@@ -14,6 +14,15 @@
  * off game.rules for the material count, so the match code never has to know the
  * HUD changed shape.
  *
+ * ONLINE, TWO MORE WORDS. An online seat (net/match.js) can resign and can
+ * offer, accept or decline a draw, and a hotseat cannot: there is nobody to
+ * say it to. So the resign and draw buttons exist only while `game.isOnline`
+ * says an online seat is in the chair (the `local` event carries the mode, and
+ * the switch in net/online.js exposes the getter), and are hidden outright in
+ * a hotseat, not merely disabled. Resign asks once - "resign? yes / no" - so a
+ * stray tap cannot end a game; his offer is a line with accept and decline,
+ * fed by the `draw-offer` / `draw-decline` events the seat emits.
+ *
  *   createHud({ bus, game, board, root, params }) -> { setMeter, debug, dispose }
  *
  * Nothing here may throw at import or at attach time: a missing node, a missing
@@ -32,6 +41,8 @@ export const TUNING = Object.freeze({
   vigMax: 0.9,         // and how strong full is
   vigBreathe: 0.7,     // past this the glow breathes
   unlocks: Object.freeze([0.25, 0.40, 0.55, 0.70]),   // the debug dot row
+  askMs: 6000,         // "resign?" withdraws itself if nobody answers it
+  noteMs: 2600,        // how long a passing note ("draw declined") stays
 });
 
 const T = TUNING;
@@ -98,6 +109,20 @@ export function createHud(opts = {}) {
     dots: pick('hud-dots'),
     chip: { w: pick('chip-w'), b: pick('chip-b') },
     tally: { w: pick('tally-w'), b: pick('tally-b') },
+    // the online block; every node optional, a page without it is a quieter HUD
+    online: {
+      root: pick('hud-online'),
+      note: pick('hud-online-note'),
+      btns: pick('hud-online-btns'),
+      resign: pick('hud-resign'),
+      draw: pick('hud-draw'),
+      ask: pick('hud-resign-ask'),
+      yes: pick('hud-resign-yes'),
+      no: pick('hud-resign-no'),
+      offer: pick('hud-draw-ask'),
+      accept: pick('hud-draw-accept'),
+      decline: pick('hud-draw-decline'),
+    },
   };
 
   let active = 'w';         // whose clock is running
@@ -105,8 +130,15 @@ export function createHud(opts = {}) {
   let meter = 0;
   let lastSecond = -1;      // so the shiver fires once a second, not every tick
   let hinted = false;
+  let online = false;       // an online seat is in the chair (see the header)
+  let asking = false;       // "resign?" is up
+  let askTimer = null;
+  let away = false;         // the server's last word: he is not there
+  let flash = '';           // a passing note, and the timer that takes it down
+  let flashTimer = null;
   const timers = new Set();
   const unbind = [];
+  const undom = [];         // DOM listeners, taken off on dispose
 
   const later = (fn, ms) => { const id = setTimeout(() => { timers.delete(id); fn(); }, ms); timers.add(id); return id; };
   const on = (type, fn) => {
@@ -216,6 +248,97 @@ export function createHud(opts = {}) {
     return sideWord(other(end.winner)) + ' kneels';
   }
 
+  /* ---- resign and the draw, online only ---------------------------------- */
+
+  /** What the seat says stands: 'me' | 'them' | null. A hotseat says null. */
+  function drawOffer() {
+    try { return game && game.drawOffer ? game.drawOffer() : null; } catch { return null; }
+  }
+
+  /** The seat this client is in, for telling his decline from the echo of ours. */
+  function mySide() {
+    try { const s = game && game.seats; return Array.isArray(s) && s.length === 1 ? s[0] : null; } catch { return null; }
+  }
+
+  /** The one line over the buttons. A passing note wins; then whatever stands. */
+  function noteText() {
+    if (flash) return flash;
+    if (drawOffer() === 'me') return 'draw offered';
+    if (away) return 'he seems to have left';
+    return '';
+  }
+
+  /**
+   * Show the block as the state says. Everything reads from state rather than
+   * being toggled in place, so an event arriving in any order lands on the
+   * same picture: no online seat, or a finished game, and the whole thing is
+   * gone; his offer takes the buttons' row; the question takes it too.
+   */
+  function paintOnline() {
+    const o = el.online;
+    if (!o.root) return;
+    const show = online && !over;
+    o.root.hidden = !show;
+    if (!show) return;
+    const offer = drawOffer();
+    const theirs = offer === 'them';
+    if (o.btns) o.btns.hidden = asking || theirs;
+    if (o.ask) o.ask.hidden = !asking;
+    if (o.offer) o.offer.hidden = asking || !theirs;
+    if (o.draw) o.draw.disabled = offer === 'me';
+    const text = noteText();
+    if (o.note) { o.note.textContent = text; o.note.hidden = !text; }
+  }
+
+  function stopAsking() {
+    asking = false;
+    if (askTimer) { clearTimeout(askTimer); timers.delete(askTimer); askTimer = null; }
+  }
+
+  function note(text) {
+    flash = text;
+    if (flashTimer) { clearTimeout(flashTimer); timers.delete(flashTimer); }
+    flashTimer = later(() => { flash = ''; flashTimer = null; paintOnline(); }, T.noteMs);
+    paintOnline();
+  }
+
+  /** A new deal. The mode on the `local` event is the word; the getter is the fallback. */
+  function newDeal(p) {
+    let isOnline = false;
+    try { isOnline = !!(game && game.isOnline); } catch { isOnline = false; }
+    if (p && typeof p.mode === 'string') isOnline = p.mode === 'online';
+    online = isOnline;
+    over = null;
+    away = false;
+    flash = '';
+    stopAsking();
+    paintOnline();
+  }
+
+  const click = (node, fn) => {
+    if (!node) return;
+    const h = (e) => {
+      e.preventDefault();
+      try { fn(); } catch (err) { console.warn('[pbp/hud] ' + (err && err.message)); }
+    };
+    node.addEventListener('click', h);
+    undom.push(() => node.removeEventListener('click', h));
+  };
+  const verb = (name) => { try { if (game && typeof game[name] === 'function') game[name](); } catch { /* the seat said no */ } };
+
+  click(el.online.resign, () => {
+    // Asked, never done: the tap that ends a game is the second one.
+    stopAsking();
+    asking = true;
+    askTimer = later(() => { askTimer = null; asking = false; paintOnline(); }, T.askMs);
+    paintOnline();
+  });
+  click(el.online.no, () => { stopAsking(); paintOnline(); });
+  click(el.online.yes, () => { stopAsking(); verb('resign'); paintOnline(); });
+  click(el.online.draw, () => { verb('offerDraw'); paintOnline(); });
+  click(el.online.accept, () => { verb('acceptDraw'); paintOnline(); });
+  click(el.online.decline, () => { verb('declineDraw'); paintOnline(); });
+
   /* ---- wiring ------------------------------------------------------------- */
 
   on('clock', (snap) => {
@@ -226,10 +349,20 @@ export function createHud(opts = {}) {
     setActive(p && p.side === 'b' ? 'b' : 'w');
     paintCheck();
     paintTally();
+    // a move clears any standing offer, server-side and in the seat, so the
+    // block is repainted off the seat's word rather than told
+    paintOnline();
   });
   on('check', () => paintCheck());
   on('capture', () => paintTally());
-  on('local', () => { paintTally(); place(true); });
+  on('local', (p) => { newDeal(p); paintTally(); place(true); });
+  on('draw-offer', () => { stopAsking(); paintOnline(); });
+  on('draw-decline', (p) => {
+    const by = p && (p.by === 'w' || p.by === 'b') ? p.by : null;
+    // his no, not the echo of ours
+    if (by && by !== mySide()) note('draw declined'); else paintOnline();
+  });
+  on('opponent', (p) => { away = !!(p && p.online === false); paintOnline(); });
   on('gameover', (p) => {
     over = p || { result: 'over' };
     const line = endLine(over);
@@ -239,6 +372,8 @@ export function createHud(opts = {}) {
       el.chip[s].classList.remove('low', 'check', 'shiver', 'shiver-hard');
     }
     if (el.line) el.line.classList.remove('on');
+    stopAsking();
+    paintOnline();
   });
 
   // The one piece of teaching copy, and it leaves on its own. The first pointer
@@ -277,11 +412,16 @@ export function createHud(opts = {}) {
   paintTally();
   paintCheck();
   setMeter(0);
+  // The HUD may be built mid-game (it is loaded late), so the block starts
+  // from whatever is in the chair rather than waiting for the next deal.
+  newDeal(null);
 
   function dispose() {
     if (moves) { try { moves.dispose(); } catch { /* already gone */ } moves = null; }
     for (const off of unbind) { try { off(); } catch { /* already gone */ } }
     unbind.length = 0;
+    for (const off of undom) { try { off(); } catch { /* already gone */ } }
+    undom.length = 0;
     for (const id of timers) clearTimeout(id);
     timers.clear();
     try { window.removeEventListener('pointermove', onPointer); } catch { /* gone */ }
@@ -307,6 +447,16 @@ export function createHud(opts = {}) {
         line: el.line ? el.line.style.transform : null,
         reducedMotion: reducedMotion(),
         moves: moves ? moves.debug() : null,
+        online: {
+          on: online,
+          shown: !!(el.online.root && !el.online.root.hidden),
+          asking,
+          offer: drawOffer(),
+          away,
+          note: el.online.note && !el.online.note.hidden ? el.online.note.textContent : null,
+          buttons: !!(el.online.btns && !el.online.btns.hidden),
+          offerRow: !!(el.online.offer && !el.online.offer.hidden),
+        },
       };
     },
   };

--- a/ConditioningControlPanel/Resources/web/piecebypiece/index.html
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/index.html
@@ -65,6 +65,32 @@
       <p class="hint" id="hud-hint" hidden>hold esc to leave the board</p>
       <div class="dots" id="hud-dots" hidden aria-hidden="true"><i></i><i></i><i></i><i></i></div>
     </div>
+
+    <!-- Resign and the draw: the two things a player can say to the referee
+         in an online game that are not a move. hud.js shows this block only
+         while an online seat is in the chair (game.isOnline); a hotseat game
+         never sees it. Bottom right rather than under the status line, which
+         slides with the turn: a button that moves is a button a stray tap
+         lands on, and "resign" is the one tap that must not be stray. The
+         rows swap in place - the question, or his offer, in the buttons'
+         stead - so the eye learns one spot. -->
+    <div class="online" id="hud-online" hidden>
+      <p class="online-note" id="hud-online-note" hidden></p>
+      <div class="online-row" id="hud-draw-ask" hidden>
+        <span class="word">he offers a draw</span>
+        <button type="button" class="hud-btn warm" id="hud-draw-accept">accept</button>
+        <button type="button" class="hud-btn" id="hud-draw-decline">decline</button>
+      </div>
+      <div class="online-row" id="hud-resign-ask" hidden>
+        <span class="word">resign?</span>
+        <button type="button" class="hud-btn warm" id="hud-resign-yes">yes</button>
+        <button type="button" class="hud-btn" id="hud-resign-no">no</button>
+      </div>
+      <div class="online-row" id="hud-online-btns">
+        <button type="button" class="hud-btn" id="hud-draw">offer draw</button>
+        <button type="button" class="hud-btn" id="hud-resign">resign</button>
+      </div>
+    </div>
   </div>
 
   <div id="fx"></div>

--- a/ConditioningControlPanel/Resources/web/piecebypiece/net/lobbyServer.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/net/lobbyServer.js
@@ -44,10 +44,24 @@ import * as defaultApi from './api.js';
 import { isHosted, identity, whenIdentity } from '../bridge.js';
 
 /**
- * The contract asks for ~2s while a lobby screen is open, and caps /quick at
- * 40/min/user, which is 1.5s. This is the fastest this may honestly poll.
+ * The contract asks for ~2s while a lobby screen is open, but every tick of
+ * this poll spends a call on GET /lobby, which is capped at 30/min/user - a
+ * 2s tick sits EXACTLY on that cap, and enter()'s own refresh and the 60s
+ * re-enter push it over. 3s is 20/min, which leaves room for both, and the
+ * list going stale by one extra second is not something a person in a lobby
+ * can see. /quick (40/min) and /challenges (30/min, and asked for only every
+ * CHALLENGE_TICKS-th tick) both sit comfortably under this.
  */
-export const POLL_MS = 2000;
+export const POLL_MS = 3000;
+
+/**
+ * The challenge list is asked for on every this-many-th tick. Incoming
+ * challenges live 300s and an ignored one ignores itself after 8s, so seeing
+ * one 6s late costs nothing; the outgoing challenge we are waiting on is the
+ * exception and is watched every tick (see refresh), which is where the
+ * contract's "~2s while a challenge screen is open" is actually needed.
+ */
+export const CHALLENGE_TICKS = 2;
 
 /**
  * A lobby listing expires after 180s of no enter/quick refresh. While the
@@ -251,7 +265,15 @@ export function createServerLobby({
 
   /* ------------------------------------------------------------------ poll */
 
-  async function refresh() {
+  /** Polls made so far, for the every-other-tick cadence. A forced refresh does not count. */
+  let polls = 0;
+
+  /**
+   * One poll. `everything` asks for the challenge list whatever the cadence
+   * says - what debug.refresh passes, so a harness that plants a challenge
+   * and refreshes sees it on that refresh and not the one after.
+   */
+  async function refresh(everything = false) {
     if (disposed || !entered) return;
 
     // Keep the listing alive. /quick counts as a refresh, so this only fires
@@ -262,7 +284,15 @@ export function createServerLobby({
       api.lobbyEnter(tc).catch(() => {});
     }
 
-    const [lob, chal] = await Promise.all([api.lobbyList(), api.challenges()]);
+    // The list every tick; the challenges every CHALLENGE_TICKS-th, unless one
+    // of ours is out, because the challenge list is the only place its answer
+    // can arrive and a person waiting on a yes can feel every second of it.
+    if (!everything) polls += 1;
+    const askChallenges = everything
+      || !!(pending && pending.kind === 'challenge')
+      || ((polls - 1) % CHALLENGE_TICKS === 0);
+
+    const [lob, chal] = await Promise.all([api.lobbyList(), askChallenges ? api.challenges() : Promise.resolve(null)]);
     if (disposed || !entered) return;
 
     if (lob.ok && Array.isArray(lob.data.players)) {
@@ -270,7 +300,7 @@ export function createServerLobby({
       emit(listListeners, list());
     }
 
-    if (chal.ok) {
+    if (chal && chal.ok) {
       const incoming = Array.isArray(chal.data.incoming) ? chal.data.incoming : [];
       const outgoing = Array.isArray(chal.data.outgoing) ? chal.data.outgoing : [];
 
@@ -403,6 +433,13 @@ export function createServerLobby({
         entered = true;
         if (!handle) handle = setT(tick, pollMs);
         (async () => {
+          // The door may press QUICK MATCH before the host's identity frame
+          // has landed - only enter() waited for it, and the menu's own quick
+          // button never went through enter(). A /quick with no unified_id on
+          // it is a 400, read here as "he left", which is a lie.
+          await whenIdentity();
+          if (disposed || !pending || pending.settled || pending.kind !== 'quick') return;
+          if (!signedIn()) { rejectLook('left'); return; }
           const res = await api.quick(tc);
           if (disposed || !pending || pending.settled || pending.kind !== 'quick') return;
           lastEnter = Date.now();
@@ -429,6 +466,10 @@ export function createServerLobby({
         entered = true;
         if (!handle) handle = setT(tick, pollMs);
         (async () => {
+          // Same wait as quickMatch, for the same reason.
+          await whenIdentity();
+          if (disposed || !pending || pending.settled || pending.kind !== 'challenge') return;
+          if (!signedIn()) { rejectLook('left'); return; }
           const res = await api.challenge(String(id), tc);
           if (disposed || !pending || pending.settled || pending.kind !== 'challenge') return;
           // He is not there any more, or the server refused the pairing. The
@@ -463,8 +504,9 @@ export function createServerLobby({
     /** Matches the mock's `debug` block, so a harness can poke either one. */
     debug: {
       isMock: false,
-      state: () => ({ entered, looking: pending ? pending.kind : null, people: list(), timeControl: tc }),
-      refresh,
+      state: () => ({ entered, looking: pending ? pending.kind : null, people: list(), timeControl: tc, polls }),
+      /** A full poll, challenges included, off the cadence - see refresh. */
+      refresh: () => refresh(true),
     },
   };
 }

--- a/ConditioningControlPanel/Resources/web/piecebypiece/net/match.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/net/match.js
@@ -2,8 +2,8 @@
  * net/match.js - one seat at an online game.
  *
  * THE SAME SHAPE AS hotseat.js, deliberately and exactly: rules, clock, start,
- * update, tryMove, takeBack, canPick, legalTargets, resign, plies, turn,
- * isOver, result, autoRemaining. boot.js swaps one for the other and nothing
+ * update, tryMove, takeBack, canPick, legalTargets, resign, record, plies,
+ * turn, isOver, result, autoRemaining. boot.js swaps one for the other and nothing
  * downstream - drag.js, promote.js, hud.js, sfx.js, the whole board - is told
  * which one it got. Every move still lands on the board through the same
  * rules-then-pieces-then-bus path, so the animation, the dust, the thud and
@@ -54,6 +54,24 @@ export const HEARTBEAT_MS = 20000;
 
 /** The long poll comes straight back on an error; these are the waits between retries. */
 const BACKOFF_MS = [500, 1000, 2000, 4000, 8000, 15000];
+
+/**
+ * How long the opponent's silence has to last before this seat asks the server
+ * to call the game abandoned. Mirrors ABANDON_MS on the server (proxy/pbp.js;
+ * contract section 3, claim_timeout condition 2: "not seen for 60 s"). The
+ * server grants the claim only once ITS record of his last contact is this
+ * old, so asking sooner is a guaranteed 409 not_expired. What starts the count
+ * here is `opponent_online: false` on the events envelope - the server's word,
+ * never a guess of ours - and the claim is retried on the poll's own backoff
+ * ladder, because the server's count began later than ours by up to one poll.
+ */
+export const ABANDON_MS = 60000;
+
+/** performance.now() where it exists, else Date.now() - see createRemoteClock for why. */
+function monotonic(now) {
+  if (now) return now;
+  return (typeof performance !== 'undefined' && performance.now) ? () => performance.now() : () => Date.now();
+}
 
 const other = (side) => (side === 'w' ? 'b' : 'w');
 
@@ -121,9 +139,7 @@ export function toUci(from, to, promotion) {
 const DISCOUNT_PROBE_MS = 250;
 
 export function createRemoteClock({ perSideMs = DEFAULT_MS, now = null } = {}) {
-  const clockNow = now || ((typeof performance !== 'undefined' && performance.now)
-    ? () => performance.now()
-    : () => Date.now());
+  const clockNow = monotonic(now);
 
   const base = { w: perSideMs, b: perSideMs };
   let total = perSideMs;
@@ -275,7 +291,8 @@ export function createOnlineMatch({
   let seatKnown = (color === 'w' || color === 'b');
   const rules = createRules();
   const pieces = board.pieces;
-  const clock = createRemoteClock({ now });
+  const monoNow = monotonic(now);
+  const clock = createRemoteClock({ now: monoNow });
   const sleep = wait || ((ms) => new Promise((r) => { const t = setTimeout(r, ms); if (t.unref) t.unref(); }));
 
   let seq = 0;                 // the last event seq we have accounted for
@@ -291,6 +308,14 @@ export function createOnlineMatch({
   let drawOffer = null;        // 'me' | 'them' | null, as the last draw_offer event left it
   let resyncing = false;
   let opponentOnline = true;   // last word from the server, not a guess of ours
+  /**
+   * His current spell of silence, or null while he is here. One object per
+   * spell, so the whole claim story - how long he has been gone, how many times
+   * we have asked, when we may ask again - ends the moment he is back and
+   * starts clean the next time he goes.
+   * @type {{since:number, attempts:number, nextAt:number, busy:boolean}|null}
+   */
+  let silence = null;
   /**
    * When the server last heard from us. The events long poll stamps our
    * heartbeat server-side (contract section 3), so a client that is polling
@@ -329,21 +354,68 @@ export function createOnlineMatch({
     hud.status.textContent = rules.turn() === me ? 'your move' : 'waiting for his move';
   }
 
+  /**
+   * Ask the server to look at its own clock and its own record of who it has
+   * heard from (contract section 3, claim_timeout: one route, two conditions).
+   * A verdict comes back as the finished match state, so it finishes the board
+   * here rather than waiting for the poll to bring the same verdict round;
+   * anything else - 409 not_expired, a network miss - is simply "not yet".
+   * Resolves true when the game ended on this answer.
+   */
+  async function claim() {
+    let res = null;
+    try { res = await api.claimTimeout(matchId); } catch (err) { res = null; }
+    if (disposed || !res || !res.ok || !res.data) return false;
+    const end = endingFrom(res.data);
+    if (end) finish(end);
+    return !!end;
+  }
+
+  /** One beat of the clock: repaint, and say so if a claim is due. */
+  function tick() {
+    if (over || disposed) return;
+    bus.emit('clock', clock.snapshot());
+    paint();
+    // OUR reading says a flag is down. We do not act on that; we ask the
+    // server to look at its own clock, once, and wait for its verdict.
+    const down = clock.flagged();
+    if (down && !claimedTimeout) {
+      claimedTimeout = true;
+      claim();
+    }
+    // He has been gone for as long as the server needs him to be. Ask it to
+    // say so - once, and if it says "not yet" (its count of his silence began
+    // later than ours), again on the backoff ladder, and no more than the
+    // ladder has rungs. A spell that outlasts the ladder is left to the poll's
+    // `abandon` event, if he ever comes back to be claimed by.
+    const t = monoNow();
+    if (silence && !silence.busy && silence.attempts < BACKOFF_MS.length
+      && t - silence.since >= ABANDON_MS && t >= silence.nextAt) {
+      const spell = silence;
+      spell.busy = true;
+      spell.attempts += 1;
+      claim().then((granted) => {
+        spell.busy = false;
+        if (granted) return;
+        spell.nextAt = monoNow() + BACKOFF_MS[Math.min(spell.attempts - 1, BACKOFF_MS.length - 1)];
+      });
+    }
+  }
+
   function startTicker() {
     if (ticker || disposed) return;
-    ticker = setInterval(() => {
-      if (over) return;
-      bus.emit('clock', clock.snapshot());
-      paint();
-      // OUR reading says a flag is down. We do not act on that; we ask the
-      // server to look at its own clock, once, and wait for its verdict.
-      const down = clock.flagged();
-      if (down && !claimedTimeout) {
-        claimedTimeout = true;
-        api.claimTimeout(matchId).catch(() => {});
-      }
-    }, TICK_MS);
+    ticker = setInterval(tick, TICK_MS);
     if (ticker.unref) ticker.unref();
+  }
+
+  /** The server's word on whether he is still there, from whichever answer carried it. */
+  function noteOpponent(flag) {
+    if (flag === undefined) return;
+    const on = flag !== false;
+    if (on === opponentOnline) return;
+    opponentOnline = on;
+    silence = on ? null : { since: monoNow(), attempts: 0, nextAt: 0, busy: false };
+    bus.emit('opponent', { online: on });
   }
 
   function startHeartbeat() {
@@ -353,7 +425,9 @@ export function createOnlineMatch({
       // Only when the poll has gone quiet. A healthy match never gets here.
       if (Date.now() - lastContactMs < HEARTBEAT_MS) return;
       lastContactMs = Date.now();
-      api.heartbeat(matchId).catch(() => {});
+      api.heartbeat(matchId)
+        .then((res) => { if (res && res.ok && res.data) noteOpponent(res.data.opponent_online); })
+        .catch(() => {});
     }, HEARTBEAT_MS);
     if (beat.unref) beat.unref();
   }
@@ -640,10 +714,7 @@ export function createOnlineMatch({
   function applyEnvelope(data) {
     if (!data || typeof data !== 'object') return 'resync';
     if (Number.isFinite(Number(data.server_now_ms))) clock.noteServerNow(Number(data.server_now_ms));
-    if (data.opponent_online !== undefined) {
-      const on = data.opponent_online !== false;
-      if (on !== opponentOnline) { opponentOnline = on; bus.emit('opponent', { online: on }); }
-    }
+    noteOpponent(data.opponent_online);
     const list = Array.isArray(data.events) ? data.events : [];
     // Ordered by seq before anything is applied: the gap check is only worth
     // having if the stream it checks is actually in order.
@@ -767,9 +838,46 @@ export function createOnlineMatch({
     api.resign(matchId).catch(() => {});
   }
 
-  function offerDraw() { if (!over) api.draw(matchId, 'offer').catch(() => {}); }
+  /**
+   * The draw verbs. Our own offer and our own decline are noted locally at
+   * once, so a HUD reading `drawOffer()` on the click sees the state the
+   * player just made rather than waiting a poll for the echo. Neither is a
+   * result, so neither decides anything: the server's `draw_offer` and
+   * `draw_decline` events say the same thing a moment later, and a refusal
+   * (409 already_offered, a match that ended first) is corrected by the next
+   * state that comes down, which applyState re-derives from `draw_offer`.
+   */
+  function offerDraw() {
+    if (over) return;
+    if (drawOffer !== 'them') drawOffer = 'me';
+    api.draw(matchId, 'offer').catch(() => {});
+  }
   function acceptDraw() { if (!over) api.draw(matchId, 'accept').catch(() => {}); }
-  function declineDraw() { if (!over) api.draw(matchId, 'decline').catch(() => {}); }
+  function declineDraw() {
+    if (over) return;
+    if (drawOffer === 'them') drawOffer = null;
+    api.draw(matchId, 'decline').catch(() => {});
+  }
+
+  /**
+   * The game as a record for the shelf, in hotseat.record()'s shape exactly -
+   * moves in SAN off the referee's own history, plies, the result if there is
+   * one, where the clocks stood - plus `me`. door/store.js keys win and loss
+   * off the seat, and the seat this driver ended in is the server's word (see
+   * `me`), which the lobby's guess at the deal may not have been.
+   */
+  function record() {
+    let moves = [];
+    try { moves = rules.chess.history(); } catch (err) { moves = []; }
+    const s = clock.snapshot();
+    return {
+      moves,
+      plies: moves.length,
+      result: over ? { result: over.result, winner: over.winner === undefined ? null : over.winner, reason: over.reason || null } : null,
+      clocks: { w: s.w, b: s.b, total: s.total },
+      me,
+    };
+  }
 
   /* --------------------------------------------------------------- lifecycle */
 
@@ -810,6 +918,7 @@ export function createOnlineMatch({
     canPick,
     legalTargets,
     resign,
+    record,
     plies: () => rules.ply(),
     turn: () => rules.turn(),
     isOver: () => !!over,
@@ -829,7 +938,7 @@ export function createOnlineMatch({
     offerDraw,
     acceptDraw,
     declineDraw,
-    claimTimeout: () => api.claimTimeout(matchId).catch(() => {}),
+    claimTimeout: claim,
     /** 'me' when we offered, 'them' when he did, null when nothing stands. */
     drawOffer: () => drawOffer,
     /** The server's last word on whether he is still there. */
@@ -844,5 +953,7 @@ export function createOnlineMatch({
     _applyEnvelope: applyEnvelope,
     _applyState: applyState,
     _inFlight: () => inFlight,
+    _tick: tick,
+    _silence: () => silence,
   };
 }

--- a/ConditioningControlPanel/Resources/web/piecebypiece/net/online.js
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/net/online.js
@@ -47,6 +47,23 @@ export function createDriverSwitch(initial) {
     result() { return cur.result(); },
     autoRemaining() { return cur.autoRemaining ? cur.autoRemaining() : 0; },
     reset(...a) { return cur.reset ? cur.reset(...a) : undefined; },
+    /**
+     * The game for the shelf. The door reads this on gameover, so a driver
+     * without one hands back an empty game rather than a TypeError - but both
+     * drivers have one, and forwarding it is what makes the shelf keep moves.
+     */
+    record(...a) { return cur.record ? cur.record(...a) : { moves: [], plies: 0, result: null, clocks: null }; },
+
+    // --- what only an online seat answers; a hotseat gets the quiet no-op ---
+    // The HUD holds this switch, never the driver, so the draw verbs have to
+    // come through here to reach the seat at all.
+    offerDraw(...a) { return cur.offerDraw ? cur.offerDraw(...a) : undefined; },
+    acceptDraw(...a) { return cur.acceptDraw ? cur.acceptDraw(...a) : undefined; },
+    declineDraw(...a) { return cur.declineDraw ? cur.declineDraw(...a) : undefined; },
+    /** 'me' | 'them' | null online; null in a hotseat, where nobody offers anybody anything. */
+    drawOffer() { return cur.drawOffer ? cur.drawOffer() : null; },
+    /** The server's last word on the opponent; a hotseat opponent is always here. */
+    opponentOnline() { return cur.opponentOnline ? cur.opponentOnline() : true; },
 
     /** The driver underneath, for anything that genuinely needs the real one. */
     get current() { return cur; },
@@ -66,6 +83,24 @@ export function createDriverSwitch(initial) {
       cur = next;
       if (old && typeof old.dispose === 'function') {
         try { old.dispose(); } catch (err) { console.warn('[pbp] old driver dispose threw', err); }
+      }
+      return cur;
+    },
+
+    /**
+     * Put the hotseat back. The seat it was holding for the page is the one
+     * the page started with, never disposed (a hotseat has nothing to stop),
+     * and it is what "play here" after an online game has to be dealt against:
+     * reset-and-start on a FINISHED online seat resyncs the finished match and
+     * fires its gameover a second time. Idempotent - the hotseat in the chair
+     * already is simply left there.
+     */
+    switchBack() {
+      if (cur === initial) return cur;
+      const old = cur;
+      cur = initial;
+      if (old && typeof old.dispose === 'function') {
+        try { old.dispose(); } catch (err) { console.warn('[pbp] online driver dispose threw', err); }
       }
       return cur;
     },

--- a/ConditioningControlPanel/Resources/web/piecebypiece/smoke/door-shot.mjs
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/smoke/door-shot.mjs
@@ -7,6 +7,14 @@
  * shelf, a replay, the profile and the end card without a host. ONE browser
  * at a time, as shoot.mjs insists.
  *
+ * The last five are the online seat's furniture and the host's states, which
+ * a plain browser cannot reach on its own: an online game is dealt against a
+ * fake transport planted through net/api.js's setTransport (the same seam
+ * online-smoke.mjs uses), so the resign / draw buttons and his standing offer
+ * can be photographed, and the hotseat shot right after proves the block is
+ * absent there; door.debug.host stands in for the desktop for the signed-out
+ * lobby and the read-only profile name.
+ *
  *   node smoke/door-shot.mjs [--out DIR] [--port 8823]
  * ==========================================================================*/
 
@@ -33,6 +41,48 @@ const SEED_SHELF = `(() => { const d = window.PBP.door.debug.shelf; window.local
   d.save({ id: 'g3', at: new Date(Date.now() - 2 * 86400e3).toISOString(), mode: 'hotseat', me: null, opponent: 'a friend here', moves: ['e4','c5','Nf3','d6','d4','cxd4','Nxd4','Nf6','Nc3','a6'], plies: 10, result: { result: 'draw', winner: null, reason: 'agreement' }, durationMs: 480e3, captures: { w: 1, b: 1 } });
   return 'shelf seeded'; })()`;
 
+/**
+ * An online seat with a server behind it that is really a closure: GET match
+ * answers a live 10+0 game with us as white, the events long poll answers
+ * empty after a real wait (so the pump does not spin), and every verb is a
+ * 200. DRAW is 'b' to have his offer standing in the state, else null.
+ */
+const MOCK_NET = (draw, then = '') => `(async () => {
+  const a = await import('./net/api.js');
+  const now = Date.now();
+  const calls = [];
+  const state = { ok: true, id: 'm_shot', you: 'w',
+    white: { id: 'p_me', display_name: 'you', rating: 1200, self: true, online: true },
+    black: { id: 'p_velvet', display_name: 'velvet', rating: 1301, self: false, online: true },
+    time_control: { initial_ms: 600000, increment_ms: 0 },
+    fen: 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1', moves: [],
+    clocks: { w_ms: 600000, b_ms: 600000, turn: 'w', server_now_ms: now, turn_started_ms: now },
+    status: 'live', result: null, draw_offer: ${JSON.stringify(draw)}, seq: 0, started_ms: now };
+  a.setTransport(async (m, p) => {
+    calls.push(m + ' ' + p.split('?')[0]);
+    if (p.includes('/events')) {
+      await new Promise((r) => setTimeout(r, 2000));
+      return { status: 200, body: JSON.stringify({ ok: true, seq: 0, server_now_ms: Date.now(), status: 'live', events: [], opponent_online: true }) };
+    }
+    if (p.includes('/match/')) return { status: 200, body: JSON.stringify(state) };
+    return { status: 200, body: '{"ok":true}' };
+  });
+  window.PBP.door.debug.matched({ id: 'm_shot', opponent: { id: 'p_velvet', name: 'velvet' }, side: 'w', clockMs: 600000, state });
+  window.PBP.door.debug.act('go');
+  await new Promise((r) => setTimeout(r, 400));
+  ${then}
+  const posts = calls.filter((c) => c.startsWith('POST')).map((c) => c.split('/').pop());
+  return JSON.stringify({ online: window.PBP.game.isOnline, hud: window.PBP.board.hud.debug().online, posts });
+})()`;
+
+/** One tap on each: the draw goes out, the resign only asks. The posts in the log are the proof. */
+const TAP_DRAW_THEN_RESIGN = `document.getElementById('hud-draw').click(); document.getElementById('hud-resign').click(); await new Promise((r) => setTimeout(r, 100));`;
+
+/** A desktop host, as far as the door can tell: hosted, and either signed in as Bambi or signed out. */
+const FAKE_HOST = (signedIn) => `window.PBP.door.debug.host({ isHosted: true,
+  identity: () => (${signedIn ? "{ unifiedId: 'u_shot0000', displayName: 'Bambi', appVersion: '0', online: true }" : "{ unifiedId: '', displayName: '', appVersion: '0', online: false }"}),
+  whenIdentity: async () => (${signedIn ? "{ unifiedId: 'u_shot0000', displayName: 'Bambi', appVersion: '0', online: true }" : "{ unifiedId: '', displayName: '', appVersion: '0', online: false }"}) })`;
+
 const SHOTS = [
   ['01-menu', 'menu', 'window.PBP.door.debug.state()'],
   ['02-lobby', 'lobby', 'window.PBP.door.debug.state()'],
@@ -44,13 +94,24 @@ const SHOTS = [
   ['08-profile', 'profile', `${SEED_SHELF}; window.PBP.door.show('profile'); 'profile'`],
   ['09-end', 'menu', `(() => { window.PBP.door.debug.act('hotseat'); for (const m of [['e2','e4'],['e7','e5'],['d1','h5'],['b8','c6'],['f1','c4'],['g8','f6'],['h5','f7']]) window.PBP.game.tryMove(m[0], m[1]); return 'mated'; })()`],
   ['10-end-online-loss', 'menu', `(() => { window.PBP.door.debug.matched({ id: 'gx', opponent: { id: 'm-velvet', name: 'velvet' }, side: 'b', clockMs: 900000 }); window.PBP.door.debug.act('go'); for (const m of [['e2','e4'],['e7','e5'],['d1','h5'],['b8','c6'],['f1','c4'],['g8','f6'],['h5','f7']]) window.PBP.game.tryMove(m[0], m[1]); return 'lost as black'; })()`],
+  // the online seat's furniture: resign / offer draw, then his offer standing
+  ['11-online-hud', 'menu', MOCK_NET(null), '1200'],
+  ['12-online-draw-ask', 'menu', MOCK_NET('b'), '1200'],
+  // and the same corner in a hotseat game, where there is nobody to say it to
+  ['13-hotseat-no-online', 'menu', `(async () => { window.PBP.door.debug.act('hotseat'); await new Promise((r) => setTimeout(r, 300)); return JSON.stringify({ online: window.PBP.game.isOnline, hud: window.PBP.board.hud.debug().online }); })()`, '1200'],
+  // hosted and signed out: one line, quick match off, never the mock's room
+  ['14-lobby-signed-out', 'menu', `(async () => { ${FAKE_HOST(false)}; window.PBP.door.show('lobby'); await new Promise((r) => setTimeout(r, 300)); return window.PBP.door.debug.state(); })()`],
+  // hosted and signed in: the account names the player, so the name is shown, not typed
+  ['15-profile-hosted', 'menu', `(async () => { ${FAKE_HOST(true)}; window.PBP.settings.playerName = 'Bambi'; ${SEED_SHELF}; window.PBP.door.show('profile'); await new Promise((r) => setTimeout(r, 200)); return { readonly: !!document.querySelector('.door-name input[readonly]'), name: document.querySelector('.door-name input').value }; })()`],
+  // one tap on offer draw and one on resign: "draw offered" stands, "resign?" is asked, and posts holds a draw and NO resign
+  ['16-online-resign-ask', 'menu', MOCK_NET(null, TAP_DRAW_THEN_RESIGN), '1200'],
 ];
 
 let failed = 0;
-for (const [name, screen, evalExpr] of SHOTS) {
+for (const [name, screen, evalExpr, afterMs] of SHOTS) {
   const url = `http://127.0.0.1:${port}/piecebypiece/index.html?lobby=mock&seed=7&media=none&screen=${screen}`;
   const file = path.join(out, name + '.png');
-  const after = name.startsWith('09') || name.startsWith('10') ? '2600' : '900';
+  const after = afterMs || (name.startsWith('09') || name.startsWith('10') ? '2600' : '900');
   const r = spawnSync('node', [path.join(here, 'shot.mjs'), '--url', url, '--out', file, '--wait', '5000', '--eval', evalExpr, '--after', after, '--port', String(9300)], { encoding: 'utf8' });
   const lines = (r.stdout || '').trim().split('\n').filter((l) => /screenshot|eval|ERROR|clean/.test(l));
   console.log(`[${name}] ${lines.join(' | ')}`);

--- a/ConditioningControlPanel/Resources/web/piecebypiece/smoke/online-smoke.mjs
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/smoke/online-smoke.mjs
@@ -37,6 +37,18 @@
  *   what door/door.js calls, including the shapes it never sees a server
  *   produce - an outgoing challenge accepted with no colour attached to it.
  *
+ *   THE SWITCH GOES BOTH WAYS. net/online.js puts an online seat in the chair
+ *   and, afterwards, puts the hotseat back - disposing the seat - and forwards
+ *   record() from whichever is there, or the shelf keeps games with no moves.
+ *
+ *   ABANDONMENT IS CLAIMED. Sixty seconds of the server saying he is not there
+ *   (ABANDON_MS, the server's own number) is one claim, retried on the backoff
+ *   ladder while the server says "not yet", and a fresh spell of silence is a
+ *   fresh claim. Never one a tick.
+ *
+ *   THE LOBBY POLLS UNDER THE CAPS. The list every tick at POLL_MS, the
+ *   challenge list every other one, except while one of ours is out.
+ *
  * The whole thing runs on an injected clock and an injected sleep, so it is
  * deterministic and finishes in milliseconds.
  * ==========================================================================*/
@@ -44,8 +56,10 @@
 import { Chess } from '../vendor/chess.js';
 import { createBus } from '../game/events.js';
 import * as api from '../net/api.js';
-import { createOnlineMatch, createRemoteClock, parseUci, toUci } from '../net/match.js';
-import { createServerLobby } from '../net/lobbyServer.js';
+import { createOnlineMatch, createRemoteClock, parseUci, toUci, ABANDON_MS } from '../net/match.js';
+import { createServerLobby, POLL_MS, CHALLENGE_TICKS } from '../net/lobbyServer.js';
+import { createDriverSwitch } from '../net/online.js';
+import { createHotseat } from '../game/hotseat.js';
 
 let passed = 0;
 const failures = [];
@@ -94,6 +108,8 @@ function createFakeServer({
     drawOffer: null,
     left: { w: initialMs, b: initialMs },
     turnStarted: SERVER_EPOCH,
+    opponentOnline: true,      // what the events envelope reports
+    grantAbandon: false,       // when set, claim_timeout finds him gone and says so
   };
   let nowMs = SERVER_EPOCH;
   const calls = [];          // every path the client asked for, for assertions
@@ -194,7 +210,7 @@ function createFakeServer({
         server_now_ms: nowMs,
         events: events.filter((e) => e.seq > since),
         status: state.status,
-        opponent_online: true,
+        opponent_online: state.opponentOnline,
       });
     }
 
@@ -235,8 +251,17 @@ function createFakeServer({
       return json(200, { ok: true, seq: state.seq });
     }
 
-    if (method === 'POST' && route === `${M}/heartbeat`) return json(200, { ok: true, opponent_online: true, seq: state.seq, status: state.status });
-    if (method === 'POST' && route === `${M}/claim_timeout`) return json(409, { error: 'not_expired', clocks: clocks() });
+    if (method === 'POST' && route === `${M}/heartbeat`) return json(200, { ok: true, opponent_online: state.opponentOnline, seq: state.seq, status: state.status });
+    if (method === 'POST' && route === `${M}/claim_timeout`) {
+      // Condition 2 of the contract's claim_timeout: the opponent unseen for
+      // ABANDON_MS. The caller wins. Otherwise "not yet", with the clocks.
+      if (state.grantAbandon && state.status === 'live') {
+        const result = finishWith(you, 'abandon');
+        push('abandon', { side: you === 'w' ? 'b' : 'w', result });
+        return json(200, snapshot());
+      }
+      return json(409, { error: 'not_expired', clocks: clocks() });
+    }
 
     return json(404, {});
   }
@@ -720,50 +745,51 @@ function harness(opts = {}) {
 /* ---------------------------------------------------------------------------
  * 13. THE LOBBY, WEARING THE FRONT DOOR'S INTERFACE
  * ------------------------------------------------------------------------- */
-{
-  // Enough of the lobby surface to answer a door, with the contract's shapes.
-  function lobbyServerFixture() {
-    const lobby = [
-      { id: 'p_aaaaaaaaaaaa', display_name: 'velvet', rating: 1301, since_ms: 1000, self: false, time_control: { initial_ms: 600000, increment_ms: 0 } },
-      { id: 'p_bbbbbbbbbbbb', display_name: 'moth', rating: null, since_ms: 500, self: false, time_control: { initial_ms: 600000, increment_ms: 0 } },
-      { id: 'p_meeeeeeeeeee', display_name: 'you', rating: 1200, since_ms: 2000, self: true, time_control: { initial_ms: 600000, increment_ms: 0 } },
-    ];
-    const st = { incoming: [], outgoing: [], quickPaired: null, calls: [], matchYou: 'b' };
-    const json = (status, obj) => ({ status, body: JSON.stringify(obj) });
-    async function transport(method, path, body) {
-      const route = String(path).split('?')[0];
-      st.calls.push(`${method} ${route}`);
-      if (route === `${api.BASE}/lobby/enter`) return json(200, { ok: true, ticket: 't_1', expires_in_sec: 180 });
-      if (route === `${api.BASE}/lobby/leave`) return json(200, { ok: true, left: true });
-      if (route === `${api.BASE}/lobby`) return json(200, { ok: true, players: lobby, server_now_ms: 1 });
-      if (route === `${api.BASE}/challenges`) return json(200, { ok: true, incoming: st.incoming, outgoing: st.outgoing });
-      if (route === `${api.BASE}/quick`) {
-        return st.quickPaired ? json(200, { ok: true, match_id: st.quickPaired, color: 'w' })
-          : json(200, { ok: true, waiting: true, queued_ms: 100 });
-      }
-      if (route === `${api.BASE}/challenge`) {
-        if (body.target === 'p_gonegonegone') return json(404, { error: 'no_such_player' });
-        st.outgoing = [{ challenge_id: 'c_mine', to: lobby[0], time_control: { initial_ms: 600000, increment_ms: 0 }, status: 'pending' }];
-        return json(200, { ok: true, challenge_id: 'c_mine', expires_in_sec: 300 });
-      }
-      if (route === `${api.BASE}/challenge/c_theirs/accept`) return json(200, { ok: true, match_id: 'm_accepted', color: 'b' });
-      if (route.startsWith(`${api.BASE}/challenge/`) && route.endsWith('/decline')) return json(200, { ok: true, declined: true });
-      if (route.startsWith(`${api.BASE}/match/`)) {
-        const id = route.split('/')[4];
-        return json(200, {
-          ok: true, id, you: st.matchYou,
-          white: { id: 'p_aaaaaaaaaaaa', display_name: 'velvet', rating: 1301, self: st.matchYou === 'w', online: true },
-          black: { id: 'p_meeeeeeeeeee', display_name: 'you', rating: 1200, self: st.matchYou === 'b', online: true },
-          time_control: { initial_ms: 600000, increment_ms: 0 },
-          fen: new Chess().fen(), moves: [], clocks: { w_ms: 600000, b_ms: 600000, turn: 'w', server_now_ms: 1, turn_started_ms: 1 },
-          status: 'live', result: null, draw_offer: null, seq: 0, started_ms: 1,
-        });
-      }
-      return json(404, {});
-    }
-    return { transport, st };
-  }
 
+/** Enough of the lobby surface to answer a door, with the contract's shapes. */
+function lobbyServerFixture() {
+  const lobby = [
+    { id: 'p_aaaaaaaaaaaa', display_name: 'velvet', rating: 1301, since_ms: 1000, self: false, time_control: { initial_ms: 600000, increment_ms: 0 } },
+    { id: 'p_bbbbbbbbbbbb', display_name: 'moth', rating: null, since_ms: 500, self: false, time_control: { initial_ms: 600000, increment_ms: 0 } },
+    { id: 'p_meeeeeeeeeee', display_name: 'you', rating: 1200, since_ms: 2000, self: true, time_control: { initial_ms: 600000, increment_ms: 0 } },
+  ];
+  const st = { incoming: [], outgoing: [], quickPaired: null, calls: [], matchYou: 'b' };
+  const json = (status, obj) => ({ status, body: JSON.stringify(obj) });
+  async function transport(method, path, body) {
+    const route = String(path).split('?')[0];
+    st.calls.push(`${method} ${route}`);
+    if (route === `${api.BASE}/lobby/enter`) return json(200, { ok: true, ticket: 't_1', expires_in_sec: 180 });
+    if (route === `${api.BASE}/lobby/leave`) return json(200, { ok: true, left: true });
+    if (route === `${api.BASE}/lobby`) return json(200, { ok: true, players: lobby, server_now_ms: 1 });
+    if (route === `${api.BASE}/challenges`) return json(200, { ok: true, incoming: st.incoming, outgoing: st.outgoing });
+    if (route === `${api.BASE}/quick`) {
+      return st.quickPaired ? json(200, { ok: true, match_id: st.quickPaired, color: 'w' })
+        : json(200, { ok: true, waiting: true, queued_ms: 100 });
+    }
+    if (route === `${api.BASE}/challenge`) {
+      if (body.target === 'p_gonegonegone') return json(404, { error: 'no_such_player' });
+      st.outgoing = [{ challenge_id: 'c_mine', to: lobby[0], time_control: { initial_ms: 600000, increment_ms: 0 }, status: 'pending' }];
+      return json(200, { ok: true, challenge_id: 'c_mine', expires_in_sec: 300 });
+    }
+    if (route === `${api.BASE}/challenge/c_theirs/accept`) return json(200, { ok: true, match_id: 'm_accepted', color: 'b' });
+    if (route.startsWith(`${api.BASE}/challenge/`) && route.endsWith('/decline')) return json(200, { ok: true, declined: true });
+    if (route.startsWith(`${api.BASE}/match/`)) {
+      const id = route.split('/')[4];
+      return json(200, {
+        ok: true, id, you: st.matchYou,
+        white: { id: 'p_aaaaaaaaaaaa', display_name: 'velvet', rating: 1301, self: st.matchYou === 'w', online: true },
+        black: { id: 'p_meeeeeeeeeee', display_name: 'you', rating: 1200, self: st.matchYou === 'b', online: true },
+        time_control: { initial_ms: 600000, increment_ms: 0 },
+        fen: new Chess().fen(), moves: [], clocks: { w_ms: 600000, b_ms: 600000, turn: 'w', server_now_ms: 1, turn_started_ms: 1 },
+        status: 'live', result: null, draw_offer: null, seq: 0, started_ms: 1,
+      });
+    }
+    return json(404, {});
+  }
+  return { transport, st };
+}
+
+{
   const fx = lobbyServerFixture();
   api.setTransport(fx.transport);
   const bus = createBus();
@@ -836,6 +862,167 @@ function harness(opts = {}) {
 
   lobby.dispose();
   eq('a page with no host and no account gets no server lobby', createServerLobby({ api }), null);
+}
+
+/* ---------------------------------------------------------------------------
+ * 14. THE SWITCH, BOTH WAYS
+ *
+ * boot.js hands everything the switch, never a driver. It has to reach the
+ * online seat while one is there, and hand the hotseat back - with the seat
+ * disposed - when the next game is dealt "here", or "play here" after an
+ * online game resets a finished seat and fires its gameover again.
+ * ------------------------------------------------------------------------- */
+{
+  const h = harness();
+  const hot = createHotseat({ bus: h.bus, board: h.board });
+  const sw = createDriverSwitch(hot);
+  eq('the hotseat starts in the chair', [sw.isOnline, sw.current === hot], [false, true]);
+  eq('record() is forwarded from a hotseat', sw.record().plies, 0);
+  eq('the draw verbs answer quietly in a hotseat', [sw.drawOffer(), sw.offerDraw()], [null, undefined]);
+
+  let disposed = false;
+  const realDispose = h.game.dispose;
+  h.game.dispose = () => { disposed = true; realDispose(); };
+  sw.switchTo(h.game);
+  eq('an online seat reads as online', sw.isOnline, true);
+  eq('and as one seat', sw.seats, ['w']);
+  await h.game._resync();
+  h.server.play('e2e4');
+  h.game._applyEnvelope({ events: h.server.events.slice(), server_now_ms: h.server.now() });
+  const rec = sw.record();
+  eq('record() is forwarded from the online seat, moves in SAN', rec.moves, ['e4']);
+  eq('in hotseat.record()\'s shape', Object.keys(rec).sort().join(','), 'clocks,me,moves,plies,result');
+  eq('with the seat on it', rec.me, 'w');
+  eq('and no result while it is live', rec.result, null);
+  eq('the draw verbs reach the seat', typeof sw.offerDraw === 'function' && sw.drawOffer(), null);
+  sw.offerDraw();
+  eq('our own offer is known at once, not a poll later', sw.drawOffer(), 'me');
+
+  const back = sw.switchBack();
+  eq('switchBack puts the hotseat back', [back === hot, sw.current === hot, sw.isOnline], [true, true, false]);
+  ok('and the online seat was disposed on the way out', disposed);
+  eq('the switch is the hotseat\'s again', sw.seats, ['w', 'b']);
+  eq('switching back twice is nothing', sw.switchBack() === hot, true);
+  api.setTransport(null);
+}
+
+/* ---------------------------------------------------------------------------
+ * 15. ABANDONMENT
+ *
+ * The server says he is gone; sixty seconds later we ask it to say so on the
+ * record. Once - and if it says not yet, again on the backoff ladder - and a
+ * fresh spell of silence is a fresh claim. The ticker is driven by hand.
+ * ------------------------------------------------------------------------- */
+{
+  const h = harness();
+  await h.game._resync();
+  const claims = () => h.server.calls.filter((c) => c.endsWith('/claim_timeout')).length;
+  const envelope = (online) => h.game._applyEnvelope({ events: [], server_now_ms: h.server.now(), opponent_online: online });
+
+  eq('the client\'s number is the server\'s', ABANDON_MS, 60000);
+  h.game._tick();
+  eq('while he is here nothing is claimed', claims(), 0);
+
+  envelope(false);
+  eq('the page hears he has gone', h.of('opponent').pop().payload.online, false);
+  ok('and the seat starts counting', h.game._silence() !== null);
+  h.game._tick();
+  eq('nothing is claimed at once', claims(), 0);
+  h.tick(ABANDON_MS - 1000);
+  h.game._tick();
+  eq('nor a second before the server would agree', claims(), 0);
+  h.tick(1000);
+  h.game._tick();
+  eq('at sixty seconds of silence, one claim goes out', claims(), 1);
+  h.game._tick();
+  h.game._tick();
+  eq('and the next ticks do not repeat it', claims(), 1);
+  await settle();
+  // The server said not_expired: its count of his silence started later than
+  // ours. The next ask waits the first step of the ladder, not the next tick.
+  h.game._tick();
+  eq('a refused claim is not retried on the very next tick', claims(), 1);
+  h.tick(499);
+  h.game._tick();
+  eq('nor a moment early', claims(), 1);
+  h.tick(1);
+  h.game._tick();
+  eq('but after the first backoff step it is', claims(), 2);
+  await settle();
+  ok('the board is still live: the server never said otherwise', !h.game.isOver());
+
+  envelope(true);
+  eq('his return ends the spell', h.game._silence(), null);
+  h.tick(5000);
+  h.game._tick();
+  eq('and nothing more is claimed for it', claims(), 2);
+
+  envelope(false);
+  h.tick(ABANDON_MS);
+  h.server.state.grantAbandon = true;
+  h.game._tick();
+  eq('a fresh silence is a fresh claim', claims(), 3);
+  await settle();
+  ok('the server\'s verdict finishes the board here, without waiting for the poll', h.game.isOver());
+  eq('as an abandonment in our favour', [h.game.result().result, h.game.result().winner], ['abandon', 'w']);
+  eq('the page was told once', h.of('gameover').length, 1);
+  h.game._tick();
+  eq('and a finished game claims nothing', claims(), 3);
+  api.setTransport(null);
+}
+
+/* ---------------------------------------------------------------------------
+ * 16. THE LOBBY'S POLL, AGAINST THE CAPS
+ *
+ * GET /lobby is 30/min/user and GET /challenges 30/min/user. The tick is
+ * driven through the injectable timer, so the cadence is counted, not timed.
+ * ------------------------------------------------------------------------- */
+{
+  const fx = lobbyServerFixture();
+  api.setTransport(fx.transport);
+  const queue = [];
+  const timer = {
+    set(fn, ms) { const t = { fn, ms }; queue.push(t); return t; },
+    clear(t) { const i = queue.indexOf(t); if (i >= 0) queue.splice(i, 1); },
+  };
+  const lobby = createServerLobby({ api, force: true, timer });
+  const count = (route) => fx.st.calls.filter((c) => c === `GET ${api.BASE}/${route}`).length;
+  /** Fire the armed tick and let its refresh run to the point of re-arming. */
+  const fire = async () => {
+    const t = queue.shift();
+    t.fn();
+    for (let i = 0; i < 60 && queue.length === 0; i++) await Promise.resolve();
+  };
+
+  ok('the poll is slower than the list cap (30/min is 2s)', POLL_MS > 2000);
+  eq('and is the number the contract\'s freshness allows', POLL_MS, 3000);
+  eq('the challenge list is asked for every other tick', CHALLENGE_TICKS, 2);
+
+  await lobby.enter({ name: 'you' });
+  eq('enter asks for the list and the challenges once', [count('lobby'), count('challenges')], [1, 1]);
+  eq('and arms the poll at POLL_MS', [queue.length, queue[0] && queue[0].ms], [1, POLL_MS]);
+  await fire();
+  eq('tick 2: the list, not the challenges', [count('lobby'), count('challenges')], [2, 1]);
+  await fire();
+  eq('tick 3: both', [count('lobby'), count('challenges')], [3, 2]);
+  await fire();
+  eq('tick 4: the list alone again', [count('lobby'), count('challenges')], [4, 2]);
+  ok('the poll re-arms itself each time', queue.length === 1);
+
+  // Our own challenge is out: the challenge list is the only place its answer
+  // can land, so it is watched every tick until it does.
+  const asked = lobby.challenge('p_aaaaaaaaaaaa');
+  await settle(6);
+  await fire();
+  await fire();
+  eq('an outgoing challenge is watched every tick', [count('lobby'), count('challenges')], [6, 4]);
+  lobby.cancel();
+  try { await asked; } catch (e) { /* cancelled, as intended */ }
+  await fire();
+  await fire();
+  eq('and the cadence resumes once it is gone', count('challenges') - 4 <= 1, true);
+  lobby.dispose();
+  eq('dispose disarms the poll', queue.length, 0);
 }
 
 /* ------------------------------------------------------------------------- */

--- a/ConditioningControlPanel/Resources/web/piecebypiece/smoke/room-smoke.mjs
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/smoke/room-smoke.mjs
@@ -12,6 +12,7 @@
  * ==========================================================================*/
 
 import { ROOM as T, domeColorAt, yawFor, glowTargets, createTweens, easeOutCubic } from '../board/roomMath.js';
+import { FRAME, fovForAspect, fitScaleFor } from '../board/frame.js';
 
 let passed = 0;
 function ok(cond, what) {
@@ -96,6 +97,29 @@ ok(T.glowHit > T.glowRest && T.glowRest > T.glowOver && T.glowOver > T.glowOff, 
   tw.to(yaw, 'value', 0, T.leanMs);
   tw.settle();
   ok(yaw.value === 0 && tw.count() === 0, 'settle jumps to the end');
+}
+
+// --- the frame: the whole board on any screen --------------------------------
+{
+  const wide = 1280 / 860;
+  ok(fovForAspect(wide) === FRAME.fovMin, 'the wide window keeps the 40 degree lens');
+  ok(fitScaleFor(wide, fovForAspect(wide)) === 1, 'and its presets stand where they always did');
+  const phone = 390 / 844;
+  const fov = fovForAspect(phone);
+  ok(fov === FRAME.fovMax, 'a phone held upright opens the lens to the cap');
+  const fit = fitScaleFor(phone, fov);
+  ok(fit > 1.5 && fit < 2.5, 'and stands the presets well back (' + fit.toFixed(2) + 'x)');
+  const half = Math.atan(Math.tan((fov * Math.PI) / 360) * phone);
+  ok(FRAME.base * fit * Math.tan(half) >= FRAME.reach * FRAME.margin - 1e-9, 'the a and h files are both inside the picture');
+  const square = fovForAspect(1);
+  ok(square > FRAME.fovMin && square < FRAME.fovMax, 'a square window sits between the two');
+  let prevFit = fitScaleFor(0.4, fovForAspect(0.4));
+  for (let a = 0.45; a <= 2.2; a += 0.05) {
+    const f = fitScaleFor(a, fovForAspect(a));
+    ok(f <= prevFit + 1e-9, 'a wider window never stands further back at ' + a.toFixed(2));
+    prevFit = f;
+  }
+  ok(fitScaleFor(NaN, NaN) >= 1 && Number.isFinite(fovForAspect(undefined)), 'garbage in, a sane lens out');
 }
 
 console.log('room smoke: ' + passed + ' checks passed');

--- a/ConditioningControlPanel/Resources/web/piecebypiece/smoke/room-smoke.mjs
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/smoke/room-smoke.mjs
@@ -1,0 +1,101 @@
+/* ============================================================================
+ * smoke/room-smoke.mjs - node checks for the room's numbers.
+ * No browser and no dependencies: run it with
+ *
+ *   node smoke/room-smoke.mjs
+ *
+ * Pins board/roomMath.js: the dome is plum at the horizon, pinker just above
+ * it and black overhead; the rig stands behind the mover; the turn tell hits
+ * full on frame one and rests at glowRest inside glowMs while the other edge
+ * waits; a tween never overshoots and a re-aimed tween starts from where it
+ * is. Exits non-zero on the first failure.
+ * ==========================================================================*/
+
+import { ROOM as T, domeColorAt, yawFor, glowTargets, createTweens, easeOutCubic } from '../board/roomMath.js';
+
+let passed = 0;
+function ok(cond, what) {
+  if (!cond) { console.log('FAIL ' + what); process.exit(1); }
+  passed++;
+}
+const lum = (c) => 0.2126 * c[0] + 0.7152 * c[1] + 0.0722 * c[2];
+const pink = (c) => c[0] - c[1];
+const near = (a, b, eps = 1e-6) => Math.abs(a - b) < eps;
+
+// --- the dome ---------------------------------------------------------------
+const atHorizon = domeColorAt(0);
+const atHaze = domeColorAt(T.hazeAt);
+const atZenith = domeColorAt(1);
+const below = domeColorAt(-1);
+ok(near(atHorizon[0], ((T.horizon >> 16) & 255) / 255), 'the horizon is the horizon colour');
+ok(pink(atHaze) > pink(atHorizon), 'the haze is pinker than the horizon');
+ok(lum(atZenith) < lum(atHaze) && lum(atZenith) < lum(atHorizon), 'overhead is the darkest');
+ok(lum(below) < lum(atHorizon), 'below the horizon is darker than the horizon');
+let prev = lum(atHaze);
+for (let h = T.hazeAt; h <= 1; h += 0.02) {
+  const l = lum(domeColorAt(h));
+  ok(l <= prev + 1e-9, 'the dome only darkens above the haze at ' + h.toFixed(2));
+  prev = l;
+}
+ok(T.fogNear < T.fogFar && T.fogFar < T.floorSize / 2, 'the fog ends before the floor does');
+ok(T.domeRadius < 120, 'the dome is inside the camera far plane');
+
+// --- the lean ---------------------------------------------------------------
+ok(yawFor('w') === 0, 'white keeps the rig where scene.js put it');
+ok(near(yawFor('b'), Math.PI), 'black gets the rig swung round');
+ok(yawFor(undefined) === 0, 'anything else reads as white');
+
+// --- the tell: targets ------------------------------------------------------
+const w = glowTargets('w');
+const b = glowTargets('b');
+const over = glowTargets(null);
+ok(w.w === T.glowRest && w.b === T.glowOff, 'white to move: white edge rests lit, black waits');
+ok(b.b === T.glowRest && b.w === T.glowOff, 'black to move: black edge rests lit, white waits');
+ok(over.w === T.glowOver && over.b === T.glowOver, 'game over: both edges dim alike');
+ok(T.glowHit > T.glowRest && T.glowRest > T.glowOver && T.glowOver > T.glowOff, 'hit > rest > over > off');
+
+// --- the tell: timeline -----------------------------------------------------
+{
+  const tw = createTweens();
+  const mat = { opacity: T.glowOff };
+  mat.opacity = T.glowHit;                       // frame one
+  tw.to(mat, 'opacity', T.glowRest, T.glowMs, easeOutCubic);
+  ok(mat.opacity === T.glowHit, 'full on the first frame');
+  let lo = Infinity, hi = -Infinity, t = 0;
+  while (tw.count()) {
+    tw.update(1 / 60); t += 1000 / 60;
+    lo = Math.min(lo, mat.opacity); hi = Math.max(hi, mat.opacity);
+  }
+  ok(mat.opacity === T.glowRest, 'and resting at glowRest at the end');
+  ok(lo >= T.glowRest - 1e-9 && hi <= T.glowHit + 1e-9, 'never outside hit..rest on the way');
+  ok(t <= T.glowMs + 1000 / 60 + 1e-6, 'done inside glowMs (+ one frame)');
+  // half way through the ease, it is already most of the way down
+  const tw2 = createTweens();
+  const m2 = { opacity: T.glowHit };
+  tw2.to(m2, 'opacity', T.glowRest, T.glowMs);
+  tw2.update(T.glowMs / 2000);
+  ok(m2.opacity < T.glowHit - 0.8 * (T.glowHit - T.glowRest), 'an ease-out: most of the drop is in the first half');
+}
+
+// --- the lean: timeline, and a re-aim mid-swing -----------------------------
+{
+  const tw = createTweens();
+  const yaw = { value: 0 };
+  tw.to(yaw, 'value', yawFor('b'), T.leanMs);
+  for (let i = 0; i < 10; i++) tw.update(1 / 60);       // 167 ms in
+  const midway = yaw.value;
+  ok(midway > 0 && midway < Math.PI, 'mid-swing the rig is between the two');
+  tw.to(yaw, 'value', yawFor('w'), T.leanMs);           // a take-back: aim home
+  ok(tw.count() === 1, 'a re-aim replaces the tween, never stacks one');
+  tw.update(0);
+  ok(near(yaw.value, midway), 'and starts from where the rig is');
+  while (tw.count()) tw.update(1 / 60);
+  ok(yaw.value === 0, 'then lands home');
+  tw.to(yaw, 'value', Math.PI, 0);
+  ok(yaw.value === Math.PI && tw.count() === 0, 'a zero-length tween lands at once (reduced motion)');
+  tw.to(yaw, 'value', 0, T.leanMs);
+  tw.settle();
+  ok(yaw.value === 0 && tw.count() === 0, 'settle jumps to the end');
+}
+
+console.log('room smoke: ' + passed + ' checks passed');

--- a/ConditioningControlPanel/Resources/web/piecebypiece/smoke/room-smoke.mjs
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/smoke/room-smoke.mjs
@@ -8,10 +8,19 @@
  * it and black overhead; the rig stands behind the mover; the turn tell hits
  * full on frame one and rests at glowRest inside glowMs while the other edge
  * waits; a tween never overshoots and a re-aimed tween starts from where it
- * is. Exits non-zero on the first failure.
+ * is. Then the room's answers: the capture dip starts at dipTo and is home
+ * by dipMs; the warmth is flat up to warmFrom and climbs to 1 without a step
+ * back; the breath is flat under breathAt and never deeper than breathDepth
+ * over it, on the vignette's own period; the game-over drain knows a win
+ * from a draw and lights the spot only for a winner; the shaft's level warms,
+ * drains and is capped from straight above. Exits non-zero on the first
+ * failure.
  * ==========================================================================*/
 
-import { ROOM as T, domeColorAt, yawFor, glowTargets, createTweens, easeOutCubic } from '../board/roomMath.js';
+import {
+  ROOM as T, domeColorAt, yawFor, glowTargets, createTweens, easeOutCubic,
+  warmthFor, breathFor, overTargets, shaftLevel,
+} from '../board/roomMath.js';
 import { FRAME, fovForAspect, fitScaleFor } from '../board/frame.js';
 
 let passed = 0;
@@ -120,6 +129,128 @@ ok(T.glowHit > T.glowRest && T.glowRest > T.glowOver && T.glowOver > T.glowOff, 
     prevFit = f;
   }
   ok(fitScaleFor(NaN, NaN) >= 1 && Number.isFinite(fovForAspect(undefined)), 'garbage in, a sane lens out');
+}
+
+// --- the capture dip ---------------------------------------------------------
+{
+  ok(T.dipMs === 440, 'the dip takes 440 ms');
+  ok(T.dipTo > 0 && T.dipTo < 1, 'and goes to a share of the key, not off');
+  const tw = createTweens();
+  const dip = { value: 1 };
+  dip.value = T.dipTo;                                    // the frame the man comes off
+  tw.to(dip, 'value', 1, T.dipMs, easeOutCubic);
+  ok(dip.value === T.dipTo, 'the dip starts at dipTo');
+  let t = 0, prevV = dip.value;
+  while (tw.count()) {
+    tw.update(1 / 60); t += 1000 / 60;
+    ok(dip.value >= prevV - 1e-9 && dip.value <= 1 + 1e-9, 'the key only recovers on the way back at ' + t.toFixed(0) + ' ms');
+    prevV = dip.value;
+  }
+  ok(dip.value === 1, 'and is back at 1');
+  ok(t <= T.dipMs + 1000 / 60 + 1e-6, 'by dipMs (+ one frame)');
+  // a second capture mid-recovery restarts it from dipTo, one tween, no stack
+  const tw2 = createTweens();
+  const d2 = { value: T.dipTo };
+  tw2.to(d2, 'value', 1, T.dipMs, easeOutCubic);
+  for (let i = 0; i < 6; i++) tw2.update(1 / 60);
+  ok(d2.value > T.dipTo, 'part way home');
+  d2.value = T.dipTo; tw2.to(d2, 'value', 1, T.dipMs, easeOutCubic);
+  ok(d2.value === T.dipTo && tw2.count() === 1, 'a second capture restarts the dip and never stacks');
+}
+
+// --- the warmth -------------------------------------------------------------
+{
+  ok(near(T.warmFrom, 0.25), 'the room stays plum for the first quarter of the meter');
+  ok(warmthFor(0) === 0 && warmthFor(T.warmFrom) === 0 && warmthFor(T.warmFrom / 2) === 0, 'no warmth at or below warmFrom');
+  ok(near(warmthFor(1), 1), 'full warmth at a full meter');
+  ok(warmthFor(-1) === 0 && near(warmthFor(2), 1) && warmthFor(NaN) === 0, 'garbage in, a clamped warmth out');
+  let prevW = 0;
+  for (let m = 0; m <= 1.0001; m += 0.01) {
+    const w = warmthFor(m);
+    ok(w >= prevW - 1e-12 && w >= 0 && w <= 1, 'the warmth only climbs at meter ' + m.toFixed(2));
+    prevW = w;
+  }
+  ok(warmthFor(0.95) > warmthFor(0.7) && warmthFor(0.7) > warmthFor(0.4), 'and climbs where the ramp does');
+  // the warm horizon is pinker than the plum one and still a horizon (dark)
+  const rgb = (hex) => [((hex >> 16) & 255) / 255, ((hex >> 8) & 255) / 255, (hex & 255) / 255];
+  ok(pink(rgb(T.warmHorizon)) > pink(rgb(T.horizon)), 'the warm horizon is pinker than the plum');
+  ok(lum(rgb(T.warmHorizon)) < 0.25, 'and still dark enough to be a horizon');
+  ok(pink(rgb(T.warmHaze)) > pink(rgb(T.haze)), 'the warm haze is pinker than the haze');
+  // the ease toward a 200 ms step is longer than the step, so no step shows
+  ok(T.warmMs > 200, 'the warmth eases over longer than the ramp\'s 200 ms step');
+}
+
+// --- the breath -------------------------------------------------------------
+{
+  ok(near(T.breathAt, 0.7), 'the room breathes from 0.7 (= hud.js vigBreathe)');
+  ok(T.breathMs === 3600, 'on the vignette\'s 3600 ms cycle');
+  ok(T.breathDepth > 0 && T.breathDepth < 0.3, 'and only a little');
+  for (let t = 0; t <= 2 * T.breathMs; t += 50) {
+    ok(breathFor(0, t) === 0 && breathFor(0.5, t) === 0 && breathFor(T.breathAt - 0.001, t) === 0, 'no breath under breathAt at ' + t + ' ms');
+    const b = breathFor(0.9, t);
+    ok(b <= 0 && b >= -T.breathDepth - 1e-12, 'over it, a dip of at most breathDepth at ' + t + ' ms');
+  }
+  ok(near(breathFor(T.breathAt, 0), 0) && near(breathFor(T.breathAt, T.breathMs), 0), 'the swell is at rest at the start and end of a cycle');
+  ok(near(breathFor(1, T.breathMs / 2), -T.breathDepth), 'and fully in at half a cycle');
+  ok(near(breathFor(1, T.breathMs / 4), -T.breathDepth / 2), 'ease-in-out: half way in at a quarter cycle');
+  ok(breathFor(NaN, 100) === 0 && Number.isFinite(breathFor(1, -100)), 'garbage in, a flat breath out');
+}
+
+// --- game over: the drain -----------------------------------------------------
+{
+  ok(T.overMs === 1200, 'the drain takes 1200 ms (= the ramp\'s sigh-out)');
+  ok(T.overLevel < T.overDraw && T.overDraw < 1, 'a win drains deeper than a draw, and a draw still dims');
+  ok(T.overRim > T.overLevel && T.overRim < 1, 'the rim keeps more than the key, and still dims');
+  const live = overTargets(null, null);
+  ok(live.key === 1 && live.fill === 1 && live.hemi === 1 && live.rim === 1 && live.spot === false, 'no result: the live room, no spot');
+  const win = overTargets('checkmate', 'w');
+  ok(win.key === T.overLevel && win.fill === T.overLevel && win.hemi === T.overLevel, 'a mate drains key, fill and hemisphere to overLevel');
+  ok(win.rim === T.overRim && win.spot === true, 'the rim to overRim, and the spot lights');
+  ok(overTargets('flag', 'b').spot === true && overTargets('resign', 'b').spot === true, 'a flag or a resignation has a winner too');
+  for (const [r, wn] of [['stalemate', null], ['draw', null], ['stalemate', 'w'], ['draw', 'b'], ['checkmate', null]]) {
+    const d = overTargets(r, wn);
+    ok(d.key === T.overDraw && d.fill === T.overDraw && d.hemi === T.overDraw && d.rim === T.overDraw, 'a draw (' + r + '/' + wn + ') only dims to overDraw');
+    ok(d.spot === false, 'and lights no spot');
+  }
+  // the drain's timeline: down to the level inside overMs, never below it
+  const tw = createTweens();
+  const drain = { key: 1, spot: 0 };
+  tw.to(drain, 'key', win.key, T.overMs, easeOutCubic);
+  tw.to(drain, 'spot', 1, T.overMs, easeOutCubic);
+  let t = 0;
+  while (tw.count()) {
+    tw.update(1 / 60); t += 1000 / 60;
+    ok(drain.key >= win.key - 1e-9 && drain.key <= 1 + 1e-9 && drain.spot >= 0 && drain.spot <= 1 + 1e-9, 'the drain stays inside its bounds at ' + t.toFixed(0) + ' ms');
+  }
+  ok(drain.key === win.key && drain.spot === 1 && t <= T.overMs + 1000 / 60 + 1e-6, 'and lands by overMs');
+  // a take-back: back to 1 over overBackMs, from where it is
+  tw.to(drain, 'key', 1, T.overBackMs, easeOutCubic);
+  tw.update(0);
+  ok(near(drain.key, win.key) && tw.count() === 1, 'the way back starts from the drained level');
+  while (tw.count()) tw.update(1 / 60);
+  ok(drain.key === 1, 'and lands at the live level');
+  ok(T.overBackMs > 0 && T.overBackMs < T.overMs, 'the way back is quicker than the drain');
+}
+
+// --- the shaft --------------------------------------------------------------
+{
+  ok(T.shaftAlpha > 0 && T.shaftAlpha <= 0.1, 'the shaft is air, never a beam');
+  ok(T.shaftTip < T.shaftRadius && T.shaftLength > 0, 'narrow at the light, wide over the board');
+  ok(T.shaftRise < T.shaftFadeTip && T.shaftFadeTip < 1, 'lit between the rise and the tip fade');
+  ok(near(shaftLevel(), T.shaftAlpha), 'at rest, level, live: the table\'s peak');
+  ok(near(shaftLevel({ warmth: 1 }), T.shaftAlpha * (1 + T.shaftWarm)), 'full warmth brightens it by shaftWarm');
+  ok(near(shaftLevel({ drain: T.overLevel }), T.shaftAlpha * T.overLevel), 'and the drain takes it down with the key');
+  const normal = 7 / Math.hypot(9.7, 7);                 // -forward.y from the normal preset
+  ok(near(shaftLevel({ topness: normal }), T.shaftAlpha), 'the normal preset sees it whole');
+  ok(near(shaftLevel({ topness: 1 }), T.shaftAlpha * T.shaftTopKeep), 'straight down it is capped to shaftTopKeep');
+  ok(shaftLevel({ topness: Math.cos(2.5 * Math.PI / 180) }) < T.shaftAlpha * (T.shaftTopKeep + 0.05), 'and the top preset is near the cap');
+  let prevL = shaftLevel({ topness: 0 });
+  for (let v = 0; v <= 1.0001; v += 0.01) {
+    const l = shaftLevel({ topness: v });
+    ok(l <= prevL + 1e-12, 'a steeper look only dims it at ' + v.toFixed(2));
+    prevL = l;
+  }
+  ok(shaftLevel({ warmth: 5, drain: 5, topness: -5 }) <= T.shaftAlpha * (1 + T.shaftWarm) + 1e-12, 'garbage in, a bounded level out');
 }
 
 console.log('room smoke: ' + passed + ' checks passed');

--- a/ConditioningControlPanel/Resources/web/piecebypiece/smoke/shot.mjs
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/smoke/shot.mjs
@@ -11,6 +11,8 @@
  *                                        window.PBP.ramp.debug() into the log
  *                       [--after <ms>]   how long to let the page run on after
  *                                        that expression (default 1200)
+ *                       [--size W,H]     the window, default 1280,860; a phone
+ *                                        held upright is about 390,844
  *
  * Needs a static server on the web root, for example:
  *   python -m http.server 8821   (run from Resources/web)
@@ -38,13 +40,14 @@ const drag = arg('drag', '');
 const hold = arg('hold', '');
 const evalExpr = arg('eval', '');
 const afterMs = Number(arg('after', '1200'));
+const size = arg('size', '1280,860');
 
 const profile = join(tmpdir(), 'pbp-edge-' + Date.now());
 const edge = spawn(EDGE, [
   '--headless=new',
   '--remote-debugging-port=' + port,
   '--user-data-dir=' + profile,
-  '--window-size=1280,860',
+  '--window-size=' + size,
   '--hide-scrollbars',
   '--no-first-run',
   '--no-default-browser-check',

--- a/ConditioningControlPanel/Resources/web/piecebypiece/smoke/whip-shot.mjs
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/smoke/whip-shot.mjs
@@ -11,6 +11,9 @@
  *
  *   node smoke/whip-shot.mjs [--url <page url>] [--out <dir>] [--wait <ms>]
  *
+ * The whip is gated off by default (settings.whip, see board/anim.js), so the
+ * page is opened with &whip=1; every assertion below is as it was.
+ *
  * Needs a static server on the web root, for example:
  *   python -m http.server 8853   (run from Resources/web)
  * Exits non-zero when the page logged an error, when the whip did not crack,
@@ -171,7 +174,7 @@ async function main() {
   await cdp.send('Page.enable');
 
   const sep = url.includes('?') ? '&' : '?';
-  const page = url + sep + 'fen=' + encodeURIComponent(FEN);
+  const page = url + sep + 'fen=' + encodeURIComponent(FEN) + '&whip=1';   // the gate: off by default
 
   // --- 1. the whip, frame by frame --------------------------------------------
   await open(page);

--- a/ConditioningControlPanel/Resources/web/piecebypiece/styles.css
+++ b/ConditioningControlPanel/Resources/web/piecebypiece/styles.css
@@ -145,6 +145,35 @@ html, body {
 .mv .m.gap { cursor: default; }
 .mv .m.sel { background: rgba(255, 105, 180, 0.34); color: #FFF3FA; opacity: 1; }
 .mv.empty { display: block; padding: 2px 5px; font-size: 11px; letter-spacing: 0.12em; opacity: 0.3; }
+/* resign and the draw, online only (hud.js shows the block; index.html says
+   why it sits here). Bottom right: under the move list's column, clear of the
+   ramp's centred card and of the .cam- row on the left. The same glass as the
+   .chip and the .moves-tab, and like the tab only the buttons take a click -
+   the words around them stay click-through with the rest of the HUD. */
+.online {
+  position: absolute; right: 18px; bottom: 22px;
+  display: flex; flex-direction: column; align-items: flex-end; gap: 6px;
+}
+.online-row { display: flex; align-items: center; gap: 6px; }
+.online-row .word, .online-note {
+  font-size: 10px; letter-spacing: 0.18em; text-transform: uppercase; opacity: 0.55;
+}
+.online-row .word { margin-right: 4px; }
+.online-note { margin: 0 4px 0 0; }
+.hud-btn {
+  pointer-events: auto; cursor: pointer;
+  padding: 6px 11px; border-radius: 10px;
+  font: 10px/1 'Segoe UI', system-ui, sans-serif; letter-spacing: 0.18em; text-transform: uppercase;
+  color: var(--pbp-ink); opacity: 0.55;
+  background: rgba(20, 20, 46, 0.55); border: 1px solid rgba(245, 230, 200, 0.12);
+  backdrop-filter: blur(3px);
+  transition: opacity 160ms ease, color 160ms ease, border-color 160ms ease;
+}
+.hud-btn:hover { opacity: 0.9; }
+.hud-btn:focus-visible { outline: 2px solid var(--pbp-pink); outline-offset: 2px; }
+.hud-btn:disabled { opacity: 0.22; cursor: default; }
+/* the answer that ends something - yes to "resign?", accept on his offer */
+.hud-btn.warm { color: var(--pbp-pink); border-color: rgba(255, 105, 180, 0.55); }
 /* --- end the HUD ---------------------------------------------------------- */
 
 /* Owned by the effects layer. Never written to by the board code. */


### PR DESCRIPTION
Backdrop layers 1-3 (board/room.js, roomMath.js, motes.js): floor, pool of shade, gradient dome matched to the fog, edge glow and light-rig lean as the turn tell, capture flinch, ramp warmth with the shared breath, game-over drain with a spot on the winner's king, one light shaft. board/frame.js keeps the whole board in frame on a phone held upright. The bishop's whip is parked behind settings.whip. Online client fixes from the readiness audit: the lobby leaves when a match starts, poll cadence under the server caps, switchBack to hotseat, resign and draw UI, abandonment claim, record() forwarded, identity awaited, account name in the lobby, a signed-out state. room-smoke 753, online-smoke 195.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W128D3krs3sKhncDdj7qse