### PR TITLE
feat(dashboard): the Home wall renders from the slot layout (phase B)

### DIFF
--- a/ConditioningControlPanel/MainWindow/MainWindow.DashboardFx.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.DashboardFx.cs
@@ -82,12 +82,14 @@ namespace ConditioningControlPanel
         private TextBlock? _browserStatusWatched;
 
         /// <summary>
-        /// The mosaic tiles. Null-tolerant - the view is a partial rewire.
+        /// The mosaic's single tiles: the nine movable ones the slot renderer built, plus the two
+        /// fixed cells that are still authored in XAML. Every single tile on the wall belongs here
+        /// or it silently keeps its motion running after a MotionLevel change - the same omission
+        /// family as ChipFyp missing from PremiumRailItems. The split tiles are the renderer's
+        /// DashboardSplitCards.
         ///
-        /// <para>Phase 3: <c>CardBrainDrain</c> joined (the G2 rescue's front door), and
-        /// <c>CardSystem</c> was kept in the tree Collapsed. Phase 8 deleted that tile - "System"
-        /// is not a feature and its entry point is the quick-toggles row's pill - so the array is
-        /// twelve real tiles now, all visible.</para>
+        /// <para>Recomputed on every read rather than cached: a render replaces every movable card
+        /// with a new object, so a cached list would be pointing at tiles nobody can see.</para>
         /// </summary>
         private IEnumerable<FeatureCard> DashboardFeatureCards
         {
@@ -95,29 +97,8 @@ namespace ConditioningControlPanel
             {
                 var tab = SettingsTab;
                 if (tab == null) return Enumerable.Empty<FeatureCard>();
-                // The 4x4 hybrid wall (2026-08-11, redesign #2). Every SINGLE tile on the mosaic
-                // belongs here or it silently keeps its motion running after a MotionLevel
-                // change - the same omission family as ChipFyp missing from PremiumRailItems.
-                // The three diagonal tiles are DashboardSplitCards, just below.
-                var all = new[]
-                {
-                    tab.CardFlash, tab.CardSubliminal, tab.CardBouncingText,
-                    tab.CardBubblePop, tab.CardLockCard,
-                    tab.CardJustDrop, tab.CardMystery, tab.CardVault,
-                };
-                return all.Where(c => c != null)!;
-            }
-        }
-
-        /// <summary>The three diagonal tiles - same motion contract as the singles above.</summary>
-        private IEnumerable<SplitFeatureCard> DashboardSplitCards
-        {
-            get
-            {
-                var tab = SettingsTab;
-                if (tab == null) return Enumerable.Empty<SplitFeatureCard>();
-                var all = new[] { tab.ComboVideoBubble, tab.ComboSpiralPink, tab.ComboMindDrain };
-                return all.Where(c => c != null)!;
+                var fixedCells = new[] { tab.CardMystery, tab.CardVault }.Where(c => c != null)!;
+                return DashboardSingleCards.Concat(fixedCells!);
             }
         }
 

--- a/ConditioningControlPanel/MainWindow/MainWindow.DashboardSlots.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.DashboardSlots.cs
@@ -1,0 +1,380 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using ConditioningControlPanel.Features;
+using ConditioningControlPanel.Localization;
+using ConditioningControlPanel.Models.Dashboard;
+using ConditioningControlPanel.Services;
+using ConditioningControlPanel.Services.Dashboard;
+
+namespace ConditioningControlPanel
+{
+    /// <summary>
+    /// THE HOME WALL'S NINE MOVABLE CELLS, built from the layout rather than from XAML.
+    ///
+    /// <para>Every tile the user can move is created here, from one <see cref="FeatureCatalog"/>
+    /// row: its title, its art, its tier livery and both of its gestures. The four places that
+    /// used to address those tiles by x:Name (art in <c>LoadFeatureImages</c>, titles in
+    /// <c>ApplyModFeatureNames</c>, rings in <c>RefreshWallActiveStates</c>, motion in
+    /// <c>MainWindow.DashboardFx</c>) now call the four Refresh methods below, so a slot's
+    /// contents can change without any of them learning a new name.</para>
+    ///
+    /// <para>Phase B renders the default layout only - there is no edit UI yet - so the wall this
+    /// paints is the wall that shipped, tile for tile. The public seam Phase C needs is
+    /// <see cref="RenderDashboardSlots"/>: change <see cref="CurrentLayout"/>, call it, done.</para>
+    /// </summary>
+    public partial class MainWindow
+    {
+        // ---- state ---------------------------------------------------------------------
+
+        private DashboardLayout? _dashboardLayout;
+        private bool _dashboardSlotsRendered;
+
+        private readonly List<FeatureCard> _dashboardSingles = new();
+        private readonly List<SplitFeatureCard> _dashboardSplits = new();
+
+        /// <summary>Which catalog row each live card is showing. Rebuilt on every render, because
+        /// every card is a new object after one.</summary>
+        private readonly Dictionary<FeatureCard, DashboardFeature> _dashboardCardRows = new();
+        private readonly Dictionary<SplitFeatureCard, (DashboardFeature A, DashboardFeature B)> _dashboardSplitRows = new();
+
+        /// <summary>
+        /// The English literal a mod's text replacements are matched against. It IS the lookup key
+        /// (<c>ModService.FeatureLabelTwins</c> says so out loud), so these are the same strings the
+        /// XAML tiles carried and <c>ApplyModFeatureNames</c> passed - losing one would silently
+        /// lose a mod's rename of that feature. Brand names are absent on purpose: they are never
+        /// localized and never renamed (<c>MainWindow.PlayTab.cs:79-80</c>).
+        /// </summary>
+        private static readonly Dictionary<string, string> DashboardEnglishTitles = new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["flash"] = "Flash Images", ["video"] = "Mandatory Video", ["subliminal"] = "Subliminals",
+            ["bouncingtext"] = "Bouncing Text", ["bubblecount"] = "Bubble Count", ["bubbles"] = "Bubble Pop",
+            ["spiral"] = "Spiral Overlay", ["pinkfilter"] = "Pink Filter", ["mindwipe"] = "Mind Wipe",
+            ["braindrain"] = "Brain Drain", ["lockcard"] = "Lock Card", ["gradedintake"] = "Graded Intake",
+            ["fyp"] = "For You", ["blinktrainer"] = "Blink Trainer", ["remotecontrol"] = "Remote Control",
+            ["bambitakeover"] = "Takeover", ["shelistening"] = "She's Listening", ["haptics"] = "Haptics",
+            ["awareness"] = "Awareness", ["lockdown"] = "Lockdown Mode", ["justdrop"] = "Just Drop",
+            ["gaze"] = "Gaze Minigame", ["focusgaze"] = "Focus Gaze",
+        };
+
+        /// <summary>The five tiles that shipped a "?" help popover. Absent = no icon, which is what
+        /// <see cref="FeatureCard.HelpSectionId"/> null already means.</summary>
+        private static readonly Dictionary<string, string> DashboardHelpSections = new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["flash"] = "FlashImages", ["subliminal"] = "Subliminals", ["bouncingtext"] = "BouncingText",
+            ["bubbles"] = "BubblePop", ["lockcard"] = "LockCard",
+        };
+
+        // ---- the layout ----------------------------------------------------------------
+
+        /// <summary>
+        /// The wall as it stands, sanitized. Read from settings the first time it is asked for;
+        /// an unreadable or empty string answers with the shipped wall rather than nine holes.
+        /// </summary>
+        internal DashboardLayout CurrentLayout =>
+            _dashboardLayout ??= DashboardLayoutRule.Sanitize(
+                DashboardLayoutRule.FromWire(App.Settings?.Current?.DashboardLayoutWire));
+
+        /// <summary>Renders once. Cheap enough to call from every entry point that might be first.</summary>
+        internal void EnsureDashboardSlotsRendered()
+        {
+            if (_dashboardSlotsRendered) return;
+            RenderDashboardSlots(CurrentLayout);
+        }
+
+        /// <summary>The single card holding <paramref name="key"/>, or null when it is not on the
+        /// wall (the user removed it) or is half of a split tile.</summary>
+        internal FeatureCard? DashboardCardFor(string key)
+            => _dashboardCardRows.FirstOrDefault(p => string.Equals(p.Value.Key, key, StringComparison.OrdinalIgnoreCase)).Key;
+
+        /// <summary>The nine live single tiles. Fed to the FX clocks; see the fixed cells in
+        /// <c>MainWindow.DashboardFx.DashboardFeatureCards</c>.</summary>
+        internal IEnumerable<FeatureCard> DashboardSingleCards => _dashboardSingles;
+
+        /// <summary>The live split tiles - however many the layout currently has.</summary>
+        internal IEnumerable<SplitFeatureCard> DashboardSplitCards => _dashboardSplits;
+
+        // ---- the render ----------------------------------------------------------------
+
+        /// <summary>
+        /// Rebuilds all nine cells from <paramref name="layout"/>. Every card is a NEW object
+        /// afterwards, which is why this re-runs the four refreshes and the FX loops itself:
+        /// anything holding a card from before this call is holding a card nobody can see.
+        /// </summary>
+        internal void RenderDashboardSlots(DashboardLayout layout)
+        {
+            var tab = SettingsTab;
+            if (tab == null) return;
+
+            try
+            {
+                _dashboardLayout = layout ?? DashboardLayout.Default();
+
+                _dashboardSingles.Clear();
+                _dashboardSplits.Clear();
+                _dashboardCardRows.Clear();
+                _dashboardSplitRows.Clear();
+
+                var hosts = new[] { tab.Slot0, tab.Slot1, tab.Slot2, tab.Slot3, tab.Slot4,
+                                    tab.Slot5, tab.Slot6, tab.Slot7, tab.Slot8 };
+
+                for (int i = 0; i < DashboardLayout.SlotCount && i < hosts.Length; i++)
+                {
+                    var host = hosts[i];
+                    if (host == null) continue;
+                    host.Children.Clear();
+
+                    var slot = _dashboardLayout.Slots[i];
+                    var primary = FeatureCatalog.Find(slot.Primary);
+                    if (primary == null) continue;   // an empty slot renders as a hole, by design
+
+                    var secondary = FeatureCatalog.Find(slot.Secondary);
+                    host.Children.Add(secondary == null
+                        ? BuildDashboardCard(primary)
+                        : BuildDashboardSplit(primary, secondary));
+                }
+
+                // Set BEFORE the refreshes: each one ensures a render, and this is the base case.
+                _dashboardSlotsRendered = true;
+
+                RefreshDashboardArt();
+                RefreshDashboardTitles();
+                RefreshDashboardActiveStates();
+                RefreshDashboardLivery();
+
+                // The clocks hold card references, and every one of them just went stale.
+                ApplyDashboardFxLoops();
+            }
+            catch (Exception ex) { App.Logger?.Warning(ex, "RenderDashboardSlots failed"); }
+        }
+
+        /// <summary>
+        /// One tile. The gestures are the wall's grammar verbatim: an FX tile opens its Studio
+        /// module on the left and toggles the feature on the right; a destination navigates on the
+        /// left and ignores the right (right-click is the rail's pin gesture, and a mosaic tile
+        /// never pins).
+        /// </summary>
+        private FeatureCard BuildDashboardCard(DashboardFeature f)
+        {
+            var card = new FeatureCard
+            {
+                // Only an FX tile with a rack key has an "off" to be dim about; a destination
+                // never receives IsActive, and focusgaze's switch is not a wall flag.
+                DimWhenInactive = f.Kind == DashboardKind.Fx && f.RackKey != null,
+                HelpSectionId = DashboardHelpSections.TryGetValue(f.Key, out var help) ? help : null,
+            };
+
+            card.Click += (_, _) => OpenDashboardFeature(f);
+            if (f.Kind == DashboardKind.Fx) card.ToggleRequested += (_, _) => ToggleDashboardFeature(f);
+
+            _dashboardSingles.Add(card);
+            _dashboardCardRows[card] = f;
+            return card;
+        }
+
+        /// <summary>
+        /// A diagonal tile. A is the top-left triangle, exactly as the three authored combos were,
+        /// and each half carries its own feature's two gestures - the same four wires
+        /// <c>SettingsTabView.xaml.cs</c> carried for ComboVideoBubble, ComboSpiralPink and
+        /// ComboMindDrain.
+        /// </summary>
+        private SplitFeatureCard BuildDashboardSplit(DashboardFeature a, DashboardFeature b)
+        {
+            var card = new SplitFeatureCard();
+            card.ClickA += (_, _) => OpenDashboardFeature(a);
+            card.ClickB += (_, _) => OpenDashboardFeature(b);
+            card.ToggleA += (_, _) => ToggleDashboardFeature(a);
+            card.ToggleB += (_, _) => ToggleDashboardFeature(b);
+
+            _dashboardSplits.Add(card);
+            _dashboardSplitRows[card] = (a, b);
+            return card;
+        }
+
+        // ---- the gestures --------------------------------------------------------------
+
+        /// <summary>
+        /// Left-click. FX opens the Studio module; a destination navigates to the one entry it
+        /// already has, and the destination's own gate does the refusing - which is how every card
+        /// in this app works. The five doors with no ShowTab key of their own are the switch below.
+        /// </summary>
+        private void OpenDashboardFeature(DashboardFeature f)
+        {
+            try
+            {
+                if (f.Kind == DashboardKind.Fx)
+                {
+                    // focusgaze is FX-shaped without being a rack module: it has no Studio page to
+                    // open, so the left click lands on the tab its checkbox lives on.
+                    if (f.RackKey != null) OpenStudioModule(f.RackKey);
+                    else ShowTab("lab");
+                    return;
+                }
+
+                // Just Drop is still teased: the click owns both branches (teaser popup while the
+                // door is withheld, navigation once it is not), so it is asked before TabKey.
+                if (string.Equals(f.Key, "justdrop", StringComparison.OrdinalIgnoreCase))
+                {
+                    TeaseCardClicked();
+                    return;
+                }
+
+                if (f.TabKey != null) { ShowTab(f.TabKey); return; }
+
+                var e = new RoutedEventArgs();
+                switch (f.Key)
+                {
+                    case "goon": BtnStartGoon_Click(this, e); break;
+                    case "dtrh": BtnStartChaos_Click(this, e); break;
+                    case "arcademy": BtnStartArcademy_Click(this, e); break;
+                    case "gaze": BtnGazeMinigame_Click(this, e); break;
+                    // Piece by Piece has no host service on this branch (the chess stack is on
+                    // main). The Play door carries its card, so the tile navigates there until the
+                    // 6.10 merge brings the launcher with it.
+                    // TODO(6.10 merge): swap to PieceByPieceHostService.Launch()
+                    case "piecebypiece": ShowTab("play"); break;
+                    default: ShowTab("play"); break;
+                }
+            }
+            catch (Exception ex) { App.Logger?.Warning(ex, "Dashboard slot open failed for {Key}", f.Key); }
+        }
+
+        /// <summary>
+        /// Right-click. The rack key goes through <see cref="ToggleWallFeature"/> with its session
+        /// refusal intact; focusgaze has no rack key, so its tile flips the Lab checkbox and lets
+        /// <c>ChkFocusGaze_Changed</c> run - the Tier 2 gate, the consent dialog and the webcam
+        /// pre-warm all live in that handler and must not be bypassed.
+        /// </summary>
+        private void ToggleDashboardFeature(DashboardFeature f)
+        {
+            try
+            {
+                if (f.RackKey != null) { ToggleWallFeature(f.RackKey); return; }
+
+                if (string.Equals(f.Key, "focusgaze", StringComparison.OrdinalIgnoreCase)
+                    && PlayTab?.ChkPlayFocusGaze != null)
+                {
+                    if (RefuseIfSessionFeatureLocked($"card:{f.Key}")) return;
+                    PlayTab.ChkPlayFocusGaze.IsChecked = PlayTab.ChkPlayFocusGaze.IsChecked != true;
+                }
+            }
+            catch (Exception ex) { App.Logger?.Warning(ex, "Dashboard slot toggle failed for {Key}", f.Key); }
+        }
+
+        // ---- the four refreshes --------------------------------------------------------
+
+        /// <summary>
+        /// Titles. Mod-aware through the SAME <see cref="ModAwareLabel"/> path the tile block of
+        /// <c>ApplyModFeatureNames</c> used, de-emoji'd the same way (the shared section keys carry
+        /// a leading glyph and these cards draw their own art). Just Drop is skipped and then
+        /// repainted by <see cref="ApplyTeaseCard"/>, which owns its title, badge and tooltip
+        /// together - naming a feature nobody is allowed to name would defeat the tease.
+        /// </summary>
+        internal void RefreshDashboardTitles()
+        {
+            EnsureDashboardSlotsRendered();
+            try
+            {
+                foreach (var (card, f) in _dashboardCardRows)
+                {
+                    if (string.Equals(f.Key, "justdrop", StringComparison.OrdinalIgnoreCase)) continue;
+                    card.Title = DashboardTitle(f);
+                }
+                foreach (var (card, pair) in _dashboardSplitRows)
+                {
+                    card.TitleA = DashboardTitle(pair.A);
+                    card.TitleB = DashboardTitle(pair.B);
+                }
+                ApplyTeaseCard();
+            }
+            catch (Exception ex) { App.Logger?.Debug("RefreshDashboardTitles: {E}", ex.Message); }
+        }
+
+        /// <summary>
+        /// Art. The catalog's paths ARE the mod override contract - never renamed, never dropped
+        /// (mod contract rule 2) - and they resolve through the same chain every tile used, now at
+        /// the tile decode cap rather than at full resolution.
+        /// </summary>
+        internal void RefreshDashboardArt()
+        {
+            EnsureDashboardSlotsRendered();
+            try
+            {
+                foreach (var (card, f) in _dashboardCardRows) card.Icon = DashboardArt(f);
+                foreach (var (card, pair) in _dashboardSplitRows)
+                {
+                    card.IconA = DashboardArt(pair.A);
+                    card.IconB = DashboardArt(pair.B);
+                }
+            }
+            catch (Exception ex) { App.Logger?.Debug("RefreshDashboardArt: {E}", ex.Message); }
+        }
+
+        /// <summary>Rings. A split tile lights per half; both halves on = the whole card glows.</summary>
+        internal void RefreshDashboardActiveStates()
+        {
+            EnsureDashboardSlotsRendered();
+            try
+            {
+                foreach (var (card, f) in _dashboardCardRows)
+                    if (f.RackKey != null) card.IsActive = IsWallFeatureOn(f.RackKey);
+                foreach (var (card, pair) in _dashboardSplitRows)
+                {
+                    if (pair.A.RackKey != null) card.IsActiveA = IsWallFeatureOn(pair.A.RackKey);
+                    if (pair.B.RackKey != null) card.IsActiveB = IsWallFeatureOn(pair.B.RackKey);
+                }
+            }
+            catch (Exception ex) { App.Logger?.Debug("RefreshDashboardActiveStates: {E}", ex.Message); }
+        }
+
+        /// <summary>
+        /// Price tags. A tile the account cannot open wears the rail's own lock wording; an
+        /// entitled one, or one whose feature is today's free rotation, wears nothing at all -
+        /// absence is how this wall says "free", and the default layout is all free, so the
+        /// shipped wall carries no tag but the tease's.
+        ///
+        /// <para>Deliberately NOT <c>TeaseTier</c>, which the plan's shorthand named: that
+        /// property is the tease COSTUME (it blurs the art past recognition and hangs a "?" over
+        /// it), and a locked door the user chose to put on their wall must still show what it is.
+        /// The livery rim therefore stays the tease's alone.</para>
+        /// </summary>
+        internal void RefreshDashboardLivery()
+        {
+            EnsureDashboardSlotsRendered();
+            try
+            {
+                foreach (var (card, f) in _dashboardCardRows)
+                {
+                    if (string.Equals(f.Key, "justdrop", StringComparison.OrdinalIgnoreCase)) continue;
+                    if (f.Tier <= 0) { card.TierBadge = null; continue; }
+
+                    var name = DashboardTitle(f);
+                    var verdict = f.Tier >= 2
+                        ? (f.DailyFreeKey != null ? TierGate.RequiresLab(name, f.DailyFreeKey) : TierGate.RequiresLab(name))
+                        : (f.DailyFreeKey != null ? TierGate.RequiresPremium(name, f.DailyFreeKey) : TierGate.RequiresPremium(name));
+
+                    SetTierBadge(card, verdict.Allowed, Loc.Get(f.Tier >= 2 ? "hm3_rail_lock_t2" : "hm3_rail_lock_t1"));
+                }
+
+                // The tease owns its own badge, blur and title as one costume.
+                ApplyTeaseCard();
+            }
+            catch (Exception ex) { App.Logger?.Debug("RefreshDashboardLivery: {E}", ex.Message); }
+        }
+
+        // ---- helpers -------------------------------------------------------------------
+
+        private static string DashboardTitle(DashboardFeature f)
+        {
+            if (f.TitleLocKey == null) return f.TitleLiteral ?? f.Key;
+            var english = DashboardEnglishTitles.TryGetValue(f.Key, out var e) ? e : Loc.Get(f.TitleLocKey);
+            return StripLeadingGlyph(ModAwareLabel(english, f.TitleLocKey));
+        }
+
+        private static System.Windows.Media.ImageSource? DashboardArt(DashboardFeature f)
+            => ModResourceResolver.ResolveImageDecoded(f.ArtPath, TileDecodeWidth)
+               ?? ModResourceResolver.ResolveImage(f.ArtPath);
+    }
+}

--- a/ConditioningControlPanel/MainWindow/MainWindow.Presets.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.Presets.cs
@@ -1068,15 +1068,9 @@ namespace ConditioningControlPanel
         // Navigation tiles still navigate to the ONE existing entry, never launch
         // (PlayTabView.xaml:1163-1167 rule).
 
-        internal void CardFlash_Click(object sender, RoutedEventArgs e) => OpenStudioModule("flash");
-
-        internal void CardSubliminal_Click(object sender, RoutedEventArgs e) => OpenStudioModule("subliminal");
-
-        internal void CardBouncingText_Click(object sender, RoutedEventArgs e) => OpenStudioModule("bouncingtext");
-
-        internal void CardBubblePop_Click(object sender, RoutedEventArgs e) => OpenStudioModule("bubbles");
-
-        internal void CardLockCard_Click(object sender, RoutedEventArgs e) => OpenStudioModule("lockcard");
+        // The per-feature Card*_Click twins are gone with the tiles that carried them: the
+        // slot renderer wires OpenStudioModule / ToggleWallFeature straight onto the card it
+        // builds, so a handler per feature name would be a second place to keep in step.
 
         /// <summary>
         /// The ? box: navigates to today's free premium feature. The tile is repainted by
@@ -1110,17 +1104,6 @@ namespace ConditioningControlPanel
         /// Patreon row uses so the pulse-clearing and lazy-init side effects stay in one place.
         /// </summary>
         internal void CardVault_Click(object sender, RoutedEventArgs e) => BtnPatreonExclusives_Click(sender, e);
-
-        /// <summary>
-        /// The mosaic's nameless TEASE tile. Everything about it - which feature it teases, which
-        /// livery it wears, whether it is still teasing at all - lives in one block at the top of
-        /// <c>MainWindow.TeaseCard.cs</c>; this is only the wall's end of the wire.
-        ///
-        /// <para>The old two-branch behaviour (navigate when the door is open, placeholder toast
-        /// when it is withheld) moved into <see cref="TeaseCardClicked"/> intact, with the toast
-        /// replaced by the teaser card the owner asked for on 2026-08-13.</para>
-        /// </summary>
-        internal void CardJustDrop_Click(object sender, RoutedEventArgs e) => TeaseCardClicked();
 
         /// <summary>
         /// Paints the mosaic's price tags and the ? box's face. The FX tiles are all free and

--- a/ConditioningControlPanel/MainWindow/MainWindow.Presets.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.Presets.cs
@@ -1137,11 +1137,10 @@ namespace ConditioningControlPanel
 
             try
             {
-                // The tease tile: blur, livery rim and a livery diamond instead of the old "SOON"
-                // price tag. It owns its own badge now (same SetTierBadge helper, called from
-                // there) because the badge, the title, the tooltip and the blur have to move as
-                // one costume - see MainWindow.TeaseCard.cs.
-                ApplyTeaseCard();
+                // The wall's price tags, and the tease tile's costume with them: the renderer
+                // paints whichever slots currently hold a tiered feature, then hands the tease
+                // its blur, rim, badge and title as one piece (MainWindow.TeaseCard.cs).
+                RefreshDashboardLivery();
 
                 RefreshMysteryTile();
                 RefreshWallActiveStates();
@@ -1403,33 +1402,7 @@ namespace ConditioningControlPanel
         /// </summary>
         internal void RefreshWallActiveStates()
         {
-            var s = App.Settings?.Current;
-            var dash = SettingsTab;
-            if (s == null || dash == null) return;
-            try
-            {
-                if (dash.CardFlash != null) dash.CardFlash.IsActive = s.FlashEnabled;
-                if (dash.CardSubliminal != null) dash.CardSubliminal.IsActive = s.SubliminalEnabled;
-                if (dash.CardBubblePop != null) dash.CardBubblePop.IsActive = s.BubblesEnabled;
-                if (dash.CardLockCard != null) dash.CardLockCard.IsActive = s.LockCardEnabled;
-                if (dash.CardBouncingText != null) dash.CardBouncingText.IsActive = s.BouncingTextEnabled;
-                if (dash.ComboVideoBubble != null)
-                {
-                    dash.ComboVideoBubble.IsActiveA = s.MandatoryVideosEnabled;
-                    dash.ComboVideoBubble.IsActiveB = s.BubbleCountEnabled;
-                }
-                if (dash.ComboSpiralPink != null)
-                {
-                    dash.ComboSpiralPink.IsActiveA = s.SpiralEnabled;
-                    dash.ComboSpiralPink.IsActiveB = s.PinkFilterEnabled;
-                }
-                if (dash.ComboMindDrain != null)
-                {
-                    dash.ComboMindDrain.IsActiveA = s.MindWipeEnabled;
-                    dash.ComboMindDrain.IsActiveB = s.BrainDrainEnabled;
-                }
-            }
-            catch (Exception ex) { App.Logger?.Debug("RefreshWallActiveStates: {E}", ex.Message); }
+            RefreshDashboardActiveStates();
         }
 
         private static void SetTierBadge(Features.FeatureCard? card, bool allowed, string badge)

--- a/ConditioningControlPanel/MainWindow/MainWindow.TabNavigation.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.TabNavigation.cs
@@ -253,6 +253,10 @@ namespace ConditioningControlPanel
                 case "settings":
                     SettingsTab.Visibility = Visibility.Visible;
                     AnimateTabIn(SettingsTab);
+                    // The nine movable cells, built from the persisted layout. A no-op after the
+                    // first render (LoadFeatureImages in the ctor normally gets there first); this
+                    // is the safety net for a Home tab shown before that ever ran.
+                    EnsureDashboardSlotsRendered();
                     RefreshPremiumRail(); // recompute chip dots (incl. Voice) from live state on every show
                     // Training Programs own the day's feature mix. Re-derived (never latched) on
                     // every show of the Dashboard, so arriving here can never find a stale lock -

--- a/ConditioningControlPanel/MainWindow/MainWindow.TeaseCard.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.TeaseCard.cs
@@ -54,8 +54,10 @@ namespace ConditioningControlPanel
 
         // ==========================================================================
 
-        /// <summary>The tile itself. Null while the dashboard view has not been built.</summary>
-        private Features.FeatureCard? TeaseCard => SettingsTab?.CardJustDrop;
+        /// <summary>The tile itself: whichever slot currently holds justdrop. Null while the
+        /// dashboard view has not been built, and null for good once a user takes Just Drop off
+        /// their wall - at which point there is no tease, which is the right answer.</summary>
+        private Features.FeatureCard? TeaseCard => DashboardCardFor("justdrop");
 
         /// <summary>
         /// Paints the tease (or takes it off). Called from <c>RefreshMosaicTierBadges</c>, which

--- a/ConditioningControlPanel/MainWindow/MainWindow.UiUpdates.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.UiUpdates.cs
@@ -101,35 +101,15 @@ namespace ConditioningControlPanel
             // (Resurrected 2026-08-11 with the FX wall - the 3x3 interlude had retired it.)
             string MLCard(string englishText, string locKey) => StripLeadingGlyph(ML(englishText, locKey));
 
-            // Velvet mosaic dashboard cards - the XAML Title="" literals are plain English
-            // design-time fallbacks, so this is the only place they get localized AND
-            // mod-renamed. Same keys as the matching Studio rack rows (RefreshRackLabels), so a
-            // mod that renames "Flash Images" renames the tile, the rack row and the panel title
+            // Velvet mosaic dashboard cards. The nine movable tiles are retitled by the slot
+            // renderer, which goes through this file's own ModAwareLabel helper with the same
+            // English literals and the same loc keys as the matching Studio rack rows - so a mod
+            // that renames "Flash Images" still renames the tile, the rack row and the panel title
             // together. Two tiles are absent on purpose: the ? box's title belongs to
-            // RefreshMysteryTile, and the tease tile's belongs to ApplyTeaseCard (a mod-aware
-            // rename of a feature nobody is allowed to name would defeat the tease). The Vault's
-            // title uses the Exclusives tab's own key.
-            if (SettingsTab.CardFlash != null) SettingsTab.CardFlash.Title = MLCard("Flash Images", "section_flash_images");
-            if (SettingsTab.CardSubliminal != null) SettingsTab.CardSubliminal.Title = MLCard("Subliminals", "section_subliminals_2");
-            if (SettingsTab.CardBouncingText != null) SettingsTab.CardBouncingText.Title = MLCard("Bouncing Text", "label_bouncing_text");
-            if (SettingsTab.CardBubblePop != null) SettingsTab.CardBubblePop.Title = MLCard("Bubble Pop", "label_bubble_pop");
-            if (SettingsTab.CardLockCard != null) SettingsTab.CardLockCard.Title = MLCard("Lock Card", "label_lock_card");
+            // RefreshMysteryTile, and the tease tile's to ApplyTeaseCard. The Vault is fixed
+            // furniture and keeps the Exclusives tab's own key.
+            RefreshDashboardTitles();
             if (SettingsTab.CardVault != null) SettingsTab.CardVault.Title = MLCard("The Vault", "tab_exclusives");
-            if (SettingsTab.ComboVideoBubble != null)
-            {
-                SettingsTab.ComboVideoBubble.TitleA = MLCard("Mandatory Video", "section_mandatory_video");
-                SettingsTab.ComboVideoBubble.TitleB = MLCard("Bubble Count", "label_bubble_count");
-            }
-            if (SettingsTab.ComboSpiralPink != null)
-            {
-                SettingsTab.ComboSpiralPink.TitleA = MLCard("Spiral Overlay", "label_spiral_overlay");
-                SettingsTab.ComboSpiralPink.TitleB = MLCard("Pink Filter", "label_pink_filter");
-            }
-            if (SettingsTab.ComboMindDrain != null)
-            {
-                SettingsTab.ComboMindDrain.TitleA = MLCard("Mind Wipe", "label_mind_wipe");
-                SettingsTab.ComboMindDrain.TitleB = MLCard("Brain Drain", "label_brain_drain");
-            }
             RefreshMysteryTile();
 
             // Phase 8: the four LegacyDashboardHost section headers (TxtFeatureFlash /

--- a/ConditioningControlPanel/MainWindow/MainWindow.xaml.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.xaml.cs
@@ -2541,36 +2541,15 @@ namespace ConditioningControlPanel
         {
             try
             {
-                // Dashboard feature cards (velvet mosaic, 4x4 hybrid wall since 2026-08-11).
-                // The FX tiles are back on their ORIGINAL art paths - the ones every .ccpmod
-                // override has always targeted - so the one-day 3x3 detour cost the contract
-                // nothing (its dtrh/loom/deeper rows shipped in no release). NO ART PATH WAS
-                // EVER RENAMED - mod contract rule 2.
-                var cardMap = new (string resourcePath, Features.FeatureCard? card)[]
-                {
-                    ("features/flash.png", SettingsTab.CardFlash),
-                    ("features/subliminal.png", SettingsTab.CardSubliminal),
-                    ("features/bouncing_text.png", SettingsTab.CardBouncingText),
-                    ("features/Bubble_pop.png", SettingsTab.CardBubblePop),
-                    ("features/Phrase_Lock.png", SettingsTab.CardLockCard),
-                    // The ? box and the Vault resolve through ModTileVariant below: built-in
-                    // mods get app-shipped themed faces (features/mysterybox_bambi.png, ...)
-                    // by filename convention - same mechanism as the takeover art fork - while
-                    // a .ccpmod that overrides the BASE path still wins outright.
-                };
-                foreach (var (path, card) in cardMap)
-                {
-                    if (card == null) continue;
-                    var image = ModResourceResolver.ResolveImage(path);
-                    if (image != null)
-                        card.Icon = image;
-                }
+                // The nine movable tiles are built and painted by MainWindow.DashboardSlots.cs
+                // (RefreshDashboardArt below) from the catalog's art paths - the SAME
+                // features/*.png every .ccpmod override has always targeted. NO ART PATH WAS EVER
+                // RENAMED - mod contract rule 2. Only the two fixed cells are addressed by name
+                // here, because only they resolve through ModTileVariant: built-in mods get
+                // app-shipped themed faces (features/mysterybox_bambi.png, ...) by filename
+                // convention, while a .ccpmod that overrides the BASE path still wins outright.
+                RefreshDashboardArt();
 
-                if (SettingsTab.CardJustDrop != null)
-                {
-                    var img = LoadModImageDecoded("features/justdrop.png", TileDecodeWidth);
-                    if (img != null) SettingsTab.CardJustDrop.Icon = img;
-                }
                 if (SettingsTab.CardMystery != null)
                 {
                     var img = ModTileVariant("mysterybox", TileDecodeWidth);
@@ -2580,30 +2559,6 @@ namespace ConditioningControlPanel
                 {
                     var img = ModTileVariant("vault", WideTileDecodeWidth);
                     if (img != null) SettingsTab.CardVault.Icon = img;
-                }
-
-                // The three diagonal tiles: per-half art through the resolver, so mods reskin
-                // each half exactly as they reskinned the old single tiles for these features.
-                if (SettingsTab.ComboVideoBubble != null)
-                {
-                    var a = ModResourceResolver.ResolveImage("features/mandatory_videos.png");
-                    var b = ModResourceResolver.ResolveImage("features/Bubble_count.png");
-                    if (a != null) SettingsTab.ComboVideoBubble.IconA = a;
-                    if (b != null) SettingsTab.ComboVideoBubble.IconB = b;
-                }
-                if (SettingsTab.ComboSpiralPink != null)
-                {
-                    var a = ModResourceResolver.ResolveImage("features/spiral_overlay.png");
-                    var b = ModResourceResolver.ResolveImage("features/Pink_filter.png");
-                    if (a != null) SettingsTab.ComboSpiralPink.IconA = a;
-                    if (b != null) SettingsTab.ComboSpiralPink.IconB = b;
-                }
-                if (SettingsTab.ComboMindDrain != null)
-                {
-                    var a = ModResourceResolver.ResolveImage("features/Mind_Wipers.png");
-                    var b = ModResourceResolver.ResolveImage("features/brain_drain.png");
-                    if (a != null) SettingsTab.ComboMindDrain.IconA = a;
-                    if (b != null) SettingsTab.ComboMindDrain.IconB = b;
                 }
 
                 // PHASE 8: the eight "legacy progression tab rectangles" rows are gone with

--- a/ConditioningControlPanel/Services/TutorialService.cs
+++ b/ConditioningControlPanel/Services/TutorialService.cs
@@ -910,7 +910,11 @@ namespace ConditioningControlPanel.Services
                     Title = Loc.Get("tut_sw_flash_title"),
                     Description = Loc.Get("tut_sw_flash_body"),
                     // The Home mosaic's flash tile: the card the user will actually click later.
-                    TargetElementName = "CardFlash",
+                    // Addressed by its CELL, not by the card: the card is built at runtime from the
+                    // slot layout and carries no x:Name any more. The host fills the cell, so the
+                    // spotlight rect is the same one - and slot 0 is where the shipped layout puts
+                    // Flash Images, which is the layout every first-run walk is looking at.
+                    TargetElementName = "Slot0",
                     RequiresTab = "settings",
                     TextPosition = TutorialStepPosition.Right,
                     // Show, do not tell. One image, on top of everything, gone again - the whole

--- a/ConditioningControlPanel/Views/Tabs/SettingsTabView.xaml
+++ b/ConditioningControlPanel/Views/Tabs/SettingsTabView.xaml
@@ -796,62 +796,28 @@
                                 Grid.Row="0" Grid.RowSpan="4"
                                 Grid.Column="0" Grid.ColumnSpan="4"/>
 
-            <!-- The Title="" literals below are English design-time fallbacks only.
-                 At runtime MainWindow.ApplyModFeatureNames() overwrites every FX title
-                 with the mod-aware localized name (same keys as the Studio rack rows).
-                 Two tiles are runtime-owned outright instead: the ? box (RefreshMysteryTile()
-                 writes today's feature name over it on every repaint) and the tease tile
-                 (ApplyTeaseCard() owns its title, badge, tooltip and blur together). -->
+            <!-- THE NINE MOVABLE CELLS. Not a tile between them: each Slot host is an empty
+                 cell, and MainWindow.DashboardSlots.cs fills it from the persisted layout. The
+                 catalog row behind a slot carries the title (mod-aware, through the same
+                 ModAwareLabel path ApplyModFeatureNames used), the art (the SAME features/*.png
+                 paths the mod contract has always named - rule 2), the tier livery and both
+                 gestures. Renaming a host, or moving one to another cell, fails
+                 DashboardSlotMapTests.
 
-            <!-- Row 1: flash, the video pair, subliminals, bouncing text -->
-            <features:FeatureCard Grid.Row="0" Grid.Column="0" x:Name="CardFlash" x:FieldModifier="internal"
-                                  Title="Flash Images"
-                                  Icon="pack://application:,,,/Resources/features/flash.png"
-                                  HelpSectionId="FlashImages"
-                                  Click="CardFlash_Click"
-                                  DimWhenInactive="True"
-                                  ToggleRequested="CardFlash_Toggle"/>
-            <features:SplitFeatureCard Grid.Row="0" Grid.Column="1" x:Name="ComboVideoBubble" x:FieldModifier="internal"
-                                       TitleA="Mandatory Video" TitleB="Bubble Count"
-                                       IconA="pack://application:,,,/Resources/features/mandatory_videos.png"
-                                       IconB="pack://application:,,,/Resources/features/Bubble_count.png"
-                                       ClickA="ComboVideoBubble_ClickA" ClickB="ComboVideoBubble_ClickB"
-                                       ToggleA="ComboVideoBubble_ToggleA" ToggleB="ComboVideoBubble_ToggleB"/>
-            <features:FeatureCard Grid.Row="0" Grid.Column="2" x:Name="CardSubliminal" x:FieldModifier="internal"
-                                  Title="Subliminals"
-                                  Icon="pack://application:,,,/Resources/features/subliminal.png"
-                                  HelpSectionId="Subliminals"
-                                  Click="CardSubliminal_Click"
-                                  DimWhenInactive="True"
-                                  ToggleRequested="CardSubliminal_Toggle"/>
-            <features:FeatureCard Grid.Row="0" Grid.Column="3" x:Name="CardBouncingText" x:FieldModifier="internal"
-                                  Title="Bouncing Text"
-                                  Icon="pack://application:,,,/Resources/features/bouncing_text.png"
-                                  HelpSectionId="BouncingText"
-                                  Click="CardBouncingText_Click"
-                                  DimWhenInactive="True"
-                                  ToggleRequested="CardBouncingText_Toggle"/>
+                 Two cards stay authored below because nothing about them moves: the ? box
+                 (RefreshMysteryTile() owns its face) and the Vault. The tease costume - "???",
+                 the blur, the livery rim, the badge - is no longer a tile either: ApplyTeaseCard()
+                 puts it on whichever slot currently holds justdrop, and on none at all once a
+                 user takes it off the wall. -->
 
-            <!-- Row 2: the TEASE tile (far left, owner spec) + centre logo + spiral pair -->
-            <!-- THE TEASE TILE. Nameless on purpose (owner, 2026-08-13): the art below is
-                 blurred past recognition by FeatureCard.TeaseTier, the title is "???", the rim
-                 is the teased feature's tier livery and the click opens a cryptic teaser rather
-                 than a door. Nothing here may name the feature.
+            <!-- Row 1: slots 0-3 -->
+            <Grid x:Name="Slot0" x:FieldModifier="internal" Grid.Row="0" Grid.Column="0"/>
+            <Grid x:Name="Slot1" x:FieldModifier="internal" Grid.Row="0" Grid.Column="1"/>
+            <Grid x:Name="Slot2" x:FieldModifier="internal" Grid.Row="0" Grid.Column="2"/>
+            <Grid x:Name="Slot3" x:FieldModifier="internal" Grid.Row="0" Grid.Column="3"/>
 
-                 The art IS still loaded, and must be: it is the substrate the blur smears into,
-                 which is what makes the tile a shape rather than an empty box. It is never
-                 legible - see the blur radius note in FeatureCard.
-
-                 Title and TeaseTier here are FIRST-FRAME values, not the authority: the switch
-                 block at the top of MainWindow.TeaseCard.cs owns both and rewrites them on every
-                 mosaic repaint (and the instant the teased feature is revealed). They are
-                 authored rather than left blank so the tile can never flash a name or an
-                 unblurred face in the frames before the first repaint. -->
-            <features:FeatureCard Grid.Row="1" Grid.Column="0" x:Name="CardJustDrop" x:FieldModifier="internal"
-                                  Title="???"
-                                  TeaseTier="2"
-                                  Icon="pack://application:,,,/Resources/features/justdrop.png"
-                                  Click="CardJustDrop_Click"/>
+            <!-- Row 2: slot 4 (the tease tile's old cell) + the centre logo + slot 5 -->
+            <Grid x:Name="Slot4" x:FieldModifier="internal" Grid.Row="1" Grid.Column="0"/>
 
             <!-- Centre logo, back at 2x2 (the 3x3 interlude had it 1x1).
                  Doubles as the weekly Graded Intake pass card: when a free account has an
@@ -1103,12 +1069,7 @@
                 </Grid>
             </Border>
     
-            <features:SplitFeatureCard Grid.Row="1" Grid.Column="3" x:Name="ComboSpiralPink" x:FieldModifier="internal"
-                                       TitleA="Spiral Overlay" TitleB="Pink Filter"
-                                       IconA="pack://application:,,,/Resources/features/spiral_overlay.png"
-                                       IconB="pack://application:,,,/Resources/features/Pink_filter.png"
-                                       ClickA="ComboSpiralPink_ClickA" ClickB="ComboSpiralPink_ClickB"
-                                       ToggleA="ComboSpiralPink_ToggleA" ToggleB="ComboSpiralPink_ToggleB"/>
+            <Grid x:Name="Slot5" x:FieldModifier="internal" Grid.Row="1" Grid.Column="3"/>
 
             <!-- Row 3: the ? box + the immersion pair -->
             <!-- The ? BOX: today's premium feature, free for the day (DailyFreeService).
@@ -1232,12 +1193,7 @@
                 <TextBlock Text="{loc:Str mosaic_new_today}"
                            Foreground="#3A2A00" FontSize="10" FontWeight="Black"/>
             </Border>
-            <features:SplitFeatureCard Grid.Row="2" Grid.Column="3" x:Name="ComboMindDrain" x:FieldModifier="internal"
-                                       TitleA="Mind Wipe" TitleB="Brain Drain"
-                                       IconA="pack://application:,,,/Resources/features/Mind_Wipers.png"
-                                       IconB="pack://application:,,,/Resources/features/brain_drain.png"
-                                       ClickA="ComboMindDrain_ClickA" ClickB="ComboMindDrain_ClickB"
-                                       ToggleA="ComboMindDrain_ToggleA" ToggleB="ComboMindDrain_ToggleB"/>
+            <Grid x:Name="Slot6" x:FieldModifier="internal" Grid.Row="2" Grid.Column="3"/>
 
             <!-- Row 4: the vault (double-wide) + the two games -->
             <!-- THE VAULT: the Exclusives storefront (Velvet Vault + the premium T2 shelf).
@@ -1273,20 +1229,8 @@
                                       BlurRadius="14" ShadowDepth="0" Opacity="0.95"/>
                 </TextBlock.Effect>
             </TextBlock>
-            <features:FeatureCard Grid.Row="3" Grid.Column="2" x:Name="CardBubblePop" x:FieldModifier="internal"
-                                  Title="Bubble Pop"
-                                  Icon="pack://application:,,,/Resources/features/Bubble_pop.png"
-                                  HelpSectionId="BubblePop"
-                                  Click="CardBubblePop_Click"
-                                  DimWhenInactive="True"
-                                  ToggleRequested="CardBubblePop_Toggle"/>
-            <features:FeatureCard Grid.Row="3" Grid.Column="3" x:Name="CardLockCard" x:FieldModifier="internal"
-                                  Title="Lock Card"
-                                  Icon="pack://application:,,,/Resources/features/Phrase_Lock.png"
-                                  HelpSectionId="LockCard"
-                                  Click="CardLockCard_Click"
-                                  DimWhenInactive="True"
-                                  ToggleRequested="CardLockCard_Toggle"/>
+            <Grid x:Name="Slot7" x:FieldModifier="internal" Grid.Row="3" Grid.Column="2"/>
+            <Grid x:Name="Slot8" x:FieldModifier="internal" Grid.Row="3" Grid.Column="3"/>
 
             <!-- ============================================================ -->
             <!-- PROGRAM FEATURE LOCK - the "why" pill. Shown only while a     -->

--- a/ConditioningControlPanel/Views/Tabs/SettingsTabView.xaml.cs
+++ b/ConditioningControlPanel/Views/Tabs/SettingsTabView.xaml.cs
@@ -219,95 +219,8 @@ namespace ConditioningControlPanel.Views.Tabs
         // back, split into left-click-opens (Card*_Click -> OpenStudioModule) and
         // right-click-toggles (Card*_Toggle -> ToggleWallFeature); the three diagonal combo
         // tiles forward per-half. Same shape as ever: the view forwards, MainWindow decides.
-        private void CardFlash_Click(object sender, RoutedEventArgs e)
-        {
-            if (Window.GetWindow(this) is MainWindow mw) mw.CardFlash_Click(sender, e);
-        }
-        private void CardFlash_Toggle(object sender, RoutedEventArgs e)
-        {
-            if (Window.GetWindow(this) is MainWindow mw) mw.ToggleWallFeature("flash");
-        }
-        private void CardSubliminal_Click(object sender, RoutedEventArgs e)
-        {
-            if (Window.GetWindow(this) is MainWindow mw) mw.CardSubliminal_Click(sender, e);
-        }
-        private void CardSubliminal_Toggle(object sender, RoutedEventArgs e)
-        {
-            if (Window.GetWindow(this) is MainWindow mw) mw.ToggleWallFeature("subliminal");
-        }
-        private void CardBouncingText_Click(object sender, RoutedEventArgs e)
-        {
-            if (Window.GetWindow(this) is MainWindow mw) mw.CardBouncingText_Click(sender, e);
-        }
-        private void CardBouncingText_Toggle(object sender, RoutedEventArgs e)
-        {
-            if (Window.GetWindow(this) is MainWindow mw) mw.ToggleWallFeature("bouncingtext");
-        }
-        private void CardBubblePop_Click(object sender, RoutedEventArgs e)
-        {
-            if (Window.GetWindow(this) is MainWindow mw) mw.CardBubblePop_Click(sender, e);
-        }
-        private void CardBubblePop_Toggle(object sender, RoutedEventArgs e)
-        {
-            if (Window.GetWindow(this) is MainWindow mw) mw.ToggleWallFeature("bubbles");
-        }
-        private void CardLockCard_Click(object sender, RoutedEventArgs e)
-        {
-            if (Window.GetWindow(this) is MainWindow mw) mw.CardLockCard_Click(sender, e);
-        }
-        private void CardLockCard_Toggle(object sender, RoutedEventArgs e)
-        {
-            if (Window.GetWindow(this) is MainWindow mw) mw.ToggleWallFeature("lockcard");
-        }
-        // Diagonal combos: A = the top-left half, B = the bottom-right, as authored in XAML.
-        private void ComboVideoBubble_ClickA(object sender, RoutedEventArgs e)
-        {
-            if (Window.GetWindow(this) is MainWindow mw) mw.OpenStudioModule("video");
-        }
-        private void ComboVideoBubble_ClickB(object sender, RoutedEventArgs e)
-        {
-            if (Window.GetWindow(this) is MainWindow mw) mw.OpenStudioModule("bubblecount");
-        }
-        private void ComboVideoBubble_ToggleA(object sender, RoutedEventArgs e)
-        {
-            if (Window.GetWindow(this) is MainWindow mw) mw.ToggleWallFeature("video");
-        }
-        private void ComboVideoBubble_ToggleB(object sender, RoutedEventArgs e)
-        {
-            if (Window.GetWindow(this) is MainWindow mw) mw.ToggleWallFeature("bubblecount");
-        }
-        private void ComboSpiralPink_ClickA(object sender, RoutedEventArgs e)
-        {
-            if (Window.GetWindow(this) is MainWindow mw) mw.OpenStudioModule("spiral");
-        }
-        private void ComboSpiralPink_ClickB(object sender, RoutedEventArgs e)
-        {
-            if (Window.GetWindow(this) is MainWindow mw) mw.OpenStudioModule("pinkfilter");
-        }
-        private void ComboSpiralPink_ToggleA(object sender, RoutedEventArgs e)
-        {
-            if (Window.GetWindow(this) is MainWindow mw) mw.ToggleWallFeature("spiral");
-        }
-        private void ComboSpiralPink_ToggleB(object sender, RoutedEventArgs e)
-        {
-            if (Window.GetWindow(this) is MainWindow mw) mw.ToggleWallFeature("pinkfilter");
-        }
-        private void ComboMindDrain_ClickA(object sender, RoutedEventArgs e)
-        {
-            if (Window.GetWindow(this) is MainWindow mw) mw.OpenStudioModule("mindwipe");
-        }
-        private void ComboMindDrain_ClickB(object sender, RoutedEventArgs e)
-        {
-            if (Window.GetWindow(this) is MainWindow mw) mw.OpenStudioModule("braindrain");
-        }
-        private void ComboMindDrain_ToggleA(object sender, RoutedEventArgs e)
-        {
-            if (Window.GetWindow(this) is MainWindow mw) mw.ToggleWallFeature("mindwipe");
-        }
-        private void ComboMindDrain_ToggleB(object sender, RoutedEventArgs e)
-        {
-            if (Window.GetWindow(this) is MainWindow mw) mw.ToggleWallFeature("braindrain");
-        }
+        // The nine movable tiles' shims are gone with the tiles: MainWindow.DashboardSlots.cs
+        // builds those cards and wires their two gestures directly. The fixed cells keep theirs.
         private void CardMystery_Click(object sender, RoutedEventArgs e)
         {
             if (Window.GetWindow(this) is MainWindow mw) mw.CardMystery_Click(sender, e);
@@ -320,11 +233,6 @@ namespace ConditioningControlPanel.Views.Tabs
         private void CardVault_Click(object sender, RoutedEventArgs e)
         {
             if (Window.GetWindow(this) is MainWindow mw) mw.CardVault_Click(sender, e);
-        }
-        private void CardJustDrop_Click(object sender, RoutedEventArgs e)
-        {
-            if (Window.GetWindow(this) is MainWindow mw)
-                mw.CardJustDrop_Click(sender, e);
         }
         private void ChkDiscordRichPresence_Changed(object sender, RoutedEventArgs e)
         {

--- a/Tests/ConditioningControlPanel.Tests/DashboardSlotMapTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/DashboardSlotMapTests.cs
@@ -1,0 +1,143 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using ConditioningControlPanel.Models.Dashboard;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// The join between the Home mosaic's nine empty cells and the layout that fills them.
+///
+/// <para>Nothing in the compiler can see this join: the renderer looks the hosts up by their
+/// generated field names (<c>tab.Slot0</c> ... <c>tab.Slot8</c>) and the XAML decides which grid
+/// cell each of those names sits in. Rename a host and the build breaks loudly; MOVE one - swap
+/// two Grid.Column values, drop a Grid.Row while retuning the wall - and nothing breaks at all.
+/// The wall just comes back in a different order, with the default layout no longer matching the
+/// wall that shipped. So the map is pinned here, scraped out of the XAML, the same way
+/// PlayDoorRenderTests pins the Play hero brushes.</para>
+/// </summary>
+public class DashboardSlotMapTests
+{
+    /// <summary>Slot index -> (row, column), as the 6.9.5 wall was authored (plan 3.1).</summary>
+    public static readonly (int Slot, int Row, int Col)[] ShippedCells =
+    {
+        (0, 0, 0), (1, 0, 1), (2, 0, 2), (3, 0, 3),
+        (4, 1, 0), (5, 1, 3), (6, 2, 3), (7, 3, 2), (8, 3, 3),
+    };
+
+    public static IEnumerable<object[]> Cells() => ShippedCells.Select(c => new object[] { c.Slot, c.Row, c.Col });
+
+    [Theory]
+    [MemberData(nameof(Cells))]
+    public void EverySlotHostSitsInTheCellItShippedIn(int slot, int row, int col)
+    {
+        var host = HostDeclaration(slot);
+        Assert.Equal(row, Attribute(host, "Grid.Row"));
+        Assert.Equal(col, Attribute(host, "Grid.Column"));
+    }
+
+    [Fact]
+    public void TheNineHostsAreInternalSoTheRendererCanReachThem()
+    {
+        // x:FieldModifier="internal" is what turns a host into a field on the generated partial.
+        // Without it the renderer cannot address the cell and the wall renders empty.
+        foreach (var (slot, _, _) in ShippedCells)
+            Assert.Contains("x:FieldModifier=\"internal\"", HostDeclaration(slot), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void TheHostsAreEmptyCells_NotTilesInDisguise()
+    {
+        // A host holds whatever the layout puts in it and nothing else. An authored child would
+        // be a tile the renderer neither knows about nor can move.
+        foreach (var (slot, _, _) in ShippedCells)
+            Assert.EndsWith("/>", HostDeclaration(slot).Trim(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void NoMovableTileIsStillAddressedByItsOldName()
+    {
+        // The nine x:Names the four render sites used to reach for. One left behind is a tile the
+        // slot model does not own, painting over the cell the renderer is filling.
+        var xaml = Xaml();
+        foreach (var name in new[]
+                 {
+                     "CardFlash", "ComboVideoBubble", "CardSubliminal", "CardBouncingText", "CardJustDrop",
+                     "ComboSpiralPink", "ComboMindDrain", "CardBubblePop", "CardLockCard",
+                 })
+            Assert.DoesNotContain($"x:Name=\"{name}\"", xaml, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void TheFixedCellsAndTheOverlaysAreUntouched()
+    {
+        var xaml = Xaml();
+        foreach (var name in new[] { "LogoBrandFrame", "MysteryFlipHost", "CardMystery", "CardVault",
+                                     "MysteryBadge", "VaultCta", "MosaicFx", "ProgramFeatureLockRibbon" })
+            Assert.Contains($"x:Name=\"{name}\"", xaml, StringComparison.Ordinal);
+
+        // MosaicFx is the grid's FIRST child on purpose: declaration order is z-order, and the fog
+        // must read through the gutters rather than over a card face.
+        var grid = xaml.IndexOf("x:Name=\"VelvetFeatureGrid\"", StringComparison.Ordinal);
+        Assert.True(grid >= 0);
+        Assert.True(xaml.IndexOf("x:Name=\"MosaicFx\"", grid, StringComparison.Ordinal)
+                    < xaml.IndexOf("x:Name=\"Slot0\"", grid, StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void ThereIsAHostForEverySlotTheLayoutCanHold()
+        => Assert.Equal(DashboardLayout.SlotCount, ShippedCells.Length);
+
+    [Fact]
+    public void TheDefaultLayoutStillNamesTheWallThatShipped()
+    {
+        // The pixel-parity claim in one line: slot N of the default layout is the feature that was
+        // authored in slot N's cell before the grid became slot-driven.
+        var expected = new[]
+        {
+            ("flash", (string?)null), ("video", "bubblecount"), ("subliminal", null), ("bouncingtext", null),
+            ("justdrop", null), ("spiral", "pinkfilter"), ("mindwipe", "braindrain"), ("bubbles", null),
+            ("lockcard", null),
+        };
+
+        var layout = DashboardLayout.Default();
+        for (int i = 0; i < DashboardLayout.SlotCount; i++)
+        {
+            Assert.Equal(expected[i].Item1, layout.Slots[i].Primary);
+            Assert.Equal(expected[i].Item2, layout.Slots[i].Secondary);
+        }
+    }
+
+    // ── the scrape ───────────────────────────────────────────────
+
+    private static string? _xaml;
+
+    private static string Xaml() => _xaml ??= File.ReadAllText(
+        Path.Combine(RepoRoot(), "ConditioningControlPanel", "Views", "Tabs", "SettingsTabView.xaml"));
+
+    private static string HostDeclaration(int slot)
+    {
+        var m = Regex.Match(Xaml(), $@"<Grid\s+x:Name=""Slot{slot}""[^>]*>");
+        Assert.True(m.Success, $"Slot{slot} has no <Grid x:Name=\"Slot{slot}\" .../> host in SettingsTabView.xaml");
+        return m.Value;
+    }
+
+    private static int Attribute(string declaration, string name)
+    {
+        var m = Regex.Match(declaration, $@"{Regex.Escape(name)}=""(\d+)""");
+        Assert.True(m.Success, $"{name} is missing from: {declaration}");
+        return int.Parse(m.Groups[1].Value);
+    }
+
+    private static string RepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir != null && !Directory.Exists(Path.Combine(dir.FullName, "ConditioningControlPanel", "Resources")))
+            dir = dir.Parent;
+        Assert.True(dir != null, "could not locate the repo root from " + AppContext.BaseDirectory);
+        return dir!.FullName;
+    }
+}


### PR DESCRIPTION
Stack 3 of 7 (base: A2). Pixel parity with today's wall on the default layout; no edit UI yet.

## What

- `SettingsTabView.xaml`: the nine movable tiles (`CardFlash`, `ComboVideoBubble`, `CardSubliminal`, `CardBouncingText`, `CardJustDrop`, `ComboSpiralPink`, `ComboMindDrain`, `CardBubblePop`, `CardLockCard`) become nine empty `Slot0..Slot8` hosts. Fixed cells, overlays, `MosaicFx` first-child and the lock ribbon untouched.
- New partial `MainWindow.DashboardSlots.cs` builds a `FeatureCard` / `SplitFeatureCard` per slot from the catalog: same art paths, mod-aware titles, `DimWhenInactive` on FX, help popovers carried over, tier badge when not entitled. Left-click FX = Studio module, right-click = toggle (session-lock refusal intact); destinations navigate; custom opens for goon, dtrh, arcademy, gaze; `justdrop` keeps the tease behaviour when the door is withheld.
- The four x:Name-addressed sites (art load, title rewrite, active rings, FX clocks) now go through the renderer. The nine old handlers are deleted (second commit).
- On this base `PieceByPieceHostService` does not exist (main-only), so `piecebypiece` opens the Play tab with a `TODO(6.10 merge)`.

## Tests

`DashboardSlotMapTests` pins `Slot0..Slot8` to their cells and the default layout to the shipped wall. All mod-art tests pass unchanged. The upgrade and first-run tours now target `Slot0`. Suite: 5990.

## Desk pass still owed

Screenshot diff of the default wall against 6.9.5 at 1679x901; hover, breath, active ring, right-click, mod switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VW2mrHU1ZQQ1RNTumPsrfm
