### PR TITLE
feat(sync): dashboard_layout rides the profile sync, fill-if-empty adopt (phase D)

### DIFF
--- a/ConditioningControlPanel/Services/Settings/ProfileSyncService.cs
+++ b/ConditioningControlPanel/Services/Settings/ProfileSyncService.cs
@@ -516,7 +516,8 @@ namespace ConditioningControlPanel.Services
         public void ResetLoadedProfileState()
         {
             _hasLoadedProfile = false;
-            App.Logger?.Debug("Profile sync: loaded-profile flag reset (logout) - defaults guard re-armed");
+            ReleaseDashboardLayoutOwnership(App.Settings?.Current);
+            App.Logger?.Debug("Profile sync: loaded-profile flag reset (logout) - defaults guard re-armed, dashboard layout released");
         }
 
         /// <summary>
@@ -2512,14 +2513,27 @@ namespace ConditioningControlPanel.Services
         /// an opinion: it is the shipped default, which must never overwrite a layout the subject
         /// arranged on another machine.
         ///
-        /// Once both hold, an explicit empty string is meaningful - it is "clear it", which the
-        /// server answers by deleting the field - so a null wire on a touched install sends "".
+        /// Once both hold, the wire goes up as-is. A touched install with a null wire is an
+        /// inconsistent state (every writer sets both), and it still sends null: "" is the server's
+        /// DELETE instruction, and nothing on the client ever means that. A reset writes the
+        /// default wire, it does not clear the field.
         /// </summary>
         internal static string? DashboardLayoutPayloadFor(string? wire, bool touched, bool hasLoadedProfile)
         {
             if (!hasLoadedProfile) return null;
             if (!touched) return null;
-            return wire ?? string.Empty;
+            return string.IsNullOrEmpty(wire) ? null : wire;
+        }
+
+        /// <summary>
+        /// Logout hands the wall back. The wire stays (the screen must not change under the
+        /// subject), but the touched flag drops so the next account's cloud layout can adopt over
+        /// it and this account's arrangement is never pushed up under someone else's id.
+        /// </summary>
+        internal static void ReleaseDashboardLayoutOwnership(Models.AppSettings? settings)
+        {
+            if (settings == null) return;
+            settings.DashboardLayoutTouched = false;
         }
 
         /// <summary>What to put in the sync payload's <c>dashboard_layout</c> field.</summary>

--- a/ConditioningControlPanel/Services/Settings/ProfileSyncService.cs
+++ b/ConditioningControlPanel/Services/Settings/ProfileSyncService.cs
@@ -1505,6 +1505,12 @@ namespace ConditioningControlPanel.Services
                         // local loadout is empty and unconfirmed - see BuildCosmeticsPayload, an
                         // all-empty object means "unequip everything" to the server.
                         cosmetics = BuildCosmeticsPayload(settings),
+                        // The nine movable Home slots, as the nine-field wire string (Phase D).
+                        // Top-level and a sibling of cosmetics, NEVER inside stats: a layout is not
+                        // progression, and keeping it out of the stats bag keeps it out of the XP
+                        // budget, the per-hour stat cap and anti_cheat_flags by construction.
+                        // Null is "no change", "" is "clear it" - see BuildDashboardLayoutPayload.
+                        dashboard_layout = BuildDashboardLayoutPayload(settings),
                         // Web XP claim ack: the id of the claim this client last APPLIED. Sent on
                         // every sync, not just the one after a claim - the server settles the pending
                         // bucket when it sees its own id come back, and ignores stale/unknown ones.
@@ -1696,6 +1702,9 @@ namespace ConditioningControlPanel.Services
                         // Trainer Card cosmetics: fill-if-empty only, so a fresh machine inherits
                         // the look and an established one is never undressed by a stale echo.
                         if (AdoptCloudCosmetics(v2Result?.Cosmetics)) App.Settings?.Save();
+
+                        // Home dashboard slots: fill-if-empty on the same terms.
+                        if (AdoptCloudDashboardLayout(v2Result?.DashboardLayout)) App.Settings?.Save();
 
                         // WEB XP CLAIM. The server mints XP for verified web activity into a pending
                         // bucket; it never touches the ledger the client authors (xp/level). It hands
@@ -2486,6 +2495,114 @@ namespace ConditioningControlPanel.Services
         }
 
         /// <summary>
+        /// Raised when <see cref="AdoptCloudDashboardLayout"/> has replaced an untouched local wall
+        /// with the account's cloud layout. The Home tab subscribes so the mosaic re-renders in
+        /// place instead of waiting for the next tab switch; nothing else should listen.
+        /// </summary>
+        internal static event Action? DashboardLayoutAdopted;
+
+        /// <summary>
+        /// The decision behind the sync body's <c>dashboard_layout</c> field, with no service state
+        /// in it so the tests can reach it.
+        ///
+        /// Null is "no change" to the server, and there are two reasons to send it. Until this
+        /// session has completed a round-trip we do not yet know what the account holds, and the V2
+        /// load path SYNCS BEFORE IT READS - the same ordering that once wiped everyone's
+        /// cosmetics (see <see cref="BuildCosmeticsPayload"/>). And an untouched local wall is not
+        /// an opinion: it is the shipped default, which must never overwrite a layout the subject
+        /// arranged on another machine.
+        ///
+        /// Once both hold, an explicit empty string is meaningful - it is "clear it", which the
+        /// server answers by deleting the field - so a null wire on a touched install sends "".
+        /// </summary>
+        internal static string? DashboardLayoutPayloadFor(string? wire, bool touched, bool hasLoadedProfile)
+        {
+            if (!hasLoadedProfile) return null;
+            if (!touched) return null;
+            return wire ?? string.Empty;
+        }
+
+        /// <summary>What to put in the sync payload's <c>dashboard_layout</c> field.</summary>
+        private string? BuildDashboardLayoutPayload(Models.AppSettings settings)
+        {
+            try
+            {
+                return DashboardLayoutPayloadFor(settings?.DashboardLayoutWire,
+                    settings?.DashboardLayoutTouched == true, _hasLoadedProfile);
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Debug("BuildDashboardLayoutPayload: {E}", ex.Message);
+                return null;   // the safe direction - "no change" never destroys anything
+            }
+        }
+
+        /// <summary>
+        /// The wire string an adopt should write, or null for "keep what is local".
+        ///
+        /// Fill-if-empty, exactly like <see cref="AdoptCloudCosmetics"/>: a layout is a choice, not
+        /// progression, so there is no higher value to merge toward and a stale echo must never
+        /// rearrange a wall the subject arranged. The gate is the touched flag rather than the
+        /// string, so resetting to the shipped wall on purpose still counts as an opinion.
+        ///
+        /// The server answers null for "never customized" and may answer "" for a layout that
+        /// sanitized down to nothing; both mean there is nothing to adopt, and neither is a licence
+        /// to clear local. A cloud string that sanitizes back to the default wall is nothing to
+        /// adopt either - it would only cost the subject their untouched flag.
+        /// </summary>
+        internal static string? DashboardLayoutToAdopt(string? cloud, bool touched)
+        {
+            if (touched) return null;
+            if (string.IsNullOrWhiteSpace(cloud)) return null;
+
+            // FromWire sanitizes on the way out: unknown keys blanked, splits reduced, dupes dropped.
+            var layout = Services.Dashboard.DashboardLayoutRule.FromWire(cloud);
+            if (layout.IsDefault) return null;
+
+            return Services.Dashboard.DashboardLayoutRule.ToWire(layout);
+        }
+
+        /// <summary>
+        /// Write an adopted layout into <paramref name="settings"/>, or leave it alone. Marking the
+        /// wall touched is the point: a machine that inherited a layout now owns it, and the next
+        /// sync carries it rather than sending "no change" forever.
+        /// Returns true when settings were changed (caller saves).
+        /// </summary>
+        internal static bool ApplyCloudDashboardLayout(Models.AppSettings? settings, string? cloud)
+        {
+            if (settings == null) return false;
+
+            var adopt = DashboardLayoutToAdopt(cloud, settings.DashboardLayoutTouched);
+            if (adopt == null) return false;
+
+            settings.DashboardLayoutWire = adopt;
+            settings.DashboardLayoutTouched = true;
+            return true;
+        }
+
+        /// <summary>
+        /// Adopt the account's Home layout into a wall this install has never edited.
+        /// Returns true when settings were changed (caller saves).
+        /// </summary>
+        private static bool AdoptCloudDashboardLayout(string? cloud)
+        {
+            try
+            {
+                if (!ApplyCloudDashboardLayout(App.Settings?.Current, cloud)) return false;
+
+                App.Logger?.Information("Adopted the cloud Home dashboard layout into an untouched local wall: {Wire}",
+                    App.Settings?.Current?.DashboardLayoutWire ?? "");
+                DashboardLayoutAdopted?.Invoke();
+                return true;
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Debug("AdoptCloudDashboardLayout skipped: {E}", ex.Message);
+                return false;
+            }
+        }
+
+        /// <summary>
         /// Merge cloud profile with local data, taking the HIGHER values to prevent progress loss.
         /// This protects against cloud data corruption, sync issues, or stale cloud profiles.
         /// </summary>
@@ -3014,6 +3131,9 @@ namespace ConditioningControlPanel.Services
             // Trainer Card cosmetics: fill-if-empty only (see AdoptCloudCosmetics for why this is
             // deliberately NOT a merge).
             if (AdoptCloudCosmetics(cloudProfile.Cosmetics)) needsSave = true;
+
+            // Home dashboard slots: same fill-if-empty rule, same reasons.
+            if (AdoptCloudDashboardLayout(cloudProfile.DashboardLayout)) needsSave = true;
 
             // Merge conditioning time - take HIGHER value to prevent loss
             if (cloudProfile.TotalConditioningMinutes.HasValue)
@@ -4835,6 +4955,13 @@ namespace ConditioningControlPanel.Services
             /// </summary>
             [JsonProperty("cosmetics")]
             public Models.ProfileCosmetics? Cosmetics { get; set; }
+
+            /// <summary>
+            /// The Home slot layout echoed by the profile read. Null means the account never
+            /// customized (keep local); it is never an instruction to clear.
+            /// </summary>
+            [JsonProperty("dashboard_layout")]
+            public string? DashboardLayout { get; set; }
         }
 
         private class ProfileSyncData
@@ -4947,6 +5074,10 @@ namespace ConditioningControlPanel.Services
             /// <summary>Trainer Card customization echoed back by /v2/user/sync (Phase 2).</summary>
             [JsonProperty("cosmetics")]
             public Models.ProfileCosmetics? Cosmetics { get; set; }
+
+            /// <summary>The Home slot layout echoed back by /v2/user/sync (Phase D).</summary>
+            [JsonProperty("dashboard_layout")]
+            public string? DashboardLayout { get; set; }
 
             [JsonProperty("level_reset")]
             public bool? LevelReset { get; set; }

--- a/Tests/ConditioningControlPanel.Tests/ProfileSyncDashboardLayoutTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/ProfileSyncDashboardLayoutTests.cs
@@ -1,0 +1,144 @@
+using ConditioningControlPanel.Models;
+using ConditioningControlPanel.Models.Dashboard;
+using ConditioningControlPanel.Services;
+using ConditioningControlPanel.Services.Dashboard;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// Phase D - the Home slot layout rides the profile sync.
+///
+/// Two decisions carry the whole feature, and both are one-way doors on a live account:
+///
+/// SEND. The V2 load path pushes before it reads. Sending the local wall unconditionally would
+/// mean a fresh install's very first POST overwrites the account's layout with the shipped
+/// default, the response then echoes that default back, and the adopt below can never fire - the
+/// exact shape of the bug that once stripped everyone's Trainer Card cosmetics. So the payload
+/// stays null ("no change") until a round-trip has happened AND the subject has actually edited
+/// something here. Only then does an empty string become meaningful, as "clear it".
+///
+/// ADOPT. Fill-if-empty, gated on the touched flag rather than the string, so a subject who
+/// deliberately reset to the shipped wall is not handed another machine's arrangement. Null and
+/// "" from the server both mean "nothing stored", never "clear yours", and a cloud string that
+/// sanitizes back to the default wall is not worth spending the untouched flag on.
+/// </summary>
+public class ProfileSyncDashboardLayoutTests
+{
+    /// <summary>A real, non-default layout: Just Drop swapped off the wall for the Arcademy.</summary>
+    private static string CustomWire()
+    {
+        var layout = DashboardLayout.Default();
+        Assert.Equal(PlaceOutcome.Replaced, DashboardLayoutRule.Place(layout, 4, "arcademy", false));
+        return DashboardLayoutRule.ToWire(layout);
+    }
+
+    // ---- the send decision ------------------------------------------------------------------
+
+    [Fact]
+    public void NothingIsSentBeforeTheFirstRoundTrip()
+    {
+        // Touched and edited, but this session has not read the account yet: still "no change".
+        Assert.Null(ProfileSyncService.DashboardLayoutPayloadFor(CustomWire(), touched: true, hasLoadedProfile: false));
+    }
+
+    [Fact]
+    public void NothingIsSentWhileTheWallIsUntouched()
+    {
+        // The shipped wall is not an opinion, so it never asserts itself over the account.
+        Assert.Null(ProfileSyncService.DashboardLayoutPayloadFor(CustomWire(), touched: false, hasLoadedProfile: true));
+        Assert.Null(ProfileSyncService.DashboardLayoutPayloadFor(null, touched: false, hasLoadedProfile: true));
+    }
+
+    [Fact]
+    public void TheWireGoesUpOnceBothHold()
+    {
+        var wire = CustomWire();
+        Assert.Equal(wire, ProfileSyncService.DashboardLayoutPayloadFor(wire, touched: true, hasLoadedProfile: true));
+    }
+
+    [Fact]
+    public void ATouchedWallWithNoWireSendsTheClear()
+    {
+        // "" is the server's delete instruction, and it is only reachable from a touched install
+        // that has already round-tripped - never from a fresh one.
+        Assert.Equal("", ProfileSyncService.DashboardLayoutPayloadFor(null, touched: true, hasLoadedProfile: true));
+    }
+
+    // ---- the adopt decision -----------------------------------------------------------------
+
+    [Fact]
+    public void AnUntouchedWallAdoptsTheCloudLayout()
+    {
+        var wire = CustomWire();
+        var settings = new AppSettings();
+
+        Assert.True(ProfileSyncService.ApplyCloudDashboardLayout(settings, wire));
+        Assert.Equal(wire, settings.DashboardLayoutWire);
+    }
+
+    [Fact]
+    public void AdoptingMarksTheWallTouched()
+    {
+        // Otherwise the inheriting machine would send "no change" forever and its own later edits
+        // would never reach the account.
+        var settings = new AppSettings();
+
+        Assert.True(ProfileSyncService.ApplyCloudDashboardLayout(settings, CustomWire()));
+        Assert.True(settings.DashboardLayoutTouched);
+    }
+
+    [Fact]
+    public void ATouchedWallIsNeverRearrangedByTheCloud()
+    {
+        var settings = new AppSettings { DashboardLayoutTouched = true, DashboardLayoutWire = null };
+
+        Assert.False(ProfileSyncService.ApplyCloudDashboardLayout(settings, CustomWire()));
+        Assert.Null(settings.DashboardLayoutWire);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void NothingStoredIsNotAnInstructionToClear(string? cloud)
+    {
+        var settings = new AppSettings();
+
+        Assert.False(ProfileSyncService.ApplyCloudDashboardLayout(settings, cloud));
+        Assert.Null(settings.DashboardLayoutWire);
+        Assert.False(settings.DashboardLayoutTouched);
+    }
+
+    [Fact]
+    public void ACloudLayoutThatSanitizesToTheDefaultWallIsNotAdopted()
+    {
+        var settings = new AppSettings();
+
+        // The shipped wall itself.
+        Assert.False(ProfileSyncService.ApplyCloudDashboardLayout(
+            settings, DashboardLayoutRule.ToWire(DashboardLayout.Default())));
+        // And nine fields of keys this build has never heard of, which sanitize down to nothing
+        // and are then promoted back to the default rather than rendered as nine holes.
+        Assert.False(ProfileSyncService.ApplyCloudDashboardLayout(settings, ",,,,,,,,"));
+        Assert.False(ProfileSyncService.ApplyCloudDashboardLayout(settings, "nope,alsonope,,,,,,,"));
+
+        Assert.Null(settings.DashboardLayoutWire);
+        Assert.False(settings.DashboardLayoutTouched);
+    }
+
+    [Fact]
+    public void AnAdoptedWireIsNormalizedBeforeItIsStored()
+    {
+        // Whatever an older or newer server hands over, what lands on disk is what this build's
+        // own renderer will read back.
+        var settings = new AppSettings();
+
+        Assert.True(ProfileSyncService.ApplyCloudDashboardLayout(
+            settings, "flash,video|bubblecount,subliminal,bouncingtext,arcademy,spiral|pinkfilter,mindwipe|braindrain,bubbles,ghostkey"));
+
+        Assert.Equal(DashboardLayoutRule.ToWire(DashboardLayoutRule.FromWire(settings.DashboardLayoutWire)),
+            settings.DashboardLayoutWire);
+        Assert.DoesNotContain("ghostkey", settings.DashboardLayoutWire!);
+    }
+}

--- a/Tests/ConditioningControlPanel.Tests/ProfileSyncDashboardLayoutTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/ProfileSyncDashboardLayoutTests.cs
@@ -58,11 +58,25 @@ public class ProfileSyncDashboardLayoutTests
     }
 
     [Fact]
-    public void ATouchedWallWithNoWireSendsTheClear()
+    public void ATouchedWallWithNoWireSendsNoChange()
     {
-        // "" is the server's delete instruction, and it is only reachable from a touched install
-        // that has already round-tripped - never from a fresh one.
-        Assert.Equal("", ProfileSyncService.DashboardLayoutPayloadFor(null, touched: true, hasLoadedProfile: true));
+        // "" is the server's delete instruction and no client path means it; an inconsistent
+        // touched-but-empty install stays silent rather than wiping the account's layout.
+        Assert.Null(ProfileSyncService.DashboardLayoutPayloadFor(null, touched: true, hasLoadedProfile: true));
+        Assert.Null(ProfileSyncService.DashboardLayoutPayloadFor("", touched: true, hasLoadedProfile: true));
+    }
+
+    [Fact]
+    public void LogoutReleasesOwnershipButKeepsTheWall()
+    {
+        var settings = new AppSettings { DashboardLayoutWire = CustomWire(), DashboardLayoutTouched = true };
+        ProfileSyncService.ReleaseDashboardLayoutOwnership(settings);
+        Assert.False(settings.DashboardLayoutTouched);
+        Assert.Equal(CustomWire(), settings.DashboardLayoutWire);
+        // Released, the wall is adoptable again and no longer pushed.
+        Assert.Null(ProfileSyncService.DashboardLayoutPayloadFor(settings.DashboardLayoutWire, settings.DashboardLayoutTouched, hasLoadedProfile: true));
+        Assert.True(ProfileSyncService.ApplyCloudDashboardLayout(settings, "lockcard,flash,,,,,,,"));
+        ProfileSyncService.ReleaseDashboardLayoutOwnership(null);
     }
 
     // ---- the adopt decision -----------------------------------------------------------------


### PR DESCRIPTION
Stack 5 of 7 (base: C). Server side is CC-Labs-llc/CCP-Server #147 and must be deployed before this merges.

## What

`ProfileSyncService` only, the cosmetics pattern:

- `dashboard_layout` rides the V2 sync body as a top-level sibling of `cosmetics`, never inside `stats`, so it is outside every anti-cheat clamp by construction.
- Send: `null` (no change) until this session has round-tripped once and the wall has been touched; then the wire string. `""` (the server's delete) is never sent.
- Receive: fill-if-empty. Adopt only when local is untouched and the cloud string sanitizes to a non-default wall; adopting marks touched. Static event `DashboardLayoutAdopted` fires after the write (Phase F re-renders on it via the Dispatcher).
- Logout releases ownership: the wire stays on screen, `Touched` drops, so the next account's cloud layout can adopt and this account's wall is never pushed under another id.

## Tests

`ProfileSyncDashboardLayoutTests` (13). Suite: 6044.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VW2mrHU1ZQQ1RNTumPsrfm
