### PR TITLE
fix(dtrh): the tape comes off when the descent does

### DIFF
--- a/ConditioningControlPanel/Services/Chaos/ChaosModeService.cs
+++ b/ConditioningControlPanel/Services/Chaos/ChaosModeService.cs
@@ -1046,9 +1046,7 @@ public sealed class ChaosModeService
             bool runClosing = _state.RunDurationSec - elapsed <= 3;
             if (App.Video?.IsPlaying == true && (capHit || runClosing))
             {
-                _chaosVideoCapUtc = DateTime.MinValue;
-                try { App.Video?.ForceCleanup(); } catch (Exception ex) { App.Logger?.Debug("Chaos video cap: {E}", ex.Message); }
-                ExtendHeavyQuarantine(VIDEO_TEARDOWN_QUARANTINE_SEC);   // ForceCleanup may not raise VideoEnded
+                StopChaosOwnedVideo(capHit ? "cap" : "run closing");
                 _state.PushEvent("▶ the tape snaps off");
                 // porn_dvd lesson: the full slice ran (the 15s cap IS the slice length);
                 // a run-closing cut before the cap is an abort and doesn't count.
@@ -2172,6 +2170,34 @@ public sealed class ChaosModeService
         if (until > _heavyUntilUtc) _heavyUntilUtc = until;
     }
 
+    /// <summary>
+    /// May a run-exit path tear the tape down? <c>App.Video.ForceCleanup()</c> closes EVERY video
+    /// window the service owns, so chaos may only fire it at a video chaos itself started: the
+    /// user's own mandatory/session video must survive the descent ending on top of it. The armed
+    /// cap is that ownership mark - it is set only when a Video payload detonates
+    /// (<see cref="FirePayloadForDetonation"/>) and cleared the moment the tape is accounted for.
+    /// Pure so the rule is pinned by a test without a WPF app behind it.
+    /// </summary>
+    internal static bool ShouldStopVideoOnRunExit(bool chaosCapArmed, bool videoPlaying)
+        => chaosCapArmed && videoPlaying;
+
+    /// <summary>
+    /// Stop a chaos-fired video and disarm the cap. Every run-exit path calls this, because the
+    /// mid-run cap in <c>RunTick</c> cannot: the tick early-returns while the run is paused (draft
+    /// card, lesson card, manual hold) and its run-closing branch only covers the clock running
+    /// out, so a quit mid-tape used to walk the video onto the results screen and the lobby behind
+    /// it (ccp-bugs #1201). Idempotent - the cap is cleared first, so a second call is a no-op.
+    /// </summary>
+    private void StopChaosOwnedVideo(string reason)
+    {
+        bool armed = _chaosVideoCapUtc != DateTime.MinValue;
+        _chaosVideoCapUtc = DateTime.MinValue;   // an armed cap never outlives the run
+        if (!ShouldStopVideoOnRunExit(armed, App.Video?.IsPlaying == true)) return;
+        try { App.Video?.ForceCleanup(); } catch (Exception ex) { App.Logger?.Debug("Chaos video teardown: {E}", ex.Message); }
+        ExtendHeavyQuarantine(VIDEO_TEARDOWN_QUARANTINE_SEC);   // ForceCleanup may not raise VideoEnded
+        App.Logger?.Information("[Chaos] tore down a chaos-fired video ({Reason})", reason);
+    }
+
     /// <summary>Mirrors the pop streak into the tunnel background so the fall accelerates with
     /// the combo and brakes when it halves/breaks. Combo only ever changes on the UI thread
     /// (timers + click handlers), so this posts straight through.</summary>
@@ -3088,6 +3114,7 @@ public sealed class ChaosModeService
         _paused = false;
         _runTimer?.Stop();
         _spawnTimer?.Stop();
+        StopChaosOwnedVideo("force shutdown");
         try { App.Bubbles?.EndChaosMode(); } catch (Exception ex) { Diag.Swallowed(ex); }
         try { App.Bubbles?.Resume(); } catch (Exception ex) { Diag.Swallowed(ex); }
         StopKeyHook();
@@ -3135,6 +3162,10 @@ public sealed class ChaosModeService
         _spawning = false;
         if (App.Video != null) App.Video.VideoStarted -= OnVideoStartedDuringRun;
         if (App.Video != null) App.Video.VideoEnded -= OnVideoEndedDuringRun;
+        // EndRun does NOT flow through CleanupAfterRun: it shows the results card and cleanup only
+        // runs when that card is dismissed, so the tape has to come off here or it plays over the
+        // results and on into the lobby.
+        StopChaosOwnedVideo("run end");
         _runTimer?.Stop();
         _spawnTimer?.Stop();
         StopKeyHook();
@@ -3229,6 +3260,7 @@ public sealed class ChaosModeService
         try { System.Windows.Media.CompositionTarget.Rendering -= OnChaosRendering; } catch (Exception ex) { Diag.Swallowed(ex); }
         if (App.Video != null) App.Video.VideoStarted -= OnVideoStartedDuringRun;   // belt-and-suspenders (mid-run close)
         if (App.Video != null) App.Video.VideoEnded -= OnVideoEndedDuringRun;
+        StopChaosOwnedVideo("cleanup");   // the last net: overlay closed mid-run, Run Again, app exit
         StopKeyHook();   // idempotent; covers the overlay-closed-mid-run path
         StopRippleHook();
         CloseToyButtons();

--- a/Tests/ConditioningControlPanel.Tests/ChaosVideoRunExitTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/ChaosVideoRunExitTests.cs
@@ -1,0 +1,40 @@
+﻿using ConditioningControlPanel.Services.Chaos;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// ccp-bugs #1201: "videos that are playing when a DTRH drop ends often get stuck and continue
+/// onto the lobby screen". The mid-run cap in <c>RunTick</c> was the only path that tore a
+/// chaos-fired video down, and the tick early-returns while the run is paused, so quitting mid-tape
+/// (or ending from a pause) carried the video onto the results card and the lobby behind it. Every
+/// run-exit path now calls the same teardown.
+///
+/// The half of that which must never regress is the OWNERSHIP rule pinned here:
+/// <c>App.Video.ForceCleanup()</c> closes every video window the service owns - the user's own
+/// mandatory/session video included - so chaos may only fire it when the armed cap says chaos
+/// started the tape.
+/// </summary>
+public class ChaosVideoRunExitTests
+{
+    [Fact]
+    public void ChaosFiredTapeStillPlaying_ComesOff()
+        => Assert.True(ChaosModeService.ShouldStopVideoOnRunExit(chaosCapArmed: true, videoPlaying: true));
+
+    /// <summary>
+    /// The one that matters: no armed cap means chaos did not start this video, so a user's own
+    /// mandatory or session video survives the descent ending on top of it.
+    /// </summary>
+    [Fact]
+    public void VideoChaosDidNotStart_IsLeftAlone()
+        => Assert.False(ChaosModeService.ShouldStopVideoOnRunExit(chaosCapArmed: false, videoPlaying: true));
+
+    /// <summary>Nothing playing: no ForceCleanup, so a run exit never yanks the audio duck or the
+    /// InteractionQueue slot out from under whatever else is up.</summary>
+    [Fact]
+    public void NothingPlaying_IsANoOp()
+    {
+        Assert.False(ChaosModeService.ShouldStopVideoOnRunExit(chaosCapArmed: true, videoPlaying: false));
+        Assert.False(ChaosModeService.ShouldStopVideoOnRunExit(chaosCapArmed: false, videoPlaying: false));
+    }
+}


### PR DESCRIPTION
## What

A Down The Rabbit Hole video kept playing after the run ended, landing on the results card and the lobby behind it.

`ChaosModeService` only tore a chaos-fired video down in one place: the mid-run cap inside `RunTick`. That tick early-returns while the run is paused (draft card, lesson card, manual hold), and its only other exit-shaped branch is `runClosing` (the last 3s of the clock), so a quit mid-tape never hit either. The three run-exit paths (`EndRun`, `ForceShutdown`, `CleanupAfterRun`) just unsubscribed `VideoStarted`/`VideoEnded` and left the player running.

`EndRun` does **not** flow through `CleanupAfterRun`: it shows the results overlay, and cleanup only runs when that overlay is dismissed (`OnOverlayClosed`). That is why the video survived all the way onto the lobby.

## Why this shape

- One shared `StopChaosOwnedVideo(reason)`, called from `EndRun`, `ForceShutdown` and `CleanupAfterRun`; the mid-run cap now routes through it too, so there is a single teardown instead of four.
- It is idempotent (the cap is cleared first), so `ForceShutdown` -> `CleanupAfterRun` double-calling is a no-op.
- **Ownership guard.** `App.Video.ForceCleanup()` closes every video window the service owns, force-unducks audio and releases the InteractionQueue slot, so chaos may only fire it at a video chaos itself started. The armed `_chaosVideoCapUtc` is that mark, set only when a `Video` payload detonates. A user's own mandatory or session video that happens to be up when a descent ends is left alone. The rule is extracted as pure `ShouldStopVideoOnRunExit(chaosCapArmed, videoPlaying)` and pinned by tests.

## Other run-spawned surfaces

Checked, not changed: `ChaosBackdropService` / `ChaosTunnelService` are already closed in `CleanupAfterRun` (deliberately kept alive behind the results card). The one real gap is the `HtLinkPayload` browser takeover: it claims `BrowserMediaService.BeginTakeover(MediaOwner.Chaos)` and no chaos run-exit path ever releases it - it relies on the heartbeat timer. Releasing a still-fullscreen browser session is a different call in a different service, so it is noted here rather than bundled in.

## Testing

- `dotnet build` green.
- `dotnet test`: 5365 passed, 3 failed. All 3 failures are in `VatFillCoordinatorTests` and reproduce unchanged on `origin/release/6.9.4` with this branch stashed - pre-existing, unrelated.
- New `ChaosVideoRunExitTests` (3 facts): chaos tape comes off, a video chaos did not start is left alone, nothing playing is a no-op.
- Not verified at runtime: no live DTRH run was played, so the end-to-end "quit mid-video, land on the lobby clean" path is unconfirmed on a desk.

No user-facing strings added, so no localisation changes. Diff: 75 insertions, 3 deletions across 2 files.

Refs CC-Labs-llc/ccp-bugs#1201

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013mR8cAipk1ivr3Em5fJjcx