### PR TITLE
feat(achievements): a locked badge shows how far along it is

### DIFF
--- a/ConditioningControlPanel/MainWindow/MainWindow.AchievementsTab.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.AchievementsTab.cs
@@ -60,6 +60,11 @@ namespace ConditioningControlPanel
             FrozenBrush(0x8C, 0xFF, 0x69, 0xB4);
         private static readonly SolidColorBrush AchvPatreonInkBrush =
             FrozenBrush(0xFF, 0xC9, 0xE3);
+        // The progress meter on a locked, countable card: pink fill on a dark track.
+        private static readonly SolidColorBrush AchvMeterFillBrush = FrozenBrush(0xFF, 0x69, 0xB4);
+        private static readonly SolidColorBrush AchvMeterTrackBrush =
+            FrozenBrush(0xCC, 0x1A, 0x1A, 0x2E);
+        private const double AchvMeterTrackPx = 4;
 
         // ---- state ----------------------------------------------------------------------
 
@@ -72,6 +77,12 @@ namespace ConditioningControlPanel
             public TextBlock NameText = null!;
             /// <summary>Requirement while locked, flavor once earned.</summary>
             public TextBlock InfoText = null!;
+            /// <summary>The progress meter under the requirement; collapsed unless the achievement
+            /// is countable and still locked. Updated in place, never rebuilt.</summary>
+            public FrameworkElement MeterHost = null!;
+            public ColumnDefinition MeterFill = null!;
+            public ColumnDefinition MeterRest = null!;
+            public TextBlock MeterLabel = null!;
             /// <summary>The bottom band's content host; rebuilt whole on unlock-state changes.</summary>
             public Grid RewardBand = null!;
             public Services.WardrobeItem? Reward;
@@ -334,6 +345,10 @@ namespace ConditioningControlPanel
                 VerticalAlignment = VerticalAlignment.Center,
             };
 
+            // The info row: requirement (or flavor) with the progress meter under it.
+            var infoStack = new StackPanel { VerticalAlignment = VerticalAlignment.Center };
+            infoStack.Children.Add(infoText);
+
             var band = new Grid();
 
             // Rows: hero art / name / info (absorbs all slack) / reward band on the bottom edge.
@@ -345,7 +360,7 @@ namespace ConditioningControlPanel
 
             Grid.SetRow(badgeHost, 0);
             Grid.SetRow(nameText, 1);
-            Grid.SetRow(infoText, 2);
+            Grid.SetRow(infoStack, 2);
 
             var bandChrome = new Border
             {
@@ -360,7 +375,7 @@ namespace ConditioningControlPanel
 
             content.Children.Add(badgeHost);
             content.Children.Add(nameText);
-            content.Children.Add(infoText);
+            content.Children.Add(infoStack);
             content.Children.Add(bandChrome);
 
             // The Patreon chip. These four live in the FREE grid on purpose (an earned receipt
@@ -412,7 +427,10 @@ namespace ConditioningControlPanel
             _achievementCards[achievement.Id] = card;
             _achievementCardParts[card] = parts;
 
+            infoStack.Children.Add(BuildAchievementMeter(parts));
+
             ApplyAchievementInfoText(parts, unlocked);
+            ApplyAchievementMeter(parts, unlocked);
             BuildRewardBand(parts);
             ApplyAchievementCardTooltip(parts, unlocked);
 
@@ -443,6 +461,98 @@ namespace ConditioningControlPanel
                 infoText.Text = AchFlavor(parts.Achievement);
                 infoText.FontStyle = FontStyles.Italic;
                 infoText.Foreground = AchvMutedBrush;
+            }
+        }
+
+        /// <summary>
+        /// The slim bar under the requirement: a dark track, a pink fill sized by two star columns
+        /// (no pixel maths, no ProgressBar template), and "current / target" centred beneath it.
+        /// Built once per card; <see cref="ApplyAchievementMeter"/> only moves the numbers.
+        /// </summary>
+        private static FrameworkElement BuildAchievementMeter(AchievementCardParts parts)
+        {
+            var fill = new ColumnDefinition { Width = new GridLength(0, GridUnitType.Star) };
+            var rest = new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) };
+            var columns = new Grid();
+            columns.ColumnDefinitions.Add(fill);
+            columns.ColumnDefinitions.Add(rest);
+            var fillBar = new Border
+            {
+                Background = AchvMeterFillBrush,
+                CornerRadius = new CornerRadius(AchvMeterTrackPx / 2),
+            };
+            Grid.SetColumn(fillBar, 0);
+            columns.Children.Add(fillBar);
+
+            // The track colour sits on the rounded Border itself: a Border does not clip its child
+            // to its corners, so a painted Grid inside it would show square ends.
+            var track = new Border
+            {
+                Height = AchvMeterTrackPx,
+                Background = AchvMeterTrackBrush,
+                CornerRadius = new CornerRadius(AchvMeterTrackPx / 2),
+                Margin = new Thickness(14, 0, 14, 0),
+                SnapsToDevicePixels = true,
+                Child = columns,
+            };
+
+            var label = new TextBlock
+            {
+                FontSize = 10,
+                Foreground = AchvMutedBrush,
+                TextAlignment = TextAlignment.Center,
+                Margin = new Thickness(12, 3, 12, 0),
+            };
+
+            var host = new StackPanel { Margin = new Thickness(0, 0, 0, 2), Visibility = Visibility.Collapsed };
+            host.Children.Add(track);
+            host.Children.Add(label);
+
+            parts.MeterHost = host;
+            parts.MeterFill = fill;
+            parts.MeterRest = rest;
+            parts.MeterLabel = label;
+            return host;
+        }
+
+        /// <summary>
+        /// One meter computation per card per refresh, from the same counters and thresholds the
+        /// trackers unlock on (<see cref="Services.AchievementMeters"/>). Locked and countable: bar
+        /// on, requirement capped at two lines so the row still fits. Anything else: bar off.
+        /// </summary>
+        private static void ApplyAchievementMeter(AchievementCardParts parts, bool unlocked)
+        {
+            if (parts.MeterHost == null) return;
+
+            var meter = unlocked ? null : ComputeAchievementMeter(parts.Achievement);
+            if (meter == null)
+            {
+                parts.MeterHost.Visibility = Visibility.Collapsed;
+                parts.InfoText.MaxHeight = 42;
+                return;
+            }
+
+            var fraction = meter.Value.Fraction;
+            parts.MeterFill.Width = new GridLength(fraction, GridUnitType.Star);
+            parts.MeterRest.Width = new GridLength(1 - fraction, GridUnitType.Star);
+            parts.MeterLabel.Text = meter.Value.Label;
+            parts.InfoText.MaxHeight = 28;
+            parts.MeterHost.Visibility = Visibility.Visible;
+        }
+
+        private static Services.AchievementMeter? ComputeAchievementMeter(Models.Achievement achievement)
+        {
+            try
+            {
+                var progress = App.Achievements?.Progress;
+                if (progress == null) return null;
+                var level = App.Settings?.Current?.PlayerLevel ?? 0;
+                return Services.AchievementMeters.Compute(achievement, progress, level);
+            }
+            catch (Exception ex)
+            {
+                Diag.Swallowed(ex, "achievement meter");
+                return null;
             }
         }
 
@@ -744,6 +854,7 @@ namespace ConditioningControlPanel
                 // somehow re-locked stops).
                 SetAchievementTileUnlocked(card, isUnlocked);
                 ApplyAchievementInfoText(parts, isUnlocked);
+                ApplyAchievementMeter(parts, isUnlocked);
                 BuildRewardBand(parts);
                 ApplyAchievementCardTooltip(parts, isUnlocked);
             }

--- a/ConditioningControlPanel/Services/GamificationBridge.cs
+++ b/ConditioningControlPanel/Services/GamificationBridge.cs
@@ -25,21 +25,24 @@ public class GamificationBridge : IDisposable
     private bool _started;
 
     // --- tunable thresholds (chosen here, flagged for review) ---
+    // The internal ones are the lifetime-counter bars; AchievementMeters reads them for the
+    // gallery's progress bars, so the card and the unlock share one number.
     private const int BestFriendsCompanionLevel = 25;   // "reach a companion level milestone"
-    private const int PillowTalkMessages = 100;          // "exchange 100 messages"
-    private const int PavlovKeywordTriggers = 500;       // "fire 500 keyword triggers"
-    private const int CuratorDistinctMods = 10;          // "activate 10 different mods"
+    internal const int PillowTalkMessages = 100;         // "exchange 100 messages"
+    internal const int PavlovKeywordTriggers = 500;      // "fire 500 keyword triggers"
+    internal const int CuratorDistinctMods = 10;         // "activate 10 different mods"
     private const int MadScientistRules = 5;             // "build using 5+ triggers" (Rules)
     private const int PuppetStringsCommands = 100;        // "100 remote commands in one session"
     private const int ThrowAwayKeyMinutes = 60;           // "60+ minute lockdown"
-    private const int CommunityModsCount = 3;             // "activate 3 community mods"
-    private const int DownTheRabbitHolePlays = 25;        // "play 25 enhancements"
+    internal const int CommunityModsCount = 3;            // "activate 3 community mods"
+    internal const int DownTheRabbitHolePlays = 25;       // "play 25 enhancements"
     private const int OnRailsTriggerTypes = 5;            // "5+ distinct trigger types"
-    private const int HandsFreeGazePops = 50;             // "pop 50 bubbles by gaze"
-    private const int HonorRollCategories = 3;            // "top marks in 3 different categories"
+    internal const int HandsFreeGazePops = 50;            // "pop 50 bubbles by gaze"
+    internal const int HonorRollCategories = 3;           // "top marks in 3 different categories"
+    internal const int BlinkAndYoullMissItBlinks = 100;   // "log 100 blinks in the Blink Trainer"
     // 25 -> 10 with the quiz retired: an intake is a 20+ minute banded descent, not a 10-question
     // quiz, so 25 of them was a different order of ask than the requirement text implied.
-    private const int TeachersPetPasses = 10;             // "pass 10 graded runs"
+    internal const int TeachersPetPasses = 10;            // "pass 10 graded runs"
     private const int HeldBackFailStreak = 3;             // "fail 3 in a row" (classic quiz only)
     private const int HeldBackQuitStreak = 3;             // "quit 3 intakes early" (the live path)
 
@@ -477,7 +480,7 @@ public class GamificationBridge : IDisposable
                 var p = Prog; if (p == null) return;
                 p.BlinkTrainerBlinks++;
                 Ach?.MarkDirty();
-                if (p.BlinkTrainerBlinks >= 100)
+                if (p.BlinkTrainerBlinks >= BlinkAndYoullMissItBlinks)
                     Ach?.TryUnlockExclusive("blink_and_youll_miss_it");
             }
             catch (Exception ex) { App.Logger?.Warning(ex, "GamificationBridge: blink handler failed"); }

--- a/ConditioningControlPanel/Services/Progression/AchievementMeter.cs
+++ b/ConditioningControlPanel/Services/Progression/AchievementMeter.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using ConditioningControlPanel.Models;
+
+namespace ConditioningControlPanel.Services;
+
+/// <summary>
+/// How far a locked, countable achievement has come: <see cref="Current"/> out of
+/// <see cref="Target"/>, both in the unit the card shows (checks, days, hours).
+/// </summary>
+public readonly record struct AchievementMeter(double Current, double Target)
+{
+    public bool IsComplete => Current >= Target;
+
+    /// <summary>0..1, for the bar.</summary>
+    public double Fraction => Target <= 0 ? 1 : Math.Clamp(Current / Target, 0, 1);
+
+    /// <summary>"76 / 100", or "5.2 / 10" when the unit is hours. No words, so no loc key.</summary>
+    public string Label => Fmt(Current) + " / " + Fmt(Target);
+
+    private static string Fmt(double v)
+    {
+        var culture = CultureInfo.CurrentCulture;
+        return Math.Abs(v - Math.Round(v)) < 0.0005
+            ? Math.Round(v).ToString("N0", culture)
+            : v.ToString("0.#", culture);
+    }
+}
+
+/// <summary>
+/// The one table that says which achievements are countable and where their number comes from.
+///
+/// <para>Countable means: the tracker that unlocks it compares ONE persisted lifetime counter on
+/// <see cref="AchievementProgress"/> (or the player level) against ONE fixed threshold. Every
+/// entry below reads the same field the tracker branches on and the same constant it branches
+/// against, so the bar on the card and the unlock can never drift apart. First-time badges
+/// (target 1), per-session windows, continuous timers that reset, flags, and anything with two
+/// alternate counters are not in this table and report no progress at all.</para>
+///
+/// <para>Pure and static on purpose: no App, no service instance, so it runs in the test host
+/// and costs one dictionary hit per card per refresh.</para>
+/// </summary>
+public static class AchievementMeters
+{
+    private delegate double Reader(AchievementProgress progress, int playerLevel);
+
+    private static readonly Dictionary<string, (Reader Read, double Target)> Rules = BuildRules();
+
+    /// <summary>Ids that carry a meter, in table order.</summary>
+    public static IEnumerable<string> CountableIds => Rules.Keys;
+
+    public static bool IsCountable(string achievementId) => Rules.ContainsKey(achievementId);
+
+    /// <summary>
+    /// Null for anything not in the table. An unlocked countable achievement reports full; a
+    /// locked one reports its counter clamped to the target (a cloud restore can push a counter
+    /// past the bar before the tracker's next tick fires the unlock).
+    /// </summary>
+    public static AchievementMeter? Compute(Achievement achievement, AchievementProgress progress, int playerLevel)
+    {
+        if (achievement == null || progress == null) return null;
+        if (!Rules.TryGetValue(achievement.Id, out var rule)) return null;
+
+        var target = rule.Target;
+        if (progress.IsUnlocked(achievement.Id)) return new AchievementMeter(target, target);
+
+        var current = rule.Read(progress, playerLevel);
+        if (double.IsNaN(current)) current = 0;
+        return new AchievementMeter(Math.Clamp(current, 0, target), target);
+    }
+
+    private static Dictionary<string, (Reader, double)> BuildRules()
+    {
+        var rules = new Dictionary<string, (Reader, double)>(StringComparer.Ordinal);
+
+        void Add(string id, double target, Reader read) => rules[id] = (read, target);
+        void Hours(string id, double targetMinutes, Func<AchievementProgress, double> minutes)
+            => Add(id, targetMinutes / 60.0, (p, _) => minutes(p) / 60.0);
+
+        // ---- progression: the level milestones, straight off the tracker's own list ----
+        foreach (var (id, level) in AchievementService.LevelMilestones)
+            Add(id, level, (_, lvl) => lvl);
+        Add("window_shopping", AchievementService.WindowShoppingPointsSpent, (p, _) => p.LifetimeSkillPointsSpent);
+
+        // ---- time & sessions ----
+        Hours("rose_tinted_reality", AchievementService.RoseTintedPinkFilterMinutes, p => p.TotalPinkFilterMinutes);
+        Hours("threadbare", AchievementService.ThreadbareSpiralMinutes, p => p.TotalSpiralMinutes);
+        Hours("screen_time", AchievementService.ScreenTimeVideoMinutes, p => p.TotalVideoMinutes);
+        Add("daily_maintenance", AchievementService.DailyMaintenanceConsecutiveDays, (p, _) => p.ConsecutiveDays);
+        Add("thirty_day_doll", AchievementService.ThirtyDayDollConsecutiveDays, (p, _) => p.ConsecutiveDays);
+        Add("retinal_burn", AchievementService.RetinalBurnFlashImages, (p, _) => p.TotalFlashImages);
+        Add("pavlov", GamificationBridge.PavlovKeywordTriggers, (p, _) => p.KeywordTriggersFired);
+
+        // ---- minigames & skill ----
+        Add("mathematicians_nightmare", AchievementService.MathematiciansNightmareStreak, (p, _) => p.BubbleCountCorrectStreak);
+        Add("pop_the_thought", AchievementService.PopTheThoughtBubbles, (p, _) => p.TotalBubblesPopped);
+        Add("word_perfect", AchievementService.WordPerfectLockCards, (p, _) => p.TotalLockCardsCompleted);
+        Add("eyes_front", AchievementService.EyesFrontAttentionChecks, (p, _) => p.TotalAttentionChecksPassed);
+        Add("mercy_beggar", AchievementService.MercyBeggarFailures, (p, _) => p.AttentionCheckFailures);
+        Add("pillow_talk", GamificationBridge.PillowTalkMessages, (p, _) => p.CompanionMessages);
+        Add("blink_and_youll_miss_it", GamificationBridge.BlinkAndYoullMissItBlinks, (p, _) => p.BlinkTrainerBlinks);
+        Add("teachers_pet", GamificationBridge.TeachersPetPasses, (p, _) => p.QuizzesPassed);
+        Add("honor_roll", GamificationBridge.HonorRollCategories, (p, _) => p.PerfectedQuizCategories.Count);
+        Add("hands_free", GamificationBridge.HandsFreeGazePops, (p, _) => p.GazePops);
+
+        // ---- deeper ----
+        Add("down_the_rabbit_hole", GamificationBridge.DownTheRabbitHolePlays, (p, _) => p.EnhancementsPlayed);
+        Hours("permanent_resident", AchievementService.PermanentResidentDeeperMinutes, p => p.DeeperMinutes);
+
+        // ---- creator ----
+        Add("curator", GamificationBridge.CuratorDistinctMods, (p, _) => p.ActivatedModIds.Count);
+        Add("community_supported", GamificationBridge.CommunityModsCount, (p, _) => p.CommunityModIds.Count);
+
+        return rules;
+    }
+}

--- a/ConditioningControlPanel/Services/Progression/AchievementService.cs
+++ b/ConditioningControlPanel/Services/Progression/AchievementService.cs
@@ -79,6 +79,45 @@ public class AchievementService : IDisposable
     /// <summary>"window_shopping" — sparkle points spent, lifetime (the Prestige metric).</summary>
     internal const long WindowShoppingPointsSpent = 100;
 
+    // The rest of the countable thresholds, pulled out of the trackers so the gallery meter
+    // (AchievementMeters) reads the number the tracker branches on, not a copy of it.
+
+    /// <summary>"rose_tinted_reality" - 10 cumulative hours of pink filter.</summary>
+    internal const double RoseTintedPinkFilterMinutes = 600;
+
+    /// <summary>"permanent_resident" - 10 cumulative hours in the Deeper player.</summary>
+    internal const double PermanentResidentDeeperMinutes = 600;
+
+    /// <summary>"daily_maintenance" - consecutive launch days.</summary>
+    internal const int DailyMaintenanceConsecutiveDays = 7;
+
+    /// <summary>"retinal_burn" - flash images shown, lifetime.</summary>
+    internal const int RetinalBurnFlashImages = 5000;
+
+    /// <summary>"pop_the_thought" - bubbles popped, lifetime.</summary>
+    internal const int PopTheThoughtBubbles = 1000;
+
+    /// <summary>"mathematicians_nightmare" - correct bubble counts in a row.</summary>
+    internal const int MathematiciansNightmareStreak = 5;
+
+    /// <summary>"mercy_beggar" - attention checks failed, lifetime.</summary>
+    internal const int MercyBeggarFailures = 3;
+
+    /// <summary>
+    /// The level milestones, lowest first. <see cref="CheckLevelAchievements"/> walks this list
+    /// and the gallery meter reads it, so the two cannot disagree.
+    /// </summary>
+    internal static readonly (string Id, int Level)[] LevelMilestones =
+    {
+        ("plastic_initiation", 10),
+        ("dumb_bimbo", 20),
+        ("fully_synthetic", 50),
+        ("docile_cow", 75),
+        ("perfect_plastic_puppet", 100),
+        ("brainwashed_slavedoll", 125),
+        ("platinum_puppet", 150),
+    };
+
 
     public event EventHandler<Achievement>? AchievementUnlocked;
 
@@ -377,7 +416,7 @@ public class AchievementService : IDisposable
                 _isDirty = true;
 
                 // Check Rose-Tinted Reality (10 hours = 600 minutes)
-                if (_progress.TotalPinkFilterMinutes >= 600)
+                if (_progress.TotalPinkFilterMinutes >= RoseTintedPinkFilterMinutes)
                 {
                     TryUnlock("rose_tinted_reality");
                 }
@@ -462,7 +501,7 @@ public class AchievementService : IDisposable
             {
                 _progress.DeeperMinutes += elapsed;
                 _isDirty = true;
-                if (_progress.DeeperMinutes >= 600)
+                if (_progress.DeeperMinutes >= PermanentResidentDeeperMinutes)
                 {
                     TryUnlock("permanent_resident");
                 }
@@ -522,13 +561,10 @@ public class AchievementService : IDisposable
     /// </summary>
     public void CheckLevelAchievements(int level)
     {
-        if (level >= 10) TryUnlock("plastic_initiation");
-        if (level >= 20) TryUnlock("dumb_bimbo");
-        if (level >= 50) TryUnlock("fully_synthetic");
-        if (level >= 75) TryUnlock("docile_cow");
-        if (level >= 100) TryUnlock("perfect_plastic_puppet");
-        if (level >= 125) TryUnlock("brainwashed_slavedoll");
-        if (level >= 150) TryUnlock("platinum_puppet");
+        foreach (var (id, milestone) in LevelMilestones)
+        {
+            if (level >= milestone) TryUnlock(id);
+        }
     }
     
     /// <summary>
@@ -538,7 +574,7 @@ public class AchievementService : IDisposable
     /// </summary>
     public void CheckDailyMaintenance()
     {
-        if (_progress.ConsecutiveDays >= 7)
+        if (_progress.ConsecutiveDays >= DailyMaintenanceConsecutiveDays)
         {
             TryUnlock("daily_maintenance");
         }
@@ -557,7 +593,7 @@ public class AchievementService : IDisposable
         _progress.TotalFlashImages++;
         _isDirty = true;
 
-        if (_progress.TotalFlashImages >= 5000)
+        if (_progress.TotalFlashImages >= RetinalBurnFlashImages)
         {
             TryUnlock("retinal_burn");
         }
@@ -574,7 +610,7 @@ public class AchievementService : IDisposable
         _progress.TotalBubblesPopped++;
         _isDirty = true;
 
-        if (_progress.TotalBubblesPopped >= 1000)
+        if (_progress.TotalBubblesPopped >= PopTheThoughtBubbles)
         {
             TryUnlock("pop_the_thought");
         }
@@ -625,7 +661,7 @@ public class AchievementService : IDisposable
         int after = _progress.TotalBubblesPopped;
         _isDirty = true;
 
-        if (before < 1000 && after >= 1000)
+        if (before < PopTheThoughtBubbles && after >= PopTheThoughtBubbles)
         {
             TryUnlock("pop_the_thought");
         }
@@ -698,7 +734,7 @@ public class AchievementService : IDisposable
                 _progress.BubbleCountBestStreak = _progress.BubbleCountCorrectStreak;
             }
 
-            if (_progress.BubbleCountCorrectStreak >= 5)
+            if (_progress.BubbleCountCorrectStreak >= MathematiciansNightmareStreak)
             {
                 TryUnlock("mathematicians_nightmare");
             }
@@ -783,7 +819,7 @@ public class AchievementService : IDisposable
         _progress.AttentionCheckFailures++;
         _isDirty = true;
         
-        if (_progress.AttentionCheckFailures >= 3)
+        if (_progress.AttentionCheckFailures >= MercyBeggarFailures)
         {
             TryUnlock("mercy_beggar");
         }

--- a/Tests/ConditioningControlPanel.Tests/AchievementMeterTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/AchievementMeterTests.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Globalization;
+using System.Linq;
+using ConditioningControlPanel.Models;
+using ConditioningControlPanel.Services;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// The progress meter on a locked achievement card reads the same counter and the same threshold
+/// the tracker unlocks on. These pin that: a stat-threshold badge reports its counter, a secret or
+/// one-shot badge reports nothing, an unlocked badge reports full, and the table only names real
+/// achievements.
+/// </summary>
+public class AchievementMeterTests
+{
+    [Fact]
+    public void StatThresholdReportsCounterAgainstTheTrackersBar()
+    {
+        var progress = new AchievementProgress { TotalAttentionChecksPassed = 76 };
+
+        var meter = AchievementMeters.Compute(Achievement.All["eyes_front"], progress, playerLevel: 1);
+
+        Assert.NotNull(meter);
+        Assert.Equal(76, meter!.Value.Current);
+        Assert.Equal(AchievementService.EyesFrontAttentionChecks, meter.Value.Target);
+        Assert.False(meter.Value.IsComplete);
+        Assert.Equal(0.76, meter.Value.Fraction, precision: 6);
+    }
+
+    [Theory]
+    [InlineData("relapse")]           // a timing window, not a counter
+    [InlineData("total_lockdown")]    // a flag
+    [InlineData("needy_doll")]        // hidden easter egg
+    [InlineData("she_remembers")]     // one-shot event
+    [InlineData("spiral_eyes")]       // continuous timer that resets
+    [InlineData("modder")]            // first-time badge
+    public void SecretAndEventAchievementsReportNoProgress(string id)
+    {
+        var progress = new AchievementProgress { ContinuousSpiralMinutes = 12, ModsInstalled = 1 };
+
+        Assert.Null(AchievementMeters.Compute(Achievement.All[id], progress, playerLevel: 50));
+        Assert.False(AchievementMeters.IsCountable(id));
+    }
+
+    [Fact]
+    public void UnlockedAchievementReportsFull()
+    {
+        var progress = new AchievementProgress { TotalAttentionChecksPassed = 3 };
+        progress.Unlock("eyes_front");
+
+        var meter = AchievementMeters.Compute(Achievement.All["eyes_front"], progress, playerLevel: 1);
+
+        Assert.NotNull(meter);
+        Assert.Equal(meter!.Value.Target, meter.Value.Current);
+        Assert.True(meter.Value.IsComplete);
+        Assert.Equal(1, meter.Value.Fraction);
+    }
+
+    [Fact]
+    public void LevelMilestonesReadThePlayerLevel()
+    {
+        var progress = new AchievementProgress();
+
+        var meter = AchievementMeters.Compute(Achievement.All["plastic_initiation"], progress, playerLevel: 4);
+
+        Assert.NotNull(meter);
+        Assert.Equal(4, meter!.Value.Current);
+        Assert.Equal(10, meter.Value.Target);
+
+        // Every milestone the tracker unlocks on is in the meter table with the same level.
+        foreach (var (id, level) in AchievementService.LevelMilestones)
+        {
+            var m = AchievementMeters.Compute(Achievement.All[id], progress, playerLevel: level);
+            Assert.True(m!.Value.IsComplete, $"'{id}' should read complete at level {level}");
+            Assert.Contains(level.ToString(CultureInfo.InvariantCulture), Achievement.All[id].Requirement);
+        }
+    }
+
+    [Fact]
+    public void CumulativeHoursShowInHoursNotMinutes()
+    {
+        var progress = new AchievementProgress { TotalSpiralMinutes = 312 };
+
+        var meter = AchievementMeters.Compute(Achievement.All["threadbare"], progress, playerLevel: 1);
+
+        Assert.NotNull(meter);
+        Assert.Equal(5.2, meter!.Value.Current, precision: 6);
+        Assert.Equal(10, meter.Value.Target);
+        Assert.False(meter.Value.IsComplete);
+    }
+
+    [Fact]
+    public void CounterPastTheBarClampsToTheTarget()
+    {
+        // A cloud restore can lift a counter past the bar before the tracker's next tick unlocks.
+        var progress = new AchievementProgress { TotalBubblesPopped = 1200 };
+
+        var meter = AchievementMeters.Compute(Achievement.All["pop_the_thought"], progress, playerLevel: 1);
+
+        Assert.Equal(AchievementService.PopTheThoughtBubbles, meter!.Value.Current);
+        Assert.True(meter.Value.IsComplete);
+    }
+
+    [Fact]
+    public void LabelIsPlainCurrentSlashTarget()
+    {
+        var previous = CultureInfo.CurrentCulture;
+        CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
+        try
+        {
+            Assert.Equal("76 / 100", new AchievementMeter(76, 100).Label);
+            Assert.Equal("5.2 / 10", new AchievementMeter(5.2, 10).Label);
+            Assert.Equal("0 / 5,000", new AchievementMeter(0, 5000).Label);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = previous;
+        }
+    }
+
+    /// <summary>
+    /// The split is a decision, not an accident: 29 countable, the rest event or secret. A new
+    /// lifetime-counter achievement belongs in the table; bump the number when you add it.
+    /// </summary>
+    [Fact]
+    public void CountableTableNamesRealAchievementsOnly()
+    {
+        var ids = AchievementMeters.CountableIds.ToList();
+
+        Assert.Equal(29, ids.Count);
+        Assert.All(ids, id => Assert.True(Achievement.All.ContainsKey(id), $"'{id}' is not in the catalogue"));
+        Assert.All(ids, id => Assert.False(Achievement.All[id].IsHidden, $"'{id}' is parked; a meter on it is dead weight"));
+    }
+
+    [Fact]
+    public void EveryCountableAchievementReadsCompleteAtItsOwnTarget()
+    {
+        // Unlocking is the one path that must always read full, whatever the counter says.
+        var progress = new AchievementProgress();
+        foreach (var id in AchievementMeters.CountableIds)
+        {
+            progress.Unlock(id);
+            var meter = AchievementMeters.Compute(Achievement.All[id], progress, playerLevel: 0);
+            Assert.True(meter!.Value.IsComplete, $"'{id}' unlocked but not full");
+            Assert.True(meter.Value.Target > 0, $"'{id}' has no target");
+        }
+    }
+}


### PR DESCRIPTION
From the Discord "New UI Feedback" thread (gg_rosalyn): locked achievements should show progress for completionists, now that rewards are on the line.

- 29 of 69 achievements are countable: the tracker unlocks them by comparing one persisted lifetime counter on AchievementProgress (or the player level) against one fixed threshold. The other 40 (first-time badges, per-session windows, resetting timers, flags and combos, the two hidden ones) show no bar.
- AchievementMeters.Compute is a pure table reading the exact field the tracker increments and the exact constant it branches on. The inline literals in AchievementService became named consts the trackers now use, so the bar and the unlock can never disagree. Unlocked reports full; a locked counter past the bar clamps to target. 600-minute badges display as hours.
- UI: a slim rounded track with pink fill and a "current / target" label under the requirement text on locked cards. Built once per card, updated in place on refresh. Blurred art and "???" untouched. No loc key needed.
- 14 new tests.

Needs eyes: the 61px fit for text plus bar on a locked card is by arithmetic, not screenshot.

Tests: 5951 green on the lane, 6020 green on the combined verification branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TE6761edxQX7wk5H1iYfSv
