### PR TITLE
fix(quests): the camera probe fails open, and a lapsed patron keeps their quest

### DIFF
--- a/ConditioningControlPanel/Models/QuestProgress.cs
+++ b/ConditioningControlPanel/Models/QuestProgress.cs
@@ -121,6 +121,15 @@ public class QuestProgress
         }
 
         int maxRerolls = hasPatreon ? 3 : 1;
+        // DELIBERATE, not the copy-paste from the daily branch above that it looks like. The skill
+        // tree has no weekly reroll node - quest_refresh and reroll_addict are the only two that
+        // feed GetDailyFreeRerolls - so the choice is between their bonus applying to both budgets
+        // or only to the daily one, and the shipped copy says both: the weekly reroll tooltip
+        // (tooltip_reroll_for_a_different_quest_once_per_week) reads "One reroll a week, three with
+        // Patreon, plus anything the skill tree adds", in all nine languages. Dropping this line
+        // would take rerolls off everyone who spent 15 and 20 skill points on those nodes and make
+        // nine translated strings wrong, which is not a thing to do quietly in a patch. If the
+        // weekly allowance is ever meant to be flat, the tooltip has to change with it.
         maxRerolls += App.SkillTree?.GetDailyFreeRerolls() ?? 0;
         maxRerolls += App.Settings?.Current?.BonusWeeklyRerolls ?? 0;
         return Math.Max(0, maxRerolls - WeeklyRerollsUsed);

--- a/ConditioningControlPanel/Services/Progression/QuestHardwareGate.cs
+++ b/ConditioningControlPanel/Services/Progression/QuestHardwareGate.cs
@@ -76,13 +76,21 @@ internal sealed class QuestHardwareGate
         _microphone.Start();
     }
 
-    /// <summary>The enumeration the Lab tab shows "(no cameras detected)" from; the service's
-    /// DirectShow + WinRT/MF pair is repeated for a roll that happens before it is up.</summary>
+    /// <summary>The enumeration the Lab tab shows "(no cameras detected)" from - the service's
+    /// DirectShow + WinRT/MF pair, repeated here so a roll that happens before the service is up
+    /// still gets an answer.</summary>
+    // STRICT on purpose, and NOT WebcamTrackingService.EnumerateDevices(): every lenient path
+    // (the DirectShow catch, the WinRT catch and timeout, the "CLSID could not be resolved" and
+    // "activation returned null" exits) turns a failure into an EMPTY LIST, which this gate would
+    // then read as absent AND resolved - a camera owner silently loses all four blink quests, the
+    // board drops the one it is holding, and no recheck is ever armed because the answer looked
+    // final. A camera that cannot be COUNTED is not a camera that is MISSING. The strict pair
+    // throws instead, CachedProbe.Run catches, and the answer is present + UNRESOLVED, exactly
+    // like the mic. Only a clean enumeration that really found nothing says "no camera".
     private static bool DetectCamera()
     {
-        var svc = App.Webcam;
-        if (svc != null) return svc.EnumerateDevices().Count > 0;
-        return WebcamDeviceEnumerator.Enumerate().Count > 0 || WebcamWinRtEnumerator.Enumerate().Count > 0;
+        if (WebcamDeviceEnumerator.EnumerateStrict().Count > 0) return true;
+        return WebcamWinRtEnumerator.EnumerateStrict().Count > 0;
     }
 
     /// <summary>The same WaveIn enumeration the speech mic picker is built from - no new probe.</summary>

--- a/ConditioningControlPanel/Services/Progression/QuestService.cs
+++ b/ConditioningControlPanel/Services/Progression/QuestService.cs
@@ -125,6 +125,10 @@ public class QuestService : IDisposable
 
         Progress = LoadProgress();
 
+        // BEFORE the board is looked at, and before PatreonService can tidy up behind us
+        // (ccp-bugs#1186 / #1192, the upgrade case). See BootstrapPremiumHistory.
+        BootstrapPremiumHistory();
+
         // Check for expired quests and generate new ones
         CheckAndGenerateQuests();
 
@@ -789,9 +793,50 @@ public class QuestService : IDisposable
 
         var settings = App.Settings?.Current;
         if (settings == null) return false;
-        return settings.PatreonPremiumValidUntil != null
-            || settings.PatreonLabValidUntil != null
-            || settings.PatreonTier > 0;
+        return HasPremiumEvidenceInSettings(
+            settings.PatreonPremiumValidUntil, settings.PatreonLabValidUntil, settings.PatreonTier);
+    }
+
+    /// <summary>
+    /// The settings half of "was this account ever premium", as a pure predicate so the launch
+    /// bootstrap and the live read cannot drift apart. Any one of the three is enough: both grace
+    /// stamps are only ever written by a validation that came back premium and are left NON-NULL
+    /// once expired, and PatreonTier is the same signal from the UI cache. All three absent is the
+    /// genuinely free account, and only that.
+    /// </summary>
+    internal static bool HasPremiumEvidenceInSettings(
+        DateTime? patreonPremiumValidUntil, DateTime? patreonLabValidUntil, int patreonTier)
+        => patreonPremiumValidUntil != null || patreonLabValidUntil != null || patreonTier > 0;
+
+    /// <summary>
+    /// THE UPGRADE CASE (ccp-bugs#1186 / #1192). LastPremiumSeenUtc is new in 6.9.4, so it is null
+    /// for every install arriving from 6.9.3, and the settings evidence WasEverPremium falls back
+    /// on is NOT durable: on a launch with no Patreon tokens and no unified session,
+    /// PatreonService.InitializeAsync zeroes PatreonTier and nulls both grace stamps - and it does
+    /// that AFTER this constructor but BEFORE any drop decision, so by the time the keep gate asks,
+    /// a lapsed patron looks exactly like someone who was never a patron at all. Their 18/25
+    /// premium quest was then dropped, on the first launch of this release, once.
+    ///
+    /// Reading the evidence HERE, while it is still on disk, turns it into the durable stamp the
+    /// gate was designed around. It can only ever ADD history, never remove it, so the intended
+    /// "never a patron, drop the quest they cannot finish" case is untouched: an account with no
+    /// evidence gets no stamp.
+    /// </summary>
+    private void BootstrapPremiumHistory()
+    {
+        if (Progress.LastPremiumSeenUtc != null) return;
+
+        var settings = App.Settings?.Current;
+        if (settings == null) return;
+        if (!HasPremiumEvidenceInSettings(
+                settings.PatreonPremiumValidUntil, settings.PatreonLabValidUntil, settings.PatreonTier))
+            return;
+
+        Progress.LastPremiumSeenUtc = DateTime.UtcNow;
+        _isDirty = true;
+        App.Logger?.Information(
+            "Quest premium history bootstrapped from cached Patreon state (tier {Tier}, premium grace {Premium}, lab grace {Lab})",
+            settings.PatreonTier, settings.PatreonPremiumValidUntil, settings.PatreonLabValidUntil);
     }
 
     /// <summary>

--- a/ConditioningControlPanel/Services/Webcam/WebcamDeviceEnumerator.cs
+++ b/ConditioningControlPanel/Services/Webcam/WebcamDeviceEnumerator.cs
@@ -46,7 +46,33 @@ namespace ConditioningControlPanel.Services
             int Write([MarshalAs(UnmanagedType.LPWStr)] string pszPropName, ref object pVar);
         }
 
+        /// <summary>
+        /// The forgiving form, and the one the webcam tracking feature uses: anything that goes
+        /// wrong is logged and read as "no cameras", because a device picker that throws is worse
+        /// than an empty one. Callers that must be able to tell "there is no camera" apart from
+        /// "the camera could not be counted" want <see cref="EnumerateStrict"/>.
+        /// </summary>
         public static IReadOnlyList<WebcamDevice> Enumerate()
+        {
+            try
+            {
+                return EnumerateStrict();
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Warning(ex, "WebcamDeviceEnumerator: enumeration threw");
+                return new List<WebcamDevice>();
+            }
+        }
+
+        /// <summary>
+        /// The same enumeration with the swallow taken off: a broken COM registration, a wedged
+        /// driver or a privacy block THROWS instead of returning an empty list. Only a clean run
+        /// that genuinely found nothing returns empty. The quest hardware gate needs that
+        /// distinction - an error read as "absent" is an answer it would then trust forever - and
+        /// nothing else should care.
+        /// </summary>
+        public static IReadOnlyList<WebcamDevice> EnumerateStrict()
         {
             var devices = new List<WebcamDevice>();
             ICreateDevEnum? devEnum = null;
@@ -56,21 +82,19 @@ namespace ConditioningControlPanel.Services
             {
                 var devEnumType = Type.GetTypeFromCLSID(CLSID_SystemDeviceEnum);
                 if (devEnumType == null)
-                {
-                    App.Logger?.Warning("WebcamDeviceEnumerator: SystemDeviceEnum CLSID could not be resolved");
-                    return devices;
-                }
+                    throw new InvalidOperationException("SystemDeviceEnum CLSID could not be resolved");
 
                 devEnum = Activator.CreateInstance(devEnumType) as ICreateDevEnum;
                 if (devEnum == null)
-                {
-                    App.Logger?.Warning("WebcamDeviceEnumerator: ICreateDevEnum activation returned null");
-                    return devices;
-                }
+                    throw new InvalidOperationException("ICreateDevEnum activation returned null");
 
                 Guid videoCat = CLSID_VideoInputDeviceCategory;
                 int hr = devEnum.CreateClassEnumerator(ref videoCat, out enumMoniker, 0);
                 // hr == 0 (S_OK) → enumMoniker valid; hr == 1 (S_FALSE) → no devices.
+                // A negative hr is a FAILURE, not an empty machine, so it throws.
+                if (hr < 0)
+                    throw Marshal.GetExceptionForHR(hr)
+                        ?? new InvalidOperationException($"CreateClassEnumerator failed (0x{hr:X8})");
                 if (hr != 0 || enumMoniker == null)
                 {
                     return devices;
@@ -115,10 +139,6 @@ namespace ConditioningControlPanel.Services
                     devices.Add(new WebcamDevice(idx, name));
                     idx++;
                 }
-            }
-            catch (Exception ex)
-            {
-                App.Logger?.Warning(ex, "WebcamDeviceEnumerator: enumeration threw");
             }
             finally
             {

--- a/ConditioningControlPanel/Services/Webcam/WebcamWinRtEnumerator.cs
+++ b/ConditioningControlPanel/Services/Webcam/WebcamWinRtEnumerator.cs
@@ -23,38 +23,52 @@ namespace ConditioningControlPanel.Services
     /// </summary>
     public static class WebcamWinRtEnumerator
     {
+        /// <summary>
+        /// The forgiving form, used by the device picker: a throw or a timeout is logged and read
+        /// as "no cameras". See <see cref="EnumerateStrict"/> for the one caller that must tell an
+        /// empty machine apart from a failed count.
+        /// </summary>
         public static IReadOnlyList<WebcamDeviceEnumerator.WebcamDevice> Enumerate()
         {
-            var devices = new List<WebcamDeviceEnumerator.WebcamDevice>();
             try
             {
-                // Run the async enumeration on a thread-pool thread and block the
-                // caller with a timeout. FindAllAsync completes off the caller's
-                // context so this can't deadlock the UI thread, and the timeout
-                // guards against a wedged device-enumeration service.
-                var task = Task.Run(async () =>
-                    await DeviceInformation.FindAllAsync(DeviceClass.VideoCapture));
-
-                if (!task.Wait(TimeSpan.FromSeconds(5)))
-                {
-                    App.Logger?.Warning("WebcamWinRtEnumerator: FindAllAsync timed out");
-                    return devices;
-                }
-
-                var collection = task.Result;
-                int idx = 0;
-                foreach (var di in collection)
-                {
-                    var name = string.IsNullOrWhiteSpace(di.Name) ? "(unnamed device)" : di.Name;
-                    devices.Add(new WebcamDeviceEnumerator.WebcamDevice(idx, name));
-                    idx++;
-                }
-                App.Logger?.Information("WebcamWinRtEnumerator: {Count} video-capture device(s) via WinRT", devices.Count);
+                return EnumerateStrict();
             }
             catch (Exception ex)
             {
                 App.Logger?.Warning(ex, "WebcamWinRtEnumerator: enumeration threw");
+                return new List<WebcamDeviceEnumerator.WebcamDevice>();
             }
+        }
+
+        /// <summary>
+        /// The same enumeration with the swallow taken off: a wedged device-enumeration service
+        /// (the timeout) or a WinRT failure THROWS, so only a clean run that found nothing returns
+        /// empty. The quest hardware gate is the caller that needs that difference.
+        /// </summary>
+        public static IReadOnlyList<WebcamDeviceEnumerator.WebcamDevice> EnumerateStrict()
+        {
+            var devices = new List<WebcamDeviceEnumerator.WebcamDevice>();
+
+            // Run the async enumeration on a thread-pool thread and block the
+            // caller with a timeout. FindAllAsync completes off the caller's
+            // context so this can't deadlock the UI thread, and the timeout
+            // guards against a wedged device-enumeration service.
+            var task = Task.Run(async () =>
+                await DeviceInformation.FindAllAsync(DeviceClass.VideoCapture));
+
+            if (!task.Wait(TimeSpan.FromSeconds(5)))
+                throw new TimeoutException("WebcamWinRtEnumerator: FindAllAsync timed out");
+
+            var collection = task.Result;
+            int idx = 0;
+            foreach (var di in collection)
+            {
+                var name = string.IsNullOrWhiteSpace(di.Name) ? "(unnamed device)" : di.Name;
+                devices.Add(new WebcamDeviceEnumerator.WebcamDevice(idx, name));
+                idx++;
+            }
+            App.Logger?.Information("WebcamWinRtEnumerator: {Count} video-capture device(s) via WinRT", devices.Count);
             return devices;
         }
     }

--- a/Tests/ConditioningControlPanel.Tests/QuestHardwareRollTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/QuestHardwareRollTests.cs
@@ -169,6 +169,56 @@ public class QuestHardwareRollTests
         Assert.False(settled.HasCamera);         // the real answer, in time for the recheck
     }
 
+    // ---- THE CAMERA PROBE'S THREE ANSWERS. A camera that cannot be COUNTED is not a camera that
+    // is MISSING: the enumerators the probe calls used to turn a broken COM registration, a wedged
+    // driver or a privacy block into an empty list, and an empty list reads as absent AND RESOLVED
+    // - the one combination this gate must never produce by accident, because it is permanent.
+
+    [Fact]
+    public void AnEnumerationThatThrows_ReadsPresentAndUNRESOLVED()
+    {
+        int probes = 0;
+        var gate = new QuestHardwareGate(
+            () => { System.Threading.Interlocked.Increment(ref probes); throw new InvalidOperationException("COM registration is broken"); },
+            () => true);
+
+        // Snapshot kicks the probe off and waits on it; a loaded runner may need more than the
+        // gate's 400ms budget, and the in-flight task is reused rather than probed again.
+        var deadline = DateTime.UtcNow.AddSeconds(5);
+        QuestHardwareState snapshot;
+        do { snapshot = gate.Snapshot(); }
+        while (System.Threading.Volatile.Read(ref probes) == 0 && DateTime.UtcNow < deadline);
+
+        Assert.Equal(1, System.Threading.Volatile.Read(ref probes));   // it ran, and it threw
+        Assert.True(snapshot.HasCamera);   // fail open: nobody loses four blink quests to a throw
+        Assert.False(snapshot.Resolved);   // ...and the recheck is armed, so it is not forever
+    }
+
+    [Fact]
+    public void ACleanEnumerationThatFoundNothing_ReadsAbsentAndRESOLVED()
+    {
+        var snapshot = SpinUntilResolved(new QuestHardwareGate(() => false, () => true));
+        Assert.False(snapshot.HasCamera);
+        Assert.True(snapshot.Resolved);    // the only way to say "this machine has no camera"
+    }
+
+    [Fact]
+    public void ACleanEnumerationThatFoundACamera_ReadsPresentAndRESOLVED()
+    {
+        var snapshot = SpinUntilResolved(new QuestHardwareGate(() => true, () => true));
+        Assert.True(snapshot.HasCamera);
+        Assert.True(snapshot.Resolved);
+    }
+
+    [Fact]
+    public void TheDevicePickersEnumeration_StillSwallowsItsOwnFailures()
+    {
+        // The other half of the fix: the strict form is for the gate alone. The webcam tracking
+        // feature keeps the forgiving one, so a device list that cannot be built is still an empty
+        // picker rather than an exception in the Lab tab.
+        Assert.Null(Record.Exception(() => WebcamDeviceEnumerator.Enumerate()));
+    }
+
     [Fact]
     public void ASettledProbe_IsResolved_SoNoRecheckIsArmedForever()
     {

--- a/Tests/ConditioningControlPanel.Tests/QuestPremiumDropTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/QuestPremiumDropTests.cs
@@ -1,3 +1,4 @@
+using System;
 using ConditioningControlPanel.Services;
 using Xunit;
 
@@ -35,6 +36,44 @@ public class QuestPremiumDropTests
             entitlementResolved: true, wasEverPremium: true, currentProgress: 0));
         Assert.True(QuestService.CanDropPremiumQuest(
             entitlementResolved: true, wasEverPremium: false, currentProgress: 0));
+    }
+
+    // ---- THE UPGRADE CASE. LastPremiumSeenUtc is new in 6.9.4, so the first launch after an
+    // upgrade has to reconstruct "was this account ever premium" from the cached Patreon state -
+    // and it has to do it BEFORE PatreonService clears that state on a tokenless launch.
+
+    [Fact]
+    public void UpgradingFromAnExpiredGraceStamp_CountsAsHistory_SoTheQuestSurvives()
+    {
+        // 6.9.3 install, tier-2 patron who cancelled last month: the grace stamp is past-dated and
+        // left non-null, which is exactly the evidence wanted.
+        var lapsed = DateTime.UtcNow.AddDays(-30);
+        Assert.True(QuestService.HasPremiumEvidenceInSettings(lapsed, null, patreonTier: 0));
+        Assert.True(QuestService.HasPremiumEvidenceInSettings(null, lapsed, patreonTier: 0));
+
+        Assert.False(QuestService.CanDropPremiumQuest(
+            entitlementResolved: true, wasEverPremium: true, currentProgress: 18));
+    }
+
+    [Fact]
+    public void AFreshAccountThatWasNeverPremium_HasNoHistory_AndStillLosesTheQuest()
+    {
+        // The case the bootstrap must not regress: no stamp, no grace, no tier, nothing to keep.
+        Assert.False(QuestService.HasPremiumEvidenceInSettings(null, null, patreonTier: 0));
+
+        Assert.True(QuestService.CanDropPremiumQuest(
+            entitlementResolved: true, wasEverPremium: false, currentProgress: 18));
+    }
+
+    [Fact]
+    public void ACurrentPatron_CountsAsHistory_FromEitherSignal()
+    {
+        Assert.True(QuestService.HasPremiumEvidenceInSettings(
+            DateTime.UtcNow.AddDays(14), null, patreonTier: 0));
+        Assert.True(QuestService.HasPremiumEvidenceInSettings(null, null, patreonTier: 2));
+
+        Assert.False(QuestService.CanDropPremiumQuest(
+            entitlementResolved: true, wasEverPremium: true, currentProgress: 18));
     }
 
     [Fact]


### PR DESCRIPTION
Three reviewed defects from the v6.9.4 quest gating work (#1048, review fix 83efb7ba4).

## 1. The camera probe failed CLOSED

`QuestHardwareGate.DetectCamera()` went through enumerators that turn every failure into an empty list: the DirectShow catch, the WinRT catch and its 5s timeout, and the two "CLSID could not be resolved" / "activation returned null" exits. The gate reads an empty list as absent AND resolved, so a user with a real webcam behind a wedged driver, a broken COM registration or a camera privacy block lost all four blink quests from the pool permanently, had any zero-progress blink quest dropped off their board, and never got a recheck, because `_hardwareRecheckPending` only arms on an unresolved probe. That is the inversion the gate's own doc forbids, and the opposite of what the mic fix did.

Both enumerators now come in two forms:

- `Enumerate()` keeps the swallow and keeps serving the webcam tracking feature and the Lab device picker, where an empty list beats an exception. Behaviour there is unchanged.
- `EnumerateStrict()` lets the failure through, and that is what the quest probe calls. A throw reaches `CachedProbe.Run`, which answers present + UNRESOLVED and arms the recheck, mirroring the mic.

Only a clean enumeration that genuinely found nothing may now say "this machine has no camera".

## 2. A lapsed patron lost an in-progress premium quest on the first 6.9.4 launch

`Progress.LastPremiumSeenUtc` is new this release, so it is null for every install arriving from 6.9.3, and the settings evidence `WasEverPremium` falls back on is not durable. On a launch with no Patreon tokens and no unified session, `PatreonService.InitializeAsync` zeroes `PatreonTier` and nulls both grace stamps, and it does that after `QuestService` is constructed (App.xaml.cs:2021) but before any drop decision (Patreon init is kicked off at :2527). By the time the keep gate asked, a tier-2 patron who cancelled last month looked exactly like someone who had never been a patron, and their 18/25 premium quest was dropped and logged as "this account has never had premium access".

The quest service now reads that evidence in its constructor, while it is still on disk, and stamps the history. It can only ever add history, never remove it, so the intended "never a patron, drop the quest they cannot finish" case is untouched: no grace stamp, no tier, no history means no stamp and the quest still goes. The predicate is split out as `HasPremiumEvidenceInSettings` so the launch bootstrap and the live read cannot drift apart.

## 3. The weekly reroll allowance: investigated, left alone

`QuestProgress.cs` adding `GetDailyFreeRerolls()` to the WEEKLY allowance looks like a paste from the daily branch six lines up. It is not one to undo:

- The skill tree has no weekly reroll node. `quest_refresh` and `reroll_addict` are the only two effects that feed `GetDailyFreeRerolls`, so the question is only whether their bonus applies to one budget or both.
- The copy shipping in this release answers it. `tooltip_reroll_for_a_different_quest_once_per_week` reads "One reroll a week, three with Patreon, plus anything the skill tree adds", and all nine languages carry that clause (written by the copy pass in cbe368dca).
- Removing the line would take up to 3 weekly rerolls off everyone who spent 15 and 20 skill points on those nodes, and make nine translated strings wrong, quietly, in a polish patch.

Left as is, with a comment recording the reasoning and naming the tooltip that has to move with it if the weekly allowance is ever meant to be flat. Worth an owner decision, not a silent nerf.

## Verification

- `dotnet build ConditioningControlPanel/ConditioningControlPanel.csproj -c Debug`: 0 errors, 364 warnings (unchanged from the branch baseline; no new warning site on an added line).
- `dotnet test --filter "FullyQualifiedName~Quest|FullyQualifiedName~Hardware|FullyQualifiedName~Patreon"`: 110 passed, 0 failed.
- Full suite: 5842 passed, 0 failed, 0 skipped (5835 before, +7 new tests).

New tests: an enumeration that throws reads present + unresolved; a clean empty read reads absent + resolved; a clean non-empty read reads present + resolved; the device picker's lenient enumeration still swallows its own failures; expired grace stamp counts as premium history; a fresh never-premium account does not; a current patron does from either signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013mR8cAipk1ivr3Em5fJjcx
