### PR TITLE
fix(loom): the base64 gate now admits a full-sized weave

### DIFF
--- a/ConditioningControlPanel/Services/Chaos/DtrhLoomStore.cs
+++ b/ConditioningControlPanel/Services/Chaos/DtrhLoomStore.cs
@@ -19,8 +19,19 @@ namespace ConditioningControlPanel.Services.Chaos;
 internal static class DtrhLoomStore
 {
     public const int MaxSpirals = 12;
-    private const int MaxBase64Chars = 8 * 1024 * 1024;      // chars of base64 accepted
-    private const int MaxGifBytes = 8 * 1024 * 1024;         // decoded ceiling (worker soft-caps at 6MB)
+
+    /// <summary>Decoded ceiling. Mirrors <c>HARD_CAP</c> in <c>engine/loomWorker.js</c>:
+    /// whatever the loom is willing to weave, this must be willing to keep.</summary>
+    internal const int MaxGifBytes = 8 * 1024 * 1024;
+
+    /// <summary>The same ceiling counted in base64 characters - 4 chars per 3 bytes, plus
+    /// padding and a little slack. It has to be DERIVED: an 8MB literal here (the decoded
+    /// number, reused) admitted only 6MB of gif, so every weave between 6 and 8MB - which the
+    /// worker emits happily, having already retried once at 512px - came back "too heavy to
+    /// hang" while sitting inside the store's own stated ceiling. The stock "bambi haze"
+    /// pattern weaves to ~6.8MB and so could never be saved at all.</summary>
+    internal const int MaxBase64Chars = ((MaxGifBytes + 2) / 3) * 4 + 1024;
+
     private const string Prefix = "loom_";
 
     private static readonly Regex SlugRe = new("^[a-z0-9_-]{1,24}$", RegexOptions.Compiled);
@@ -72,7 +83,11 @@ internal static class DtrhLoomStore
     {
         var slug = Slugify(name);
         if (slug == null) return (false, null, "bad-name");
-        if (string.IsNullOrEmpty(gifBase64) || gifBase64.Length > MaxBase64Chars) return (false, slug, "too-big");
+        // nothing arrived is not the same complaint as too much arrived: an empty payload used
+        // to be reported as "too heavy to hang", which sends the weaver off simplifying a
+        // pattern that was never the problem.
+        if (string.IsNullOrEmpty(gifBase64)) return (false, slug, "bad-gif");
+        if (gifBase64.Length > MaxBase64Chars) return (false, slug, "too-big");
 
         try
         {

--- a/Tests/ConditioningControlPanel.Tests/LoomWeightCeilingTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/LoomWeightCeilingTests.cs
@@ -1,0 +1,148 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using ConditioningControlPanel.Services.Chaos;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// THE LOOM's size gate (v6.9.4). The loom weaves a spiral in a web worker, hands the GIF to
+/// C# as base64, and <see cref="DtrhLoomStore"/> decides whether it may hang on the rack.
+///
+/// <para>The bug these tests pin: the base64 ceiling was written as the same literal as the
+/// decoded ceiling (8MB both), but base64 costs 4 characters per 3 bytes - so the gate that
+/// claimed to admit 8MB of gif admitted 6MB, and everything in between was answered "too heavy
+/// to hang. simpler colors, fewer arms." The worker's own retry ladder aims at 6MB and settles
+/// for anything under 8MB, so that band is exactly where its output lands. One of the eight
+/// shipped patterns - "bambi haze" - lives there, which is how a first-time weaver saving an
+/// untouched default pattern got told their rack was too heavy.</para>
+///
+/// <para>The numbers in <see cref="DefaultPatternWeights"/> were measured by running the real
+/// encoder (<c>Resources/web/dtrh/engine/loomWorker.js</c>, WebGL field + gifenc, ANGLE
+/// SwiftShader) over every entry of the <c>PRESETS</c> table in <c>game/loomStudio.js</c> at its
+/// shipped defaults, 2026-09-11. They are a floor, not a promise: a different GPU's antialiasing
+/// moves them by a few percent, which is why the headroom assertions below are the point rather
+/// than the exact byte counts.</para>
+/// </summary>
+public class LoomWeightCeilingTests
+{
+    /// <summary>base64 length for a payload of <paramref name="bytes"/> bytes, padding included -
+    /// the same arithmetic the page's btoa does on its way to the bridge.</summary>
+    private static long Base64Len(long bytes) => ((bytes + 2) / 3) * 4;
+
+    private static string RepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir != null && !Directory.Exists(Path.Combine(dir.FullName, "ConditioningControlPanel", "Resources")))
+            dir = dir.Parent;
+        Assert.True(dir != null, "could not locate the repo root from " + AppContext.BaseDirectory);
+        return dir!.FullName;
+    }
+
+    private static string ReadLoomSource(params string[] parts) =>
+        File.ReadAllText(Path.Combine(new[] { RepoRoot(), "ConditioningControlPanel", "Resources", "web", "dtrh" }
+            .Concat(parts).ToArray()));
+
+    /// <summary>Pattern name -> weave size in bytes, as the shipped worker produces it.</summary>
+    private static readonly (string Name, int Bytes)[] Weighed =
+    {
+        ("classic ccp", 3_053_418),
+        ("bambi haze", 6_807_218),     // the one the underfed ceiling refused
+        ("sissy swirl", 1_593_659),
+        ("drone protocol", 2_265_466),
+        ("locked in", 4_972_392),
+        ("hypno teal", 1_070_116),
+        ("candy tunnel", 2_783_640),
+        ("void bloom", 3_900_414),
+    };
+
+    public static TheoryData<string, int> DefaultPatternWeights()
+    {
+        var data = new TheoryData<string, int>();
+        foreach (var (name, bytes) in Weighed) data.Add(name, bytes);
+        return data;
+    }
+
+    /// <summary>Every pattern the loom ships with must survive both halves of the gate - the
+    /// base64 length check the payload meets first, and the decoded check after.</summary>
+    [Theory]
+    [MemberData(nameof(DefaultPatternWeights))]
+    public void ShippedDefaultPatternsAllPassTheWeightCheck(string name, int bytes)
+    {
+        Assert.True(bytes <= DtrhLoomStore.MaxGifBytes,
+            $"default pattern '{name}' weaves to {bytes} bytes, over the {DtrhLoomStore.MaxGifBytes}-byte decoded ceiling");
+        Assert.True(Base64Len(bytes) <= DtrhLoomStore.MaxBase64Chars,
+            $"default pattern '{name}' weaves to {bytes} bytes = {Base64Len(bytes)} base64 chars, over the " +
+            $"{DtrhLoomStore.MaxBase64Chars}-char ceiling - it would come back 'too heavy to hang'");
+    }
+
+    /// <summary>The measured table has to cover the patterns that actually ship: adding a ninth
+    /// preset without weighing it is how the next "bambi haze" gets in.</summary>
+    [Fact]
+    public void TheWeighedPatternsAreExactlyTheShippedOnes()
+    {
+        var src = ReadLoomSource("game", "loomStudio.js");
+        var block = Regex.Match(src, @"const PRESETS = \[(?<body>[\s\S]*?)\n\];");
+        Assert.True(block.Success, "could not find the PRESETS table in loomStudio.js");
+
+        // one row per line: ['name', { ... }] - the inner '#rrggbb' colour lists must not count
+        var shipped = Regex.Matches(block.Groups["body"].Value, @"^\s*\['(?<name>[^']+)',\s*\{", RegexOptions.Multiline)
+            .Select(m => m.Groups["name"].Value).ToList();
+        Assert.NotEmpty(shipped);
+        Assert.Equal(shipped.OrderBy(s => s, StringComparer.Ordinal),
+                     Weighed.Select(w => w.Name).OrderBy(s => s, StringComparer.Ordinal));
+    }
+
+    /// <summary>The base64 gate must admit a full decoded ceiling's worth of gif. This is the
+    /// regression itself: with both constants written as 8MB literals the biggest gif that could
+    /// reach the disk was 6MB.</summary>
+    [Fact]
+    public void TheBase64CeilingAdmitsAFullSizedGif()
+    {
+        Assert.True(DtrhLoomStore.MaxBase64Chars >= Base64Len(DtrhLoomStore.MaxGifBytes),
+            $"{DtrhLoomStore.MaxBase64Chars} base64 chars only carries {DtrhLoomStore.MaxBase64Chars / 4 * 3} bytes, " +
+            $"but the store claims to keep {DtrhLoomStore.MaxGifBytes}");
+    }
+
+    /// <summary>...and the worker must not be allowed to weave something the store will not take:
+    /// its HARD_CAP is the promise, MaxGifBytes is the acceptance.</summary>
+    [Fact]
+    public void TheWorkerHardCapFitsInsideTheStoreCeiling()
+    {
+        var src = ReadLoomSource("engine", "loomWorker.js");
+        var m = Regex.Match(src, @"HARD_CAP\s*=\s*(?<n>\d+)\s*\*\s*1024\s*\*\s*1024");
+        Assert.True(m.Success, "could not read HARD_CAP out of loomWorker.js");
+
+        var hardCap = int.Parse(m.Groups["n"].Value) * 1024 * 1024;
+        Assert.True(hardCap <= DtrhLoomStore.MaxGifBytes,
+            $"loomWorker.js emits gifs up to {hardCap} bytes but the store keeps only {DtrhLoomStore.MaxGifBytes}");
+        Assert.True(Base64Len(hardCap) <= DtrhLoomStore.MaxBase64Chars,
+            $"a HARD_CAP gif is {Base64Len(hardCap)} base64 chars, past the {DtrhLoomStore.MaxBase64Chars}-char gate");
+    }
+
+    /// <summary>An empty payload is a broken weave, not a heavy one. It used to answer "too-big",
+    /// which the pane renders as "too heavy to hang. simpler colors, fewer arms." - advice for a
+    /// pattern that never reached C# at all.</summary>
+    [Theory]
+    [InlineData("")]
+    [InlineData(null)]
+    public void AnEmptyWeaveIsNotCalledHeavy(string? payload)
+    {
+        var (ok, _, error) = DtrhLoomStore.Save("weight test", payload, null, overwrite: false);
+        Assert.False(ok);
+        Assert.Equal("bad-gif", error);
+    }
+
+    /// <summary>A payload past the gate still gets the honest complaint.</summary>
+    [Fact]
+    public void AnOversizeWeaveIsStillRefusedAsTooBig()
+    {
+        var payload = new string('A', DtrhLoomStore.MaxBase64Chars + 1);
+        var (ok, _, error) = DtrhLoomStore.Save("weight test", payload, null, overwrite: false);
+        Assert.False(ok);
+        Assert.Equal("too-big", error);
+    }
+}


### PR DESCRIPTION
## What

`DtrhLoomStore` guarded the incoming weave with two ceilings written as the same
`8 * 1024 * 1024` literal - but one counts decoded bytes and the other counts base64
characters, and base64 costs 4 characters per 3 bytes. The gate that claimed to keep 8MB of
gif kept 6MB. `MaxBase64Chars` is now derived from `MaxGifBytes`, so the store accepts exactly
what `engine/loomWorker.js` is willing to emit (its `HARD_CAP`, also 8MB).

An empty payload also answered `too-big` - rendered in the pane as "too heavy to hang. simpler
colors, fewer arms." It answers `bad-gif` now. Nothing arrived is not the same complaint as too
much arrived, and the old code sent the weaver off simplifying a pattern that never reached C#.

## Why

Discord #ask-support, message id 1547373031939379270: Tock could not save a default, unmodified
Loom pattern, on an empty rack, and got "too heavy to hang. simpler colors, fewer arms." A
helper guessed the 12-spiral rack was full; it was his first pattern.

It was not the rack. The worker weaves at 640px, retries once at 512px if the file is over its
6MB SOFT_CAP, and ships anything under its 8MB HARD_CAP. Everything it emits between 6 and 8MB
was refused by the store on base64 length alone, before the decode. Running the shipped worker
over every entry of the `PRESETS` table in `game/loomStudio.js` (real WebGL field + gifenc,
headless Chrome / ANGLE SwiftShader) at its shipped defaults:

| pattern | weave | base64 chars | old gate (8,388,608) |
|---|---|---|---|
| classic ccp | 3,053,418 | 4,071,224 | ok |
| **bambi haze** | **6,807,218** (retried to 512px) | **9,076,292** | **refused** |
| sissy swirl | 1,593,659 | 2,124,880 | ok |
| drone protocol | 2,265,466 | 3,020,624 | ok |
| locked in | 4,972,392 | 6,629,856 | ok |
| hypno teal | 1,070,116 | 1,426,824 | ok |
| candy tunnel | 2,783,640 | 3,711,520 | ok |
| void bloom | 3,900,414 | 5,200,552 | ok |

"bambi haze" - the flagship Bambi preset, second in the pattern strip - could never be saved by
anyone, on any rack, since the Loom shipped. The new ceiling is 11,185,836 chars, which carries
a full 8MB gif.

## Tests

`LoomWeightCeilingTests` (14 cases): every shipped pattern against both halves of the gate, the
derived ceiling against a full-sized gif, the worker's `HARD_CAP` against the store's ceiling
(so the two sides cannot drift), the empty payload, the genuinely oversize payload, and a guard
that fails if a ninth preset is added to `PRESETS` without being weighed. With the old literal
restored, 3 of the 14 fail; with the fix, all pass. Full suite: 5376 passed, 3 pre-existing
`VatFillCoordinatorTests` failures unrelated to this change (they fail identically on a clean
`release/6.9.4` tree).

All three `loom-save` entry points (`LoomHostService`, `DtrhHostService`, `IntakeHostService`)
funnel into `DtrhLoomStore.Save`, so one fix covers the Loom window, the Warren pane and the
intake recap. Changed lines: 166.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013mR8cAipk1ivr3Em5fJjcx
