### PR TITLE
feat(diag): the hang report now names the stuck op and carries its stack

### DIFF
--- a/ConditioningControlPanel/App.xaml.cs
+++ b/ConditioningControlPanel/App.xaml.cs
@@ -1625,6 +1625,12 @@ namespace ConditioningControlPanel
             // to the logs folder when the dispatcher stops responding for 10s.
             Services.UiHangWatchdog.Start(Dispatcher);
 
+            // ...and name the dispatcher operation that is stuck when it fires. One hook covers
+            // every BeginInvoke/Invoke in the app; the per-operation cost is an array store
+            // (ccp-bugs #1189/#1179/#1159/#984, where "a Send-priority op has run for 137s" is
+            // all we ever learn). Must be installed before any feature posts work.
+            Services.UiOpTracker.Install(Dispatcher);
+
             // Flush-on-write trace for the mandatory-video show/heal path and the panic key
             // (#616/#617/#621/#622/#623). Separate from the Serilog rolling file on purpose: the
             // relaunch a user needs in order to FILE the report scrolls the freeze window out of

--- a/ConditioningControlPanel/ConditioningControlPanel.csproj
+++ b/ConditioningControlPanel/ConditioningControlPanel.csproj
@@ -115,6 +115,13 @@
     <PackageReference Include="org.k2fsa.sherpa.onnx" Version="1.13.3" />
     <PackageReference Include="org.k2fsa.sherpa.onnx.runtime.win-x64" Version="1.13.3" />
     
+    <!-- Hang forensics (ccp-bugs #1189/#1179/#1159/#984). ClrMD reads the managed stacks of a
+         PSS snapshot of our OWN process, which is how UiThreadStacks turns "the UI thread has
+         been silent for 90s" into named frames inside hang_*.txt. Pinned exactly: this runs in
+         a wedged process and an unattended minor bump is not worth the risk. 3.1.512801 ships a
+         net6.0 lib (clean on net8.0-windows); the 4.x line only carries net10.0/netstandard2.0. -->
+    <PackageReference Include="Microsoft.Diagnostics.Runtime" Version="3.1.512801" />
+
     <!-- Logging -->
     <PackageReference Include="Serilog" Version="3.1.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />

--- a/ConditioningControlPanel/Helpers/DispatcherHelper.cs
+++ b/ConditioningControlPanel/Helpers/DispatcherHelper.cs
@@ -72,6 +72,10 @@ public static class DispatcherHelper
 
         if (dispatcher.CheckAccess())
         {
+            // Same-thread fast path: WPF creates no DispatcherOperation here, so the dispatcher
+            // hook that names ops (UiOpTracker) sees nothing. `caller` is a compile-time constant,
+            // so naming it costs two volatile writes and no allocation.
+            using var _op = Services.UiOpTracker.Scope(caller);
             action();
             return;
         }

--- a/ConditioningControlPanel/Services/BugReportService.cs
+++ b/ConditioningControlPanel/Services/BugReportService.cs
@@ -42,6 +42,10 @@ namespace ConditioningControlPanel.Services
         // keep the whole app-log field inside the server's 200,000-char limit with room to spare.
         private const int MaxAppLogChars = 120_000;
         private const int MaxDiagDumpChars = 60_000;
+        // The UI-hang report (hang_*.txt) now carries the UI thread's managed stack, which is the
+        // one thing the #1189/#1179/#1159/#984 freeze family has never had. It is the smallest and
+        // most valuable attachment in the report, so it gets its own (generous) budget.
+        internal const int MaxHangReportChars = 24_000;
         internal const int MaxAppLogFieldChars = 190_000;
         // Diagnostic-line rescue (#634 + freeze reports). The last-N tail scrolls the [RES]/
         // [WATCHDOG] history out of every report because a relaunch writes far more startup
@@ -207,6 +211,16 @@ namespace ConditioningControlPanel.Services
                 if (!string.IsNullOrWhiteSpace(diagSampled))
                     combined = combined + Environment.NewLine + Environment.NewLine +
                         "## Diagnostics (sampled)" + Environment.NewLine + diagSampled;
+
+                // The watchdog's own hang report. Until now it only ever reached us as the single
+                // [WATCHDOG] line the sampled-diagnostics scan rescued from the rolling app log -
+                // the file itself, which holds the feature state AND (since 6.9.4) the UI thread's
+                // managed stack, was never attached to anything and never left the user's machine.
+                // It survives the relaunch a hard freeze forces, so it is here rather than in the
+                // scrolled tail.
+                var hangReport = BuildHangReportSection(TryReadNewestHangReport(out var hangAt), hangAt);
+                if (!string.IsNullOrWhiteSpace(hangReport))
+                    combined = combined + Environment.NewLine + Environment.NewLine + hangReport;
 
                 (scrubbedApp, appCounts) = LogScrubber.Scrub(combined);
 
@@ -703,6 +717,64 @@ namespace ConditioningControlPanel.Services
             if (section.Length > MaxDiagSectionChars)
                 section = section.Substring(section.Length - MaxDiagSectionChars);
             return section;
+        }
+
+        internal const string HangReportHeader = "===== UI-hang report (logs/hang_*.txt) =====";
+
+        /// <summary>
+        /// Wrap the newest hang report in its delimiter and cap it at <see cref="MaxHangReportChars"/>,
+        /// keeping the NEWEST bytes - the tail is where the stack capture is appended, and the stack
+        /// is the whole reason this section exists. Empty in, empty out (the overwhelming majority
+        /// of reports are not freezes and must not carry an empty header). Pure, so the shape that
+        /// lands in the GitHub issue can be pinned by a test.
+        /// </summary>
+        internal static string BuildHangReportSection(string? hangReportText, DateTime? writtenLocal = null)
+        {
+            if (string.IsNullOrWhiteSpace(hangReportText)) return string.Empty;
+            // The watchdog keeps the four newest reports, so a user whose LAST freeze was weeks ago
+            // and who is now filing an unrelated bug would otherwise hand triage a stale stack with
+            // nothing to date it (the report's own "when" header is what the cap trims away first).
+            var header = writtenLocal is DateTime at
+                ? HangReportHeader + " written " + at.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture)
+                : HangReportHeader;
+            return header + Environment.NewLine + Tail(hangReportText!.Trim(), MaxHangReportChars);
+        }
+
+        /// <summary>
+        /// Newest <c>hang_*.txt</c> from the logs folder (the watchdog keeps the four most recent).
+        /// Opened share-all because the watchdog may still be appending the stack capture to it.
+        /// Never throws.
+        /// </summary>
+        private static string TryReadNewestHangReport(out DateTime? writtenLocal)
+        {
+            writtenLocal = null;
+            try
+            {
+                var logDir = Path.Combine(App.UserDataPath, "logs");
+                if (!Directory.Exists(logDir)) return string.Empty;
+
+                string? newest = null;
+                DateTime newestAt = DateTime.MinValue;
+                foreach (var file in Directory.GetFiles(logDir, "hang_*.txt"))
+                {
+                    var at = File.GetLastWriteTimeUtc(file);
+                    if (at <= newestAt) continue;
+                    newestAt = at;
+                    newest = file;
+                }
+                if (newest == null) return string.Empty;
+                writtenLocal = newestAt.ToLocalTime();
+
+                using var fs = new FileStream(newest, FileMode.Open, FileAccess.Read,
+                    FileShare.ReadWrite | FileShare.Delete);
+                using var sr = new StreamReader(fs, Encoding.UTF8);
+                return sr.ReadToEnd();
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Debug("[BugReport] hang report read failed: {Msg}", ex.Message);
+                return string.Empty;
+            }
         }
 
         /// <summary>Keep the last <paramref name="maxChars"/> characters. Empty in, empty out.</summary>

--- a/ConditioningControlPanel/Services/LockCard/LockCardService.cs
+++ b/ConditioningControlPanel/Services/LockCard/LockCardService.cs
@@ -139,6 +139,11 @@ namespace ConditioningControlPanel.Services
 
         private void Timer_Tick(object? sender, EventArgs e)
         {
+            // Every DispatcherTimer in the app posts the SAME internal WPF delegate, so the hang
+            // report cannot tell one stuck tick from another without a label. lockCardRunning=True
+            // is the one thing the #1189 freeze family has in common, so this tick gets a name.
+            using var _op = UiOpTracker.Scope("LockCard.Tick");
+
             // Recalculate next interval with randomness
             var settings = App.Settings.Current;
             var perHour = Math.Max(1, settings.LockCardFrequency);

--- a/ConditioningControlPanel/Services/UI/HangContext.cs
+++ b/ConditioningControlPanel/Services/UI/HangContext.cs
@@ -132,6 +132,10 @@ public static class HangContext
         try
         {
             sb.Append("uptime=").Append((UptimeMs / 1000.0).ToString("F0", CultureInfo.InvariantCulture)).AppendLine("s");
+            // WHICH dispatcher operation the UI thread is inside. The #1189 family all show a
+            // Send-priority op running for a minute-plus with lockCardRunning=True and no name;
+            // this line is what turns that into something greppable. See UiOpTracker.
+            sb.Append("op=").AppendLine(Safe(UiOpTracker.Describe));
             sb.Append("lastUiMark=").AppendLine(Safe(() => VideoDiag.UiMarkDescription));
             sb.Append("uiStallMs=").AppendLine(Safe(() => VideoDiag.UiStallMs.ToString(CultureInfo.InvariantCulture)));
             // Input starved while uiStallMs stays small = the thread is BUSY above Input priority,
@@ -158,6 +162,7 @@ public static class HangContext
         {
             return string.Concat(
                 "uptime=", (UptimeMs / 1000).ToString(CultureInfo.InvariantCulture), "s",
+                " op=", Safe(UiOpTracker.Describe),
                 " active=[", DescribeActive(), "]",
                 " last=", LastBreadcrumb());
         }

--- a/ConditioningControlPanel/Services/UI/UiHangWatchdog.cs
+++ b/ConditioningControlPanel/Services/UI/UiHangWatchdog.cs
@@ -19,6 +19,12 @@ namespace ConditioningControlPanel.Services;
 /// for all thread stacks, managed included). The hang and any later recovery are also
 /// logged, which timestamps the freeze exactly even if the dump fails.
 ///
+/// Since 6.9.4 the small hang_*.txt report ALSO carries the UI thread's managed stack,
+/// captured in-process from a PSS snapshot (see UiThreadStacks) and named by the
+/// dispatcher operation that never returned (see UiOpTracker). That matters because the
+/// dump, which has the same information, has never once reached us: the bug reporter now
+/// attaches the text report, and cannot attach a 40MB dump.
+///
 /// STARTUP PHASE: OnStartup runs the whole service init synchronously on the UI thread,
 /// so the dispatcher cannot pump a single heartbeat until startup completes — that
 /// silence is BY DESIGN, not a hang. Until the first heartbeat ever lands, a much longer
@@ -156,7 +162,7 @@ public static class UiHangWatchdog
                         // Durable, human-readable report + the cross-session sentinel. Written
                         // BEFORE the minidump because the dump can take up to 60s (or never finish)
                         // and a task-kill during it must still leave evidence behind.
-                        WriteHangReport(silence, started, mark);
+                        WriteHangReport(silence, started, mark, SafeUiManagedThreadId(dispatcher));
                     }
                     if (!_dumpWritten)
                     {
@@ -296,7 +302,7 @@ public static class UiHangWatchdog
 
     private static string SentinelPath => Path.Combine(App.UserDataPath, "logs", "ui_hang.pending");
 
-    private static void WriteHangReport(long silenceMs, bool startedPumping, string mark)
+    private static void WriteHangReport(long silenceMs, bool startedPumping, string mark, int uiManagedThreadId)
     {
         try
         {
@@ -341,6 +347,12 @@ public static class UiHangWatchdog
             // A frozen UI is exactly the case where the last few hundred Debug lines - which have
             // never reached a disk before - say which subsystem stopped answering.
             Services.Logging.FlightRecorderSink.DumpIfActive("hang");
+
+            // ...and only NOW the expensive part. The whole report above is already flushed to the
+            // platter, so a stack capture that stalls for its full budget (or that the user
+            // task-kills us in the middle of) can no longer cost us the evidence we already had -
+            // it can only add to it. See AppendUiThreadStacks.
+            AppendUiThreadStacks(path, text, uiManagedThreadId);
         }
         catch (Exception ex)
         {
@@ -349,6 +361,71 @@ public static class UiHangWatchdog
             {
                 App.Logger?.Error("[WATCHDOG] hang report file failed ({E}); state inline:{NL}{State}",
                     ex.Message, Environment.NewLine, HangContext.Describe());
+            }
+            catch { }
+        }
+    }
+
+    /// <summary>
+    /// How long the in-process stack capture may take before the watchdog gives up on it. Generous
+    /// enough for a cold DAC load on a machine that is already thrashing (a healthy capture
+    /// measures ~100ms), short enough that the watchdog is back to writing the minidump quickly.
+    /// </summary>
+    private const int StackCaptureBudgetMs = 20_000;
+
+    /// <summary>
+    /// Which managed thread the dispatcher belongs to. Read through a guard because this is called
+    /// from the hang path, where a dispatcher mid-shutdown can throw on property access.
+    /// </summary>
+    private static int SafeUiManagedThreadId(Dispatcher dispatcher)
+    {
+        try { return dispatcher.Thread.ManagedThreadId; }
+        catch { return -1; }
+    }
+
+    /// <summary>
+    /// Capture the UI thread's managed stack and append it to the report that was just written,
+    /// then re-arm the sentinel with the fuller text so a task-killed session still carries the
+    /// stack into the NEXT session's log.
+    ///
+    /// This is the answer to the #1189 family: those reports show a Send-priority operation running
+    /// for 71-137s with no stack at all, so there is nothing to fix. Appending (rather than
+    /// building the stack into the first write) is deliberate - the durable evidence lands first
+    /// and this can only add to it.
+    /// </summary>
+    private static void AppendUiThreadStacks(string path, string reportSoFar, int uiManagedThreadId)
+    {
+        try
+        {
+            string stacks = UiThreadStacks.CaptureWithBudget(uiManagedThreadId, StackCaptureBudgetMs);
+            string block = "ui thread managed stack (captured in-process at hang time)" +
+                           Environment.NewLine + stacks;
+
+            using (var fs = new FileStream(path, FileMode.Append, FileAccess.Write,
+                       FileShare.ReadWrite | FileShare.Delete, 4096, FileOptions.WriteThrough))
+            using (var sw = new StreamWriter(fs, Encoding.UTF8))
+            {
+                sw.Write(Environment.NewLine);
+                sw.Write(block);
+                sw.Flush();
+                fs.Flush(true);
+            }
+
+            // The sentinel is the copy that survives a task-kill, so it has to be re-armed with the
+            // stack too - otherwise the next session re-logs the half of the report that was
+            // already useless.
+            ArmSentinel(reportSoFar + Environment.NewLine + block);
+
+            App.Logger?.Error("[WATCHDOG] ui thread stack captured into {Path}{NL}{Stacks}",
+                path, Environment.NewLine, stacks);
+            VideoDiag.Log("WATCHDOG", "ui thread stack captured into " + path);
+        }
+        catch (Exception ex)
+        {
+            try
+            {
+                App.Logger?.Error("[WATCHDOG] ui thread stack capture failed: {E}", ex.Message);
+                VideoDiag.Log("WATCHDOG", "ui thread stack capture failed: " + ex.Message);
             }
             catch { }
         }

--- a/ConditioningControlPanel/Services/UI/UiOpTracker.cs
+++ b/ConditioningControlPanel/Services/UI/UiOpTracker.cs
@@ -1,0 +1,219 @@
+using System;
+using System.Globalization;
+using System.Reflection;
+using System.Threading;
+using System.Windows.Threading;
+
+namespace ConditioningControlPanel.Services;
+
+/// <summary>
+/// Names the dispatcher operation the UI thread is currently inside.
+///
+/// WHY (ccp-bugs #1189 / #1179 / #1159 / #984): every report in the sudden-freeze family shows a
+/// Send-priority dispatcher operation that has been running for 71-137 seconds with
+/// <c>lockCardRunning=True</c> and no stack. "A dispatcher op is stuck" is not an actionable fact;
+/// "LockCardWindow.EmergencyRecoveryCleanup has been stuck for 92s at Send priority" is. This class
+/// is the cheap half of that answer (<see cref="UiThreadStacks"/> is the expensive half).
+///
+/// HOW: one subscription to <see cref="DispatcherHooks"/> covers all ~440 BeginInvoke/Invoke call
+/// sites at once, which no per-call-site change could. OperationStarted fires on the dispatcher
+/// thread immediately before the delegate runs and OperationCompleted/Aborted after, so a push/pop
+/// pair leaves the WEDGED operation on top of the stack exactly when the watchdog reads it. Nested
+/// dispatcher frames nest correctly because Finish pops back to the matching entry.
+///
+/// COST CONTRACT (this runs on EVERY dispatcher operation, so it must be ~free): Start is one
+/// array store plus a volatile int write, Finish a scan of an at-most-32-entry array. No
+/// reflection, no allocation, no string work on the hot path - the delegate's name is resolved
+/// lazily in <see cref="Describe"/>, once per hang, on the watchdog thread.
+/// </summary>
+public static class UiOpTracker
+{
+    /// <summary>Real nesting is 1-3 (a nested pump inside a modal); the cap only exists so a
+    /// pathological re-entry cannot grow this into a leak.</summary>
+    private const int MaxDepth = 32;
+
+    private struct Slot
+    {
+        public DispatcherOperation? Op;
+        public long StartedTick;
+    }
+
+    private static readonly Slot[] _stack = new Slot[MaxDepth];
+    private static int _depth;          // occupied slots; published with release semantics
+    private static int _overflowed;     // ops dropped because the stack was full (should stay 0)
+    private static bool _installed;
+
+    /// <summary>Explicit label for the work the UI thread is doing right now (see
+    /// <see cref="Scope"/>). Wins over the delegate name, which for a lambda reads as
+    /// <c>&lt;Tick&gt;b__42_0</c>. Same shape as <see cref="VideoDiag.UiScope"/>: two writes,
+    /// no allocation.</summary>
+    private static string? _label;
+
+    /// <summary>Subscribe to the dispatcher hooks; called once from App startup. Idempotent and
+    /// never throws: this runs before MainWindow exists, and a diagnostic that can break startup
+    /// is worse than no diagnostic.</summary>
+    public static void Install(Dispatcher dispatcher)
+    {
+        try
+        {
+            if (_installed || dispatcher == null) return;
+            _installed = true;
+            var hooks = dispatcher.Hooks;
+            hooks.OperationStarted += OnStarted;
+            hooks.OperationCompleted += OnFinished;
+            hooks.OperationAborted += OnFinished;
+        }
+        catch (Exception ex)
+        {
+            // Leaves Describe() reporting "(untracked)" — the rest of the hang report is unaffected.
+            try { App.Logger?.Warning("[WATCHDOG] dispatcher op tracking unavailable: {E}", ex.Message); } catch { }
+        }
+    }
+
+    private static void OnStarted(object? sender, DispatcherHookEventArgs e)
+    {
+        try
+        {
+            int d = _depth;
+            if ((uint)d >= MaxDepth) { _overflowed++; return; }
+            _stack[d].Op = e.Operation;
+            _stack[d].StartedTick = Environment.TickCount64;
+            // Release write: the slot above must be visible to the watchdog thread before the
+            // depth that makes it readable is.
+            Volatile.Write(ref _depth, d + 1);
+        }
+        catch { }
+    }
+
+    private static void OnFinished(object? sender, DispatcherHookEventArgs e)
+    {
+        try
+        {
+            var op = e.Operation;
+            int d = _depth;
+            if ((uint)d > MaxDepth) return;
+            for (int i = d - 1; i >= 0; i--)
+            {
+                if (!ReferenceEquals(_stack[i].Op, op)) continue;
+                // Pop this entry AND anything above it. An operation that completes while entries
+                // sit on top of it means we missed their completion (an aborted nested pump); the
+                // alternative is a stack that only ever grows and then reports a stale name.
+                for (int j = d - 1; j >= i; j--) _stack[j].Op = null;
+                Volatile.Write(ref _depth, i);
+                return;
+            }
+        }
+        catch { }
+    }
+
+    /// <summary><c>using var _ = UiOpTracker.Scope("LockCard.Tick");</c> — a short human name
+    /// instead of the compiler's lambda spelling. Restores the previous label on dispose.</summary>
+    public static OpScope Scope(string label) => new(label);
+
+    public readonly struct OpScope : IDisposable
+    {
+        private readonly string? _previous;
+        internal OpScope(string label) { _previous = _label; _label = label; }
+        public void Dispose() => _label = _previous;
+    }
+
+    /// <summary>
+    /// One line for the hang report: which operation the UI thread is inside, how long it has been
+    /// there and at what priority. Runs on the WATCHDOG thread while the UI thread is presumed
+    /// dead, so it takes no lock and touches no DispatcherObject — only already-published fields
+    /// and (lazily, once) reflection over the operation's delegate. Never throws.
+    /// </summary>
+    public static string Describe()
+    {
+        try
+        {
+            string? label = _label;
+            int d = Volatile.Read(ref _depth);
+            if ((uint)d > MaxDepth) d = 0;
+            if (d <= 0)
+                return label ?? (_installed ? "(none running)" : "(untracked)");
+
+            var slot = _stack[d - 1];
+            var op = slot.Op;
+            long ageSec = Math.Max(0, Environment.TickCount64 - slot.StartedTick) / 1000;
+
+            string name = label ?? NameOf(op);
+            string priority = "?";
+            try { if (op != null) priority = op.Priority.ToString(); } catch { }
+
+            var text = string.Concat(
+                name, " (", ageSec.ToString(CultureInfo.InvariantCulture), "s, ", priority, ")");
+            if (d > 1) text += " nested=" + d.ToString(CultureInfo.InvariantCulture);
+            if (_overflowed > 0) text += " overflowed=" + _overflowed.ToString(CultureInfo.InvariantCulture);
+            return text;
+        }
+        catch { return "(unavailable)"; }
+    }
+
+    // ── Delegate name resolution (watchdog thread only, never on the hot path) ───────────────
+
+    private static FieldInfo? _methodField;
+    private static bool _methodFieldTried;
+
+    /// <summary><see cref="DispatcherOperation"/> does not expose the delegate it runs, so the name
+    /// comes from its internal <c>_method</c> field. Resolved once and cached; if a future WPF
+    /// renames it the report degrades to "(unnamed op)" rather than failing.</summary>
+    private static string NameOf(DispatcherOperation? op)
+    {
+        if (op == null) return "(unnamed op)";
+        try
+        {
+            if (!_methodFieldTried)
+            {
+                _methodFieldTried = true;
+                _methodField = typeof(DispatcherOperation)
+                    .GetField("_method", BindingFlags.Instance | BindingFlags.NonPublic);
+            }
+            if (_methodField?.GetValue(op) is not Delegate del) return "(unnamed op)";
+            var method = del.Method;
+            return ShortName(method.DeclaringType, method.Name);
+        }
+        catch { return "(unnamed op)"; }
+    }
+
+    /// <summary>
+    /// Turn a compiler-mangled lambda into something greppable:
+    /// <c>LockCardWindow+&lt;&gt;c__DisplayClass7_0.&lt;Tick&gt;b__0</c> becomes <c>LockCardWindow.Tick</c>.
+    /// Internal so the shape the report prints can be pinned by a test.
+    /// </summary>
+    internal static string ShortName(Type? declaringType, string? methodName)
+    {
+        string method = UnmangleMethod(methodName);
+
+        var type = declaringType;
+        // Closure/state-machine types are named "<>c", "<>c__DisplayClass7_0", "<Foo>d__12" — all
+        // nested inside the type the reader actually cares about. Walk out to the first real one.
+        while (type != null && type.Name.StartsWith("<", StringComparison.Ordinal))
+            type = type.DeclaringType;
+
+        string typeName = type?.Name ?? declaringType?.Name ?? "?";
+        return string.IsNullOrEmpty(method) ? typeName : typeName + "." + method;
+    }
+
+    private static string UnmangleMethod(string? methodName)
+    {
+        if (string.IsNullOrEmpty(methodName)) return string.Empty;
+        // "<Tick>b__0" / "<MoveNext>d__3" -> "Tick" / "MoveNext".
+        if (methodName![0] == '<')
+        {
+            int close = methodName.IndexOf('>');
+            if (close > 1) return methodName.Substring(1, close - 1);
+            return methodName;
+        }
+        return methodName;
+    }
+
+    /// <summary>Test seam: drop any tracked state so one test cannot leak into the next.</summary>
+    internal static void ResetForTests()
+    {
+        _label = null;
+        _overflowed = 0;
+        for (int i = 0; i < MaxDepth; i++) _stack[i].Op = null;
+        Volatile.Write(ref _depth, 0);
+    }
+}

--- a/ConditioningControlPanel/Services/UI/UiThreadStacks.cs
+++ b/ConditioningControlPanel/Services/UI/UiThreadStacks.cs
@@ -1,0 +1,175 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading;
+
+namespace ConditioningControlPanel.Services;
+
+/// <summary>
+/// The missing half of every sudden-freeze report (ccp-bugs #1189 / #1179 / #1159 / #984): the UI
+/// thread's MANAGED STACK, captured in-process at the moment the watchdog declares the hang, and
+/// written into hang_*.txt where the bug reporter can carry it.
+///
+/// WHY NOT THE MINIDUMP. The watchdog already writes one hang_*.dmp per session and it does contain
+/// the stacks - but nobody ever sees it: tens of MB, the user is never told it exists, the in-app
+/// bug reporter cannot attach it, and reading it takes WinDbg plus the matching runtime. Across the
+/// whole #1189 family not one dump has reached us. A dozen lines of text inside the report that
+/// DOES reach us beats a perfect dump that does not.
+///
+/// WHY CLRMD SNAPSHOT-AND-ATTACH. <c>DataTarget.CreateSnapshotAndAttach</c> takes a PSS
+/// (copy-on-write) snapshot of our own process and walks THAT, so it never suspends, interrupts or
+/// mutates live threads - which matters here, because the process being inspected is already wedged
+/// and must not be made worse. A passive <c>AttachToProcess</c> on self, or any dbghelp self-walk,
+/// reads memory the runtime is still mutating. Measured: ~95ms for the snapshot plus the full
+/// managed stack of a blocked thread.
+///
+/// SAFETY CONTRACT. Runs ONLY from the watchdog after its existing 10s trigger (there is no new
+/// setting), on its own thread, under a hard time budget. A forensics routine that itself hangs
+/// would turn a recoverable freeze into a permanent one, so the budget is enforced by abandoning
+/// the worker thread rather than by trusting ClrMD to return.
+/// </summary>
+internal static class UiThreadStacks
+{
+    /// <summary>Frames kept for the UI thread. Deep enough for a WPF stack with room to spare.</summary>
+    private const int MaxUiFrames = 64;
+    /// <summary>Other managed threads summarised, newest-first as the runtime lists them.</summary>
+    private const int MaxOtherThreads = 12;
+    private const int MaxOtherFrames = 8;
+
+    /// <summary>
+    /// Capture the managed stack of the thread with <paramref name="uiManagedThreadId"/> (plus a
+    /// short summary of the other managed threads, which is where the other end of a deadlock
+    /// lives) and return it as report-ready text. Never throws; always returns something printable,
+    /// including when the capture fails or runs out of budget.
+    /// </summary>
+    public static string CaptureWithBudget(int uiManagedThreadId, int budgetMs)
+    {
+        // The worker thread exists purely so the budget is ENFORCEABLE. .NET 8 has no
+        // Thread.Abort, so if ClrMD blocks (a snapshot that cannot be taken, a DAC that will not
+        // load) the only way to keep our promise is to stop waiting and walk away. The worker is a
+        // background thread, so an abandoned one cannot hold the process open either.
+        string result = "(stack capture produced nothing)";
+        try
+        {
+            var done = new ManualResetEventSlim(false);
+            var worker = new Thread(() =>
+            {
+                try { result = CaptureCore(uiManagedThreadId); }
+                catch (Exception ex) { result = "(stack capture failed: " + ex.GetType().Name + ": " + ex.Message + ")"; }
+                finally { try { done.Set(); } catch { } }
+            })
+            {
+                IsBackground = true,
+                Name = "UiHangStackCapture",
+                Priority = ThreadPriority.BelowNormal,
+            };
+            worker.Start();
+
+            // `done` is deliberately never disposed on either path: an abandoned worker may still
+            // Set() it, and even on the happy path Wait can return while the worker is inside
+            // Set(). Disposing under it would throw there, for nothing.
+            if (!done.Wait(budgetMs))
+            {
+                return "(stack capture exceeded its "
+                       + (budgetMs / 1000).ToString(CultureInfo.InvariantCulture)
+                       + "s budget and was abandoned; see the hang_*.dmp beside this file)";
+            }
+            return result;
+        }
+        catch (Exception ex)
+        {
+            return "(stack capture unavailable: " + ex.Message + ")";
+        }
+    }
+
+    /// <summary>
+    /// The ClrMD work itself. NoInlining is load-bearing: it keeps every reference to the ClrMD
+    /// types inside THIS method, so if the assembly is missing from a build the JIT failure lands
+    /// as a catchable exception at the call above instead of taking the caller down with it.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static string CaptureCore(int uiManagedThreadId)
+    {
+        var sb = new StringBuilder(4096);
+
+        using var target = Microsoft.Diagnostics.Runtime.DataTarget
+            .CreateSnapshotAndAttach(Environment.ProcessId);
+
+        var clr = target.ClrVersions.FirstOrDefault();
+        if (clr == null) return "(no CLR found in the process snapshot)";
+
+        using var runtime = clr.CreateRuntime();
+
+        var threads = runtime.Threads;
+        var ui = threads.FirstOrDefault(t => t.ManagedThreadId == uiManagedThreadId);
+        if (ui == null)
+        {
+            sb.Append("(UI thread managed id ")
+              .Append(uiManagedThreadId.ToString(CultureInfo.InvariantCulture))
+              .Append(" not present in the snapshot; ")
+              .Append(threads.Length.ToString(CultureInfo.InvariantCulture))
+              .AppendLine(" managed threads seen)");
+        }
+        else
+        {
+            sb.Append("UI thread  managed=").Append(ui.ManagedThreadId.ToString(CultureInfo.InvariantCulture))
+              .Append(" os=0x").AppendLine(ui.OSThreadId.ToString("x", CultureInfo.InvariantCulture));
+            int frames = 0;
+            foreach (var line in Frames(ui, MaxUiFrames))
+            {
+                sb.Append("  ").AppendLine(line);
+                frames++;
+            }
+            if (frames == 0) sb.AppendLine("  (no managed frames - the thread is parked in native code; read the .dmp)");
+        }
+
+        // The other end of a deadlock is on some OTHER thread, and it is never in the reports.
+        // A short head of each remaining managed stack is usually enough to name it.
+        sb.AppendLine();
+        sb.AppendLine("other managed threads (top frames):");
+        int shown = 0;
+        foreach (var t in threads)
+        {
+            if (shown >= MaxOtherThreads) break;
+            if (t.ManagedThreadId == uiManagedThreadId) continue;
+            var head = Frames(t, MaxOtherFrames).ToList();
+            if (head.Count == 0) continue;      // idle pool threads with empty stacks are noise
+            shown++;
+            sb.Append("  managed=").Append(t.ManagedThreadId.ToString(CultureInfo.InvariantCulture))
+              .Append(" os=0x").AppendLine(t.OSThreadId.ToString("x", CultureInfo.InvariantCulture));
+            foreach (var line in head) sb.Append("    ").AppendLine(line);
+        }
+        if (shown == 0) sb.AppendLine("  (none with managed frames)");
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Frame text for one thread, capped. Each frame is independently guarded: one unresolvable
+    /// method must not cost us the rest of the stack, which is the part that names the wedge.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static IEnumerable<string> Frames(Microsoft.Diagnostics.Runtime.ClrThread thread, int max)
+    {
+        var outp = new List<string>(max);
+        try
+        {
+            foreach (var frame in thread.EnumerateStackTrace())
+            {
+                if (outp.Count >= max) { outp.Add("... (truncated)"); break; }
+                string text;
+                try { text = frame.Method?.Signature ?? frame.FrameName ?? "(unknown frame)"; }
+                catch { text = "(frame unreadable)"; }
+                outp.Add(text);
+            }
+        }
+        catch (Exception ex)
+        {
+            outp.Add("(stack walk stopped: " + ex.GetType().Name + ")");
+        }
+        return outp;
+    }
+}

--- a/Tests/ConditioningControlPanel.Tests/BugReportDiagnosticsTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/BugReportDiagnosticsTests.cs
@@ -331,4 +331,47 @@ public class BugReportDiagnosticsTests
         Assert.DoesNotContain("session counters cleared", result);
         Assert.DoesNotContain("[Session", result);
     }
+
+    // -- The UI-hang report attachment (ccp-bugs #1189/#1179/#1159/#984) -----------------
+    //
+    // hang_*.txt has existed since v6.8.2 and has never reached us: nothing attached it, so every
+    // freeze report arrived with the feature state (and now the UI thread's managed stack) sitting
+    // unread on the user's disk. These pin the section the report carries.
+
+    [Fact]
+    public void NoHangReport_AddsNoSection()
+    {
+        // The overwhelming majority of reports are not freezes. An empty header would be noise in
+        // every one of them.
+        Assert.Equal(string.Empty, BugReportService.BuildHangReportSection(null));
+        Assert.Equal(string.Empty, BugReportService.BuildHangReportSection(""));
+        Assert.Equal(string.Empty, BugReportService.BuildHangReportSection("   \r\n  "));
+    }
+
+    [Fact]
+    public void AHangReport_IsDelimitedSoTriageCanFindIt()
+    {
+        var section = BugReportService.BuildHangReportSection(
+            "CCP UI-hang report\nop=LockCard.Tick (92s, Send)\nui thread managed stack\n  Foo.Bar()");
+
+        Assert.StartsWith(BugReportService.HangReportHeader, section);
+        Assert.Contains("op=LockCard.Tick (92s, Send)", section);
+        Assert.Contains("Foo.Bar()", section);
+    }
+
+    [Fact]
+    public void AnOversizedHangReport_KeepsTheNewestBytes()
+    {
+        // The stack capture is APPENDED to the report, so it lives at the end. Trimming from the
+        // front is what keeps it; trimming from the back would throw away the only new evidence.
+        var body = new string('x', BugReportService.MaxHangReportChars + 5_000)
+                   + "\nui thread managed stack\n  System.Threading.Monitor.ReliableEnter()";
+
+        var section = BugReportService.BuildHangReportSection(body);
+
+        Assert.Contains("System.Threading.Monitor.ReliableEnter()", section);
+        Assert.True(section.Length <= BugReportService.MaxHangReportChars
+                                      + BugReportService.HangReportHeader.Length
+                                      + Environment.NewLine.Length);
+    }
 }

--- a/Tests/ConditioningControlPanel.Tests/UiOpNamingTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/UiOpNamingTests.cs
@@ -1,0 +1,127 @@
+using System;
+using ConditioningControlPanel.Services;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// ccp-bugs #1189 / #1179 / #1159 / #984 — the sudden-freeze family. Every one of those reports
+/// says the same useless thing: a Send-priority dispatcher operation has been running for 71-137
+/// seconds with <c>lockCardRunning=True</c>, and nothing names it. <see cref="UiOpTracker"/> is the
+/// fix, and the part of it that can be tested headlessly is the NAME: what the hang report actually
+/// prints on the <c>op=</c> line. A wrong name here is worse than no name, because triage would
+/// chase the wrong subsystem.
+///
+/// The push/pop half runs on dispatcher hooks and is only exercised by a real WPF message loop, so
+/// what is pinned below is the naming and the explicit-label contract.
+/// </summary>
+public class UiOpNamingTests
+{
+    public UiOpNamingTests() => UiOpTracker.ResetForTests();
+
+    // ── Delegate name unmangling ─────────────────────────────────────────────
+
+    [Fact]
+    public void APlainMethodKeepsItsOwnName()
+    {
+        Action plain = PlainTarget;
+        Assert.Equal("UiOpNamingTests.PlainTarget",
+            UiOpTracker.ShortName(plain.Method.DeclaringType, plain.Method.Name));
+    }
+
+    [Fact]
+    public void AClosureLambdaReportsTheEnclosingTypeAndMethod()
+    {
+        // This is the shape nearly every dispatcher op in the app has: a lambda that captured a
+        // local, so the compiler put it on a "<>c__DisplayClass" nested inside the real type and
+        // named it "<TheMethod>b__0". Raw, that reads as gibberish in a bug report.
+        int captured = 7;
+        Action lambda = () => GC.KeepAlive(captured);
+
+        var name = UiOpTracker.ShortName(lambda.Method.DeclaringType, lambda.Method.Name);
+
+        Assert.Equal("UiOpNamingTests.AClosureLambdaReportsTheEnclosingTypeAndMethod", name);
+        Assert.DoesNotContain("<", name);
+        Assert.DoesNotContain("DisplayClass", name);
+    }
+
+    [Fact]
+    public void ACachedLambdaWithNoCaptureAlsoUnwrapsToTheRealType()
+    {
+        // No capture => the compiler uses the singleton "<>c" cache class instead, a different
+        // nesting shape that must unwrap the same way.
+        Action lambda = static () => { };
+        var name = UiOpTracker.ShortName(lambda.Method.DeclaringType, lambda.Method.Name);
+
+        Assert.StartsWith("UiOpNamingTests.", name);
+        Assert.DoesNotContain("<>", name);
+    }
+
+    [Fact]
+    public void AMissingDeclaringTypeStillProducesAPrintableName()
+    {
+        // Diagnostics must degrade, never throw: the watchdog calls this while the UI is wedged.
+        Assert.Equal("?.Something", UiOpTracker.ShortName(null, "Something"));
+        Assert.Equal("UiOpNamingTests", UiOpTracker.ShortName(typeof(UiOpNamingTests), null));
+        Assert.Equal("UiOpNamingTests", UiOpTracker.ShortName(typeof(UiOpNamingTests), ""));
+    }
+
+    // ── Explicit labels ──────────────────────────────────────────────────────
+
+    [Fact]
+    public void AnExplicitLabelIsWhatTheReportPrints()
+    {
+        // DispatcherTimer ticks all post the SAME internal WPF delegate, so the auto name cannot
+        // tell the lock card's tick from any other timer in the app. The label is the only way.
+        using (UiOpTracker.Scope("LockCard.Tick"))
+        {
+            Assert.Contains("LockCard.Tick", UiOpTracker.Describe());
+        }
+    }
+
+    [Fact]
+    public void ALabelIsClearedOnDisposeSoItCannotGoStale()
+    {
+        using (UiOpTracker.Scope("LockCard.Tick")) { }
+        Assert.DoesNotContain("LockCard.Tick", UiOpTracker.Describe());
+    }
+
+    [Fact]
+    public void NestedLabelsRestoreTheOuterOne()
+    {
+        using (UiOpTracker.Scope("Outer"))
+        {
+            using (UiOpTracker.Scope("Inner"))
+            {
+                Assert.Contains("Inner", UiOpTracker.Describe());
+            }
+            // A restore bug here would blame the wrong subsystem for the next hang, which is
+            // exactly the failure mode this whole change exists to end.
+            Assert.Contains("Outer", UiOpTracker.Describe());
+        }
+    }
+
+    [Fact]
+    public void DescribeNeverThrowsAndAlwaysSaysSomething()
+    {
+        var text = UiOpTracker.Describe();
+        Assert.False(string.IsNullOrWhiteSpace(text));
+    }
+
+    // ── The line the hang report carries ─────────────────────────────────────
+
+    [Fact]
+    public void TheCompactHangSnapshotCarriesTheOpName()
+    {
+        // This is the string that lands in the [WATCHDOG] log line and in hang_*.txt. If "op=" is
+        // missing the whole change is invisible to triage.
+        using (UiOpTracker.Scope("LockCard.Tick"))
+        {
+            var compact = HangContext.DescribeCompact();
+            Assert.Contains("op=", compact);
+            Assert.Contains("LockCard.Tick", compact);
+        }
+    }
+
+    private static void PlainTarget() { }
+}

--- a/Tests/ConditioningControlPanel.Tests/UiThreadStackCaptureTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/UiThreadStackCaptureTests.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Diagnostics;
+using ConditioningControlPanel.Services;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// The capture route itself (ccp-bugs #1189 / #1179 / #1159 / #984). Everything else in this
+/// change is formatting; this is the part that either produces frames or does not, and the only
+/// way to be sure a wedged 6.9.4 will produce them is to take a real snapshot of a real process
+/// here. It runs against the app assembly, so it also proves the pinned ClrMD package actually
+/// resolves at runtime rather than merely compiling.
+///
+/// It cannot reproduce a WPF UI hang (no message loop in a test host) — it proves the mechanism:
+/// snapshot this process from another thread, find a named managed thread in it, read its frames.
+/// A hung UI thread is strictly EASIER than this, because it is not moving.
+/// </summary>
+public class UiThreadStackCaptureTests
+{
+    [Fact]
+    public void ASelfSnapshotYieldsTheCallingThreadsManagedFrames()
+    {
+        var sw = Stopwatch.StartNew();
+        var text = UiThreadStacks.CaptureWithBudget(Environment.CurrentManagedThreadId, 20_000);
+        sw.Stop();
+
+        // This test method's own frame must appear: that is a managed stack walk having worked,
+        // not a placeholder string. Every report in the freeze family is missing exactly this.
+        Assert.Contains(nameof(ASelfSnapshotYieldsTheCallingThreadsManagedFrames), text);
+        Assert.Contains("UI thread", text);
+
+        // The watchdog runs this on a process that is already in trouble. Measured at ~100ms; the
+        // assert is loose because it shares a machine with the rest of the suite, but a capture
+        // that took seconds would mean the snapshot route regressed into something unshippable.
+        Assert.True(sw.ElapsedMilliseconds < 10_000,
+            $"stack capture took {sw.ElapsedMilliseconds}ms");
+    }
+
+    [Fact]
+    public void AnUnknownThreadIdDegradesInsteadOfThrowing()
+    {
+        // SafeUiManagedThreadId returns -1 when the dispatcher will not answer, and a wedged
+        // process is exactly where that happens. The report must still get a printable line.
+        var text = UiThreadStacks.CaptureWithBudget(-1, 20_000);
+
+        Assert.False(string.IsNullOrWhiteSpace(text));
+        Assert.Contains("not present in the snapshot", text);
+    }
+
+    [Fact]
+    public void AnImpossibleBudgetIsAbandonedRatherThanWaitedOut()
+    {
+        // The rule the whole design turns on: a hang capture that itself hangs is worse than no
+        // capture. Zero budget is the degenerate case of that promise.
+        var sw = Stopwatch.StartNew();
+        var text = UiThreadStacks.CaptureWithBudget(Environment.CurrentManagedThreadId, 0);
+        sw.Stop();
+
+        Assert.Contains("budget", text);
+        Assert.True(sw.ElapsedMilliseconds < 5_000, $"gave up after {sw.ElapsedMilliseconds}ms");
+    }
+}


### PR DESCRIPTION
## What

The next 6.9.4 UI freeze writes a `hang_*.txt` that answers the question the current one only poses.

1. **The UI thread's managed stack, in the text report.** `Services/UI/UiThreadStacks.cs` takes a PSS copy-on-write snapshot of our own process (ClrMD `DataTarget.CreateSnapshotAndAttach`, pinned at `3.1.512801`) and walks the dispatcher thread's managed frames, plus the top frames of every other managed thread - which is where the other end of a deadlock lives, and which no report has ever carried.
2. **A name for the stuck operation.** `Services/UI/UiOpTracker.cs` subscribes once to `Dispatcher.Hooks` and keeps the currently executing operation on a small stack, so `lockCardRunning=True` becomes `op=LockCard.Tick (92s, Send)`. `HangContext` prints it in both the full report and the one-line `[WATCHDOG]` log line.
3. **Delivery.** `BugReportService` now attaches the newest `hang_*.txt`, date-stamped, under its own delimiter. Until now nothing attached it: the file has existed since v6.8.2 and has never left a user's disk.

## Why

`#1189` / `#1179` / `#1159` / `#984` all report a Send-priority dispatcher op running 71-137s with `lockCardRunning=True` and no stack. The minidump beside it has the stacks - and in that whole family not one dump has reached us: tens of MB, the user is never told it exists, the bug reporter cannot attach it, and reading it needs WinDbg plus the matching runtime. A dozen lines of text in the report that *does* reach us is worth more than a perfect dump that does not.

## Route choice

Self-attach was evaluated before it was written. `CreateSnapshotAndAttach` never suspends, interrupts or mutates the live threads, which matters when the process being inspected is already wedged; a passive `AttachToProcess` on self, or any dbghelp self-walk, reads memory the runtime is still mutating. Measured against the app assembly: ~95ms for the snapshot plus a blocked thread's full managed stack. `UiThreadStackCaptureTests` pins that end to end.

## Safety

No new setting: the capture runs only behind the watchdog's existing 10s trigger. It runs on its own thread under a 20s budget and is abandoned rather than waited out, because a hang capture that itself hangs is worse than none. It runs only *after* the report is already flushed with `WriteThrough`, so it can only add to the evidence, never cost it. Every layer is independently try/caught and degrades to a printable line.

## Tests

`dotnet build` green. `dotnet test`: 5377 passed, 3 failed - all three in `VatFillCoordinatorTests`, pre-existing on `origin/release/6.9.4` (verified by stashing this branch and re-running).

New: `UiThreadStackCaptureTests` (real self-snapshot yields real frames; unknown thread id degrades; zero budget is abandoned), `UiOpNamingTests` (lambda/closure/display-class unmangling, label nesting and restore, the `op=` line the report prints), plus three cases in `BugReportDiagnosticsTests` for the attachment section.

## Not verified here

A real UI hang cannot be triggered in this environment. A manual test needs: run the app, wedge the UI thread for >13s (a `Thread.Sleep(20000)` on a button handler will do), then confirm `%LOCALAPPDATA%/ConditioningControlPanel/logs/hang_*.txt` contains an `op=` line and a populated `ui thread managed stack` block, and that a bug report filed on the next launch carries the `UI-hang report` section. The DAC load also wants one check against a real Velopack `PublishSingleFile`/`SelfContained` build rather than `dotnet build` output.

## Size

805 changed lines against the ~600 cap. 233 of those are tests and ~400 are two new self-contained diagnostic files; the three parts are one mechanism (a stack nobody can attach, or a name with no stack, each ships nothing usable), so splitting would land half a report.

Refs CC-Labs-llc/ccp-bugs#1189, CC-Labs-llc/ccp-bugs#1179, CC-Labs-llc/ccp-bugs#1159, CC-Labs-llc/ccp-bugs#984

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013mR8cAipk1ivr3Em5fJjcx
