### PR TITLE
fix(lost-and-found): fit the marquee wrap to the frame so a phone row is never bare

### DIFF
--- a/ConditioningControlPanel/Resources/web/arcademy/CLAUDE.md
+++ b/ConditioningControlPanel/Resources/web/arcademy/CLAUDE.md
@@ -3491,6 +3491,32 @@ and it is not a third gate** - see trap 99, `init.devAnnex`.
     `--pass-every`, `--kbps`). MANIFEST_AHEAD_* in provider/index.js now count ENTRIES
     (posters included), which is why they doubled.
 
+146. **A TOROIDAL MARQUEE IS ONLY SEAMLESS WHILE THE COPIES STILL ON SCREEN COVER THE FRAME
+    (LOST & FOUND, phone wave, 2026-09-11).** Owner's landscape-phone shot: "FIND HER 0 / 26",
+    row 1 three thumbnails then nothing, row 3 one tile, most of the wall bare - read as "the
+    thumbnails never load". Nothing was unloaded: the bare stretch is the strip's own TAIL.
+    `board.js` builds a row as `reps` copies of its tiles and `styles.js` slides exactly one
+    copy per cycle, so the wrap only closes when `(reps - 1) x copy width >= frame width`.
+    `reps` was a build-time guess (3 under 6 tiles, else 2) written against a desktop tile; on
+    a 844-930px landscape phone the touch floor deals ~26 tiles in 4 rows, a 6-tile copy is
+    ~560px, and once a cycle the tail crossed the frame and left up to a third of the row
+    empty - no skin, no border, because there is no element there. Measured on the throttled
+    rig (2 Mbps, 100ms, x4, 844x390 coarse): 30 of 33 one-second samples had a row with >40px
+    uncovered, worst 280px; after: 0 of 33. The cure is `fitWrap()`: once the mosaic is in
+    the document (and debounced on resize/orientationchange) measure the frame and each
+    strip, ADD clone sets until the law holds (never remove; `WRAP_REPS_MAX` 6), paint the new
+    seats from the row's current looks, restart the strip's animation so the new shift is
+    picked up, and only THEN compute the element budgets (maxReps counts the fitted wrap; a
+    1600x900 desktop deals 9-11 tiles a row and stays at x2 with its caps untouched, a frame
+    that does grow to x3 sees `liveCap` fall 24 -> 18 by the ceiling's own law).
+    The keyframes are now per clone count (`data-lf-reps` -> `g-lf-driftL3` etc., a plain
+    percentage of the strip) instead of `calc(-100% / var(--g-lf-reps))`, so no phone engine
+    has to resolve a custom property inside @keyframes to land on the seam; the var form
+    stays as the fallback. The audit that missed it counted opacity/display/media per tile;
+    the one that catches it measures the UNCOVERED width of the viewport per row every
+    second (scratchpad `lfroom-drive.mjs`, `wrap gap` line). Any marquee that clones for a
+    wrap has this law; check it against the narrowest tile the mobile pass can deal.
+
 ## 5. The game module contract (short version)
 
 ```js

--- a/ConditioningControlPanel/Resources/web/arcademy/games/lost-and-found/board.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/lost-and-found/board.js
@@ -68,6 +68,22 @@ import { el, clamp, shuffle } from './util.js';
 /** Marquee period band, seconds. drift 0 -> slow, drift 1 -> fast. */
 const DUR_SLOW_SEC = 44;
 const DUR_FAST_SEC = 12;
+/**
+ * THE WRAP LAW (phone wave, 0911). A row is `reps` copies of its tiles and the
+ * marquee slides exactly ONE copy per cycle, so the wrap is seamless only while
+ * the copies still on screen cover the frame: (reps - 1) x one copy's width
+ * must be >= the frame width. The build-time guess (3 copies under 6 tiles,
+ * else 2) was written against a desktop tile; on a landscape phone a 6-tile
+ * copy is ~560px against a 930px frame, and every cycle the strip's tail
+ * crossed the frame and left a third of the row bare - which the owner read as
+ * "the thumbnails never load". fitWrap() measures the real widths once the
+ * mosaic is in the document (and again on a resize/rotation) and ADDS clone
+ * sets until the law holds. Clone sets are never removed: an extra copy only
+ * costs elements, a missing one costs the illusion. Capped so a degenerate
+ * measurement (a 20px tile in a 4k frame) cannot mint a thousand seats.
+ */
+const WRAP_REPS_MAX = 6;
+const WRAP_FIT_DEBOUNCE_MS = 180;
 
 /* ----------------------------------------------------------------------------
  * LOOK PAINTING - shared by the board tiles and by every card in hud.js, so a
@@ -306,12 +322,17 @@ export function createBoard(o) {
   sizes.forEach((count, r) => {
     const rowEl = el('div', 'g-lf-row');
     const strip = el('div', 'g-lf-strip' + (r % 2 ? ' g-lf-rev' : ''));
-    // Enough repeats that the wrap never exposes a gap on a wide view.
+    // The build-time FLOOR; fitWrap() below grows it against the measured
+    // frame once the mosaic is in the document (see THE WRAP LAW).
     const reps = count <= 5 ? 3 : 2;
     const durSec = (DUR_SLOW_SEC - (DUR_SLOW_SEC - DUR_FAST_SEC) * clamp(opts.drift, 0, 1))
       * (0.85 + 0.3 * rng());
     if (strip) {
       strip.style.setProperty('--g-lf-reps', String(reps));
+      // The attribute picks a var-free keyframe set in styles.js: the shift
+      // is a plain percentage of the strip, nothing a phone engine has to
+      // resolve inside @keyframes.
+      strip.setAttribute('data-lf-reps', String(reps));
       strip.style.setProperty('--g-lf-dur', durSec.toFixed(1) + 's');
       if (reduced) strip.classList.add('g-lf-static');
     }
@@ -437,11 +458,110 @@ export function createBoard(o) {
     if (typeof requestAnimationFrame === 'function') pressRafId = requestAnimationFrame(pressStampLoop);
   }
 
+  /* ------------------------------------------------------------ the wrap */
+  let frozen = false;      // freeze() state, re-applied when a drift restarts
+  let fitTimer = 0;
+  let onResize = null;
+
+  /** Grow one row to `need` clone sets, every new seat wearing the row's
+   *  current looks (bare at build; a rotation mid-class copies the media). */
+  function padRow(row, need) {
+    if (!row || !row.strip) return 0;
+    let added = 0;
+    for (let rep = row.reps; rep < need; rep++) {
+      for (const tile of row.tiles) {
+        const node = buildTileEl(tile, rep);
+        if (!node) continue;
+        try { paintLook(node, tile); } catch (e) { /* the skin still shows */ }
+        row.strip.appendChild(node);
+        added += 1;
+      }
+    }
+    row.reps = need;
+    try {
+      row.strip.style.setProperty('--g-lf-reps', String(need));
+      row.strip.setAttribute('data-lf-reps', String(need));
+    } catch (e) { /* ignore */ }
+    return added;
+  }
+
+  /** The keyframe set changed under a running animation: restart it so every
+   *  engine re-resolves the shift (a frozen wall stays frozen). */
+  function restartDrift(strip) {
+    if (!strip || !strip.style) return;
+    try {
+      strip.style.animation = 'none';
+      void strip.offsetWidth;               // flush, so the reset is observed
+      strip.style.animation = '';
+      strip.style.animationPlayState = frozen ? 'paused' : 'running';
+    } catch (e) { /* ignore */ }
+    refStripAnim = null;                     // the press road re-finds its clock
+  }
+
+  /**
+   * Measure the frame and every row's copy width; add clone sets until
+   * (reps - 1) copies cover the frame. Returns the number of seats added. A
+   * board with no layout (the headless double, a detached mosaic) measures 0
+   * and keeps the build-time floor, which is exactly the old behaviour.
+   */
+  function fitWrap(why) {
+    if (destroyed || !mosaic) return 0;
+    let frameW = 0;
+    try {
+      frameW = mosaic.clientWidth || (mosaic.getBoundingClientRect ? mosaic.getBoundingClientRect().width : 0) || 0;
+    } catch (e) { return 0; }
+    if (!(frameW > 0)) return 0;
+    let added = 0;
+    const grown = [];
+    for (const row of rows) {
+      const strip = row.strip;
+      if (!strip || !row.tiles.length) continue;
+      let total = 0;
+      try {
+        total = strip.scrollWidth || (strip.getBoundingClientRect ? strip.getBoundingClientRect().width : 0) || 0;
+      } catch (e) { continue; }
+      const copyW = total / Math.max(1, row.reps | 0);
+      if (!(copyW > 0)) continue;
+      const need = clamp(Math.ceil(frameW / copyW) + 1, row.reps | 0, WRAP_REPS_MAX);
+      if (need <= row.reps) continue;
+      const before = row.reps;
+      added += padRow(row, need);
+      grown.push('row ' + rows.indexOf(row) + ' x' + before + '->x' + need);
+      restartDrift(strip);
+    }
+    if (added) say('wrap fit (' + (why || 'build') + '): frame ' + Math.round(frameW) + 'px, +' + added + ' seats: ' + grown.join(', '));
+    return added;
+  }
+
+  if (opts.mount && mosaic && opts.mount.appendChild) {
+    // The wall fills the window (immersion wave): the row count is only known
+    // here, so it is PUBLISHED here and styles.js solves the tile height from it
+    // (rows always fill the frame; density never changes with the window - the
+    // tile SIZE breathes, the tile COUNT is a tuned dial).
+    if (opts.mount.style) {
+      opts.mount.style.setProperty('--g-lf-rows', String(sizes.length));
+    }
+    opts.mount.appendChild(mosaic);
+    // In the document now, so the frame and the copies can be measured.
+    fitWrap('build');
+    if (typeof window !== 'undefined' && window.addEventListener) {
+      onResize = () => {
+        if (destroyed) return;
+        if (fitTimer) clearTimeout(fitTimer);
+        fitTimer = setTimeout(() => { fitTimer = 0; fitWrap('resize'); }, WRAP_FIT_DEBOUNCE_MS);
+      };
+      window.addEventListener('resize', onResize);
+      window.addEventListener('orientationchange', onResize);
+    }
+  }
+
   /* ------------------------------------------------------------- budgets */
   /* Every budget here counts what Chromium actually pays for. `maxReps` is the
      multiplier the toroidal wrap applies to every live element, so it has to be
      known before a single url is dealt - which is why this sits AFTER the build
-     rather than at the top of the factory. */
+     AND the wrap fit rather than at the top of the factory. (A rotation that
+     grows the wrap later is not re-budgeted: the caps were set for a smaller
+     wall and an over-shot of one clone set is the cheaper of the two errors.) */
   let maxReps = 1;
   for (const r of rows) maxReps = Math.max(maxReps, (r.reps | 0) || 1);
 
@@ -467,17 +587,6 @@ export function createBoard(o) {
   }
   say('board budgets: ' + density + ' tiles x' + maxReps + ' reps, live cap '
     + liveCap + ', video cap ' + videoCap + (reduced ? ' (reduced motion)' : ''));
-
-  if (opts.mount && mosaic && opts.mount.appendChild) {
-    // The wall fills the window (immersion wave): the row count is only known
-    // here, so it is PUBLISHED here and styles.js solves the tile height from it
-    // (rows always fill the frame; density never changes with the window - the
-    // tile SIZE breathes, the tile COUNT is a tuned dial).
-    if (opts.mount.style) {
-      opts.mount.style.setProperty('--g-lf-rows', String(sizes.length));
-    }
-    opts.mount.appendChild(mosaic);
-  }
 
   function buildTileEl(tile, rep) {
     const node = el('div', 'g-lf-tile');
@@ -753,6 +862,10 @@ export function createBoard(o) {
     },
     /** The PRIMARY element copy of a tile (ceremonies anchor to it). */
     primaryEl(tile) { return tile && tile.els.length ? tile.els[0] : null; },
+    /** Re-measure the wrap now (a host that resized the frame itself). */
+    fitWrap(why) { return fitWrap(why || 'host'); },
+    /** Clone sets per row, after the fit. */
+    repsPerRow() { return rows.map((r) => r.reps | 0); },
     tileFor(node) { return byEl.get(node) || null; },
     targetTile() { return tiles.find((t) => t.target) || null; },
 
@@ -780,6 +893,7 @@ export function createBoard(o) {
      *  Gif tiles cannot be paused from script at all; they are budgeted
      *  instead, which is the whole point of the live window. */
     freeze(on) {
+      frozen = !!on;
       for (const r of rows) {
         if (!r.strip || !r.strip.style) continue;
         try { r.strip.style.animationPlayState = on ? 'paused' : 'running'; } catch (e) { /* ignore */ }
@@ -837,6 +951,11 @@ export function createBoard(o) {
 
     destroy() {
       destroyed = true;
+      if (fitTimer) { clearTimeout(fitTimer); fitTimer = 0; }
+      if (onResize && typeof window !== 'undefined' && window.removeEventListener) {
+        try { window.removeEventListener('resize', onResize); window.removeEventListener('orientationchange', onResize); } catch (e) { /* ignore */ }
+      }
+      onResize = null;
       if (pressRafId && typeof cancelAnimationFrame === 'function') {
         try { cancelAnimationFrame(pressRafId); } catch (e) { /* ignore */ }
       }

--- a/ConditioningControlPanel/Resources/web/arcademy/games/lost-and-found/styles.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/lost-and-found/styles.js
@@ -101,7 +101,24 @@ export const CSS = [
   '.g-lf-strip { display:flex; gap:var(--g-lf-gap); width:max-content; height:100%;',
   '  animation:g-lf-driftL var(--g-lf-dur,26s) linear infinite; }',
   '.g-lf-strip.g-lf-rev { animation-name:g-lf-driftR; }',
-  '.g-lf-strip.g-lf-static { animation:none; }',
+  /* THE WRAP SHIFT, one keyframe set per clone count (board.js WRAP_REPS_MAX,
+     the attribute is `data-lf-reps`). The shift is exactly one copy of the
+     row, and it is written as a plain percentage of the strip rather than the
+     `calc(-100% / var(--g-lf-reps))` it used to be, so no engine has to
+     resolve a custom property inside @keyframes to land the wrap on the seam,
+     and a wrap the board GROWS mid-class (a rotation) re-targets by attribute.
+     The var form stays as the fallback for a strip with no attribute. */
+  ...[2, 3, 4, 5, 6].map((n) => {
+    const pct = (100 / n).toFixed(4);
+    return '.g-lf-strip[data-lf-reps="' + n + '"] { animation-name:g-lf-driftL' + n + '; }'
+      + ' .g-lf-strip.g-lf-rev[data-lf-reps="' + n + '"] { animation-name:g-lf-driftR' + n + '; }'
+      + ' @keyframes g-lf-driftL' + n + ' { from { transform:translateX(0); } to { transform:translateX(-' + pct + '%); } }'
+      + ' @keyframes g-lf-driftR' + n + ' { from { transform:translateX(-' + pct + '%); } to { transform:translateX(0); } }';
+  }),
+  /* Reduced motion wins over every attribute form above (same specificity as
+     the rev+attr selector, later in the sheet). */
+  '.g-lf-strip.g-lf-static, .g-lf-strip.g-lf-static[data-lf-reps],',
+  '.g-lf-strip.g-lf-rev.g-lf-static[data-lf-reps] { animation:none; }',
   '@keyframes g-lf-driftL { from { transform:translateX(0); }',
   '  to { transform:translateX(calc(-100% / var(--g-lf-reps,2))); } }',
   '@keyframes g-lf-driftR { from { transform:translateX(calc(-100% / var(--g-lf-reps,2))); }',


### PR DESCRIPTION
## What the phone showed

Landscape phone, Lost & Found, "FIND HER 0 / 26": row 1 has three thumbnails then nothing, row 3 one tile, rows 2 and 4 full. Read as "the thumbnails never load", like the sort room.

## Root cause (not the sort-room cause)

Nothing was unloaded. The bare stretch is the marquee strip's own tail. `board.js` builds a row as `reps` copies of its tiles and `styles.js` slides exactly one copy per cycle, so the toroidal wrap is seamless only while `(reps - 1) x copy width >= frame width`. `reps` was a build-time guess (3 under 6 tiles, else 2) written against a desktop tile. On a landscape phone the touch floor deals ~26 tiles in 4 rows, a 6-tile copy is ~560px against an 844-930px frame, and once a cycle the tail crosses the frame and leaves up to a third of the row with no element in it - no skin, no border, just the stage.

## Fix

- `board.js`: `fitWrap()` measures the frame and each strip once the mosaic is in the document (and debounced on `resize` / `orientationchange`), adds clone sets until the law holds (never removes; `WRAP_REPS_MAX` 6), paints the new seats from the row's current looks, restarts the strip animation so the new shift lands, and the element budgets are now computed after the fit so `maxReps` counts the wrap that is really on the wall. A board with no layout (the headless double) measures 0 and keeps the old floor. `freeze()` state is remembered so a restart never thaws a frozen wall. Two read-only helpers on the api: `fitWrap(why)`, `repsPerRow()`.
- `styles.js`: one keyframe set per clone count (`data-lf-reps` -> `g-lf-driftL3` etc., a plain percentage of the strip) instead of `calc(-100% / var(--g-lf-reps))`, so no phone engine has to resolve a custom property inside `@keyframes` to land on the seam. The var form stays as the fallback. Reduced motion still wins.
- `CLAUDE.md`: trap 146.

## Measured (headless Edge over CDP, mock Scrolller feed, 2 Mbps / 100 ms / x4 CPU)

| profile | uncovered-row samples (1 s, 33 per class) | worst gap | reps |
| --- | --- | --- | --- |
| main, 844x390 coarse touch | 30 / 33 | 280 px | 2/2/2/2 |
| fix, 844x390 coarse touch | 0 / 33 | 0 px | 3/3/3/3 |
| fix, 667x375 coarse touch | 0 / 33 | 0 px | 3/2/3/3 (only the rows that need it grow) |
| fix, portrait 390x844 -> landscape 844x390 at t+2 s | 0 / 33 | 0 px | 2 -> 3 on the resize path (+26 seats) |
| fix, desktop 1600x900, no throttle | 0 / 33 | 0 px | 2/2/2/2/2, live cap 24 / video cap 6 unchanged |

Counters (fix, 844x390): a tap on a wrong tile (a wrap clone) -> Misses 1; tap-toggle peek -> peek card up, Peek 1; a tap on the target (a wrap clone) -> "1 / 26" with the found card. Blank/nomedia tiles 0 in every run; console errors 0.

## Not verified

- Real iOS Safari: the rig is headless Chromium. The measured mechanism reproduces the owner's shot at the same geometry (rows of 6 x 2 copies on an 844px frame); the owner's gap was wider than the rig's worst, which the measured fit covers whatever its size, and the var-free keyframes remove the one Safari-specific way a wrap could overshoot.
- No visible seam jump expected on rotation (the animation restarts from phase 0 when a row grows), not eyeballed on a device.

Deploy: this branch is the app repo side only. Once merged into `main`, dispatch `sync-arcademy.yml` on cclabs-web (`gh workflow run sync-arcademy.yml -R CodeBambi/cclabs-web --ref main`); the push is the deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NDhyuyET1jY4ZKSp4RFu7F
