### PR TITLE
fix(mods): a Bambi install keeps its intake niche, its pet name and its banner

### DIFF
--- a/ConditioningControlPanel/MainWindow/MainWindow.Marquee.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.Marquee.cs
@@ -652,21 +652,45 @@ namespace ConditioningControlPanel
 
         #region Marquee Banner
 
+        /// <summary>
+        /// The banner to show when there is nothing of the user's to show - a blank saved message or
+        /// one of the retired house defaults. Resolves through the active mod (which walks to CCP
+        /// Default, whose banner is the neutral <see cref="AppSettings.DefaultMarqueeMessage"/>), so
+        /// an unmodded install is neutral and a themed one keeps its own line. Never called over
+        /// text the user typed.
+        /// </summary>
+        private static string ResolveDefaultMarqueeMessage()
+        {
+            try
+            {
+                var banner = App.Mods?.GetMarqueeBannerMessage();
+                if (!string.IsNullOrWhiteSpace(banner)) return banner!;
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Warning(ex, "Marquee: mod banner lookup failed; using the neutral default");
+            }
+            return AppSettings.DefaultMarqueeMessage;
+        }
+
         private void InitializeMarqueeBanner()
         {
             try
             {
-                // One-shot: users still parked on the old gendered default get the neutral one.
-                // Anyone who typed their own banner is left alone.
-                App.Settings.Current.MigrateMarqueeMessage();
+                // One-shot: users on an UNMODDED install still parked on the old gendered default
+                // get the neutral one. A themed mod is skipped - that text is its voice. Anyone who
+                // typed their own banner is left alone either way.
+                App.Settings.Current.MigrateMarqueeMessage(App.Mods?.ActiveModId);
 
-                // Migrate old message to new default if needed
+                // Migrate old message to new default if needed. The replacement comes from the
+                // active mod, not the neutral const: this branch only fires on a banner the user
+                // never wrote, and handing a Bambi install the house line is the same regression.
                 var currentSaved = App.Settings.Current.MarqueeMessage;
                 if (string.IsNullOrWhiteSpace(currentSaved) ||
                     currentSaved.Contains("WELCOME TO YOUR CONDITIONING") ||
                     currentSaved.Contains("RELAX AND SUBMIT"))
                 {
-                    App.Settings.Current.MarqueeMessage = AppSettings.DefaultMarqueeMessage;
+                    App.Settings.Current.MarqueeMessage = ResolveDefaultMarqueeMessage();
                 }
 
                 // Need to wait for layout to measure text width
@@ -1147,7 +1171,7 @@ namespace ConditioningControlPanel
                 var message = App.Settings.Current.MarqueeMessage;
                 if (string.IsNullOrWhiteSpace(message))
                 {
-                    message = AppSettings.DefaultMarqueeMessage;
+                    message = ResolveDefaultMarqueeMessage();
                 }
                 message = message.ToUpperInvariant();
 

--- a/ConditioningControlPanel/Models/AppSettings.cs
+++ b/ConditioningControlPanel/Models/AppSettings.cs
@@ -2098,15 +2098,31 @@ namespace ConditioningControlPanel.Models
         }
 
         /// <summary>
-        /// Move existing users off the old gendered default banner text. Keyed on an exact match of
-        /// <see cref="LegacyGenderedMarqueeMessage"/>, so anyone who customised their banner - by even
-        /// one character - keeps what they wrote. Runs once, from InitializeMarqueeBanner().
+        /// Move users with NO themed mod off the old gendered default banner text. Keyed on an exact
+        /// match of <see cref="LegacyGenderedMarqueeMessage"/>, so anyone who customised their banner
+        /// - by even one character - keeps what they wrote. Runs once, from InitializeMarqueeBanner().
+        ///
+        /// <para>A themed mod is skipped and the one-shot flag is still latched, deliberately. The
+        /// old text is that mod's own voice, so rewriting it is the visible, one-way change 6.9.4
+        /// promised would not happen to anyone with a mod active; and latching means a later switch
+        /// to CCP Default does not spring the same rewrite on them months afterwards.</para>
         /// </summary>
-        internal void MigrateMarqueeMessage()
+        /// <param name="activeModId">
+        /// <see cref="Services.ModService.ActiveModId"/>. Null means the mod layer is not up yet, and
+        /// the migration DEFERS - it neither rewrites nor latches, so the next launch that does know
+        /// the mod decides. ModService is constructed in App.OnStartup, well before the only caller,
+        /// so the deferral is a safety net rather than an expected path.
+        /// </param>
+        internal void MigrateMarqueeMessage(string? activeModId)
         {
             if (_marqueeNeutralDefaultMigrated) return;
-            if (string.Equals(_marqueeMessage?.Trim(), LegacyGenderedMarqueeMessage.Trim(), StringComparison.Ordinal))
+            if (string.IsNullOrWhiteSpace(activeModId)) return;
+
+            if (string.Equals(activeModId, BuiltInMods.CCPDefaultId, StringComparison.Ordinal) &&
+                string.Equals(_marqueeMessage?.Trim(), LegacyGenderedMarqueeMessage.Trim(), StringComparison.Ordinal))
+            {
                 MarqueeMessage = DefaultMarqueeMessage;
+            }
             MarqueeNeutralDefaultMigrated = true;
         }
 

--- a/ConditioningControlPanel/Models/BuiltInMods.cs
+++ b/ConditioningControlPanel/Models/BuiltInMods.cs
@@ -54,7 +54,12 @@ namespace ConditioningControlPanel.Models
                     ModeDisplayName = "Bambi Sleep",
                     TalkToLabel = "Talk to Bambi",
                     TakeoverLabel = "Bambi Takeover",
-                    Affirmation = "Good Girl"
+                    Affirmation = "Good Girl",
+                    // Descent vocabulary. "good girl" is not decoration here: it is the exact word
+                    // the Deeper speak prompt praised every user with until 6.9.4 routed that seed
+                    // through {petname}, and an unset PetName made it read "sweetie" for this mod.
+                    PetName = "good girl",
+                    Collective = "good girls"
                 },
 
                 SubliminalPool = new Dictionary<string, bool>
@@ -132,7 +137,10 @@ namespace ConditioningControlPanel.Models
                     AttentionCheckTroll = "GOOD GIRL!\nWATCH AGAIN \U0001F61C",
                     GazeCorrect = "GOOD GIRL",
                     QuizTrickQuestion = "Are you a good girl?",
-                    QuizTrickAnswer = "Obviously"
+                    QuizTrickAnswer = "Obviously",
+                    // The 6.9.3 house banner. It shipped as the default on every install, so a user
+                    // of this mod who never edited the marquee had been reading it for years.
+                    MarqueeBanner = "GOOD GIRLS CONDITION DAILY     ❤️🔒"
                 },
 
                 Browser = new ModBrowser
@@ -499,7 +507,11 @@ namespace ConditioningControlPanel.Models
                     TalkToLabel = "Ask your Bimbo",
                     TakeoverLabel = "Bimbo Takeover",
                     Affirmation = "babe",
-                    RankSubject = "Babe"
+                    RankSubject = "Babe",
+                    // Same 6.9.3 word as BambiSleep, for the same reason #1053 gave this mod the
+                    // same gaze and troll lines: they were shared literals, and both mods speak it.
+                    PetName = "good girl",
+                    Collective = "good girls"
                 },
 
                 // NO BAMBISLEEP TRIGGERS IN HERE. This pool started life as the BambiSleep pool
@@ -587,7 +599,8 @@ namespace ConditioningControlPanel.Models
                     AttentionCheckTroll = "GOOD GIRL!\nWATCH AGAIN \U0001F61C",
                     GazeCorrect = "GOOD GIRL",
                     QuizTrickQuestion = "Are you a good girl?",
-                    QuizTrickAnswer = "Obviously"
+                    QuizTrickAnswer = "Obviously",
+                    MarqueeBanner = "GOOD GIRLS CONDITION DAILY     ❤️🔒"
                 },
 
                 Browser = new ModBrowser
@@ -983,6 +996,10 @@ namespace ConditioningControlPanel.Models
                     TalkToLabel = "Talk to Companion",
                     TakeoverLabel = "Takeover",
                     Affirmation = "Subject"
+                    // PetName/Collective deliberately unset: the neutral pair is owner-locked at
+                    // VocabTokens.VanillaPetName / VanillaCollective ("sweetie"/"sweeties"), and
+                    // that const is the single config point. Naming it again here would make the
+                    // two drift the first time one of them is edited.
                 },
 
                 SubliminalPool = new Dictionary<string, bool>
@@ -1053,7 +1070,11 @@ namespace ConditioningControlPanel.Models
                     // The neutral answers. CCP Default is the base mod, so these are also
                     // what a mod that names neither of them falls back to.
                     AttentionCheckTroll = "NICE TRY!\nWATCH AGAIN \U0001F61C",
-                    GazeCorrect = "GOOD"
+                    GazeCorrect = "GOOD",
+                    // Kept identical to AppSettings.DefaultMarqueeMessage: an unmodded install
+                    // never reads this field (the settings default is already this text), so the
+                    // two can only drift on a mod that names no banner of its own.
+                    MarqueeBanner = "CONDITION DAILY     ❤️🔒"
                     // No QuizTrickQuestion on purpose: the neutral trick pool is the
                     // six-line array in QuizWindow, and that accessor never walks to base.
                 },
@@ -1324,7 +1345,10 @@ namespace ConditioningControlPanel.Models
                     ModeDisplayName = "Drone Mode",
                     TalkToLabel = "Query DroneOS",
                     TakeoverLabel = "System Override",
-                    Affirmation = "Unit"
+                    Affirmation = "Unit",
+                    // Its own voice rather than the 6.9.3 shared word, which was never a fit here.
+                    PetName = "unit",
+                    Collective = "units"
                 },
 
                 SubliminalPool = new Dictionary<string, bool>
@@ -1401,7 +1425,8 @@ namespace ConditioningControlPanel.Models
                     AttentionCheckTroll = "COMPLIANCE LOGGED\nRE-RUN ANYWAY \U0001F61C",
                     GazeCorrect = "COMPLIANT",
                     QuizTrickQuestion = "Is the unit ready to comply?",
-                    QuizTrickAnswer = "Affirmative"
+                    QuizTrickAnswer = "Affirmative",
+                    MarqueeBanner = "UNITS CONDITION DAILY     ❤️🔒"
                 },
 
                 Browser = new ModBrowser
@@ -2076,7 +2101,10 @@ namespace ConditioningControlPanel.Models
                     TalkToLabel = "Talk to Circe",
                     TakeoverLabel = "Surrender Control",
                     Affirmation = "Good boy",
-                    RankSubject = "pet"
+                    RankSubject = "pet",
+                    // Its own voice rather than the 6.9.3 shared word - a keeper addresses a pet.
+                    PetName = "pet",
+                    Collective = "pets"
                 },
 
                 SubliminalPool = new Dictionary<string, bool>
@@ -2169,7 +2197,8 @@ namespace ConditioningControlPanel.Models
                     AttentionCheckTroll = "Good pet.\nWatch it again for me \U0001F61C",
                     GazeCorrect = "GOOD PET",
                     QuizTrickQuestion = "Are you Circe's good pet?",
-                    QuizTrickAnswer = "Always"
+                    QuizTrickAnswer = "Always",
+                    MarqueeBanner = "GOOD PETS CONDITION DAILY     ❤️🔒"
                 },
 
                 Browser = new ModBrowser

--- a/ConditioningControlPanel/Models/ModManifest.cs
+++ b/ConditioningControlPanel/Models/ModManifest.cs
@@ -296,6 +296,14 @@ namespace ConditioningControlPanel.Models
         /// <summary>The answer shown on all four buttons for <see cref="QuizTrickQuestion"/>.</summary>
         [JsonProperty("quizTrickAnswer")]
         public string? QuizTrickAnswer { get; set; }
+
+        /// <summary>
+        /// This mod's default scrolling banner over the Settings marquee. Only ever used for a
+        /// banner the user has NOT written themselves: a blank saved message, or one of the two
+        /// retired house defaults. A user who typed their own banner keeps it in every mod.
+        /// </summary>
+        [JsonProperty("marqueeBanner")]
+        public string? MarqueeBanner { get; set; }
     }
 
     public class ModBrowser

--- a/ConditioningControlPanel/Services/ModService.cs
+++ b/ConditioningControlPanel/Services/ModService.cs
@@ -650,6 +650,9 @@ namespace ConditioningControlPanel.Services
                 // Capped shorter: both land inside a fixed quiz card, not a scrolling surface.
                 if (manifest.Messages.QuizTrickQuestion?.Length > 200) manifest.Messages.QuizTrickQuestion = manifest.Messages.QuizTrickQuestion[..200];
                 if (manifest.Messages.QuizTrickAnswer?.Length > 60) manifest.Messages.QuizTrickAnswer = manifest.Messages.QuizTrickAnswer[..60];
+                // The marquee scrolls one line forever; a long one is a performance problem, not a
+                // wrapping one, so it is capped hardest of the set.
+                if (manifest.Messages.MarqueeBanner?.Length > 120) manifest.Messages.MarqueeBanner = manifest.Messages.MarqueeBanner[..120];
             }
             if (manifest.Triggers != null)
             {
@@ -1173,6 +1176,14 @@ namespace ConditioningControlPanel.Services
         public string GetGazeCorrectMessage() =>
             GetStringValue(m => m.Messages?.GazeCorrect, m => m.Messages!.GazeCorrect!);
 
+        /// <summary>
+        /// This mod's default marquee banner, walking to CCP Default (the neutral house banner) for
+        /// a mod that names none. Read only where a banner has to be INVENTED - a blank saved
+        /// message, or a retired house default nobody typed - never over text the user wrote.
+        /// </summary>
+        public string GetMarqueeBannerMessage() =>
+            GetStringValue(m => m.Messages?.MarqueeBanner, m => m.Messages!.MarqueeBanner!);
+
         // The quiz trick question deliberately does NOT walk to the base mod, and deliberately
         // returns null rather than a default: the neutral pool lives in QuizWindow.TrickQuestions
         // and is six lines, not one. Null here means "this mod has no themed trick question, leave
@@ -1496,7 +1507,8 @@ namespace ConditioningControlPanel.Services
                     AttentionCheckTroll = GetAttentionCheckTrollMessage(),
                     GazeCorrect = GetGazeCorrectMessage(),
                     QuizTrickQuestion = GetQuizTrickQuestionOverride(),
-                    QuizTrickAnswer = GetQuizTrickAnswerOverride()
+                    QuizTrickAnswer = GetQuizTrickAnswerOverride(),
+                    MarqueeBanner = GetMarqueeBannerMessage()
                 },
                 Browser = new ModBrowser
                 {

--- a/ConditioningControlPanel/Services/Quiz/IntakeHostService.cs
+++ b/ConditioningControlPanel/Services/Quiz/IntakeHostService.cs
@@ -874,8 +874,9 @@ namespace ConditioningControlPanel.Services.Quiz
         /// bank-availability clamp. Mapped from the mod, not the legacy two-value ContentMode enum
         /// (which has no drone value and collapses every non-sissy mod to BambiSleep — that mapping
         /// served drone-mode users the whole bambi prompt bank). Built-in ids win; third-party mods
-        /// declare theirs via a manifest tag. Defaults to bambi. A dedicated picker is a Phase-3 UX
-        /// concern. The mapping itself now lives in <see cref="IntakeNiche"/> so the weekly pass
+        /// declare theirs via a manifest tag. Defaults to the neutral "default" niche - an install
+        /// with no themed mod signal gets the house bank, not somebody else's persona. A dedicated
+        /// picker is a Phase-3 UX concern. The mapping itself now lives in <see cref="IntakeNiche"/> so the weekly pass
         /// card and its nudge popup show art for the same niche this picks a prompt bank for.</summary>
         private static string DesiredNiche() => IntakeNiche.Current();
 

--- a/ConditioningControlPanel/Services/Quiz/IntakeNiche.cs
+++ b/ConditioningControlPanel/Services/Quiz/IntakeNiche.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Windows.Media;
 using ConditioningControlPanel.Models;
 
@@ -39,31 +40,52 @@ namespace ConditioningControlPanel.Services.Quiz
         {
             try
             {
-                var modId = App.Mods?.ActiveModId;
-                if (modId == BuiltInMods.DronificationId) return "drone";
-                if (modId == BuiltInMods.SissyHypnoId) return "sissy";
-                if (modId == BuiltInMods.LockedId) return "circe";
-
-                // Locked's own tags ("locked"/"chastity") read as circe too.
-                var tags = App.Mods?.ActiveMod?.Manifest?.Tags;
-                if (tags != null)
-                {
-                    foreach (var tag in tags)
-                    {
-                        if (string.Equals(tag, "drone", StringComparison.OrdinalIgnoreCase)) return "drone";
-                        if (string.Equals(tag, "sissy", StringComparison.OrdinalIgnoreCase)) return "sissy";
-                        if (string.Equals(tag, "circe", StringComparison.OrdinalIgnoreCase)) return "circe";
-                        if (string.Equals(tag, "locked", StringComparison.OrdinalIgnoreCase)) return "circe";
-                        if (string.Equals(tag, "chastity", StringComparison.OrdinalIgnoreCase)) return "circe";
-                    }
-                }
-
-                // Only the positive SissyHypno reading counts. ContentMode's other value means
-                // "no sissy mod", not "bambi", so everything else lands on the neutral niche.
-                if (App.Settings?.Current?.ContentMode == ContentMode.SissyHypno) return "sissy";
-                return Fallback;
+                return Resolve(
+                    App.Mods?.ActiveModId,
+                    App.Mods?.ActiveMod?.Manifest?.Tags,
+                    App.Settings?.Current?.ContentMode == ContentMode.SissyHypno);
             }
             catch { return Fallback; }
+        }
+
+        /// <summary>
+        /// The pure half of <see cref="Current"/>: mod id, then manifest tags, then the one legacy
+        /// signal. Separated so it can be exercised without an App - the four themed ids are easy to
+        /// drop one of (6.9.4 shipped without the BambiSleep branch, which silently moved every
+        /// Bambi user onto the neutral pass card and prompt bank), and a test is the only thing that
+        /// notices.
+        /// </summary>
+        /// <param name="modId">Active mod id, or null when there is no mod service yet.</param>
+        /// <param name="tags">Active mod's manifest tags, for third-party .ccpmod files.</param>
+        /// <param name="sissyContentMode">The legacy enum's one positive reading.</param>
+        internal static string Resolve(string? modId, IEnumerable<string>? tags, bool sissyContentMode)
+        {
+            // BambiSleep ships its own pass card and prompt bank, so it names its own niche here
+            // like every other themed built-in. It was the Fallback until 6.9.4 made the fallback
+            // neutral, which left "bambi" unreachable from every code path.
+            if (modId == BuiltInMods.BambiSleepId) return "bambi";
+            if (modId == BuiltInMods.DronificationId) return "drone";
+            if (modId == BuiltInMods.SissyHypnoId) return "sissy";
+            if (modId == BuiltInMods.LockedId) return "circe";
+
+            // Locked's own tags ("locked"/"chastity") read as circe too.
+            if (tags != null)
+            {
+                foreach (var tag in tags)
+                {
+                    if (string.Equals(tag, "bambi", StringComparison.OrdinalIgnoreCase)) return "bambi";
+                    if (string.Equals(tag, "drone", StringComparison.OrdinalIgnoreCase)) return "drone";
+                    if (string.Equals(tag, "sissy", StringComparison.OrdinalIgnoreCase)) return "sissy";
+                    if (string.Equals(tag, "circe", StringComparison.OrdinalIgnoreCase)) return "circe";
+                    if (string.Equals(tag, "locked", StringComparison.OrdinalIgnoreCase)) return "circe";
+                    if (string.Equals(tag, "chastity", StringComparison.OrdinalIgnoreCase)) return "circe";
+                }
+            }
+
+            // Only the positive SissyHypno reading counts. ContentMode's other value means
+            // "no sissy mod", not "bambi", so everything else lands on the neutral niche.
+            if (sissyContentMode) return "sissy";
+            return Fallback;
         }
 
         /// <summary>

--- a/ConditioningControlPanel/Views/Deeper/DeeperEditorWindow.xaml
+++ b/ConditioningControlPanel/Views/Deeper/DeeperEditorWindow.xaml
@@ -1688,7 +1688,7 @@
                             <TextBlock Text="Praise (on correct)" Style="{StaticResource EditorLabel}"/>
                             <TextBox x:Name="TxtSpeakCorrect" Style="{StaticResource EditorTextBox}"
                                      MaxLength="40"
-                                     ToolTip="Flashed after each correct rep, e.g. 'that&apos;s it, sweetie'."
+                                     ToolTip="Flashed after each correct rep."
                                      TextChanged="EffectField_TextChanged"/>
                             <TextBlock Text="Scold (on miss)" Style="{StaticResource EditorLabel}"/>
                             <TextBox x:Name="TxtSpeakIncorrect" Style="{StaticResource EditorTextBox}"

--- a/ConditioningControlPanel/Views/Deeper/DeeperEditorWindow.xaml.cs
+++ b/ConditioningControlPanel/Views/Deeper/DeeperEditorWindow.xaml.cs
@@ -166,6 +166,12 @@ namespace ConditioningControlPanel.Views.Deeper
             _playheadTimer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(80) };
             _playheadTimer.Tick += PlayheadTimer_Tick;
 
+            // The example has to name the ACTIVE mod's word, not the vanilla one: the praise this
+            // box is seeded with reads "that's it, {petname}", so a hard-coded "sweetie" advertised
+            // the wrong word to every user with a mod.
+            TxtSpeakCorrect.ToolTip =
+                $"Flashed after each correct rep, e.g. 'that's it, {Localization.VocabTokens.PetName}'.";
+
             BuildColorSwatches();
             BuildPatternCombo();
             FillHapticTargetCombo(CmbHapticTarget);

--- a/Tests/ConditioningControlPanel.Tests/NeutralModGatingWave2Tests.cs
+++ b/Tests/ConditioningControlPanel.Tests/NeutralModGatingWave2Tests.cs
@@ -1,0 +1,255 @@
+using System.Collections.Generic;
+using ConditioningControlPanel.Localization;
+using ConditioningControlPanel.Models;
+using ConditioningControlPanel.Services;
+using ConditioningControlPanel.Services.Quiz;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// The second pass over Wave 1's ungated sites. #1053 closed four; a review of the release branch
+/// found three more places where "nothing changes for anyone who already has a mod active" was
+/// false, and all three are pinned here:
+///
+/// <list type="number">
+///   <item>the weekly Intake niche, where the BambiSleep branch went missing and took the mod's
+///         pass card and prompt bank with it;</item>
+///   <item><c>Identity.PetName</c>, declared but set by no themed built-in, which made the Deeper
+///         speak prompt praise a Bambi user with the vanilla word;</item>
+///   <item>the marquee banner migration, which rewrote a themed mod's default banner once and
+///         permanently on the first launch of 6.9.4.</item>
+/// </list>
+///
+/// Everything here reads the built-in manifests or a pure resolver, so no App statics are needed.
+/// </summary>
+public class NeutralModGatingWave2Tests
+{
+    // ---- Intake niche ------------------------------------------------------
+
+    /// <summary>
+    /// The regression that started this pass: Wave 1 moved the fallback from "bambi" to "default"
+    /// without adding the branch the other three themed built-ins have, so "bambi" became
+    /// unreachable and every Bambi user silently changed pass card and prompt bank.
+    /// </summary>
+    [Theory]
+    [InlineData(BuiltInMods.BambiSleepId, "bambi")]
+    [InlineData(BuiltInMods.SissyHypnoId, "sissy")]
+    [InlineData(BuiltInMods.DronificationId, "drone")]
+    [InlineData(BuiltInMods.LockedId, "circe")]
+    public void Every_themed_builtin_names_its_own_intake_niche(string modId, string expected)
+        => Assert.Equal(expected, IntakeNiche.Resolve(modId, tags: null, sissyContentMode: false));
+
+    [Fact]
+    public void CcpDefault_and_no_mod_stay_on_the_neutral_niche()
+    {
+        Assert.Equal(IntakeNiche.Fallback, IntakeNiche.Resolve(BuiltInMods.CCPDefaultId, null, false));
+        Assert.Equal(IntakeNiche.Fallback, IntakeNiche.Resolve(null, null, false));
+    }
+
+    /// <summary>A third-party .ccpmod asks through its manifest tags instead of an id.</summary>
+    [Theory]
+    [InlineData("bambi", "bambi")]
+    [InlineData("Sissy", "sissy")]
+    [InlineData("DRONE", "drone")]
+    [InlineData("chastity", "circe")]
+    public void A_third_party_mod_asks_for_a_niche_by_tag(string tag, string expected)
+        => Assert.Equal(expected, IntakeNiche.Resolve("some-creator-mod", new List<string> { tag }, false));
+
+    /// <summary>
+    /// The legacy enum has exactly one positive reading. Its other value means "no sissy mod", not
+    /// "bambi", so it must not resurrect the pre-6.9.4 themed fallback.
+    /// </summary>
+    [Fact]
+    public void The_legacy_content_mode_only_speaks_for_sissy()
+    {
+        Assert.Equal("sissy", IntakeNiche.Resolve(null, null, sissyContentMode: true));
+        Assert.Equal(IntakeNiche.Fallback, IntakeNiche.Resolve(null, null, sissyContentMode: false));
+    }
+
+    /// <summary>Every niche the resolver can return has to be one this build ships art for.</summary>
+    [Fact]
+    public void Every_resolvable_niche_is_a_shipped_niche()
+    {
+        foreach (var modId in new[]
+                 {
+                     BuiltInMods.BambiSleepId, BuiltInMods.SissyHypnoId,
+                     BuiltInMods.DronificationId, BuiltInMods.LockedId, BuiltInMods.CCPDefaultId
+                 })
+        {
+            Assert.Contains(IntakeNiche.Resolve(modId, null, false), IntakeNiche.All);
+        }
+    }
+
+    // ---- Pet name ----------------------------------------------------------
+
+    /// <summary>
+    /// #1053 pointed the Deeper seeded praise at <c>VocabTokens.PetName</c>, but no themed built-in
+    /// set one, so the swap was a no-op and every themed mod read the vanilla word.
+    /// </summary>
+    [Theory]
+    [InlineData(nameof(BuiltInMods.BambiSleep))]
+    [InlineData(nameof(BuiltInMods.SissyHypno))]
+    [InlineData(nameof(BuiltInMods.Dronification))]
+    [InlineData(nameof(BuiltInMods.Locked))]
+    public void Every_themed_builtin_names_its_own_pet_name(string mod)
+    {
+        var identity = Manifest(mod).Identity!;
+
+        Assert.False(string.IsNullOrWhiteSpace(identity.PetName));
+        Assert.False(string.IsNullOrWhiteSpace(identity.Collective));
+        Assert.NotEqual(VocabTokens.VanillaPetName, identity.PetName);
+    }
+
+    /// <summary>
+    /// The one that has to read exactly right: in 6.9.3 a Bambi user's speak prompt praised them
+    /// with "good girl", and the seed is now "that's it, {petname}".
+    /// </summary>
+    [Fact]
+    public void BambiSleep_speak_prompt_praise_still_says_good_girl()
+    {
+        Assert.Equal("good girl", BuiltInMods.BambiSleep.Identity!.PetName);
+        Assert.Equal("that's it, good girl", $"that's it, {BuiltInMods.BambiSleep.Identity!.PetName}");
+    }
+
+    /// <summary>
+    /// CCP Default must NOT name one. VocabTokens owns the owner-locked vanilla pair, and a second
+    /// copy here would drift the first time one of the two is edited.
+    /// </summary>
+    [Fact]
+    public void CcpDefault_leaves_the_vanilla_pet_name_to_VocabTokens()
+    {
+        Assert.Null(BuiltInMods.CCPDefault.Identity!.PetName);
+        Assert.Null(BuiltInMods.CCPDefault.Identity!.Collective);
+        Assert.Equal("sweetie", VocabTokens.VanillaPetName);
+    }
+
+    // ---- Marquee banner ----------------------------------------------------
+
+    /// <summary>An unmodded install still gets moved off the gendered default exactly once.</summary>
+    [Fact]
+    public void The_marquee_migration_still_runs_for_an_unmodded_install()
+    {
+        var settings = new AppSettings { MarqueeMessage = AppSettings.LegacyGenderedMarqueeMessage };
+
+        settings.MigrateMarqueeMessage(BuiltInMods.CCPDefaultId);
+
+        Assert.Equal(AppSettings.DefaultMarqueeMessage, settings.MarqueeMessage);
+        Assert.True(settings.MarqueeNeutralDefaultMigrated);
+    }
+
+    /// <summary>
+    /// The regression: a themed mod's banner is that mod's voice, and rewriting it is a visible,
+    /// one-way change to a user who was promised none. The flag still latches, so a later switch to
+    /// CCP Default does not spring the same rewrite on them months afterwards.
+    /// </summary>
+    [Theory]
+    [InlineData(BuiltInMods.BambiSleepId)]
+    [InlineData(BuiltInMods.SissyHypnoId)]
+    [InlineData(BuiltInMods.DronificationId)]
+    [InlineData(BuiltInMods.LockedId)]
+    [InlineData("some-creator-mod")]
+    public void A_themed_mod_keeps_its_banner_and_is_never_asked_again(string modId)
+    {
+        var settings = new AppSettings { MarqueeMessage = AppSettings.LegacyGenderedMarqueeMessage };
+
+        settings.MigrateMarqueeMessage(modId);
+
+        Assert.Equal(AppSettings.LegacyGenderedMarqueeMessage, settings.MarqueeMessage);
+        Assert.True(settings.MarqueeNeutralDefaultMigrated);
+    }
+
+    /// <summary>
+    /// No mod service yet means no answer yet. The migration defers rather than guessing, because
+    /// guessing wrong here is permanent.
+    /// </summary>
+    [Fact]
+    public void An_unknown_mod_defers_the_migration_instead_of_guessing()
+    {
+        var settings = new AppSettings { MarqueeMessage = AppSettings.LegacyGenderedMarqueeMessage };
+
+        settings.MigrateMarqueeMessage(null);
+
+        Assert.Equal(AppSettings.LegacyGenderedMarqueeMessage, settings.MarqueeMessage);
+        Assert.False(settings.MarqueeNeutralDefaultMigrated);
+    }
+
+    /// <summary>A banner the user wrote is never touched, in any mod.</summary>
+    [Fact]
+    public void A_hand_written_banner_survives_the_migration()
+    {
+        var settings = new AppSettings { MarqueeMessage = "MY OWN WORDS" };
+
+        settings.MigrateMarqueeMessage(BuiltInMods.CCPDefaultId);
+
+        Assert.Equal("MY OWN WORDS", settings.MarqueeMessage);
+    }
+
+    /// <summary>It is a one-shot: a user who types the old text back in keeps it.</summary>
+    [Fact]
+    public void The_migration_never_runs_twice()
+    {
+        var settings = new AppSettings
+        {
+            MarqueeMessage = AppSettings.LegacyGenderedMarqueeMessage,
+            MarqueeNeutralDefaultMigrated = true
+        };
+
+        settings.MigrateMarqueeMessage(BuiltInMods.CCPDefaultId);
+
+        Assert.Equal(AppSettings.LegacyGenderedMarqueeMessage, settings.MarqueeMessage);
+    }
+
+    /// <summary>
+    /// The blank-banner fallback resolves through the mod, so every built-in has to name one, and
+    /// CCP Default's has to be the neutral const the settings default already uses.
+    /// </summary>
+    [Fact]
+    public void CcpDefault_banner_is_the_neutral_settings_default()
+        => Assert.Equal(AppSettings.DefaultMarqueeMessage, BuiltInMods.CCPDefault.Messages!.MarqueeBanner);
+
+    [Fact]
+    public void BambiSleep_and_SissyHypno_keep_the_6_9_3_banner()
+    {
+        Assert.Equal(AppSettings.LegacyGenderedMarqueeMessage, BuiltInMods.BambiSleep.Messages!.MarqueeBanner);
+        Assert.Equal(AppSettings.LegacyGenderedMarqueeMessage, BuiltInMods.SissyHypno.Messages!.MarqueeBanner);
+    }
+
+    [Theory]
+    [InlineData(nameof(BuiltInMods.Dronification))]
+    [InlineData(nameof(BuiltInMods.Locked))]
+    public void The_two_mods_the_6_9_3_banner_never_fitted_speak_for_themselves(string mod)
+    {
+        var banner = Manifest(mod).Messages!.MarqueeBanner;
+
+        Assert.False(string.IsNullOrWhiteSpace(banner));
+        Assert.NotEqual(AppSettings.LegacyGenderedMarqueeMessage, banner);
+        Assert.NotEqual(AppSettings.DefaultMarqueeMessage, banner);
+    }
+
+    /// <summary>Author-supplied in a downloaded .ccpmod, so capped like every other manifest string.</summary>
+    [Fact]
+    public void An_over_long_mod_banner_is_truncated_not_rejected()
+    {
+        var manifest = new ModManifest
+        {
+            Id = "test-banner-cap",
+            Name = "Banner cap",
+            Messages = new ModMessages { MarqueeBanner = new string('x', 900) }
+        };
+
+        var error = ModService.SanitizeManifest(manifest);
+
+        Assert.Null(error);
+        Assert.Equal(120, manifest.Messages.MarqueeBanner!.Length);
+    }
+
+    private static ModManifest Manifest(string name) => name switch
+    {
+        nameof(BuiltInMods.BambiSleep) => BuiltInMods.BambiSleep,
+        nameof(BuiltInMods.SissyHypno) => BuiltInMods.SissyHypno,
+        nameof(BuiltInMods.Dronification) => BuiltInMods.Dronification,
+        nameof(BuiltInMods.Locked) => BuiltInMods.Locked,
+        _ => BuiltInMods.CCPDefault
+    };
+}


### PR DESCRIPTION
The release notes promise "a fresh install with no mod picked is neutral by default. nothing changes for anyone who already has a mod active." The review of `release/6.9.4` found the second sentence is false in several places. #1053 closed four of them; this closes three more, in the same shape: the neutral wording belongs to CCP Default, a themed mod speaks for itself, and a resolver decides which one you get.

The remaining two (the Pop Quiz bank and the session generator) are stacked on this branch in a follow-up PR, to keep each one reviewable.

## Sites restored

**1. The weekly Intake niche - `Services/Quiz/IntakeNiche.cs`**

Wave 1 (`22932f7b0`) moved `Fallback` from `"bambi"` to `"default"` but never added the `BambiSleepId` branch the other three themed built-ins have, and the Bambi manifest carries no `Tags`. `"bambi"` became unreachable from every code path, so `Resources/intake/pass_card_bambi.png` and `Resources/web/intake/banks/bambi.json` went dead and every Bambi user's weekly pass card art and prompt bank silently became the neutral ones. Nothing logged it: `SafeNiche()`'s missing-bank warning only fires for a niche with no bank, and `"default"` has one.

- `BuiltInMods.BambiSleepId` branch restored alongside Drone / Sissy / Locked.
- `"bambi"` added to the manifest-tag branch so a third-party `.ccpmod` can ask for it.
- The mapping is split into a pure `Resolve(modId, tags, sissyContentMode)` that `Current()` calls, so it can be exercised without an `App`. There were zero tests over this file, which is why one missing line shipped.
- `IntakeHostService`'s "Defaults to bambi" doc was stale and now describes the neutral default.

**2. `Identity.PetName` - `Models/BuiltInMods.cs`**

`PetName` is declared on `ModIdentity` and read by `VocabTokens.PetName`, but the only built-in that set one was the Goon Virus stub. That made #1053's `VanillaPetName` to `PetName` swap a no-op for every shipped mod: `SpeakPromptSession.cs:68` seeds `$"that's it, {VocabTokens.PetName}"`, which in 6.9.3 read `"good girl"` and in 6.9.4 read `"that's it, sweetie"` - for a mod whose `Affirmation` is literally "Good Girl".

- BambiSleep and SissyHypno: `"good girl"` / `"good girls"`, the exact 6.9.3 word, for the same reason #1053 gave both mods the same gaze and troll lines.
- Dronification `"unit"` / `"units"`, Circe's Lock `"pet"` / `"pets"` - their own voice for a line the shared 6.9.3 word never fitted.
- CCP Default names neither, deliberately: `VocabTokens.VanillaPetName` / `VanillaCollective` is the owner-locked single config point, and a second copy here would drift the first time one is edited.
- `DeeperEditorWindow`'s praise tooltip hard-coded "that's it, sweetie" as its example; it now reads the active mod's word at construction.

**3. The marquee banner - `Models/AppSettings.cs`, `MainWindow/MainWindow.Marquee.cs`**

`MigrateMarqueeMessage()` matched the exact legacy default `"GOOD GIRLS CONDITION DAILY ❤️🔒"` and rewrote it to the neutral one, then latched a one-shot flag - for every user, mod or no mod. A BambiSleep user who never touched their banner lost it on the first launch of 6.9.4 and could only get it back by retyping it character for character.

- `MigrateMarqueeMessage(string? activeModId)`: CCP Default migrates; a themed mod is skipped, with the flag still latched so a later switch to CCP Default does not spring the same rewrite on them months afterwards; a null id (mod layer not up) defers without latching. `ModService` is constructed in `App.OnStartup`, long before the only caller, so the deferral is a safety net rather than an expected path.
- The two places that invent a banner over a blank or retired saved message (`InitializeMarqueeBanner`, and the runtime fallback in `StartMarqueeAnimation`) now go through a new `ModMessages.marqueeBanner`, walking active mod to CCP Default. Bambi and Sissy carry the 6.9.3 line, CCP Default carries the neutral one (identical to `AppSettings.DefaultMarqueeMessage`), Drone and Circe get their own. Capped at 120 chars in `SanitizeManifest` - the marquee scrolls one line forever, so a long one is a performance problem.

## Notes

- No new user-facing strings, so no localisation keys: every string added here is mod flavour text living in `BuiltInMods.cs`, where 6.9.3 kept it.
- `Tests/ConditioningControlPanel.Tests/NeutralModGatingWave2Tests.cs` (new, 255 lines) pins all three: every themed built-in names its own niche, its own pet name and its own banner; CCP Default stays neutral and leaves the vanilla pet name to `VocabTokens`; the migration runs for an unmodded install, skips a themed one, defers on an unknown one, never runs twice and never touches a hand-written banner.

## Verification

- `dotnet build ConditioningControlPanel/ConditioningControlPanel.csproj -c Debug` - **0 errors**, 364 warnings (unchanged).
- `dotnet test --filter "FullyQualifiedName~Mod|Quiz|Intake|Marquee|Neutral"` - **995 passed, 0 failed, 0 skipped**.
- Full suite green (see the stacked PR, which runs on top of this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013mR8cAipk1ivr3Em5fJjcx
