### PR TITLE
feat(deeper): the library list says how long each enhancement runs

### DIFF
--- a/ConditioningControlPanel/MainWindow/MainWindow.DeeperHub.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.DeeperHub.cs
@@ -50,6 +50,11 @@ namespace ConditioningControlPanel
             public string TimestampDisplay { get; init; } = "";
             public Visibility ShowTimestamp { get; init; } = Visibility.Collapsed;
 
+            // Media length in the mini timeline's m:ss / h:mm:ss shape.
+            // Collapsed (not "0:00") while nobody knows.
+            public string DurationDisplay { get; init; } = "";
+            public Visibility ShowDuration { get; init; } = Visibility.Collapsed;
+
             // Tag chips (small visual list)
             public List<DeeperAutoTagVm> Tags { get; init; } = new();
             public Visibility ShowTags { get; init; } = Visibility.Collapsed;
@@ -217,6 +222,9 @@ namespace ConditioningControlPanel
 
                 TimestampDisplay = FormatRelativeTime(e.LastModified),
                 ShowTimestamp    = e.LastModified == default ? Visibility.Collapsed : Visibility.Visible,
+
+                DurationDisplay  = e.DurationSeconds > 0 ? MediaDurationCache.Format(e.DurationSeconds) : "",
+                ShowDuration     = e.DurationSeconds > 0 ? Visibility.Visible : Visibility.Collapsed,
 
                 Tags     = tags,
                 ShowTags = tags.Count == 0 ? Visibility.Collapsed : Visibility.Visible,
@@ -522,6 +530,66 @@ namespace ConditioningControlPanel
             ApplyDeeperFilterAndSort();
             if (DeeperTab.TxtDeeperLibraryCount != null)
                 DeeperTab.TxtDeeperLibraryCount.Text = string.Format(Loc.Get("deeper_library_count_fmt"), _deeperAllEntries.Count);
+            ProbeDeeperDurations();
+        }
+
+        // -------------------------------------------------------------------
+        // Duration back-fill. The list renders first; then rows whose file
+        // carries no media_duration and whose media is a local file get
+        // probed one at a time on a worker thread. Each answer lands in
+        // MediaDurationCache (so the next scan reads it for free) and on the
+        // matching entries; the list is rebuilt in small batches so a long
+        // library fills in as it goes. Failures are remembered for the
+        // session so a broken file is never opened twice. Remote media is
+        // never touched.
+        // -------------------------------------------------------------------
+
+        private bool _deeperDurationProbeRunning;
+        private readonly HashSet<string> _deeperDurationProbeTried = new(StringComparer.OrdinalIgnoreCase);
+        private const int DeeperDurationRefreshBatch = 5;
+
+        private List<string> PendingDeeperDurationProbes() => _deeperAllEntries
+            .Where(e => e.DurationSeconds <= 0
+                        && !string.IsNullOrEmpty(e.MediaSource)
+                        && !_deeperDurationProbeTried.Contains(e.MediaSource)
+                        && MediaDurationCache.IsProbeable(e.MediaSource))
+            .Select(e => e.MediaSource)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        private async void ProbeDeeperDurations()
+        {
+            if (_deeperDurationProbeRunning) return;
+            var pending = PendingDeeperDurationProbes();
+            if (pending.Count == 0) return;
+            _deeperDurationProbeRunning = true;
+            try
+            {
+                while (pending.Count > 0)
+                {
+                    int found = 0;
+                    foreach (var source in pending)
+                    {
+                        _deeperDurationProbeTried.Add(source);
+                        var seconds = await MediaDurationCache.ProbeAsync(source);
+                        if (seconds is not > 0) continue;
+                        MediaDurationCache.Remember(source, seconds.Value);
+                        foreach (var entry in _deeperAllEntries)
+                        {
+                            if (entry.DurationSeconds <= 0
+                                && string.Equals(entry.MediaSource, source, StringComparison.OrdinalIgnoreCase))
+                                entry.DurationSeconds = seconds.Value;
+                        }
+                        found++;
+                        if (found % DeeperDurationRefreshBatch == 0) ApplyDeeperFilterAndSort();
+                    }
+                    if (found > 0 && found % DeeperDurationRefreshBatch != 0) ApplyDeeperFilterAndSort();
+                    // A reload while probing can bring in fresh rows; sweep again.
+                    pending = PendingDeeperDurationProbes();
+                }
+            }
+            catch (Exception ex) { App.Logger?.Debug("ProbeDeeperDurations error: {Error}", ex.Message); }
+            finally { _deeperDurationProbeRunning = false; }
         }
     }
 }

--- a/ConditioningControlPanel/Models/Deeper/Enhancement.cs
+++ b/ConditioningControlPanel/Models/Deeper/Enhancement.cs
@@ -85,6 +85,12 @@ namespace ConditioningControlPanel.Models.Deeper
         [JsonProperty("featured")]
         public bool Featured { get; set; }
 
+        // Length of the bound media in seconds, written by the editor on save
+        // once the preview knows it. Lets the library list show a duration
+        // without opening the media; absent in files saved by older builds.
+        [JsonProperty("media_duration", NullValueHandling = NullValueHandling.Ignore)]
+        public double? MediaDurationSeconds { get; set; }
+
         [JsonExtensionData]
         public IDictionary<string, JToken>? UnknownFields { get; set; }
     }

--- a/ConditioningControlPanel/Services/Deeper/EnhancementLibrary.cs
+++ b/ConditioningControlPanel/Services/Deeper/EnhancementLibrary.cs
@@ -19,6 +19,10 @@ namespace ConditioningControlPanel.Services.Deeper
         // surfaced by the catalogue browser so downloaders can see equipment
         // requirements at a glance. May be empty for files saved by older builds.
         public List<string> AutoTags { get; set; } = new();
+        // Media length in seconds; 0 when nobody knows yet. Filled from the
+        // enhancement file's media_duration, else from MediaDurationCache for
+        // local media, else by the hub's background probe after the list shows.
+        public double DurationSeconds { get; set; }
     }
 
     /// <summary>
@@ -453,22 +457,38 @@ namespace ConditioningControlPanel.Services.Deeper
             try
             {
                 var enhancement = EnhancementSerializer.LoadFromFile(path);
-                return new EnhancementLibraryEntry
-                {
-                    FilePath = path,
-                    Name = enhancement.Metadata?.Name ?? Path.GetFileNameWithoutExtension(path),
-                    Creator = enhancement.Metadata?.Creator ?? "",
-                    MediaType = enhancement.MediaType,
-                    MediaSource = enhancement.MediaSource,
-                    LastModified = File.GetLastWriteTime(path),
-                    AutoTags = enhancement.Metadata?.AutoTags ?? new List<string>()
-                };
+                return BuildEntry(enhancement, path, File.GetLastWriteTime(path));
             }
             catch (Exception ex)
             {
                 App.Logger?.Debug("EnhancementLibrary: skipping unreadable file {Path}: {Error}", path, ex.Message);
                 return null;
             }
+        }
+
+        // Projects a loaded enhancement into a list row. The duration comes
+        // from the file when it carries one; otherwise the cache is asked,
+        // and only for local media that exists (a dictionary lookup plus one
+        // stat, so the scan stays instant). Remote media stays at 0 unless
+        // the file says otherwise.
+        internal static EnhancementLibraryEntry BuildEntry(Enhancement enhancement, string path, DateTime lastModified)
+        {
+            var fromFile = enhancement.Metadata?.MediaDurationSeconds ?? 0;
+            double duration = fromFile > 0 && !double.IsNaN(fromFile) ? fromFile : 0;
+            if (duration <= 0 && MediaDurationCache.TryGetCached(enhancement.MediaSource, out var cached))
+                duration = cached;
+
+            return new EnhancementLibraryEntry
+            {
+                FilePath = path,
+                Name = enhancement.Metadata?.Name ?? Path.GetFileNameWithoutExtension(path),
+                Creator = enhancement.Metadata?.Creator ?? "",
+                MediaType = enhancement.MediaType,
+                MediaSource = enhancement.MediaSource,
+                LastModified = lastModified,
+                AutoTags = enhancement.Metadata?.AutoTags ?? new List<string>(),
+                DurationSeconds = duration
+            };
         }
     }
 }

--- a/ConditioningControlPanel/Services/Deeper/MediaDurationCache.cs
+++ b/ConditioningControlPanel/Services/Deeper/MediaDurationCache.cs
@@ -1,0 +1,207 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using LibVLCSharp.Shared;
+using NAudio.Wave;
+using Newtonsoft.Json;
+
+namespace ConditioningControlPanel.Services.Deeper
+{
+    /// <summary>
+    /// Answers "how long is this media?" for the Deeper library list without
+    /// opening every file on every visit. Three sources, cheapest first:
+    /// the enhancement file itself (the editor writes metadata.media_duration
+    /// on save), this cache (a small JSON map next to the waveform cache, keyed
+    /// by path + size + last-write so a re-encoded file re-probes), and finally
+    /// a background probe of a local file. Remote sources are never probed.
+    /// </summary>
+    public static class MediaDurationCache
+    {
+        private const int MaxEntries = 4000;
+        private const int VlcParseTimeoutMs = 5000;
+
+        private static readonly object Gate = new();
+        private static Dictionary<string, double>? _store;
+
+        public static string StorePath => Path.Combine(AudioWaveformCache.CacheFolder, "media-durations.json");
+
+        /// <summary>
+        /// The mini timeline readout format: m:ss under an hour, h:mm:ss from
+        /// an hour up. Negative and NaN read as 0:00; callers that want an
+        /// empty string for "unknown" check for a positive value first.
+        /// </summary>
+        public static string Format(double seconds)
+        {
+            if (seconds < 0 || double.IsNaN(seconds) || double.IsInfinity(seconds)) seconds = 0;
+            var ts = TimeSpan.FromSeconds(seconds);
+            return ts.TotalHours >= 1
+                ? $"{(int)ts.TotalHours}:{ts.Minutes:00}:{ts.Seconds:00}"
+                : $"{ts.Minutes}:{ts.Seconds:00}";
+        }
+
+        /// <summary>
+        /// True when the source is a local file that exists on disk. URLs
+        /// (hypnotube, bambicloud, anything http) and missing files are not
+        /// probeable; those rows only get a duration the enhancement file carries.
+        /// </summary>
+        public static bool IsProbeable(string? mediaSource)
+        {
+            if (string.IsNullOrWhiteSpace(mediaSource)) return false;
+            if (mediaSource.Contains("://", StringComparison.Ordinal)) return false;
+            if (mediaSource.EndsWith("*", StringComparison.Ordinal)) return false;
+            try { return Path.IsPathRooted(mediaSource) && File.Exists(mediaSource); }
+            catch { return false; }
+        }
+
+        /// <summary>Cached duration for a local file, if the file is unchanged since it was probed.</summary>
+        public static bool TryGetCached(string? mediaPath, out double seconds)
+        {
+            seconds = 0;
+            if (!IsProbeable(mediaPath)) return false;
+            try
+            {
+                var key = KeyFor(mediaPath!);
+                lock (Gate)
+                {
+                    var store = LoadStoreLocked();
+                    return store.TryGetValue(key, out seconds) && seconds > 0;
+                }
+            }
+            catch (Exception ex)
+            {
+                Diag.Swallowed(ex);
+                return false;
+            }
+        }
+
+        /// <summary>Records a known duration for a local file and flushes to disk off the caller's thread.</summary>
+        public static void Remember(string? mediaPath, double seconds)
+        {
+            if (seconds <= 0 || double.IsNaN(seconds) || !IsProbeable(mediaPath)) return;
+            try
+            {
+                var key = KeyFor(mediaPath!);
+                lock (Gate)
+                {
+                    var store = LoadStoreLocked();
+                    if (store.TryGetValue(key, out var existing) && Math.Abs(existing - seconds) < 0.5) return;
+                    store[key] = Math.Round(seconds, 1);
+                    if (store.Count > MaxEntries)
+                    {
+                        foreach (var stale in store.Keys.Take(store.Count - MaxEntries).ToList())
+                            store.Remove(stale);
+                    }
+                }
+                _ = Task.Run(Flush);
+            }
+            catch (Exception ex) { Diag.Swallowed(ex); }
+        }
+
+        /// <summary>
+        /// Reads the duration of a local file on a worker thread. MediaFoundation
+        /// first (header read, no decode, same reader the waveform cache uses),
+        /// then a LibVLC parse-only pass for containers MediaFoundation cannot
+        /// open. Null when neither source knows.
+        /// </summary>
+        public static async Task<double?> ProbeAsync(string mediaPath)
+        {
+            if (!IsProbeable(mediaPath)) return null;
+            var viaMf = await Task.Run(() => ProbeMediaFoundation(mediaPath)).ConfigureAwait(false);
+            if (viaMf is > 0) return viaMf;
+            return await ProbeLibVlcAsync(mediaPath).ConfigureAwait(false);
+        }
+
+        private static double? ProbeMediaFoundation(string path)
+        {
+            try
+            {
+                using var reader = new MediaFoundationReader(path);
+                var seconds = reader.TotalTime.TotalSeconds;
+                return seconds > 0 ? seconds : null;
+            }
+            catch (Exception ex)
+            {
+                Diag.Swallowed(ex);
+                return null;
+            }
+        }
+
+        private static async Task<double?> ProbeLibVlcAsync(string path)
+        {
+            try
+            {
+                var vlc = VideoService.SharedLibVLC;
+                if (vlc == null) return null;
+                using var media = new Media(vlc, path, FromType.FromPath);
+                var status = await media.Parse(MediaParseOptions.ParseLocal, VlcParseTimeoutMs).ConfigureAwait(false);
+                if (status != MediaParsedStatus.Done) return null;
+                var ms = media.Duration;
+                return ms > 0 ? ms / 1000.0 : null;
+            }
+            catch (Exception ex)
+            {
+                Diag.Swallowed(ex);
+                return null;
+            }
+        }
+
+        // -- store ----------------------------------------------------------
+
+        internal static string KeyFor(string mediaPath)
+        {
+            var info = new FileInfo(mediaPath);
+            return KeyFor(mediaPath, info.Length, info.LastWriteTimeUtc.Ticks);
+        }
+
+        internal static string KeyFor(string mediaPath, long length, long lastWriteUtcTicks)
+            => string.Create(CultureInfo.InvariantCulture, $"{mediaPath.ToLowerInvariant()}|{length}|{lastWriteUtcTicks}");
+
+        private static Dictionary<string, double> LoadStoreLocked()
+        {
+            if (_store != null) return _store;
+            _store = new Dictionary<string, double>(StringComparer.Ordinal);
+            try
+            {
+                if (File.Exists(StorePath))
+                    _store = ParseStore(File.ReadAllText(StorePath));
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Debug("MediaDurationCache: store read failed: {Error}", ex.Message);
+            }
+            return _store;
+        }
+
+        internal static Dictionary<string, double> ParseStore(string json)
+        {
+            var parsed = JsonConvert.DeserializeObject<Dictionary<string, double>>(json);
+            var store = new Dictionary<string, double>(StringComparer.Ordinal);
+            if (parsed == null) return store;
+            foreach (var kv in parsed)
+                if (!string.IsNullOrEmpty(kv.Key) && kv.Value > 0) store[kv.Key] = kv.Value;
+            return store;
+        }
+
+        private static void Flush()
+        {
+            try
+            {
+                string json;
+                lock (Gate)
+                {
+                    if (_store == null) return;
+                    json = JsonConvert.SerializeObject(_store);
+                }
+                Directory.CreateDirectory(AudioWaveformCache.CacheFolder);
+                File.WriteAllText(StorePath, json);
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Debug("MediaDurationCache: store write failed: {Error}", ex.Message);
+            }
+        }
+    }
+}

--- a/ConditioningControlPanel/Views/Deeper/DeeperEditorWindow.xaml.cs
+++ b/ConditioningControlPanel/Views/Deeper/DeeperEditorWindow.xaml.cs
@@ -4385,6 +4385,13 @@ namespace ConditioningControlPanel.Views.Deeper
                 if (_enhancement.Metadata != null)
                     _enhancement.Metadata.AutoTags = EnhancementAutoTagger.Detect(_enhancement);
 
+                // Carry the media length in the file so the library list can
+                // show it without opening the media. Only when the preview
+                // actually measured it; a file saved before any media loaded
+                // keeps whatever it had.
+                if (_enhancement.Metadata != null && _totalSeconds > 0 && !double.IsNaN(_totalSeconds))
+                    _enhancement.Metadata.MediaDurationSeconds = Math.Round(_totalSeconds, 1);
+
                 App.EnhancementLibrary?.Save(_enhancement, path);
                 _filePath = path;
                 _isDirty = false;

--- a/ConditioningControlPanel/Views/Deeper/EnhancementPlayerWindow.xaml.cs
+++ b/ConditioningControlPanel/Views/Deeper/EnhancementPlayerWindow.xaml.cs
@@ -911,7 +911,11 @@ namespace ConditioningControlPanel.Views.Deeper
                 var t = _videoSource.GetCurrentTimeSeconds();
                 var d = _videoSource.GetDurationSeconds();
                 TxtCurrent.Text = FormatTime(t);
-                if (d > 0) TxtTotal.Text = FormatTime(d);
+                if (d > 0)
+                {
+                    TxtTotal.Text = FormatTime(d);
+                    RememberDurationOnce(_lastMediaPathForCreateNew ?? _miniEnhancement?.MediaSource, d);
+                }
                 BtnPlayPause.Content = _videoSource.IsPlaying ? "⏸" : "▶";
             }
             else
@@ -919,6 +923,7 @@ namespace ConditioningControlPanel.Views.Deeper
                 var ms = _player.CurrentTimeMs;
                 TxtCurrent.Text = FormatTime(ms / 1000.0);
                 UpdatePlayhead(_player.DurationMs > 0 ? (double)ms / _player.DurationMs : 0);
+                if (_player.DurationMs > 0) RememberDurationOnce(_lastAudioPath, _player.DurationMs / 1000.0);
             }
 
             // Mission 3 mini-timeline + overlay + status pill updates.
@@ -2330,13 +2335,19 @@ namespace ConditioningControlPanel.Views.Deeper
             try { VideoBrowser?.Dispose(); } catch (Exception ex) { Diag.Swallowed(ex); }
         }
 
-        private static string FormatTime(double seconds)
+        private static string FormatTime(double seconds) => MediaDurationCache.Format(seconds);
+
+        // Once per loaded local file, hand the measured length to the
+        // duration cache so the library list shows it next time without a
+        // probe. Remote URLs are rejected by the cache itself.
+        private string? _durationRememberedFor;
+        private void RememberDurationOnce(string? mediaPath, double seconds)
         {
-            if (seconds < 0 || double.IsNaN(seconds)) seconds = 0;
-            var ts = TimeSpan.FromSeconds(seconds);
-            return ts.TotalHours >= 1
-                ? $"{(int)ts.TotalHours}:{ts.Minutes:00}:{ts.Seconds:00}"
-                : $"{ts.Minutes}:{ts.Seconds:00}";
+            if (string.IsNullOrEmpty(mediaPath) || seconds <= 0) return;
+            if (string.Equals(_durationRememberedFor, mediaPath, StringComparison.OrdinalIgnoreCase)) return;
+            _durationRememberedFor = mediaPath;
+            try { MediaDurationCache.Remember(mediaPath, seconds); }
+            catch (Exception ex) { Diag.Swallowed(ex); }
         }
     }
 }

--- a/ConditioningControlPanel/Views/Tabs/DeeperTabView.xaml
+++ b/ConditioningControlPanel/Views/Tabs/DeeperTabView.xaml
@@ -155,6 +155,13 @@
                                 <TextBlock Text=" · "
                                            Foreground="{DynamicResource TextDimBrush}" FontSize="11"/>
                             </StackPanel>
+                            <!-- Media length (m:ss or h:mm:ss); collapsed while unknown -->
+                            <TextBlock Text="{Binding DurationDisplay}"
+                                       Visibility="{Binding ShowDuration}"
+                                       Foreground="{DynamicResource TextDimBrush}" FontSize="11"/>
+                            <TextBlock Text=" · "
+                                       Visibility="{Binding ShowDuration}"
+                                       Foreground="{DynamicResource TextDimBrush}" FontSize="11"/>
                             <!-- Auto-tag chips -->
                             <ItemsControl ItemsSource="{Binding Tags}"
                                           Visibility="{Binding ShowTags}">

--- a/Tests/ConditioningControlPanel.Tests/DeeperLibraryDurationTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/DeeperLibraryDurationTests.cs
@@ -1,0 +1,202 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using ConditioningControlPanel.Models.Deeper;
+using ConditioningControlPanel.Services.Deeper;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// A Discord user asked to see how long a video is from the Deeper library list, before
+/// opening it. The cheapest reliable source is the enhancement file itself: the editor
+/// writes <c>metadata.media_duration</c> on save, and the library reads it at index time.
+/// Files from older builds carry no such field and must index as "unknown" (0, never
+/// 0:00), leaving the hub's background probe to fill local media in later.
+///
+/// <para>Pinned here: the readout format the row shares with the mini timeline, the
+/// file-carried read on both sides of the serializer, the "unknown stays unknown" rule for
+/// remote and missing media, and the probe gate that keeps hypnotube / bambicloud rows off
+/// the probe path.</para>
+/// </summary>
+public class DeeperLibraryDurationTests
+{
+    // =====================================================================================
+    //  format
+    // =====================================================================================
+
+    [Theory]
+    [InlineData(0, "0:00")]
+    [InlineData(5, "0:05")]
+    [InlineData(61.4, "1:01")]
+    [InlineData(272.9, "4:32")]
+    [InlineData(3599, "59:59")]
+    [InlineData(3600, "1:00:00")]
+    [InlineData(7325, "2:02:05")]
+    [InlineData(-5, "0:00")]
+    [InlineData(double.NaN, "0:00")]
+    public void Format_matches_the_mini_timeline_readout(double seconds, string expected)
+    {
+        Assert.Equal(expected, MediaDurationCache.Format(seconds));
+    }
+
+    // =====================================================================================
+    //  file-carried duration
+    // =====================================================================================
+
+    private static string Fixture(string metadataExtra, string mediaSource = "https://hypnotube.com/video/abc") =>
+        "{" +
+        "\"$schema\":\"" + Enhancement.SchemaTag + "\"," +
+        "\"version\":1," +
+        "\"media_type\":\"video\"," +
+        "\"media_source\":\"" + mediaSource.Replace("\\", "\\\\") + "\"," +
+        "\"metadata\":{\"name\":\"Spiral\",\"creator\":\"Bambi\"" + metadataExtra + "}" +
+        "}";
+
+    [Fact]
+    public void Load_reads_media_duration_from_the_file()
+    {
+        var enh = EnhancementSerializer.Load(Fixture(",\"media_duration\":272.5"));
+
+        Assert.Equal(272.5, enh.Metadata.MediaDurationSeconds);
+    }
+
+    [Fact]
+    public void Load_leaves_an_older_file_without_a_duration()
+    {
+        var enh = EnhancementSerializer.Load(Fixture(""));
+
+        Assert.Null(enh.Metadata.MediaDurationSeconds);
+    }
+
+    [Fact]
+    public void Save_writes_media_duration_only_when_known()
+    {
+        var known = EnhancementSerializer.Load(Fixture(",\"media_duration\":272.5"));
+        var unknown = EnhancementSerializer.Load(Fixture(""));
+
+        Assert.Contains("\"media_duration\": 272.5", EnhancementSerializer.Save(known));
+        Assert.DoesNotContain("media_duration", EnhancementSerializer.Save(unknown));
+    }
+
+    [Fact]
+    public void Save_round_trips_the_duration_through_an_older_file_shape()
+    {
+        var original = EnhancementSerializer.Load(Fixture(",\"media_duration\":90"));
+        var again = EnhancementSerializer.Load(EnhancementSerializer.Save(original));
+
+        Assert.Equal(90, again.Metadata.MediaDurationSeconds);
+    }
+
+    // =====================================================================================
+    //  library entry projection
+    // =====================================================================================
+
+    [Fact]
+    public void BuildEntry_takes_the_duration_the_file_carries()
+    {
+        var enh = EnhancementSerializer.Load(Fixture(",\"media_duration\":272.5"));
+
+        var entry = EnhancementLibrary.BuildEntry(enh, @"C:\lib\spiral.ccpenh.json", new DateTime(2026, 9, 1));
+
+        Assert.Equal(272.5, entry.DurationSeconds);
+        Assert.Equal("Spiral", entry.Name);
+        Assert.Equal("Bambi", entry.Creator);
+        Assert.Equal(new DateTime(2026, 9, 1), entry.LastModified);
+    }
+
+    [Fact]
+    public void BuildEntry_leaves_a_remote_source_unknown_when_the_file_is_silent()
+    {
+        var enh = EnhancementSerializer.Load(Fixture(""));
+
+        var entry = EnhancementLibrary.BuildEntry(enh, @"C:\lib\spiral.ccpenh.json", DateTime.Now);
+
+        Assert.Equal(0, entry.DurationSeconds);
+    }
+
+    [Fact]
+    public void BuildEntry_leaves_a_missing_local_file_unknown()
+    {
+        var missing = Path.Combine(Path.GetTempPath(), "ccp-no-such-" + Guid.NewGuid().ToString("N") + ".mp4");
+        var enh = EnhancementSerializer.Load(Fixture("", missing));
+
+        var entry = EnhancementLibrary.BuildEntry(enh, @"C:\lib\spiral.ccpenh.json", DateTime.Now);
+
+        Assert.Equal(0, entry.DurationSeconds);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-3)]
+    [InlineData(double.NaN)]
+    public void BuildEntry_treats_a_non_positive_file_value_as_unknown(double bad)
+    {
+        var enh = EnhancementSerializer.Load(Fixture(""));
+        enh.Metadata.MediaDurationSeconds = bad;
+
+        var entry = EnhancementLibrary.BuildEntry(enh, @"C:\lib\spiral.ccpenh.json", DateTime.Now);
+
+        Assert.Equal(0, entry.DurationSeconds);
+    }
+
+    // =====================================================================================
+    //  probe gate + cache key
+    // =====================================================================================
+
+    [Theory]
+    [InlineData("https://hypnotube.com/video/abc")]
+    [InlineData("http://bambicloud.com/x.mp4")]
+    [InlineData("*")]
+    [InlineData("spiral*")]
+    [InlineData("")]
+    [InlineData(null)]
+    public void IsProbeable_rejects_remote_patterns_and_blanks(string? source)
+    {
+        Assert.False(MediaDurationCache.IsProbeable(source));
+    }
+
+    [Fact]
+    public void IsProbeable_accepts_only_a_local_file_that_exists()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "ccp-dur-" + Guid.NewGuid().ToString("N") + ".mp4");
+        Assert.False(MediaDurationCache.IsProbeable(path));
+        File.WriteAllBytes(path, new byte[] { 0 });
+        try
+        {
+            Assert.True(MediaDurationCache.IsProbeable(path));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void KeyFor_folds_case_and_pins_size_and_write_time()
+    {
+        var a = MediaDurationCache.KeyFor(@"C:\Media\Spiral.MP4", 1234, 5678);
+        var b = MediaDurationCache.KeyFor(@"c:\media\spiral.mp4", 1234, 5678);
+        var resized = MediaDurationCache.KeyFor(@"c:\media\spiral.mp4", 1235, 5678);
+        var rewritten = MediaDurationCache.KeyFor(@"c:\media\spiral.mp4", 1234, 5679);
+
+        Assert.Equal(a, b);
+        Assert.NotEqual(a, resized);
+        Assert.NotEqual(a, rewritten);
+    }
+
+    [Fact]
+    public void ParseStore_keeps_positive_values_and_drops_the_rest()
+    {
+        var store = MediaDurationCache.ParseStore("{\"a|1|1\":12.5,\"b|1|1\":0,\"c|1|1\":-4,\"\":9}");
+
+        Assert.Equal(new Dictionary<string, double> { ["a|1|1"] = 12.5 }, store);
+    }
+
+    [Fact]
+    public void ParseStore_of_an_empty_document_is_an_empty_store()
+    {
+        Assert.Empty(MediaDurationCache.ParseStore("null"));
+        Assert.Empty(MediaDurationCache.ParseStore("{}"));
+    }
+}


### PR DESCRIPTION
From the Discord "New UI Feedback" thread (wobberjockey): the Deeper library should say how long a video is.

Three sources, cheapest first:
1. File-carried: new metadata.media_duration, written by the editor on save when the media length is known. The only way remote (hypnotube / bambicloud) rows get a number. Old files never gain a null.
2. Sidecar cache deeper-cache/media-durations.json keyed path|size|lastWrite, written by the player once per loaded local file, capped at 4000 entries.
3. Lazy background probe on the hub for local rows still unknown: MediaFoundation header read first, then Media.Parse on the shared LibVLC. One at a time, never on the UI thread, never for URLs or missing files.

Row reads creator · source · 4:32 · [Haptics] 3w ago; the segment collapses when unknown, never 0:00. MediaDurationCache.Format is now the single readout helper (m:ss, h:mm:ss). 29 new tests.

Needs eyes: rows fill in a few seconds after the tab opens; an HT row shows a length after a re-save from the editor; .webm/.mkv rows need LibVLC preloaded for the fallback.

Tests: 5966 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TE6761edxQX7wk5H1iYfSv
