### PR TITLE
feat(usage): per-day engagement events on the feature log + rebaseline after the minutes merge

### DIFF
--- a/ConditioningControlPanel/App.xaml.cs
+++ b/ConditioningControlPanel/App.xaml.cs
@@ -3968,6 +3968,9 @@ namespace ConditioningControlPanel
                 if (backup == null) { PostRestoreFailedInboxItem(); return; }
 
                 ApplyRestoredSettings(backup);
+                // The restore takes the higher TotalConditioningMinutes; that history belongs to
+                // the days it happened on, not to today's day-log entry.
+                FeatureDayLog?.Rebaseline("welcome-back restore");
 
                 // The backup remembers an OLDER LastSeenVersion, and ApplyRestoredSettings does not
                 // preserve this one - so without this line the restore re-arms What's New for a

--- a/ConditioningControlPanel/AvatarTube/AvatarTubeWindow.ChatInput.cs
+++ b/ConditioningControlPanel/AvatarTube/AvatarTubeWindow.ChatInput.cs
@@ -762,6 +762,7 @@ namespace ConditioningControlPanel
 
             TxtUserInput.Text = "";
             ToggleInputPanel();
+            SeasonRecapService.TrackFeature(SeasonFeatureKeys.Companion);
 
             // Which of the send paths below this message takes. Decided ONCE, up front, so the
             // EMIT hook and the actual call can't disagree if the kill switch — or IsAvailable,

--- a/ConditioningControlPanel/Models/FeatureDayLog.cs
+++ b/ConditioningControlPanel/Models/FeatureDayLog.cs
@@ -18,6 +18,23 @@ public class FeatureDayEntry
     /// <summary>The 11 counter keys, in contract order. <c>d</c> is not a counter.</summary>
     public static readonly string[] CounterKeys = { "xp", "cm", "fl", "bb", "pf", "sp", "vd", "lk", "ac", "bc", "ss" };
 
+    /// <summary>
+    /// The engagement event keys (wire contract 2): how many times that day a session started
+    /// with the feature enabled, or a Lab mode was launched. Fed by
+    /// <c>FeatureDayLogService.Note</c> from the hooks (via SeasonRecapService.TrackFeature),
+    /// not diffed from a lifetime counter, so they carry no baseline. Kept in
+    /// <see cref="Events"/> (local file field <c>ev</c>) and flattened onto the wire beside the
+    /// counters; the server whitelists exactly this list, so a key that is not here never leaves
+    /// the machine.
+    /// </summary>
+    public static readonly string[] EventKeys =
+    {
+        "e_fl", "e_vd", "e_sb", "e_ov", "e_bb", "e_bc", "e_bt", "e_lk", "e_mw",
+        "e_pq", "e_bl", "e_cp", "e_ch", "e_dt", "e_rc", "e_pb"
+    };
+
+    public static bool IsEventKey(string key) => Array.IndexOf(EventKeys, key) >= 0;
+
     [JsonProperty("d")]
     [JsonPropertyName("d")]
     public string D { get; set; } = "";
@@ -45,6 +62,11 @@ public class FeatureDayEntry
     /// <summary>Sessions started.</summary>
     [JsonProperty("ss")] [JsonPropertyName("ss")] public int Ss { get; set; }
 
+    /// <summary>Engagement events for the day, keyed by <see cref="EventKeys"/>.</summary>
+    [JsonProperty("ev", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("ev")]
+    public Dictionary<string, int> Events { get; set; } = new();
+
     public FeatureDayEntry() { }
 
     public FeatureDayEntry(string day) { D = day; }
@@ -53,7 +75,7 @@ public class FeatureDayEntry
     {
         "xp" => Xp, "cm" => Cm, "fl" => Fl, "bb" => Bb, "pf" => Pf, "sp" => Sp,
         "vd" => Vd, "lk" => Lk, "ac" => Ac, "bc" => Bc, "ss" => Ss,
-        _ => 0
+        _ => Events != null && Events.TryGetValue(key, out var ev) ? ev : 0
     };
 
     /// <summary>Add <paramref name="amount"/> (never negative) to one counter.</summary>
@@ -73,13 +95,18 @@ public class FeatureDayEntry
             case "ac": Ac += amount; break;
             case "bc": Bc += amount; break;
             case "ss": Ss += amount; break;
+            default:
+                if (!IsEventKey(key)) return;
+                Events ??= new();
+                Events[key] = (Events.TryGetValue(key, out var cur) ? cur : 0) + amount;
+                break;
         }
     }
 
     /// <summary>True when every counter is zero: such a day is never put on the wire.</summary>
     [Newtonsoft.Json.JsonIgnore]
     [System.Text.Json.Serialization.JsonIgnore]
-    public bool IsEmpty => CounterKeys.All(k => Get(k) <= 0);
+    public bool IsEmpty => CounterKeys.All(k => Get(k) <= 0) && (Events == null || Events.All(kv => kv.Value <= 0));
 
     /// <summary>
     /// The wire shape: <c>d</c> always, then only the counters that are above zero. Zero-valued
@@ -89,6 +116,11 @@ public class FeatureDayEntry
     {
         var wire = new Dictionary<string, object> { ["d"] = D };
         foreach (var key in CounterKeys)
+        {
+            var v = Get(key);
+            if (v > 0) wire[key] = v;
+        }
+        foreach (var key in EventKeys)
         {
             var v = Get(key);
             if (v > 0) wire[key] = v;

--- a/ConditioningControlPanel/Models/SeasonRecap.cs
+++ b/ConditioningControlPanel/Models/SeasonRecap.cs
@@ -26,6 +26,26 @@ namespace ConditioningControlPanel.Models
         public const string MindWipe = "mindwipe";
         public const string BlinkTrainer = "blink";
         public const string Companion = "companion";
+        // Lab modes. Not in the Catalog (the recap card shows conditioning effects only); they
+        // exist so the same TrackFeature hook can feed the per-day engagement log below.
+        public const string ChaosMode = "chaos";
+        public const string Dtrh = "dtrh";
+        public const string Race = "race";
+        public const string PieceByPiece = "pbp";
+
+        /// <summary>
+        /// The day-log event key (<see cref="FeatureDayEntry.EventKeys"/>) a season feature key
+        /// maps to, or null for one that never goes on the wire. Lives here so the two lists
+        /// cannot drift apart without the build noticing.
+        /// </summary>
+        public static string? ToDayLogEvent(string key) => key switch
+        {
+            Flash => "e_fl", Video => "e_vd", Subliminal => "e_sb", Overlay => "e_ov",
+            Bubbles => "e_bb", BubbleCount => "e_bc", BouncingText => "e_bt", LockCard => "e_lk",
+            MindWipe => "e_mw", PopQuiz => "e_pq", BlinkTrainer => "e_bl", Companion => "e_cp",
+            ChaosMode => "e_ch", Dtrh => "e_dt", Race => "e_rc", PieceByPiece => "e_pb",
+            _ => null
+        };
 
         public sealed record FeatureDef(string Key, string LabelLocKey, string ImagePath);
 

--- a/ConditioningControlPanel/Services/BlinkTrainerService.cs
+++ b/ConditioningControlPanel/Services/BlinkTrainerService.cs
@@ -15,6 +15,7 @@ using System.Windows.Media.Imaging;
 using System.Windows.Threading;
 using ConditioningControlPanel.Localization;
 using XamlAnimatedGif;
+using ConditioningControlPanel.Models;
 
 namespace ConditioningControlPanel.Services;
 
@@ -173,6 +174,7 @@ public class BlinkTrainerService : IDisposable
             _durationTimer.Start();
 
             IsRunning = true;
+            SeasonRecapService.TrackFeature(SeasonFeatureKeys.BlinkTrainer);
             LastError = "";
             App.Logger?.Information(
                 "BlinkTrainer: started — pool={Count} assets, duration={Mins}m, opacity={Opacity}%, screens={Screens}",

--- a/ConditioningControlPanel/Services/Chaos/CaucusHostService.cs
+++ b/ConditioningControlPanel/Services/Chaos/CaucusHostService.cs
@@ -11,6 +11,8 @@ using ConditioningControlPanel.Models.Race;
 using ConditioningControlPanel.Services.Race;
 using Microsoft.Web.WebView2.Core;
 using Newtonsoft.Json.Linq;
+using ConditioningControlPanel.Models;
+using ConditioningControlPanel.Services;
 
 namespace ConditioningControlPanel.Services.Chaos;
 
@@ -278,6 +280,7 @@ internal static class CaucusHostService
                 break;
             case "run-started":
                 _runActive = true;
+                SeasonRecapService.TrackFeature(SeasonFeatureKeys.Race);
                 App.Logger?.Information("RaceHost: run started (seed={Seed})", (string?)o["seed"]);
                 break;
             case "run-ended":

--- a/ConditioningControlPanel/Services/Chaos/ChaosModeService.cs
+++ b/ConditioningControlPanel/Services/Chaos/ChaosModeService.cs
@@ -3,6 +3,8 @@ using System.Linq;
 using System.Windows;
 using System.Windows.Media;
 using System.Windows.Threading;
+using ConditioningControlPanel.Models;
+using ConditioningControlPanel.Services;
 
 namespace ConditioningControlPanel.Services.Chaos;
 
@@ -294,6 +296,7 @@ public sealed class ChaosModeService
     public void StartRun(ChaosRunConfig? config = null, bool isRestart = false)
     {
         if (_active) return;
+        if (!isRestart) SeasonRecapService.TrackFeature(SeasonFeatureKeys.ChaosMode);
 
         // A chaos run takes over the screen with its own overlays/HUD; stop any running
         // conditioning engine or AI session first so the two don't fight over the display.

--- a/ConditioningControlPanel/Services/Chaos/DtrhHostService.cs
+++ b/ConditioningControlPanel/Services/Chaos/DtrhHostService.cs
@@ -6,6 +6,8 @@ using System.Windows;
 using System.Windows.Threading;
 using Microsoft.Web.WebView2.Core;
 using Newtonsoft.Json.Linq;
+using ConditioningControlPanel.Models;
+using ConditioningControlPanel.Services;
 
 namespace ConditioningControlPanel.Services.Chaos;
 
@@ -290,6 +292,7 @@ internal static class DtrhHostService
             case "run-started":
             {
                 _runActive = true;
+                SeasonRecapService.TrackFeature(SeasonFeatureKeys.Dtrh);
                 _vnSpeaking = false;   // never carry a stale duck into a run
                 ApplyWorldFreeze(false);   // a stale freeze from a crashed prior run must not bleed into this descent's dedup state
                 ResetRunMetrics();     // fresh native engagement counters for this descent

--- a/ConditioningControlPanel/Services/PieceByPiece/PieceByPieceHostService.cs
+++ b/ConditioningControlPanel/Services/PieceByPiece/PieceByPieceHostService.cs
@@ -10,6 +10,8 @@ using System.Windows.Threading;
 using ConditioningControlPanel.Services.Chaos;
 using Microsoft.Web.WebView2.Core;
 using Newtonsoft.Json.Linq;
+using ConditioningControlPanel.Models;
+using ConditioningControlPanel.Services;
 
 namespace ConditioningControlPanel.Services.PieceByPiece;
 
@@ -142,6 +144,7 @@ internal static class PieceByPieceHostService
         // The same door the Arcademy and the descent ask for: a card's lockband is decoration, and
         // the one code path that actually opens the window has to be the one that can say no.
         if (!TierGate.DemandLab(ProductName)) return;
+        SeasonRecapService.TrackFeature(SeasonFeatureKeys.PieceByPiece);
 
         try
         {

--- a/ConditioningControlPanel/Services/Progression/FeatureDayLogService.cs
+++ b/ConditioningControlPanel/Services/Progression/FeatureDayLogService.cs
@@ -126,6 +126,24 @@ public class FeatureDayLogService : IDisposable
     }
 
     /// <summary>
+    /// Credit today with one engagement event (wire contract 2, <see cref="FeatureDayEntry.EventKeys"/>).
+    /// Unlike the counters there is no lifetime source to diff against, so the hook IS the record:
+    /// a key outside the whitelist is dropped here rather than stored. Safe from any thread; the
+    /// 60 s timer (or the next sync's Flush) writes it to disk.
+    /// </summary>
+    public void Note(string eventKey, int amount = 1)
+    {
+        if (amount <= 0 || string.IsNullOrEmpty(eventKey) || !FeatureDayEntry.IsEventKey(eventKey)) return;
+        lock (_lock)
+        {
+            var today = DateTime.Today;
+            Log.GetOrAddDay(DayKey(today)).Add(eventKey, amount);
+            Log.Prune(DayKey(today.AddDays(-FeatureDayLog.MaxDays)));
+            _dirty = true;
+        }
+    }
+
+    /// <summary>
     /// Move every baseline to the current lifetime value without crediting the difference. For
     /// the moment a cloud merge lifts the local counters to what another device banked: that
     /// gain belongs to other days, not to today.

--- a/ConditioningControlPanel/Services/Progression/SeasonRecapService.cs
+++ b/ConditioningControlPanel/Services/Progression/SeasonRecapService.cs
@@ -205,6 +205,15 @@ namespace ConditioningControlPanel.Services
 
         public static void TrackFeature(string featureKey)
         {
+            // The one hook every feature calls also feeds the per-day engagement log the server
+            // aggregates (stats.feature_day_log event keys). Keys with no wire name stay local.
+            var ev = SeasonFeatureKeys.ToDayLogEvent(featureKey);
+            if (ev != null) App.FeatureDayLog?.Note(ev);
+
+            // The season bucket (recap card badge row, Ditzy Data lifetime bars) only knows the
+            // Catalog: a Lab launch or a chat message counted there would skew those bars.
+            if (SeasonFeatureKeys.Find(featureKey) == null) return;
+
             var s = App.Settings?.Current; if (s == null) return;
             EnsureBucket(s);
             s.TrackSeasonFeature(featureKey);

--- a/ConditioningControlPanel/Services/Quiz/PopQuizService.cs
+++ b/ConditioningControlPanel/Services/Quiz/PopQuizService.cs
@@ -3,6 +3,8 @@ using System.Linq;
 using System.Windows;
 using System.Windows.Threading;
 using ConditioningControlPanel.Helpers;
+using ConditioningControlPanel.Models;
+using ConditioningControlPanel.Services;
 
 namespace ConditioningControlPanel.Services
 {
@@ -244,6 +246,7 @@ namespace ConditioningControlPanel.Services
                     // Don't set Owner — WPF ties owned window z-order to owner,
                     // which fights with our Win32 HWND_TOPMOST positioning
                     window.Show();
+                    if (!isTest) SeasonRecapService.TrackFeature(SeasonFeatureKeys.PopQuiz);
 
                     App.Logger?.Information("Pop Quiz shown: {Question}", question.QuestionText);
                 }

--- a/ConditioningControlPanel/Services/Settings/ProfileSyncService.cs
+++ b/ConditioningControlPanel/Services/Settings/ProfileSyncService.cs
@@ -1872,6 +1872,7 @@ namespace ConditioningControlPanel.Services
                         // ConsecutiveDays, daily_quest_streak, completion dates, etc.) was never refreshed
                         // from cloud, so admin restores / cross-device progress stayed invisible until the
                         // V1 fallback ran. Mirror MergeCloudProfile's stats merge for V2.
+                        var liftedLifetime = false;
                         if (v2Result?.User?.Stats != null)
                         {
                             if (MergeV2CloudStatsIntoLocalProgress(v2Result.User.Stats, v2Result.ForceStreakOverride == true))
@@ -1882,8 +1883,9 @@ namespace ConditioningControlPanel.Services
                                 App.Settings?.Save();
                                 App.Achievements?.Save();
                                 // Same rule as the legacy path: a lifted lifetime counter is
-                                // another device's history, not today's use.
-                                App.FeatureDayLog?.Rebaseline("v2 cloud merge");
+                                // another device's history, not today's use. The re-baseline
+                                // itself waits until after the minutes merge below.
+                                liftedLifetime = true;
                             }
                         }
 
@@ -1921,7 +1923,16 @@ namespace ConditioningControlPanel.Services
                                 v2Result.TotalConditioningMinutes.Value, settings.TotalConditioningMinutes);
                             settings.TotalConditioningMinutes = v2Result.TotalConditioningMinutes.Value;
                             App.Settings?.Save();
+                            liftedLifetime = true;
                         }
+
+                        // A take-higher merge just lifted lifetime counters to what another device
+                        // banked. That gain is not today's: move the day log's baseline past it.
+                        // AFTER the minutes merge, deliberately: the day log diffs
+                        // TotalConditioningMinutes too, and a re-baseline taken before that lift
+                        // booked another device's whole history onto today (the 1,000-minute days
+                        // in the server archive).
+                        if (liftedLifetime) App.FeatureDayLog?.Rebaseline("v2 cloud merge");
 
                         // Merge companion progress from server (per-companion, higher level wins)
                         if (v2Result?.CompanionProgress != null && v2Result.CompanionProgress.Count > 0)

--- a/Tests/ConditioningControlPanel.Tests/FeatureDayLogTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/FeatureDayLogTests.cs
@@ -1,0 +1,127 @@
+using System.Collections.Generic;
+using System.Linq;
+using ConditioningControlPanel.Models;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// The wire shape of <c>stats.feature_day_log</c> (Spiral rail contracts 1 and 2). The server
+/// whitelists keys and treats an absent key as 0, so what matters here is exactly which keys a
+/// day puts on the wire: counters and engagement events above zero, nothing else, ever.
+/// Only the model is exercised; <c>FeatureDayLogService</c> reads live app statics.
+/// </summary>
+public class FeatureDayLogTests
+{
+    [Fact]
+    public void ToWire_OmitsZeroCountersAndCarriesDay()
+    {
+        var e = new FeatureDayEntry("2026-09-11");
+        e.Add("fl", 12);
+        e.Add("cm", 30);
+
+        var wire = e.ToWire();
+
+        Assert.Equal("2026-09-11", wire["d"]);
+        Assert.Equal(12, wire["fl"]);
+        Assert.Equal(30, wire["cm"]);
+        Assert.Equal(3, wire.Count);
+    }
+
+    [Fact]
+    public void EventKeys_RideBesideCountersOnTheWire()
+    {
+        var e = new FeatureDayEntry("2026-09-11");
+        e.Add("e_fl", 1);
+        e.Add("e_fl", 1);
+        e.Add("e_dt", 3);
+
+        var wire = e.ToWire();
+
+        Assert.Equal(2, wire["e_fl"]);
+        Assert.Equal(3, wire["e_dt"]);
+        Assert.Equal(2, e.Get("e_fl"));
+        Assert.False(e.IsEmpty);
+        Assert.Equal(3, wire.Count);
+    }
+
+    [Fact]
+    public void UnknownKeys_NeverStoredOrSent()
+    {
+        var e = new FeatureDayEntry("2026-09-11");
+        e.Add("e_nope", 5);
+        e.Add("bogus", 5);
+
+        Assert.True(e.IsEmpty);
+        Assert.Equal(0, e.Get("e_nope"));
+        Assert.Single(e.ToWire());          // only "d"
+        Assert.Empty(e.Events);
+    }
+
+    [Fact]
+    public void AllEventKeys_HaveWireNamesAndNoOverlapWithCounters()
+    {
+        Assert.Equal(16, FeatureDayEntry.EventKeys.Length);
+        Assert.All(FeatureDayEntry.EventKeys, k => Assert.StartsWith("e_", k));
+        Assert.Empty(FeatureDayEntry.EventKeys.Intersect(FeatureDayEntry.CounterKeys));
+        Assert.Equal(FeatureDayEntry.EventKeys.Length, FeatureDayEntry.EventKeys.Distinct().Count());
+    }
+
+    [Fact]
+    public void SeasonFeatureKeys_MapOntoDayLogEvents()
+    {
+        // Every catalogued conditioning effect and every Lab mode reaches the wire under a
+        // whitelisted event key; an unknown season key maps to nothing.
+        foreach (var def in SeasonFeatureKeys.Catalog)
+        {
+            var ev = SeasonFeatureKeys.ToDayLogEvent(def.Key);
+            Assert.NotNull(ev);
+            Assert.True(FeatureDayEntry.IsEventKey(ev!), $"{def.Key} -> {ev} is not whitelisted");
+        }
+        foreach (var lab in new[] { SeasonFeatureKeys.ChaosMode, SeasonFeatureKeys.Dtrh, SeasonFeatureKeys.Race,
+                                    SeasonFeatureKeys.PieceByPiece, SeasonFeatureKeys.PopQuiz,
+                                    SeasonFeatureKeys.BlinkTrainer, SeasonFeatureKeys.Companion })
+        {
+            Assert.True(FeatureDayEntry.IsEventKey(SeasonFeatureKeys.ToDayLogEvent(lab)!), lab);
+        }
+        Assert.Null(SeasonFeatureKeys.ToDayLogEvent("not-a-feature"));
+    }
+
+    [Fact]
+    public void LocalFile_RoundTripsEventsThroughBothSerializers()
+    {
+        var log = new FeatureDayLog();
+        var day = log.GetOrAddDay("2026-09-11");
+        day.Add("xp", 100);
+        day.Add("e_cp", 4);
+        log.Baseline["xp"] = 100.5;
+
+        // Local file: System.Text.Json.
+        var stj = System.Text.Json.JsonSerializer.Serialize(log);
+        var backStj = System.Text.Json.JsonSerializer.Deserialize<FeatureDayLog>(stj)!;
+        Assert.Equal(4, backStj.Days.Single().Get("e_cp"));
+        Assert.Equal(100, backStj.Days.Single().Xp);
+        Assert.Equal(100.5, backStj.Baseline["xp"]);
+
+        // Sync body: Newtonsoft, which is what the wire dictionaries go through.
+        var nsj = JsonConvert.SerializeObject(day.ToWire());
+        var wire = JsonConvert.DeserializeObject<Dictionary<string, object>>(nsj)!;
+        Assert.Equal("2026-09-11", wire["d"]);
+        Assert.Equal(4L, wire["e_cp"]);
+        Assert.False(wire.ContainsKey("ev"));   // events are flat on the wire, never nested
+    }
+
+    [Fact]
+    public void Prune_KeepsOnlyTheWindow()
+    {
+        var log = new FeatureDayLog();
+        log.GetOrAddDay("2025-01-01").Add("e_fl", 1);
+        log.GetOrAddDay("2026-09-10").Add("e_fl", 1);
+        log.GetOrAddDay("2026-09-11").Add("e_fl", 1);
+
+        log.Prune("2026-01-01");
+
+        Assert.Equal(new[] { "2026-09-10", "2026-09-11" }, log.Days.Select(d => d.D).OrderBy(d => d));
+    }
+}


### PR DESCRIPTION
## What

The feature day log (`stats.feature_day_log`, live since v6.9.3) measured volume only. This adds **wire contract 2**: 16 per-day engagement event keys so the server can rank features by reach and retention, and fixes the booking bug visible in the first two days of production archives.

- **Event keys** `e_fl e_vd e_sb e_ov e_bb e_bc e_bt e_lk e_mw` (session started with the feature on), `e_pq` pop quiz shown, `e_bl` blink trainer started, `e_cp` companion message sent, `e_ch` Chaos Mode run, `e_dt` DtRH run, `e_rc` Racing Thoughts run, `e_pb` Piece by Piece launch. Stored in an `ev` dictionary locally, flattened on the wire, whitelisted on both ends.
- **One hook**: `SeasonRecapService.TrackFeature` feeds the day log for every key and the season bucket only for Catalog keys, so the recap card and Ditzy Data bars keep their scale.
- **Rebaseline fix**: the V2 sync re-baselined the day log before the take-higher `TotalConditioningMinutes` merge, so another device's whole minute history got booked onto one day (7 of 594 archives show 1,000+ minute days). Now one re-baseline after both merges, plus one after the welcome-back restore.
- 7 new tests in `FeatureDayLogTests`; full suite 5457/5457.

## Server pairing

CCP-Server branch `feat/feature-usage-admin`: `COUNTER_KEYS + EVENT_KEYS`, minute keys clamped to 1440/day, `GET /admin/feature-usage?days=N`. Old servers drop the unknown keys, so this is safe to ship in either order.

## Vehicle

6.9.5 (next release), per owner. Not for release/6.9.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D2ancJoKH8MjM37L3wB1QG
