### PR TITLE
test(descent): the vat fixtures parse on a machine that writes 40,98 (6.9.4 cherry-pick of #1024)

### DIFF
--- a/Tests/ConditioningControlPanel.Tests/VatFillCoordinatorTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/VatFillCoordinatorTests.cs
@@ -1,4 +1,4 @@
-using ConditioningControlPanel.Services.Descent;
+﻿using ConditioningControlPanel.Services.Descent;
 using Newtonsoft.Json.Linq;
 using Xunit;
 
@@ -17,9 +17,10 @@ namespace ConditioningControlPanel.Tests;
 public class VatFillCoordinatorTests
 {
     private static DescentBlock? BlockWith(int cap, int todayXp, double fillPct, double lipPct = 120)
-        => DescentReader.Parse(DescentReader.ParseWire(
-            $"{{ \"devotion_days\": 10, \"vat\": {{ \"cap\": {cap}, \"today_xp\": {todayXp}, " +
-            $"\"fill_pct\": {fillPct}, \"fill_lip_pct\": {lipPct} }} }}"));
+        // Invariant on purpose: a plain interpolation writes 40,98 on an it-IT machine and the wire
+        // JSON stops parsing, which reads as Ignored and fails every fractional case below.
+        => DescentReader.Parse(DescentReader.ParseWire(System.FormattableString.Invariant(
+            $"{{ \"devotion_days\": 10, \"vat\": {{ \"cap\": {cap}, \"today_xp\": {todayXp}, \"fill_pct\": {fillPct}, \"fill_lip_pct\": {lipPct} }} }}")));
 
     // ------------------------------------------------------------- the threshold
 


### PR DESCRIPTION
Cherry-pick of #1024 (0efd6b41f) onto the 6.9.4 release line. Test-only: the three VatFillCoordinator tests fail on an it-IT machine without it, which is what every 6.9.4 branch run shows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013mR8cAipk1ivr3Em5fJjcx