### PR TITLE
fix(dashboard): an off tile goes grey, an on tile keeps its colour

### DIFF
--- a/ConditioningControlPanel/Features/FeatureCard.xaml
+++ b/ConditioningControlPanel/Features/FeatureCard.xaml
@@ -32,9 +32,19 @@
              a XAML EventTrigger has no way to ask. -->
 
         <Grid x:Name="ContentRoot" SizeChanged="OnContentRootSizeChanged">
-            <!-- Full-bleed background image via ImageBrush (respects parent CornerRadius) -->
+            <!-- Full-bleed background image via ImageBrush (respects parent CornerRadius).
+                 The child is the same art in greyscale (Services/ArtDesaturate), painted OVER
+                 the colour and faded in while the feature is off: an off tile is grey, an on
+                 tile is the only one wearing its palette. A child rather than a sibling so the
+                 hover pop (scale + wobble on ImgIconHost) and the tease blur carry both layers
+                 as one picture. Opacity is written only by FeatureCard.ApplyMute. -->
             <Border x:Name="ImgIconHost" CornerRadius="11"
-                    RenderOptions.BitmapScalingMode="HighQuality"/>
+                    RenderOptions.BitmapScalingMode="HighQuality">
+                <Border x:Name="ImgIconMute" CornerRadius="11"
+                        RenderOptions.BitmapScalingMode="HighQuality"
+                        IsHitTestVisible="False"
+                        Opacity="0"/>
+            </Border>
 
             <!-- Glyph fallback (for cards without an image) -->
             <Border x:Name="GlyphHost"

--- a/ConditioningControlPanel/Features/FeatureCard.xaml.cs
+++ b/ConditioningControlPanel/Features/FeatureCard.xaml.cs
@@ -41,8 +41,16 @@ namespace ConditioningControlPanel.Features
         /// <summary>Resting opacity for a switched-OFF card that opted into
         /// <see cref="DimWhenInactive"/>. Deep enough that the lit tiles win the eye at a glance,
         /// shallow enough that the art still reads and the tile still looks clickable - and well
-        /// clear of the 0.35 lock veil, which has to keep meaning something else.</summary>
+        /// clear of the 0.35 lock veil, which has to keep meaning something else.
+        ///
+        /// <para>Since 6.9.4 the dim is not the whole story: the same off tile also drains to
+        /// greyscale (ImgIconMute, <see cref="ApplyMute"/>). Opacity alone was read as "a bit
+        /// further away", never as "off"; colour is what a glance actually sorts by.</para></summary>
         private const double InactiveContentOpacity = 0.62;
+
+        /// <summary>The title's weight on a muted tile. Chrome follows the art: a grey picture
+        /// with a bright white label still half-says "on".</summary>
+        private const double MutedTitleOpacity = 0.72;
 
         /// <summary>Blur radius for a teased card's art. Tuned to "coloured smear": at the
         /// mosaic's tile size this leaves a mood and a palette and no recognisable shape, which
@@ -264,12 +272,23 @@ namespace ConditioningControlPanel.Features
                     Stretch = System.Windows.Media.Stretch.UniformToFill,
                     AlignmentY = AlignmentY.Center
                 };
+                // The grey twin rides the same brush settings, so the two layers register
+                // pixel for pixel and the fade between them reads as colour draining, not as
+                // a second picture sliding in. Null (non-bitmap art) leaves the opacity dim
+                // to say "off" on its own.
+                var grey = ArtDesaturate.Of(src);
+                c.ImgIconMute.Background = grey == null ? null : new ImageBrush(grey)
+                {
+                    Stretch = System.Windows.Media.Stretch.UniformToFill,
+                    AlignmentY = AlignmentY.Center
+                };
                 c.ImgIconHost.Visibility = Visibility.Visible;
                 c.GlyphHost.Visibility = Visibility.Collapsed;
             }
             else
             {
                 c.ImgIconHost.Background = null;
+                c.ImgIconMute.Background = null;
                 if (!string.IsNullOrEmpty(c.Glyph))
                 {
                     c.ImgIconHost.Visibility = Visibility.Collapsed;
@@ -324,7 +343,9 @@ namespace ConditioningControlPanel.Features
 
         private static void OnTeaseTierChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
-            if (d is FeatureCard c) c.ApplyTeaseState();
+            if (d is not FeatureCard c) return;
+            c.ApplyTeaseState();
+            c.ApplyMute(0);
         }
 
         /// <summary>
@@ -437,6 +458,7 @@ namespace ConditioningControlPanel.Features
             var showActive = IsActive && !IsLocked;
             ActiveBorder.Visibility = showActive ? Visibility.Visible : Visibility.Collapsed;
             ApplyRestOpacity();
+            ApplyMute(CardMuteRule.TransitionMs(MotionFx.AllowTransitions, IsLoaded));
             ApplyActiveBreath(showActive);
         }
 
@@ -458,6 +480,39 @@ namespace ConditioningControlPanel.Features
                 : DimWhenInactive && !IsActive && !_hovered ? InactiveContentOpacity
                 : 1.0;
             ContentRoot.Opacity = target;
+        }
+
+        /// <summary>
+        /// The ONE writer for the grey layer's opacity and the title's muted weight. Lock, tease,
+        /// active and hover are weighed by <see cref="CardMuteRule"/>; this only paints the
+        /// verdict. A locked tile is never muted (its veil is a different sentence), a teased
+        /// tile keeps its blur, and a hover hands the colour straight back.
+        ///
+        /// <para>Always through BeginAnimation: a To-only fade when <paramref name="ms"/> is
+        /// positive, a cleared animation plus a plain assignment otherwise, so an earlier fade
+        /// can never be left holding the property against a later snap.</para>
+        /// </summary>
+        private void ApplyMute(int ms)
+        {
+            try
+            {
+                if (ImgIconMute == null || TxtTitle == null) return;
+                bool mute = CardMuteRule.ShouldMute(DimWhenInactive, IsActive, IsLocked, _hovered, TeaseTier > 0);
+                double to = mute ? 1.0 : 0.0;
+                TxtTitle.Opacity = mute ? MutedTitleOpacity : 1.0;
+                if (ms <= 0)
+                {
+                    ImgIconMute.BeginAnimation(OpacityProperty, null);
+                    ImgIconMute.Opacity = to;
+                    return;
+                }
+                var fade = new DoubleAnimation(to, TimeSpan.FromMilliseconds(ms))
+                {
+                    EasingFunction = new QuadraticEase { EasingMode = EasingMode.EaseOut },
+                };
+                ImgIconMute.BeginAnimation(OpacityProperty, fade);
+            }
+            catch (Exception ex) { App.Logger?.Debug("FeatureCard.ApplyMute: {E}", ex.Message); }
         }
 
         // ============================== FX ==============================
@@ -634,10 +689,11 @@ namespace ConditioningControlPanel.Features
                 // that does nothing.
                 if (IsLocked) on = false;
 
-                // An inactive tile rests dim; hovering hands it back its full art so the pointer
-                // proves the tile is still live. ApplyRestOpacity re-reads IsLocked, so this stays
-                // correct for a locked card, whose veil must not lift.
+                // An inactive tile rests dim and grey; hovering hands it back its full art so the
+                // pointer proves the tile is still live. Both writers re-read IsLocked, so this
+                // stays correct for a locked card, whose veil must not lift.
                 ApplyRestOpacity();
+                ApplyMute(CardMuteRule.TransitionMs(MotionFx.AllowTransitions, IsLoaded));
 
                 MotionFx.HoverLift(RootBorder, on);
                 if (on) HoverPop.Enter(ImgIconHost); else HoverPop.Leave(ImgIconHost);

--- a/ConditioningControlPanel/Features/SplitFeatureCard.xaml
+++ b/ConditioningControlPanel/Features/SplitFeatureCard.xaml
@@ -65,11 +65,24 @@
         </Border.Effect>
 
         <Grid x:Name="ContentRoot" SizeChanged="OnContentSizeChanged">
-            <!-- The two art halves. Full-bleed brushes, triangle-clipped in code. -->
+            <!-- The two art halves. Full-bleed brushes, triangle-clipped in code. Each host
+                 carries its own greyscale twin as a child (Services/ArtDesaturate), faded in
+                 while that half's feature is off - so a combo tile with one half lit says so
+                 in colour, not only in ring. Inside the host so the region clip, the fill
+                 sweep and the peek wedge take both layers as one picture; opacity is written
+                 only by SplitFeatureCard.ApplyHalfMute. -->
             <Border x:Name="HalfHostA" CornerRadius="11"
-                    RenderOptions.BitmapScalingMode="HighQuality"/>
+                    RenderOptions.BitmapScalingMode="HighQuality">
+                <Border x:Name="HalfMuteA" CornerRadius="11"
+                        RenderOptions.BitmapScalingMode="HighQuality"
+                        IsHitTestVisible="False" Opacity="0"/>
+            </Border>
             <Border x:Name="HalfHostB" CornerRadius="11"
-                    RenderOptions.BitmapScalingMode="HighQuality"/>
+                    RenderOptions.BitmapScalingMode="HighQuality">
+                <Border x:Name="HalfMuteB" CornerRadius="11"
+                        RenderOptions.BitmapScalingMode="HighQuality"
+                        IsHitTestVisible="False" Opacity="0"/>
+            </Border>
 
             <!-- Per-half hover wash: opacity flips on MouseMove, and the geometry rides
                  the same seam parameter as the clips, so the wash fills with its half. -->

--- a/ConditioningControlPanel/Features/SplitFeatureCard.xaml.cs
+++ b/ConditioningControlPanel/Features/SplitFeatureCard.xaml.cs
@@ -81,7 +81,11 @@ namespace ConditioningControlPanel.Features
         ///
         /// <para>No opt-out property here, unlike FeatureCard: a split tile exists to carry two
         /// toggles (it raises ToggleA/ToggleB and nothing else), so there is no destination-tile
-        /// case to exclude.</para></summary>
+        /// case to exclude.</para>
+        ///
+        /// <para>Since 6.9.4 an off half also drains to greyscale (HalfMuteA/B,
+        /// <see cref="ApplyHalfMute"/>), on the same per-half rule and the same hover
+        /// exception, for the reason FeatureCard gives.</para></summary>
         private const double InactiveHalfOpacity = 0.62;
 
         /// <summary>Shared frozen stand-in for a region the seam has swept out of existence.</summary>
@@ -102,11 +106,11 @@ namespace ConditioningControlPanel.Features
 
         public static readonly DependencyProperty IconAProperty =
             DependencyProperty.Register(nameof(IconA), typeof(ImageSource), typeof(SplitFeatureCard),
-                new PropertyMetadata(null, (d, e) => ((SplitFeatureCard)d).ApplyIcon(((SplitFeatureCard)d).HalfHostA, e.NewValue as ImageSource)));
+                new PropertyMetadata(null, (d, e) => ((SplitFeatureCard)d).ApplyIcon(((SplitFeatureCard)d).HalfHostA, ((SplitFeatureCard)d).HalfMuteA, e.NewValue as ImageSource)));
 
         public static readonly DependencyProperty IconBProperty =
             DependencyProperty.Register(nameof(IconB), typeof(ImageSource), typeof(SplitFeatureCard),
-                new PropertyMetadata(null, (d, e) => ((SplitFeatureCard)d).ApplyIcon(((SplitFeatureCard)d).HalfHostB, e.NewValue as ImageSource)));
+                new PropertyMetadata(null, (d, e) => ((SplitFeatureCard)d).ApplyIcon(((SplitFeatureCard)d).HalfHostB, ((SplitFeatureCard)d).HalfMuteB, e.NewValue as ImageSource)));
 
         public static readonly DependencyProperty IsActiveAProperty =
             DependencyProperty.Register(nameof(IsActiveA), typeof(bool), typeof(SplitFeatureCard),
@@ -150,6 +154,7 @@ namespace ConditioningControlPanel.Features
             // Both halves start OFF and their DP callbacks only fire on a CHANGE, so a card whose
             // features are off at startup would never be handed its resting dim without this.
             ApplyHalfRestOpacity();
+            ApplyHalfMute(0);
             Loaded += OnCardLoaded;
             Unloaded += OnCardUnloaded;
             // A tile hidden mid-hover (tab switch out of the dashboard) can be denied its
@@ -159,11 +164,17 @@ namespace ConditioningControlPanel.Features
             MouseLeave += (_, _) => { ApplyHover(false); SetHalfHover(null); };
         }
 
-        private void ApplyIcon(Border host, ImageSource? src)
+        private void ApplyIcon(Border host, Border mute, ImageSource? src)
         {
             host.Background = src == null
                 ? null
                 : new ImageBrush(src) { Stretch = Stretch.UniformToFill, AlignmentY = AlignmentY.Center };
+            // Same brush settings as the colour layer so the two register pixel for pixel; null
+            // (non-bitmap art) leaves the opacity dim to say "off" on its own.
+            var grey = ArtDesaturate.Of(src);
+            mute.Background = grey == null
+                ? null
+                : new ImageBrush(grey) { Stretch = Stretch.UniformToFill, AlignmentY = AlignmentY.Center };
         }
 
         // ============================== geometry ==============================
@@ -405,9 +416,10 @@ namespace ConditioningControlPanel.Features
             if (_halfHover == halfA) return;
             _halfHover = halfA;
 
-            // The committed half is about to fill the tile, so it gets its full art back even
-            // while its feature is off - the reveal is the point of the sweep.
+            // The committed half is about to fill the tile, so it gets its full art back - colour
+            // and all - even while its feature is off; the reveal is the point of the sweep.
             ApplyHalfRestOpacity();
+            ApplyHalfMute(CardMuteRule.TransitionMs(MotionFx.AllowTransitions, IsLoaded));
 
             HoverWashA.Opacity = halfA == true ? 1 : 0;
             HoverWashB.Opacity = halfA == false ? 1 : 0;
@@ -522,6 +534,7 @@ namespace ConditioningControlPanel.Features
                 // ResetSplit clears _halfHover behind SetHalfHover's back, so the half that was
                 // committed would otherwise stay at full brightness with no hover to explain it.
                 ApplyHalfRestOpacity();
+                ApplyHalfMute(0);
                 BeginAnimation(SplitProgressProperty, null);
                 SplitProgress = SplitRest;
                 // Assigning a value it already holds raises no property-changed callback, so the
@@ -565,6 +578,7 @@ namespace ConditioningControlPanel.Features
             ActiveRingA.Visibility = IsActiveA ? Visibility.Visible : Visibility.Collapsed;
             ActiveRingB.Visibility = IsActiveB ? Visibility.Visible : Visibility.Collapsed;
             ApplyHalfRestOpacity();
+            ApplyHalfMute(CardMuteRule.TransitionMs(MotionFx.AllowTransitions, IsLoaded));
             // RebuildGeometry only draws the rings that are on screen (it also runs per frame of
             // the hover fill), so a ring that just came on needs this to get its geometry.
             SafeRebuildGeometry();
@@ -624,6 +638,39 @@ namespace ConditioningControlPanel.Features
             if (HalfHostA == null || HalfHostB == null) return;
             HalfHostA.Opacity = IsActiveA || _halfHover == true ? 1.0 : InactiveHalfOpacity;
             HalfHostB.Opacity = IsActiveB || _halfHover == false ? 1.0 : InactiveHalfOpacity;
+        }
+
+        /// <summary>
+        /// The ONE writer for the two grey layers' Opacity, on <see cref="CardMuteRule"/>'s
+        /// per-half verdict: an OFF half is grey unless the mouse has committed the card to it.
+        /// Always through BeginAnimation - a To-only fade for a positive <paramref name="ms"/>,
+        /// a cleared animation plus a plain assignment otherwise - so no earlier fade can hold
+        /// the property against a later snap.
+        /// </summary>
+        private void ApplyHalfMute(int ms)
+        {
+            try
+            {
+                if (HalfMuteA == null || HalfMuteB == null) return;
+                FadeMute(HalfMuteA, CardMuteRule.ShouldMuteHalf(IsActiveA, _halfHover == true), ms);
+                FadeMute(HalfMuteB, CardMuteRule.ShouldMuteHalf(IsActiveB, _halfHover == false), ms);
+            }
+            catch (Exception ex) { App.Logger?.Debug("SplitFeatureCard.ApplyHalfMute: {E}", ex.Message); }
+        }
+
+        private static void FadeMute(UIElement layer, bool mute, int ms)
+        {
+            double to = mute ? 1.0 : 0.0;
+            if (ms <= 0)
+            {
+                layer.BeginAnimation(OpacityProperty, null);
+                layer.Opacity = to;
+                return;
+            }
+            layer.BeginAnimation(OpacityProperty, new DoubleAnimation(to, TimeSpan.FromMilliseconds(ms))
+            {
+                EasingFunction = new QuadraticEase { EasingMode = EasingMode.EaseOut },
+            });
         }
 
         private static void ParkRing(System.Windows.Shapes.Path ring)

--- a/ConditioningControlPanel/Services/CardMute.cs
+++ b/ConditioningControlPanel/Services/CardMute.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Runtime.CompilerServices;
+using System.Windows;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+
+namespace ConditioningControlPanel.Services
+{
+    /// <summary>
+    /// When a dashboard tile's art goes grey: the ONE answer both card controls ask.
+    ///
+    /// <para>The mosaic's off tiles used to rest at 62% opacity and nothing else, and the Discord
+    /// verdict was that on and off look the same. Opacity on a dark wall reads as "a bit further
+    /// away", not as "off". Colour does: an active tile is the only one wearing its own
+    /// palette, and a glance down the wall says what START will run.</para>
+    ///
+    /// <para>Pure on purpose, so the priority order lives in one testable place: a lock veil
+    /// wins over the mute (a locked tile keeps the look it always had and must not read as
+    /// merely switched off), a tease keeps its blur, and a hover hands the colour back so an off
+    /// tile still reads as live.</para>
+    /// </summary>
+    public static class CardMuteRule
+    {
+        /// <summary>How long the colour takes to drain or return on a state change or a hover.
+        /// Interaction motion, so it runs whenever <see cref="MotionFx.AllowTransitions"/> does;
+        /// under Off the tile snaps.</summary>
+        public const int FadeMs = 200;
+
+        /// <summary>A single tile: grey only when it opted into dimming, its feature is off, it is
+        /// not locked, not teased, and the mouse is elsewhere.</summary>
+        public static bool ShouldMute(bool dimWhenInactive, bool isActive, bool isLocked, bool hovered, bool teased)
+            => dimWhenInactive && !isActive && !isLocked && !teased && !hovered;
+
+        /// <summary>One half of a split tile: grey when its feature is off and the mouse has not
+        /// committed the card to it. No opt-in here - a split tile only ever carries toggles.</summary>
+        public static bool ShouldMuteHalf(bool isActive, bool halfHovered)
+            => !isActive && !halfHovered;
+
+        /// <summary>Snap or fade: fade only when motion is allowed AND the card is already on
+        /// screen, so a tile never animates its first frame.</summary>
+        public static int TransitionMs(bool allowTransitions, bool loaded)
+            => allowTransitions && loaded ? FadeMs : 0;
+    }
+
+    /// <summary>
+    /// A greyscale twin of a tile's art, built once per source and cached for its lifetime.
+    ///
+    /// <para>Not a pixel shader: WPF's ShaderEffect needs a compiled .ps and a build step this
+    /// repo does not have, and the cheap alternative is at least as good here. The twin is
+    /// downscaled to <see cref="MaxEdge"/> before conversion (a tile is ~150px on the wall, the
+    /// source art is 1024), so the conversion is a few thousand pixels, alpha survives (the
+    /// vault and the tease tile art carry it; a Gray8 FormatConvertedBitmap would drop it), and
+    /// the result is a frozen bitmap the card can paint under its colour layer for free.</para>
+    /// </summary>
+    public static class ArtDesaturate
+    {
+        /// <summary>Longest edge of the grey twin. Larger than a wall tile, smaller than the
+        /// source, so the twin never looks soft on the tile and never costs a full decode.</summary>
+        public const int MaxEdge = 320;
+
+        private static readonly ConditionalWeakTable<ImageSource, ImageSource> Cache = new();
+
+        /// <summary>The grey twin, or null when the source is not a bitmap (a DrawingImage, say)
+        /// or cannot be read - the caller then falls back to the opacity dim alone.</summary>
+        public static ImageSource? Of(ImageSource? source)
+        {
+            if (source is not BitmapSource bmp) return null;
+            try
+            {
+                if (Cache.TryGetValue(source, out var hit)) return hit;
+                var grey = Build(bmp);
+                if (grey == null) return null;
+                Cache.AddOrUpdate(source, grey);
+                return grey;
+            }
+            catch (Exception ex)
+            {
+                Diag.Swallowed(ex, "art desaturate");
+                return null;
+            }
+        }
+
+        private static ImageSource? Build(BitmapSource bmp)
+        {
+            if (bmp.PixelWidth <= 0 || bmp.PixelHeight <= 0) return null;
+
+            BitmapSource src = bmp;
+            int longest = Math.Max(bmp.PixelWidth, bmp.PixelHeight);
+            if (longest > MaxEdge)
+            {
+                double scale = (double)MaxEdge / longest;
+                src = new TransformedBitmap(bmp, new ScaleTransform(scale, scale));
+            }
+            if (src.Format != PixelFormats.Bgra32)
+                src = new FormatConvertedBitmap(src, PixelFormats.Bgra32, null, 0);
+
+            int w = src.PixelWidth, h = src.PixelHeight, stride = w * 4;
+            var pixels = new byte[stride * h];
+            src.CopyPixels(pixels, stride, 0);
+            ToGrey(pixels);
+
+            var result = BitmapSource.Create(w, h, 96, 96, PixelFormats.Bgra32, null, pixels, stride);
+            result.Freeze();
+            return result;
+        }
+
+        /// <summary>
+        /// In-place Rec.601 luma over a BGRA32 buffer. Alpha is untouched, and every colour
+        /// channel lands on the same value, so the pixel is grey by construction. Kept pure so
+        /// the maths can be pinned by a test with no bitmap in sight.
+        /// </summary>
+        internal static void ToGrey(byte[] bgra)
+        {
+            for (int i = 0; i + 3 < bgra.Length; i += 4)
+            {
+                // 0.114 B + 0.587 G + 0.299 R, in 16.16 fixed point - no doubles per pixel.
+                int luma = (bgra[i] * 7471 + bgra[i + 1] * 38470 + bgra[i + 2] * 19595 + 32768) >> 16;
+                bgra[i] = bgra[i + 1] = bgra[i + 2] = (byte)luma;
+            }
+        }
+    }
+}

--- a/Tests/ConditioningControlPanel.Tests/CardMuteRuleTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/CardMuteRuleTests.cs
@@ -1,0 +1,76 @@
+using ConditioningControlPanel.Services;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// The dashboard's off-tile treatment, the part of it that is pure: when a tile goes grey, when
+/// a fade is allowed, and that the greyscale maths keeps alpha and lands every channel on the
+/// same value.
+/// </summary>
+public class CardMuteRuleTests
+{
+    [Theory]
+    // dim, active, locked, hovered, teased -> muted
+    [InlineData(true, false, false, false, false, true)]   // off and left alone: grey
+    [InlineData(true, true, false, false, false, false)]   // on: colour
+    [InlineData(true, false, true, false, false, false)]   // locked: the veil, never the grey
+    [InlineData(true, false, false, true, false, false)]   // hover hands the colour back
+    [InlineData(true, false, false, false, true, false)]   // teased: keeps its blur
+    [InlineData(false, false, false, false, false, false)] // destination tiles never opt in
+    public void A_tile_is_grey_only_when_off_unlocked_unteased_and_not_hovered(
+        bool dim, bool active, bool locked, bool hovered, bool teased, bool muted)
+    {
+        Assert.Equal(muted, CardMuteRule.ShouldMute(dim, active, locked, hovered, teased));
+    }
+
+    [Theory]
+    [InlineData(false, false, true)]  // off half, mouse elsewhere: grey
+    [InlineData(true, false, false)]  // on half: colour
+    [InlineData(false, true, false)]  // off half the mouse committed to: colour (the reveal)
+    [InlineData(true, true, false)]
+    public void A_half_is_grey_only_when_off_and_not_the_committed_half(bool active, bool hovered, bool muted)
+    {
+        Assert.Equal(muted, CardMuteRule.ShouldMuteHalf(active, hovered));
+    }
+
+    [Theory]
+    [InlineData(true, true, CardMuteRule.FadeMs)] // motion on, card on screen: fade
+    [InlineData(false, true, 0)]                  // reduced motion: snap
+    [InlineData(true, false, 0)]                  // first frame: snap, never animate in
+    [InlineData(false, false, 0)]
+    public void The_fade_runs_only_with_motion_allowed_and_the_card_loaded(bool motion, bool loaded, int ms)
+    {
+        Assert.Equal(ms, CardMuteRule.TransitionMs(motion, loaded));
+    }
+
+    [Fact]
+    public void Greyscale_keeps_alpha_and_equalises_the_colour_channels()
+    {
+        // Two BGRA pixels: a saturated pink at 200 alpha, and a pure blue at 0 alpha.
+        var px = new byte[] { 0xB4, 0x69, 0xFF, 200, 0xFF, 0x00, 0x00, 0 };
+
+        ArtDesaturate.ToGrey(px);
+
+        Assert.Equal(px[0], px[1]);
+        Assert.Equal(px[1], px[2]);
+        Assert.Equal(200, px[3]);
+        // Rec.601 of (R 255, G 105, B 180): 0.299*255 + 0.587*105 + 0.114*180 = 158.4
+        Assert.InRange(px[0], 157, 159);
+
+        Assert.Equal(px[4], px[5]);
+        Assert.Equal(px[5], px[6]);
+        Assert.Equal(0, px[7]);
+        // Pure blue is dark under luma weighting: 0.114 * 255 = 29.
+        Assert.InRange(px[4], 28, 30);
+    }
+
+    [Fact]
+    public void Greyscale_leaves_a_trailing_partial_pixel_alone()
+    {
+        var px = new byte[] { 10, 20, 30, 255, 99, 98 };
+        ArtDesaturate.ToGrey(px);
+        Assert.Equal(99, px[4]);
+        Assert.Equal(98, px[5]);
+    }
+}


### PR DESCRIPTION
From the Discord "New UI Feedback" thread (wobberjockey, mort5366): the dashboard should show at a glance which features will run on START.

- An off tile now goes grey: a desaturated twin of the art fades over the existing dim, title at 72%. On tiles keep full colour and the ring.
- Locked tiles keep their veil and are never muted. Teased tiles keep their blur. Hover hands the colour back.
- Split tiles apply the rule per half, inside the region clip, so the seam sweep and corner peek still carry both layers.
- Fade is 200 ms only when MotionFx allows transitions; reduced motion and first paint snap.
- No pixel shader (the repo has no .ps build step). The grey twin is built once per source at 320px and cached.
- New CardMuteRule + 16 tests. Click grammar and the #1075 DashToggleHint untouched.

Needs eyes: first-paint timing (enabled tiles may fade grey to colour if RefreshWallActiveStates runs after Loaded), and the twin's sharpness at high DPI.

Tests: 5953 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TE6761edxQX7wk5H1iYfSv
