### PR TITLE
fix(descent): the daily vat fills on sign-in, not on the next lucky poll

### DIFF
--- a/ConditioningControlPanel/MainWindow/MainWindow.ProfileVat.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.ProfileVat.cs
@@ -30,11 +30,16 @@ namespace ConditioningControlPanel
     ///     block; it is the one request that can light a dark key up,
     ///   • every 60s while the card is the visible tab AND the window is in front of
     ///     somebody AND the key is lit (<see cref="EvaluateVatPoll"/>),
-    ///   • and immediately after an accepted /v2/user/sync, also key-gated
+    ///   • immediately after an accepted /v2/user/sync, also key-gated
     ///     (ProfileSyncService.SyncProfileAsync) — the moment today's XP actually
-    ///     lands in the server vat.
+    ///     lands in the server vat,
+    ///   • and on sign-in (DescentService.OnSignedIn, from every login path), which
+    ///     is what repaints a card opened before the auth token landed: the open's
+    ///     request is remembered by the service and goes out then.
     /// A 10s floor inside DescentService keeps a burst of those from becoming a
-    /// burst of requests, and offline mode stops all three at the service.
+    /// burst of requests (a request inside it after a failed fetch is deferred to
+    /// the end of the floor rather than dropped), and offline mode stops all of
+    /// them at the service.
     /// </summary>
     public partial class MainWindow
     {

--- a/ConditioningControlPanel/MainWindow/MainWindow.xaml.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.xaml.cs
@@ -753,16 +753,15 @@ namespace ConditioningControlPanel
                 _avatarTubeWindow?.UpdateAvatarForLevel(App.Settings.Current.PlayerLevel);
 
                 // THE VAT'S LATE KEY. Opening the Trainer Card fires exactly one ungated
-                // Descent request (MainWindow.ProfileVat.OnProfileVatVisibilityChanged), but
-                // DescentService.RefreshAsync returns false without a word when UnifiedId or
-                // AuthToken is not populated yet — and auth lands well after startup (the
-                // restore-session path alone sleeps 3s). Nothing then re-poked Descent: the
-                // post-sync hook in ProfileSyncService is gated on HasSeenBlock, which that
-                // silent miss left false, so the jar, its faucet tooltip and the XP readout
-                // all stayed dark until a sign-out/in or the 60s background poll happened to
-                // catch up. Profile-loaded is the app's "server data has landed" signal, so
-                // ask again here. RequestRefresh is fire-and-forget and self-throttling
-                // (MinFetchInterval + in-flight gate), so an already-lit vat costs nothing.
+                // Descent request (MainWindow.ProfileVat.OnProfileVatVisibilityChanged), and
+                // auth lands well after startup (the restore-session path alone sleeps 3s).
+                // Profile-loaded is the app's "server data has landed" signal, so ask again
+                // here. Belt and braces now: DescentService remembers an ask it could not
+                // serve and fires it from OnSignedIn (every login path), and an ask inside
+                // its floor after a failed fetch is deferred, not dropped. RequestRefresh is
+                // fire-and-forget and self-throttling (a same-credential fetch that already
+                // answered inside the floor makes this a no-op), so an already-lit vat costs
+                // nothing.
                 App.Descent?.RequestRefresh("profile loaded");
 
                 // Re-arm autonomy after profile load ONLY if the user opted into resume-on-startup

--- a/ConditioningControlPanel/Services/Descent/DescentRefreshGate.cs
+++ b/ConditioningControlPanel/Services/Descent/DescentRefreshGate.cs
@@ -1,0 +1,173 @@
+using System;
+
+namespace ConditioningControlPanel.Services.Descent
+{
+    /// <summary>What <see cref="DescentRefreshGate.Ask"/> wants the service to do with one request.</summary>
+    internal enum DescentRefreshVerdict
+    {
+        /// <summary>Go now. The caller stamps the fetch with <see cref="DescentRefreshGate.BeginFetch"/>.</summary>
+        Fetch,
+
+        /// <summary>
+        /// Not now, but soon: ask again after the retry delay. The want is remembered, so the
+        /// retry only has to check <see cref="DescentRefreshGate.Pending"/> when it lands.
+        /// </summary>
+        Defer,
+
+        /// <summary>
+        /// No account or no auth token yet. The want is remembered and the service fires it
+        /// from <see cref="DescentService.OnSignedIn"/> once a login path declares the account
+        /// usable.
+        /// </summary>
+        WaitForSignIn,
+
+        /// <summary>
+        /// Nothing to do: offline mode (the hard floor, never remembered), or a fetch with these
+        /// same credentials already answered inside the floor and this request is the burst the
+        /// floor exists to coalesce.
+        /// </summary>
+        Skip,
+    }
+
+    /// <summary>
+    /// THE VAT'S REFRESH MEMORY. Pure: no clock, no settings, no network, so the sign-in and
+    /// throttle rules can be pinned by tests without a dispatcher.
+    ///
+    /// <para><b>Why it exists.</b> DescentService.RefreshAsync used to answer every request it could
+    /// not serve with a silent <c>false</c>: no token yet, a fetch already in flight, or inside the
+    /// 10s floor. A request made before the auth token landed was simply gone, and the surfaces
+    /// that asked (the Trainer Card on open, MainWindow on profile-loaded) never asked again. The
+    /// only recovery was the 60s background poll or a sign-out. This gate remembers every want it
+    /// cannot serve right now and says when to come back for it.</para>
+    ///
+    /// <para><b>The floor is still a floor.</b> A request inside the 10s window after a fetch that
+    /// ANSWERED with the SAME credentials is redundant and stays dropped; that is the burst
+    /// coalescing the floor was built for. A request inside the window after a fetch that failed,
+    /// or that went out with other credentials (the token was rotated or healed), is deferred to
+    /// the end of the window instead, because the answer it would have coalesced into is not one
+    /// this account can use.</para>
+    /// </summary>
+    internal sealed class DescentRefreshGate
+    {
+        /// <summary>
+        /// Floor between two fetches, whatever asks. The Trainer Card polls at 60s and a sync can
+        /// land at any moment; without this, a burst of syncs would each fire a profile GET.
+        /// </summary>
+        public static readonly TimeSpan MinFetchInterval = TimeSpan.FromSeconds(10);
+
+        /// <summary>
+        /// A deferred retry never lands sooner than this, so an in-flight fetch that outlives the
+        /// floor (a hung request has a 30s client timeout) cannot turn the retry into a busy loop.
+        /// </summary>
+        public static readonly TimeSpan MinRetryDelay = TimeSpan.FromSeconds(1);
+
+        private DateTime _lastFetchUtc = DateTime.MinValue;
+        private string? _lastFetchUnifiedId;
+        private string? _lastFetchToken;
+        private bool _lastFetchAnswered;
+
+        /// <summary>A request was made that no fetch has answered yet.</summary>
+        public bool Pending { get; private set; }
+
+        /// <summary>The first reason still waiting, for the log line when it finally goes out.</summary>
+        public string? PendingReason { get; private set; }
+
+        /// <summary>When the last fetch went out (UTC); MinValue until one has.</summary>
+        public DateTime LastFetchUtc => _lastFetchUtc;
+
+        public DescentRefreshVerdict Ask(
+            DateTime nowUtc,
+            string? unifiedId,
+            string? authToken,
+            bool offline,
+            bool inFlight,
+            bool force,
+            string reason,
+            out TimeSpan retryIn)
+        {
+            retryIn = TimeSpan.Zero;
+
+            // OFFLINE MODE IS A HARD FLOOR, not a preference this feature gets to outrank, and
+            // not a want to remember either: the user turned networking off.
+            if (offline) return DescentRefreshVerdict.Skip;
+
+            if (string.IsNullOrEmpty(unifiedId) || string.IsNullOrEmpty(authToken))
+            {
+                Remember(reason);
+                return DescentRefreshVerdict.WaitForSignIn;
+            }
+
+            if (inFlight)
+            {
+                // The fetch in the air may have gone out with older credentials than these, so
+                // its answer is not assumed to cover this request. If it does answer, EndFetch
+                // clears the want and the retry finds nothing to do.
+                Remember(reason);
+                retryIn = RemainingFloor(nowUtc);
+                return DescentRefreshVerdict.Defer;
+            }
+
+            var age = nowUtc - _lastFetchUtc;
+            if (!force && age < MinFetchInterval)
+            {
+                if (_lastFetchAnswered
+                    && string.Equals(unifiedId, _lastFetchUnifiedId, StringComparison.Ordinal)
+                    && string.Equals(authToken, _lastFetchToken, StringComparison.Ordinal))
+                {
+                    return DescentRefreshVerdict.Skip;   // the floor doing its job
+                }
+
+                Remember(reason);
+                retryIn = Clamp(MinFetchInterval - age);
+                return DescentRefreshVerdict.Defer;
+            }
+
+            return DescentRefreshVerdict.Fetch;
+        }
+
+        /// <summary>Stamp the fetch that is about to go out, with the credentials it carries.</summary>
+        public void BeginFetch(DateTime nowUtc, string unifiedId, string authToken)
+        {
+            _lastFetchUtc = nowUtc;
+            _lastFetchUnifiedId = unifiedId;
+            _lastFetchToken = authToken;
+            _lastFetchAnswered = false;
+        }
+
+        /// <summary>
+        /// The fetch came back. <paramref name="answered"/> is "the server sent a readable user
+        /// node", whether or not it carried a descent block; a null node (non-2xx, network) is not
+        /// an answer, and a want made during that fetch stays standing.
+        /// </summary>
+        public void EndFetch(bool answered)
+        {
+            _lastFetchAnswered = answered;
+            if (!answered) return;
+            Pending = false;
+            PendingReason = null;
+        }
+
+        /// <summary>Logout. Forget the floor, the credentials the last fetch used, and any want.</summary>
+        public void Reset()
+        {
+            _lastFetchUtc = DateTime.MinValue;
+            _lastFetchUnifiedId = null;
+            _lastFetchToken = null;
+            _lastFetchAnswered = false;
+            Pending = false;
+            PendingReason = null;
+        }
+
+        private void Remember(string reason)
+        {
+            Pending = true;
+            PendingReason ??= reason;   // the first ask is the one that explains the log
+        }
+
+        private TimeSpan RemainingFloor(DateTime nowUtc)
+            => Clamp(MinFetchInterval - (nowUtc - _lastFetchUtc));
+
+        private static TimeSpan Clamp(TimeSpan delay)
+            => delay < MinRetryDelay ? MinRetryDelay : delay;
+    }
+}

--- a/ConditioningControlPanel/Services/Descent/DescentService.cs
+++ b/ConditioningControlPanel/Services/Descent/DescentService.cs
@@ -28,15 +28,29 @@ namespace ConditioningControlPanel.Services.Descent
     /// </summary>
     public sealed class DescentService
     {
-        /// <summary>
-        /// Floor between two fetches, whatever asks. The Trainer Card polls at 60s
-        /// and a sync can land at any moment; without this, a burst of syncs would
-        /// each fire a profile GET.
-        /// </summary>
-        private static readonly TimeSpan MinFetchInterval = TimeSpan.FromSeconds(10);
-
+        /// <summary>One fetch in the air at a time.</summary>
         private readonly SemaphoreSlim _gate = new(1, 1);
-        private DateTime _lastFetchUtc = DateTime.MinValue;
+
+        /// <summary>
+        /// The 10s floor, the credentials the last fetch carried, and every want this service
+        /// could not serve on the spot (<see cref="DescentRefreshGate"/>). Locked on itself:
+        /// Ask runs on the pool, <see cref="Reset"/> on the UI thread, and the background poll
+        /// reads the floor.
+        /// </summary>
+        private readonly DescentRefreshGate _refreshGate = new();
+
+        /// <summary>
+        /// Bumped by <see cref="Reset"/>. A fetch that went out for the account that just
+        /// signed out lands after Reset carrying the wrong account's block; the mismatch is
+        /// how it is discarded instead of standing on user B's Trainer Card.
+        /// </summary>
+        private int _generation;
+
+        /// <summary>
+        /// 1 while a deferred retry is in the air. One is enough: when it lands it re-asks
+        /// the gate, which remembers every want made in the meantime.
+        /// </summary>
+        private int _deferredArmed;
 
         /// <summary>The last well-formed block, or null. See the tri-state note above.</summary>
         public DescentBlock? Current { get; private set; }
@@ -80,10 +94,32 @@ namespace ConditioningControlPanel.Services.Descent
         }
 
         /// <summary>
+        /// THE SIGN-IN POKE. Called from ProfileSyncService.StartHeartbeat, which every
+        /// login path reaches once the account is usable (the three startup restores, the
+        /// login dialog, the AccountService flows, the 401 token self-heal); the mirror of
+        /// <see cref="Reset"/> on the way out.
+        ///
+        /// Why the vat needed one: the Trainer Card asks exactly once on open, and when the
+        /// card is on screen before the auth token lands (a launch that opens on the card, a
+        /// login made from it) that one ask used to die silently in <see cref="RefreshAsync"/>.
+        /// ProfileLoaded is not a sign-in signal: it fires only when a sync succeeds or the
+        /// progression moved, so a login that took any other branch never re-asked, and the
+        /// jar, its tooltip and the XP readout stayed dark until a sign-out or the 60s
+        /// background poll. Now the ask is remembered and this is what fires it.
+        ///
+        /// Safe to call more than once per login (a Patreon and a Discord restore both reach
+        /// StartHeartbeat): the gate answers a second ask inside the floor with Skip when a
+        /// fetch with these same credentials already answered, so nothing doubles on the wire.
+        /// </summary>
+        public void OnSignedIn() => RequestRefresh("signed in");
+
+        /// <summary>
         /// Fetch and parse the block. Returns true when a fetch actually happened
-        /// (whether or not it produced a block); false when it was skipped — offline
-        /// mode, no account, no auth token, a fetch already in flight, or inside the
-        /// floor.
+        /// (whether or not it produced a block); false when it was skipped: offline
+        /// mode, no account or token yet (remembered, fired by <see cref="OnSignedIn"/>),
+        /// a fetch already in flight or inside the floor (remembered, retried when the
+        /// floor clears), or a request the floor coalesced into a fetch that already
+        /// answered with these same credentials. See <see cref="DescentRefreshGate"/>.
         /// </summary>
         public async Task<bool> RefreshAsync(string reason, bool force = false)
         {
@@ -91,29 +127,59 @@ namespace ConditioningControlPanel.Services.Descent
             // outrank. It is the same check every other network path takes
             // (ProfileSyncService.LoadProfileAsync / SyncProfileAsync /
             // SendHeartbeatAsync): a user who turned the app's networking off must
-            // not be able to see a request leave for a decorative meter.
-            if (App.Settings?.Current?.OfflineMode == true) return false;
+            // not be able to see a request leave for a decorative meter. The gate
+            // answers it with Skip and, unlike the other skips, does not remember it.
+            var settings = App.Settings?.Current;
+            bool offline = settings?.OfflineMode == true;
+            string? unifiedId = settings?.UnifiedId;
+            string? authToken = settings?.AuthToken;
 
-            string? unifiedId = App.Settings?.Current?.UnifiedId;
-            if (string.IsNullOrEmpty(unifiedId)) return false;
-            if (string.IsNullOrEmpty(App.Settings?.Current?.AuthToken)) return false;
-
-            if (!_gate.Wait(0)) return false;
+            bool haveGate = _gate.Wait(0);
             try
             {
-                if (!force && DateTime.UtcNow - _lastFetchUtc < MinFetchInterval) return false;
-                _lastFetchUtc = DateTime.UtcNow;
+                DescentRefreshVerdict verdict;
+                TimeSpan retryIn;
+                lock (_refreshGate)
+                    verdict = _refreshGate.Ask(DateTime.UtcNow, unifiedId, authToken, offline, inFlight: !haveGate, force, reason, out retryIn);
 
-                var userNode = await new V2AuthService().GetUserProfileNodeAsync(unifiedId).ConfigureAwait(false);
+                switch (verdict)
+                {
+                    case DescentRefreshVerdict.Skip:
+                        return false;
+                    case DescentRefreshVerdict.WaitForSignIn:
+                        Log.Debug("[Descent] refresh '{Reason}' waits for sign-in", reason);
+                        return false;
+                    case DescentRefreshVerdict.Defer:
+                        ScheduleDeferredRetry(retryIn, reason);
+                        return false;
+                }
+
+                int generation = Volatile.Read(ref _generation);
+                lock (_refreshGate) _refreshGate.BeginFetch(DateTime.UtcNow, unifiedId!, authToken!);
+
+                var userNode = await new V2AuthService().GetUserProfileNodeAsync(unifiedId!).ConfigureAwait(false);
+
+                if (generation != Volatile.Read(ref _generation))
+                {
+                    // Reset ran while this was in the air: the answer belongs to the account
+                    // that signed out. Not applied, not counted as an answer for whoever is
+                    // signed in now (their own ask, if any, is still standing in the gate).
+                    Log.Debug("[Descent] profile read landed after logout, discarded ({Reason})", reason);
+                    return true;
+                }
+
                 if (userNode is null)
                 {
                     // A failed read is NOT "the user has no descent". Leave the last
                     // known block standing rather than blanking a vat over a flaky
                     // network — the alternative is a meter that flickers out of
-                    // existence every time Vercel hiccups.
+                    // existence every time Vercel hiccups. It is not an answer either:
+                    // a want made during this fetch stays standing for the retry.
+                    lock (_refreshGate) _refreshGate.EndFetch(answered: false);
                     Log.Debug("[Descent] profile read returned nothing ({Reason})", reason);
                     return true;
                 }
+                lock (_refreshGate) _refreshGate.EndFetch(answered: true);
 
                 // THE POLL'S SECOND READING (feat/xp-economy). The same response carries the
                 // account's level/xp/current_season, which this service used to throw away —
@@ -137,8 +203,42 @@ namespace ConditioningControlPanel.Services.Descent
             }
             finally
             {
-                _gate.Release();
+                if (haveGate) _gate.Release();
             }
+        }
+
+        /// <summary>
+        /// Come back for a want the gate could not serve on the spot. One retry in the air
+        /// at a time; when it lands it asks <see cref="DescentRefreshGate.Pending"/> first,
+        /// so a fetch that answered in the meantime (the in-flight one, a poll) makes it a
+        /// no-op, and a logout in the meantime (which clears the want) does too. It does not
+        /// loop on its own: a retry that fails on the wire stands down until somebody asks
+        /// again, which the 60s polls always do.
+        /// </summary>
+        private void ScheduleDeferredRetry(TimeSpan delay, string reason)
+        {
+            if (Interlocked.CompareExchange(ref _deferredArmed, 1, 0) != 0) return;
+
+            Log.Debug("[Descent] refresh '{Reason}' deferred {Seconds:F1}s", reason, delay.TotalSeconds);
+            _ = Task.Run(async () =>
+            {
+                try
+                {
+                    await Task.Delay(delay).ConfigureAwait(false);
+                    Interlocked.Exchange(ref _deferredArmed, 0);
+
+                    string? wanted;
+                    lock (_refreshGate) wanted = _refreshGate.Pending ? _refreshGate.PendingReason ?? reason : null;
+                    if (wanted is null) return;
+
+                    await RefreshAsync("deferred: " + wanted).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    Interlocked.Exchange(ref _deferredArmed, 0);
+                    Log.Debug("[Descent] deferred refresh '{Reason}' failed: {Error}", reason, ex.Message);
+                }
+            });
         }
 
         /// <summary>
@@ -200,7 +300,9 @@ namespace ConditioningControlPanel.Services.Descent
             {
                 try
                 {
-                    if (DateTime.UtcNow - _lastFetchUtc < BackgroundPollFreshEnough) return;
+                    DateTime lastFetchUtc;
+                    lock (_refreshGate) lastFetchUtc = _refreshGate.LastFetchUtc;
+                    if (DateTime.UtcNow - lastFetchUtc < BackgroundPollFreshEnough) return;
                     RequestRefresh("background profile poll");
                 }
                 catch (Exception ex) { Log.Debug("[Descent] background poll tick failed: {Error}", ex.Message); }
@@ -220,9 +322,10 @@ namespace ConditioningControlPanel.Services.Descent
         /// </summary>
         public void Reset()
         {
+            Interlocked.Increment(ref _generation);     // a fetch still in the air belongs to the old account
+            lock (_refreshGate) _refreshGate.Reset();   // the floor (a re-login may ask at once), its credentials, any want
             Current = null;
             HasSeenBlock = false;
-            _lastFetchUtc = DateTime.MinValue;   // a re-login may ask again at once
             Log.Debug("[Descent] state cleared (logout)");
             RaiseBlockChanged();
         }

--- a/ConditioningControlPanel/Services/Settings/ProfileSyncService.cs
+++ b/ConditioningControlPanel/Services/Settings/ProfileSyncService.cs
@@ -480,6 +480,13 @@ namespace ConditioningControlPanel.Services
         /// </summary>
         public void StartHeartbeat()
         {
+            // THE VAT'S SIGN-IN POKE, before the idempotency return on purpose: every login
+            // path lands here once the account is usable, and a second arrival (the 401
+            // self-heal, a Discord restore after a Patreon one) may carry a rotated token.
+            // DescentService dedupes against its own floor, so this never doubles a request
+            // on the wire. Mirror of the App.Descent.Reset() call in ClearAccountData.
+            App.Descent?.OnSignedIn();
+
             if (_heartbeatTimer != null) return;
 
             _heartbeatTimer = new DispatcherTimer

--- a/Tests/ConditioningControlPanel.Tests/DescentRefreshGateTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/DescentRefreshGateTests.cs
@@ -1,0 +1,208 @@
+using System;
+using ConditioningControlPanel.Services.Descent;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// THE VAT'S REFRESH MEMORY, pinned. The Discord report behind it: the daily vat on the Trainer
+/// Card (jar, tooltip, XP readout) sometimes stayed dark after logging in until a sign-out and
+/// sign-in. DescentService answered a request it could not serve (no token yet, a fetch in
+/// flight, inside the 10s floor) with a silent false and nothing ever asked again. These tests
+/// hold the gate to the opposite rule: a want is remembered until a fetch answers it, the floor
+/// only drops a request that a same-credential fetch has ALREADY answered, and sign-in and logout
+/// leave the gate exactly where each needs it.
+/// </summary>
+public class DescentRefreshGateTests
+{
+    private static readonly DateTime T0 = new(2026, 9, 11, 12, 0, 0, DateTimeKind.Utc);
+
+    private const string Uid = "u_1";
+    private const string Token = "tok_a";
+
+    private static DescentRefreshVerdict Ask(
+        DescentRefreshGate gate, DateTime now, out TimeSpan retryIn,
+        string? uid = Uid, string? token = Token,
+        bool offline = false, bool inFlight = false, bool force = false, string reason = "test")
+        => gate.Ask(now, uid, token, offline, inFlight, force, reason, out retryIn);
+
+    // ---------------------------------------------------------------- sign-in
+
+    /// <summary>
+    /// THE REPORTED RACE. The Trainer Card opens before the auth token lands: the request is
+    /// not lost, it waits, and the sign-in poke turns it into a fetch.
+    /// </summary>
+    [Fact]
+    public void NoToken_IsRememberedAndFetchesOnSignIn()
+    {
+        var gate = new DescentRefreshGate();
+
+        var v = Ask(gate, T0, out _, token: null, reason: "trainer card open");
+        Assert.Equal(DescentRefreshVerdict.WaitForSignIn, v);
+        Assert.True(gate.Pending);
+        Assert.Equal("trainer card open", gate.PendingReason);
+
+        // The sign-in poke, credentials now in hand.
+        v = Ask(gate, T0.AddSeconds(3), out _, reason: "signed in");
+        Assert.Equal(DescentRefreshVerdict.Fetch, v);
+        Assert.Equal("trainer card open", gate.PendingReason);   // the first ask explains the log
+
+        gate.BeginFetch(T0.AddSeconds(3), Uid, Token);
+        gate.EndFetch(answered: true);
+        Assert.False(gate.Pending);
+        Assert.Null(gate.PendingReason);
+    }
+
+    [Fact]
+    public void NoAccount_WaitsTheSameWay()
+    {
+        var gate = new DescentRefreshGate();
+        Assert.Equal(DescentRefreshVerdict.WaitForSignIn, Ask(gate, T0, out _, uid: ""));
+        Assert.True(gate.Pending);
+    }
+
+    // ---------------------------------------------------------------- the floor
+
+    /// <summary>The floor's whole purpose: a burst after an answered fetch is one fetch.</summary>
+    [Fact]
+    public void InsideTheFloor_AfterAnAnsweredFetchWithTheSameCredentials_IsRedundant()
+    {
+        var gate = new DescentRefreshGate();
+        Assert.Equal(DescentRefreshVerdict.Fetch, Ask(gate, T0, out _));
+        gate.BeginFetch(T0, Uid, Token);
+        gate.EndFetch(answered: true);
+
+        var v = Ask(gate, T0.AddSeconds(4), out var retryIn, reason: "profile loaded");
+        Assert.Equal(DescentRefreshVerdict.Skip, v);
+        Assert.Equal(TimeSpan.Zero, retryIn);
+        Assert.False(gate.Pending);
+    }
+
+    /// <summary>
+    /// The half the old service got wrong: a request inside the floor after a fetch that did NOT
+    /// answer (a 401 on a rotated token, a network hiccup) is deferred to the end of the window,
+    /// not dropped.
+    /// </summary>
+    [Fact]
+    public void InsideTheFloor_AfterAFailedFetch_IsDeferredToTheEndOfTheFloor()
+    {
+        var gate = new DescentRefreshGate();
+        gate.BeginFetch(T0, Uid, Token);
+        gate.EndFetch(answered: false);
+
+        var v = Ask(gate, T0.AddSeconds(4), out var retryIn, reason: "profile loaded");
+        Assert.Equal(DescentRefreshVerdict.Defer, v);
+        Assert.Equal(TimeSpan.FromSeconds(6), retryIn);
+        Assert.True(gate.Pending);
+    }
+
+    /// <summary>A token healed or rotated since the last fetch makes that fetch's answer stale.</summary>
+    [Fact]
+    public void InsideTheFloor_AfterAFetchWithOtherCredentials_IsDeferred()
+    {
+        var gate = new DescentRefreshGate();
+        gate.BeginFetch(T0, Uid, "tok_old");
+        gate.EndFetch(answered: true);
+
+        var v = Ask(gate, T0.AddSeconds(2), out var retryIn, token: "tok_new", reason: "signed in");
+        Assert.Equal(DescentRefreshVerdict.Defer, v);
+        Assert.Equal(TimeSpan.FromSeconds(8), retryIn);
+        Assert.True(gate.Pending);
+    }
+
+    [Fact]
+    public void PastTheFloor_Fetches()
+    {
+        var gate = new DescentRefreshGate();
+        gate.BeginFetch(T0, Uid, Token);
+        gate.EndFetch(answered: true);
+
+        Assert.Equal(DescentRefreshVerdict.Fetch, Ask(gate, T0.AddSeconds(10), out _));
+    }
+
+    [Fact]
+    public void Force_BypassesTheFloor()
+    {
+        var gate = new DescentRefreshGate();
+        gate.BeginFetch(T0, Uid, Token);
+        gate.EndFetch(answered: true);
+
+        Assert.Equal(DescentRefreshVerdict.Fetch, Ask(gate, T0.AddSeconds(1), out _, force: true));
+    }
+
+    // ---------------------------------------------------------------- in flight
+
+    /// <summary>
+    /// A request during a fetch is deferred; if that fetch answers, the want is satisfied and the
+    /// retry has nothing to do. No double network call.
+    /// </summary>
+    [Fact]
+    public void InFlight_IsDeferred_AndTheAnsweredFetchClearsTheWant()
+    {
+        var gate = new DescentRefreshGate();
+        gate.BeginFetch(T0, Uid, Token);
+
+        var v = Ask(gate, T0.AddSeconds(2), out var retryIn, inFlight: true, reason: "signed in");
+        Assert.Equal(DescentRefreshVerdict.Defer, v);
+        Assert.Equal(TimeSpan.FromSeconds(8), retryIn);
+        Assert.True(gate.Pending);
+
+        gate.EndFetch(answered: true);
+        Assert.False(gate.Pending);
+    }
+
+    /// <summary>...and if that fetch fails, the want stands for the retry.</summary>
+    [Fact]
+    public void InFlight_AFailedFetchLeavesTheWantStanding()
+    {
+        var gate = new DescentRefreshGate();
+        gate.BeginFetch(T0, Uid, Token);
+        Ask(gate, T0.AddSeconds(2), out _, inFlight: true);
+
+        gate.EndFetch(answered: false);
+        Assert.True(gate.Pending);
+        Assert.Equal(DescentRefreshVerdict.Fetch, Ask(gate, T0.AddSeconds(10), out _));
+    }
+
+    [Fact]
+    public void RetryDelay_NeverDropsBelowTheMinimum()
+    {
+        var gate = new DescentRefreshGate();
+        gate.BeginFetch(T0, Uid, Token);
+
+        // A hung request past the floor: the retry still waits a beat instead of spinning.
+        Ask(gate, T0.AddSeconds(30), out var retryIn, inFlight: true);
+        Assert.Equal(DescentRefreshGate.MinRetryDelay, retryIn);
+    }
+
+    // ---------------------------------------------------------------- offline, logout
+
+    [Fact]
+    public void Offline_IsSkippedAndNotRemembered()
+    {
+        var gate = new DescentRefreshGate();
+        Assert.Equal(DescentRefreshVerdict.Skip, Ask(gate, T0, out _, offline: true));
+        Assert.False(gate.Pending);
+    }
+
+    /// <summary>
+    /// Logout drops the floor, the credentials and the want, so the next account's first request
+    /// goes straight out and user A's pending ask cannot fire for user B.
+    /// </summary>
+    [Fact]
+    public void Reset_ClearsTheFloorTheCredentialsAndTheWant()
+    {
+        var gate = new DescentRefreshGate();
+        gate.BeginFetch(T0, Uid, Token);
+        gate.EndFetch(answered: false);
+        Ask(gate, T0.AddSeconds(1), out _, reason: "trainer card open");
+        Assert.True(gate.Pending);
+
+        gate.Reset();
+        Assert.False(gate.Pending);
+        Assert.Null(gate.PendingReason);
+        Assert.Equal(DateTime.MinValue, gate.LastFetchUtc);
+
+        Assert.Equal(DescentRefreshVerdict.Fetch, Ask(gate, T0.AddSeconds(2), out _, uid: "u_2", token: "tok_b"));
+    }
+}


### PR DESCRIPTION
From the Discord "New UI Feedback" thread (gg_rosalyn): the daily vat on the Trainer Card sometimes comes up empty after login and only a sign-out / sign-in brings it back.

The race: DescentService.RefreshAsync answered three situations with a silent return false and forgot the ask (no credentials yet, a fetch in flight, inside the 10 s floor). The Trainer Card asks exactly once on open, so a card already on screen when the token lands lost its ask, and the re-pokes that remained (ProfileLoaded, the post-sync hook, the card poll) were either not sign-in signals or gated on a HasSeenBlock the lost ask never set.

- ProfileSyncService.StartHeartbeat, reached by every login path, now calls App.Descent.OnSignedIn() before its idempotency return, mirroring the existing Reset() on ClearAccountData.
- New pure DescentRefreshGate owns the floor, last-fetch credentials and a Pending want: WaitForSignIn, Defer (one-shot retry at floor end), Skip (same-credential fetch already answered inside the floor), Fetch. Reset() bumps a generation so a fetch in flight for a signed-out account is discarded instead of landing on the next account's card.
- Repaint path unchanged: fetch -> BlockChanged -> OnDescentBlockChanged -> ApplyDescentToVat.
- 12 new tests.

Needs eyes: a fresh launch with the Trainer Card as the landing tab. If users still see it never recover, suspect a server-side factor (block not attached until the day's first sync).

Tests: 5949 green on the lane, 6006 green on the combined verification branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TE6761edxQX7wk5H1iYfSv
