### PR TITLE
feat(dashboard): slot layout model, wire format and placement rule (phase A2)

### DIFF
--- a/ConditioningControlPanel/Models/AppSettings.cs
+++ b/ConditioningControlPanel/Models/AppSettings.cs
@@ -8012,6 +8012,34 @@ namespace ConditioningControlPanel.Models
         /// </summary>
         public int DashboardToggleHintUses { get; set; }
 
+        private string? _dashboardLayoutWire = null;
+        /// <summary>
+        /// The nine movable Home slots, encoded by
+        /// <see cref="Services.Dashboard.DashboardLayoutRule.ToWire"/>: nine comma-separated feature
+        /// keys, a pipe joining a split tile. A string rather than an object so the server
+        /// sanitizer and the client share one parser. Null means "never edited", which renders the
+        /// shipped wall.
+        /// </summary>
+        [JsonProperty("dashboard_layout")]
+        public string? DashboardLayoutWire
+        {
+            get => _dashboardLayoutWire;
+            set { _dashboardLayoutWire = value; OnPropertyChanged(); }
+        }
+
+        private bool _dashboardLayoutTouched = false;
+        /// <summary>
+        /// Set on the user's first slot edit and never cleared, a reset to default included. The
+        /// fill-if-empty cloud adopt reads this rather than the string, so a user who deliberately
+        /// went back to the shipped wall does not get another machine's layout pushed onto them.
+        /// </summary>
+        [JsonProperty("dashboard_layout_touched")]
+        public bool DashboardLayoutTouched
+        {
+            get => _dashboardLayoutTouched;
+            set { _dashboardLayoutTouched = value; OnPropertyChanged(); }
+        }
+
         #endregion
 
         #region First-time experience

--- a/ConditioningControlPanel/Models/Dashboard/DashboardLayout.cs
+++ b/ConditioningControlPanel/Models/Dashboard/DashboardLayout.cs
@@ -1,0 +1,75 @@
+using System;
+
+namespace ConditioningControlPanel.Models.Dashboard
+{
+    /// <summary>
+    /// One movable cell of the Home mosaic. <see cref="Secondary"/> non-null means a split tile
+    /// (two FX halves); a slot is a feature key and nothing more - no per-slot settings.
+    /// </summary>
+    public sealed class DashboardSlot
+    {
+        public string? Primary { get; set; }
+        public string? Secondary { get; set; }
+        public bool IsEmpty => string.IsNullOrEmpty(Primary) && string.IsNullOrEmpty(Secondary);
+        public bool IsSplit => !string.IsNullOrEmpty(Primary) && !string.IsNullOrEmpty(Secondary);
+    }
+
+    /// <summary>
+    /// The persisted shape: nine movable slots, in the grid order the renderer walks. The fixed
+    /// cells (logo, Vault, ? BOX) are not in here and never move.
+    /// </summary>
+    public sealed class DashboardLayout
+    {
+        public const int SlotCount = 9;
+
+        private DashboardSlot[] _slots = NewSlots();
+
+        /// <summary>Always exactly <see cref="SlotCount"/> entries; a short or long array is normalized on set.</summary>
+        public DashboardSlot[] Slots
+        {
+            get => _slots;
+            set
+            {
+                var next = NewSlots();
+                for (int i = 0; value != null && i < SlotCount && i < value.Length; i++)
+                    next[i] = value[i] ?? new DashboardSlot();
+                _slots = next;
+            }
+        }
+
+        /// <summary>Today's wall, so a user who never opens the picker sees zero change.</summary>
+        public static DashboardLayout Default()
+        {
+            var l = new DashboardLayout();
+            Set(0, "flash", null); Set(1, "video", "bubblecount"); Set(2, "subliminal", null);
+            Set(3, "bouncingtext", null); Set(4, "justdrop", null); Set(5, "spiral", "pinkfilter");
+            Set(6, "mindwipe", "braindrain"); Set(7, "bubbles", null); Set(8, "lockcard", null);
+            return l;
+
+            void Set(int i, string p, string? s) { l.Slots[i].Primary = p; l.Slots[i].Secondary = s; }
+        }
+
+        /// <summary>True when this layout is slot-for-slot the shipped wall.</summary>
+        public bool IsDefault
+        {
+            get
+            {
+                var d = Default();
+                for (int i = 0; i < SlotCount; i++)
+                    if (!Same(Slots[i].Primary, d.Slots[i].Primary) ||
+                        !Same(Slots[i].Secondary, d.Slots[i].Secondary)) return false;
+                return true;
+
+                static bool Same(string? a, string? b)
+                    => string.Equals(a ?? "", b ?? "", StringComparison.OrdinalIgnoreCase);
+            }
+        }
+
+        private static DashboardSlot[] NewSlots()
+        {
+            var slots = new DashboardSlot[SlotCount];
+            for (int i = 0; i < SlotCount; i++) slots[i] = new DashboardSlot();
+            return slots;
+        }
+    }
+}

--- a/ConditioningControlPanel/Services/Dashboard/DashboardLayoutRule.cs
+++ b/ConditioningControlPanel/Services/Dashboard/DashboardLayoutRule.cs
@@ -1,0 +1,192 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using ConditioningControlPanel.Models.Dashboard;
+
+namespace ConditioningControlPanel.Services.Dashboard
+{
+    /// <summary>What <see cref="DashboardLayoutRule.Place"/> did. The two Refused values change nothing.</summary>
+    public enum PlaceOutcome
+    {
+        Placed, Replaced, Split, MovedFrom, RefusedNotSplittable, RefusedUnknownKey,
+    }
+
+    /// <summary>
+    /// Every rule the Home slot grid obeys, with no WPF type in sight: the picker, the renderer,
+    /// the settings round trip and the cloud adopt all bind to this, and the tests bind to it
+    /// instead of to a window. The invariant worth naming: a feature is on the wall at most once,
+    /// so placing one that is already somewhere is a move, not a copy.
+    /// </summary>
+    public static class DashboardLayoutRule
+    {
+        /// <summary>The server sanitizer's byte cap; anything longer is not a layout we wrote.</summary>
+        private const int MaxWireLength = 256;
+
+        /// <summary>
+        /// Make any layout - a hand-edited settings file, an older client's wire string, a newer
+        /// one's - safe to render: unknown keys blanked, a Secondary that cannot be a split half
+        /// dropped, duplicates kept only at their first appearance, and a layout with nothing left
+        /// in it promoted to the default rather than shown as nine holes. Never mutates the input.
+        /// </summary>
+        public static DashboardLayout Sanitize(DashboardLayout? raw)
+        {
+            if (raw == null) return DashboardLayout.Default();
+
+            var clean = new DashboardLayout();
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            for (int i = 0; i < DashboardLayout.SlotCount; i++)
+            {
+                var primary = Keep(raw.Slots[i].Primary, seen);
+                var secondary = Keep(raw.Slots[i].Secondary, seen);
+
+                // An orphaned second half is promoted rather than thrown away.
+                if (primary == null && secondary != null) { primary = secondary; secondary = null; }
+
+                // Only two FX make a split tile. A door never has a second half, and never is one.
+                if (secondary != null &&
+                    !(FeatureCatalog.CanSplit(primary) && FeatureCatalog.CanSplit(secondary)))
+                    secondary = null;
+
+                clean.Slots[i].Primary = primary;
+                clean.Slots[i].Secondary = secondary;
+            }
+
+            return IsEmptyLayout(clean) ? DashboardLayout.Default() : clean;
+
+            static string? Keep(string? key, HashSet<string> seen)
+            {
+                var row = FeatureCatalog.Find(key);
+                return row != null && seen.Add(row.Key) ? row.Key : null;
+            }
+        }
+
+        /// <summary>
+        /// Put <paramref name="key"/> in <paramref name="slot"/>. Precedence: an unknown key
+        /// refuses; a split the pair cannot form refuses; a feature already on the wall reports
+        /// MovedFrom even when it also displaced an occupant, because the move is the surprising
+        /// half and the picker's replace prompt has been answered by then; otherwise an occupied
+        /// target is Replaced and an empty one is Placed.
+        /// </summary>
+        /// <exception cref="ArgumentOutOfRangeException">Slot outside 0..8.</exception>
+        public static PlaceOutcome Place(DashboardLayout layout, int slot, string key, bool split)
+        {
+            if (layout == null) throw new ArgumentNullException(nameof(layout));
+            RequireSlot(slot);
+
+            var row = FeatureCatalog.Find(key);
+            if (row == null) return PlaceOutcome.RefusedUnknownKey;
+
+            var target = layout.Slots[slot];
+
+            if (split)
+            {
+                // A split needs a free second half and two FX. Landing on its own primary would
+                // put one feature on both halves, which the once-only invariant forbids.
+                if (target.Secondary != null
+                    || target.Primary == null
+                    || !FeatureCatalog.CanSplit(target.Primary)
+                    || row.Kind != DashboardKind.Fx
+                    || string.Equals(target.Primary, row.Key, StringComparison.OrdinalIgnoreCase))
+                    return PlaceOutcome.RefusedNotSplittable;
+
+                Remove(layout, row.Key);
+                target.Secondary = row.Key;
+                return PlaceOutcome.Split;
+            }
+
+            var from = IndexOf(layout, row.Key);
+            var occupied = !target.IsEmpty;
+
+            Remove(layout, row.Key);
+            target.Primary = row.Key;
+            target.Secondary = null;
+
+            if (from >= 0 && from != slot) return PlaceOutcome.MovedFrom;
+            return occupied ? PlaceOutcome.Replaced : PlaceOutcome.Placed;
+        }
+
+        /// <summary>Empty a slot. An empty slot renders as a hole, which is a legal layout.</summary>
+        /// <exception cref="ArgumentOutOfRangeException">Slot outside 0..8.</exception>
+        public static void Clear(DashboardLayout layout, int slot)
+        {
+            if (layout == null) throw new ArgumentNullException(nameof(layout));
+            RequireSlot(slot);
+            layout.Slots[slot].Primary = null;
+            layout.Slots[slot].Secondary = null;
+        }
+
+        /// <summary>
+        /// The settings and cloud encoding: nine comma-separated fields, a pipe joining a split,
+        /// an empty field for an empty slot. Under 200 bytes for every layout the picker can build.
+        /// </summary>
+        public static string ToWire(DashboardLayout? layout)
+        {
+            var sb = new StringBuilder();
+            for (int i = 0; i < DashboardLayout.SlotCount; i++)
+            {
+                if (i > 0) sb.Append(',');
+                var s = layout?.Slots[i];
+                if (s == null || string.IsNullOrEmpty(s.Primary)) continue;
+                sb.Append(s.Primary);
+                if (!string.IsNullOrEmpty(s.Secondary)) sb.Append('|').Append(s.Secondary);
+            }
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// The other end of <see cref="ToWire"/>, sanitized on the way out so a caller can hand the
+        /// result straight to the renderer. Anything unreadable answers with the default wall, and
+        /// so does a string that clears every slot - the same promotion Sanitize makes.
+        /// </summary>
+        public static DashboardLayout FromWire(string? wire)
+        {
+            if (string.IsNullOrWhiteSpace(wire) || wire!.Length > MaxWireLength)
+                return DashboardLayout.Default();
+
+            var raw = new DashboardLayout();
+            var fields = wire.Split(',');
+            for (int i = 0; i < DashboardLayout.SlotCount && i < fields.Length; i++)
+            {
+                var field = fields[i].Trim();
+                if (field.Length == 0) continue;
+                var halves = field.Split('|');
+                raw.Slots[i].Primary = halves[0].Trim();
+                if (halves.Length > 1) raw.Slots[i].Secondary = halves[1].Trim();
+            }
+            return Sanitize(raw);
+        }
+
+        private static void RequireSlot(int slot)
+        {
+            if (slot < 0 || slot >= DashboardLayout.SlotCount)
+                throw new ArgumentOutOfRangeException(nameof(slot), slot, "Dashboard slot must be 0..8.");
+        }
+
+        private static bool IsEmptyLayout(DashboardLayout l)
+        {
+            for (int i = 0; i < DashboardLayout.SlotCount; i++) if (!l.Slots[i].IsEmpty) return false;
+            return true;
+        }
+
+        private static int IndexOf(DashboardLayout l, string key)
+        {
+            for (int i = 0; i < DashboardLayout.SlotCount; i++)
+                if (Is(l.Slots[i].Primary, key) || Is(l.Slots[i].Secondary, key)) return i;
+            return -1;
+        }
+
+        /// <summary>Take a key off the wall wherever it sits, promoting a widowed second half.</summary>
+        private static void Remove(DashboardLayout l, string key)
+        {
+            for (int i = 0; i < DashboardLayout.SlotCount; i++)
+            {
+                var s = l.Slots[i];
+                if (Is(s.Secondary, key)) s.Secondary = null;
+                if (Is(s.Primary, key)) { s.Primary = s.Secondary; s.Secondary = null; }
+            }
+        }
+
+        private static bool Is(string? a, string b) => string.Equals(a, b, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/Tests/ConditioningControlPanel.Tests/DashboardLayoutRuleTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/DashboardLayoutRuleTests.cs
@@ -1,0 +1,262 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using ConditioningControlPanel.Models.Dashboard;
+using ConditioningControlPanel.Services.Dashboard;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// The slot rules, pinned away from any window. The picker, the renderer and the cloud adopt all
+/// depend on <see cref="DashboardLayoutRule"/>, and the invariant that matters most is the quiet
+/// one: a feature is on the wall at most once, so placing it where it already is moves it.
+/// </summary>
+public class DashboardLayoutRuleTests
+{
+    private const string DefaultWire =
+        "flash,video|bubblecount,subliminal,bouncingtext,justdrop,spiral|pinkfilter,mindwipe|braindrain,bubbles,lockcard";
+
+    private static DashboardLayout Empty() => new();
+
+    private static IEnumerable<string> Keys(DashboardLayout l) =>
+        l.Slots.SelectMany(s => new[] { s.Primary, s.Secondary }).Where(k => k != null)!;
+
+    // ── wire ─────────────────────────────────────────────────────
+
+    [Fact]
+    public void Default_round_trips_through_the_wire()
+    {
+        var wire = DashboardLayoutRule.ToWire(DashboardLayout.Default());
+        Assert.Equal(DefaultWire, wire);
+        Assert.Equal(9, wire.Split(',').Length);
+        Assert.True(wire.Length < 200, $"{wire.Length} bytes");
+        var back = DashboardLayoutRule.FromWire(wire);
+        Assert.True(back.IsDefault);
+        Assert.Equal(wire, DashboardLayoutRule.ToWire(back));
+    }
+
+    [Fact]
+    public void An_empty_slot_is_an_empty_field()
+    {
+        var l = DashboardLayout.Default();
+        DashboardLayoutRule.Clear(l, 0);
+        DashboardLayoutRule.Clear(l, 8);
+        var wire = DashboardLayoutRule.ToWire(l);
+        Assert.StartsWith(",", wire);
+        Assert.EndsWith(",", wire);
+        Assert.Equal(9, wire.Split(',').Length);
+        Assert.Null(DashboardLayoutRule.FromWire(wire).Slots[0].Primary);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(",,,,,,,,")]              // every slot cleared promotes back to the default
+    [InlineData("nonsense,rubbish")]
+    public void An_unusable_wire_answers_with_the_default_wall(string? wire)
+        => Assert.True(DashboardLayoutRule.FromWire(wire).IsDefault);
+
+    [Fact]
+    public void A_tenth_field_is_dropped_an_oversize_string_is_refused_and_spacing_survives()
+    {
+        var ten = DashboardLayoutRule.FromWire(DefaultWire + ",fyp");
+        Assert.True(ten.IsDefault);
+        Assert.DoesNotContain("fyp", Keys(ten));
+        Assert.True(DashboardLayoutRule.FromWire(new string('a', 257)).IsDefault);
+
+        var loose = DashboardLayoutRule.FromWire(" FLASH | Bubbles ,,,,,,,,fyp");
+        Assert.Equal("flash", loose.Slots[0].Primary);
+        Assert.Equal("bubbles", loose.Slots[0].Secondary);
+        Assert.Equal("fyp", loose.Slots[8].Primary);
+    }
+
+    // ── sanitize ─────────────────────────────────────────────────
+
+    [Fact]
+    public void Sanitize_of_nothing_is_the_default_wall()
+    {
+        Assert.True(DashboardLayoutRule.Sanitize(null).IsDefault);
+        Assert.True(DashboardLayoutRule.Sanitize(Empty()).IsDefault);
+    }
+
+    [Fact]
+    public void Sanitize_blanks_unknown_keys()
+    {
+        var raw = Empty();
+        raw.Slots[0].Primary = "flash";
+        raw.Slots[1].Primary = "a_feature_from_a_newer_build";
+        raw.Slots[2].Primary = "vault";   // a fixed cell is not a catalog row
+        var clean = DashboardLayoutRule.Sanitize(raw);
+        Assert.Equal("flash", clean.Slots[0].Primary);
+        Assert.Null(clean.Slots[1].Primary);
+        Assert.Null(clean.Slots[2].Primary);
+    }
+
+    [Fact]
+    public void Sanitize_keeps_only_the_first_copy_of_a_key()
+    {
+        var raw = Empty();
+        raw.Slots[0].Primary = "flash";
+        raw.Slots[3].Primary = "flash";
+        raw.Slots[3].Secondary = "bubbles";
+        var clean = DashboardLayoutRule.Sanitize(raw);
+        Assert.Equal("flash", clean.Slots[0].Primary);
+        // The duplicate is blanked and the surviving half promoted, not dropped with it.
+        Assert.Equal("bubbles", clean.Slots[3].Primary);
+        Assert.Null(clean.Slots[3].Secondary);
+        Assert.Equal(Keys(clean).Count(), Keys(clean).Distinct().Count());
+    }
+
+    [Fact]
+    public void Sanitize_strips_a_secondary_that_cannot_be_a_split_half_and_leaves_the_input_alone()
+    {
+        var raw = Empty();
+        raw.Slots[0].Primary = "justdrop"; raw.Slots[0].Secondary = "flash";  // a door has no half
+        raw.Slots[1].Primary = "spiral";   raw.Slots[1].Secondary = "fyp";    // and is never one
+        var clean = DashboardLayoutRule.Sanitize(raw);
+        Assert.Equal("justdrop", clean.Slots[0].Primary);
+        Assert.Null(clean.Slots[0].Secondary);
+        Assert.Equal("spiral", clean.Slots[1].Primary);
+        Assert.Null(clean.Slots[1].Secondary);
+        Assert.Equal("flash", raw.Slots[0].Secondary);
+    }
+
+    // ── place ────────────────────────────────────────────────────
+
+    [Fact]
+    public void Place_into_an_empty_slot_is_Placed_and_over_an_occupant_is_Replaced()
+    {
+        var l = Empty();
+        Assert.Equal(PlaceOutcome.Placed, DashboardLayoutRule.Place(l, 4, "fyp", false));
+        Assert.Equal("fyp", l.Slots[4].Primary);
+        Assert.Equal(PlaceOutcome.Replaced, DashboardLayoutRule.Place(l, 4, "flash", false));
+        Assert.Equal("flash", l.Slots[4].Primary);
+        Assert.DoesNotContain("fyp", Keys(l));
+    }
+
+    [Fact]
+    public void Place_of_something_already_on_the_wall_is_MovedFrom()
+    {
+        var l = DashboardLayout.Default();
+        Assert.Equal(PlaceOutcome.MovedFrom, DashboardLayoutRule.Place(l, 0, "lockcard", false));
+        Assert.Equal("lockcard", l.Slots[0].Primary);
+        Assert.True(l.Slots[8].IsEmpty);          // its old slot is now a hole
+        Assert.DoesNotContain("flash", Keys(l));  // and the tile it landed on is gone
+    }
+
+    [Fact]
+    public void Moving_the_primary_of_a_split_promotes_the_other_half()
+    {
+        var l = DashboardLayout.Default();
+        Assert.Equal(PlaceOutcome.MovedFrom, DashboardLayoutRule.Place(l, 0, "video", false));
+        Assert.Equal("bubblecount", l.Slots[1].Primary);
+        Assert.Null(l.Slots[1].Secondary);
+    }
+
+    [Fact]
+    public void Place_split_on_two_fx_is_Split_and_moves_the_half_off_its_old_slot()
+    {
+        var l = DashboardLayout.Default();
+        Assert.Equal(PlaceOutcome.Split, DashboardLayoutRule.Place(l, 0, "bubbles", true));
+        Assert.Equal("flash", l.Slots[0].Primary);
+        Assert.Equal("bubbles", l.Slots[0].Secondary);
+        Assert.True(l.Slots[0].IsSplit);
+        Assert.True(l.Slots[7].IsEmpty);
+    }
+
+    [Theory]
+    [InlineData("justdrop", "flash")]   // the occupant is a door
+    [InlineData("flash", "justdrop")]   // the newcomer is a door
+    [InlineData("flash", "flash")]      // one feature cannot be both halves
+    public void Place_split_that_cannot_form_a_pair_is_RefusedNotSplittable(string sitting, string arriving)
+    {
+        var l = Empty();
+        DashboardLayoutRule.Place(l, 5, sitting, false);
+        Assert.Equal(PlaceOutcome.RefusedNotSplittable, DashboardLayoutRule.Place(l, 5, arriving, true));
+        Assert.Null(l.Slots[5].Secondary);
+    }
+
+    [Fact]
+    public void Place_split_on_an_empty_or_already_split_slot_is_RefusedNotSplittable()
+    {
+        var l = Empty();
+        Assert.Equal(PlaceOutcome.RefusedNotSplittable, DashboardLayoutRule.Place(l, 3, "flash", true));
+        DashboardLayoutRule.Place(l, 3, "flash", false);
+        DashboardLayoutRule.Place(l, 3, "bubbles", true);
+        Assert.Equal(PlaceOutcome.RefusedNotSplittable, DashboardLayoutRule.Place(l, 3, "spiral", true));
+        Assert.Equal("bubbles", l.Slots[3].Secondary);
+    }
+
+    [Fact]
+    public void Place_of_an_unknown_key_is_RefusedUnknownKey_and_changes_nothing()
+    {
+        var l = DashboardLayout.Default();
+        var before = DashboardLayoutRule.ToWire(l);
+        Assert.Equal(PlaceOutcome.RefusedUnknownKey, DashboardLayoutRule.Place(l, 0, "vault", false));
+        Assert.Equal(PlaceOutcome.RefusedUnknownKey, DashboardLayoutRule.Place(l, 0, "vault", true));
+        Assert.Equal(before, DashboardLayoutRule.ToWire(l));
+    }
+
+    [Fact]
+    public void Every_outcome_is_reachable()
+    {
+        var l = Empty();
+        var seen = new HashSet<PlaceOutcome>
+        {
+            DashboardLayoutRule.Place(l, 0, "flash", false),    // Placed
+            DashboardLayoutRule.Place(l, 0, "spiral", false),   // Replaced
+            DashboardLayoutRule.Place(l, 0, "bubbles", true),   // Split
+            DashboardLayoutRule.Place(l, 1, "spiral", false),   // MovedFrom
+            DashboardLayoutRule.Place(l, 1, "fyp", true),       // RefusedNotSplittable
+            DashboardLayoutRule.Place(l, 1, "nope", false),     // RefusedUnknownKey
+        };
+        Assert.Equal(Enum.GetValues<PlaceOutcome>().OrderBy(o => o), seen.OrderBy(o => o));
+    }
+
+    [Fact]
+    public void Place_never_leaves_the_same_key_in_two_slots()
+    {
+        var l = DashboardLayout.Default();
+        var keys = FeatureCatalog.All.Select(f => f.Key).ToList();
+        for (int i = 0; i < keys.Count; i++)
+        {
+            DashboardLayoutRule.Place(l, i % DashboardLayout.SlotCount, keys[i], i % 3 == 0);
+            var placed = Keys(l).ToList();
+            Assert.Equal(placed.Count, placed.Distinct(StringComparer.OrdinalIgnoreCase).Count());
+            Assert.True(placed.Count <= DashboardLayout.SlotCount * 2);
+        }
+    }
+
+    // ── clear, bounds and the layout itself ──────────────────────
+
+    [Fact]
+    public void Clear_empties_both_halves()
+    {
+        var l = DashboardLayout.Default();
+        DashboardLayoutRule.Clear(l, 1);
+        Assert.True(l.Slots[1].IsEmpty);
+        Assert.False(l.IsDefault);
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(9)]
+    [InlineData(int.MaxValue)]
+    public void A_slot_outside_the_grid_throws(int slot)
+    {
+        var l = DashboardLayout.Default();
+        Assert.Throws<ArgumentOutOfRangeException>(() => DashboardLayoutRule.Place(l, slot, "flash", false));
+        Assert.Throws<ArgumentOutOfRangeException>(() => DashboardLayoutRule.Clear(l, slot));
+    }
+
+    [Fact]
+    public void A_layout_is_always_nine_slots_however_it_is_assigned()
+    {
+        var stub = new DashboardLayout { Slots = new[] { new DashboardSlot { Primary = "flash" } } };
+        Assert.Equal(DashboardLayout.SlotCount, stub.Slots.Length);
+        Assert.Equal("flash", stub.Slots[0].Primary);
+        Assert.All(stub.Slots, s => Assert.NotNull(s));
+    }
+}


### PR DESCRIPTION
Stack 2 of 7 (base: A1 #1092). No UI change.

## What

- `Models/Dashboard/DashboardLayout.cs`: nine slots, each a feature key or an FX pair; `Default()` is today's wall.
- `Services/Dashboard/DashboardLayoutRule.cs`: pure. `Sanitize` (unknown keys blanked, dupes first-wins, split stripped off a destination, all-empty promotes to default), `Place` (place / replace / split / move; a key is on the wall at most once), `ToWire` / `FromWire` (9 comma fields, `key` or `key|key`, the exact string the server stores, 256-byte cap).
- `AppSettings.DashboardLayoutWire` (`dashboard_layout`) and `DashboardLayoutTouched`. Both stay in the settings backup.

## Tests

`DashboardLayoutRuleTests`: wire round trip, every sanitize rule, every `PlaceOutcome` branch, no duplicate key after `Place`. Suite: 5975.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VW2mrHU1ZQQ1RNTumPsrfm