### PR TITLE
fix(dashboard): an off feature reads off, and the asset browser keeps its floor

### DIFF
--- a/ConditioningControlPanel/Features/FeatureCard.xaml.cs
+++ b/ConditioningControlPanel/Features/FeatureCard.xaml.cs
@@ -34,6 +34,16 @@ namespace ConditioningControlPanel.Features
         private const int RimLightMs = 150;
         private const int AmbientFrameRate = 24;
 
+        /// <summary>Resting opacity for a locked card. Unchanged from the value that has always
+        /// ridden on <see cref="IsLocked"/>.</summary>
+        private const double LockedContentOpacity = 0.35;
+
+        /// <summary>Resting opacity for a switched-OFF card that opted into
+        /// <see cref="DimWhenInactive"/>. Deep enough that the lit tiles win the eye at a glance,
+        /// shallow enough that the art still reads and the tile still looks clickable - and well
+        /// clear of the 0.35 lock veil, which has to keep meaning something else.</summary>
+        private const double InactiveContentOpacity = 0.62;
+
         /// <summary>Blur radius for a teased card's art. Tuned to "coloured smear": at the
         /// mosaic's tile size this leaves a mood and a palette and no recognisable shape, which
         /// is the whole point - the art must not name the feature.</summary>
@@ -74,6 +84,10 @@ namespace ConditioningControlPanel.Features
 
         public static readonly DependencyProperty IsActiveProperty =
             DependencyProperty.Register(nameof(IsActive), typeof(bool), typeof(FeatureCard),
+                new PropertyMetadata(false, OnActiveStateChanged));
+
+        public static readonly DependencyProperty DimWhenInactiveProperty =
+            DependencyProperty.Register(nameof(DimWhenInactive), typeof(bool), typeof(FeatureCard),
                 new PropertyMetadata(false, OnActiveStateChanged));
 
         public static readonly DependencyProperty HelpSectionIdProperty =
@@ -135,6 +149,23 @@ namespace ConditioningControlPanel.Features
         {
             get => (bool)GetValue(IsActiveProperty);
             set => SetValue(IsActiveProperty, value);
+        }
+
+        /// <summary>
+        /// Opt-in: while this card's feature is OFF, rest the art at
+        /// <see cref="InactiveContentOpacity"/> so the wall's lit tiles are the ones the eye
+        /// lands on. Hovering lifts it back to full, so an off tile still reads as a live
+        /// affordance rather than as something disabled.
+        ///
+        /// <para>Opt-in rather than automatic because <see cref="IsActive"/> is only meaningful
+        /// on the tiles that actually toggle. The destination tiles (Just Drop, Mystery, the
+        /// Vault) never receive an IsActive write, so an automatic rule would park them at 62%
+        /// forever and say "off" about something that has no off.</para>
+        /// </summary>
+        public bool DimWhenInactive
+        {
+            get => (bool)GetValue(DimWhenInactiveProperty);
+            set => SetValue(DimWhenInactiveProperty, value);
         }
 
         /// <summary>
@@ -391,12 +422,10 @@ namespace ConditioningControlPanel.Features
             {
                 LockedOverlay.Visibility = Visibility.Visible;
                 TxtLockLabel.Text = LockLevel > 0 ? $"Lvl {LockLevel}" : "Locked";
-                ContentRoot.Opacity = 0.35;
             }
             else
             {
                 LockedOverlay.Visibility = Visibility.Collapsed;
-                ContentRoot.Opacity = 1.0;
             }
             ApplyActiveState();
         }
@@ -407,7 +436,28 @@ namespace ConditioningControlPanel.Features
             // can't really be "on" even if the underlying setting is true.
             var showActive = IsActive && !IsLocked;
             ActiveBorder.Visibility = showActive ? Visibility.Visible : Visibility.Collapsed;
+            ApplyRestOpacity();
             ApplyActiveBreath(showActive);
+        }
+
+        /// <summary>
+        /// The ONE writer for <c>ContentRoot.Opacity</c>. Lock, inactive-dim and hover all want
+        /// that channel, so they are resolved here in priority order instead of each assigning it
+        /// from its own handler - two writers on one property is how a card ends up stuck at 35%
+        /// after a lock is lifted.
+        ///
+        /// <para>A plain assignment, never a DoubleAnimation: an animation on this property would
+        /// hold its final value at local precedence, and every later assignment here would then be
+        /// silently ignored.</para>
+        /// </summary>
+        private void ApplyRestOpacity()
+        {
+            if (ContentRoot == null) return;
+            double target =
+                IsLocked ? LockedContentOpacity
+                : DimWhenInactive && !IsActive && !_hovered ? InactiveContentOpacity
+                : 1.0;
+            ContentRoot.Opacity = target;
         }
 
         // ============================== FX ==============================
@@ -583,6 +633,11 @@ namespace ConditioningControlPanel.Features
                 // A locked tile is not an affordance; lighting it up on hover promises a click
                 // that does nothing.
                 if (IsLocked) on = false;
+
+                // An inactive tile rests dim; hovering hands it back its full art so the pointer
+                // proves the tile is still live. ApplyRestOpacity re-reads IsLocked, so this stays
+                // correct for a locked card, whose veil must not lift.
+                ApplyRestOpacity();
 
                 MotionFx.HoverLift(RootBorder, on);
                 if (on) HoverPop.Enter(ImgIconHost); else HoverPop.Leave(ImgIconHost);

--- a/ConditioningControlPanel/Features/SplitFeatureCard.xaml.cs
+++ b/ConditioningControlPanel/Features/SplitFeatureCard.xaml.cs
@@ -75,6 +75,15 @@ namespace ConditioningControlPanel.Features
         private const int SplitReducedMs = 110;
         private const int SplitFrameRate = 30;
 
+        /// <summary>Resting opacity for the half whose feature is OFF, matching FeatureCard's
+        /// InactiveContentOpacity. Applied per half rather than per card: each half is its own
+        /// on/off feature, so a combo tile with one half lit has to be able to say so.
+        ///
+        /// <para>No opt-out property here, unlike FeatureCard: a split tile exists to carry two
+        /// toggles (it raises ToggleA/ToggleB and nothing else), so there is no destination-tile
+        /// case to exclude.</para></summary>
+        private const double InactiveHalfOpacity = 0.62;
+
         /// <summary>Shared frozen stand-in for a region the seam has swept out of existence.</summary>
         private static readonly PathGeometry EmptyGeometry = CreateEmptyGeometry();
 
@@ -138,6 +147,9 @@ namespace ConditioningControlPanel.Features
         public SplitFeatureCard()
         {
             InitializeComponent();
+            // Both halves start OFF and their DP callbacks only fire on a CHANGE, so a card whose
+            // features are off at startup would never be handed its resting dim without this.
+            ApplyHalfRestOpacity();
             Loaded += OnCardLoaded;
             Unloaded += OnCardUnloaded;
             // A tile hidden mid-hover (tab switch out of the dashboard) can be denied its
@@ -393,6 +405,10 @@ namespace ConditioningControlPanel.Features
             if (_halfHover == halfA) return;
             _halfHover = halfA;
 
+            // The committed half is about to fill the tile, so it gets its full art back even
+            // while its feature is off - the reveal is the point of the sweep.
+            ApplyHalfRestOpacity();
+
             HoverWashA.Opacity = halfA == true ? 1 : 0;
             HoverWashB.Opacity = halfA == false ? 1 : 0;
 
@@ -503,6 +519,9 @@ namespace ConditioningControlPanel.Features
             try
             {
                 _halfHover = null;
+                // ResetSplit clears _halfHover behind SetHalfHover's back, so the half that was
+                // committed would otherwise stay at full brightness with no hover to explain it.
+                ApplyHalfRestOpacity();
                 BeginAnimation(SplitProgressProperty, null);
                 SplitProgress = SplitRest;
                 // Assigning a value it already holds raises no property-changed callback, so the
@@ -545,6 +564,7 @@ namespace ConditioningControlPanel.Features
         {
             ActiveRingA.Visibility = IsActiveA ? Visibility.Visible : Visibility.Collapsed;
             ActiveRingB.Visibility = IsActiveB ? Visibility.Visible : Visibility.Collapsed;
+            ApplyHalfRestOpacity();
             // RebuildGeometry only draws the rings that are on screen (it also runs per frame of
             // the hover fill), so a ring that just came on needs this to get its geometry.
             SafeRebuildGeometry();
@@ -592,6 +612,18 @@ namespace ConditioningControlPanel.Features
                 if (IsActiveB) Breathe(ActiveRingB, OpacityProperty, ActiveRingMinOpacity, ActiveRingMaxOpacity); else ParkRing(ActiveRingB);
             }
             catch (Exception ex) { App.Logger?.Debug("SplitFeatureCard.ApplyActiveBreath: {E}", ex.Message); }
+        }
+
+        /// <summary>
+        /// The ONE writer for the two half hosts' Opacity: an OFF half rests dim unless the mouse
+        /// has committed the card to it. A plain assignment rather than an animation, so a later
+        /// call can never be shadowed by an animation still holding the property.
+        /// </summary>
+        private void ApplyHalfRestOpacity()
+        {
+            if (HalfHostA == null || HalfHostB == null) return;
+            HalfHostA.Opacity = IsActiveA || _halfHover == true ? 1.0 : InactiveHalfOpacity;
+            HalfHostB.Opacity = IsActiveB || _halfHover == false ? 1.0 : InactiveHalfOpacity;
         }
 
         private static void ParkRing(System.Windows.Shapes.Path ring)

--- a/ConditioningControlPanel/Views/Tabs/AssetsTabView.xaml
+++ b/ConditioningControlPanel/Views/Tabs/AssetsTabView.xaml
@@ -59,12 +59,19 @@
         </Style>
     </UserControl.Resources>
         <Grid>
+        <!-- Row 1 (media source) is Auto, row 4 (asset browser) is the only star row, so
+             anything row 1 unfolds comes straight out of the browser's height. In Reddit or
+             Both that is the whole niche/custom-sub block, which is why the browser used to
+             shrink to a sliver: the fix is a scroll cap inside row 1 (see RemoteMediaScroll)
+             plus a floor here, so the browser can never be measured away entirely.
+             Row 3 is Auto rather than a literal 5 because its splitter is collapsed and a
+             literal height cannot give the 5px back. -->
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto" MaxHeight="340"/>
-            <RowDefinition Height="5"/>
-            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*" MinHeight="220"/>
         </Grid.RowDefinitions>
     
         <!-- Header with title and actions -->
@@ -120,7 +127,15 @@
                 <WrapPanel x:Name="RemoteSourceChips" x:FieldModifier="internal"/>
 
                 <!-- Everything below is dead weight while the source is "local", so it only
-                     unfolds once remote media is actually in play. -->
+                     unfolds once remote media is actually in play. In Reddit or Both it is
+                     tall (13 niche chips, a resolved-subreddit line per checked niche, and up
+                     to 20 custom-sub chips), and this row is Auto inside a grid whose only
+                     star row is the asset browser, so an uncapped unfold ate the browser.
+                     The cap lives on the ScrollViewer rather than on the RowDefinition so the
+                     overflow scrolls instead of clipping, and so RemoteMediaDetails keeps its
+                     name and its Visibility contract with MainWindow.Assets.cs. -->
+                <ScrollViewer x:Name="RemoteMediaScroll" MaxHeight="300"
+                              VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
                 <StackPanel x:Name="RemoteMediaDetails" x:FieldModifier="internal" Visibility="Collapsed">
 
                     <!-- Mix ratio: only meaningful in "Both" -->
@@ -187,6 +202,7 @@
                                TextWrapping="Wrap" Margin="0,0,0,6" Visibility="Collapsed"/>
                     <WrapPanel x:Name="RemoteCustomSubChips" x:FieldModifier="internal"/>
                 </StackPanel>
+                </ScrollViewer>
             </StackPanel>
         </Border>
 

--- a/ConditioningControlPanel/Views/Tabs/SettingsTabView.xaml
+++ b/ConditioningControlPanel/Views/Tabs/SettingsTabView.xaml
@@ -802,6 +802,7 @@
                                   Icon="pack://application:,,,/Resources/features/flash.png"
                                   HelpSectionId="FlashImages"
                                   Click="CardFlash_Click"
+                                  DimWhenInactive="True"
                                   ToggleRequested="CardFlash_Toggle"/>
             <features:SplitFeatureCard Grid.Row="0" Grid.Column="1" x:Name="ComboVideoBubble" x:FieldModifier="internal"
                                        TitleA="Mandatory Video" TitleB="Bubble Count"
@@ -814,12 +815,14 @@
                                   Icon="pack://application:,,,/Resources/features/subliminal.png"
                                   HelpSectionId="Subliminals"
                                   Click="CardSubliminal_Click"
+                                  DimWhenInactive="True"
                                   ToggleRequested="CardSubliminal_Toggle"/>
             <features:FeatureCard Grid.Row="0" Grid.Column="3" x:Name="CardBouncingText" x:FieldModifier="internal"
                                   Title="Bouncing Text"
                                   Icon="pack://application:,,,/Resources/features/bouncing_text.png"
                                   HelpSectionId="BouncingText"
                                   Click="CardBouncingText_Click"
+                                  DimWhenInactive="True"
                                   ToggleRequested="CardBouncingText_Toggle"/>
 
             <!-- Row 2: the TEASE tile (far left, owner spec) + centre logo + spiral pair -->
@@ -1255,12 +1258,14 @@
                                   Icon="pack://application:,,,/Resources/features/Bubble_pop.png"
                                   HelpSectionId="BubblePop"
                                   Click="CardBubblePop_Click"
+                                  DimWhenInactive="True"
                                   ToggleRequested="CardBubblePop_Toggle"/>
             <features:FeatureCard Grid.Row="3" Grid.Column="3" x:Name="CardLockCard" x:FieldModifier="internal"
                                   Title="Lock Card"
                                   Icon="pack://application:,,,/Resources/features/Phrase_Lock.png"
                                   HelpSectionId="LockCard"
                                   Click="CardLockCard_Click"
+                                  DimWhenInactive="True"
                                   ToggleRequested="CardLockCard_Toggle"/>
 
             <!-- ============================================================ -->


### PR DESCRIPTION
Two UI polish asks from Wobberjockey in the UI-feedback thread (`1539078861944397855`).

## 1. Desaturate inactive feature cards

Discord `1547554763585888387` ("infection control doesn't really do a great job of jumping off the screen with what is active ... coloring/desaturating the buttons for pressed/not pressed?"), agreed by Mort at `1547555784357978192`.

Every tile on the home wall rested at full brightness whether its feature was on or off. The ON state was carried only by the glow ring, which reads as decoration on a wall of bright art.

- New opt-in DP `FeatureCard.DimWhenInactive`. When set, the card rests its `ContentRoot` at **0.62** while `IsActive` is false, returns to 1.0 when the feature is on, and also returns to 1.0 while the pointer is over it so an off tile still reads as a live affordance.
- `SplitFeatureCard` does it **per half** (`HalfHostA` / `HalfHostB`), so a combo tile with one side on says which side.
- Opted in: `CardFlash`, `CardSubliminal`, `CardBouncingText`, `CardBubblePop`, `CardLockCard`, and all three combos. **Not** opted in: `CardJustDrop`, `CardMystery`, `CardVault`. Those are destinations, never receive an `IsActive` write, and an automatic rule would have parked them at 62% forever saying "off" about something with no off.

### Collisions checked, none taken

- `IsLocked` already owned `ContentRoot.Opacity` at **0.35**. `ApplyLockState` no longer writes that property; the single writer is now `ApplyRestOpacity`, which resolves **lock, then dim, then hover** in that order. 0.62 stays well clear of 0.35 so the lock veil keeps its own meaning. (`IsLocked` is currently never set true on any mosaic card, but the channel is still owned there.)
- Tier gating on this wall is a **badge**, deliberately not a dim (`FeatureCard.xaml:135-150`) - untouched.
- The tease costume (`CardJustDrop`) owns `ImgIconHost.Effect` and the rim brushes - untouched, and that card does not opt in.
- First-run / tutorial highlight is a separate always-on-top window (`TutorialOverlay`) that never mutates a card DP - no interaction.

No new animation. Both appliers are plain assignments, never `DoubleAnimation`: an animation on `Opacity` holds its final value at local precedence and would silently swallow every later write.

## 2. Asset library unusably small in Reddit / Both

Discord `1547790163306881027` ("can the asset library tab get a pass. it becomes unusably small on Reddit and both mode").

**Why it collapsed.** `AssetsTabView`'s root grid is `Auto / Auto / Auto(max 340) / 5 / *`, and row 4 (the asset browser) is the only star row. Switching Local to Reddit or Both makes `RemoteMediaDetails` visible, which unfolds 13 niche chips, one wrapping resolved-subreddit line per checked niche, the custom-sub label/hint/add row and up to 20 custom-sub chips into row 1. WPF measures `Auto` rows first against unbounded height and gives `*` only the remainder, so 200-400px of unfolded chips came straight out of the browser and the tree plus thumbnails rendered as a sliver. Nothing in code sets a height; it was purely a measure-time consequence. The tab has no outer `ScrollViewer`, so there was nowhere for the overflow to go either.

**Fix.**
- `RemoteMediaDetails` is wrapped in `RemoteMediaScroll`, `MaxHeight="300"`, `VerticalScrollBarVisibility="Auto"`. The cap is on the ScrollViewer rather than on the RowDefinition so the overflow scrolls instead of clipping, and so `RemoteMediaDetails` keeps its name and its `Visibility` contract with `MainWindow.Assets.cs`.
- Row 4 gains `MinHeight="220"` as a floor for short windows.
- Row 3 becomes `Auto` instead of a literal `5`: `PacksSplitter` is `Visibility="Collapsed"`, and a literal height cannot give those 5px back.

## Testing

- `dotnet build` green, 0 errors, warning count unchanged at 362.
- `dotnet test`: 5362 passed, 3 failed. The 3 failures are `VatFillCoordinatorTests` and were verified to fail identically on the unmodified base (`git stash` + rerun) - pre-existing, unrelated.
- **Not verified at runtime**: this is a headless session, so the two looks have not been seen on screen. Worth eyeballing the 0.62 value against the darker plates, and the 300px cap in Both mode on a short window.

Changed lines: `113 insertions(+), 5 deletions(-)` - within the 600-line cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013mR8cAipk1ivr3Em5fJjcx

