### PR TITLE
fix(assets): the browser keeps two thumbnail rows in Reddit and Both

### DIFF
--- a/ConditioningControlPanel/Localization/Languages/de.json
+++ b/ConditioningControlPanel/Localization/Languages/de.json
@@ -4657,6 +4657,7 @@
   "label_remote_niches": "Nischen",
   "label_remote_niches_shared": "Wird mit dem For-You-Feed geteilt - eine Auswahl, beide Orte.",
   "label_remote_custom_subs": "Deine eigenen Subreddits",
+  "label_remote_custom_subs_summary": "{0} in Nutzung · {1} gemerkt",
   "tooltip_remote_custom_sub_add": "Gib einen Subreddit-Namen ein (das r/ ist optional) oder füge den Link ein, dann drücke Hinzufügen.",
   "label_remote_sub_verified": "Bestätigt · {0} Clips auf Reddit",
   "label_remote_sub_verified_stills": "Bestätigt · nur Bilder",

--- a/ConditioningControlPanel/Localization/Languages/en.json
+++ b/ConditioningControlPanel/Localization/Languages/en.json
@@ -5238,6 +5238,7 @@
   "label_remote_niches": "Niches",
   "label_remote_niches_shared": "Shared with the For You feed - one selection, both places.",
   "label_remote_custom_subs": "Your own subreddits",
+  "label_remote_custom_subs_summary": "{0} in use · {1} kept",
   "label_remote_custom_subs_kept": "Kept subreddits - click one to use it here, X forgets it everywhere.",
   "tooltip_remote_library_remove": "Forget this subreddit everywhere",
   "tooltip_remote_sub_in_pool": "In your media pool - click to drop it",

--- a/ConditioningControlPanel/Localization/Languages/es.json
+++ b/ConditioningControlPanel/Localization/Languages/es.json
@@ -4648,6 +4648,7 @@
   "label_remote_niches": "Nichos",
   "label_remote_niches_shared": "Compartido con el feed For You - una sola selección, los dos sitios.",
   "label_remote_custom_subs": "Tus propios subreddits",
+  "label_remote_custom_subs_summary": "{0} en uso · {1} guardados",
   "tooltip_remote_custom_sub_add": "Escribe el nombre de un subreddit (la r/ es opcional) o pega su enlace, y pulsa Añadir.",
   "label_remote_sub_verified": "Verificado · {0} clips en Reddit",
   "label_remote_sub_verified_stills": "Verificado · solo imágenes",

--- a/ConditioningControlPanel/Localization/Languages/fr.json
+++ b/ConditioningControlPanel/Localization/Languages/fr.json
@@ -4657,6 +4657,7 @@
   "label_remote_niches": "Niches",
   "label_remote_niches_shared": "Partagé avec le fil For You - une seule sélection, aux deux endroits.",
   "label_remote_custom_subs": "Tes propres subreddits",
+  "label_remote_custom_subs_summary": "{0} utilisés · {1} gardés",
   "tooltip_remote_custom_sub_add": "Saisis un nom de subreddit (le r/ est facultatif) ou colle son lien, puis appuie sur Ajouter.",
   "label_remote_sub_verified": "Vérifié · {0} clips sur Reddit",
   "label_remote_sub_verified_stills": "Vérifié · images seulement",

--- a/ConditioningControlPanel/Localization/Languages/ja.json
+++ b/ConditioningControlPanel/Localization/Languages/ja.json
@@ -4648,6 +4648,7 @@
   "label_remote_niches": "ニッチ",
   "label_remote_niches_shared": "For You フィードと共有されます - 選択はひとつ、どちらにも反映されます。",
   "label_remote_custom_subs": "自分のサブレディット",
+  "label_remote_custom_subs_summary": "使用中 {0} · 保存済み {1}",
   "tooltip_remote_custom_sub_add": "サブレディット名を入力するか（r/ は省略可）、リンクを貼り付けて「追加」を押してください。",
   "label_remote_sub_verified": "確認済み · Reddit に {0} 本のクリップ",
   "label_remote_sub_verified_stills": "確認済み · 静止画のみ",

--- a/ConditioningControlPanel/Localization/Languages/ko.json
+++ b/ConditioningControlPanel/Localization/Languages/ko.json
@@ -4655,6 +4655,7 @@
   "label_remote_niches": "니치",
   "label_remote_niches_shared": "For You 피드와 공유됩니다 - 선택은 하나, 두 곳 모두에 적용됩니다.",
   "label_remote_custom_subs": "내 서브레딧",
+  "label_remote_custom_subs_summary": "사용 중 {0}개 · 보관 {1}개",
   "tooltip_remote_custom_sub_add": "서브레딧 이름을 입력하거나(r/ 는 생략 가능) 링크를 붙여넣은 뒤 추가를 누르세요.",
   "label_remote_sub_verified": "확인됨 · Reddit에 클립 {0}개",
   "label_remote_sub_verified_stills": "확인됨 · 사진만",

--- a/ConditioningControlPanel/Localization/Languages/pt-BR.json
+++ b/ConditioningControlPanel/Localization/Languages/pt-BR.json
@@ -4656,6 +4656,7 @@
   "label_remote_niches": "Nichos",
   "label_remote_niches_shared": "Compartilhado com o feed For You - uma seleção, os dois lugares.",
   "label_remote_custom_subs": "Seus próprios subreddits",
+  "label_remote_custom_subs_summary": "{0} em uso · {1} guardados",
   "tooltip_remote_custom_sub_add": "Digite o nome de um subreddit (o r/ é opcional) ou cole o link e clique em Adicionar.",
   "label_remote_sub_verified": "Verificado · {0} clipes no Reddit",
   "label_remote_sub_verified_stills": "Verificado · só imagens",

--- a/ConditioningControlPanel/Localization/Languages/ru.json
+++ b/ConditioningControlPanel/Localization/Languages/ru.json
@@ -4655,6 +4655,7 @@
   "label_remote_niches": "Ниши",
   "label_remote_niches_shared": "Общее с лентой For You - один выбор, оба места.",
   "label_remote_custom_subs": "Твои сабреддиты",
+  "label_remote_custom_subs_summary": "{0} используется · {1} сохранено",
   "tooltip_remote_custom_sub_add": "Введи название сабреддита (r/ необязательно) или вставь ссылку, затем нажми «Добавить».",
   "label_remote_sub_verified": "Проверено · {0} клипов на Reddit",
   "label_remote_sub_verified_stills": "Проверено · только картинки",

--- a/ConditioningControlPanel/Localization/Languages/zh-CN.json
+++ b/ConditioningControlPanel/Localization/Languages/zh-CN.json
@@ -5113,6 +5113,7 @@
   "label_remote_niches": "领域",
   "label_remote_niches_shared": "与 For You 信息流共用 - 选一次，两处生效。",
   "label_remote_custom_subs": "你自己的子版块",
+  "label_remote_custom_subs_summary": "使用中 {0} 个 · 已保存 {1} 个",
   "tooltip_remote_custom_sub_add": "输入子版块名称（r/ 可省略）或粘贴其链接，然后点击添加。",
   "label_remote_sub_verified": "已验证 · Reddit 上有 {0} 段视频",
   "label_remote_sub_verified_stills": "已验证 · 仅静图",

--- a/ConditioningControlPanel/MainWindow/MainWindow.Assets.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.Assets.cs
@@ -2199,6 +2199,12 @@ namespace ConditioningControlPanel
         /// key, and a fresh launch showing every niche as one tidy line is the better default.</summary>
         private readonly HashSet<string> _remoteNicheExpanded = new(StringComparer.OrdinalIgnoreCase);
 
+        /// <summary>Whether the custom-subreddit block (hint, add row, library chips) is
+        /// unfolded. Folded on every launch for the same reason the niche lines are: the block
+        /// is the tallest thing in the media-source panel and the asset browser below pays for
+        /// every pixel of it (AssetsTabView.xaml, RemoteMediaScroll). Session-only, no key.</summary>
+        private bool _remoteCustomSubsExpanded;
+
         /// <summary>The sub being probed right now, or null. Held as state rather than as a
         /// captured Border so the pending pill survives a picker repaint mid-probe.</summary>
         private string? _remoteSubPending;
@@ -2227,6 +2233,8 @@ namespace ConditioningControlPanel
                         tab.BtnRemoteAddSub.Click += BtnRemoteAddSub_Click;
                     if (tab.TxtRemoteCustomSub != null)
                         tab.TxtRemoteCustomSub.KeyDown += TxtRemoteCustomSub_KeyDown;
+                    if (tab.RemoteCustomSubsToggle != null)
+                        tab.RemoteCustomSubsToggle.MouseLeftButtonUp += RemoteCustomSubsToggle_Click;
                 }
 
                 RefreshRemoteMediaPicker();
@@ -2750,6 +2758,53 @@ namespace ConditioningControlPanel
             if (host.Children.Count == 0)
                 host.Children.Add(MutedRemoteNote(LocOr("label_remote_custom_subs_none",
                     "None yet - the niches above are plenty to start with.")));
+
+            PaintRemoteCustomSubsToggle(settings);
+        }
+
+        /// <summary>The disclosure line above the custom-sub block. Folded it reads
+        /// "▸ Your own subreddits · 2 in use · 5 kept", so the counts the chips would have shown
+        /// are still one glance away; unfolded it is just the heading with a ▾. Runs after every
+        /// chip rebuild because the counts move with the library.</summary>
+        private void PaintRemoteCustomSubsToggle(Models.AppSettings settings)
+        {
+            var tab = AssetsTab;
+            if (tab?.RemoteCustomSubsToggle == null || tab.RemoteCustomSubsBody == null) return;
+
+            try
+            {
+                var title = LocOr("label_remote_custom_subs", "Your own subreddits");
+                if (_remoteCustomSubsExpanded)
+                {
+                    tab.RemoteCustomSubsToggle.Text = $"▾ {title}";
+                    tab.RemoteCustomSubsBody.Visibility = Visibility.Visible;
+                    return;
+                }
+
+                int kept = 0, inUse = 0;
+                foreach (var row in settings.BuildRemoteSubLibraryView())
+                {
+                    kept++;
+                    if (row.Selected) inUse++;
+                }
+                tab.RemoteCustomSubsToggle.Text = $"▸ {title} · " +
+                    string.Format(LocOr("label_remote_custom_subs_summary", "{0} in use · {1} kept"), inUse, kept);
+                tab.RemoteCustomSubsBody.Visibility = Visibility.Collapsed;
+            }
+            catch (Exception ex) { App.Logger?.Debug("Painting the custom sub toggle failed: {E}", ex.Message); }
+        }
+
+        private void RemoteCustomSubsToggle_Click(object sender, MouseButtonEventArgs e)
+        {
+            try
+            {
+                _remoteCustomSubsExpanded = !_remoteCustomSubsExpanded;
+                var settings = App.Settings?.Current;
+                if (settings != null) PaintRemoteCustomSubsToggle(settings);
+                // Unfolding is nearly always a prelude to typing a name.
+                if (_remoteCustomSubsExpanded) AssetsTab?.TxtRemoteCustomSub?.Focus();
+            }
+            catch (Exception ex) { App.Logger?.Debug("Custom sub toggle failed: {E}", ex.Message); }
         }
 
         /// <summary>A removable pill. Same look as the niche toggles, with the companion tab's

--- a/ConditioningControlPanel/Views/Tabs/AssetsTabView.xaml
+++ b/ConditioningControlPanel/Views/Tabs/AssetsTabView.xaml
@@ -64,6 +64,14 @@
              Both that is the whole niche/custom-sub block, which is why the browser used to
              shrink to a sliver: the fix is a scroll cap inside row 1 (see RemoteMediaScroll)
              plus a floor here, so the browser can never be measured away entirely.
+
+             The numbers are DIP on the fixed 1585x901 design canvas (MainWindow.xaml), so
+             they do not move with the window: the Viewbox scales the whole canvas. This tab
+             gets roughly 650 of those 901. Row 0 costs ~40, row 1 ~110 in local mode and
+             ~110 + the scroll cap in Reddit/Both, and the browser needs ~90 of its own for
+             header, action bar and padding before a single thumbnail row (128) fits. Cap 200
+             + floor 260 leaves the browser ~300 in the worst case, two thumbnail rows in the
+             typical one, and never lets the floor out-vote the canvas (40+310+260 < 650).
              Row 3 is Auto rather than a literal 5 because its splitter is collapsed and a
              literal height cannot give the 5px back. -->
         <Grid.RowDefinitions>
@@ -71,7 +79,7 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto" MaxHeight="340"/>
             <RowDefinition Height="Auto"/>
-            <RowDefinition Height="*" MinHeight="120"/>
+            <RowDefinition Height="*" MinHeight="260"/>
         </Grid.RowDefinitions>
     
         <!-- Header with title and actions -->
@@ -133,8 +141,12 @@
                      star row is the asset browser, so an uncapped unfold ate the browser.
                      The cap lives on the ScrollViewer rather than on the RowDefinition so the
                      overflow scrolls instead of clipping, and so RemoteMediaDetails keeps its
-                     name and its Visibility contract with MainWindow.Assets.cs. -->
-                <ScrollViewer x:Name="RemoteMediaScroll" MaxHeight="300"
+                     name and its Visibility contract with MainWindow.Assets.cs. 200 is the
+                     budget worked out on the root grid above; the typical Both layout (ratio
+                     row, niche chips, a handful of niche lines, the folded custom-sub line)
+                     fits inside it without a scrollbar, and only the everything-checked case
+                     scrolls. -->
+                <ScrollViewer x:Name="RemoteMediaScroll" MaxHeight="200"
                               VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
                 <StackPanel x:Name="RemoteMediaDetails" x:FieldModifier="internal" Visibility="Collapsed">
 
@@ -179,28 +191,39 @@
                     <!-- Custom subreddits. The chips below are the LIBRARY (every sub kept
                          anywhere in the app, AppSettings.RemoteSubLibrary): a lit pill is in
                          this machine's media pool (FypOnlineCustomSubs), a dashed one is kept
-                         but unused here, and the X forgets the name everywhere at once. -->
-                    <TextBlock Text="{loc:Str label_remote_custom_subs}" Style="{StaticResource SettingLabel}"
-                               FontSize="12" Margin="0,6,0,2"/>
-                    <TextBlock Text="{loc:Str label_remote_custom_subs_kept}"
-                               Foreground="{StaticResource TextMutedBrush}" FontSize="11"
-                               TextWrapping="Wrap" Margin="0,0,0,4"/>
-                    <StackPanel Orientation="Horizontal" Margin="0,0,0,6">
-                        <TextBox x:Name="TxtRemoteCustomSub" x:FieldModifier="internal" Width="200"
-                                 Background="#1E1E32" Foreground="White" BorderBrush="#3A3A5A"
-                                 FontSize="11" Padding="6,4" VerticalAlignment="Center"
-                                 ToolTip="{loc:Str tooltip_remote_custom_sub_add}"/>
-                        <Button x:Name="BtnRemoteAddSub" x:FieldModifier="internal" Content="{loc:Str btn_add}"
-                                Style="{StaticResource SmallPinkButton}" Padding="10,4" FontSize="11"
-                                Margin="6,0,0,0"/>
+                         but unused here, and the X forgets the name everywhere at once.
+
+                         Folded by default behind the same ▸ line the niche sub lists use, and
+                         for the same reason the scroll cap exists: up to 20 pills plus the add
+                         row is the tallest thing in this panel, and most visits never touch
+                         it. The folded line carries the counts, so nothing is hidden that the
+                         chips would have told you at a glance. Text and click are painted from
+                         MainWindow.Assets.cs (PaintRemoteCustomSubsToggle); expansion state is
+                         session-only, like _remoteNicheExpanded. -->
+                    <TextBlock x:Name="RemoteCustomSubsToggle" x:FieldModifier="internal"
+                               Text="{loc:Str label_remote_custom_subs}" Style="{StaticResource SettingLabel}"
+                               FontSize="12" Margin="0,6,0,2" Cursor="Hand" Background="Transparent"/>
+                    <StackPanel x:Name="RemoteCustomSubsBody" x:FieldModifier="internal" Visibility="Collapsed">
+                        <TextBlock Text="{loc:Str label_remote_custom_subs_kept}"
+                                   Foreground="{StaticResource TextMutedBrush}" FontSize="11"
+                                   TextWrapping="Wrap" Margin="0,0,0,4"/>
+                        <StackPanel Orientation="Horizontal" Margin="0,0,0,6">
+                            <TextBox x:Name="TxtRemoteCustomSub" x:FieldModifier="internal" Width="200"
+                                     Background="#1E1E32" Foreground="White" BorderBrush="#3A3A5A"
+                                     FontSize="11" Padding="6,4" VerticalAlignment="Center"
+                                     ToolTip="{loc:Str tooltip_remote_custom_sub_add}"/>
+                            <Button x:Name="BtnRemoteAddSub" x:FieldModifier="internal" Content="{loc:Str btn_add}"
+                                    Style="{StaticResource SmallPinkButton}" Padding="10,4" FontSize="11"
+                                    Margin="6,0,0,0"/>
+                        </StackPanel>
+                        <!-- Inline, non-blocking. This replaced a modal MessageBox: a typo in a
+                             subreddit name does not deserve a dialog, and the probe result (not
+                             found / offline) has nowhere else to land. -->
+                        <TextBlock x:Name="TxtRemoteSubError" x:FieldModifier="internal"
+                                   Foreground="{StaticResource RemoteSubErrorBrush}" FontSize="11"
+                                   TextWrapping="Wrap" Margin="0,0,0,6" Visibility="Collapsed"/>
+                        <WrapPanel x:Name="RemoteCustomSubChips" x:FieldModifier="internal"/>
                     </StackPanel>
-                    <!-- Inline, non-blocking. This replaced a modal MessageBox: a typo in a
-                         subreddit name does not deserve a dialog, and the probe result (not
-                         found / offline) has nowhere else to land. -->
-                    <TextBlock x:Name="TxtRemoteSubError" x:FieldModifier="internal"
-                               Foreground="{StaticResource RemoteSubErrorBrush}" FontSize="11"
-                               TextWrapping="Wrap" Margin="0,0,0,6" Visibility="Collapsed"/>
-                    <WrapPanel x:Name="RemoteCustomSubChips" x:FieldModifier="internal"/>
                 </StackPanel>
                 </ScrollViewer>
             </StackPanel>


### PR DESCRIPTION
From the Discord "New UI Feedback" thread (wobberjockey): the Assets library "becomes unusably small on Reddit and Both mode".

The whole UI sits on a fixed 1585x901 DIP canvas under a Viewbox, so the window size is irrelevant; the tab gets ~650 DIP and the Both-mode media panel was eating the browser row. This supersedes the 1b9514f68 numbers already on this branch.

- Media-source panel cap: RemoteMediaScroll MaxHeight 300 -> 200, overflow scrolls inside the panel.
- Browser floor: MinHeight 120 -> 260, so two thumbnail rows survive worst case.
- Custom subreddits fold behind a click line ("Your own subreddits · 2 in use · 5 kept"), collapsed by default, same disclosure language as the niche lines. Session-only state. One new loc key in all 9 languages.
- Media-source behaviour untouched.

Needs eyes: Own -> Reddit -> Both on the Assets tab; if the browser's bottom edge clips with every niche checked, lower the floor to 240 rather than the cap. If the 6.9.4 notes mention the asset-browser floor, describe this shape.

Tests: 5937 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TE6761edxQX7wk5H1iYfSv
