### PR TITLE
fix(web): the sorting room has a door, and its sign is legible upright

### DIFF
--- a/ConditioningControlPanel/Resources/web/arcademy/CLAUDE.md
+++ b/ConditioningControlPanel/Resources/web/arcademy/CLAUDE.md
@@ -98,15 +98,22 @@ shell/room.js      THE ROOM SCENE (VN antechamber): the painted set between the
                    highlight that big reads as a bug), the_deep_end (The
                    Pool 105, vn-08, open lane water + the ladder), and the
                    Semester II + III five: sort (The Sorting Room 201, vn-12,
-                   the card conveyor - the belt, not the three bins),
+                   the card conveyor - the belt, not the three bins - plus the
+                   green door leaf on the right wall, which this table called an
+                   alcove until ccp-bugs#1165),
                    echo (Music Room 202, vn-13, the four lit drum heads on the
                    stage), instant_recall (Lecture Hall 203, vn-14, the blank
                    projection screen - NOT the lectern), anomaly (Darkroom 301,
                    vn-15, the drying lines framed on the ONE crooked print +
                    the black light-trap curtain as the painted exit) and
                    composure (The Studio 302, vn-16, the sliding-tile canvas on
-                   the easel). Three of the ten have a painted exit (101, 103,
-                   301); the other seven are doorless and that is legal.
+                   the easel). FOUR of the ten have a painted exit (101, 103,
+                   201, 301); the other six are doorless and that is legal.
+                   The sign under a painted exit is drawn in STAGE pixels, so
+                   it is sized twice - once for landscape's ~0.5 fit and once
+                   for portrait's ~0.28 (rooms.css, "the painted door, held
+                   upright"). `shell/smoke/exit-sign-check.mjs` does the
+                   arithmetic for every door on every phone in range.
                    TWO PLATES ARE COMPOSITED, never regenerated: vn-16's wall
                    sign was painted "COMPOSUE", so the sign rect was cloned out
                    and logo-composure-keyed.png pasted back in (the homeroom

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/room.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/room.js
@@ -78,8 +78,11 @@ const HEAD_GAP = 8;
  *  - `hotspot`  : the class furniture - the ONE lit thing, wears the action tag.
  *  - `exit`     : optional painted way out (a door in the art). Same verb as
  *                 the apron's back slab; a room without one just keeps the slab.
- *                 Only rooms whose art actually HAS a door get one - seven of
- *                 the ten are painted doorless and that stays legal.
+ *                 Only rooms whose art actually HAS a door get one - six of
+ *                 the ten are painted doorless and that stays legal. Read the
+ *                 plate before you call a room doorless: the Sorting Room was
+ *                 called that for a fortnight and its door was in the art the
+ *                 whole time (ccp-bugs#1165).
  *  - `freeSwim` : optional second furniture, for a game that declares
  *                 `manifest.endless`. Renders only when the shell hands down an
  *                 onFreeSwim; spends the same one-class latch as the hotspot.
@@ -128,11 +131,27 @@ const SCENES = Object.freeze({
    * where a decision LANDS, the belt is where it is asked for, and the deck of
    * face-down cards riding up it is the two-pile swipe sitting in the furniture.
    * The rect takes the belt's whole diagonal run, so the last card is caught at
-   * the mouth of the pink bin. Doorless: the far-right recess is a dark alcove
-   * behind a bin, not a painted way out. */
+   * the mouth of the pink bin.
+   *
+   * AND IT IS NOT DOORLESS (ccp-bugs#1165, "Sort room ... does not have a
+   * 'return to campus' door in the image"). This row used to write the
+   * far-right shape off as "a dark alcove behind a bin", and that was a
+   * misreading of the plate. The ALCOVE is the unlit corridor past x1328; in
+   * FRONT of it the art paints a whole door, and the pixels say so - sampled
+   * row by row off vn-12 rather than read off a spec: a header moulding across
+   * the top, the jamb shadow at x1220..1237, a lit green leaf at x1238..1312
+   * (a different, warmer green than the wall) carrying a navy window pane at
+   * x1252..1300 / y205..315, and the leaf's own lit edge at x1313..1327. The
+   * three bins only reach y342 at that x, so the leaf stands clear of them all
+   * the way down from the moulding.
+   *
+   * The rect is the LEAF PLUS ITS EDGE and stops short of the alcove: what the
+   * player points at when they say "the door" is the thing with a handle side
+   * and a window in it, not the hole in the wall beside it. */
   sort: Object.freeze({
     art: 'vn-12-sorting-room-201.png',
     hotspot: Object.freeze([744, 402, 320, 168]),
+    exit: Object.freeze([1240, 170, 92, 172]),       // the green leaf + its edge
   }),
   /* THE MUSIC ROOM 202. The four lit drum heads on the low stage - pink, gold,
    * cream, purple - which is the Simon ring already dealt out as furniture, and

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/rooms.css
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/rooms.css
@@ -839,3 +839,46 @@ html.arc-mobile[data-arc-orient="portrait"] .arm-lever .arc-lever-pos {
   padding: 0 12px;
   font-size: 11px;
 }
+
+/* ------------------- the painted door, held upright ---------------------- */
+
+/* AND THE DOOR'S OWN FURNITURE IS STAGE PIXELS, SO PORTRAIT HAS TO PAY FOR IT
+   TWICE (ticket 1544742846899294288, second half). The phone block above
+   doubled the exit's rim and its sign "because a phone fits that plane at about
+   a half" - and that is LANDSCAPE's number. Portrait fits the 1376x768 plate by
+   WIDTH, and `fit()` is `min(w / 1376, h / 768)`, so the scale is:
+
+     844x390 landscape   min(0.613, 0.508) = 0.508   <- what the doubling bought
+     430x932 portrait    min(0.3125, 1.21) = 0.3125
+     390x844 portrait    min(0.2834, 1.10) = 0.2834
+     360x780 portrait    min(0.2616, 1.02) = 0.2616  <- the narrowest in range
+
+   A phone held upright therefore renders the 22px sign at 5.8-6.9 REAL pixels
+   and the 5px rim at 1.3-1.6 of one. That is trap 101's lesson wearing a
+   different hat: the sign is not cut off any more, it is a smudge, and the rim
+   that is supposed to say "this is a door" is a hairline. Both numbers are
+   re-derived for portrait's own scale rather than tuned by eye - 42px of sign
+   lands at 11.0-13.1 real px (the phone block's landscape sign measures 11.2),
+   and 10px of rim lands at 2.6-3.1 against landscape's 2.5.
+
+   THE PIN AND THE PRESS ARE UNTOUCHED. `right: 0` still hangs the sign off the
+   door's own right edge so it grows leftwards into the room (the 2026-09-03
+   fix), and at 42px the widest English label measures ~500 stage px against the
+   four painted doors' right edges - 1346 Homeroom, 1332 the Sorting Room, 1096
+   Discipline Hall, 1064 the Darkroom, 1322 the Records storeroom - so every one
+   of them leaves the sign hundreds of pixels clear of x0. `bottom` is 46 rather
+   than a full sign height because the tag has to finish ABOVE y640: the apron
+   owns the floor, and the storeroom's door is the deep one (bottom y583, so the
+   sign ends at 629). The rect under it does not move, so the press is the same
+   press, and landscape keeps every number it was signed off with. */
+html.arc-mobile[data-arc-orient="portrait"] .arm-hot.arm-exit {
+  box-shadow: inset 0 0 0 10px rgba(190, 160, 255, 0.50),
+              0 0 60px 14px rgba(150, 120, 230, 0.22);
+}
+html.arc-mobile[data-arc-orient="portrait"] .arm-hot.arm-exit .arm-hot-tag {
+  bottom: -46px;
+  padding: 11px 26px;
+  border-width: 2px;
+  border-radius: 8px;
+  font-size: 42px;
+}

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/smoke/exit-sign-check.mjs
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/smoke/exit-sign-check.mjs
@@ -1,0 +1,179 @@
+/* ============================================================================
+ * shell/smoke/exit-sign-check.mjs - THE PAINTED DOOR AND ITS SIGN.
+ *
+ *   node shell/smoke/exit-sign-check.mjs      (from Resources/web/arcademy; 0 on pass)
+ *
+ * Two reports, one rect and one stylesheet:
+ *
+ *   ccp-bugs#1165  "Sort room on app.cclabs.app/arcademy does not have a
+ *                   'return to campus' door in the image" - the SCENES row had
+ *                   written the painted door off as an alcove, so the room
+ *                   rendered no `.arm-exit` at all.
+ *   ticket 1544742846899294288  the sign under a painted door at phone width -
+ *                   pinned back inside the frame on 2026-09-03, but still
+ *                   drawn at LANDSCAPE's scale, which on an upright phone is a
+ *                   ~6px smudge.
+ *
+ * Neither half can be asserted by importing the module: `SCENES` is private and
+ * the geometry that matters is the product of a stage-pixel rect, a stage-pixel
+ * type size and the `fit()` scale of a real phone. So this reads the two files
+ * as TEXT (test-hostfixes.mjs's tripwire shape) and does the arithmetic that
+ * the eye was doing badly. It is a floor, not a substitute for a shot at
+ * 390x844.
+ * ==========================================================================*/
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SHELL = join(HERE, '..');
+
+let fails = 0;
+const ok = (cond, what) => { if (!cond) { console.error('FAIL ' + what); fails++; } else console.log('  ok  ' + what); };
+const ge = (got, want, what) => ok(got >= want, what + ' (got ' + got + ', want >= ' + want + ')');
+const le = (got, want, what) => ok(got <= want, what + ' (got ' + got + ', want <= ' + want + ')');
+
+const roomJs = readFileSync(join(SHELL, 'room.js'), 'utf8');
+const roomsCss = readFileSync(join(SHELL, 'rooms.css'), 'utf8');
+const recordsJs = readFileSync(join(SHELL, 'recordsroom.js'), 'utf8');
+
+/* ---------------------------------------------------- the plane's own law -- */
+const num = (src, name) => {
+  const m = src.match(new RegExp('const\\s+' + name + '\\s*=\\s*(\\d+)'));
+  return m ? Number(m[1]) : NaN;
+};
+const STAGE_W = num(roomJs, 'STAGE_W');
+const STAGE_H = num(roomJs, 'STAGE_H');
+const APRON_STAGE_TOP = num(roomJs, 'APRON_STAGE_TOP');
+ok(STAGE_W === 1376 && STAGE_H === 768, 'the stage plane is still 1376x768');
+ok(APRON_STAGE_TOP === 640, 'the apron still owns the floor from y640');
+
+/* --------------------------------------------------- every painted door --- */
+/* room.js's SCENES rows, read off the source: `key: Object.freeze({ ... })`
+ * with an optional `exit: Object.freeze([x, y, w, h])` inside it. */
+const scenes = {};
+const rowRe = /\n {2}([a-z_]+): Object\.freeze\(\{([\s\S]*?)\n {2}\}\),/g;
+let m;
+while ((m = rowRe.exec(roomJs))) {
+  const body = m[2];
+  const rect = (field) => {
+    const r = body.match(new RegExp(field + ':\\s*Object\\.freeze\\(\\[([-\\d,\\s]+)\\]\\)'));
+    return r ? r[1].split(',').map((v) => Number(v.trim())) : null;
+  };
+  scenes[m[1]] = { hotspot: rect('hotspot'), exit: rect('exit'), freeSwim: rect('freeSwim') };
+}
+ok(Object.keys(scenes).length === 10, 'all ten class rooms are still in the table (got ' + Object.keys(scenes).length + ')');
+
+/* The Records Office storeroom is the fifth `.arm-exit` in the building - a
+ * scene.js hotspot with `quiet: true`, which rooms.css skins with the same
+ * class. It rides every rule below, so it is measured with the others. */
+const doorRe = /door: Object\.freeze\(\[([-\d,\s]+)\]\)/;
+const storeroom = recordsJs.match(doorRe);
+ok(!!storeroom, 'the records storeroom rect is still readable');
+
+const doors = [];
+for (const [key, row] of Object.entries(scenes)) if (row.exit) doors.push([key, row.exit]);
+if (storeroom) doors.push(['records_storeroom', storeroom[1].split(',').map((v) => Number(v.trim()))]);
+
+/* ================================= 1. THE SORTING ROOM HAS ITS DOOR ===== */
+{
+  const sort = scenes.sort;
+  ok(!!sort, 'the sort row is in SCENES');
+  ok(!!(sort && sort.exit), 'ccp-bugs#1165: the sorting room has a painted exit rect');
+  if (sort && sort.exit) {
+    const [x, y, w, h] = sort.exit;
+    ge(x, 0, 'sort exit: left edge is on the plane');
+    le(x + w, STAGE_W, 'sort exit: right edge is on the plane');
+    le(y + h, APRON_STAGE_TOP, 'sort exit: the apron does not sit on it');
+    ge(w, 60, 'sort exit: wide enough to be a thumb target at half scale');
+    ge(h, 60, 'sort exit: tall enough to be a thumb target at half scale');
+    /* The one lit thing may never share pixels with the quiet way out, or the
+     * breath and the rim fight over the same press. */
+    const [hx, hy, hw, hh] = sort.hotspot;
+    const overlap = x < hx + hw && hx < x + w && y < hy + hh && hy < y + h;
+    ok(!overlap, 'sort exit: does not overlap the conveyor hotspot');
+  }
+}
+
+/* ================================= 2. EVERY DOOR IS ON THE PLANE ======== */
+for (const [key, [x, y, w, h]] of doors) {
+  ge(x, 0, key + ': exit left edge on the plane');
+  le(x + w, STAGE_W, key + ': exit right edge on the plane');
+  ge(y, 0, key + ': exit top edge on the plane');
+}
+ok(doors.length === 5, 'four painted class doors plus the storeroom (got ' + doors.length + ')');
+
+/* ================================= 3. THE SIGN AT PHONE WIDTH ========== */
+/* The phone rules, read back out of the stylesheet rather than retyped. */
+const ruleBody = (selector) => {
+  const i = roomsCss.indexOf(selector + ' {');
+  if (i < 0) return null;
+  return roomsCss.slice(i + selector.length + 2, roomsCss.indexOf('}', i));
+};
+const px = (body, prop) => {
+  if (!body) return NaN;
+  const r = body.match(new RegExp('(?:^|[;\\s])' + prop + ':\\s*(-?[\\d.]+)px'));
+  return r ? Number(r[1]) : NaN;
+};
+
+const LAND = ruleBody('html.arc-mobile .arm-hot.arm-exit .arm-hot-tag');
+const PORT_OWN = ruleBody('html.arc-mobile[data-arc-orient="portrait"] .arm-hot.arm-exit .arm-hot-tag');
+/* Portrait is `html.arc-mobile` too, so with no rule of its own it RESOLVES to
+ * the landscape body - which is the whole bug, and modelling the cascade is
+ * what makes the numbers below the real ones rather than NaN. */
+const PORT = PORT_OWN || LAND;
+ok(!!LAND, 'the phone sign rule is still in rooms.css');
+ok(!!PORT_OWN, 'portrait has a sign rule of its own');
+
+/* The 2026-09-03 pin: the sign hangs off the DOOR'S right edge and grows left,
+ * so it can never reach the frame however long the localised string runs. */
+ok(/right:\s*0/.test(LAND || '') && /left:\s*auto/.test(LAND || '') && /transform:\s*none/.test(LAND || ''),
+  'the sign is still pinned to the door right edge, not centred on it');
+ok(!/left:\s*50%/.test(PORT_OWN || '') && !/transform:/.test(PORT_OWN || ''),
+  'portrait does not undo the pin');
+
+/* `fit()` is min(w / STAGE_W, h / STAGE_H). These are the phones in range. */
+const fit = (w, h) => Math.min(w / STAGE_W, h / STAGE_H);
+const PHONES = [
+  ['360x780 portrait', fit(360, 780), PORT],
+  ['390x844 portrait', fit(390, 844), PORT],
+  ['430x932 portrait', fit(430, 932), PORT],
+  ['844x390 landscape', fit(844, 390), LAND],
+];
+
+/* THE SMUDGE FLOOR. A sign is decoration, but decoration that cannot be read is
+ * a bug with a nicer name - 10 real px is the corkboard's own floor for body
+ * copy on a phone (recordsroom's FIT), so it is the floor here too. */
+for (const [name, s, body] of PHONES) {
+  const fontStage = px(body, 'font-size');
+  ge(Number((fontStage * s).toFixed(1)), 10, name + ': the sign renders at 10+ real px');
+}
+
+/* THE FRAME. Tracked display caps measure about 0.74em an advance (0.62 of
+ * glyph plus the 0.12em `letter-spacing` the base rule sets). 24 characters is
+ * "Back to campus" with room for a language that spends twice the words. */
+const LABEL_CHARS = 24;
+for (const [name, , body] of PHONES) {
+  const font = px(body, 'font-size');
+  const pad = (() => {
+    const r = (body || '').match(/padding:\s*[\d.]+px\s+([\d.]+)px/);
+    return r ? Number(r[1]) * 2 : 0;
+  })();
+  const wide = LABEL_CHARS * font * 0.74 + pad + 4;
+  for (const [key, [x, , w]] of doors) {
+    ge(Math.round(x + w - wide), 0, name + ' / ' + key + ': the sign stays on the plane');
+  }
+}
+
+/* THE FLOOR LINE. `bottom: -N` hangs the sign below the door; the apron owns
+ * everything past y640, so the tag has to finish above it. */
+for (const [name, , body] of PHONES) {
+  const drop = -px(body, 'bottom');
+  for (const [key, [, y, , h]] of doors) {
+    le(y + h + drop, APRON_STAGE_TOP, name + ' / ' + key + ': the sign finishes above the apron');
+  }
+}
+
+console.log(fails ? '\n' + fails + ' FAILED' : '\nall green');
+process.exit(fails ? 1 : 0);


### PR DESCRIPTION
## What

Two web-side fixes for the Arcademy room scene, both about the painted way out.

**1. The Sorting Room gets its door back.** `shell/room.js`'s `SCENES.sort` row
had no `exit` rect, on the strength of a comment calling the far-right shape
"a dark alcove behind a bin". Sampling `art/vn/vn-12-sorting-room-201.png` row
by row says that is a misreading: the alcove is the unlit corridor past x1328,
and in front of it the plate paints a whole door - a header moulding across the
top, the jamb shadow at x1220..1237, a lit green leaf at x1238..1312 (a warmer
green than the wall) carrying a navy window pane at x1252..1300 / y205..315, and
the leaf's own lit edge at x1313..1327. The three bins only reach y342 at that x,
so the leaf stands clear of them. The row gains `exit: [1240, 170, 92, 172]` -
the leaf plus its edge, stopping short of the alcove.

**2. The door's sign is sized for portrait.** The sign was pinned back inside the
frame on 2026-09-03 (`766f6e4ae`) and that half holds. What did not is the type:
`fit()` is `min(w / 1376, h / 768)`, so a phone held upright scales the plane by
0.26 to 0.31 where landscape scales it by 0.51. The phone rule's 22px sign and
5px rim were derived from landscape's number, so on an upright phone they render
at 5.8 to 6.9 real pixels and about 1.4 of one. Portrait now sizes both for its
own scale - 42px of sign lands at 11.0 to 13.1 real px against landscape's 11.2,
and 10px of rim at 2.6 to 3.1 against landscape's 2.5. The pin, the rect under
it and every landscape number are untouched.

## Why

The sorting room was the one painted room whose door the table denied, so the
only way out was the apron slab - which is exactly what #1165 reported. And the
sign that names a door is not much use at six pixels, which is what the ticket's
screenshot shows once the clipping is taken out of it.

## Verification

`shell/smoke/exit-sign-check.mjs` (new, 179 lines, no test seam in the shipped
files - it reads them as text). It pulls every `.arm-exit` rect out of `room.js`
and `recordsroom.js` and the sign sizes out of `rooms.css`, models the cascade
(portrait with no rule of its own resolves to the landscape body, which is the
bug), and holds all five doors on all four phones in range to three laws:

- the sign renders at 10+ real px (the corkboard's own floor for phone copy);
- the right-pinned sign stays on the plane for a 24 character label;
- the sign finishes above the apron line at y640.

```
cd ConditioningControlPanel/Resources/web/arcademy
node shell/smoke/exit-sign-check.mjs     # all green
```

Red control, the same script against the two files restored from `HEAD`:

```
FAIL ccp-bugs#1165: the sorting room has a painted exit rect
FAIL four painted class doors plus the storeroom (got 4)
FAIL portrait has a sign rule of its own
FAIL 360x780 portrait: the sign renders at 10+ real px (got 5.8, want >= 10)
FAIL 390x844 portrait: the sign renders at 10+ real px (got 6.2, want >= 10)
FAIL 430x932 portrait: the sign renders at 10+ real px (got 6.9, want >= 10)
```

Also: `room.js` imports clean as an ES module in bare node (trap 144 - checked
from a directory carrying a `"type":"module"` package.json, not a bare path),
`hasRoomScene('sort')` and `artUrlFor('sort')` still answer, and `rooms.css`
braces balance with no new empty declarations.

**Not verified:** no browser shot. The arithmetic is asserted, the pixels are
not - this wants the 390x844 / 667x375 pass from the CDP rig before it is called
done, and a thumb on the sorting room's new door.

**Reaching the phone:** `Resources/web/arcademy` is the source of truth and
cclabs-web vendors it, so this needs `gh workflow run sync-arcademy.yml
-R CodeBambi/cclabs-web --ref main` (or the next cron slot) after it lands to
reach `app.cclabs.app/arcademy`. The push is the deploy on that side.

Changed lines: 255 insertions, 7 deletions.

Refs CC-Labs-llc/ccp-bugs#1165
Refs Discord ticket 1544742846899294288

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013mR8cAipk1ivr3Em5fJjcx
