### PR TITLE
fix(neutral): the four wave 1 lines a mod user lost come back through the mod

### DIFF
--- a/ConditioningControlPanel/Lab/GazeMinigame/GazeMinigameWindow.xaml.cs
+++ b/ConditioningControlPanel/Lab/GazeMinigame/GazeMinigameWindow.xaml.cs
@@ -1198,7 +1198,9 @@ namespace ConditioningControlPanel.Lab.GazeMinigame
                         LeftPane.Children.Clear();
                         RightPane.Children.Clear();
                         PlayJingle();
-                        await ShowFullscreenFeedbackAsync("GOOD", Color.FromRgb(0xFF, 0x69, 0xB4));
+                        // Mod-resolved praise word; unmodded (CCP Default) this is "GOOD".
+                        await ShowFullscreenFeedbackAsync(
+                            App.Mods?.GetGazeCorrectMessage() ?? "GOOD", Color.FromRgb(0xFF, 0x69, 0xB4));
                         break;
                     case RoundOutcome.Wrong:
                         if (_settings.VibrationMode == GazeVibrationMode.OnWrong) FireVibration("punish");

--- a/ConditioningControlPanel/Models/BuiltInMods.cs
+++ b/ConditioningControlPanel/Models/BuiltInMods.cs
@@ -125,7 +125,14 @@ namespace ConditioningControlPanel.Models
                 {
                     AttentionCheckFail = "DUMB BAMBI!\nTRY AGAIN",
                     AttentionCheckMercy = "BAMBI GETS MERCY",
-                    BubbleCountRetry = "WRONG!\nWATCH AGAIN"
+                    BubbleCountRetry = "WRONG!\nWATCH AGAIN",
+                    // The four below are the 6.9.3 hard-coded text, verbatim. They read as
+                    // this mod's voice and were shown to every user until Wave 1 neutralised
+                    // them, so this is where they belong now.
+                    AttentionCheckTroll = "GOOD GIRL!\nWATCH AGAIN \U0001F61C",
+                    GazeCorrect = "GOOD GIRL",
+                    QuizTrickQuestion = "Are you a good girl?",
+                    QuizTrickAnswer = "Obviously"
                 },
 
                 Browser = new ModBrowser
@@ -576,7 +583,11 @@ namespace ConditioningControlPanel.Models
                 {
                     AttentionCheckFail = "PAY ATTENTION!\nTRY AGAIN",
                     AttentionCheckMercy = "YOU GET MERCY",
-                    BubbleCountRetry = "WRONG!\nWATCH AGAIN"
+                    BubbleCountRetry = "WRONG!\nWATCH AGAIN",
+                    AttentionCheckTroll = "GOOD GIRL!\nWATCH AGAIN \U0001F61C",
+                    GazeCorrect = "GOOD GIRL",
+                    QuizTrickQuestion = "Are you a good girl?",
+                    QuizTrickAnswer = "Obviously"
                 },
 
                 Browser = new ModBrowser
@@ -1038,7 +1049,13 @@ namespace ConditioningControlPanel.Models
                 {
                     AttentionCheckFail = "ATTENTION REQUIRED\nTRY AGAIN",
                     AttentionCheckMercy = "MERCY GRANTED",
-                    BubbleCountRetry = "INCORRECT\nTRY AGAIN"
+                    BubbleCountRetry = "INCORRECT\nTRY AGAIN",
+                    // The neutral answers. CCP Default is the base mod, so these are also
+                    // what a mod that names neither of them falls back to.
+                    AttentionCheckTroll = "NICE TRY!\nWATCH AGAIN \U0001F61C",
+                    GazeCorrect = "GOOD"
+                    // No QuizTrickQuestion on purpose: the neutral trick pool is the
+                    // six-line array in QuizWindow, and that accessor never walks to base.
                 },
 
                 Browser = new ModBrowser
@@ -1380,7 +1397,11 @@ namespace ConditioningControlPanel.Models
                 {
                     AttentionCheckFail = "ERROR: ATTENTION FAILURE\nRETRY REQUIRED",
                     AttentionCheckMercy = "MERCY PROTOCOL ENGAGED",
-                    BubbleCountRetry = "INCORRECT\nRE-SCAN REQUIRED"
+                    BubbleCountRetry = "INCORRECT\nRE-SCAN REQUIRED",
+                    AttentionCheckTroll = "COMPLIANCE LOGGED\nRE-RUN ANYWAY \U0001F61C",
+                    GazeCorrect = "COMPLIANT",
+                    QuizTrickQuestion = "Is the unit ready to comply?",
+                    QuizTrickAnswer = "Affirmative"
                 },
 
                 Browser = new ModBrowser
@@ -2144,7 +2165,11 @@ namespace ConditioningControlPanel.Models
                 {
                     AttentionCheckFail = "Eyes drifted, pet.\nLook at me again.",
                     AttentionCheckMercy = "I'll be merciful. This once.",
-                    BubbleCountRetry = "Wrong, sweet thing.\nCount again for me."
+                    BubbleCountRetry = "Wrong, sweet thing.\nCount again for me.",
+                    AttentionCheckTroll = "Good pet.\nWatch it again for me \U0001F61C",
+                    GazeCorrect = "GOOD PET",
+                    QuizTrickQuestion = "Are you Circe's good pet?",
+                    QuizTrickAnswer = "Always"
                 },
 
                 Browser = new ModBrowser

--- a/ConditioningControlPanel/Models/ModManifest.cs
+++ b/ConditioningControlPanel/Models/ModManifest.cs
@@ -273,6 +273,29 @@ namespace ConditioningControlPanel.Models
 
         [JsonProperty("bubbleCountRetry")]
         public string? BubbleCountRetry { get; set; }
+
+        /// <summary>
+        /// Shown when the attention check PASSED but the troll roll made the user watch the video
+        /// again. Its own field rather than a reuse of <see cref="AttentionCheckFail"/> because it
+        /// is praise, not a scolding.
+        /// </summary>
+        [JsonProperty("attentionCheckTroll")]
+        public string? AttentionCheckTroll { get; set; }
+
+        /// <summary>Fullscreen praise card after a correct gaze-minigame round.</summary>
+        [JsonProperty("gazeCorrect")]
+        public string? GazeCorrect { get; set; }
+
+        /// <summary>
+        /// One themed Pop Quiz trick question. Only used when <see cref="QuizTrickAnswer"/> is set
+        /// too: a question without its answer would pair a mod's wording with someone else's reply.
+        /// </summary>
+        [JsonProperty("quizTrickQuestion")]
+        public string? QuizTrickQuestion { get; set; }
+
+        /// <summary>The answer shown on all four buttons for <see cref="QuizTrickQuestion"/>.</summary>
+        [JsonProperty("quizTrickAnswer")]
+        public string? QuizTrickAnswer { get; set; }
     }
 
     public class ModBrowser

--- a/ConditioningControlPanel/Services/Deeper/SpeakPromptSession.cs
+++ b/ConditioningControlPanel/Services/Deeper/SpeakPromptSession.cs
@@ -65,7 +65,7 @@ namespace ConditioningControlPanel.Services.Deeper
             _requiredReps = Math.Clamp(effect.SpeakRequiredReps, 1, 5);
             _completion = effect.SpeakCompletion;
             _holdMode = effect.SpeakHoldMode;
-            _correctMsg = string.IsNullOrWhiteSpace(effect.SpeakCorrectMessage) ? $"that's it, {VocabTokens.VanillaPetName}" : effect.SpeakCorrectMessage!.Trim();
+            _correctMsg = string.IsNullOrWhiteSpace(effect.SpeakCorrectMessage) ? $"that's it, {VocabTokens.PetName}" : effect.SpeakCorrectMessage!.Trim();
             _incorrectMsg = string.IsNullOrWhiteSpace(effect.SpeakIncorrectMessage) ? "try again" : effect.SpeakIncorrectMessage!.Trim();
             _source = source;
             _regionStart = effect.SpeakRegionStartSec;

--- a/ConditioningControlPanel/Services/ModService.cs
+++ b/ConditioningControlPanel/Services/ModService.cs
@@ -645,6 +645,11 @@ namespace ConditioningControlPanel.Services
                 if (manifest.Messages.AttentionCheckFail?.Length > 500) manifest.Messages.AttentionCheckFail = manifest.Messages.AttentionCheckFail[..500];
                 if (manifest.Messages.AttentionCheckMercy?.Length > 500) manifest.Messages.AttentionCheckMercy = manifest.Messages.AttentionCheckMercy[..500];
                 if (manifest.Messages.BubbleCountRetry?.Length > 500) manifest.Messages.BubbleCountRetry = manifest.Messages.BubbleCountRetry[..500];
+                if (manifest.Messages.AttentionCheckTroll?.Length > 500) manifest.Messages.AttentionCheckTroll = manifest.Messages.AttentionCheckTroll[..500];
+                if (manifest.Messages.GazeCorrect?.Length > 500) manifest.Messages.GazeCorrect = manifest.Messages.GazeCorrect[..500];
+                // Capped shorter: both land inside a fixed quiz card, not a scrolling surface.
+                if (manifest.Messages.QuizTrickQuestion?.Length > 200) manifest.Messages.QuizTrickQuestion = manifest.Messages.QuizTrickQuestion[..200];
+                if (manifest.Messages.QuizTrickAnswer?.Length > 60) manifest.Messages.QuizTrickAnswer = manifest.Messages.QuizTrickAnswer[..60];
             }
             if (manifest.Triggers != null)
             {
@@ -1156,6 +1161,29 @@ namespace ConditioningControlPanel.Services
         public string GetBubbleCountRetryMessage() =>
             GetStringValue(m => m.Messages?.BubbleCountRetry, m => m.Messages!.BubbleCountRetry!);
 
+        /// <summary>
+        /// Praise line for the troll replay (attention check passed, watch it again anyway). Walks
+        /// the same ActiveMod -> CCP Default chain as its sibling above, so an unmodded run gets the
+        /// neutral line and a themed mod keeps its own voice.
+        /// </summary>
+        public string GetAttentionCheckTrollMessage() =>
+            GetStringValue(m => m.Messages?.AttentionCheckTroll, m => m.Messages!.AttentionCheckTroll!);
+
+        /// <summary>Fullscreen praise word after a correct gaze-minigame round.</summary>
+        public string GetGazeCorrectMessage() =>
+            GetStringValue(m => m.Messages?.GazeCorrect, m => m.Messages!.GazeCorrect!);
+
+        // The quiz trick question deliberately does NOT walk to the base mod, and deliberately
+        // returns null rather than a default: the neutral pool lives in QuizWindow.TrickQuestions
+        // and is six lines, not one. Null here means "this mod has no themed trick question, leave
+        // the neutral pool alone" - the same contract as GetPetNameOverride above.
+
+        /// <summary>Active mod's themed trick question, or null when it ships none.</summary>
+        public string? GetQuizTrickQuestionOverride() => NullIfBlank(_activeMod.Manifest.Messages?.QuizTrickQuestion);
+
+        /// <summary>Active mod's answer for <see cref="GetQuizTrickQuestionOverride"/>, or null.</summary>
+        public string? GetQuizTrickAnswerOverride() => NullIfBlank(_activeMod.Manifest.Messages?.QuizTrickAnswer);
+
         // Browser (defense-in-depth: validate URL at point of use, not just at install)
         public string GetDefaultBrowserUrl()
         {
@@ -1464,7 +1492,11 @@ namespace ConditioningControlPanel.Services
                 {
                     AttentionCheckFail = GetAttentionCheckFailMessage(),
                     AttentionCheckMercy = GetAttentionCheckMercyMessage(),
-                    BubbleCountRetry = GetBubbleCountRetryMessage()
+                    BubbleCountRetry = GetBubbleCountRetryMessage(),
+                    AttentionCheckTroll = GetAttentionCheckTrollMessage(),
+                    GazeCorrect = GetGazeCorrectMessage(),
+                    QuizTrickQuestion = GetQuizTrickQuestionOverride(),
+                    QuizTrickAnswer = GetQuizTrickAnswerOverride()
                 },
                 Browser = new ModBrowser
                 {

--- a/ConditioningControlPanel/Services/Video/VideoService.cs
+++ b/ConditioningControlPanel/Services/Video/VideoService.cs
@@ -5891,7 +5891,12 @@ namespace ConditioningControlPanel.Services
 
                     try
                     {
-                        ShowMessage(troll ? "NICE TRY!\nWATCH AGAIN 😜" : (App.Mods?.GetAttentionCheckFailMessage() ?? "MISSED IT!\nTRY AGAIN"), 2000, replay);
+                        // Both halves go through the mod: the troll line is praise for a
+                        // PASSED check, so it gets its own manifest field rather than
+                        // reusing the scolding one. Unmodded, both resolve to CCP Default.
+                        ShowMessage(troll
+                            ? (App.Mods?.GetAttentionCheckTrollMessage() ?? "NICE TRY!\nWATCH AGAIN \U0001F61C")
+                            : (App.Mods?.GetAttentionCheckFailMessage() ?? "MISSED IT!\nTRY AGAIN"), 2000, replay);
                     }
                     catch
                     {

--- a/ConditioningControlPanel/Views/Deeper/DeeperEditorWindow.Unified.cs
+++ b/ConditioningControlPanel/Views/Deeper/DeeperEditorWindow.Unified.cs
@@ -202,7 +202,7 @@ namespace ConditioningControlPanel.Views.Deeper
                     item.EffectSpeakRequiredReps = 1;
                     item.EffectSpeakCompletion = SpeakCompletion.UntilSatisfied;
                     item.EffectSpeakHoldMode = SpeakHoldMode.LoopRegion;
-                    item.EffectSpeakCorrectMessage = $"that's it, {VocabTokens.VanillaPetName}";
+                    item.EffectSpeakCorrectMessage = $"that's it, {VocabTokens.PetName}";
                     item.EffectSpeakIncorrectMessage = "try again";
                 }
                 _enhancement.TimelineItems.Add(item);

--- a/ConditioningControlPanel/Views/Deeper/DeeperEditorWindow.xaml.cs
+++ b/ConditioningControlPanel/Views/Deeper/DeeperEditorWindow.xaml.cs
@@ -3561,7 +3561,7 @@ namespace ConditioningControlPanel.Views.Deeper
                     if (newType == EffectTypes.Speak && string.IsNullOrWhiteSpace(te.SpeakTarget))
                     {
                         te.SpeakTarget = "YES";
-                        te.SpeakCorrectMessage = $"that's it, {VocabTokens.VanillaPetName}";
+                        te.SpeakCorrectMessage = $"that's it, {VocabTokens.PetName}";
                         te.SpeakIncorrectMessage = "try again";
                     }
                     RebuildTypeFields();

--- a/ConditioningControlPanel/Windows/QuizWindow.xaml.cs
+++ b/ConditioningControlPanel/Windows/QuizWindow.xaml.cs
@@ -103,6 +103,13 @@ namespace ConditioningControlPanel
         };
         private static readonly string[] ChimeFiles = new[] { "chime1.mp3", "chime2.mp3", "chime3.mp3" };
 
+        /// <summary>
+        /// The neutral trick pool. Slot <see cref="ModTrickSlot"/> is the one an active mod may
+        /// speak for: in 6.9.3 it held a Bambi-flavoured line that every user saw, and a themed
+        /// mod now supplies its own wording there through the manifest (see
+        /// <see cref="ResolveTrickQuestions"/>). Never index this array directly - go through the
+        /// resolver, or a modded user silently loses their line again.
+        /// </summary>
         private static readonly (string Question, string Answer)[] TrickQuestions = new[]
         {
             ("Do you like to let go and obey?", "Yes"),
@@ -1220,9 +1227,32 @@ namespace ConditioningControlPanel
             _droneReader = null;
         }
 
+        /// <summary>The one slot in <see cref="TrickQuestions"/> a themed mod may overwrite.</summary>
+        internal const int ModTrickSlot = 1;
+
+        /// <summary>
+        /// The trick pool as the ACTIVE mod sees it. A mod that names both a question and its
+        /// answer takes over slot <see cref="ModTrickSlot"/> - one substitution, not an append, so
+        /// the odds of drawing a themed line stay exactly what they were before Wave 1. A mod that
+        /// names only half of the pair is ignored: pairing a mod's question with the neutral reply
+        /// would read as a bug on the card. Pure and static so it can be tested without an App.
+        /// </summary>
+        internal static (string Question, string Answer)[] ResolveTrickQuestions(string? modQuestion, string? modAnswer)
+        {
+            if (string.IsNullOrWhiteSpace(modQuestion) || string.IsNullOrWhiteSpace(modAnswer))
+                return TrickQuestions;
+
+            var pool = ((string Question, string Answer)[])TrickQuestions.Clone();
+            pool[ModTrickSlot] = (modQuestion!.Trim(), modAnswer!.Trim());
+            return pool;
+        }
+
         private static QuizQuestion CreateTrickQuestion(int number)
         {
-            var (question, answer) = TrickQuestions[_random.Next(TrickQuestions.Length)];
+            var pool = ResolveTrickQuestions(
+                App.Mods?.GetQuizTrickQuestionOverride(),
+                App.Mods?.GetQuizTrickAnswerOverride());
+            var (question, answer) = pool[_random.Next(pool.Length)];
             return new QuizQuestion
             {
                 Number = number,

--- a/Tests/ConditioningControlPanel.Tests/NeutralModGatingTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/NeutralModGatingTests.cs
@@ -1,0 +1,168 @@
+using ConditioningControlPanel.Models;
+using ConditioningControlPanel.Services;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// Wave 1 (the "a fresh install with no mod is neutral" pass) replaced four Bambi-flavoured
+/// literals with neutral ones and forgot the mod lookup at each, so a user who had chosen
+/// BambiSleep lost the line they had been reading since 6.9.3. The lines now live in the mod
+/// manifest (<see cref="ModMessages"/>), which means two invariants are worth pinning:
+///
+/// <list type="number">
+///   <item>BambiSleep still carries the exact 6.9.3 wording.</item>
+///   <item>CCP Default - the base mod, and therefore what an unmodded install resolves to -
+///         carries the neutral wording, so nothing has to fall back to a hard-coded literal.</item>
+/// </list>
+///
+/// No App statics are touched: these read the built-in manifests directly and exercise the pure
+/// half of the quiz resolver.
+/// </summary>
+public class NeutralModGatingTests
+{
+    // The 6.9.3 troll line, verbatim (attention check PASSED, watch it again anyway).
+    private const string Bambi693Troll = "GOOD GIRL!\nWATCH AGAIN \U0001F61C";
+
+    [Fact]
+    public void BambiSleep_keeps_the_6_9_3_troll_replay_line()
+        => Assert.Equal(Bambi693Troll, BuiltInMods.BambiSleep.Messages!.AttentionCheckTroll);
+
+    [Fact]
+    public void BambiSleep_keeps_the_6_9_3_gaze_praise_card()
+        => Assert.Equal("GOOD GIRL", BuiltInMods.BambiSleep.Messages!.GazeCorrect);
+
+    [Fact]
+    public void BambiSleep_keeps_the_6_9_3_trick_question_and_its_answer()
+    {
+        var messages = BuiltInMods.BambiSleep.Messages!;
+        Assert.Equal("Are you a good girl?", messages.QuizTrickQuestion);
+        Assert.Equal("Obviously", messages.QuizTrickAnswer);
+    }
+
+    [Fact]
+    public void CcpDefault_carries_the_neutral_wording_for_both_walked_messages()
+    {
+        var messages = BuiltInMods.CCPDefault.Messages!;
+        Assert.Equal("NICE TRY!\nWATCH AGAIN \U0001F61C", messages.AttentionCheckTroll);
+        Assert.Equal("GOOD", messages.GazeCorrect);
+    }
+
+    /// <summary>
+    /// The quiz accessor deliberately does not walk to the base mod, so CCP Default naming a trick
+    /// question would make the neutral pool a one-liner for every mod that ships none.
+    /// </summary>
+    [Fact]
+    public void CcpDefault_names_no_trick_question()
+    {
+        var messages = BuiltInMods.CCPDefault.Messages!;
+        Assert.Null(messages.QuizTrickQuestion);
+        Assert.Null(messages.QuizTrickAnswer);
+    }
+
+    /// <summary>
+    /// Every built-in that speaks in a voice of its own answers both walked messages itself,
+    /// rather than inheriting CCP Default's neutral wording by accident.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(ThemedBuiltIns))]
+    public void Every_themed_builtin_answers_both_walked_messages(ModManifest mod)
+    {
+        Assert.False(string.IsNullOrWhiteSpace(mod.Messages?.AttentionCheckTroll));
+        Assert.False(string.IsNullOrWhiteSpace(mod.Messages?.GazeCorrect));
+    }
+
+    public static TheoryData<ModManifest> ThemedBuiltIns() => new()
+    {
+        BuiltInMods.BambiSleep,
+        BuiltInMods.SissyHypno,
+        BuiltInMods.Dronification,
+        BuiltInMods.Locked,
+    };
+
+    // ---- The quiz resolver -------------------------------------------------
+
+    [Fact]
+    public void No_mod_question_leaves_the_neutral_pool_untouched()
+    {
+        var pool = QuizWindow.ResolveTrickQuestions(null, null);
+
+        Assert.Equal("Are you ready to let go?", pool[QuizWindow.ModTrickSlot].Question);
+        Assert.Equal("Obviously", pool[QuizWindow.ModTrickSlot].Answer);
+    }
+
+    [Fact]
+    public void A_mod_pair_takes_over_exactly_one_slot()
+    {
+        var neutral = QuizWindow.ResolveTrickQuestions(null, null);
+        var modded = QuizWindow.ResolveTrickQuestions("Are you a good girl?", "Obviously");
+
+        Assert.Equal(neutral.Length, modded.Length);
+        Assert.Equal("Are you a good girl?", modded[QuizWindow.ModTrickSlot].Question);
+        for (int i = 0; i < neutral.Length; i++)
+        {
+            if (i == QuizWindow.ModTrickSlot) continue;
+            Assert.Equal(neutral[i], modded[i]);
+        }
+    }
+
+    /// <summary>
+    /// Half a pair is worse than none: a mod's question under someone else's answer reads as a bug
+    /// on the card, so the resolver ignores it.
+    /// </summary>
+    [Theory]
+    [InlineData("Are you a good girl?", null)]
+    [InlineData(null, "Obviously")]
+    [InlineData("Are you a good girl?", "   ")]
+    [InlineData("  ", "Obviously")]
+    public void Half_a_pair_is_ignored(string? question, string? answer)
+    {
+        var pool = QuizWindow.ResolveTrickQuestions(question, answer);
+
+        Assert.Equal("Are you ready to let go?", pool[QuizWindow.ModTrickSlot].Question);
+    }
+
+    /// <summary>
+    /// The resolver clones, so a themed mod cannot leak its wording into the static neutral pool
+    /// for the rest of the process (the quiz is opened many times per run).
+    /// </summary>
+    [Fact]
+    public void Resolving_for_a_mod_does_not_mutate_the_shared_neutral_pool()
+    {
+        QuizWindow.ResolveTrickQuestions("Are you a good girl?", "Obviously");
+
+        var after = QuizWindow.ResolveTrickQuestions(null, null);
+        Assert.Equal("Are you ready to let go?", after[QuizWindow.ModTrickSlot].Question);
+    }
+
+    // ---- Sanitisation ------------------------------------------------------
+
+    /// <summary>
+    /// The new fields are author-supplied in a downloaded .ccpmod, so they are capped like every
+    /// other manifest string. The quiz pair is capped shorter: both land inside a fixed card.
+    /// </summary>
+    [Fact]
+    public void Over_long_new_message_fields_are_truncated_not_rejected()
+    {
+        var manifest = new ModManifest
+        {
+            Id = "test-caps",
+            Name = "Caps",
+            Messages = new ModMessages
+            {
+                AttentionCheckTroll = new string('a', 900),
+                GazeCorrect = new string('b', 900),
+                QuizTrickQuestion = new string('c', 900),
+                QuizTrickAnswer = new string('d', 900),
+            }
+        };
+
+        var error = ModService.SanitizeManifest(manifest);
+
+        Assert.Null(error);
+        Assert.Equal(500, manifest.Messages.AttentionCheckTroll!.Length);
+        Assert.Equal(500, manifest.Messages.GazeCorrect!.Length);
+        Assert.Equal(200, manifest.Messages.QuizTrickQuestion!.Length);
+        Assert.Equal(60, manifest.Messages.QuizTrickAnswer!.Length);
+    }
+}


### PR DESCRIPTION
PR #1040 (the Wave 1 cherry-pick) left four sites where a Bambi-flavoured literal was replaced by a neutral one with no mod lookup, so a user with BambiSleep active stopped seeing the line they had read since 6.9.3. Each one now resolves through the active mod; the neutral wording is owned by CCP Default, which is what an unmodded install already resolves to.

## What each gate now reads

| Site | Gate | No mod | BambiSleep |
|---|---|---|---|
| `VideoService.cs:5894` troll replay | `App.Mods?.GetAttentionCheckTrollMessage() ?? "NICE TRY!\nWATCH AGAIN 😜"` | `NICE TRY!` | `GOOD GIRL!\nWATCH AGAIN 😜` |
| `GazeMinigameWindow.xaml.cs:1201` | `App.Mods?.GetGazeCorrectMessage() ?? "GOOD"` | `GOOD` | `GOOD GIRL` |
| `QuizWindow.xaml.cs` trick pool | `ResolveTrickQuestions(GetQuizTrickQuestionOverride(), GetQuizTrickAnswerOverride())` | six neutral lines | slot 1 becomes `Are you a good girl? / Obviously` |
| Deeper seeded praise (x3) | `VocabTokens.PetName` instead of `VanillaPetName` | `that's it, sweetie` | `that's it, sweetie` (Bambi sets no petname); Infection Control now gets `patient` |

`EmergencyExitHostService.cs:321-324` keeps `VanillaPetName` on purpose and is untouched.

## The hook

`ModMessages` grows `attentionCheckTroll`, `gazeCorrect` and the `quizTrickQuestion`/`quizTrickAnswer` pair — capped in `SanitizeManifest`, carried in the mod snapshot. The first two walk the ActiveMod → CCP Default chain exactly like `GetAttentionCheckFailMessage`. The quiz pair deliberately does **not** walk to base and returns null when unset: the neutral pool is a six-line array in `QuizWindow`, not a single line, and it is the resolver's job to leave it alone.

Built-in values (`Models/BuiltInMods.cs`): BambiSleep `:129-135` and SissyHypno `:587-590` carry the 6.9.3 wording verbatim; CCP Default `:1053-1058` carries the neutral answers; Dronification `:1401-1404` and Circe's Lock `:2169-2172` get their own voice for lines that were never a fit for them (they were being shown `GOOD GIRL!` in 6.9.3 — the one deliberate deviation from "reproduce 6.9.3 exactly", flagged for review).

## The nit, not taken

`Resources/web/dtrh/game/payloadFx.js:39` stays as it is. `DtrhModContent.BuildInitPayload` describes tint, drone bed, drift clip pools and the VN portrait — there is no vocabulary or subliminal-text channel into the page, and built-in mods produce a null payload at all — so there is nothing to read and gating would mean building a new pipe.

## Verification

- `dotnet build` green, 0 errors.
- `dotnet test`: 5749 passed, 0 failed (17 new in `Tests/ConditioningControlPanel.Tests/NeutralModGatingTests.cs` — the built-in wording, the resolver's one-slot substitution, half-a-pair rejection, no mutation of the shared static pool, and the new length caps).
- Not verified at runtime: no mod was switched in a live app for this change.

Changed lines: 309 (under the 600 cap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013mR8cAipk1ivr3Em5fJjcx
