### PR TITLE
fix(emi): the dock chip and her mute prompt survive a lockdown

### DIFF
--- a/ConditioningControlPanel/MainWindow/MainWindow.Possession.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.Possession.cs
@@ -228,11 +228,24 @@ namespace ConditioningControlPanel
         /// <para><c>TxtXP</c> is here for a mechanical reason rather than a rule: the BANK odometer
         /// (MainWindow.BankFx.cs, StepBankCounter) rewrites that readout roughly every 70 ms for the
         /// length of a token flight. A text effect that took it would be a silent no-op - overwritten
-        /// before anyone could read it - while still burning a ghost slot and a 45 s target cooldown.</para></summary>
+        /// before anyone could read it - while still burning a ghost slot and a 45 s target cooldown.</para>
+        ///
+        /// <para><c>EmiDockChip</c> is here because it is the ONLY way into EMI that a user can see
+        /// (ccp-bugs #1190). The summon chord is a global hotkey people have to be told about and
+        /// there is no tray entry: grep for callers of <c>EmiDeskService.Toggle</c> and the dock chip
+        /// is the whole list. Blocklisting the UserControl rather than its inner <c>BtnChip</c> is
+        /// what makes it stick - WalkPossession returns at the named element and never descends, so
+        /// the button inside it cannot be enrolled either. Left alone the chip is an ordinary Button
+        /// target, which puts swap on it (it glides into a neighbour's seat and STAYS there for 30 s)
+        /// along with dissolve and melt - and Possession only ever runs during a lockdown, which is
+        /// why the report reads as "EMI is not available in lockdown" rather than as a haunt. She is
+        /// not an exit, so this is reachability rather than a POSSESSION.md hard rule, but a
+        /// companion nobody can reach is a broken feature for the length of the hold.</para></summary>
         private static readonly HashSet<string> PossessionNeverNames = new(StringComparer.Ordinal)
         {
             "TxtLockdownTimer", "TxtLockdownExit", "BtnEmergencyExit", "EERoot",
             "LockdownGate", "TxtPossessionRung", "PossessionPips", "TxtXP",
+            "EmiDockChip",
         };
 
         /// <summary>Labels are the one role that can run to the hundreds on a dense tab, and a deck full

--- a/ConditioningControlPanel/Windows/EmiDesk/EmiMutePromptWindow.xaml
+++ b/ConditioningControlPanel/Windows/EmiDesk/EmiMutePromptWindow.xaml
@@ -9,12 +9,23 @@
         ResizeMode="NoResize"
         SizeToContent="Height"
         Width="420"
+        Topmost="True"
         WindowStartupLocation="CenterOwner">
 
     <!--
         The summon-time mute question. Deliberately self-contained: every brush is a literal, so it
         cannot take a BAML EndOfStream from a cross-dictionary StaticResource lookup the way the
         Velvet Kit work did. Three answers, no default button: the user has to say which.
+
+        TOPMOST, like every other window in this folder (desk, book, options, ring). Not decoration:
+        the one moment this dialog is certain to appear is a summon while something is already
+        talking, and during a lockdown that something is a strict video window which is itself
+        Topmost and fullscreen. Owner alone only lifts this above MainWindow, and MainWindow is
+        underneath that video - so the modal opened out of sight while its nested message pump held
+        the summon, and EMI never arrived (ccp-bugs #1190). It does not weaken the lockdown: all
+        three answers are about the AVATAR, there is no exit affordance here, Escape means "keep the
+        avatar" rather than "let me out", and the strict video window deliberately does not
+        re-activate itself on Deactivated (VideoService.cs), so nothing fights this for the z-order.
     -->
     <Window.Resources>
         <Style x:Key="EmiPromptButton" TargetType="Button">

--- a/Tests/ConditioningControlPanel.Tests/EmiLockdownReachTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/EmiLockdownReachTests.cs
@@ -1,0 +1,103 @@
+using System;
+using System.IO;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// EMI has to stay reachable while a lockdown runs (ccp-bugs #1190). Two independent things made
+/// her unreachable and both are pinned here:
+///
+/// <list type="number">
+/// <item>the dock chip was an ordinary Possession Button target, so swap / dissolve / melt could
+/// take it for the length of a hold - and Possession only ever runs DURING a lockdown, which is
+/// why the report reads as "EMI is not available in lockdown" rather than as a haunt;</item>
+/// <item>the mute prompt was a modal with no <c>Topmost</c>, so on the one path certain to raise
+/// it - a summon while something is already talking - it opened behind the strict video window
+/// and its nested message pump held the summon.</item>
+/// </list>
+///
+/// <para><b>Why these are source reads.</b> Both contracts live in a WPF window this suite cannot
+/// afford to realize (the same call NavRailFlyoutTests makes for the nav rail), and neither is
+/// observable from a rendered tree anyway: <c>PossessionNeverNames</c> is a private static on
+/// MainWindow, and a window's z-band does not show up in a static render. What can rot is the
+/// wiring, so the wiring is what is pinned.</para>
+/// </summary>
+public class EmiLockdownReachTests
+{
+    private static string RepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir != null && !Directory.Exists(Path.Combine(dir.FullName, "ConditioningControlPanel", "Resources")))
+            dir = dir.Parent;
+        Assert.True(dir != null, "could not locate the repo root from " + AppContext.BaseDirectory);
+        return dir!.FullName;
+    }
+
+    private static string AppFile(params string[] parts)
+        => File.ReadAllText(Path.Combine(RepoRoot(), Path.Combine("ConditioningControlPanel", Path.Combine(parts))));
+
+    /// <summary>The blocklist's initializer body only, so a name that appears solely in the doc
+    /// comment above it cannot make any of this pass on prose.</summary>
+    private static string NeverNamesBody()
+    {
+        var src = AppFile("MainWindow", "MainWindow.Possession.cs");
+        var m = Regex.Match(
+            src,
+            @"PossessionNeverNames\s*=\s*new\(StringComparer\.Ordinal\)\s*\{(?<body>[^}]*)\}",
+            RegexOptions.Singleline);
+        Assert.True(m.Success,
+            "PossessionNeverNames is gone from MainWindow.Possession.cs, or it is no longer a collection initializer");
+        return m.Groups["body"].Value;
+    }
+
+    [Theory]
+    // The chip. It is the only route into EMI a user can SEE, and WalkPossession stops at the named
+    // element, so blocking the UserControl covers the BtnChip inside it too.
+    [InlineData("EmiDockChip")]
+    // The neighbours it now shares the list with, named so a careless edit to the initializer
+    // cannot quietly drop an exit on the way to adding the chip.
+    [InlineData("TxtLockdownTimer")]
+    [InlineData("TxtLockdownExit")]
+    [InlineData("BtnEmergencyExit")]
+    [InlineData("EERoot")]
+    public void TheBlocklistHolds(string name)
+        => Assert.Contains("\"" + name + "\"", NeverNamesBody(), StringComparison.Ordinal);
+
+    /// <summary>The blocklist matches <c>x:Name</c> with <c>StringComparer.Ordinal</c>, so an entry
+    /// whose element has been renamed is an entry that silently does nothing.</summary>
+    [Fact]
+    public void TheChipStillCarriesThatName()
+    {
+        var xaml = AppFile("MainWindow", "MainWindow.xaml");
+        Assert.Contains("<controls:EmiDock x:Name=\"EmiDockChip\"", xaml, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The mute prompt rides the same z-band as the rest of Windows/EmiDesk. Without it the dialog
+    /// is merely owned by MainWindow, which during a lockdown sits under a fullscreen strict video
+    /// window that is itself Topmost - so the modal is invisible and the summon waits behind it.
+    /// </summary>
+    [Fact]
+    public void TheMutePromptIsTopmost()
+    {
+        var xaml = AppFile("Windows", "EmiDesk", "EmiMutePromptWindow.xaml");
+        var head = xaml.Substring(0, xaml.IndexOf(">", StringComparison.Ordinal) + 1);
+        Assert.Contains("Topmost=\"True\"", head, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// And it stays a dialog about the AVATAR. A Topmost window over a mandatory video is only
+    /// acceptable while it offers no way out of the lockdown, so the three answers are pinned: a
+    /// fourth button here would need that z-order argument made again from scratch.
+    /// </summary>
+    [Fact]
+    public void TheMutePromptOffersNoExit()
+    {
+        var code = AppFile("Windows", "EmiDesk", "EmiMutePromptWindow.xaml.cs");
+        Assert.Equal(3, Regex.Matches(code, @"\bBtn\w+\.Click \+=").Count);
+        // Escape is "keep the avatar", never an exit and never a mute.
+        Assert.Contains("if (e.Key == Key.Escape) Answer(EmiMuteChoice.Keep);", code, StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
## What

EMI is unreachable once a lockdown is running. Two independent mechanisms, both fixed.

**1. `EmiDockChip` joins `PossessionNeverNames`** (`MainWindow/MainWindow.Possession.cs`).

The chip is a `UserControl` wrapping a `Button`, so the auto-tag walk enrolled its `BtnChip` as an ordinary `PossessionRole.Button` target. That puts `swap` on it (two buttons glide into each other's seats and **stay** there for 30 s), plus `dissolve` and `melt`. Possession only ever runs *during* a lockdown, which is exactly why the report reads as "EMI is not available in lockdown" rather than as a haunt.

Blocklisting the `UserControl` rather than the inner button is what makes it stick: `WalkPossession` does `return default` at a never-named element, so it never descends and the button inside cannot be enrolled either.

It matters more than it looks: the dock chip is the **only** route into EMI a user can see. `grep` for callers of `EmiDeskService.Toggle` returns exactly one hit, `Controls/EmiDock.xaml.cs:194`. The summon chord is a global hotkey people have to be told about, and there is no tray entry despite what an older comment claims.

**2. `EmiMutePromptWindow` becomes `Topmost`** (`Windows/EmiDesk/EmiMutePromptWindow.xaml`).

It was the only window in `Windows/EmiDesk/` without it (desk, book, options and ring all declare `Topmost="True"`). The one moment this modal is certain to appear is a summon while something is already talking - and during a lockdown that something is a strict video window which is itself `Topmost` and fullscreen. `Owner = MainWindow` only lifts the dialog above MainWindow, and MainWindow is *underneath* that video, so the modal opened out of sight while `ShowDialog`'s nested message pump held the summon: click the chip, nothing happens.

### Why this does not weaken the lockdown

- The dialog offers no exit affordance. Three buttons, all about the **avatar**; `Escape` is wired to `Keep`, never to a mute and never to an exit. Pinned by a test so a fourth button cannot be added without re-making this argument.
- `POSSESSION.md`'s hard rules are about the exits (timer value, secret phrase box, Emergency Exit, hit-testing of the real close button). The chip is reachability, not an exit, and is documented as such.
- Nothing fights it for the z-order: the strict video window's `Deactivated` handler deliberately does **not** re-activate ("reactivation causes a focus-stealing loop that interferes with LibVLC's child HWND rendering", `Services/Video/VideoService.cs`). Only `GracePauseOverlayWindow` re-asserts `Topmost` on a timer, and it is not a lockdown surface.
- The Emergency Exit host is intentionally owned-not-topmost (`EmergencyExitHostService.cs:155`); a transient modal the user opened themselves, dismissible with `Escape`, does not change that door's story.

### Other gates

I looked for an explicit gate hiding or disabling the chip during a lockdown and there is none: `EmiDock.xaml`/`.xaml.cs` carry no lockdown check, `EmiDeskService.Summon` gates only on `EmiDeskEnabled` and disposal, and `SetLockdownActiveUi` (`MainWindow.PremiumRail.cs`) touches only the Lockdown card's own rows. Nothing to preserve, so nothing was.

## Tests

`Tests/ConditioningControlPanel.Tests/EmiLockdownReachTests.cs`, 8 tests, all passing. Source reads for the same reason `NavRailFlyoutTests` is one: realizing `MainWindow` is not affordable here, `PossessionNeverNames` is a private static, and a window's z-band does not show up in a static render. The blocklist scrape reads the **initializer body only**, so it cannot pass on the doc comment above it, and a companion test pins `x:Name="EmiDockChip"` in `MainWindow.xaml` since the list matches on name with `StringComparer.Ordinal`.

Full suite: 5370 passed, 3 failed. The 3 are `VatFillCoordinatorTests` and are pre-existing - verified failing on a clean `release/6.9.4` tree before these changes.

`dotnet build`: 0 errors.

## Not verified

Runtime behaviour was not exercised: no lockdown was started and the mute prompt was not raised over a live strict video. Worth one manual pass (start a lockdown without EMI out, click the chip with an avatar talking).

Diff: 128 insertions, 1 deletion across 3 files, well under the 600-line cap.

Refs CC-Labs-llc/ccp-bugs#1190

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013mR8cAipk1ivr3Em5fJjcx
