### PR TITLE
feat(race): a lighter switch in the options, for a phone being recorded

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
@@ -302,6 +302,16 @@ race.css can take every filter, the backdrop blur and the colour keyframes off t
 glitch shudders on transform alone, a heavier fill stands in for the blur, the melt's sag drops its
 saturate). The masks stay: a mask is a composite, not a per-frame filter pass. The desktop rules
 are untouched, the Descent passes no cap. `race/smoke/loom-spiral-check.mjs` section 7b.
+LIGHTER (2026-09-10: the phone "seems to be going great unless i record my phone. It starts to lag
+then"). A screen recording is a load the page cannot see, so it is a hand switch: the options row
+`lighter` (race/menu.js, persisted in `race.options` as `lite`, default off), read by raceBoot into
+`settings.lite` (`?lite=1|0` overrides it for a check). run.js pulls the four levers the perf passes
+left unpulled, for the next launch: the resolution lid at `LITE_DPR` 0.6 from the first frame and
+held there (race/pixel.js, the governor stands down), live bubbles capped at 80 under the tier's own
+cap (`createBubbleField({cap})`), the spiral canvas at 20 fps on any tier (loomSpiralFx
+`LITE_FRAME_MS`), and the spiral and pink holds composited flat (race.css `[data-lite="1"]`
+`mix-blend-mode: normal`, with the spiral's inline cap lowered to 0.6 and the touch tier's no-filter
+block stamped along with it). Off is the run exactly as it was. Section 7d of the same smoke.
 The second pass (2026-09-10, "smoother but still not good enough ... the gifs, pink filter and
 spiral ... the blink shutter effect on the bambi sleep trigger"): under the same stamp the melt's
 drip (an animated background-position, a 3 M px repaint per frame) is gone and only the sag stays;

--- a/ConditioningControlPanel/Resources/web/dtrh/race/bubbles.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/bubbles.js
@@ -77,7 +77,7 @@ function makeDotTex() {
   } catch (e) { return null; }
 }
 
-export function createBubbleField({ scene, layout, media, getIntensity, getRoom, getElapsed, onTexture }) {
+export function createBubbleField({ scene, layout, media, getIntensity, getRoom, getElapsed, onTexture, cap = 0 }) {
   void media;   // reserved: flash media is drawn by payloadFx at pop time, never here
   void onTexture;   // see the loader below: crisp-layer sprites keep their own filters
   const T = layout.totalDepth;
@@ -114,7 +114,8 @@ export function createBubbleField({ scene, layout, media, getIntensity, getRoom,
   const baseKey = (kindId) => kindId + (texOf[kindId] && texOf[kindId] !== dotTex ? ':png' : ':dot');
 
   // ---- pools ---------------------------------------------------------------
-  const CAP = Q.bubbleCap || 160, SHARD_CAP = Q.bubbleShards || 64, VIEW_AHEAD = Q.bubbleViewAhead || 110;
+  // `cap` (run.js, the lighter switch): a caller's ceiling UNDER the tier's, never over it
+  const CAP = cap > 0 ? Math.min(cap, Q.bubbleCap || 160) : (Q.bubbleCap || 160), SHARD_CAP = Q.bubbleShards || 64, VIEW_AHEAD = Q.bubbleViewAhead || 110;
   /** riptide (race/pickups.js): bubbles this far ahead slide into the kart's lane over this long. */
   const PULL_M = 40, PULL_SEC = 0.5;
   const group = new THREE.Group();

--- a/ConditioningControlPanel/Resources/web/dtrh/race/loomSpiralFx.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/loomSpiralFx.js
@@ -76,6 +76,8 @@ export const BACK_LONG = 512;
 export const BACK_LONG_TOUCH = 256;
 /** 24 fps under touch; the desktop runs at display rate. */
 export const TOUCH_FRAME_MS = 42;
+/** 20 fps under the lighter switch (race/menu.js), on any tier. */
+export const LITE_FRAME_MS = 50;
 /** payloadFx's `.sf-pfx-layer` fade is 0.45 s; the canvas outlives the hold by that plus a breath. */
 export const FADE_MS = 700;
 
@@ -120,8 +122,10 @@ export function backingFor(w, h, touch) {
  *
  * @param {Object} o { reducedMotion?: bool, log?: (msg)=>void }
  */
-export function createLoomSpiralFx({ reducedMotion = false, log = null } = {}) {
+export function createLoomSpiralFx({ reducedMotion = false, log = null, lite = false } = {}) {
   const say = typeof log === 'function' ? log : () => {};
+  /** The frame cap: the lighter switch's 20 fps beats the touch tier's 24; the desktop has none. */
+  const capMs = () => (lite ? LITE_FRAME_MS : touch ? TOUCH_FRAME_MS : 0);
   /** el -> { el, view, ctx, q, loop, kind, timer, id, onLost } - the 2D view over the shared field */
   const live = new Map();
   /** THE ONE FIELD. A GL canvas (never in the DOM) and loomField's renderer over it, built on the
@@ -183,8 +187,9 @@ export function createLoomSpiralFx({ reducedMotion = false, log = null } = {}) {
     rafId = 0;
     if (disposed || lost || !live.size || hidden()) return;
     const t = Number.isFinite(now) ? now : Date.now();
-    if (touch && t - lastAt < TOUCH_FRAME_MS - 1) {
-      toId = setTimeout(() => { toId = 0; rafId = raf(frame); }, TOUCH_FRAME_MS);
+    const cap = capMs();
+    if (cap && t - lastAt < cap - 1) {
+      toId = setTimeout(() => { toId = 0; rafId = raf(frame); }, cap);
       return;
     }
     lastAt = t;
@@ -360,7 +365,7 @@ export function createLoomSpiralFx({ reducedMotion = false, log = null } = {}) {
         backing: r.view.width + 'x' + r.view.height,
         mounted: r.view.parentNode === r.el,
       }));
-      return { holds, touch, lost, disposed, still: !!reducedMotion, field: !!field, ...stats };
+      return { holds, touch, lite: !!lite, frameMs: capMs(), lost, disposed, still: !!reducedMotion, field: !!field, ...stats };
     },
   };
   return api;

--- a/ConditioningControlPanel/Resources/web/dtrh/race/menu.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/menu.js
@@ -116,8 +116,14 @@ export const ROSTER = [
 ];
 // `pixel` is the one default that reads the device: off on a coarse pointer, the smallest block on a
 // fine one (race/pixel.js pixelDefault). loadOptions below migrates the old fixed default onto it.
-const DEFAULTS = { pixel: pixelDefault(), music: 0.8, sfx: 0.8, motion: 'system', seed: 'daily', seedValue: 7 };
+const DEFAULTS = { pixel: pixelDefault(), music: 0.8, sfx: 0.8, motion: 'system', lite: 'off', seed: 'daily', seedValue: 7 };
 const MOTIONS = ['system', 'on', 'off'], SEEDS = ['daily', 'random', 'custom'];
+/** LIGHTER (2026-09-10, the owner: the phone "seems to be going great unless i record my phone. It
+ *  starts to lag then"). A screen recording runs the encoder and a second composite on the GPU the
+ *  run is already filling, and a page cannot tell it is being recorded, so this is a hand switch:
+ *  the four levers the perf passes left unpulled, all at once, for the next launch (raceBoot reads
+ *  it into settings.lite; run.js does the rest). Off is the run exactly as it was. */
+const LITES = ['off', 'on'];
 const GLASS = 'EMI_glass', FADE = 0.3, ONE_SHOTS = ['wave', 'hop', 'drum'];
 const BEAT_MIN = 3, BEAT_MAX = 6, PEEK_GAP = 6;
 // Stage metres, all of them read off props.glb so the placeholders and the real props agree.
@@ -196,6 +202,7 @@ export function loadOptions() {
       if (typeof raw.pixel === 'number' && normalizeBlock(raw.pixel) !== PIXEL_LEGACY_DEFAULT) o.pixel = normalizeBlock(raw.pixel);
       for (const k of ['music', 'sfx']) if (typeof raw[k] === 'number' && isFinite(raw[k])) o[k] = clamp(raw[k], 0, 1);
       if (MOTIONS.includes(raw.motion)) o.motion = raw.motion;
+      if (LITES.includes(raw.lite)) o.lite = raw.lite;
       if (SEEDS.includes(raw.seed)) o.seed = raw.seed;
       if (typeof raw.seedValue === 'number' && isFinite(raw.seedValue)) o.seedValue = raw.seedValue >>> 0;
     }
@@ -211,6 +218,8 @@ export function seedFromOptions(o, now = new Date()) {
   return (Math.imul(day, 0x9e3779b1) ^ 0x5bd1e995) >>> 0;
 }
 export function wantsReducedMotion(o, system) { return o.motion === 'on' ? true : o.motion === 'off' ? false : !!system; }
+/** The lighter switch, as raceBoot reads it into `settings.lite`. */
+export function wantsLite(o) { return !!o && o.lite === 'on'; }
 
 // ---- textures the placeholders need ------------------------------------------------------------
 function checkerTexture(a, b, repeat = 15) {
@@ -652,6 +661,7 @@ export function createMenu({ root, renderer, pixel, audio, settings = {}, log = 
     { id: 'music', label: 'music', get: () => pct(options.music), move: (d) => step('music', d * 0.1), dim: !canLevels },
     { id: 'sfx', label: 'sfx', get: () => pct(options.sfx), move: (d) => step('sfx', d * 0.1), dim: !canLevels },
     { id: 'motion', label: 'reduced motion', get: () => options.motion, move: (d) => { options.motion = cyc(MOTIONS, options.motion, d); stage.setReduced(reduced()); layer.dataset.motion = options.motion; }, hint: 'stage and intro now, the run on the next launch' },
+    { id: 'lite', label: 'lighter', get: () => options.lite, move: (d) => { options.lite = cyc(LITES, options.lite, d); }, hint: 'for recording: lower resolution, fewer bubbles, flat washes. the run on the next launch' },
     { id: 'seed', label: 'seed', get: () => (options.seed === 'custom' ? `custom ${options.seedValue}` : options.seed), move: (d) => { options.seed = cyc(SEEDS, options.seed, d); seedIn.hidden = options.seed !== 'custom'; }, press: () => { if (options.seed === 'custom') seedIn.focus(); } },
     { id: 'back', label: 'back', get: () => '', press: () => open('main') },
   ];

--- a/ConditioningControlPanel/Resources/web/dtrh/race/pixel.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/pixel.js
@@ -37,6 +37,10 @@
  * the frame, and a hold that drops it needs an answer in two seconds, not five.
  * It climbs back the same way, one rung at a time, when the average frame is
  * under FAST_MS again.
+ * LIGHTER (2026-09-10, the owner: it lags "unless i record my phone"): with
+ * `lite` the lid is LITE_DPR from the first frame and the governor never lifts
+ * it. A recording is a load the page cannot see, so the player asks for the
+ * headroom up front instead of the governor finding it two seconds late.
  * ==========================================================================*/
 
 import * as THREE from 'three';
@@ -61,6 +65,8 @@ const FRAME_WIN = 300;         // frames kept for the avg / p95
 const SLOW_MS = 24, FAST_MS = 13;   // governor thresholds on the avg frame (about 42 and 77 fps)
 /** The coarse pointer's lower rung and its faster read (see THE GOVERNOR in the header). */
 export const TOUCH_DPR_FLOOR = 0.8, GOV_TOUCH_SEC = 2;
+/** The lighter switch's fixed lid (see LIGHTER in the header). */
+export const LITE_DPR = 0.6;
 /** `(pointer: coarse)` and nothing else, the way pixelDefault reads it - `?coarse=` forces it for a check. */
 export function coarsePointer(win) {
   const w = win || (typeof window !== 'undefined' ? window : null);
@@ -133,10 +139,10 @@ const BLIT_FRAG = `
     #include <colorspace_fragment>
   }`;
 
-export function createPixelizer({ renderer, canvas, block = pixelDefault(), log = null }) {
+export function createPixelizer({ renderer, canvas, block = pixelDefault(), log = null, lite = false }) {
   let cur = normalizeBlock(block);
   let w = 1, h = 1;
-  let dprCap = Infinity;         // the governor's lid on the device pixel ratio (1 while slow, the touch floor while slower)
+  let dprCap = lite ? LITE_DPR : Infinity;   // the governor's lid on the device pixel ratio (1 while slow, the touch floor while slower, LITE_DPR for good under lighter)
   const touch = coarsePointer();
   const screenDpr = () => Math.min(window.devicePixelRatio || 1, Q.maxDpr, 1.5);
   const nativeDpr = () => Math.min(screenDpr(), dprCap);
@@ -193,7 +199,7 @@ export function createPixelizer({ renderer, canvas, block = pixelDefault(), log 
   }
 
   // ---- the frame ---------------------------------------------------------------------------
-  const stats = { calls: 0, triangles: 0, passes: 0, frameMs: 0, frameP95: 0, dprCap: Infinity, touch };
+  const stats = { calls: 0, triangles: 0, passes: 0, frameMs: 0, frameP95: 0, dprCap: lite ? LITE_DPR : Infinity, touch, lite: !!lite };
   let fCalls = 0, fTris = 0, fPasses = 0, perfLast = 0;
   const info = renderer.info;
   function tally() { if (!info || !info.render) return; fCalls += info.render.calls; fTris += info.render.triangles; fPasses++; }
@@ -209,6 +215,7 @@ export function createPixelizer({ renderer, canvas, block = pixelDefault(), log 
     return { avg: sum / gapN, p95: view[Math.min(gapN - 1, Math.floor(gapN * 0.95))] };
   }
   function govern(avg) {
+    if (lite) return;              // the lid is the player's, not the governor's
     if (gapN < 60) return;
     const native = screenDpr();
     if (avg > SLOW_MS && dprCap > 1 && native > 1) { dprCap = 1; apply(); if (log) log(`[race-perf] governor: dpr 1 (avg frame ${avg.toFixed(1)} ms)`); }

--- a/ConditioningControlPanel/Resources/web/dtrh/race/race.css
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/race.css
@@ -560,6 +560,16 @@
 }
 #race-root[data-touch="1"][data-rm="1"] .sf-pfx-pink.is-melting { animation: none; }
 
+/* ---- LIGHTER (run.js stamps data-lite="1" for the options row of that name) ----
+   2026-09-10, the owner: the phone "seems to be going great unless i record my phone. It starts to
+   lag then". A recording is a load the page cannot see. This is the last of the four levers the perf
+   passes left unpulled, the one that changes the look: the spiral and pink holds are composited
+   FLAT instead of through `mix-blend-mode: screen`, which on WebKit isolates everything under the
+   hold into its own group before the blend. run.js caps the spiral lower (0.6) for it, since an
+   opaque canvas laid flat at the screen-blend cap reads as a dimmer. The other three levers are
+   run.js's (resolution lid, bubble cap, spiral fps); the touch block above rides along. */
+#race-root[data-lite="1"] .sf-pfx-spiral, #race-root[data-lite="1"] .sf-pfx-pink { mix-blend-mode: normal; }
+
 /* ---- THE PHONE'S LAYERS, second pass (2026-09-10: "smoother but still not good enough ... it
    gets worse on fullscreen effects (the gifs, pink filter and spiral) and the effect like the
    blink shutter effect we got on the bambi sleep trigger"). The same law as the block above, applied

--- a/ConditioningControlPanel/Resources/web/dtrh/race/run.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/run.js
@@ -116,6 +116,15 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1, onExi
   const reducedMotion = settings.reducedMotion != null ? !!settings.reducedMotion
     : !!(typeof matchMedia === 'function' && matchMedia('(prefers-reduced-motion: reduce)').matches);
   const intensityFloor = clamp(Number(settings.intensityFloor) || 0, 0, 1);
+  // LIGHTER (race/menu.js `lighter`, raceBoot -> settings.lite; 2026-09-10, the owner: the phone lags
+  // "unless i record my phone"). A recording is a load the page cannot see, so this is the player
+  // asking for the headroom up front: the resolution lid at 0.6 from the first frame (race/pixel.js
+  // LITE_DPR), live bubbles capped at LITE_BUBBLE_CAP, the spiral canvas at 20 fps
+  // (loomSpiralFx LITE_FRAME_MS), and the spiral and pink holds composited flat instead of through
+  // their screen blend (race.css `[data-lite="1"]`, with the touch tier's no-filter rules along for
+  // the ride, since the same law applies). Off is the run exactly as it was.
+  const lite = !!settings.lite;
+  const LITE_BUBBLE_CAP = 80;
   const send = (m) => { try { bridge.send(m); } catch (e) { /* host gone */ } };
   const sfx = (name, scale = 0.8) => audio.sfx(name, scale);   // race/audio.js: host legs + in-page beats
 
@@ -123,7 +132,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1, onExi
   const renderer = new THREE.WebGLRenderer({ canvas, antialias: Q.antialias, alpha: false, powerPreference: 'high-performance' });
   // the big-pixel look: the world at low resolution, bubbles + wall media crisp on top (race/pixel.js);
   // host settings.pixel / ?pixel=N override, 0 = off; draw-call stats go to the host log every ~5 s
-  const pixel = createPixelizer({ renderer, canvas, block: settings.pixel == null ? pixelDefault() : settings.pixel, log: (m) => { if (bridge.log) bridge.log(m); } });
+  const pixel = createPixelizer({ renderer, canvas, block: settings.pixel == null ? pixelDefault() : settings.pixel, lite, log: (m) => { if (bridge.log) bridge.log(m); } });
   if ('outputColorSpace' in renderer) renderer.outputColorSpace = THREE.SRGBColorSpace;
   const scene = new THREE.Scene();
   scene.background = new THREE.Color(0x12261f);
@@ -288,7 +297,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1, onExi
     word: () => (S.elapsed - echoAt <= ECHO_SEC ? echoWord : ''),
   });
   setLoomBook(loomBook.draw);
-  const spiralFx = createLoomSpiralFx({ reducedMotion, log: bridge.log });
+  const spiralFx = createLoomSpiralFx({ reducedMotion, log: bridge.log, lite });
   // THE PHONE'S LAYERS (2026-09-10, phone testing: "we still lag a lot on the fullscreen effects
   // on iphone. the glitch bubble fullscreen in particular and the spiral"). Every sustained hold is
   // a fullscreen DOM layer over the WebGL glass, composited at device resolution (3x on an iPhone).
@@ -301,10 +310,12 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1, onExi
   // is the one thing the phone does not get.
   const touchTier = isTouchTier();
   const TOUCH_CAP = { spiral: 0.78, pink: 0.7, braindrain: 0.86, gifwash: 0.85 };
-  const holdCap = (kind) => (kind === 'pink' && root.dataset.tint === '2' ? 0.92 : (TOUCH_CAP[kind] || 1));
+  // under lighter the spiral's opaque canvas is composited flat (no screen blend), so its cap is lower or it reads as a dimmer
+  const LITE_SPIRAL_CAP = 0.6;
+  const holdCap = (kind) => (kind === 'pink' && root.dataset.tint === '2' ? 0.92 : kind === 'spiral' && lite ? LITE_SPIRAL_CAP : (TOUCH_CAP[kind] || 1));
   const payloadFx = createPayloadFx({ hud: sfHud, fx: fxProxy, media,
     subliminalFx: subl ? ({ text }) => subl.show({ text }) : null, spiralFx,
-    opacityCap: touchTier ? holdCap : null });
+    opacityCap: touchTier || lite ? holdCap : null });
   // Q.leanSpirals (mobile): the GIF FLOOR under a live spiral (and the wash's own fallback) draws
   // from the two lightest bundled gifs, fetched while the intro plays (warmFx) rather than 2-5 MB
   // mid-lap. With WebGL up nothing here is ever fetched at all; this is what a lost context lands on.
@@ -320,7 +331,8 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1, onExi
   // shudder exactly the way `prefers-reduced-motion` does for a player who never opened the menu.
   if (reducedMotion) root.dataset.rm = '1'; else root.removeAttribute('data-rm');
   // the tier, for the same reason: race.css lightens the payload layers under `[data-touch="1"]`
-  if (touchTier) root.dataset.touch = '1'; else root.removeAttribute('data-touch');
+  if (touchTier || lite) root.dataset.touch = '1'; else root.removeAttribute('data-touch');
+  if (lite) root.dataset.lite = '1'; else root.removeAttribute('data-lite');
   const input = createInput({ root });   // root: the touch layer, on a phone, is built inside its .race-hud
   const audio = createRaceAudio({ bridge, hud, settings, input });
   const speedFx = createSpeedFx({ scene, camera, root, reducedMotion });
@@ -384,7 +396,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1, onExi
       if (!r || S.jackpotBias === 1) return r;
       return { ...r, bubbleBias: { ...r.bubbleBias, golden: (r.bubbleBias.golden == null ? 1 : r.bubbleBias.golden) * S.jackpotBias } };
     };
-    const field = createBubbleField({ scene, layout, media, getIntensity: () => S.intensity, getRoom, getElapsed: () => S.elapsed, onTexture: pixel.filterTexture });
+    const field = createBubbleField({ scene, layout, media, getIntensity: () => S.intensity, getRoom, getElapsed: () => S.elapsed, onTexture: pixel.filterTexture, cap: lite ? LITE_BUBBLE_CAP : 0 });
     const pickups = createPickups({ rng, spots: layout.chunks.flatMap((c) => c.features || []).filter((f) => f.type === 'pickup'), totalDepth: layout.totalDepth });
     // the word flash rolls off its OWN seeded stream, for the same reason the DOM posters do: a draw
     // that depends on what the player popped must never shift the rolls the ROAD is built from.
@@ -1197,7 +1209,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1, onExi
       frameMs: st.frameMs || 0, programs: info.programs ? info.programs.length : -1,
       geometries: mem.geometries == null ? -1 : mem.geometries, textures: mem.textures == null ? -1 : mem.textures, texMax,
       audio: audio._tracks ? audio._tracks.size : -1, dpr: renderer.getPixelRatio(), block: pixel.block,
-      dprCap: st.dprCap == null ? null : st.dprCap, touch: !!st.touch,   // the governor's lid and its ladder (race/pixel.js)
+      dprCap: st.dprCap == null ? null : st.dprCap, touch: !!st.touch, lite,   // the governor's lid and its ladder (race/pixel.js), and the lighter switch
       world: !!W, stage: !!stage, running: S.running, bubbles: W ? W.field.liveCount : 0,
       // the pace envelope and what the kart actually did with it (race/pace.js, race/smoke/pace-check.mjs)
       speed: W ? W.kart.state.speed : 0, boosting: W ? W.kart.state.boostSec > 0 : false, pace: S.pace ? { ...S.pace } : null,

--- a/ConditioningControlPanel/Resources/web/dtrh/race/smoke/loom-spiral-check.mjs
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/smoke/loom-spiral-check.mjs
@@ -258,7 +258,7 @@ eq(JSON.parse(await ev(HOLD)).canvases, 0, 'every pop after a loss is a gif, wit
  * ==========================================================================*/
 {
   const run = readFileSync(resolve(RACE, 'run.js'), 'utf8');
-  ok(/opacityCap:\s*touchTier\s*\?/.test(run), 'run.js passes the inline cap on the touch tier only');
+  ok(/opacityCap:\s*touchTier(?:\s*\|\|\s*lite)?\s*\?/.test(run), 'run.js passes the inline cap on the touch tier only (and under the lighter switch)');
   ok(/dataset\.touch\s*=\s*'1'/.test(run), 'and stamps data-touch on the root for race.css');
   const LAYER = (sel) => `(() => { const el = document.querySelector('${sel}'); if (!el) return JSON.stringify({ there: false });
     const cs = getComputedStyle(el); return JSON.stringify({ there: true, filter: cs.filter, bf: cs.backdropFilter || cs.webkitBackdropFilter, anim: cs.animationName, mask: cs.maskImage || cs.webkitMaskImage }); })()`;
@@ -387,6 +387,49 @@ eq(JSON.parse(await ev(HOLD)).canvases, 0, 'every pop after a loss is a gif, wit
   eq(gov.sec, 2, 'and is read every two seconds');
   ok(gov.coarseOn === true && gov.coarseOff === false, '?coarse= forces the answer either way');
   eq(gov.touch, false, 'this desktop run is not on the touch ladder');
+}
+
+/* ============================================================================
+ * 7d. LIGHTER (race/menu.js `lighter` -> settings.lite): the four levers at once,
+ *     for a phone being screen-recorded. Off is the run exactly as it was.
+ * ==========================================================================*/
+{
+  const menu = readFileSync(resolve(RACE, 'menu.js'), 'utf8');
+  const boot = readFileSync(resolve(DTRH, 'raceBoot.js'), 'utf8');
+  const run = readFileSync(resolve(RACE, 'run.js'), 'utf8');
+  ok(/id:\s*'lite',\s*label:\s*'lighter'/.test(menu), 'the options panel has the lighter row');
+  ok(/LITES\.includes\(raw\.lite\)/.test(menu) && /lite:\s*'off'/.test(menu), 'it persists with the other options and defaults off');
+  ok(/settings\.lite\s*=\s*wantsLite\(opts\)/.test(boot), 'raceBoot reads it into settings.lite');
+  ok(/createPixelizer\(\{[^}]*\blite\b/.test(run) && /createLoomSpiralFx\(\{[^}]*\blite\b/.test(run) && /cap:\s*lite\s*\?\s*LITE_BUBBLE_CAP/.test(run), 'run.js hands it to the pixelizer, the spiral canvas and the bubble field');
+  ok(/dataset\.lite\s*=\s*'1'/.test(run), 'and stamps data-lite on the root for race.css');
+  const lv = await parse(`(async () => {
+    const px = await import('/dtrh/race/pixel.js');
+    const m = await import('/dtrh/race/loomSpiralFx.js');
+    const b = await import('/dtrh/race/loomBook.js');
+    const fx = m.createLoomSpiralFx({ lite: true });
+    const el = document.createElement('div');
+    el.className = 'sf-pfx-layer sf-pfx-spiral rh-loom-probe';
+    document.querySelector('.sf-pfx').appendChild(el);
+    fx.mount(el, b.createLoomBook({ seed: 5 }).draw({ room: 'chapel' }), { kind: 'spiral', durMs: 4000 });
+    const d = fx.diagnostics();
+    fx.dispose(); el.remove();
+    const plain = m.createLoomSpiralFx({}).diagnostics();
+    return JSON.stringify({ liteDpr: px.LITE_DPR, frameMs: d.frameMs, lite: d.lite, plainMs: plain.frameMs, plainTouch: plain.touch });
+  })()`);
+  eq(lv.liteDpr, 0.6, 'the resolution lid under lighter is 0.6');
+  eq(lv.frameMs, 50, 'the spiral canvas paces at 20 fps under lighter');
+  ok(lv.lite === true, 'and says so');
+  ok(lv.plainTouch ? lv.plainMs === 42 : lv.plainMs === 0, `without it the tier's own pace stands (${lv.plainMs} ms)`);
+  await ev(`window.__race.race.debugPayload('overlay', { overlay: 'spiral', strength: 60 })`);
+  await sleep(150);
+  const before = await ev(`getComputedStyle(document.querySelector('.sf-pfx-spiral')).mixBlendMode`);
+  eq(before, 'screen', 'the spiral hold blends with screen off the switch');
+  await ev(`document.getElementById('race-root').dataset.lite = '1'`);
+  await sleep(50);
+  const after = await ev(`getComputedStyle(document.querySelector('.sf-pfx-spiral')).mixBlendMode`);
+  eq(after, 'normal', 'and flat under it');
+  await ev(`delete document.getElementById('race-root').dataset.lite`);
+  await sleep(4500);
 }
 
 /* ============================================================================

--- a/ConditioningControlPanel/Resources/web/dtrh/raceBoot.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/raceBoot.js
@@ -357,13 +357,16 @@ async function boot() {
   booted = true;
   const t0 = performance.now();
   try {
-    const [{ createRace }, { createMenu, loadOptions, seedFromOptions, wantsReducedMotion }] = await Promise.all([import('./race/run.js'), import('./race/menu.js')]);
+    const [{ createRace }, { createMenu, loadOptions, seedFromOptions, wantsReducedMotion, wantsLite }] = await Promise.all([import('./race/run.js'), import('./race/menu.js')]);
     const opts = loadOptions();
     settings = { ...((initMsg && initMsg.settings) || {}) };
     if (opts.pixel !== undefined) settings.pixel = opts.pixel;
     if (params.has('pixel') && params.get('pixel') !== '') settings.pixel = Number(params.get('pixel'));
     settings.reducedMotion = wantsReducedMotion(opts, settings.reducedMotion != null ? settings.reducedMotion : !!(matchMedia && matchMedia('(prefers-reduced-motion: reduce)').matches));
     settings.musicVolume = opts.music; settings.sfxVolume = opts.sfx;   // audio.js reads masterVolume; the two sliders go in through setLevels below
+    // LIGHTER (race/menu.js): the options row, or `?lite=1|0` for a check. run.js reads settings.lite.
+    settings.lite = wantsLite(opts);
+    if (params.get('lite') === '1') settings.lite = true; else if (params.get('lite') === '0') settings.lite = false;
     settings.seedLock = seedFromOptions(opts);
     // The file dialog is the host's; standalone loads a track off the query string. A host may also
     // say `trackPick: false` in its init: the browser host (cclabs-web scripts/race-web-ext) is


### PR DESCRIPTION
The owner, 2026-09-10, after the three perf passes:

> Uff seems to be going great unless i record my phone. It starts to lag then. Any workaround?

## why it is a switch

A screen recording runs the hardware encoder and a second compositor pass on the same GPU the run is filling every frame, and there is no web API that says "you are being recorded", so nothing can adapt on its own. This is the player asking for the headroom up front. It is one options row, `lighter`, hidden with the rest, persisted in `race.options`, default off. Off is the run exactly as it was.

## what it pulls, for the next launch

The four levers the perf passes deliberately left unpulled, all at once:

| lever | where | what |
|---|---|---|
| resolution lid 0.6 | `race/pixel.js` `LITE_DPR` | from the first frame, held there; the governor stands down rather than finding it two seconds late |
| live bubbles 80 | `race/bubbles.js` `createBubbleField({cap})` | a caller's ceiling under the tier's own, never over it |
| spiral canvas 20 fps | `race/loomSpiralFx.js` `LITE_FRAME_MS` | on any tier; the touch tier's 24 stands without the switch |
| flat holds | `race/race.css` `[data-lite="1"]` | the spiral and pink holds composite with `mix-blend-mode: normal`; run.js caps the spiral inline at 0.6 for it, since an opaque canvas laid flat at the screen-blend cap reads as a dimmer |

The touch tier's no-filter block is stamped along with it, since the same law applies. `raceBoot` reads the row into `settings.lite`; `?lite=1|0` overrides it for a check. `perf()` reports `lite`.

## what moved

| file | what |
|---|---|
| `race/menu.js` | the row, `LITES`, the default, load/persist, `wantsLite` |
| `raceBoot.js` | `settings.lite` from the options or the query |
| `race/run.js` | `lite`, `LITE_BUBBLE_CAP`, `LITE_SPIRAL_CAP`, the four hand-offs, `data-lite` on the root |
| `race/pixel.js`, `race/loomSpiralFx.js`, `race/bubbles.js`, `race/race.css` | the levers above |
| `race/smoke/loom-spiral-check.mjs` | section 7d |
| `race/CONTRACT.md` | LIGHTER |

## the bar

`node --check` on every changed file. Smokes green: loom-spiral-check (new section 7d: the row exists, persists and defaults off, raceBoot reads it, run.js hands it to all three modules and stamps the root, the lid is 0.6, the canvas paces at 50 ms with it and at the tier's own pace without, the spiral hold blends with screen off the switch and flat under it), pixel-default-check, menu-return-check, spiral-pool-check, popped-check.

Not verified on the real phone. 119 insertions, 18 deletions across 9 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015spkaJxek5LPpH1N6rdCru
