### PR TITLE
fix(companion): a cloud reply that ran out of tokens ends on a sentence, and awareness says why she is quiet

### DIFF
--- a/ConditioningControlPanel/Services/AIService/AiTextHygiene.cs
+++ b/ConditioningControlPanel/Services/AIService/AiTextHygiene.cs
@@ -340,6 +340,117 @@ namespace ConditioningControlPanel.Services
             }
         }
 
+        // Characters a finished sentence may end on. '~' and '…' are in because the companion's own
+        // voice uses both as terminators ("good girl~").
+        private static readonly char[] SentenceEnders = { '.', '!', '?', '…', '~', ':', ';' };
+
+        /// <summary>
+        /// Pessimistic characters-per-token. Real English prose runs ~4, so requiring 3 means a reply
+        /// counts as "hit the cap" only when it is long enough that no honest short answer could be.
+        /// </summary>
+        private const int CharsPerTokenFloor = 3;
+
+        /// <summary>A trim that would throw away more than half the reply is not a repair.</summary>
+        private const double MinKeptFraction = 0.5;
+
+        /// <summary>Below this there is no reply left worth showing, so the fragment stays.</summary>
+        private const int MinKeptChars = 20;
+
+        // Closing marks that may sit AFTER the terminator: quotes, brackets and markdown emphasis.
+        // Emoji are deliberately NOT in here — see EndsMidSentence.
+        private static bool IsClosingMark(char ch) =>
+            ch == '"' || ch == '\'' || ch == ')' || ch == ']' || ch == '}' ||
+            ch == '»' || ch == '”' || ch == '’' || ch == '*' || ch == '_';
+
+        // Emoji and their glue (surrogate pairs, variation selectors, zero-width joiners) plus any
+        // other symbol. An emoji is how this companion ends a bubble, so one is treated as the end of
+        // a finished thought rather than something to look past.
+        private static bool IsEmojiLike(char ch) =>
+            char.IsSurrogate(ch) || char.IsSymbol(ch) ||
+            char.GetUnicodeCategory(ch) == System.Globalization.UnicodeCategory.NonSpacingMark ||
+            char.GetUnicodeCategory(ch) == System.Globalization.UnicodeCategory.Format;
+
+        /// <summary>
+        /// True when the text stops on a word rather than on a sentence, so "I was thinking we could"
+        /// is unfinished while "good girl~", "deeper." and "so cute 💕" are not.
+        ///
+        /// <para>Errs towards FINISHED on purpose: missing a truncation costs the user one ragged
+        /// bubble, while calling a complete reply truncated costs them a sentence she really wrote.
+        /// That is why a trailing emoji ends the question instead of being skipped past.</para>
+        /// </summary>
+        internal static bool EndsMidSentence(string? text)
+        {
+            if (string.IsNullOrWhiteSpace(text)) return false;
+
+            var i = text!.Length - 1;
+            while (i >= 0 && char.IsWhiteSpace(text[i])) i--;
+            while (i >= 0 && IsClosingMark(text[i])) i--;
+            while (i >= 0 && char.IsWhiteSpace(text[i])) i--;
+            if (i < 0) return false;
+
+            if (IsEmojiLike(text[i])) return false;
+
+            foreach (var ender in SentenceEnders)
+                if (text[i] == ender) return false;
+
+            return true;
+        }
+
+        /// <summary>
+        /// Cuts the half-written last sentence off a reply the provider's token cap guillotined.
+        ///
+        /// <para><b>Why this exists (ccp-bugs #1164, "the message seem to be cropped").</b> The cloud
+        /// proxy caps a reply at <c>AiService.MaxTokensHardCap</c> = 100 tokens, the lowest ceiling of
+        /// the three transports, and it is the only one that never noticed. The OpenAI-compatible path
+        /// reads <c>finish_reason</c> and the Ollama path reads <c>done_reason</c>; the proxy's response
+        /// shape (<c>ProxyChatResponse</c>) carries neither, so a reply that stopped mid-word reached
+        /// the speech bubble exactly as the model left it, with nothing in the log to say so. The
+        /// bubble is the wrong place to learn that a budget ran out.</para>
+        ///
+        /// <para>Two guards keep it off ordinary short replies, which frequently and correctly end with
+        /// no punctuation at all ("good girl"):</para>
+        /// <list type="number">
+        /// <item>the reply must be long enough to have plausibly HIT the cap —
+        /// <paramref name="maxTokens"/> × <see cref="CharsPerTokenFloor"/> characters;</item>
+        /// <item>the trim must leave a whole sentence and at least <see cref="MinKeptFraction"/> of the
+        /// text behind. A single long sentence with no earlier terminator is returned untouched: a
+        /// fragment the user can read beats an empty bubble.</item>
+        /// </list>
+        /// </summary>
+        /// <param name="maxTokens">The response cap this call was sent with.</param>
+        /// <param name="trimmed">True when a dangling fragment was actually removed.</param>
+        internal static string TrimCutOffTail(string? text, int maxTokens, out bool trimmed)
+        {
+            trimmed = false;
+            if (string.IsNullOrWhiteSpace(text)) return text ?? string.Empty;
+            if (maxTokens <= 0) return text!;
+
+            var body = text!.TrimEnd();
+            if (body.Length < maxTokens * CharsPerTokenFloor) return text!;
+            if (!EndsMidSentence(body)) return text!;
+
+            var urls = new List<Match>();
+            foreach (Match m in AnyUrl.Matches(body)) urls.Add(m);
+
+            var cut = -1;
+            for (int i = body.Length - 1; i >= 0; i--)
+            {
+                var ch = body[i];
+                if (ch != '.' && ch != '!' && ch != '?' && ch != '…' && ch != '~') continue;
+                if (InsideAny(urls, i)) continue;   // "naughty-bambi-109749.html" is not a sentence end
+                cut = i;
+                break;
+            }
+
+            if (cut < 0) return text!;
+
+            var kept = body.Substring(0, cut + 1).TrimEnd();
+            if (kept.Length < MinKeptChars || kept.Length < body.Length * MinKeptFraction) return text!;
+
+            trimmed = true;
+            return kept;
+        }
+
         /// <summary>
         /// Strip tokenizer artifacts and reasoning blocks. Whitespace is normalised but the text is
         /// otherwise left alone - callers layer their own product-specific sanitising on top.

--- a/ConditioningControlPanel/Services/AiService.cs
+++ b/ConditioningControlPanel/Services/AiService.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
@@ -331,7 +331,7 @@ namespace ConditioningControlPanel.Services
 
             // Sanitize response to remove any leaked metadata tags FIRST (so context-tag
             // echoes don't accidentally trip moderation regexes).
-            var sanitized = SanitizeResponse(raw);
+            var sanitized = SanitizeResponse(raw, MaxTokensHardCap);
 
             // OUTPUT MODERATION (Layer 1). Discard prohibited model output before display.
             if (guard != null)
@@ -789,7 +789,7 @@ namespace ConditioningControlPanel.Services
             }
 
             var raw = post.Content!;
-            var sanitized = SanitizeResponse(raw);
+            var sanitized = SanitizeResponse(raw, maxTokens);
 
             // OUTPUT MODERATION (Layer 1). Prohibited model output is discarded before display;
             // the caller (CompanionBrain) rolls the turn back so it never reaches disk (P2/H5).
@@ -819,7 +819,12 @@ namespace ConditioningControlPanel.Services
         /// Sanitizes AI response by removing any leaked internal metadata tags.
         /// The AI sometimes echoes context tags that should be hidden from users.
         /// </summary>
-        private static string SanitizeResponse(string? response)
+        /// <param name="maxTokens">
+        /// The cap this call was actually sent with, so a reply the cap guillotined can be recognised
+        /// and ended cleanly rather than mid-word (ccp-bugs #1164). See
+        /// <see cref="AiTextHygiene.TrimCutOffTail"/>.
+        /// </param>
+        private static string SanitizeResponse(string? response, int maxTokens)
         {
             if (string.IsNullOrEmpty(response))
                 return response ?? string.Empty;
@@ -832,6 +837,19 @@ namespace ConditioningControlPanel.Services
             // reaction tags like [Media/Streaming], and the truncated variants the 100-token cap
             // produces. Shared with the parser path so both stay in step.
             var sanitized = AiTextHygiene.StripMetadataTags(response);
+
+            // #1164: the proxy reports no finish_reason, so the only evidence a reply was cut off is
+            // the reply itself — long enough to have hit the cap, and stopping on a word. Ending on
+            // the previous sentence reads as a short answer; ending mid-word reads as a broken app.
+            // Length only in the log line: the reply is the companion talking to the user.
+            var repaired = AiTextHygiene.TrimCutOffTail(sanitized, maxTokens, out var trimmed);
+            if (trimmed)
+            {
+                App.Logger?.Warning(
+                    "[AI] cloud reply hit the {Cap}-token cap and stopped mid-sentence - trimmed the dangling " +
+                    "fragment ({Before} -> {After} chars)", maxTokens, sanitized.Length, repaired.Length);
+                sanitized = repaired;
+            }
 
             // If sanitization removed everything meaningful, return a fallback
             if (string.IsNullOrWhiteSpace(sanitized))

--- a/ConditioningControlPanel/Services/Awareness/AwarenessObserver.cs
+++ b/ConditioningControlPanel/Services/Awareness/AwarenessObserver.cs
@@ -128,6 +128,11 @@ namespace ConditioningControlPanel.Services.Awareness
         private string? _currentAppId;
         private ContextFrame? _lastFrame;
 
+        // Reason counts for the Information-level summary. Every per-frame [AWARE] line is Debug and
+        // therefore invisible in a bug report (ccp-bugs #1176); this is the part that survives.
+        private readonly AwarenessTally _tally = new();
+        private DateTime _lastTallyFlush;
+
         /// <summary>
         /// Production constructor. The four collaborators are required: an observer with no ledger, no
         /// scorer, no arbiter or no memory is not a degraded observer, it is a bug with a heartbeat.
@@ -310,6 +315,7 @@ namespace ConditioningControlPanel.Services.Awareness
             _gateWindowStart = now;
             _fullscreenSince = now;
             _lastTickAt = now;
+            _lastTallyFlush = now;
 
             try { _input.Start(); } catch (Exception ex) { App.Logger?.Debug("AwarenessObserver: input probe start failed - {Error}", ex.Message); }
             try { _media?.Start(); } catch (Exception ex) { App.Logger?.Debug("AwarenessObserver: media watcher start failed - {Error}", ex.Message); }
@@ -326,8 +332,17 @@ namespace ConditioningControlPanel.Services.Awareness
             _pollTimer.Tick += OnPollTick;
             _pollTimer.Start();
 
-            App.Logger?.Information("AwarenessObserver: started (poll {Ms}ms, dwell gate {Gate}s)",
-                (int)PollInterval.TotalMilliseconds, DwellGateSeconds);
+            // The dial state belongs in the ONE line that is guaranteed to reach a bug report. #1176
+            // arrived saying "no filter, all my programs on the title allow list" with no way to check
+            // either claim against the running config. Counts and the enum name only — never entries.
+            var settings = _policy();
+            App.Logger?.Information(
+                "AwarenessObserver: started (poll {Ms}ms, dwell gate {Gate}s, intensity={Intensity}, " +
+                "deny={Deny} entries, title-allow={Allow} entries, adult react/record={Reactions}/{Recording})",
+                (int)PollInterval.TotalMilliseconds, DwellGateSeconds,
+                AwarenessIntensityProfile.Current,
+                settings?.DenyList?.Count ?? -1, settings?.TitleAllowList?.Count ?? -1,
+                settings?.AdultReactionsEnabled, settings?.AdultRecordingEnabled);
         }
 
         /// <summary>Disarms the poll and flushes the ledger. Safe to call when never started.</summary>
@@ -357,6 +372,9 @@ namespace ConditioningControlPanel.Services.Awareness
 
             try { _ledger.NoteFocusEnd(_clock()); } catch { }
             _ledger.Stop();
+            // Last call: a session that ends before the 10-minute window closes still reports why she
+            // was quiet, which is the common shape for "I switched it on, nothing happened, I gave up".
+            FlushTally(force: true);
             ResetTransientState();
             App.Logger?.Debug("AwarenessObserver: stopped");
         }
@@ -459,6 +477,12 @@ namespace ConditioningControlPanel.Services.Awareness
                 // frame that does get spoken.
                 if (decision.Verdict != AwarenessVerdict.Silence) _ledger.CommitTrends(trends);
 
+                // The arbiter's gate token is the last thing between a cut frame and a spoken line, so
+                // it is the one the summary most needs. A delivery counts as its verdict, not its reason.
+                _tally.Note("arbiter", decision.Verdict == AwarenessVerdict.Silence
+                    ? decision.Reason
+                    : decision.Verdict.ToString());
+
                 App.Logger?.Debug("[AWARE] arbiter verdict={Verdict} tier={Tier} gate={Reason}",
                     decision.Verdict, decision.Tier, decision.Reason);
             }
@@ -482,7 +506,35 @@ namespace ConditioningControlPanel.Services.Awareness
             // of Observe(), so a lapsed account's window titles are never read, let alone recorded.
             if (!IsEnabled) return;
 
-            _ = TickAsync(_clock());
+            var tickAt = _clock();
+            FlushTally(force: false, now: tickAt);
+            _ = TickAsync(tickAt);
+        }
+
+        /// <summary>
+        /// Writes the reason summary at Information, which is the only level a bug report carries
+        /// (<c>LogPipeline</c> floors the session file there, and <c>[AWARE]</c> is not a
+        /// <c>BugReportService</c> diag marker). Counts and reason tokens only — see
+        /// <see cref="AwarenessTally"/> for why that is the whole line.
+        /// </summary>
+        private void FlushTally(bool force, DateTime? now = null)
+        {
+            try
+            {
+                var at = now ?? _clock();
+                if (!force && at - _lastTallyFlush < AwarenessTally.FlushInterval) return;
+                _lastTallyFlush = at;
+
+                var summary = _tally.Drain();
+                if (summary.Length == 0) return;
+
+                App.Logger?.Information("[AWARE] {Minutes}m summary: {Summary}",
+                    (int)AwarenessTally.FlushInterval.TotalMinutes, summary);
+            }
+            catch (Exception ex)
+            {
+                Diag.Swallowed(ex, "awareness summary is diagnostics, never a failure path");
+            }
         }
 
         // =================================================================================
@@ -728,6 +780,7 @@ namespace ConditioningControlPanel.Services.Awareness
 
             if (dnd != DndGate.None)
             {
+                _tally.Note("dnd", dnd);
                 // Invariant: every candidate leaves exactly one [AWARE] line. Debug, not Information:
                 // it names the resolved app id, and Serilog's floor is Information (see
                 // ReactionArbiter.Log for the whole argument).
@@ -762,7 +815,11 @@ namespace ConditioningControlPanel.Services.Awareness
 
             // Logs the one authoritative [AWARE] line for this event.
             var scored = _scorer.Score(input, now);
-            if (scored.Verdict == AwarenessVerdict.Silence) return;
+            if (scored.Verdict == AwarenessVerdict.Silence)
+            {
+                _tally.Note("scored", scored.Reason);
+                return;
+            }
 
             var habits = await SafeHabitsAsync(verdict.AppId, verdict.Cluster).ConfigureAwait(false);
             var recent = await SafeRecentAsync().ConfigureAwait(false);
@@ -847,6 +904,10 @@ namespace ConditioningControlPanel.Services.Awareness
             _currentAppId = null;
 
             if (drop == FrameDrop.None) return;
+
+            // Counted on EVERY drop, not once per change: "she says nothing" is a question about how
+            // much of the session was dropped, and the de-duplicated log line below cannot answer it.
+            _tally.Note("drop", drop);
 
             // Logged once per change: a deny-listed window in the foreground would otherwise write a
             // line every 1.5 seconds for as long as the user sits there.

--- a/ConditioningControlPanel/Services/Awareness/AwarenessTally.cs
+++ b/ConditioningControlPanel/Services/Awareness/AwarenessTally.cs
@@ -1,0 +1,136 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace ConditioningControlPanel.Services.Awareness
+{
+    /// <summary>
+    /// Counts the reasons the companion stayed quiet, so a bug report can say WHY.
+    ///
+    /// <para><b>Why this exists (ccp-bugs #1176, "does not comment on programs/window titles at
+    /// all").</b> Every decision point in the awareness pipeline already logs its reason — the
+    /// privacy drop, the do-not-disturb gate, the worthiness verdict and the arbiter's gate all
+    /// write an <c>[AWARE]</c> line. All of them write it at <b>Debug</b>, deliberately: those lines
+    /// name the resolved app id, adult-cluster ones included, and the session log is the file the
+    /// bug-report flow attaches. Debug never reaches that file
+    /// (<c>LogPipeline</c> floors the file sink at Information unless the run asked for verbose) and
+    /// <c>[AWARE]</c> is not one of <c>BugReportService.DiagMarkers</c>, so the flight-recorder
+    /// sample does not carry it either. The result is the one in #1176: a report about awareness
+    /// saying nothing with 107 log lines and not a single one of them about awareness.</para>
+    ///
+    /// <para><b>What makes this safe to log at Information.</b> Reason tokens and counts, and
+    /// nothing else. No app id, no window title, no cluster — the buckets are enum names the code
+    /// already owns, so the summary cannot leak what the per-frame lines are kept at Debug to
+    /// protect. That is the same discipline the logging policy asks for: "IDs, counts, enums, and
+    /// status codes only".</para>
+    /// </summary>
+    internal sealed class AwarenessTally
+    {
+        /// <summary>How often the summary is emitted while the observer runs.</summary>
+        public static readonly TimeSpan FlushInterval = TimeSpan.FromMinutes(10);
+
+        private readonly object _gate = new();
+        private readonly Dictionary<string, Dictionary<string, int>> _buckets =
+            new(StringComparer.Ordinal);
+        private int _total;
+
+        /// <summary>True while nothing has happened worth reporting.</summary>
+        public bool IsEmpty { get { lock (_gate) return _total == 0; } }
+
+        /// <summary>
+        /// Records one outcome. <paramref name="bucket"/> is the stage ("drop", "dnd", "scored",
+        /// "arbiter"); <paramref name="reason"/> is that stage's own reason token.
+        /// </summary>
+        public void Note(string bucket, string? reason)
+        {
+            if (string.IsNullOrWhiteSpace(bucket)) return;
+            var key = Normalize(reason);
+
+            lock (_gate)
+            {
+                if (!_buckets.TryGetValue(bucket, out var counts))
+                {
+                    counts = new Dictionary<string, int>(StringComparer.Ordinal);
+                    _buckets[bucket] = counts;
+                }
+                counts[key] = counts.TryGetValue(key, out var n) ? n + 1 : 1;
+                _total++;
+            }
+        }
+
+        /// <summary>Records one outcome from an enum value, using its lower-cased name.</summary>
+        public void Note<T>(string bucket, T reason) where T : struct, Enum =>
+            Note(bucket, reason.ToString());
+
+        /// <summary>
+        /// Renders the summary and clears the counters, so each line covers only its own window and a
+        /// quiet stretch after a busy one cannot read as more of the same.
+        /// </summary>
+        public string Drain()
+        {
+            lock (_gate)
+            {
+                if (_total == 0) return string.Empty;
+
+                var sb = new StringBuilder();
+                foreach (var bucket in _buckets.Keys.OrderBy(k => k, StringComparer.Ordinal))
+                {
+                    var counts = _buckets[bucket];
+                    if (counts.Count == 0) continue;
+
+                    if (sb.Length > 0) sb.Append("; ");
+                    sb.Append(bucket).Append('=');
+
+                    var first = true;
+                    // Loudest reason first: the answer to "why is she quiet" is almost always the top one.
+                    foreach (var pair in counts.OrderByDescending(p => p.Value).ThenBy(p => p.Key, StringComparer.Ordinal))
+                    {
+                        if (!first) sb.Append(',');
+                        sb.Append(pair.Key).Append(':').Append(pair.Value);
+                        first = false;
+                    }
+                }
+
+                _buckets.Clear();
+                _total = 0;
+                return sb.ToString();
+            }
+        }
+
+        /// <summary>Longest a reason token may be. Every code-owned token is far shorter.</summary>
+        private const int MaxTokenLength = 32;
+
+        /// <summary>
+        /// Reason tokens are log KEYS, not free text. Every caller passes an enum name or a token the
+        /// code owns ("below-floor", "llm-unavailable/no-bark"), so anything that does not look like
+        /// one — too long, or carrying a character a token never has — is replaced wholesale with
+        /// <c>other</c> rather than slugified through.
+        ///
+        /// <para>This line is Information, which means it ships in bug reports, which means a caller
+        /// that one day passes a window title would leak it. Refusing the shape is cheap; noticing the
+        /// leak afterwards is not.</para>
+        /// </summary>
+        private static string Normalize(string? reason)
+        {
+            if (string.IsNullOrWhiteSpace(reason)) return "none";
+
+            var trimmed = reason!.Trim();
+            if (trimmed.Length > MaxTokenLength) return "other";
+
+            var sb = new StringBuilder(trimmed.Length);
+            foreach (var ch in trimmed)
+            {
+                if (char.IsLetterOrDigit(ch)) sb.Append(char.ToLowerInvariant(ch));
+                else if (ch == '-' || ch == '_' || ch == '/' || ch == ' ')
+                {
+                    if (sb.Length > 0 && sb[sb.Length - 1] != '-') sb.Append('-');
+                }
+                else return "other";   // punctuation a reason token never carries: @ ( ) : \ . …
+            }
+
+            var token = sb.ToString().Trim('-');
+            return token.Length == 0 ? "none" : token;
+        }
+    }
+}

--- a/Tests/ConditioningControlPanel.Tests/AiTruncatedReplyTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/AiTruncatedReplyTests.cs
@@ -1,0 +1,123 @@
+using ConditioningControlPanel.Services;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// ccp-bugs #1164 — "sometimes the companion doesn't display a full answer and the message seem to be
+/// cropped".
+///
+/// The cloud proxy caps a reply at AiService.MaxTokensHardCap (100 tokens, the lowest of the three
+/// transports) and reports no finish_reason, so a guillotined reply reached the speech bubble
+/// mid-word. The repair ends her on the previous sentence instead — but it may never eat an ordinary
+/// short reply, which in this app's voice very often has no terminating punctuation at all.
+/// </summary>
+public class AiTruncatedReplyTests
+{
+    private const int Cap = 100;   // AiService.MaxTokensHardCap
+
+    // 300+ chars on its own, so the "long enough to have hit the cap" guard is satisfied.
+    private static string LongPrefix =>
+        "Good girl, that's exactly the kind of thinking I like to hear from you. " +
+        "You've been so obedient lately and it really does show in the way you answer me. " +
+        "Every session leaves you softer and slower and a great deal easier to lead. " +
+        "I keep noticing how much easier it gets for you every single time we do this together. ";
+
+    [Fact]
+    public void DanglingFragmentIsTrimmedBackToTheLastSentence()
+    {
+        var reply = LongPrefix + "So tonight I was thinking we could";
+        var result = AiTextHygiene.TrimCutOffTail(reply, Cap, out var trimmed);
+
+        Assert.True(trimmed);
+        Assert.EndsWith("every single time we do this together.", result);
+        Assert.DoesNotContain("So tonight I was thinking", result);
+    }
+
+    [Fact]
+    public void ACompleteReplyIsLeftAlone()
+    {
+        var reply = LongPrefix + "Keep going just like that.";
+        var result = AiTextHygiene.TrimCutOffTail(reply, Cap, out var trimmed);
+
+        Assert.False(trimmed);
+        Assert.Equal(reply, result);
+    }
+
+    [Fact]
+    public void ShortRepliesWithNoPunctuationSurvive()
+    {
+        // The most common bubble there is. Nothing about it says "truncated", and trimming it would
+        // turn one report about cropped text into a hundred about missing text.
+        foreach (var line in new[] { "good girl", "mmm~", "Such a good doll 💕", "yes" })
+        {
+            var result = AiTextHygiene.TrimCutOffTail(line, Cap, out var trimmed);
+            Assert.False(trimmed);
+            Assert.Equal(line, result);
+        }
+    }
+
+    [Fact]
+    public void ALongReplyEndingInEmojiCountsAsFinished()
+    {
+        var reply = LongPrefix + "Sink a little deeper for me~ 💕";
+        AiTextHygiene.TrimCutOffTail(reply, Cap, out var trimmed);
+        Assert.False(trimmed);
+    }
+
+    [Fact]
+    public void ASingleRunOnSentenceIsNotGutted()
+    {
+        // No earlier terminator to fall back to: a fragment the user can read beats an empty bubble.
+        var reply = new string('a', 60) + " and then " + new string('b', 260) + " and then";
+        var result = AiTextHygiene.TrimCutOffTail(reply, Cap, out var trimmed);
+
+        Assert.False(trimmed);
+        Assert.Equal(reply, result);
+    }
+
+    [Fact]
+    public void ATrimThatWouldThrowAwayMostOfTheReplyIsRefused()
+    {
+        // One short sentence then a very long dangling one: trimming keeps 5% of the text, which is
+        // not a repair.
+        var reply = "Hi. " + new string('x', 200) + " " + new string('y', 200);
+        var result = AiTextHygiene.TrimCutOffTail(reply, Cap, out var trimmed);
+
+        Assert.False(trimmed);
+        Assert.Equal(reply, result);
+    }
+
+    [Fact]
+    public void AUrlDotIsNotASentenceEnd()
+    {
+        var reply = LongPrefix + "Watch https://hypnotube.com/naughty-bambi-109749.html and then tell me how";
+        var result = AiTextHygiene.TrimCutOffTail(reply, Cap, out var trimmed);
+
+        Assert.True(trimmed);
+        // The cut landed on the prose sentence, not inside the link.
+        Assert.DoesNotContain("hypnotube.com", result);
+        Assert.EndsWith("every single time we do this together.", result);
+    }
+
+    [Theory]
+    [InlineData("I was thinking we could", true)]
+    [InlineData("Good girl.", false)]
+    [InlineData("Good girl~", false)]
+    [InlineData("Ready? ", false)]
+    [InlineData("So cute 💕", false)]
+    [InlineData("\"deeper now\"", true)]
+    [InlineData("", false)]
+    public void EndsMidSentenceReadsTheLastRealCharacter(string text, bool expected)
+        => Assert.Equal(expected, AiTextHygiene.EndsMidSentence(text));
+
+    [Fact]
+    public void ACapOfZeroDisablesTheRepair()
+    {
+        var reply = LongPrefix + "and then we";
+        var result = AiTextHygiene.TrimCutOffTail(reply, 0, out var trimmed);
+
+        Assert.False(trimmed);
+        Assert.Equal(reply, result);
+    }
+}

--- a/Tests/ConditioningControlPanel.Tests/AwarenessTallyTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/AwarenessTallyTests.cs
@@ -1,0 +1,71 @@
+using ConditioningControlPanel.Services.Awareness;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// ccp-bugs #1176 — "companion does not comment on programs/window titles at all".
+///
+/// The report arrived with 107 log lines and not one of them about awareness: every per-frame
+/// [AWARE] line is Debug (they name the resolved app id), Debug never reaches the session file the
+/// bug-report flow attaches, and [AWARE] is not a BugReportService diag marker. This summary is the
+/// part that does reach a report, so what it may and may not carry is the thing worth pinning: reason
+/// tokens and counts, never an app id, a title or a cluster.
+/// </summary>
+public class AwarenessTallyTests
+{
+    [Fact]
+    public void AnEmptyTallyRendersNothing()
+    {
+        var tally = new AwarenessTally();
+        Assert.True(tally.IsEmpty);
+        Assert.Equal(string.Empty, tally.Drain());
+    }
+
+    [Fact]
+    public void BucketsAreGroupedAndTheLoudestReasonComesFirst()
+    {
+        var tally = new AwarenessTally();
+        tally.Note("drop", FrameDrop.OwnProcess);
+        tally.Note("drop", FrameDrop.OwnProcess);
+        tally.Note("drop", FrameDrop.DenyListed);
+        tally.Note("dnd", DndGate.TypingBurst);
+        tally.Note("arbiter", "llm-unavailable/no-bark");
+
+        var line = tally.Drain();
+
+        Assert.Equal("arbiter=llm-unavailable-no-bark:1; dnd=typingburst:1; drop=ownprocess:2,denylisted:1", line);
+    }
+
+    [Fact]
+    public void DrainClearsSoEachWindowStandsAlone()
+    {
+        var tally = new AwarenessTally();
+        tally.Note("scored", "below-floor");
+        Assert.NotEqual(string.Empty, tally.Drain());
+
+        Assert.True(tally.IsEmpty);
+        Assert.Equal(string.Empty, tally.Drain());
+    }
+
+    [Fact]
+    public void AnythingThatDoesNotLookLikeAReasonTokenIsRefused()
+    {
+        // Defence in depth: every caller passes an enum or a code-owned token today, but this line is
+        // Information and therefore ships in bug reports, so the one thing it must never do is put a
+        // window title into a GitHub issue.
+        var tally = new AwarenessTally();
+        tally.Note("drop", "Inbox (14) - beebee@example.com - Outlook");
+        tally.Note("drop", "Naughty Bambi 109749 - the longest video title in the pool");
+
+        Assert.Equal("drop=other:2", tally.Drain());
+    }
+
+    [Fact]
+    public void ABlankReasonStillCounts()
+    {
+        var tally = new AwarenessTally();
+        tally.Note("arbiter", (string?)null);
+        Assert.Equal("arbiter=none:1", tally.Drain());
+    }
+}


### PR DESCRIPTION
Two open AI-companion reports on 6.9.1: one root-caused and fixed, one that could not be root-caused from what the report carries, so it is instrumented instead of guessed at.

## #1164 — "the message seem to be cropped"

**Root cause.** The reporter's log says `AiService initialized (proxy mode, V2 auth or Patreon)`, so they are on the cloud transport. That transport caps every reply at `Services/AiService.cs:36` (`MaxTokensHardCap = 100`, applied at `Services/AiService.cs:735`) — the lowest of the three ceilings, against Ollama's 512 — and it is the only one of the three that never notices when the cap lands. `Services/AIService/OpenAiCompatibleService.cs:512` reads `finish_reason`, `Services/AIService/LocalAiService.cs:1053` reads `done_reason`; the proxy's response shape (`Models/PatreonModels.cs:259` `ProxyChatResponse`) carries neither, and nothing on the path looked. A reply longer than ~75 words therefore arrived guillotined mid-word and was rendered verbatim, which is exactly "doesn't display a full answer" — and "sometimes", because only long answers reach the cap.

**What changed.** `AiTextHygiene.TrimCutOffTail` ends her on the previous sentence and logs the cap it hit, wired into `AiService.SanitizeResponse` so both cloud entry points get it. Two guards keep it off ordinary replies, which in this voice very often carry no terminating punctuation ("good girl"): the reply must be long enough to have plausibly hit the cap (`maxTokens × 3` chars), and the trim must leave a whole sentence and at least half the text behind — otherwise the fragment stays, because a fragment the user can read beats an empty bubble. Sentence detection errs towards "finished": a trailing emoji ends the question rather than being skipped past.

Not changed, and worth a decision separately: the ceiling itself. `AiCallOptions.Chat.MaxTokens` is 100, so raising `MaxTokensHardCap` alone would buy nothing for plain chat — longer cloud answers are a cost call, not a bug fix.

## #1176 — "does not comment on programs/window titles at all without takeover enabled"

**No root cause, and here is why one cannot be had.** The report carries 107 log lines and not one of them is about awareness (`grep -c AWARE` on the issue body: 0). Every decision point in the pipeline already logs its reason — the privacy drop, the DND gate, the worthiness verdict, the arbiter's gate — but all of them at **Debug**, deliberately, because those lines name the resolved app id including adult-cluster ones. Debug reaches neither of the two things a report actually carries: the session file is floored at Information (`Services/Logging/LogPipeline.cs:150`), and the flight-recorder sample only keeps lines matching `Services/BugReportService.cs:66` `DiagMarkers`, which has no `[AWARE]` entry. Adding one would push adult app ids into public GitHub issues, so that is not the fix.

**What changed instead.** `Services/Awareness/AwarenessTally.cs` counts outcomes by stage and reason; `AwarenessObserver` notes a drop, a DND gate, a scored silence and every arbiter verdict, and writes one Information line every ten minutes and on stop:

```
[AWARE] 10m summary: arbiter=llm-unavailable-no-bark:12; dnd=typingburst:4; drop=ownprocess:88
```

Reason tokens and counts only — no app id, no title, no cluster — and `Normalize` refuses anything that does not look like a code-owned token (too long, or carrying punctuation a token never has) rather than slugifying it through, since this line ships in bug reports. The observer's start line now also carries the dial state (intensity, deny/title-allow list sizes, adult toggles), so "no filter, all my programs on the title allow list" can be checked against the running config instead of taken on trust.

## Tests

`AiTruncatedReplyTests` (10) and `AwarenessTallyTests` (5). Full suite: 5382 passed, 3 failed — the three `VatFillCoordinatorTests` failures reproduce on `origin/release/6.9.4` with this branch stashed and are unrelated.

Changed lines: 536 (`git diff --stat`), under the 600 cap. No user-facing strings, so no localisation keys.

Refs CC-Labs-llc/ccp-bugs#1164, CC-Labs-llc/ccp-bugs#1176

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013mR8cAipk1ivr3Em5fJjcx
