### PR TITLE
feat(rail): doors open on hover

### DIFF
--- a/ConditioningControlPanel/MainWindow/MainWindow.NavRail.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.NavRail.cs
@@ -9,6 +9,7 @@ using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Media.Effects;
 using System.Windows.Shapes;
+using System.Windows.Threading;
 using ConditioningControlPanel.Services;
 
 namespace ConditioningControlPanel
@@ -104,6 +105,15 @@ namespace ConditioningControlPanel
         /// tween and a re-entry mid-collapse simply re-targets the same Width clock.</para>
         /// </summary>
         private const int NavRailCollapseAnimMs = 150;
+
+        /// <summary>
+        /// Dwell before a hovered door header opens its accordion (owner call, Discord "New UI
+        /// Feedback", 2026-09-11: doors open on hover, not only on click). Long enough that a
+        /// pointer crossing the rail on its way somewhere does not flip three doors, short enough
+        /// to read as "it opened when I got there". Cancelled by MouseLeave; a click still opens
+        /// the door at once through NavDoor_Click.
+        /// </summary>
+        private const int NavDoorHoverDwellMs = 250;
 
         // ===================== medallion door rows (CONTRACT, 2026-08-12) =====================
         // Sizes are animated between these two states; MainWindow.xaml authors the COLLAPSED
@@ -209,6 +219,10 @@ namespace ConditioningControlPanel
         /// must not release the other's hold.</summary>
         private int _navRailHoldCount;
 
+        /// <summary>The door under the pointer whose dwell is running, or null.</summary>
+        private string? _navDoorHoverPending;
+        private DispatcherTimer? _navDoorHoverTimer;
+
         /// <summary>Every label in the rail, cached once. Faded rather than collapsed: a
         /// Visibility flip would re-measure the door panels mid-tween and fight the accordion's
         /// own Height animation.</summary>
@@ -269,6 +283,7 @@ namespace ConditioningControlPanel
                 // Doors first: it seeds _navDoorLabelTexts, which the walk below reads.
                 CacheNavDoorRows();
                 HookNavDoorRerouteSeam();
+                HookNavDoorHover();
                 CacheNavRailParts(NavSidebar);
 
                 // The medallion art is mod-aware from the first frame; MainWindow.xaml's literal
@@ -362,6 +377,76 @@ namespace ConditioningControlPanel
                 }
             }
             catch (Exception ex) { App.Logger?.Warning(ex, "HookNavDoorRerouteSeam failed; doors route normally"); }
+        }
+
+        /// <summary>
+        /// Doors open on hover. Every door header that has a panel gets a dwell: the pointer
+        /// resting on it for <see cref="NavDoorHoverDwellMs"/> moves the accordion there through
+        /// <see cref="SetExpandedDoor"/>, which is the same one-door-at-a-time move a click makes
+        /// and animates only while MotionFx allows. Leaving the header before the dwell lands
+        /// cancels it, so a pointer crossing the rail opens nothing on the way.
+        ///
+        /// <para>Hover never navigates: the page stays where it is and the "you are here" ring
+        /// does not move. Click still does both (NavDoor_Click -> ShowTab -> ExpandDoorForTab).
+        /// The dwell also stands down while the rail is shut (<see cref="SetExpandedDoor"/> opens
+        /// no panel then anyway) and while a hold is up, so a tutorial spotlight is not re-homed
+        /// by a passing hand. ApplyNavRailDoorState still shuts every panel on collapse; this
+        /// only ever changes which door is the chosen one.</para>
+        /// </summary>
+        private void HookNavDoorHover()
+        {
+            try
+            {
+                foreach (var d in NavDoorMap)
+                {
+                    var parts = NavDoorParts(d.Door);
+                    if (parts.Header == null || parts.Panel == null) continue;
+                    var door = d.Door;
+                    parts.Header.MouseEnter += (_, __) => StartNavDoorHoverDwell(door);
+                    parts.Header.MouseLeave += (_, __) => CancelNavDoorHoverDwell();
+                }
+            }
+            catch (Exception ex) { App.Logger?.Warning(ex, "HookNavDoorHover failed; doors open on click only"); }
+        }
+
+        private void StartNavDoorHoverDwell(string door)
+        {
+            try
+            {
+                if (string.Equals(door, _expandedDoor, StringComparison.Ordinal)) return;
+                _navDoorHoverPending = door;
+                if (_navDoorHoverTimer == null)
+                {
+                    _navDoorHoverTimer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(NavDoorHoverDwellMs) };
+                    _navDoorHoverTimer.Tick += (_, __) => NavDoorHoverDwellElapsed();
+                }
+                _navDoorHoverTimer.Stop();
+                _navDoorHoverTimer.Start();
+            }
+            catch (Exception ex) { App.Logger?.Debug("StartNavDoorHoverDwell({Door}): {E}", door, ex.Message); }
+        }
+
+        private void CancelNavDoorHoverDwell()
+        {
+            _navDoorHoverPending = null;
+            _navDoorHoverTimer?.Stop();
+        }
+
+        private void NavDoorHoverDwellElapsed()
+        {
+            try
+            {
+                _navDoorHoverTimer?.Stop();
+                var door = _navDoorHoverPending;
+                _navDoorHoverPending = null;
+                if (door == null || !_navRailExpanded || _navRailHoldCount > 0) return;
+                // The pointer has to still be on the header: a leave that never arrived (the
+                // same missed-edge family SyncNavRailToPointer exists for) must not open a door
+                // nobody is looking at.
+                if (NavDoorParts(door).Header?.IsMouseOver != true) return;
+                SetExpandedDoor(door);
+            }
+            catch (Exception ex) { App.Logger?.Debug("NavDoorHoverDwellElapsed: {E}", ex.Message); }
         }
 
         /// <summary>

--- a/Tests/ConditioningControlPanel.Tests/NavRailFlyoutTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/NavRailFlyoutTests.cs
@@ -45,6 +45,33 @@ public class NavRailFlyoutTests
         return double.Parse(m.Groups[1].Value, CultureInfo.InvariantCulture);
     }
 
+    /// <summary>Doors open on hover (owner call, 2026-09-11): a short dwell, cancelled on leave,
+    /// through the same one-door-at-a-time move a click makes. The dwell is a constant, not a
+    /// setting.</summary>
+    [Fact]
+    public void DoorsOpenOnHover_AfterAShortDwell_CancelledOnLeave()
+    {
+        var src = NavRailSource();
+        var dwell = ConstValue(src, "NavDoorHoverDwellMs");
+        Assert.InRange(dwell, 150, 400);
+
+        var hook = Regex.Match(src, @"private void HookNavDoorHover\(\).*?\n        \}", RegexOptions.Singleline);
+        Assert.True(hook.Success, "HookNavDoorHover is gone - doors no longer open on hover");
+        Assert.Contains("MouseEnter += (_, __) => StartNavDoorHoverDwell(door)", hook.Value);
+        Assert.Contains("MouseLeave += (_, __) => CancelNavDoorHoverDwell()", hook.Value);
+
+        var elapsed = Regex.Match(src, @"private void NavDoorHoverDwellElapsed\(\).*?\n        \}", RegexOptions.Singleline);
+        Assert.True(elapsed.Success, "NavDoorHoverDwellElapsed is gone");
+        // One door at a time, through the accordion's own move; never a navigation.
+        Assert.Contains("SetExpandedDoor(door)", elapsed.Value);
+        Assert.DoesNotContain("ShowTab(", elapsed.Value);
+        // A shut rail and a held rail both stand the dwell down.
+        Assert.Contains("!_navRailExpanded || _navRailHoldCount > 0", elapsed.Value);
+
+        Assert.Contains("HookNavDoorHover();", src);
+        Assert.DoesNotContain("NavDoorHoverDwell", File.ReadAllText(Path.Combine(RepoRoot(), "ConditioningControlPanel", "Models", "AppSettings.cs")));
+    }
+
     [Fact]
     public void LeavingTheRailCollapsesItOnTheSpot()
     {


### PR DESCRIPTION
Stacked on https://github.com/CodeBambi/Conditioning-Control-Panel---CSharp-WPF/pull/1089. Step 4: doors open on hover (beebeethetoy asked for fewer clicks), owner decision Sep 11.

- Hovering a door header expands it after a 250 ms dwell, cancelled on leave. Click still works. One door open at a time via the existing _expandedDoor; ApplyNavRailDoorState still shuts everything on collapse. Respects MotionFx. No new settings.

Needs eyes: dwell feel, no flicker when crossing the rail, behaviour with motion off.

Tests: 5956 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TE6761edxQX7wk5H1iYfSv
