### PR TITLE
fix(chaos): a video the descent asked for dies with the descent, even before it starts

### DIFF
--- a/ConditioningControlPanel/Services/Chaos/ChaosModeService.cs
+++ b/ConditioningControlPanel/Services/Chaos/ChaosModeService.cs
@@ -2183,6 +2183,16 @@ public sealed class ChaosModeService
         => chaosCapArmed && videoPlaying;
 
     /// <summary>
+    /// Is the chaos tape actually on screen? Playing is the ordinary answer. Windows with no
+    /// playback is the sliver where <c>PlayVideo</c> has built its fullscreen surfaces and the
+    /// player has not started yet - still something to close. A teardown already in flight is
+    /// neither: <c>ForceCleanup</c> is doing the work, and re-entering it pumps the dispatcher
+    /// inside its own pump. Pure, so the rule is pinned by a test with no video service behind it.
+    /// </summary>
+    internal static bool ChaosTapeIsOnScreen(bool videoPlaying, bool hasOpenWindows, bool cleaningUp)
+        => videoPlaying || (hasOpenWindows && !cleaningUp);
+
+    /// <summary>
     /// Stop a chaos-fired video and disarm the cap. Every run-exit path calls this, because the
     /// mid-run cap in <c>RunTick</c> cannot: the tick early-returns while the run is paused (draft
     /// card, lesson card, manual hold) and its run-closing branch only covers the clock running
@@ -2193,7 +2203,24 @@ public sealed class ChaosModeService
     {
         bool armed = _chaosVideoCapUtc != DateTime.MinValue;
         _chaosVideoCapUtc = DateTime.MinValue;   // an armed cap never outlives the run
-        if (!ShouldStopVideoOnRunExit(armed, App.Video?.IsPlaying == true)) return;
+        if (!armed) return;                      // chaos started no tape: the user's own video is not ours to touch
+
+        // The tape may not be on screen YET, and that was the hole this teardown left open. A video
+        // bubble arms the cap at detonation, but the request still has to choose a clip off the UI
+        // thread, sit out the 800ms freeze delay, and possibly wait its turn in the InteractionQueue
+        // behind a bubble count or a lock card. Quitting a second after the pop therefore found
+        // nothing playing, tore nothing down, and the video opened over the results card and the
+        // lobby a moment later - the reported #1201 symptom, on a window of at least 800ms.
+        // Cancelling the pending request closes it, and it can only ever reach a request chaos
+        // itself made: the user's own video and the scheduler's carry no token.
+        try { App.Video?.CancelPendingChaosVideo(reason); }
+        catch (Exception ex) { App.Logger?.Debug("Chaos video cancel: {E}", ex.Message); }
+
+        bool onScreen = ChaosTapeIsOnScreen(
+            App.Video?.IsPlaying == true,
+            App.Video?.HasOpenWindows == true,
+            App.Video?.IsCleaningUp == true);
+        if (!ShouldStopVideoOnRunExit(armed, onScreen)) return;
         try { App.Video?.ForceCleanup(); } catch (Exception ex) { App.Logger?.Debug("Chaos video teardown: {E}", ex.Message); }
         ExtendHeavyQuarantine(VIDEO_TEARDOWN_QUARANTINE_SEC);   // ForceCleanup may not raise VideoEnded
         App.Logger?.Information("[Chaos] tore down a chaos-fired video ({Reason})", reason);
@@ -2268,6 +2295,12 @@ public sealed class ChaosModeService
         {
             _chaosVideoCapUtc = DateTime.UtcNow.AddSeconds(VIDEO_HARD_CAP_SEC);
             _heavyUntilUtc = DateTime.UtcNow.AddSeconds(VIDEO_HARD_CAP_SEC + 3);   // cap + open/close slack
+            // Ownership begins HERE, not when the tape appears. The request is about to travel
+            // through an off-thread clip selection, an 800ms freeze delay and possibly the
+            // InteractionQueue, and a run that ends inside that window has to be able to call it
+            // back (#1201). The cap alone cannot do that - it only says a video is owed.
+            if (spec.Payload is VideoPayload video)
+                video.ChaosToken = App.Video?.ClaimChaosVideoToken() ?? 0;
         }
         else if (kind == EffectBubblePayloadKind.GifCascade)
         {

--- a/ConditioningControlPanel/Services/Chaos/EffectPayload.cs
+++ b/ConditioningControlPanel/Services/Chaos/EffectPayload.cs
@@ -167,6 +167,14 @@ public sealed class VideoPayload : EffectPayload
     /// <summary>Seconds of video the chaos tape shows — a random slice, ended by the chaos hard cap.</summary>
     public const double SEGMENT_SEC = 15;
 
+    /// <summary>
+    /// Nonzero while a descent run owns this request: the token VideoService hands back from
+    /// ClaimChaosVideoToken, taken by ChaosModeService at detonation so the run can call the video
+    /// back if it ends before the tape reaches the screen (ccp-bugs #1201). Zero for a dashboard
+    /// trigger bubble, which no run owns and nothing may cancel.
+    /// </summary>
+    public int ChaosToken { get; set; }
+
     public override void Fire()
     {
         try
@@ -188,7 +196,7 @@ public sealed class VideoPayload : EffectPayload
             // this call from the background scheduler, and the guards inside TriggerVideo that exist
             // to keep the SCHEDULER out of the user's way read it so they no longer eat a video the
             // user asked for (#1135).
-            App.Video.TriggerVideo(silentIfEmpty: true, userEarned: true);
+            App.Video.TriggerVideo(silentIfEmpty: true, userEarned: true, chaosToken: ChaosToken);
         }
         catch (Exception ex)
         {

--- a/ConditioningControlPanel/Services/Video/VideoService.cs
+++ b/ConditioningControlPanel/Services/Video/VideoService.cs
@@ -224,6 +224,77 @@ namespace ConditioningControlPanel.Services
         /// 5-minute stuck detector, which is what used to be the only way out.</summary>
         internal static readonly TimeSpan TriggerStallCeiling = TimeSpan.FromSeconds(45);
 
+        // ---- a video the descent asked for (ccp-bugs #1201) ------------------------------
+        // A chaos video is REQUESTED when the bubble detonates and only reaches the screen much
+        // later: clip selection runs off the UI thread, the freeze delay adds another 800ms, and
+        // the request can sit parked in the InteractionQueue behind a bubble count or a lock card
+        // for longer still. "Is a video playing" therefore cannot answer "does the descent still
+        // own a video" at run exit, and quitting right after a video bubble popped left the tape
+        // opening over the results card and the lobby behind it - the reported #1201 symptom.
+        //
+        // So every chaos request carries a token. ChaosModeService cancels through the last token
+        // handed out when the run ends by any path, and each resumption point between the request
+        // and the first frame abandons a cancelled one. A request with no token (0) belongs to the
+        // user or to the scheduler, and nothing here can touch it.
+        private int _chaosVideoToken;             // last token handed out; 0 is never a token
+        private int _chaosVideoCancelledThrough;  // every token <= this one has been cancelled
+
+        /// <summary>
+        /// The pure rule behind the cancellation, extracted so a test can pin it without LibVLC
+        /// behind it (the same seam <see cref="EvaluateTriggerGuard"/> uses). A request is
+        /// abandoned only when it carries a token AND a cancel has swept through that token, so a
+        /// video requested AFTER the cancel - the next run's, or the user's own - still plays.
+        /// </summary>
+        internal static bool ShouldAbandonVideoRequest(int requestToken, int cancelledThrough)
+            => requestToken != 0 && requestToken <= cancelledThrough;
+
+        /// <summary>
+        /// Take a token for a video a descent run is about to fire. Claimed at DETONATION time,
+        /// not at playback time: the whole point is to own the request through the window where
+        /// nothing is on screen yet.
+        /// </summary>
+        public int ClaimChaosVideoToken() => Interlocked.Increment(ref _chaosVideoToken);
+
+        /// <summary>
+        /// Cancel every chaos-owned video request made so far that has not reached the screen.
+        /// Cheap, synchronous and non-blocking: it moves one integer, and the requests discover
+        /// they are obsolete at their own next step. It cannot touch a video the user or the
+        /// scheduler asked for (those carry no token), and it does not tear down a tape already
+        /// playing - that stays <see cref="ForceCleanup"/>'s job, behind the caller's ownership
+        /// check. Returns true if there was anything outstanding to cancel.
+        /// </summary>
+        public bool CancelPendingChaosVideo(string reason)
+        {
+            int through = Volatile.Read(ref _chaosVideoToken);
+            if (through <= Volatile.Read(ref _chaosVideoCancelledThrough)) return false;
+            Volatile.Write(ref _chaosVideoCancelledThrough, through);
+            App.Logger?.Information("VideoService: every pending chaos video request through #{Token} is cancelled ({Reason})",
+                through, reason);
+            return true;
+        }
+
+        private bool IsChaosVideoRequestCancelled(int requestToken)
+            => ShouldAbandonVideoRequest(requestToken, Volatile.Read(ref _chaosVideoCancelledThrough));
+
+        /// <summary>
+        /// The shared abandon step for a cancelled chaos request. It also hands the InteractionQueue
+        /// its Video slot back when this call is a dequeued replay holding it, or the next
+        /// interaction would wait out the queue's 5-minute stuck window. Guarded exactly like the
+        /// cascade and feed releases: current==Video with nothing playing only happens right after
+        /// a dequeue.
+        /// </summary>
+        private bool AbandonCancelledChaosRequest(int requestToken, string where)
+        {
+            if (!IsChaosVideoRequestCancelled(requestToken)) return false;
+            App.Logger?.Information("VideoService: {Where} abandoned - the descent that asked for this video has ended", where);
+            if (!_videoPlaying &&
+                App.InteractionQueue?.CurrentInteraction == InteractionQueueService.InteractionType.Video)
+            {
+                App.InteractionQueue.Complete(InteractionQueueService.InteractionType.Video);
+            }
+            return true;
+        }
+
         private bool _strictActive;
         // True across the strict retry GAP: from the moment a strict run's attention check fails
         // until the replacement video is actually on screen. ShowMessage deliberately clears
@@ -1839,7 +1910,7 @@ namespace ConditioningControlPanel.Services
         private DateTime _cascadeDeferDeadlineUtc = DateTime.MinValue;
 
         /// <summary>#871: hold a trigger the gif-cascade guard refused and replay it once the rain stops.</summary>
-        private void DeferTriggerPastCascade(bool silentIfEmpty, bool? strictOverride, bool userEarned = false)
+        private void DeferTriggerPastCascade(bool silentIfEmpty, bool? strictOverride, bool userEarned = false, int chaosToken = 0)
         {
             if (_cascadeDeferPending)
             {
@@ -1886,7 +1957,7 @@ namespace ConditioningControlPanel.Services
                         return;
                     }
 
-                    TriggerVideo(silentIfEmpty, strictOverride, userEarned);
+                    TriggerVideo(silentIfEmpty, strictOverride, userEarned, chaosToken);
 
                     // TriggerVideo may have parked itself again (a new cascade). Only release the
                     // ceiling when the chain really ended, so the re-defer above inherits it.
@@ -1927,7 +1998,7 @@ namespace ConditioningControlPanel.Services
 
         /// <summary>#1073: hold a trigger the For You guard refused and replay it once the feed leaves
         /// the screen (closed, or ghosted away).</summary>
-        private void DeferTriggerPastFeed(bool silentIfEmpty, bool? strictOverride, bool userEarned = false)
+        private void DeferTriggerPastFeed(bool silentIfEmpty, bool? strictOverride, bool userEarned = false, int chaosToken = 0)
         {
             if (_feedDeferPending)
             {
@@ -1968,7 +2039,7 @@ namespace ConditioningControlPanel.Services
                         return;
                     }
 
-                    TriggerVideo(silentIfEmpty, strictOverride, userEarned);
+                    TriggerVideo(silentIfEmpty, strictOverride, userEarned, chaosToken);
 
                     // TriggerVideo may have parked itself again (the feed came back, or a cascade
                     // started). Only release the ceiling when the chain really ended, so a re-defer
@@ -2088,9 +2159,19 @@ namespace ConditioningControlPanel.Services
         /// the unrelated mandatory-video SCHEDULER happens to be off. See the For You guard below
         /// and the replay re-asserts in DeferTriggerPastFeed / DeferTriggerPastCascade.
         /// </param>
-        public void TriggerVideo(bool silentIfEmpty = false, bool? strictOverride = null, bool userEarned = false)
+        /// <param name="chaosToken">
+        /// Nonzero when a descent run asked for this video (<see cref="ClaimChaosVideoToken"/>).
+        /// The request is then abandoned, at every point between here and the first frame, once the
+        /// run that asked for it has ended (#1201). Zero - the default - is a video the user or the
+        /// scheduler asked for, which nothing here may cancel.
+        /// </param>
+        public void TriggerVideo(bool silentIfEmpty = false, bool? strictOverride = null, bool userEarned = false, int chaosToken = 0)
         {
             App.Logger?.Information("VideoService: TriggerVideo called (userEarned={UserEarned})", userEarned);
+
+            // The run can have ended while this request sat in the queue, or behind a cascade or
+            // the feed. Nothing is on screen yet, so this is the cheapest place to stop.
+            if (AbandonCancelledChaosRequest(chaosToken, "TriggerVideo")) return;
 
             // Prevent overlapping triggers (e.g. during 800ms freeze delay).
             //
@@ -2158,7 +2239,7 @@ namespace ConditioningControlPanel.Services
                 {
                     App.InteractionQueue.Complete(InteractionQueueService.InteractionType.Video);
                 }
-                DeferTriggerPastCascade(silentIfEmpty, strictOverride, userEarned);
+                DeferTriggerPastCascade(silentIfEmpty, strictOverride, userEarned, chaosToken);
                 return;
             }
 
@@ -2206,7 +2287,7 @@ namespace ConditioningControlPanel.Services
                 {
                     App.InteractionQueue.Complete(InteractionQueueService.InteractionType.Video);
                 }
-                DeferTriggerPastFeed(silentIfEmpty, strictOverride, userEarned);
+                DeferTriggerPastFeed(silentIfEmpty, strictOverride, userEarned, chaosToken);
                 return;
             }
 
@@ -2220,7 +2301,7 @@ namespace ConditioningControlPanel.Services
                     App.InteractionQueue.CurrentInteraction);
                 App.InteractionQueue.TryStart(
                     InteractionQueueService.InteractionType.Video,
-                    () => TriggerVideo(silentIfEmpty, strictOverride, userEarned),
+                    () => TriggerVideo(silentIfEmpty, strictOverride, userEarned, chaosToken),
                     queue: true);
                 return;
             }
@@ -2279,7 +2360,7 @@ namespace ConditioningControlPanel.Services
                 {
                     try
                     {
-                        ContinueTriggerVideo(selected, strict, silentIfEmpty);
+                        ContinueTriggerVideo(selected, strict, silentIfEmpty, chaosToken);
                     }
                     catch (Exception ex)
                     {
@@ -2296,9 +2377,18 @@ namespace ConditioningControlPanel.Services
         /// chosen off it (#732). Split out rather than inlined so the expensive selection cannot
         /// drift back onto the dispatcher.
         /// </summary>
-        private void ContinueTriggerVideo(string? path, bool strict, bool silentIfEmpty)
+        private void ContinueTriggerVideo(string? path, bool strict, bool silentIfEmpty, int chaosToken = 0)
         {
             App.Logger?.Information("VideoService: GetNextVideo returned: {Path}", path ?? "(null)");
+
+            // Selection ran off the UI thread and can take seconds (a content-pack decrypt, a
+            // full-library refill), which is most of the window #1201 falls into. Release the
+            // trigger guard along with the request, or the next video is dropped as an overlap.
+            if (AbandonCancelledChaosRequest(chaosToken, "the chosen clip"))
+            {
+                _triggerInProgress = false;
+                return;
+            }
 
             if (string.IsNullOrEmpty(path))
             {
@@ -2419,7 +2509,7 @@ namespace ConditioningControlPanel.Services
                         // is no result to wait for, so the queued call just runs when the thread frees.
                         DispatcherHelper.RunOnUI(() =>
                         {
-                            try { PlayVideo(path, strict); }
+                            try { PlayVideo(path, strict, chaosToken: chaosToken); }
                             catch (Exception ex)
                             {
                                 App.Logger?.Error(ex, "VideoService: PlayVideo after the freeze delay failed");
@@ -2440,7 +2530,7 @@ namespace ConditioningControlPanel.Services
             {
                 // Attention checks or minigame active - play video without freeze
                 App.Logger?.Debug("VideoService: Playing video immediately (skipFreeze=true)");
-                PlayVideo(path, strict);
+                PlayVideo(path, strict, chaosToken: chaosToken);
             }
         }
 
@@ -2906,7 +2996,7 @@ namespace ConditioningControlPanel.Services
             _scheduler.Start();
         }
 
-        private void PlayVideo(string path, bool strict, bool isVoutRetry = false)
+        private void PlayVideo(string path, bool strict, bool isVoutRetry = false, int chaosToken = 0)
         {
             App.Logger?.Information("VideoService: PlayVideo called for {File}", Path.GetFileName(path));
 
@@ -2925,6 +3015,15 @@ namespace ConditioningControlPanel.Services
                 App.Settings?.Current?.DualMonitorEnabled == true));
 
             _triggerInProgress = false;
+
+            // The last gate before any fullscreen surface exists, and the one the 800ms freeze
+            // delay lands on: a descent that ended while this request waited does not get its tape
+            // opened over the results card and the lobby (#1201).
+            if (AbandonCancelledChaosRequest(chaosToken, "PlayVideo"))
+            {
+                VideoDiag.Log("VIDEO", "SKIP - the descent that asked for this video has ended");
+                return;
+            }
 
             if (_videoPlaying)
             {

--- a/Tests/ConditioningControlPanel.Tests/ChaosVideoStartWindowTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/ChaosVideoStartWindowTests.cs
@@ -1,0 +1,162 @@
+using System;
+using ConditioningControlPanel.Services;
+using ConditioningControlPanel.Services.Chaos;
+using Xunit;
+using IType = ConditioningControlPanel.Services.InteractionQueueService.InteractionType;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// ccp-bugs #1201, the half the first fix did not reach: the START window.
+///
+/// A video bubble arms the ownership cap the instant it detonates, but the video itself is only
+/// REQUESTED then. Choosing a clip runs off the UI thread and can take seconds (a content-pack
+/// decrypt, a full-library refill), the freeze delay adds another 800ms, and the request can be
+/// parked in the InteractionQueue behind a bubble count or a lock card for longer still. So a run
+/// ending a second after the pop asked "is a video playing", was told no, tore nothing down, and
+/// the tape opened over the results card and the lobby a moment later - exactly the reported
+/// symptom, on a window of at least 800ms that anyone quitting right after a pop lands in.
+///
+/// The request now carries a token taken at detonation. A run exit cancels through it, and every
+/// step between the request and the first frame abandons a cancelled one. These tests pin the two
+/// pure rules that decide it, plus the queue-parked case end to end on the real queue.
+/// </summary>
+public class ChaosVideoStartWindowTests : IDisposable
+{
+    private readonly Action<Action> _originalScheduler;
+
+    public ChaosVideoStartWindowTests()
+    {
+        _originalScheduler = InteractionQueueService.TriggerScheduler;
+        // Run a dequeued replay inline rather than through the (absent) Dispatcher.
+        InteractionQueueService.TriggerScheduler = a => a();
+    }
+
+    public void Dispose() => InteractionQueueService.TriggerScheduler = _originalScheduler;
+
+    /// <summary>
+    /// Armed but not yet playing, and the run ends: the request is cancelled, so no video opens
+    /// over the lobby. This is the case the old teardown missed entirely.
+    /// </summary>
+    [Fact]
+    public void ArmedButNotPlayingYet_TheRequestIsCancelled()
+    {
+        int token = 1;                 // the detonation took a token
+        int cancelledThrough = token;  // the run ended and swept through it
+
+        Assert.True(VideoService.ShouldAbandonVideoRequest(token, cancelledThrough));
+    }
+
+    /// <summary>
+    /// The ownership half, restated on the new seam: a video nobody in the descent asked for
+    /// carries no token, so a run exit cannot cancel a user's own mandatory or session video -
+    /// however many chaos requests have been cancelled around it.
+    /// </summary>
+    [Fact]
+    public void AVideoTheUserAskedFor_IsNeverCancelled()
+    {
+        Assert.False(VideoService.ShouldAbandonVideoRequest(requestToken: 0, cancelledThrough: 0));
+        Assert.False(VideoService.ShouldAbandonVideoRequest(requestToken: 0, cancelledThrough: 47));
+    }
+
+    /// <summary>A video the NEXT run asks for is newer than the cancel and must still play, or one
+    /// quit would poison every descent after it.</summary>
+    [Fact]
+    public void ARequestMadeAfterTheCancel_StillPlays()
+    {
+        Assert.False(VideoService.ShouldAbandonVideoRequest(requestToken: 2, cancelledThrough: 1));
+    }
+
+    /// <summary>Several bubbles can have popped in one run; ending it takes them all, not just the
+    /// last one.</summary>
+    [Fact]
+    public void EveryOutstandingRequestOfTheRun_GoesTogether()
+    {
+        Assert.True(VideoService.ShouldAbandonVideoRequest(requestToken: 1, cancelledThrough: 3));
+        Assert.True(VideoService.ShouldAbandonVideoRequest(requestToken: 2, cancelledThrough: 3));
+        Assert.True(VideoService.ShouldAbandonVideoRequest(requestToken: 3, cancelledThrough: 3));
+    }
+
+    /// <summary>
+    /// The queue path, end to end on the real InteractionQueueService. A chaos video that arrives
+    /// while a bubble count owns the screen is parked with a replay callback; the run then ends,
+    /// and the card closes minutes later. The replay must find itself obsolete and hand the slot
+    /// straight back rather than playing a video for a descent that is over.
+    /// </summary>
+    [Fact]
+    public void AParkedChaosVideo_IsNotReplayedAfterTheRunEnds()
+    {
+        var q = new InteractionQueueService();
+        q.TryStart(IType.BubbleCount, () => { });   // a bubble count owns the screen
+
+        const int token = 1;
+        int cancelledThrough = 0;
+        int played = 0;
+
+        // What VideoService parks: the same TriggerVideo call, carrying the token.
+        q.TryStart(IType.Video, () =>
+        {
+            if (VideoService.ShouldAbandonVideoRequest(token, cancelledThrough))
+            {
+                q.CompleteIfCurrent(IType.Video);
+                return;
+            }
+            played++;
+        }, queue: true);
+
+        Assert.Equal(1, q.QueuedCount);
+
+        cancelledThrough = token;       // the run ends: StopChaosOwnedVideo cancels the request
+        q.Complete(IType.BubbleCount);  // the card closes and the queue replays the parked video
+
+        Assert.Equal(0, played);
+        Assert.False(q.IsBusy);         // and the slot is not left claimed for the 5-minute stuck window
+    }
+
+    /// <summary>The same park, with no run behind it: a video the user earned outside a descent is
+    /// still replayed when the card closes.</summary>
+    [Fact]
+    public void AParkedVideoWithNoRunBehindIt_StillPlays()
+    {
+        var q = new InteractionQueueService();
+        q.TryStart(IType.BubbleCount, () => { });
+
+        int cancelledThrough = 9;   // descents have come and gone
+        int played = 0;
+
+        q.TryStart(IType.Video, () =>
+        {
+            if (VideoService.ShouldAbandonVideoRequest(0, cancelledThrough)) return;
+            played++;
+        }, queue: true);
+
+        q.Complete(IType.BubbleCount);
+
+        Assert.Equal(1, played);
+    }
+
+    /// <summary>A tape whose windows are up but whose player has not started is still something to
+    /// close on the way out.</summary>
+    [Fact]
+    public void WindowsUpWithoutPlayback_IsStillOnScreen()
+    {
+        Assert.True(ChaosModeService.ChaosTapeIsOnScreen(videoPlaying: false, hasOpenWindows: true, cleaningUp: false));
+        Assert.True(ChaosModeService.ChaosTapeIsOnScreen(videoPlaying: true, hasOpenWindows: false, cleaningUp: false));
+    }
+
+    /// <summary>A teardown already in flight is not "on screen": ForceCleanup is doing the work,
+    /// and re-entering it pumps the dispatcher inside its own pump.</summary>
+    [Fact]
+    public void ATeardownAlreadyRunning_IsNotReEntered()
+    {
+        Assert.False(ChaosModeService.ChaosTapeIsOnScreen(videoPlaying: false, hasOpenWindows: true, cleaningUp: true));
+    }
+
+    /// <summary>Nothing up at all: no ForceCleanup, so a run exit never yanks the audio duck or the
+    /// queue slot out from under whatever else is on screen.</summary>
+    [Fact]
+    public void NothingUp_IsNotOnScreen()
+    {
+        Assert.False(ChaosModeService.ChaosTapeIsOnScreen(videoPlaying: false, hasOpenWindows: false, cleaningUp: false));
+    }
+}


### PR DESCRIPTION
Closes review finding F1 (lane 1) / finding 12 (lane 4) on release/6.9.4.

## The window that was still open

The 6.9.4 teardown routes every run exit through `StopChaosOwnedVideo`, and the notes say
"a video the descent started ends when the descent does". That is true once the tape is on
screen, and only then.

A video bubble arms the ownership cap (`_chaosVideoCapUtc`) the instant it detonates, but
the video is only REQUESTED at that moment:

- clip selection runs on `Task.Run` off the UI thread and can take seconds (a content-pack
  decrypt, a full-library refill),
- the freeze delay adds a flat 800ms,
- `_videoPlaying` is set only inside `PlayVideo`,
- and the request can be parked in the InteractionQueue behind a bubble count or a lock
  card, then replayed long after.

`StopChaosOwnedVideo` cleared the cap first and then asked `App.Video?.IsPlaying == true`.
Hit Exit 400ms after a video bubble pops and the answer is no: the cap is disarmed, nothing
is torn down, `RunTick` is stopped, and ~700ms later a fullscreen mandatory video opens over
the results card and the lobby with nothing left that would ever close it. That is ccp-bugs
#1201, on a window of at least 800ms.

## The fix

A chaos video request now carries a token, claimed at detonation, alongside the cap:

- `VideoService.ClaimChaosVideoToken()` hands one out; `ChaosModeService` takes it in
  `FirePayloadForDetonation` and puts it on the `VideoPayload`, which passes it to
  `TriggerVideo`.
- `VideoService.CancelPendingChaosVideo(reason)` cancels every outstanding request by moving
  one integer. No sleep, no poll, no dispatcher work, nothing blocking.
- Every resumption point between the request and the first frame abandons a cancelled one:
  `TriggerVideo` (so a dequeued queue replay and both defer replays die on arrival), the
  continuation after off-thread selection, and `PlayVideo` itself, which is the gate the
  800ms freeze delay lands on. Each abandon hands the queue's Video slot back, so nothing
  waits out the 5-minute stuck window.
- `StopChaosOwnedVideo` cancels first, then tears down what is on screen as before. Every
  run exit already funnels here: `EndRun`, `ForceShutdown`, `CleanupAfterRun`, the `RunTick`
  cap, and through `ForceShutdown` also app exit, the title-bar close and the panic stop.

Ownership is unchanged and now carried by the same mark twice over. A video the user or the
scheduler asked for carries token 0, and `ShouldAbandonVideoRequest` can never abandon a
zero token however many chaos requests are cancelled around it; `ForceCleanup` still only
runs behind an armed cap, through the unchanged `ShouldStopVideoOnRunExit`. The
`OnVideoEndedDuringRun` disarm from `c132ade28` is untouched.

One small widening: the on-screen test is now `IsPlaying || (HasOpenWindows && !IsCleaningUp)`,
which catches the sliver where `PlayVideo` has built its fullscreen surfaces but the player
has not started, and stands down while a teardown is already pumping the dispatcher.

## Tests

`Tests/ConditioningControlPanel.Tests/ChaosVideoStartWindowTests.cs`, 10 new tests on the two
pure seams plus the queue path end to end on the real `InteractionQueueService`:

- armed but not playing yet, run ends -> the request is abandoned,
- parked in the queue, run ends, card closes later -> not replayed, and the slot is released,
- a parked video with no run behind it -> still played,
- a user's own video (token 0) -> never cancelled, at any cancel watermark,
- a request made after the cancel (the next run's) -> still plays,
- several requests in one run -> all go together,
- windows without playback -> still on screen; a teardown in flight -> not re-entered.

## Verification

- `dotnet build ConditioningControlPanel/ConditioningControlPanel.csproj -c Debug`: 0 errors,
  364 warnings (unchanged).
- `dotnet test --filter "FullyQualifiedName~Chaos|FullyQualifiedName~Video"`: 174 passed, 0 failed.
- Full suite: 5844 passed, 0 failed, 0 skipped.

## Residual

The cancel and the last gate both run on the UI thread, so their order is deterministic on
every run-exit path in the app today. A cancel raised from a background thread could in
principle land between `PlayVideo`'s gate and its first frame; the teardown that follows the
cancel in `StopChaosOwnedVideo` is what covers that, since the tape is on screen by then.
Runtime verification (pop a video bubble, hit Exit inside the first second, confirm nothing
opens over the lobby) is still owed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013mR8cAipk1ivr3Em5fJjcx
