### PR TITLE
fix(quests): a board that never deals what this machine cannot do

### DIFF
--- a/ConditioningControlPanel/Models/Quest.cs
+++ b/ConditioningControlPanel/Models/Quest.cs
@@ -98,6 +98,16 @@ public class QuestDefinition
     public bool RequiresPremium { get; set; }
 
     /// <summary>
+    /// Devices this quest cannot be completed without, as published by the definitions channel:
+    /// "camera"/"webcam", "microphone"/"mic", or several separated by commas or spaces. Null on
+    /// every embedded quest - their requirements come from the category instead
+    /// (QuestHardwareGate.NeedsCamera / NeedsMicrophone). Unknown words are ignored, so a typo in
+    /// hand-authored JSON costs the gate rather than the player's quest. ccp-bugs#1151.
+    /// </summary>
+    [JsonProperty("requiresHardware")]
+    public string? RequiresHardware { get; set; }
+
+    /// <summary>
     /// Whether this is a seasonal quest (temporary/event-based)
     /// </summary>
     [JsonProperty("seasonal")]

--- a/ConditioningControlPanel/Models/QuestProgress.cs
+++ b/ConditioningControlPanel/Models/QuestProgress.cs
@@ -79,6 +79,15 @@ public class QuestProgress
     // in): treated as owned by whoever logs in next, matching the old behavior at worst.
     public string? OwnerUnifiedId { get; set; }
 
+    // ccp-bugs#1186 / #1192: the last moment this account was OBSERVED with resolved premium
+    // access, stamped by QuestService on any pass that sees one. It is the only durable answer to
+    // "was this user ever premium", and the premium-loss reroll needs that answer: keeping an
+    // in-progress premium quest is right for a LAPSED patron and wrong for someone who was never
+    // premium at all, who is simply stuck with a quest they cannot finish. Null = never seen
+    // premium (a fresh file, or a genuinely free account). Never cleared except by the
+    // different-account wipe, because "used to be a patron" does not stop being true.
+    public DateTime? LastPremiumSeenUtc { get; set; }
+
     /// <summary>
     /// Get remaining daily rerolls (1 base + 2 for Patreon + skill tree bonuses)
     /// </summary>

--- a/ConditioningControlPanel/Services/Progression/QuestDefinitionService.cs
+++ b/ConditioningControlPanel/Services/Progression/QuestDefinitionService.cs
@@ -257,6 +257,9 @@ public class QuestDefinitionService : IDisposable
                         ? QuestDefinition.BundledArtPath(q["id"]!.ToString())
                         : GetFallbackImagePath(q["category"]?.ToString()),
                     RequiresPremium = (bool?)q["requiresPremium"] ?? false,
+                    // ccp-bugs#1151: lets the channel publish a quest that needs a camera or a
+                    // microphone without a client update. Read by QuestHardwareGate.
+                    RequiresHardware = q["requiresHardware"]?.ToString(),
                     IsSeasonal = (bool?)q["seasonal"] ?? false,
                     ActiveFrom = q["activeFrom"]?.ToString(),
                     ActiveUntil = q["activeUntil"]?.ToString()

--- a/ConditioningControlPanel/Services/Progression/QuestHardwareGate.cs
+++ b/ConditioningControlPanel/Services/Progression/QuestHardwareGate.cs
@@ -7,72 +7,73 @@ using ConditioningControlPanel.Models;
 namespace ConditioningControlPanel.Services;
 
 /// <summary>
+/// What this machine actually has, as one answer read once per roll. <see cref="Resolved"/> is
+/// false when a probe has not landed yet (it timed out, or it is still running): the presence
+/// flags then read PRESENT - fail open - and the caller arms a recheck so the board is looked at
+/// again once the real answer is in. Without that flag the 400ms budget WAS half the bug: a cold
+/// DirectShow enumeration at startup rarely finishes inside it, so the launch roll answered
+/// "camera present", dealt the blink quest, and nothing ever revisited the decision.
+/// </summary>
+internal readonly record struct QuestHardwareState(bool HasCamera, bool HasMicrophone, bool Resolved);
+
+/// <summary>
 /// THE HARDWARE GATE ON THE QUEST ROLL (ccp-bugs#1151). A machine with no webcam was still dealt
 /// the blink-trainer quests (blink_drill_d, obedient_eyes_d, blink_century_w, eyes_trained_w):
 /// impossible to move, and the only way out was to burn a reroll on a board that could deal
-/// another one straight back. The roll now asks whether this machine HAS a camera first.
+/// another one straight back. The roll asks whether this machine HAS the hardware first, and -
+/// since 6.9.4 - so does every pass that decides whether to KEEP a quest already on the board.
 ///
-/// CAMERA ONLY, deliberately. No quest category needs the microphone: the one voice-adjacent
-/// category is Mantra, and mantras are completed by TYPING them (MantraService.TryCompleteMantra)
-/// - the mic-verified spoken path (CreditExternalMantra) is an extra way in, never the only one.
-/// A future voice-only category needs a second predicate here and nothing else.
+/// BOTH HALVES ARE NEEDED, which is why the first fix did not close the report. Gating only the
+/// roll left three ways for an impossible quest to sit there anyway: a board dealt by a build
+/// older than the gate, a weekly slot that survives a whole week unexamined, and a roll that ran
+/// before the probe answered. The keep gate (QuestService.ReconcileDailySlots step 4, and the
+/// weekly block in CheckAndGenerateQuests) closes all three.
 ///
-/// Three rules the callers depend on. ONE probe per roll: the answer is cached, so dealing three
-/// daily seats enumerates devices once and a camera plugged in later is still noticed. NEVER
-/// BLOCK: the roll can run on the UI thread (QuestService's constructor), so the probe runs on the
-/// thread pool and the caller waits at most ProbeBudget for it. FAIL OPEN: a probe that throws,
-/// times out or has never run reads as PRESENT, because narrowing the pool on an error would
-/// silently take quests away from people who own the camera.
+/// Two devices, two probes, one discipline each. ONE probe per roll: answers are cached, so three
+/// daily seats enumerate devices once and hardware plugged in later is still noticed. NEVER BLOCK:
+/// a roll can run on the UI thread, so a probe runs on the thread pool and the caller waits at
+/// most ProbeBudget. FAIL OPEN: a probe that throws, times out or has never run reads as PRESENT -
+/// narrowing the pool on an error would take quests from people who own the device - but it also
+/// reads as UNRESOLVED, which is what makes the fail-open temporary instead of permanent.
 /// </summary>
 internal sealed class QuestHardwareGate
 {
-    /// <summary>The instance the roll uses. Tests construct their own with a fake probe.</summary>
+    /// <summary>The instance the roll uses. Tests construct their own with fake probes.</summary>
     public static readonly QuestHardwareGate Shared = new();
 
     private static readonly TimeSpan CacheTtl = TimeSpan.FromMinutes(5);
     private static readonly TimeSpan ProbeBudget = TimeSpan.FromMilliseconds(400);
 
-    private readonly Func<bool> _cameraProbe;
-    private readonly object _lock = new();
-    private Task? _inFlight;
-    private bool _hasCamera = true;
-    private DateTime _probedAtUtc = DateTime.MinValue;
+    private readonly CachedProbe _camera;
+    private readonly CachedProbe _microphone;
 
-    internal QuestHardwareGate(Func<bool>? cameraProbe = null) => _cameraProbe = cameraProbe ?? DetectCamera;
-
-    /// <summary>Whether this machine has a camera, cached. Safe to call from the UI thread.</summary>
-    public bool HasCamera()
+    internal QuestHardwareGate(Func<bool>? cameraProbe = null, Func<bool>? microphoneProbe = null)
     {
-        Task probe;
-        lock (_lock)
-        {
-            if (DateTime.UtcNow - _probedAtUtc < CacheTtl) return _hasCamera;
-            probe = _inFlight ??= Task.Run(RunProbe);
-        }
-        try
-        {
-            // On timeout: answer "present" and let the probe land for the next roll.
-            if (!probe.Wait(ProbeBudget)) return true;
-        }
-        catch (Exception ex)
-        {
-            App.Logger?.Warning(ex, "Quest camera probe failed; assuming a camera is present");
-            return true;
-        }
-        lock (_lock) { return _hasCamera; }
+        _camera = new CachedProbe("camera", cameraProbe ?? DetectCamera);
+        _microphone = new CachedProbe("microphone", microphoneProbe ?? DetectMicrophone);
     }
 
-    private void RunProbe()
+    /// <summary>Whether this machine has a camera, cached. Safe to call from the UI thread.</summary>
+    public bool HasCamera() => _camera.IsPresent(out _);
+
+    /// <summary>Whether this machine has an audio capture device, cached.</summary>
+    public bool HasMicrophone() => _microphone.IsPresent(out _);
+
+    /// <summary>Both answers plus whether they can be trusted, for one roll. Read ONCE per roll
+    /// and pass the struct down, or a probe landing mid-roll can split the answer.</summary>
+    public QuestHardwareState Snapshot()
     {
-        bool found;
-        try { found = _cameraProbe(); }
-        catch (Exception ex)
-        {
-            App.Logger?.Warning(ex, "Quest camera probe threw; assuming a camera is present");
-            found = true;
-        }
-        lock (_lock) { _hasCamera = found; _probedAtUtc = DateTime.UtcNow; _inFlight = null; }
-        App.Logger?.Information("Quest hardware probe: camera={HasCamera}", found);
+        var hasCamera = _camera.IsPresent(out var cameraResolved);
+        var hasMic = _microphone.IsPresent(out var micResolved);
+        return new QuestHardwareState(hasCamera, hasMic, cameraResolved && micResolved);
+    }
+
+    /// <summary>Kick both probes off without waiting. Called early in startup so the first roll
+    /// reads a cached answer instead of losing the race against the 400ms budget.</summary>
+    public void Prime()
+    {
+        _camera.Start();
+        _microphone.Start();
     }
 
     /// <summary>The enumeration the Lab tab shows "(no cameras detected)" from; the service's
@@ -84,16 +85,130 @@ internal sealed class QuestHardwareGate
         return WebcamDeviceEnumerator.Enumerate().Count > 0 || WebcamWinRtEnumerator.Enumerate().Count > 0;
     }
 
+    /// <summary>The same WaveIn enumeration the speech mic picker is built from - no new probe.</summary>
+    private static bool DetectMicrophone() => Speech.SpeechService.HasCaptureDevice;
+
     /// <summary>Categories that cannot move without a webcam.</summary>
     internal static bool NeedsCamera(QuestCategory category) => category == QuestCategory.BlinkTrainer;
 
-    /// <summary>Drops what this machine cannot serve - and hands the ungated pool back untouched if
-    /// that would leave nothing to roll. A missing camera costs the player blink quests, never the
-    /// day itself, so the gate is the first predicate dropped when the pool runs dry.</summary>
-    internal static List<QuestDefinition> GateOrFallBack(List<QuestDefinition> pool, bool hasCamera)
+    /// <summary>
+    /// Categories that cannot move without a microphone. EMPTY TODAY, and not an oversight: the
+    /// one voice-adjacent embedded category is Mantra, and mantras are completed by TYPING them
+    /// (MantraService.TryCompleteMantra) - the mic-verified path (CreditExternalMantra) is an
+    /// extra way in, never the only one. The predicate exists because the definitions channel can
+    /// publish a quest that DOES need one, declared with
+    /// <see cref="QuestDefinition.RequiresHardware"/>. A voice-only category is one line here.
+    /// </summary>
+    internal static bool NeedsMicrophone(QuestCategory category) => false;
+
+    /// <summary>Camera requirement of a whole definition: its category, or what it declares.</summary>
+    internal static bool NeedsCamera(QuestDefinition quest) =>
+        NeedsCamera(quest.Category) || DeclaresHardware(quest.RequiresHardware, "camera", "webcam");
+
+    /// <summary>Microphone requirement of a whole definition: its category, or what it declares.</summary>
+    internal static bool NeedsMicrophone(QuestDefinition quest) =>
+        NeedsMicrophone(quest.Category) || DeclaresHardware(quest.RequiresHardware, "microphone", "mic");
+
+    /// <summary>Reads the server's optional `requiresHardware` field. Comma or space separated,
+    /// case insensitive, unknown words ignored - a typo in hand-authored JSON must cost the gate,
+    /// never the player's quest.</summary>
+    private static bool DeclaresHardware(string? declared, params string[] names)
     {
-        if (hasCamera) return pool;
-        var gated = pool.Where(q => !NeedsCamera(q.Category)).ToList();
+        if (string.IsNullOrWhiteSpace(declared)) return false;
+        foreach (var part in declared.Split(new[] { ',', ';', ' ', '+', '|' }, StringSplitOptions.RemoveEmptyEntries))
+        {
+            foreach (var name in names)
+                if (string.Equals(part.Trim(), name, StringComparison.OrdinalIgnoreCase)) return true;
+        }
+        return false;
+    }
+
+    /// <summary>True when this quest needs a device this machine does not have. The one predicate
+    /// both the roll filters and the keep gates are built on, so they cannot drift apart.</summary>
+    internal static bool NeedsAbsentHardware(QuestDefinition quest, bool hasCamera, bool hasMicrophone)
+        => (!hasCamera && NeedsCamera(quest)) || (!hasMicrophone && NeedsMicrophone(quest));
+
+    /// <summary>Drops what this machine cannot serve - and hands the ungated pool back untouched if
+    /// that would leave nothing to roll. Missing hardware costs the player those quests, never the
+    /// day itself, so the gate is the first predicate dropped when the pool runs dry.</summary>
+    internal static List<QuestDefinition> GateOrFallBack(
+        List<QuestDefinition> pool, bool hasCamera, bool hasMicrophone = true)
+    {
+        if (hasCamera && hasMicrophone) return pool;
+        var gated = pool.Where(q => !NeedsAbsentHardware(q, hasCamera, hasMicrophone)).ToList();
         return gated.Count > 0 ? gated : pool;
+    }
+
+    /// <summary>One device's answer, probed off the UI thread and cached.</summary>
+    private sealed class CachedProbe
+    {
+        private readonly string _label;
+        private readonly Func<bool> _probe;
+        private readonly object _lock = new();
+        private Task? _inFlight;
+        private bool _present = true;
+        private bool _resolved;
+        private DateTime _probedAtUtc = DateTime.MinValue;
+
+        internal CachedProbe(string label, Func<bool> probe)
+        {
+            _label = label;
+            _probe = probe;
+        }
+
+        /// <summary>Kick the probe off without waiting for it. Idempotent.</summary>
+        internal void Start()
+        {
+            lock (_lock)
+            {
+                if (DateTime.UtcNow - _probedAtUtc < CacheTtl) return;
+                _inFlight ??= Task.Run(Run);
+            }
+        }
+
+        /// <summary>
+        /// Present/absent, with <paramref name="resolved"/> false when the answer is the fail-open
+        /// default rather than something a probe actually returned.
+        /// </summary>
+        internal bool IsPresent(out bool resolved)
+        {
+            Task probe;
+            lock (_lock)
+            {
+                if (DateTime.UtcNow - _probedAtUtc < CacheTtl)
+                {
+                    resolved = _resolved;
+                    return _present;
+                }
+                probe = _inFlight ??= Task.Run(Run);
+            }
+            try
+            {
+                // On timeout: answer "present", UNRESOLVED, and let the probe land for the recheck.
+                if (!probe.Wait(ProbeBudget)) { resolved = false; return true; }
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Warning(ex, "Quest {Device} probe failed; assuming the device is present", _label);
+                resolved = false;
+                return true;
+            }
+            lock (_lock) { resolved = _resolved; return _present; }
+        }
+
+        private void Run()
+        {
+            bool found;
+            bool resolved = true;
+            try { found = _probe(); }
+            catch (Exception ex)
+            {
+                App.Logger?.Warning(ex, "Quest {Device} probe threw; assuming the device is present", _label);
+                found = true;
+                resolved = false;
+            }
+            lock (_lock) { _present = found; _resolved = resolved; _probedAtUtc = DateTime.UtcNow; _inFlight = null; }
+            App.Logger?.Information("Quest hardware probe: {Device}={Present}", _label, found);
+        }
     }
 }

--- a/ConditioningControlPanel/Services/Progression/QuestService.cs
+++ b/ConditioningControlPanel/Services/Progression/QuestService.cs
@@ -62,6 +62,13 @@ public class QuestService : IDisposable
     private static readonly TimeSpan EntitlementSettleWindow = TimeSpan.FromSeconds(90);
     private bool _premiumRecheckPending;
 
+    // ccp-bugs#1151: the twin of the flag above, for the hardware probe. A pass that ran while the
+    // camera/mic answer was still unresolved (the 400ms budget expiring on a cold DirectShow
+    // enumeration is the ordinary case at launch) read "present" and may have dealt or kept a
+    // quest this machine cannot serve. Arm this, and the refresh tick reconciles the board once
+    // the probe has actually landed. In-memory only: the probe re-runs every launch anyway.
+    private bool _hardwareRecheckPending;
+
     // Accumulators for fractional minutes (time-based quests are called with small increments)
     private double _spiralMinutesAccumulator;
     private double _pinkFilterMinutesAccumulator;
@@ -106,6 +113,12 @@ public class QuestService : IDisposable
 
     public QuestService()
     {
+        // FIRST LINE ON PURPOSE (ccp-bugs#1151). The board is rolled a few statements below, and
+        // the camera probe is a cold DirectShow enumeration that rarely finishes inside the gate's
+        // 400ms budget. Starting it before the quests.json read buys it that read; the recheck
+        // flag covers the times it still is not back.
+        QuestHardwareGate.Shared.Prime();
+
         _progressPath = Path.Combine(
             App.UserDataPath,
             "quests.json");
@@ -154,8 +167,15 @@ public class QuestService : IDisposable
             // A premium-loss decision deferred at launch (#889) is retried here, once the
             // entitlement answer has landed.
             var premiumRecheck = _premiumRecheckPending && IsEntitlementResolved();
-            if (dailyExpired || weeklyExpired || premiumRecheck)
+            // ccp-bugs#1151: same shape for the hardware answer. Only fires once the probe has
+            // actually landed, so a probe that keeps failing can never spin this tick.
+            var hardwareRecheck = _hardwareRecheckPending && QuestHardwareGate.Shared.Snapshot().Resolved;
+            if (dailyExpired || weeklyExpired || premiumRecheck || hardwareRecheck)
             {
+                if (dailyExpired || weeklyExpired)
+                {
+                    App.Logger?.Information("Quest rollover detected (daily={Daily}, weekly={Weekly})", dailyExpired, weeklyExpired);
+                }
                 if (premiumRecheck)
                 {
                     // NOT cleared here: CheckAndGenerateQuests recomputes the flag from what is
@@ -163,9 +183,10 @@ public class QuestService : IDisposable
                     // entitlement flapped back to unresolved before the inner check ran.
                     App.Logger?.Information("Quest premium recheck: entitlement resolved, reconciling deferred quests");
                 }
-                else
+                if (hardwareRecheck)
                 {
-                    App.Logger?.Information("Quest rollover detected (daily={Daily}, weekly={Weekly})", dailyExpired, weeklyExpired);
+                    // Same rule: cleared by CheckAndGenerateQuests, not here.
+                    App.Logger?.Information("Quest hardware recheck: probe resolved, reconciling the board");
                 }
                 CheckAndGenerateQuests();
                 QuestsRefreshed?.Invoke(this, EventArgs.Empty);
@@ -261,6 +282,16 @@ public class QuestService : IDisposable
         // defers a decision (CanDropPremiumQuest, the generators, the re-roll blocks at the end)
         // re-arms it, so a decision can never be lost between the arming and the retry.
         _premiumRecheckPending = false;
+        // Same contract for the hardware answer: every roll and every keep gate below re-arms it
+        // while the probe is unresolved, so clearing it here cannot lose a deferred decision - and
+        // once the probe HAS landed the flag stays clear, which is what stops the refresh tick
+        // from reconciling the board once a minute forever.
+        _hardwareRecheckPending = false;
+
+        // ccp-bugs#1186 / #1192: before anything decides to drop a premium quest, record that this
+        // account HAS premium right now if it does. This is the only durable "was ever premium"
+        // evidence the client keeps, and CanDropPremiumQuest reads it.
+        if (StampPremiumSeen()) changed = true;
 
         // THE DAILY BOARD. All three of today's quests are dealt at once and reconciled as a
         // set - rollover, migration from the old one-at-a-time file, top-up, and the per-slot
@@ -295,6 +326,23 @@ public class QuestService : IDisposable
                 App.Logger?.Information("Weekly quest '{QuestId}' requires premium (access lost), regenerating",
                     Progress.WeeklyQuest.DefinitionId);
                 GenerateNewWeeklyQuest();
+                changed = true;
+            }
+        }
+
+        // THE WEEKLY KEEP GATE (ccp-bugs#1151). The daily equivalent is per-slot inside
+        // ReconcileDailySlots. Without this the weekly slot was the worst offender in the report:
+        // a blink quest dealt once - by an older build, or by a roll that ran before the camera
+        // probe answered - was never looked at again until the week turned over.
+        if (Progress.WeeklyQuest != null && !Progress.WeeklyQuest.IsCompleted)
+        {
+            var weeklyDef = GetCurrentWeeklyDefinition();
+            if (weeklyDef != null && NeedsAbsentHardware(weeklyDef)
+                && CanDropUnservableQuest(Progress.WeeklyQuest, "weekly"))
+            {
+                App.Logger?.Information("Weekly quest '{QuestId}' needs hardware this machine does not have, regenerating",
+                    Progress.WeeklyQuest.DefinitionId);
+                GenerateNewWeeklyQuest(excludeId: Progress.WeeklyQuest.DefinitionId);
                 changed = true;
             }
         }
@@ -449,6 +497,13 @@ public class QuestService : IDisposable
             {
                 reason = "requires premium (access lost)";
             }
+            else if (NeedsAbsentHardware(def) && CanDropUnservableQuest(slot, "daily slot " + (i + 1)))
+            {
+                // ccp-bugs#1151. Gating the ROLL was never enough on its own: a board dealt by a
+                // build older than the gate, or dealt while the probe had not answered yet, kept
+                // its impossible quest for as long as the player did not burn a reroll on it.
+                reason = "needs hardware this machine does not have";
+            }
             else if (!IsQuestAvailableForLevel(def.Category))
             {
                 reason = "requires locked feature (" + def.Category + ")";
@@ -566,9 +621,14 @@ public class QuestService : IDisposable
         // Use remote quests from QuestDefinitionService if available, fall back to embedded
         var questPool = App.QuestDefinitions?.GetDailyQuests() ?? QuestDefinition.DailyQuests.ToList();
         var hasPremium = App.Patreon?.HasPremiumAccess == true;
-        // Cached, so dealing all three seats enumerates devices once (ccp-bugs#1151).
-        var hasCamera = QuestHardwareGate.Shared.HasCamera();
-        var availableQuests = FilterDailyRollPool(questPool, excludeIds, hasPremium, DateTime.Today, applyDateWindow: true, hasCamera);
+        // Cached, so dealing all three seats enumerates devices once (ccp-bugs#1151). An
+        // unresolved answer rolls from the everything-present pool and arms the recheck, exactly
+        // as an unresolved entitlement rolls from the free pool and arms its own.
+        var hw = QuestHardwareGate.Shared.Snapshot();
+        if (!hw.Resolved) _hardwareRecheckPending = true;
+        var hasCamera = hw.HasCamera;
+        var hasMic = hw.HasMicrophone;
+        var availableQuests = FilterDailyRollPool(questPool, excludeIds, hasPremium, DateTime.Today, applyDateWindow: true, hasCamera, hasMic);
 
         // THE WINDOW MUST NEVER STARVE THE PLAYER. If a date window emptied the pool,
         // fall back to the undated pool rather than leaving the day questless: an event
@@ -576,7 +636,7 @@ public class QuestService : IDisposable
         // with it. See IsQuestInDateWindow.
         if (availableQuests.Count == 0)
         {
-            availableQuests = FilterDailyRollPool(questPool, excludeIds, hasPremium, DateTime.Today, applyDateWindow: false, hasCamera);
+            availableQuests = FilterDailyRollPool(questPool, excludeIds, hasPremium, DateTime.Today, applyDateWindow: false, hasCamera, hasMic);
         }
 
         // LAST RESORT: three slots can drain a pool that one slot never could (a low-level
@@ -588,7 +648,7 @@ public class QuestService : IDisposable
             // Through the same helper, with the exclusions dropped rather than the predicates.
             // Hand-rolling this filter is how a Remote quest gets onto the board: it is the one
             // path that never sees IsRollableAsDaily unless it goes through here.
-            availableQuests = FilterDailyRollPool(questPool, (ICollection<string>?)null, hasPremium, DateTime.Today, applyDateWindow: false, hasCamera);
+            availableQuests = FilterDailyRollPool(questPool, (ICollection<string>?)null, hasPremium, DateTime.Today, applyDateWindow: false, hasCamera, hasMic);
         }
 
         if (availableQuests.Count == 0) return null;
@@ -624,14 +684,17 @@ public class QuestService : IDisposable
 
         // Use remote quests from QuestDefinitionService if available, fall back to embedded
         var questPool = App.QuestDefinitions?.GetWeeklyQuests() ?? QuestDefinition.WeeklyQuests.ToList();
-        // Same hardware gate as the daily roll (ccp-bugs#1151): no webcam, no blink weekly.
-        var hasCamera = QuestHardwareGate.Shared.HasCamera();
+        // Same hardware gate as the daily roll (ccp-bugs#1151): no webcam, no blink weekly. The
+        // weekly slot is the one that hurt most - nothing re-examined it until the week turned
+        // over, so a blink quest dealt here sat on the board for seven days.
+        var hw = QuestHardwareGate.Shared.Snapshot();
+        if (!hw.Resolved) _hardwareRecheckPending = true;
         var availableQuests = QuestHardwareGate.GateOrFallBack(questPool
             .Where(q => q.Id != excludeId)
             .Where(q => IsQuestAvailableForLevel(q.Category))
             .Where(IsQuestAvailableForTier)
             .Where(IsQuestInDateWindow)
-            .ToList(), hasCamera);
+            .ToList(), hw.HasCamera, hw.HasMicrophone);
 
         // Same starvation guard as the daily generator — see the note there.
         if (availableQuests.Count == 0)
@@ -640,7 +703,7 @@ public class QuestService : IDisposable
                 .Where(q => q.Id != excludeId)
                 .Where(q => IsQuestAvailableForLevel(q.Category))
                 .Where(IsQuestAvailableForTier)
-                .ToList(), hasCamera);
+                .ToList(), hw.HasCamera, hw.HasMicrophone);
         }
 
         if (availableQuests.Count == 0) return;
@@ -657,20 +720,21 @@ public class QuestService : IDisposable
     /// <summary>
     /// Guards the "requires premium, access lost" rerolls (#889). Throwing a premium quest away is
     /// only correct once we actually KNOW the entitlement, and a Patreon answer arrives seconds
-    /// after launch — before it does, every patron looks free. Progress is also protected: a quest
-    /// the player has already worked on is never taken away mid-run. A deferred decision is retried
-    /// by the refresh timer, so a genuinely lapsed patron still gets a free quest a tick later.
+    /// after launch - before it does, every patron looks free. A deferred decision is retried by
+    /// the refresh timer, so a genuinely lapsed patron still gets a free quest a tick later.
+    ///
+    /// THE PROGRESS GUARD IS NOT UNCONDITIONAL ANY MORE (ccp-bugs#1186, #1192). It was written for
+    /// one person: the LAPSED patron, mid-way through a premium quest when their pledge ended, who
+    /// should be allowed to finish what they started. Applied to someone who was NEVER premium it
+    /// does the exact opposite of its purpose - they cannot finish it, cannot be given another,
+    /// and watch the slot sit there until the day or the week turns over. So the guard now asks
+    /// who it is protecting: <see cref="WasEverPremium"/>.
     /// </summary>
     private bool CanDropPremiumQuest(ActiveQuest quest, string slot)
     {
-        if (quest.CurrentProgress > 0)
-        {
-            App.Logger?.Information(
-                "Premium {Slot} quest '{QuestId}' kept: it already has progress ({Progress})",
-                slot, quest.DefinitionId, quest.CurrentProgress);
-            return false;
-        }
-
+        // Resolution FIRST, so an unresolved entitlement always arms the recheck. Under the old
+        // order a quest with progress returned early and armed nothing, and the decision was not
+        // retried until something else happened to arm the flag.
         if (!IsEntitlementResolved())
         {
             _premiumRecheckPending = true;
@@ -680,6 +744,103 @@ public class QuestService : IDisposable
             return false;
         }
 
+        var canDrop = CanDropPremiumQuest(entitlementResolved: true, WasEverPremium(), quest.CurrentProgress);
+        if (!canDrop)
+        {
+            App.Logger?.Information(
+                "Premium {Slot} quest '{QuestId}' kept: lapsed patron, already has progress ({Progress})",
+                slot, quest.DefinitionId, quest.CurrentProgress);
+        }
+        else if (quest.CurrentProgress > 0)
+        {
+            App.Logger?.Information(
+                "Premium {Slot} quest '{QuestId}' dropped despite progress ({Progress}): this account has never had premium access",
+                slot, quest.DefinitionId, quest.CurrentProgress);
+        }
+        return canDrop;
+    }
+
+    /// <summary>
+    /// Pure form of the guard, split out so it is testable without a live App. The whole of
+    /// ccp-bugs#1186 / #1192 is the middle term: progress alone used to be enough to keep a
+    /// premium quest, for everybody.
+    /// </summary>
+    internal static bool CanDropPremiumQuest(bool entitlementResolved, bool wasEverPremium, int currentProgress)
+        => entitlementResolved && (currentProgress <= 0 || !wasEverPremium);
+
+    /// <summary>
+    /// Has this account EVER been seen with premium access? There is no tier history on the client
+    /// - the subscription cache only ever holds the current answer - so the durable half is a stamp
+    /// the quest ledger writes itself (<see cref="QuestProgress.LastPremiumSeenUtc"/>).
+    ///
+    /// The settings clauses are the bootstrap, so the answer is not simply "no" for every existing
+    /// install on the first launch after this ships. The two grace stamps are only ever written by
+    /// a validation that came back premium, and are left NON-NULL once expired, which makes a
+    /// past-dated stamp exactly the evidence wanted; PatreonTier is the same signal from the UI
+    /// cache. All three are cleared on an explicit logout - harmless, because a signed-out session
+    /// is unresolved (IsEntitlementResolved) and never reaches a drop decision at all.
+    ///
+    /// Deliberately generous: a false "yes" keeps a quest one more day, a false "no" takes a real
+    /// patron's half-finished quest away.
+    /// </summary>
+    private bool WasEverPremium()
+    {
+        if (Progress.LastPremiumSeenUtc != null) return true;
+
+        var settings = App.Settings?.Current;
+        if (settings == null) return false;
+        return settings.PatreonPremiumValidUntil != null
+            || settings.PatreonLabValidUntil != null
+            || settings.PatreonTier > 0;
+    }
+
+    /// <summary>
+    /// Record that premium access was observed, once the entitlement is trustworthy. Called from
+    /// the reconcile pass, which runs at launch and on every refresh tick, so a patron's stamp is
+    /// refreshed long before it could ever matter.
+    /// </summary>
+    private bool StampPremiumSeen()
+    {
+        if (App.Patreon?.HasPremiumAccess != true || !IsEntitlementResolved()) return false;
+        // A day's resolution is plenty: this only answers "ever", and rewriting it on every tick
+        // would dirty the file once a minute for the whole session.
+        var now = DateTime.UtcNow;
+        if (Progress.LastPremiumSeenUtc is { } seen && now - seen < TimeSpan.FromHours(12)) return false;
+        Progress.LastPremiumSeenUtc = now;
+        return true;
+    }
+
+    /// <summary>
+    /// THE KEEP GATE'S PREDICATE (ccp-bugs#1151): does this quest need a camera or a microphone
+    /// this machine does not have? An unresolved probe answers NO and arms the recheck, so the
+    /// fail-open never costs a quest and never becomes permanent.
+    /// </summary>
+    private bool NeedsAbsentHardware(QuestDefinition def)
+    {
+        var hw = QuestHardwareGate.Shared.Snapshot();
+        if (!hw.Resolved)
+        {
+            _hardwareRecheckPending = true;
+            return false;
+        }
+        return QuestHardwareGate.NeedsAbsentHardware(def, hw.HasCamera, hw.HasMicrophone);
+    }
+
+    /// <summary>
+    /// Whether a quest the machine cannot serve may be taken off the board. Progress is protected
+    /// the same way the premium guard protects it: a quest with points on it means the hardware
+    /// worked at some point, so the honest reading is "the device was unplugged", not "this was
+    /// always impossible". The player still has the reroll button, and the next rollover clears it.
+    /// </summary>
+    private bool CanDropUnservableQuest(ActiveQuest quest, string slot)
+    {
+        if (quest.CurrentProgress > 0)
+        {
+            App.Logger?.Information(
+                "Unservable {Slot} quest '{QuestId}' kept: it already has progress ({Progress})",
+                slot, quest.DefinitionId, quest.CurrentProgress);
+            return false;
+        }
         return true;
     }
 
@@ -777,11 +938,11 @@ public class QuestService : IDisposable
     /// </summary>
     internal static List<QuestDefinition> FilterDailyRollPool(
         IEnumerable<QuestDefinition> pool, string? excludeId, bool hasPremium,
-        DateTime today, bool applyDateWindow, bool hasCamera = true)
+        DateTime today, bool applyDateWindow, bool hasCamera = true, bool hasMicrophone = true)
         => FilterDailyRollPool(
             pool,
             string.IsNullOrEmpty(excludeId) ? null : new[] { excludeId },
-            hasPremium, today, applyDateWindow, hasCamera);
+            hasPremium, today, applyDateWindow, hasCamera, hasMicrophone);
 
     /// <summary>
     /// Set-excluding form, for the three-up daily board. Each seat has to roll against every id
@@ -793,7 +954,7 @@ public class QuestService : IDisposable
     /// </summary>
     internal static List<QuestDefinition> FilterDailyRollPool(
         IEnumerable<QuestDefinition> pool, ICollection<string>? excludeIds, bool hasPremium,
-        DateTime today, bool applyDateWindow, bool hasCamera = true)
+        DateTime today, bool applyDateWindow, bool hasCamera = true, bool hasMicrophone = true)
     {
         var filtered = pool
             .Where(q => excludeIds == null || !excludeIds.Contains(q.Id))
@@ -804,7 +965,7 @@ public class QuestService : IDisposable
             .ToList();
         // LAST predicate, and the first one dropped when the pool runs dry: a machine with no
         // webcam must not be dealt a blink quest (ccp-bugs#1151) but must still be dealt a quest.
-        return QuestHardwareGate.GateOrFallBack(filtered, hasCamera);
+        return QuestHardwareGate.GateOrFallBack(filtered, hasCamera, hasMicrophone);
     }
 
     /// <summary>

--- a/Tests/ConditioningControlPanel.Tests/QuestHardwareRollTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/QuestHardwareRollTests.cs
@@ -10,17 +10,20 @@ namespace ConditioningControlPanel.Tests;
 /// <summary>
 /// ccp-bugs#1151: a machine with no webcam was still dealt the blink-trainer quests, which it can
 /// never complete - and rerolling could deal another one straight back. These exercise the same
-/// pure predicates the daily and weekly rolls call, with the camera probe injected, so nothing
-/// here touches a real device.
+/// pure predicates the daily and weekly rolls call, with the probes injected, so nothing here
+/// touches a real device.
 /// </summary>
 public class QuestHardwareRollTests
 {
     private static readonly DateTime AnyDay = new(2026, 9, 5);
 
-    private static List<QuestDefinition> DailyPool(bool hasCamera) =>
+    private static List<QuestDefinition> DailyPool(bool hasCamera, bool hasMicrophone = true) =>
         QuestService.FilterDailyRollPool(
             QuestDefinition.DailyQuests, excludeId: null, hasPremium: true,
-            today: AnyDay, applyDateWindow: true, hasCamera: hasCamera);
+            today: AnyDay, applyDateWindow: true, hasCamera: hasCamera, hasMicrophone: hasMicrophone);
+
+    private static QuestDefinition Blink(string id) =>
+        QuestDefinition.DailyQuests.Concat(QuestDefinition.WeeklyQuests).First(q => q.Id == id);
 
     [Fact]
     public void DailyRoll_WithNoCamera_NeverYieldsABlinkTrainerQuest()
@@ -72,10 +75,116 @@ public class QuestHardwareRollTests
     public void ProbeIsRunOnceAndCached_SoAThreeSeatRollEnumeratesOnce()
     {
         int probes = 0;
-        var gate = new QuestHardwareGate(() => { probes++; return false; });
+        var gate = new QuestHardwareGate(() => { probes++; return false; }, () => true);
         Assert.False(gate.HasCamera());
         gate.HasCamera();
         gate.HasCamera();
         Assert.Equal(1, probes);
+    }
+
+    // ---- THE KEEP GATE. The half that was missing, and the reason #1151 kept reproducing: the
+    // roll was gated but nothing ever re-examined a quest already sitting on the board.
+
+    [Fact]
+    public void KeepGate_DropsABlinkQuestAlreadyOnTheBoard_WhenTheCameraIsGone()
+    {
+        Assert.True(QuestHardwareGate.NeedsAbsentHardware(Blink("obedient_eyes_d"), hasCamera: false, hasMicrophone: true));
+        Assert.True(QuestHardwareGate.NeedsAbsentHardware(Blink("blink_century_w"), hasCamera: false, hasMicrophone: true));
+    }
+
+    [Fact]
+    public void KeepGate_LeavesEveryOtherQuestAlone()
+    {
+        foreach (var q in QuestDefinition.DailyQuests.Concat(QuestDefinition.WeeklyQuests))
+        {
+            var expected = q.Category == QuestCategory.BlinkTrainer;
+            Assert.Equal(expected, QuestHardwareGate.NeedsAbsentHardware(q, hasCamera: false, hasMicrophone: false));
+        }
+    }
+
+    [Fact]
+    public void KeepGate_IsSilentWhenTheHardwareIsThere()
+    {
+        foreach (var q in QuestDefinition.DailyQuests.Concat(QuestDefinition.WeeklyQuests))
+            Assert.False(QuestHardwareGate.NeedsAbsentHardware(q, hasCamera: true, hasMicrophone: true));
+    }
+
+    // ---- THE MICROPHONE. No embedded category needs one (mantras are typed), so the mic half of
+    // the report is served by the definitions channel's `requiresHardware` field.
+
+    [Fact]
+    public void NoEmbeddedQuestNeedsAMicrophone_SoAMiclessMachineLosesNothing()
+    {
+        var all = QuestDefinition.DailyQuests.Concat(QuestDefinition.WeeklyQuests).ToList();
+        Assert.DoesNotContain(all, q => QuestHardwareGate.NeedsMicrophone(q));
+        Assert.Equal(
+            DailyPool(hasCamera: true, hasMicrophone: true).Count,
+            DailyPool(hasCamera: true, hasMicrophone: false).Count);
+    }
+
+    [Theory]
+    [InlineData("microphone")]
+    [InlineData("mic")]
+    [InlineData("MIC")]
+    [InlineData("camera, microphone")]
+    public void AServerQuestDeclaringAMicrophone_IsGatedOnAMiclessMachine(string declared)
+    {
+        var quest = new QuestDefinition("spoken_w", "Spoken", "", QuestType.Weekly,
+            QuestCategory.Mantra, 10, 100, "*") { RequiresHardware = declared };
+
+        Assert.True(QuestHardwareGate.NeedsAbsentHardware(quest, hasCamera: true, hasMicrophone: false));
+        Assert.False(QuestHardwareGate.NeedsAbsentHardware(quest, hasCamera: true, hasMicrophone: true));
+
+        var pool = new List<QuestDefinition> { QuestDefinition.WeeklyQuests[0], quest };
+        Assert.DoesNotContain(
+            QuestHardwareGate.GateOrFallBack(pool, hasCamera: true, hasMicrophone: false),
+            q => q.Id == "spoken_w");
+    }
+
+    [Fact]
+    public void AnUnrecognisedHardwareWord_GatesNothing_ATypoMustNotCostAQuest()
+    {
+        var quest = new QuestDefinition("odd_w", "Odd", "", QuestType.Weekly,
+            QuestCategory.Flash, 10, 100, "*") { RequiresHardware = "cammera" };
+        Assert.False(QuestHardwareGate.NeedsAbsentHardware(quest, hasCamera: false, hasMicrophone: false));
+    }
+
+    // ---- RESOLUTION. The fail-open must be temporary, or it is just the old bug with a comment.
+
+    [Fact]
+    public void ATimedOutProbe_ReadsPresentButUnresolved_SoTheBoardIsRecheckedLater()
+    {
+        using var released = new System.Threading.ManualResetEventSlim(false);
+        var gate = new QuestHardwareGate(
+            () => { released.Wait(TimeSpan.FromSeconds(5)); return false; },
+            () => true);
+
+        var duringProbe = gate.Snapshot();
+        Assert.True(duringProbe.HasCamera);      // fail open: nobody loses a quest to a slow probe
+        Assert.False(duringProbe.Resolved);      // ...but the decision is explicitly not trusted
+
+        released.Set();
+        var settled = SpinUntilResolved(gate);
+        Assert.True(settled.Resolved);
+        Assert.False(settled.HasCamera);         // the real answer, in time for the recheck
+    }
+
+    [Fact]
+    public void ASettledProbe_IsResolved_SoNoRecheckIsArmedForever()
+    {
+        var gate = new QuestHardwareGate(() => false, () => false);
+        var snapshot = SpinUntilResolved(gate);
+        Assert.True(snapshot.Resolved);
+        Assert.False(snapshot.HasCamera);
+        Assert.False(snapshot.HasMicrophone);
+    }
+
+    private static QuestHardwareState SpinUntilResolved(QuestHardwareGate gate)
+    {
+        var deadline = DateTime.UtcNow.AddSeconds(5);
+        QuestHardwareState snapshot;
+        do { snapshot = gate.Snapshot(); }
+        while (!snapshot.Resolved && DateTime.UtcNow < deadline);
+        return snapshot;
     }
 }

--- a/Tests/ConditioningControlPanel.Tests/QuestPremiumDropTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/QuestPremiumDropTests.cs
@@ -1,0 +1,52 @@
+using ConditioningControlPanel.Services;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// ccp-bugs#1186 (and its duplicate #1192): a free user who ended up wearing a premium quest could
+/// not finish it and could not be given another, because the guard that keeps a LAPSED patron's
+/// half-finished quest refused to drop anything with progress on it - for everybody.
+///
+/// The guard now asks who it is protecting. These pin the four corners of that decision.
+/// </summary>
+public class QuestPremiumDropTests
+{
+    [Fact]
+    public void LapsedPatron_KeepsTheQuestTheyHaveAlreadyWorkedOn()
+    {
+        // The case the guard was written for, and the one that must not regress.
+        Assert.False(QuestService.CanDropPremiumQuest(
+            entitlementResolved: true, wasEverPremium: true, currentProgress: 12));
+    }
+
+    [Fact]
+    public void NeverPremium_LosesTheQuestEvenWithProgressOnIt()
+    {
+        // #1186. Progress is not a reason to keep a quest this account can never finish.
+        Assert.True(QuestService.CanDropPremiumQuest(
+            entitlementResolved: true, wasEverPremium: false, currentProgress: 12));
+    }
+
+    [Fact]
+    public void AnUntouchedPremiumQuest_IsDroppedForEitherKindOfUser()
+    {
+        Assert.True(QuestService.CanDropPremiumQuest(
+            entitlementResolved: true, wasEverPremium: true, currentProgress: 0));
+        Assert.True(QuestService.CanDropPremiumQuest(
+            entitlementResolved: true, wasEverPremium: false, currentProgress: 0));
+    }
+
+    [Fact]
+    public void NothingIsDroppedWhileTheEntitlementIsUnresolved()
+    {
+        // #889: for the first ~90 seconds of a launch every patron looks free. Deciding then is
+        // how a paying subscriber lost their premium quest on every single startup.
+        Assert.False(QuestService.CanDropPremiumQuest(
+            entitlementResolved: false, wasEverPremium: false, currentProgress: 0));
+        Assert.False(QuestService.CanDropPremiumQuest(
+            entitlementResolved: false, wasEverPremium: false, currentProgress: 12));
+        Assert.False(QuestService.CanDropPremiumQuest(
+            entitlementResolved: false, wasEverPremium: true, currentProgress: 12));
+    }
+}


### PR DESCRIPTION
Two quest-gating bugs, both of which leave a player with a slot they cannot move.

## (A) Hardware quests on machines with no hardware — #1151

The 6.9.2 gate (#840) exists and works, but it only gates the **roll**. Angie is still seeing a daily "Obedient Eyes 0/50" and a weekly "Blink Century 0/100" on 6.9.3 with "no cameras detected" in Settings > Devices, because there were three ways past it:

1. **Nothing re-examined a quest already on the board.** `ReconcileDailySlots` step 4 dropped a slot for a missing definition, a lost tier or a locked level — never for missing hardware. The weekly slot had no equivalent check at all, so a blink weekly dealt once sat there for seven days.
2. **The probe budget lost the race.** `QuestHardwareGate` waits 400ms and fails open. The first roll happens in `QuestService`'s constructor, where `App.Webcam` is not up yet, so the probe is a cold DirectShow/WinRT enumeration that rarely finishes in 400ms. Every launch answered "camera present", dealt the blink quest, and the real answer that landed a moment later had nothing left to correct.
3. **Only the camera was ever probed.**

Changes:

- The gate now answers with a `QuestHardwareState` — presence **plus** whether the probe actually landed. An unresolved answer still fails open (nobody loses a quest to a slow enumeration) but arms `_hardwareRecheckPending`, and the refresh tick reconciles the board once the probe is in. It only fires when the probe has resolved, so a permanently failing probe cannot spin the tick.
- A **keep gate** runs beside the premium and level gates: per slot in `ReconcileDailySlots`, and as its own block for the weekly in `CheckAndGenerateQuests`. A quest the machine cannot serve is now dropped, not kept.
- A second probe covers the **microphone**, using `SpeechService.HasCaptureDevice` — the same `WaveIn` enumeration the speech mic picker is built from, no new probe.
- Both probes are primed on the first line of the service constructor, which buys the camera the `quests.json` read.

On the mic specifically: **no embedded quest category needs one.** The only voice-adjacent category is `Mantra`, and mantras are completed by typing (`MantraService.TryCompleteMantra`); the mic-verified spoken path is an extra way in, never the only one. So rather than invent a fake requirement, the mic gate is reachable through a new optional `requiresHardware` field on a published definition (`"camera"`, `"mic"`, `"microphone"`, comma separated), and `NeedsMicrophone(QuestCategory)` is one line away from covering a future voice-only category. Unrecognised words gate nothing — a typo in hand-authored JSON must not cost a player their quest.

## (B) Premium quests for users who were never premium — #1192 (dup of #1186)

`CanDropPremiumQuest` returned false for any quest with `CurrentProgress > 0`. That guard was written for the **lapsed patron** who should be allowed to finish what they started. Applied to someone who was never premium it does the opposite of its purpose: they cannot finish it, cannot be dealt another, and the slot sits dead until the day or week turns over.

The guard now asks who it is protecting. **There is no tier history anywhere on the client** — no profile field, no persisted flag, and `PatreonSubscriptionCache` only ever holds the current answer — so:

- The durable half is a stamp the quest ledger writes itself: `QuestProgress.LastPremiumSeenUtc`, set by `StampPremiumSeen()` on any reconcile pass that sees resolved premium access (rate-limited to 12h so it does not dirty the file every tick).
- The bootstrap, so the answer is not "no" for every existing install on the first launch after this ships, is `AppSettings.PatreonPremiumValidUntil` / `PatreonLabValidUntil` / `PatreonTier`. **This is the most defensible existing signal and worth calling out:** those grace stamps are only ever written by a validation that came back premium, and they are left non-null once expired, so a past-dated stamp is exactly the evidence wanted. They are cleared on an explicit logout — harmless, because a signed-out session reads as unresolved (`IsEntitlementResolved`) and never reaches a drop decision.
- Deliberately generous. A false "yes" keeps a quest one more day; a false "no" takes a real patron's half-finished quest away.

Also moved the resolution check **first** in that method. Under the old order a quest with progress returned early and armed no recheck, so the decision was not retried until something else happened to arm the flag.

## Notes

- No user-facing strings added or changed (every new message is a log line), so no `Localization/Languages/*.json` edits.
- `git diff --stat origin/release/6.9.4...HEAD` = 621 changed lines, 81 of which are the old single-probe gate being replaced in place.
- Tests: `QuestHardwareRollTests` extended (keep gate, mic declaration, probe resolution) and `QuestPremiumDropTests` added for the four corners of the split guard. 5377 pass; the 3 `VatFillCoordinatorTests` failures are pre-existing on `release/6.9.4` and unrelated.
- Not verified at runtime: no machine here has zero cameras, so the "probe returns false" path is covered by injected fakes in the tests, not by a real cameraless box.

Refs CC-Labs-llc/ccp-bugs#1151, CC-Labs-llc/ccp-bugs#1192, CC-Labs-llc/ccp-bugs#1186

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013mR8cAipk1ivr3Em5fJjcx
