### PR TITLE
fix(mods): the pop quiz and the generated sessions keep a themed mod's lines

### DIFF
--- a/ConditioningControlPanel/Models/BuiltInMods.cs
+++ b/ConditioningControlPanel/Models/BuiltInMods.cs
@@ -140,6 +140,9 @@ namespace ConditioningControlPanel.Models
                     QuizTrickAnswer = "Obviously",
                     // The 6.9.3 house banner. It shipped as the default on every install, so a user
                     // of this mod who never edited the marquee had been reading it for years.
+                    QuizPraise = "Good girl.",
+                    QuizObedienceQuestion = "What do good girls do?",
+                    QuizPraiseHeardQuestion = "When I hear 'good girl,' I feel...",
                     MarqueeBanner = "GOOD GIRLS CONDITION DAILY     ❤️🔒"
                 },
 
@@ -403,6 +406,50 @@ namespace ConditioningControlPanel.Models
                         "Ooh, get the bubble!",
                         "Pop it for me, good girl~"
                     },
+                    // The generic quiz-session pools. These three categories are drawn by a user
+                    // of ANY mod - the quiz picks them from a score, not from a niche - so the
+                    // 6.9.3 wording lived in the generator and was neutralised for everybody by
+                    // Wave 1. Carrying it here gives it back to this mod and leaves the neutral
+                    // copy in QuizSessionGenerator as the unmodded answer.
+                    ["QuizObedienceSubliminal"] = new[]
+                    {
+                        "Obey", "Submit", "Good girls listen", "Follow instructions",
+                        "Compliance is bliss", "Do as you're told", "Obedience is pleasure",
+                        "Listen and obey", "You love to comply", "Surrender control"
+                    },
+                    ["QuizObedienceLockCard"] = new[]
+                    {
+                        "I love to obey", "Good girls follow instructions", "Obedience is pleasure",
+                        "I submit willingly", "Compliance makes me happy", "I do as I am told",
+                        "Listening is easy", "I surrender control"
+                    },
+                    ["QuizSubmissionSubliminal"] = new[]
+                    {
+                        "Submit", "Surrender", "Give in", "You are owned",
+                        "Good girls submit", "Let go of control", "Deeper submission",
+                        "You belong", "Surrender completely", "Submit and feel bliss"
+                    },
+                    ["QuizSubmissionLockCard"] = new[]
+                    {
+                        "I submit willingly", "Surrender feels so good", "I give in completely",
+                        "I belong", "Good girls surrender", "I let go of control",
+                        "Submission is bliss", "I am deeply submissive"
+                    },
+                    ["QuizCustomSubliminal"] = new[]
+                    {
+                        "Good girl", "Obey", "Submit", "Let go", "Deeper",
+                        "Surrender", "Empty mind", "So pretty", "Accept it", "Drift away"
+                    },
+                    ["QuizCustomBouncingText"] = new[]
+                    {
+                        "OBEY", "SUBMIT", "DEEPER", "GOOD GIRL", "LET GO", "SURRENDER"
+                    },
+                    ["QuizCustomLockCard"] = new[]
+                    {
+                        "I am a good girl", "I love to obey", "Surrender feels good",
+                        "I submit willingly", "Empty and happy", "Good girls listen",
+                        "I let go of control", "Deeper and deeper"
+                    },
                     ["BubbleCountMercy"] = new[]
                     {
                         "BAMBI NEEDS TO FOCUS",
@@ -600,6 +647,9 @@ namespace ConditioningControlPanel.Models
                     GazeCorrect = "GOOD GIRL",
                     QuizTrickQuestion = "Are you a good girl?",
                     QuizTrickAnswer = "Obviously",
+                    QuizPraise = "Good girl.",
+                    QuizObedienceQuestion = "What do good girls do?",
+                    QuizPraiseHeardQuestion = "When I hear 'good girl,' I feel...",
                     MarqueeBanner = "GOOD GIRLS CONDITION DAILY     ❤️🔒"
                 },
 
@@ -858,6 +908,50 @@ namespace ConditioningControlPanel.Models
                         "*giggles* Pop it quick!",
                         "Ooh, get the bubble!",
                         "Pop it for me, good girl~"
+                    },
+                    // The generic quiz-session pools. These three categories are drawn by a user
+                    // of ANY mod - the quiz picks them from a score, not from a niche - so the
+                    // 6.9.3 wording lived in the generator and was neutralised for everybody by
+                    // Wave 1. Carrying it here gives it back to this mod and leaves the neutral
+                    // copy in QuizSessionGenerator as the unmodded answer.
+                    ["QuizObedienceSubliminal"] = new[]
+                    {
+                        "Obey", "Submit", "Good girls listen", "Follow instructions",
+                        "Compliance is bliss", "Do as you're told", "Obedience is pleasure",
+                        "Listen and obey", "You love to comply", "Surrender control"
+                    },
+                    ["QuizObedienceLockCard"] = new[]
+                    {
+                        "I love to obey", "Good girls follow instructions", "Obedience is pleasure",
+                        "I submit willingly", "Compliance makes me happy", "I do as I am told",
+                        "Listening is easy", "I surrender control"
+                    },
+                    ["QuizSubmissionSubliminal"] = new[]
+                    {
+                        "Submit", "Surrender", "Give in", "You are owned",
+                        "Good girls submit", "Let go of control", "Deeper submission",
+                        "You belong", "Surrender completely", "Submit and feel bliss"
+                    },
+                    ["QuizSubmissionLockCard"] = new[]
+                    {
+                        "I submit willingly", "Surrender feels so good", "I give in completely",
+                        "I belong", "Good girls surrender", "I let go of control",
+                        "Submission is bliss", "I am deeply submissive"
+                    },
+                    ["QuizCustomSubliminal"] = new[]
+                    {
+                        "Good girl", "Obey", "Submit", "Let go", "Deeper",
+                        "Surrender", "Empty mind", "So pretty", "Accept it", "Drift away"
+                    },
+                    ["QuizCustomBouncingText"] = new[]
+                    {
+                        "OBEY", "SUBMIT", "DEEPER", "GOOD GIRL", "LET GO", "SURRENDER"
+                    },
+                    ["QuizCustomLockCard"] = new[]
+                    {
+                        "I am a good girl", "I love to obey", "Surrender feels good",
+                        "I submit willingly", "Empty and happy", "Good girls listen",
+                        "I let go of control", "Deeper and deeper"
                     },
                     ["BubbleCountMercy"] = new[]
                     {
@@ -1426,6 +1520,9 @@ namespace ConditioningControlPanel.Models
                     GazeCorrect = "COMPLIANT",
                     QuizTrickQuestion = "Is the unit ready to comply?",
                     QuizTrickAnswer = "Affirmative",
+                    QuizPraise = "Compliant.",
+                    QuizObedienceQuestion = "What does a good unit do?",
+                    QuizPraiseHeardQuestion = "When I am told 'compliant,' the unit feels...",
                     MarqueeBanner = "UNITS CONDITION DAILY     ❤️🔒"
                 },
 
@@ -2198,6 +2295,9 @@ namespace ConditioningControlPanel.Models
                     GazeCorrect = "GOOD PET",
                     QuizTrickQuestion = "Are you Circe's good pet?",
                     QuizTrickAnswer = "Always",
+                    QuizPraise = "Good pet.",
+                    QuizObedienceQuestion = "What do good pets do?",
+                    QuizPraiseHeardQuestion = "When I hear 'good pet,' I feel...",
                     MarqueeBanner = "GOOD PETS CONDITION DAILY     ❤️🔒"
                 },
 

--- a/ConditioningControlPanel/Models/ModManifest.cs
+++ b/ConditioningControlPanel/Models/ModManifest.cs
@@ -298,6 +298,29 @@ namespace ConditioningControlPanel.Models
         public string? QuizTrickAnswer { get; set; }
 
         /// <summary>
+        /// Praise line on a Pop Quiz card, as a sentence ("Good girl."). Also supplies the answer
+        /// chip in the "your favorite word is" question, with any trailing full stop trimmed - a
+        /// chip is a word, not a sentence. Required for any of the three themed quiz slots: a mod's
+        /// question over the neutral praise reads as a bug on the card.
+        /// </summary>
+        [JsonProperty("quizPraise")]
+        public string? QuizPraise { get; set; }
+
+        /// <summary>
+        /// This mod's wording for the Pop Quiz obedience question ("What do good girls do?").
+        /// Used only when <see cref="QuizPraise"/> is set too.
+        /// </summary>
+        [JsonProperty("quizObedienceQuestion")]
+        public string? QuizObedienceQuestion { get; set; }
+
+        /// <summary>
+        /// This mod's wording for the Pop Quiz question about hearing praise
+        /// ("When I hear 'good girl,' I feel..."). Used only when <see cref="QuizPraise"/> is set.
+        /// </summary>
+        [JsonProperty("quizPraiseHeardQuestion")]
+        public string? QuizPraiseHeardQuestion { get; set; }
+
+        /// <summary>
         /// This mod's default scrolling banner over the Settings marquee. Only ever used for a
         /// banner the user has NOT written themselves: a blank saved message, or one of the two
         /// retired house defaults. A user who typed their own banner keeps it in every mod.

--- a/ConditioningControlPanel/Services/ModService.cs
+++ b/ConditioningControlPanel/Services/ModService.cs
@@ -650,6 +650,10 @@ namespace ConditioningControlPanel.Services
                 // Capped shorter: both land inside a fixed quiz card, not a scrolling surface.
                 if (manifest.Messages.QuizTrickQuestion?.Length > 200) manifest.Messages.QuizTrickQuestion = manifest.Messages.QuizTrickQuestion[..200];
                 if (manifest.Messages.QuizTrickAnswer?.Length > 60) manifest.Messages.QuizTrickAnswer = manifest.Messages.QuizTrickAnswer[..60];
+                // Both quiz questions land on a fixed card, like the trick pair above.
+                if (manifest.Messages.QuizPraise?.Length > 60) manifest.Messages.QuizPraise = manifest.Messages.QuizPraise[..60];
+                if (manifest.Messages.QuizObedienceQuestion?.Length > 200) manifest.Messages.QuizObedienceQuestion = manifest.Messages.QuizObedienceQuestion[..200];
+                if (manifest.Messages.QuizPraiseHeardQuestion?.Length > 200) manifest.Messages.QuizPraiseHeardQuestion = manifest.Messages.QuizPraiseHeardQuestion[..200];
                 // The marquee scrolls one line forever; a long one is a performance problem, not a
                 // wrapping one, so it is capped hardest of the set.
                 if (manifest.Messages.MarqueeBanner?.Length > 120) manifest.Messages.MarqueeBanner = manifest.Messages.MarqueeBanner[..120];
@@ -1195,6 +1199,19 @@ namespace ConditioningControlPanel.Services
         /// <summary>Active mod's answer for <see cref="GetQuizTrickQuestionOverride"/>, or null.</summary>
         public string? GetQuizTrickAnswerOverride() => NullIfBlank(_activeMod.Manifest.Messages?.QuizTrickAnswer);
 
+        // The Pop Quiz overrides follow the same contract as the trick pair above: active mod only,
+        // null for "no opinion". The neutral wording is the 25-question array in PopQuizService, so
+        // walking to CCP Default would replace a pool with a single line.
+
+        /// <summary>Active mod's Pop Quiz praise sentence, or null when it ships none.</summary>
+        public string? GetQuizPraiseOverride() => NullIfBlank(_activeMod.Manifest.Messages?.QuizPraise);
+
+        /// <summary>Active mod's wording for the Pop Quiz obedience question, or null.</summary>
+        public string? GetQuizObedienceQuestionOverride() => NullIfBlank(_activeMod.Manifest.Messages?.QuizObedienceQuestion);
+
+        /// <summary>Active mod's wording for the Pop Quiz "when I hear praise" question, or null.</summary>
+        public string? GetQuizPraiseHeardQuestionOverride() => NullIfBlank(_activeMod.Manifest.Messages?.QuizPraiseHeardQuestion);
+
         // Browser (defense-in-depth: validate URL at point of use, not just at install)
         public string GetDefaultBrowserUrl()
         {
@@ -1508,7 +1525,10 @@ namespace ConditioningControlPanel.Services
                     GazeCorrect = GetGazeCorrectMessage(),
                     QuizTrickQuestion = GetQuizTrickQuestionOverride(),
                     QuizTrickAnswer = GetQuizTrickAnswerOverride(),
-                    MarqueeBanner = GetMarqueeBannerMessage()
+                    MarqueeBanner = GetMarqueeBannerMessage(),
+                    QuizPraise = GetQuizPraiseOverride(),
+                    QuizObedienceQuestion = GetQuizObedienceQuestionOverride(),
+                    QuizPraiseHeardQuestion = GetQuizPraiseHeardQuestionOverride()
                 },
                 Browser = new ModBrowser
                 {

--- a/ConditioningControlPanel/Services/Quiz/PopQuizService.cs
+++ b/ConditioningControlPanel/Services/Quiz/PopQuizService.cs
@@ -20,6 +20,13 @@ namespace ConditioningControlPanel.Services
 
         public bool IsRunning => _isRunning;
 
+        /// <summary>
+        /// The neutral question bank. Three of its entries carried Bambi-flavoured wording until
+        /// Wave 1 neutralised them with no mod lookup, so a themed mod may speak for those three
+        /// slots (see <see cref="ResolveQuestionPool"/>) and everything else stays as written.
+        /// Never index this array directly - go through the resolver, or a modded user silently
+        /// loses their wording again.
+        /// </summary>
         public static readonly PopQuizQuestion[] QuestionPool = new[]
         {
             new PopQuizQuestion("How does obedience feel?",
@@ -238,8 +245,12 @@ namespace ConditioningControlPanel.Services
                             queue: false);
                     }
 
-                    // Pick a random question
-                    var question = QuestionPool[_random.Next(QuestionPool.Length)];
+                    // Pick a random question from the pool as the ACTIVE MOD sees it.
+                    var pool = ResolveQuestionPool(
+                        App.Mods?.GetQuizPraiseOverride(),
+                        App.Mods?.GetQuizObedienceQuestionOverride(),
+                        App.Mods?.GetQuizPraiseHeardQuestionOverride());
+                    var question = pool[_random.Next(pool.Length)];
                     var window = new PopQuizWindow(question, isTest);
                     // Don't set Owner — WPF ties owned window z-order to owner,
                     // which fights with our Win32 HWND_TOPMOST positioning
@@ -260,12 +271,82 @@ namespace ConditioningControlPanel.Services
             ShowPopQuiz(isTest: true);
         }
 
+        /// <summary>
+        /// The question bank as the ACTIVE mod sees it. A mod that names a praise line takes over
+        /// the three slots it can speak for; everything else is the neutral wording, unchanged.
+        /// Substitution, never an append, so the odds of drawing any one question stay what they
+        /// were. A mod with no praise line is ignored entirely - its question under the neutral
+        /// praise would read as a bug on the card, the same rule the trick pair follows.
+        /// Pure and static so it can be tested without an App.
+        /// </summary>
+        /// <param name="praise">The mod's praise sentence, e.g. "Good girl."</param>
+        /// <param name="obedienceQuestion">Its wording for the obedience question, or null.</param>
+        /// <param name="praiseHeardQuestion">Its wording for the praise question, or null.</param>
+        internal static PopQuizQuestion[] ResolveQuestionPool(
+            string? praise, string? obedienceQuestion, string? praiseHeardQuestion)
+        {
+            if (string.IsNullOrWhiteSpace(praise)) return QuestionPool;
+
+            var line = praise!.Trim();
+            // The answer chip is a word, not a sentence, so the praise loses its full stop there.
+            var word = line.TrimEnd('.', ' ');
+            if (word.Length == 0) return QuestionPool;
+
+            var pool = (PopQuizQuestion[])QuestionPool.Clone();
+
+            if (!string.IsNullOrWhiteSpace(obedienceQuestion))
+                pool[PopQuizSlots.Obedience] = WithFirstAffirmation(
+                    pool[PopQuizSlots.Obedience], obedienceQuestion!.Trim(), line);
+
+            if (!string.IsNullOrWhiteSpace(praiseHeardQuestion))
+                pool[PopQuizSlots.PraiseHeard] = WithFirstAffirmation(
+                    pool[PopQuizSlots.PraiseHeard], praiseHeardQuestion!.Trim(), line);
+
+            var favourite = pool[PopQuizSlots.FavouriteWord];
+            var answers = (string[])favourite.Answers.Clone();
+            var affirmations = (string[])favourite.Affirmations.Clone();
+            answers[PopQuizSlots.FavouriteWordAnswer] = word;
+            affirmations[PopQuizSlots.FavouriteWordAnswer] = line;
+            pool[PopQuizSlots.FavouriteWord] = new PopQuizQuestion(favourite.QuestionText, answers, affirmations);
+
+            return pool;
+        }
+
+        /// <summary>One question with the mod's wording and its praise in the first answer slot,
+        /// which is where the 6.9.3 text put it in both affected questions.</summary>
+        private static PopQuizQuestion WithFirstAffirmation(PopQuizQuestion source, string question, string praise)
+        {
+            var affirmations = (string[])source.Affirmations.Clone();
+            affirmations[0] = praise;
+            return new PopQuizQuestion(question, source.Answers, affirmations);
+        }
+
         public void Dispose()
         {
             if (_isDisposed) return;
             _isDisposed = true;
             Stop();
         }
+    }
+
+    /// <summary>
+    /// The three slots in <see cref="PopQuizService.QuestionPool"/> a themed mod may speak for.
+    /// In 6.9.3 all three held Bambi-flavoured text that every user read; Wave 1 rewrote them
+    /// neutral for everybody, which is the regression this closes.
+    /// </summary>
+    internal static class PopQuizSlots
+    {
+        /// <summary>"What do good subjects do?" - the obedience question.</summary>
+        internal const int Obedience = 3;
+
+        /// <summary>"When I hear praise, I feel..." - the praise question.</summary>
+        internal const int PraiseHeard = 6;
+
+        /// <summary>"Your favorite word is..." - only its last answer and affirmation move.</summary>
+        internal const int FavouriteWord = 15;
+
+        /// <summary>The slot in the favourite-word question's four answers the mod speaks for.</summary>
+        internal const int FavouriteWordAnswer = 3;
     }
 
     public class PopQuizQuestion

--- a/ConditioningControlPanel/Services/Quiz/QuizSessionGenerator.cs
+++ b/ConditioningControlPanel/Services/Quiz/QuizSessionGenerator.cs
@@ -703,6 +703,31 @@ namespace ConditioningControlPanel.Services
             };
         }
 
+        /// <summary>
+        /// One phrase pool as the ACTIVE mod sees it. The generic categories below (obedience,
+        /// submission, and the catch-all) are drawn by every user whatever mod they run, and Wave 1
+        /// rewrote several of their phrases neutral with no mod lookup - so a themed mod may own
+        /// the whole pool through its manifest <c>phrases</c> dictionary, and the neutral list here
+        /// is what an unmodded install gets. CCP Default deliberately names none of these
+        /// categories: the neutral wording lives here, once, and a second copy would drift.
+        ///
+        /// <para>The per-niche cases (bambi / sissy / circe) are untouched - those are already the
+        /// mod's own words, chosen by the intake niche rather than a quiz score.</para>
+        /// </summary>
+        private static List<string> ThemedOrNeutral(string category, List<string> neutral)
+        {
+            try
+            {
+                var themed = App.Mods?.GetPhrases(category);
+                if (themed is { Length: > 0 }) return new List<string>(themed);
+            }
+            catch
+            {
+                // No mod layer (tests, very early startup): the neutral pool is the right answer.
+            }
+            return neutral;
+        }
+
         public static SessionTextContent GetFallbackContent(string categoryId, double scorePercentage)
         {
             var content = new SessionTextContent();
@@ -791,22 +816,22 @@ namespace ConditioningControlPanel.Services
                 case "obedience":
                     content.Name = $"{diffPrefix} Obedience Training";
                     content.Description = "A session designed to reinforce obedience and compliance.";
-                    content.SubliminalPhrases = new List<string>
+                    content.SubliminalPhrases = ThemedOrNeutral("QuizObedienceSubliminal", new List<string>
                     {
                         "Obey", "Submit", "Listening is easy", "Follow instructions",
                         "Compliance is bliss", "Do as you're told", "Obedience is pleasure",
                         "Listen and obey", "You love to comply", "Surrender control"
-                    };
+                    });
                     content.BouncingTextPhrases = new List<string>
                     {
                         "OBEY", "SUBMIT", "COMPLY", "LISTEN", "FOLLOW", "SURRENDER"
                     };
-                    content.LockCardPhrases = new List<string>
+                    content.LockCardPhrases = ThemedOrNeutral("QuizObedienceLockCard", new List<string>
                     {
                         "I love to obey", "I follow instructions", "Obedience is pleasure",
                         "I submit willingly", "Compliance makes me happy", "I do as I am told",
                         "Listening is easy", "I surrender control"
-                    };
+                    });
                     break;
 
                 case "mindlessness":
@@ -833,42 +858,42 @@ namespace ConditioningControlPanel.Services
                 case "submission":
                     content.Name = $"{diffPrefix} Submission";
                     content.Description = "A session to deepen submission and surrender.";
-                    content.SubliminalPhrases = new List<string>
+                    content.SubliminalPhrases = ThemedOrNeutral("QuizSubmissionSubliminal", new List<string>
                     {
                         "Submit", "Surrender", "Give in", "You are owned",
                         "Submission is easy", "Let go of control", "Deeper submission",
                         "You belong", "Surrender completely", "Submit and feel bliss"
-                    };
+                    });
                     content.BouncingTextPhrases = new List<string>
                     {
                         "SUBMIT", "SURRENDER", "GIVE IN", "OWNED", "DEEPER", "BELONG"
                     };
-                    content.LockCardPhrases = new List<string>
+                    content.LockCardPhrases = ThemedOrNeutral("QuizSubmissionLockCard", new List<string>
                     {
                         "I submit willingly", "Surrender feels so good", "I give in completely",
                         "I belong", "I surrender", "I let go of control",
                         "Submission is bliss", "I am deeply submissive"
-                    };
+                    });
                     break;
 
                 default:
                     content.Name = $"{diffPrefix} Conditioning";
                     content.Description = "A personalized conditioning session.";
-                    content.SubliminalPhrases = new List<string>
+                    content.SubliminalPhrases = ThemedOrNeutral("QuizCustomSubliminal", new List<string>
                     {
                         "Good", "Obey", "Submit", "Let go", "Deeper",
                         "Surrender", "Empty mind", "So good", "Accept it", "Drift away"
-                    };
-                    content.BouncingTextPhrases = new List<string>
+                    });
+                    content.BouncingTextPhrases = ThemedOrNeutral("QuizCustomBouncingText", new List<string>
                     {
                         "OBEY", "SUBMIT", "DEEPER", "SO GOOD", "LET GO", "SURRENDER"
-                    };
-                    content.LockCardPhrases = new List<string>
+                    });
+                    content.LockCardPhrases = ThemedOrNeutral("QuizCustomLockCard", new List<string>
                     {
                         "I am good for this", "I love to obey", "Surrender feels good",
                         "I submit willingly", "Empty and happy", "I listen",
                         "I let go of control", "Deeper and deeper"
-                    };
+                    });
                     break;
             }
 

--- a/Tests/ConditioningControlPanel.Tests/NeutralModGatingQuizTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/NeutralModGatingQuizTests.cs
@@ -1,0 +1,302 @@
+using System.Linq;
+using ConditioningControlPanel.Models;
+using ConditioningControlPanel.Services;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// The last two ungated Wave 1 sites: the Pop Quiz question bank and the generated-session phrase
+/// pools. Both were neutralised with no mod lookup at all, so a user with BambiSleep active was
+/// asked "What do good subjects do?" and praised with "Good." - wording they had never seen, in a
+/// voice that is not their mod's.
+///
+/// Both resolvers are pure and static, so nothing here needs an App: the Pop Quiz one is called
+/// with the strings a mod would supply, and the generator's pool swap is proven through the
+/// built-in manifests plus the no-mod path.
+/// </summary>
+public class NeutralModGatingQuizTests
+{
+    // ---- Pop Quiz ----------------------------------------------------------
+
+    /// <summary>
+    /// The slot constants are indices into a 25-entry array, so they are exactly the kind of thing
+    /// that rots when a question is inserted. Pin the neutral text at each one.
+    /// </summary>
+    [Fact]
+    public void The_three_themed_slots_still_point_at_the_right_questions()
+    {
+        Assert.Equal("What do good subjects do?", PopQuizService.QuestionPool[PopQuizSlots.Obedience].QuestionText);
+        Assert.Equal("When I hear praise, I feel...", PopQuizService.QuestionPool[PopQuizSlots.PraiseHeard].QuestionText);
+        Assert.Equal("Your favorite word is...", PopQuizService.QuestionPool[PopQuizSlots.FavouriteWord].QuestionText);
+    }
+
+    /// <summary>An unmodded install gets the neutral bank back, by reference.</summary>
+    [Fact]
+    public void No_mod_gets_the_neutral_bank_untouched()
+        => Assert.Same(PopQuizService.QuestionPool, PopQuizService.ResolveQuestionPool(null, null, null));
+
+    /// <summary>The 6.9.3 wording, restored for a mod that carries it.</summary>
+    [Fact]
+    public void BambiSleep_gets_its_6_9_3_questions_and_praise_back()
+    {
+        var messages = BuiltInMods.BambiSleep.Messages!;
+
+        var pool = PopQuizService.ResolveQuestionPool(
+            messages.QuizPraise, messages.QuizObedienceQuestion, messages.QuizPraiseHeardQuestion);
+
+        Assert.Equal("What do good girls do?", pool[PopQuizSlots.Obedience].QuestionText);
+        Assert.Equal("Good girl.", pool[PopQuizSlots.Obedience].Affirmations[0]);
+        Assert.Equal("When I hear 'good girl,' I feel...", pool[PopQuizSlots.PraiseHeard].QuestionText);
+        Assert.Equal("Good girl.", pool[PopQuizSlots.PraiseHeard].Affirmations[0]);
+        Assert.Equal("Good girl", pool[PopQuizSlots.FavouriteWord].Answers[PopQuizSlots.FavouriteWordAnswer]);
+        Assert.Equal("Good girl.", pool[PopQuizSlots.FavouriteWord].Affirmations[PopQuizSlots.FavouriteWordAnswer]);
+    }
+
+    /// <summary>Substitution, not an append: the odds of drawing any one question do not move.</summary>
+    [Fact]
+    public void A_themed_pool_is_the_same_size_and_only_the_three_slots_differ()
+    {
+        var messages = BuiltInMods.BambiSleep.Messages!;
+
+        var pool = PopQuizService.ResolveQuestionPool(
+            messages.QuizPraise, messages.QuizObedienceQuestion, messages.QuizPraiseHeardQuestion);
+
+        Assert.Equal(PopQuizService.QuestionPool.Length, pool.Length);
+        for (int i = 0; i < pool.Length; i++)
+        {
+            if (i is PopQuizSlots.Obedience or PopQuizSlots.PraiseHeard or PopQuizSlots.FavouriteWord) continue;
+            Assert.Same(PopQuizService.QuestionPool[i], pool[i]);
+        }
+    }
+
+    /// <summary>
+    /// A mod's question under the neutral praise reads as a bug on the card, so the praise line
+    /// gates all three slots - the same rule the trick pair follows.
+    /// </summary>
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(".")]
+    public void A_mod_with_no_praise_line_is_ignored_entirely(string? praise)
+    {
+        var pool = PopQuizService.ResolveQuestionPool(praise, "What do good girls do?", "When I hear 'good girl,' I feel...");
+
+        Assert.Equal("What do good subjects do?", pool[PopQuizSlots.Obedience].QuestionText);
+    }
+
+    /// <summary>
+    /// Half of a slot is allowed to be missing the other way round: a mod that names a praise line
+    /// but no question still gets its praise on the answer chip, which needs no question of its own.
+    /// </summary>
+    [Fact]
+    public void A_praise_line_alone_still_reaches_the_answer_chip()
+    {
+        var pool = PopQuizService.ResolveQuestionPool("Good pet.", null, null);
+
+        Assert.Equal("What do good subjects do?", pool[PopQuizSlots.Obedience].QuestionText);
+        Assert.Equal("Good pet", pool[PopQuizSlots.FavouriteWord].Answers[PopQuizSlots.FavouriteWordAnswer]);
+        Assert.Equal("Good pet.", pool[PopQuizSlots.FavouriteWord].Affirmations[PopQuizSlots.FavouriteWordAnswer]);
+    }
+
+    /// <summary>
+    /// The resolver clones. The Pop Quiz draws many times a session, and one leak would make a
+    /// themed mod's wording permanent for the rest of the process.
+    /// </summary>
+    [Fact]
+    public void Resolving_for_a_mod_does_not_mutate_the_shared_neutral_bank()
+    {
+        PopQuizService.ResolveQuestionPool("Good girl.", "What do good girls do?", "When I hear 'good girl,' I feel...");
+
+        Assert.Equal("What do good subjects do?", PopQuizService.QuestionPool[PopQuizSlots.Obedience].QuestionText);
+        Assert.Equal("Good.", PopQuizService.QuestionPool[PopQuizSlots.Obedience].Affirmations[0]);
+        Assert.Equal("Deeper", PopQuizService.QuestionPool[PopQuizSlots.FavouriteWord].Answers[PopQuizSlots.FavouriteWordAnswer]);
+    }
+
+    /// <summary>Every themed built-in answers both halves, or neither - never a lone question.</summary>
+    [Theory]
+    [InlineData(nameof(BuiltInMods.BambiSleep))]
+    [InlineData(nameof(BuiltInMods.SissyHypno))]
+    [InlineData(nameof(BuiltInMods.Dronification))]
+    [InlineData(nameof(BuiltInMods.Locked))]
+    public void Every_themed_builtin_names_a_praise_line_for_the_questions_it_names(string mod)
+    {
+        var messages = Manifest(mod).Messages!;
+
+        Assert.False(string.IsNullOrWhiteSpace(messages.QuizPraise));
+        Assert.False(string.IsNullOrWhiteSpace(messages.QuizObedienceQuestion));
+        Assert.False(string.IsNullOrWhiteSpace(messages.QuizPraiseHeardQuestion));
+    }
+
+    /// <summary>
+    /// CCP Default names none. The neutral bank is 25 questions in PopQuizService, and the accessors
+    /// do not walk to the base mod, so a value here would be dead weight that silently drifts.
+    /// </summary>
+    [Fact]
+    public void CcpDefault_names_no_quiz_wording()
+    {
+        var messages = BuiltInMods.CCPDefault.Messages!;
+
+        Assert.Null(messages.QuizPraise);
+        Assert.Null(messages.QuizObedienceQuestion);
+        Assert.Null(messages.QuizPraiseHeardQuestion);
+    }
+
+    [Fact]
+    public void Over_long_quiz_wording_is_truncated_not_rejected()
+    {
+        var manifest = new ModManifest
+        {
+            Id = "test-quiz-caps",
+            Name = "Quiz caps",
+            Messages = new ModMessages
+            {
+                QuizPraise = new string('a', 900),
+                QuizObedienceQuestion = new string('b', 900),
+                QuizPraiseHeardQuestion = new string('c', 900)
+            }
+        };
+
+        var error = ModService.SanitizeManifest(manifest);
+
+        Assert.Null(error);
+        Assert.Equal(60, manifest.Messages.QuizPraise!.Length);
+        Assert.Equal(200, manifest.Messages.QuizObedienceQuestion!.Length);
+        Assert.Equal(200, manifest.Messages.QuizPraiseHeardQuestion!.Length);
+    }
+
+    // ---- Generated session phrase pools ------------------------------------
+
+    /// <summary>
+    /// The seven pools Wave 1 rewrote. A mod that carries them has to carry all seven, or a session
+    /// reads half in its voice and half in the house one.
+    /// </summary>
+    private static readonly string[] QuizPoolCategories =
+    {
+        "QuizObedienceSubliminal", "QuizObedienceLockCard",
+        "QuizSubmissionSubliminal", "QuizSubmissionLockCard",
+        "QuizCustomSubliminal", "QuizCustomBouncingText", "QuizCustomLockCard"
+    };
+
+    [Theory]
+    [InlineData(nameof(BuiltInMods.BambiSleep))]
+    [InlineData(nameof(BuiltInMods.SissyHypno))]
+    public void The_two_mods_that_owned_the_6_9_3_wording_carry_all_seven_pools(string mod)
+    {
+        var phrases = Manifest(mod).Phrases!;
+
+        foreach (var category in QuizPoolCategories)
+        {
+            Assert.True(phrases.ContainsKey(category), $"{mod} is missing {category}");
+            Assert.NotEmpty(phrases[category]);
+        }
+    }
+
+    /// <summary>The exact phrases the neutral pass took away, spot-checked per pool.</summary>
+    [Fact]
+    public void BambiSleep_keeps_the_6_9_3_session_phrases()
+    {
+        var phrases = BuiltInMods.BambiSleep.Phrases!;
+
+        Assert.Contains("Good girls listen", phrases["QuizObedienceSubliminal"]);
+        Assert.Contains("Good girls follow instructions", phrases["QuizObedienceLockCard"]);
+        Assert.Contains("Good girls submit", phrases["QuizSubmissionSubliminal"]);
+        Assert.Contains("Good girls surrender", phrases["QuizSubmissionLockCard"]);
+        Assert.Contains("Good girl", phrases["QuizCustomSubliminal"]);
+        Assert.Contains("So pretty", phrases["QuizCustomSubliminal"]);
+        Assert.Contains("GOOD GIRL", phrases["QuizCustomBouncingText"]);
+        Assert.Contains("I am a good girl", phrases["QuizCustomLockCard"]);
+    }
+
+    /// <summary>
+    /// A themed pool has to be a drop-in replacement for the neutral one, or a session drawn from
+    /// it is shorter or longer than the generator's own shaping expects.
+    /// </summary>
+    [Fact]
+    public void A_themed_pool_is_the_same_size_as_the_neutral_one_it_replaces()
+    {
+        var phrases = BuiltInMods.BambiSleep.Phrases!;
+        var obedience = QuizSessionGenerator.GetFallbackContent("obedience", 50);
+        var submission = QuizSessionGenerator.GetFallbackContent("submission", 50);
+        var custom = QuizSessionGenerator.GetFallbackContent("whatever-else", 50);
+
+        Assert.Equal(obedience.SubliminalPhrases.Count, phrases["QuizObedienceSubliminal"].Length);
+        Assert.Equal(obedience.LockCardPhrases.Count, phrases["QuizObedienceLockCard"].Length);
+        Assert.Equal(submission.SubliminalPhrases.Count, phrases["QuizSubmissionSubliminal"].Length);
+        Assert.Equal(submission.LockCardPhrases.Count, phrases["QuizSubmissionLockCard"].Length);
+        Assert.Equal(custom.SubliminalPhrases.Count, phrases["QuizCustomSubliminal"].Length);
+        Assert.Equal(custom.BouncingTextPhrases.Count, phrases["QuizCustomBouncingText"].Length);
+        Assert.Equal(custom.LockCardPhrases.Count, phrases["QuizCustomLockCard"].Length);
+    }
+
+    /// <summary>
+    /// With no mod layer the generator still answers, in the neutral wording. This is the unmodded
+    /// path and also the one every other test in this suite runs on.
+    /// </summary>
+    [Fact]
+    public void With_no_mod_the_generator_serves_the_neutral_pools()
+    {
+        var obedience = QuizSessionGenerator.GetFallbackContent("obedience", 50);
+        var custom = QuizSessionGenerator.GetFallbackContent("whatever-else", 50);
+
+        Assert.Contains("Listening is easy", obedience.SubliminalPhrases);
+        Assert.DoesNotContain("Good girls listen", obedience.SubliminalPhrases);
+        Assert.Contains("SO GOOD", custom.BouncingTextPhrases);
+        Assert.DoesNotContain("GOOD GIRL", custom.BouncingTextPhrases);
+    }
+
+    /// <summary>
+    /// The per-niche cases are chosen by the intake niche, not by a quiz score, so they were always
+    /// the mod's own words and Wave 1 left them alone. Guard against a later pass "neutralising"
+    /// them, which would empty the themed niches of their voice.
+    /// </summary>
+    [Fact]
+    public void The_per_niche_cases_are_still_themed()
+    {
+        Assert.Contains("Bambi Sleep", QuizSessionGenerator.GetFallbackContent("bambi", 50).SubliminalPhrases);
+        Assert.Contains("Good girl", QuizSessionGenerator.GetFallbackContent("sissy", 50).SubliminalPhrases);
+        Assert.Contains("She holds the key", QuizSessionGenerator.GetFallbackContent("circe", 50).SubliminalPhrases);
+    }
+
+    /// <summary>The seven new categories fit inside the manifest's 50-category ceiling.</summary>
+    [Theory]
+    [InlineData(nameof(BuiltInMods.BambiSleep))]
+    [InlineData(nameof(BuiltInMods.SissyHypno))]
+    [InlineData(nameof(BuiltInMods.Dronification))]
+    [InlineData(nameof(BuiltInMods.Locked))]
+    [InlineData(nameof(BuiltInMods.CCPDefault))]
+    public void No_builtin_mod_exceeds_the_phrase_category_ceiling(string mod)
+    {
+        // Read-only on purpose: SanitizeManifest mutates, and these manifests are process-wide
+        // singletons that every other test reads.
+        var manifest = Manifest(mod);
+
+        Assert.True(manifest.Phrases!.Count <= 50, $"{mod} has {manifest.Phrases.Count} phrase categories");
+    }
+
+    /// <summary>
+    /// Dronification and Circe's Lock deliberately carry none of the seven. The 6.9.3 wording was
+    /// never theirs ("good girls" for a drone), so the neutral pool is the better answer and this
+    /// records that as a choice rather than an omission.
+    /// </summary>
+    [Theory]
+    [InlineData(nameof(BuiltInMods.Dronification))]
+    [InlineData(nameof(BuiltInMods.Locked))]
+    [InlineData(nameof(BuiltInMods.CCPDefault))]
+    public void The_mods_the_6_9_3_wording_never_fitted_stay_on_the_neutral_pools(string mod)
+    {
+        var phrases = Manifest(mod).Phrases!;
+
+        Assert.Empty(QuizPoolCategories.Where(phrases.ContainsKey));
+    }
+
+    private static ModManifest Manifest(string name) => name switch
+    {
+        nameof(BuiltInMods.BambiSleep) => BuiltInMods.BambiSleep,
+        nameof(BuiltInMods.SissyHypno) => BuiltInMods.SissyHypno,
+        nameof(BuiltInMods.Dronification) => BuiltInMods.Dronification,
+        nameof(BuiltInMods.Locked) => BuiltInMods.Locked,
+        _ => BuiltInMods.CCPDefault
+    };
+}


### PR DESCRIPTION
Stacked on #1072 (base is `fix/694-mod-gating-2`, not `release/6.9.4` - retarget it to `release/6.9.4` once #1072 lands). Split out to keep both diffs reviewable.

These are the last two Wave 1 sites with no mod awareness at all: neither file mentions `App.Mods`, `BuiltInMods` or `VocabTokens` even once. A user with BambiSleep active opens a Pop Quiz in 6.9.4 and is asked "What do good subjects do?" and praised with "Good." - text they have never seen, in a voice that is not their mod's.

## Sites restored

**1. The Pop Quiz question bank - `Services/Quiz/PopQuizService.cs`**

`22932f7b0` rewrote three of the 25 questions and left no way to get the old wording back:

| slot | 6.9.3 | 6.9.4 |
|---|---|---|
| 3 | "What do good girls do?" / praise "Good girl." | "What do good subjects do?" / "Good." |
| 6 | "When I hear 'good girl,' I feel..." / praise "Good girl." | "When I hear praise, I feel..." / "That's it." |
| 15 | answer + praise "Good girl" / "Good girl." | "Deeper" / "Deeper." |

`ResolveQuestionPool(praise, obedienceQuestion, praiseHeardQuestion)` is the twin of `QuizWindow.ResolveTrickQuestions`: pure, static, clones, and **substitutes** rather than appends, so the odds of drawing any one question stay exactly what they were. Slot indices are named in `PopQuizSlots` and pinned by a test, because they are indices into a 25-entry array.

A mod speaks for the slots through three new `ModMessages` fields: `quizPraise` (the praise sentence; its answer-chip form is the same string with the trailing full stop trimmed, because a chip is a word, not a sentence), `quizObedienceQuestion` and `quizPraiseHeardQuestion`. A mod with no praise line is ignored entirely - its question under the house praise reads as a bug on the card, which is the rule the trick pair already follows. Capped in `SanitizeManifest` at 60 / 200 / 200.

**2. The generated-session phrase pools - `Services/Quiz/QuizSessionGenerator.cs`**

`GetFallbackContent` has per-niche cases (bambi / sissy / circe) that Wave 1 correctly left alone - those are chosen by the intake niche and were always the mod's own words. The three **generic** cases are the problem: obedience, submission and the catch-all are picked from a quiz *score*, so a user of any mod draws them, which is how their 6.9.3 wording reached everybody. Wave 1 rewrote ten phrases across seven pools with no mod branch.

Each of the seven now goes through `ThemedOrNeutral(category, neutral)`, reading the manifest's existing `phrases` dictionary (active mod, then base mod, then the inline neutral list). New categories: `QuizObedienceSubliminal`, `QuizObedienceLockCard`, `QuizSubmissionSubliminal`, `QuizSubmissionLockCard`, `QuizCustomSubliminal`, `QuizCustomBouncingText`, `QuizCustomLockCard`. It also means a creator `.ccpmod` can own these pools, which it could not before.

## Who gets what

- **BambiSleep** and **SissyHypno**: the 6.9.3 wording verbatim in both places - "What do good girls do?", "Good girl.", "Good girls listen", "Good girls surrender", "GOOD GIRL", "I am a good girl", and the rest.
- **Dronification** and **Circe's Lock**: the three quiz questions in their own voice ("What does a good unit do?", "What do good pets do?"), and deliberately **no** session pools. "Good girls submit" was never theirs; neutral is the better answer than a word they never used, and a test records that as a choice rather than an omission.
- **CCP Default**: names nothing. Neither accessor walks to the base mod, so the single copy of the neutral text stays in the two services and cannot drift.

## Notes

- No new user-facing strings, so no localisation keys: everything added is mod flavour text in `BuiltInMods.cs`, where 6.9.3 kept it.
- Phrase categories per built-in go 28 to 35, well inside the manifest's 50-category ceiling (pinned by a test).
- `Tests/ConditioningControlPanel.Tests/NeutralModGatingQuizTests.cs` (new, 302 lines): slot indices, the Bambi round-trip, same-size substitution, the no-praise gate, no mutation of the shared static bank, all seven pools present and the same length as the neutral ones they replace, the per-niche cases still themed, and the no-mod path still neutral.

## Verification

- `dotnet build ConditioningControlPanel/ConditioningControlPanel.csproj -c Debug` - **0 errors**, 364 warnings (unchanged).
- `dotnet test --filter "FullyQualifiedName~Mod|Quiz|Intake|Marquee|Neutral"` - **1025 passed, 0 failed**.
- Full suite - **5896 passed, 0 failed, 0 skipped** (5835 before these two PRs; +61 new tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013mR8cAipk1ivr3Em5fJjcx
