### PR TITLE
feat(flash): a slider for how fast animated flashes play

### DIFF
--- a/ConditioningControlPanel/Features/VisualsFeatureControl.xaml
+++ b/ConditioningControlPanel/Features/VisualsFeatureControl.xaml
@@ -107,6 +107,25 @@
                                            FontSize="13" FontWeight="Bold"/>
                             </Grid>
 
+                            <!-- #1194: animated flashes only. 1.0x is the file's own timing; the row
+                                 simply disappears into the same dial stack rather than earning a section. -->
+                            <Grid Height="36" Background="Transparent" ToolTip="{loc:Str tooltip_playback_speed_for_animated_flash_images_gif}">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto" MinWidth="120"/>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto" MinWidth="56"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" Text="{loc:Str setting_gif_speed}" FontSize="13" FontWeight="SemiBold"
+                                           Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
+                                <Slider Grid.Column="1" x:Name="SliderGifSpeed" Minimum="0.25" Maximum="4" Value="1"
+                                        SmallChange="0.25" LargeChange="0.25" TickFrequency="0.25" IsSnapToTickEnabled="True"
+                                        VerticalAlignment="Center" Margin="14,0"
+                                        ValueChanged="SliderGifSpeed_Changed"/>
+                                <TextBlock Grid.Column="2" x:Name="TxtGifSpeed" Text="1.0x" HorizontalAlignment="Right"
+                                           VerticalAlignment="Center" Foreground="{DynamicResource PinkBrush}"
+                                           FontSize="13" FontWeight="Bold"/>
+                            </Grid>
+
                             <Border Height="1" Background="{DynamicResource GlassBorderBrush}" Margin="0,6"/>
 
                             <!-- Link to Audio.

--- a/ConditioningControlPanel/Features/VisualsFeatureControl.xaml.cs
+++ b/ConditioningControlPanel/Features/VisualsFeatureControl.xaml.cs
@@ -1,5 +1,6 @@
 using System;
 using System.ComponentModel;
+using System.Globalization;
 using System.Windows;
 using System.Windows.Controls;
 
@@ -47,6 +48,8 @@ namespace ConditioningControlPanel.Features
                 TxtFade.Text = $"{s.FadeDuration}%";
                 SliderDuration.Value = s.FlashDuration;
                 TxtDuration.Text = $"{s.FlashDuration}s";
+                SliderGifSpeed.Value = s.FlashGifSpeedMultiplier;
+                TxtGifSpeed.Text = FormatGifSpeed(s.FlashGifSpeedMultiplier);
                 ChkAudio.IsChecked = s.FlashAudioEnabled;
             }
             finally { _isLoading = false; }
@@ -58,6 +61,7 @@ namespace ConditioningControlPanel.Features
                 e.PropertyName == nameof(Models.AppSettings.FlashOpacity) ||
                 e.PropertyName == nameof(Models.AppSettings.FadeDuration) ||
                 e.PropertyName == nameof(Models.AppSettings.FlashDuration) ||
+                e.PropertyName == nameof(Models.AppSettings.FlashGifSpeedMultiplier) ||
                 e.PropertyName == nameof(Models.AppSettings.FlashAudioEnabled))
             {
                 Dispatcher.BeginInvoke(new Action(LoadFromSettings));
@@ -105,6 +109,20 @@ namespace ConditioningControlPanel.Features
             var v = (int)e.NewValue;
             TxtDuration.Text = $"{v}s";
             s.FlashDuration = v;
+            App.Settings?.Save();
+        }
+
+        /// <summary>One decimal, invariant, so the readout is "1.0x" in every locale.</summary>
+        private static string FormatGifSpeed(double multiplier)
+            => multiplier.ToString("0.0", CultureInfo.InvariantCulture) + "x";
+
+        private void SliderGifSpeed_Changed(object sender, RoutedPropertyChangedEventArgs<double> e)
+        {
+            if (_isLoading) return;
+            var s = App.Settings?.Current;
+            if (s == null) return;
+            s.FlashGifSpeedMultiplier = e.NewValue;   // the setter clamps to 0.25-4.0
+            TxtGifSpeed.Text = FormatGifSpeed(s.FlashGifSpeedMultiplier);
             App.Settings?.Save();
         }
 

--- a/ConditioningControlPanel/Localization/Languages/de.json
+++ b/ConditioningControlPanel/Localization/Languages/de.json
@@ -185,6 +185,8 @@
   "setting_click": "Klick",
   "setting_max_on_screen": "Max. auf Bildschirm",
   "setting_duration": "Dauer",
+  "setting_gif_speed": "GIF-Tempo",
+  "tooltip_playback_speed_for_animated_flash_images_gif": "Wiedergabetempo animierter Flash-Bilder.\n1.0x behält das Timing der Datei bei.",
   "setting_interval": "Intervall",
   "setting_opacity": "Deckkraft",
   "setting_intensity": "Intensität",

--- a/ConditioningControlPanel/Localization/Languages/en.json
+++ b/ConditioningControlPanel/Localization/Languages/en.json
@@ -960,6 +960,8 @@
   "setting_click": "Click",
   "setting_max_on_screen": "Max On Screen",
   "setting_duration": "Duration",
+  "setting_gif_speed": "GIF speed",
+  "tooltip_playback_speed_for_animated_flash_images_gif": "Playback speed for animated flash images.\n1.0x keeps the file's own timing.",
   "setting_interval": "Interval",
   "setting_opacity": "Opacity",
   "setting_intensity": "Intensity",

--- a/ConditioningControlPanel/Localization/Languages/es.json
+++ b/ConditioningControlPanel/Localization/Languages/es.json
@@ -185,6 +185,8 @@
   "setting_click": "Clic",
   "setting_max_on_screen": "Máx en Pantalla",
   "setting_duration": "Duración",
+  "setting_gif_speed": "Velocidad GIF",
+  "tooltip_playback_speed_for_animated_flash_images_gif": "Velocidad de reproducción de las imágenes flash animadas.\n1.0x mantiene el ritmo del archivo.",
   "setting_interval": "Intervalo",
   "setting_opacity": "Opacidad",
   "setting_intensity": "Intensidad",

--- a/ConditioningControlPanel/Localization/Languages/fr.json
+++ b/ConditioningControlPanel/Localization/Languages/fr.json
@@ -185,6 +185,8 @@
   "setting_click": "Clic",
   "setting_max_on_screen": "Max à l'écran",
   "setting_duration": "Durée",
+  "setting_gif_speed": "Vitesse GIF",
+  "tooltip_playback_speed_for_animated_flash_images_gif": "Vitesse de lecture des images flash animées.\n1.0x conserve le rythme du fichier.",
   "setting_interval": "Intervalle",
   "setting_opacity": "Opacité",
   "setting_intensity": "Intensité",

--- a/ConditioningControlPanel/Localization/Languages/ja.json
+++ b/ConditioningControlPanel/Localization/Languages/ja.json
@@ -185,6 +185,8 @@
   "setting_click": "クリック",
   "setting_max_on_screen": "最大表示数",
   "setting_duration": "表示時間",
+  "setting_gif_speed": "GIF速度",
+  "tooltip_playback_speed_for_animated_flash_images_gif": "アニメーションフラッシュ画像の再生速度。\n1.0x はファイル本来の速度です。",
   "setting_interval": "間隔",
   "setting_opacity": "不透明度",
   "setting_intensity": "強度",

--- a/ConditioningControlPanel/Localization/Languages/ko.json
+++ b/ConditioningControlPanel/Localization/Languages/ko.json
@@ -185,6 +185,8 @@
   "setting_click": "클릭",
   "setting_max_on_screen": "최대 화면 표시",
   "setting_duration": "지속 시간",
+  "setting_gif_speed": "GIF 속도",
+  "tooltip_playback_speed_for_animated_flash_images_gif": "애니메이션 플래시 이미지의 재생 속도입니다.\n1.0x는 파일 원래의 속도입니다.",
   "setting_interval": "간격",
   "setting_opacity": "불투명도",
   "setting_intensity": "강도",

--- a/ConditioningControlPanel/Localization/Languages/pt-BR.json
+++ b/ConditioningControlPanel/Localization/Languages/pt-BR.json
@@ -185,6 +185,8 @@
   "setting_click": "Clique",
   "setting_max_on_screen": "Máx. na Tela",
   "setting_duration": "Duração",
+  "setting_gif_speed": "Velocidade do GIF",
+  "tooltip_playback_speed_for_animated_flash_images_gif": "Velocidade de reprodução das imagens flash animadas.\n1.0x mantém o ritmo do arquivo.",
   "setting_interval": "Intervalo",
   "setting_opacity": "Opacidade",
   "setting_intensity": "Intensidade",

--- a/ConditioningControlPanel/Localization/Languages/ru.json
+++ b/ConditioningControlPanel/Localization/Languages/ru.json
@@ -185,6 +185,8 @@
   "setting_click": "Клик",
   "setting_max_on_screen": "Макс. изображений на экране",
   "setting_duration": "Длительность",
+  "setting_gif_speed": "Скорость GIF",
+  "tooltip_playback_speed_for_animated_flash_images_gif": "Скорость воспроизведения анимированных флеш-изображений.\n1.0x сохраняет исходный темп файла.",
   "setting_interval": "Интервал",
   "setting_opacity": "Прозрачность",
   "setting_intensity": "Интенсивность",

--- a/ConditioningControlPanel/Localization/Languages/zh-CN.json
+++ b/ConditioningControlPanel/Localization/Languages/zh-CN.json
@@ -773,6 +773,8 @@
   "setting_click": "点击",
   "setting_max_on_screen": "最大显示数量",
   "setting_duration": "持续时间",
+  "setting_gif_speed": "GIF 速度",
+  "tooltip_playback_speed_for_animated_flash_images_gif": "动态闪现图片的播放速度。\n1.0x 保持文件原本的节奏。",
   "setting_interval": "间隔",
   "setting_opacity": "透明度",
   "setting_intensity": "强度",

--- a/ConditioningControlPanel/Models/AppSettings.cs
+++ b/ConditioningControlPanel/Models/AppSettings.cs
@@ -1055,6 +1055,24 @@ namespace ConditioningControlPanel.Models
             set { _flashDuration = Math.Clamp(value, 1, 30); OnPropertyChanged(); }
         }
 
+        // #1194: animated flashes used to play at whatever timing the file carried, which is far
+        // too slow for some GIFs and far too fast for others. 1.0 keeps the file's own timing;
+        // 2.0 plays it twice as fast. Applied by FlashService.ScaleFrameDelay when a flash window
+        // is handed its frames, so it touches FLASH windows only - the avatar's XamlAnimatedGif
+        // clips and the spiral overlay's own pump keep their own timing.
+        private double _flashGifSpeedMultiplier = 1.0; // 0.25x (quarter speed) .. 4x
+        /// <summary>
+        /// Playback speed multiplier for animated flash images (GIF / animated WebP).
+        /// Clamped 0.25-4.0; the resulting per-frame delay is additionally floored at
+        /// <see cref="ConditioningControlPanel.Services.FlashService.MIN_GIF_FRAME_DELAY_MS"/> ms
+        /// so a 4x on an already-fast GIF cannot spin the UI thread.
+        /// </summary>
+        public double FlashGifSpeedMultiplier
+        {
+            get => _flashGifSpeedMultiplier;
+            set { _flashGifSpeedMultiplier = Math.Clamp(value, 0.25, 4.0); OnPropertyChanged(); }
+        }
+
         // Gaming quality-of-life (#770): keep flashes out of a centered square on every monitor so
         // they never land on the crosshair / HUD centre. This is a PURE GLOBAL USER PREFERENCE —
         // deliberately absent from SessionSettings, SessionEngine's save/restore, Preset and the

--- a/ConditioningControlPanel/Services/Flash/FlashService.cs
+++ b/ConditioningControlPanel/Services/Flash/FlashService.cs
@@ -65,6 +65,32 @@ namespace ConditioningControlPanel.Services
             => (useLayer || useHost) ? MAX_CONCURRENT_FLASH_HOST : MAX_CONCURRENT_FLASH;
 
         /// <summary>
+        /// Floor for an animated flash's per-frame delay, in milliseconds. A 4x multiplier on a GIF
+        /// that already carries a 10-20ms frame time would otherwise ask the heartbeat for a new
+        /// frame every tick on every live window; 10ms (100fps) is past what anyone can see and
+        /// keeps the UI thread out of a spin. It also guards the frame-index division below against
+        /// a decoder that hands back a zero delay.
+        /// </summary>
+        internal const double MIN_GIF_FRAME_DELAY_MS = 10.0;
+
+        /// <summary>
+        /// The per-frame delay an animated flash should actually play at: the file's own delay
+        /// divided by the user's speed multiplier (2x = half the delay = twice as fast), floored at
+        /// <see cref="MIN_GIF_FRAME_DELAY_MS"/>. A non-positive or non-finite source delay falls back
+        /// to the decoders' own 100ms default, and a garbage multiplier falls back to 1.0 before the
+        /// 0.25-4.0 clamp, so this never returns zero or NaN.
+        /// Pure so it can be unit-tested without spinning up WPF.
+        /// </summary>
+        internal static TimeSpan ScaleFrameDelay(TimeSpan sourceDelay, double multiplier)
+        {
+            var ms = sourceDelay.TotalMilliseconds;
+            if (double.IsNaN(ms) || double.IsInfinity(ms) || ms <= 0) ms = 100.0;
+            if (double.IsNaN(multiplier) || double.IsInfinity(multiplier) || multiplier <= 0) multiplier = 1.0;
+            multiplier = Math.Clamp(multiplier, 0.25, 4.0);
+            return TimeSpan.FromMilliseconds(Math.Max(MIN_GIF_FRAME_DELAY_MS, ms / multiplier));
+        }
+
+        /// <summary>
         /// The current run's cancellation token, or <see cref="CancellationToken.None"/> when no run
         /// owns one (Stop retires it - see #1107). Tolerates a source disposed by a racing Stop.
         /// </summary>
@@ -1471,7 +1497,8 @@ namespace ConditioningControlPanel.Services
                 window.Left = finalX;
                 window.Top = finalY;
                 window.Frames = imageData.Frames;
-                window.FrameDelay = imageData.FrameDelay;
+                // #1194: the user's GIF speed slider, applied once here rather than per tick.
+                window.FrameDelay = ScaleFrameDelay(imageData.FrameDelay, settings.FlashGifSpeedMultiplier);
                 window.StartTime = DateTime.Now;
                 window.CurrentFrameIndex = 0;
                 // The shared host is fully click-through (pops on it would need the global mouse

--- a/Tests/ConditioningControlPanel.Tests/FlashGifSpeedTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/FlashGifSpeedTests.cs
@@ -1,0 +1,77 @@
+using System;
+using ConditioningControlPanel.Models;
+using ConditioningControlPanel.Services;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// ccp-bugs #1194 - the flash GIF speed slider. The multiplier scales the per-frame delay the
+/// flash heartbeat divides by, so the two things worth pinning are the direction of the maths
+/// (faster = SHORTER delay) and the floor that stops a 4x on an already-fast GIF from asking for
+/// a new frame on every single heartbeat tick.
+/// </summary>
+public class FlashGifSpeedTests
+{
+    [Fact]
+    public void DefaultMultiplier_LeavesTheFileTimingAlone()
+        => Assert.Equal(100, FlashService.ScaleFrameDelay(TimeSpan.FromMilliseconds(100), 1.0).TotalMilliseconds, 3);
+
+    [Theory]
+    [InlineData(2.0, 50)]      // twice as fast -> half the delay
+    [InlineData(4.0, 25)]      // ceiling
+    [InlineData(0.5, 200)]     // half speed -> twice the delay
+    [InlineData(0.25, 400)]    // floor of the RANGE (not of the delay)
+    public void MultiplierDividesTheDelay(double multiplier, double expectedMs)
+        => Assert.Equal(expectedMs, FlashService.ScaleFrameDelay(TimeSpan.FromMilliseconds(100), multiplier).TotalMilliseconds, 3);
+
+    [Theory]
+    [InlineData(8.0)]          // above the 4x ceiling
+    [InlineData(-1.0)]         // nonsense
+    [InlineData(0.01)]         // below the 0.25x floor
+    public void MultiplierIsClampedBeforeItDivides(double multiplier)
+    {
+        var d = FlashService.ScaleFrameDelay(TimeSpan.FromMilliseconds(100), multiplier).TotalMilliseconds;
+        Assert.InRange(d, 25, 400);
+    }
+
+    [Fact]
+    public void FastGifAtMaxSpeed_StopsAtTheFloor()
+    {
+        // A 20ms/frame GIF at 4x wants 5ms, which is under one heartbeat tick on every live window.
+        var d = FlashService.ScaleFrameDelay(TimeSpan.FromMilliseconds(20), 4.0);
+        Assert.Equal(FlashService.MIN_GIF_FRAME_DELAY_MS, d.TotalMilliseconds, 3);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-40)]
+    public void NonPositiveSourceDelay_FallsBackToTheDecoderDefault(double sourceMs)
+    {
+        // Never zero: the heartbeat divides by this value to pick a frame index.
+        var d = FlashService.ScaleFrameDelay(TimeSpan.FromMilliseconds(sourceMs), 1.0);
+        Assert.Equal(100, d.TotalMilliseconds, 3);
+    }
+
+    [Fact]
+    public void ScaledDelayIsNeverBelowTheFloor()
+    {
+        foreach (var src in new[] { 1.0, 5.0, 10.0, 16.0, 33.0, 100.0, 1000.0 })
+            foreach (var mult in new[] { 0.25, 0.5, 1.0, 2.0, 4.0 })
+                Assert.True(FlashService.ScaleFrameDelay(TimeSpan.FromMilliseconds(src), mult).TotalMilliseconds
+                            >= FlashService.MIN_GIF_FRAME_DELAY_MS);
+    }
+
+    [Fact]
+    public void SettingClampsToTheSliderRange()
+    {
+        var s = new AppSettings();
+        Assert.Equal(1.0, s.FlashGifSpeedMultiplier);
+
+        s.FlashGifSpeedMultiplier = 9.0;
+        Assert.Equal(4.0, s.FlashGifSpeedMultiplier);
+
+        s.FlashGifSpeedMultiplier = 0.0;
+        Assert.Equal(0.25, s.FlashGifSpeedMultiplier);
+    }
+}


### PR DESCRIPTION
## What

A **GIF speed** slider in the Visuals card, under Duration, 0.25x to 4x, default 1.0x, shown as `1.0x`.

## Why

`Refs CC-Labs-llc/ccp-bugs#1194` - flashes play an animated file at whatever frame timing the file carries, and there was no way to change it. The request was for faster; the slider goes both ways since the same dial gives it for free.

## How

- `AppSettings.FlashGifSpeedMultiplier` (double, default 1.0, setter clamps 0.25-4.0), declared beside `FlashDuration` in the Flash region. An older `settings.json` has no key, so the field initializer gives it 1.0 and nothing moves for anyone who does not touch the slider.
- `FlashService.ScaleFrameDelay(sourceDelay, multiplier)` - pure and unit-tested - divides the file's own delay by the multiplier and floors the result at `MIN_GIF_FRAME_DELAY_MS` (10ms). Called once where a flash window is handed its frames, not per heartbeat tick.

```csharp
var ms = sourceDelay.TotalMilliseconds;
if (double.IsNaN(ms) || double.IsInfinity(ms) || ms <= 0) ms = 100.0;
if (double.IsNaN(multiplier) || double.IsInfinity(multiplier) || multiplier <= 0) multiplier = 1.0;
multiplier = Math.Clamp(multiplier, 0.25, 4.0);
return TimeSpan.FromMilliseconds(Math.Max(MIN_GIF_FRAME_DELAY_MS, ms / multiplier));
```

  The floor is the point of the exercise: a 4x on a GIF that already carries a 16ms frame time would otherwise want a new frame on every heartbeat tick of every live window. It also means the frame-index division in the pump (`elapsed / window.FrameDelay`) can no longer be handed a zero.
- One row in the existing dial stack. No new section, no new card.
- `setting_gif_speed` + `tooltip_playback_speed_for_animated_flash_images_gif` added to all 9 language files; no key removed.

## Scope

Flash windows only. The avatar's XamlAnimatedGif clips (`AvatarTube/`), `OverlayService`'s spiral pump and the shared `AnimatedWebp` decoder are untouched and keep their own timing.

## Cloud sync

Nothing to do. `AppSettings` serializes opt-out, and `App.ApplyRestoredSettings` names only the identity and progression fields it wants to keep local, so a plain new dial rides along with every other setting.

## Testing

`Tests/ConditioningControlPanel.Tests/FlashGifSpeedTests.cs`, 13 cases: direction of the maths, the 0.25-4.0 clamp, the 10ms floor at max speed on a fast GIF, a non-positive source delay falling back to 100ms, a sweep asserting the result never drops under the floor, and the setting's own clamp.

- `dotnet build` green (0 errors).
- Full suite: 5375 passed, 3 failed - `VatFillCoordinatorTests` (3), which fail identically on `origin/release/6.9.4` with this branch stashed. Not from this change.
- Not verified at runtime: no desk run, so the slider has not been dragged against a real GIF.

Changed lines: 179 (`git diff --stat origin/release/6.9.4...HEAD`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013mR8cAipk1ivr3Em5fJjcx
