### PR TITLE
feat(dashboard): rolodex picker page, three.js, mock-testable (phase E)

### DIFF
--- a/ConditioningControlPanel/Resources/web/rolodex/CLAUDE.md
+++ b/ConditioningControlPanel/Resources/web/rolodex/CLAUDE.md
@@ -1,0 +1,133 @@
+# Rolodex - the 3D feature picker (Resources\web\rolodex)
+
+The picker for the customizable Home dashboard: four stacked rings of 16:9 cards, one ring per
+tier band, spun with the mouse or the arrow keys. Phase E of `home-dashboard-slots-rolodex.md`.
+
+Hosted by the WPF app in a WebView2 at **`https://ccp.game/rolodex/index.html`** (virtual host
+`ccp.game` -> `Resources\web`, `CoreWebView2HostResourceAccessKind.Allow` so canvas textures work).
+Also runs in a plain browser with `?mock=1`, which is how the 3D is iterated without the app.
+
+## 1. Files
+
+| File | What it is |
+|---|---|
+| `index.html` | import map (`three` -> `../vendor/three/three.module.min.js`), the canvas, the DOM HUD |
+| `rolodex.js` | the whole page: scene, card textures, input, HUD, bridge handlers, mock fixture |
+| `bridge.js` | verbatim copy of `dtrh\bridge.js` (protocol v1) apart from its header comment |
+| `style.css` | HUD chrome, velvet palette, the CSS vignette |
+
+No bundler, no build step, no network fetch, no dependency beyond the vendored three.js r169.
+`Resources\web\**\*` is already `Content` in the csproj (and in the `WebFiles` publish glob), so
+this folder ships with **no csproj change**. `Resources\web\**\CLAUDE.md` is excluded from both, so
+this document does not ship.
+
+## 2. The message contract
+
+postMessage JSON both ways, `{type: ...}` envelope, exactly like dtrh. The page announces `ready`
+on load and the host flushes whatever it queued.
+
+### Host -> page
+
+```jsonc
+{
+  "type": "init",
+  "rings": [                       // 1..4, in display order, top ring first
+    { "ring": 1,
+      "faces": [                   // one card per feature, in ring order
+        { "key": "flash",          // the canonical slot key (plan 3.3)
+          "title": "Flash Images", // already localized by the host
+          "blurb": "One line.",    // already localized, one line, no wrapping
+          "tier": 0,               // 0 free, 1 = Tier 1 (gold), 2 = Lab (diamond)
+          "locked": false,         // not entitled: draws the LOCKED band
+          "art": "data:image/jpeg;base64,..." }   // or null for a placeholder
+      ] }
+  ],
+  "slot": 4,                       // int or null; display only ("slot 5" in the header)
+  "mode": "edit",                  // "edit" | "tour"
+  "picks": 1,                      // tour mode: how many faces to collect
+  "reducedMotion": false,          // OR'd with the page's prefers-reduced-motion
+  "lang": "en"                     // carried for completeness; the page localizes nothing
+}
+```
+
+`{ "type": "focus", "key": "dtrh" }` - make that face's ring the focused one and spin to it.
+`{ "type": "close" }` - the host is disposing the view; the page goes inert and stops accepting input.
+
+### Page -> host
+
+| Message | When |
+|---|---|
+| `{type:'ready', protocol:1}` | once, on load, from `bridge.announceReady()` |
+| `{type:'pick', key}` | edit mode, on Enter / click on the front card. One per open: the page marks itself inert and the host closes it |
+| `{type:'tourDone', keys:[...]}` | tour mode, when Done is pressed (Done appears once `picks` faces are picked) |
+| `{type:'close'}` | Esc or the close button. Also fires after a `tourDone` if the user then presses Esc |
+| `{type:'log', level, msg}` | `bridge.log`; `level` is debug / info / warn / error, msg capped at 400 chars |
+
+The page never knows the layout rules. Replace / Split / Move prompting, session-lock refusal and
+slot assignment all stay WPF-side after `pick` / `tourDone`. A **locked** face is still pickable by
+design (owner call: every slot is a user-chosen upsell); the host's own tier gate refuses later.
+
+## 3. Interaction
+
+| Input | Effect |
+|---|---|
+| horizontal drag, Left / Right | rotate the focused ring, snapping to the nearest card |
+| vertical drag, wheel, Up / Down | step the focus between rings (camera dollies, other rings dim to 34%) |
+| Enter, Space, click on the front card | pick |
+| click on any other card | focus that ring and spin that card to the front |
+| Esc, the close button | `close` |
+
+Tour mode adds a `pick N` counter in the header, a check mark on picked cards, and a Done button
+that appears at N. Picking a face that is already picked toggles it off; picking past N drops the
+oldest pick so the newest choice always lands.
+
+Rotation is stored as an **unbounded continuous** `group.rotation.y`, so there is never a wrap
+discontinuity to tween across; `nearestTurnFor` resolves a face index to the shortest-way turn count.
+
+`reducedMotion` (from `init` or from `prefers-reduced-motion`) makes `tween()` and `approach()`
+assign straight to the target, so every move is a cut. There is no animation that is not routed
+through those two helpers.
+
+## 4. Layout maths
+
+Ring N has `faces.length` cards on a cylinder of radius
+`max(1.55, (CARD_W * 1.22) / (2 * sin(pi / n)))`, which keeps the chord between neighbours wider
+than a card, so a ring can gain faces without cards overlapping. Cards are flat
+`PlaneGeometry(1.6, 0.9)` parented to a ring `Group` at angle `2*pi*i/n`, normal pointing out of
+the cylinder; a second dark plane at `angle + pi` gives the far side card backs instead of holes.
+The camera sits at `radius + 2.85` in front of the focused ring, so the front card is always the
+same size no matter how many faces the ring carries.
+
+## 5. Card texture
+
+One 512x288 canvas per face, redrawn only on build, on art load and on a pick toggle:
+cover-fit art (or a hue-tinted placeholder keyed off the feature key, with the title's initial),
+a bottom scrim, title + one-line blurb (measured and ellipsized, never wrapped), a tier badge
+(`TIER 1` gold / `LAB` diamond, tier 0 has none), a translucent `LOCKED` band across the bottom,
+a purple check disc when picked, and a rim in the tier colour drawn outside the clip.
+
+Art arrives as a data URI in `init` (the host builds JPEGs at decode width 512, quality 80, cached
+per mod switch). The page never fetches anything.
+
+## 6. Mock mode
+
+`?mock=1` edit mode, `?mock=tour` tour mode with `picks:3`, `&reduced=1` forces reduced motion.
+Mock also engages automatically when `window.chrome.webview` is absent. The fixture carries the 27
+real keys in their four rings with `art:null` (placeholder art only) and a stable pseudo-random
+locked mix; `pick` / `tourDone` / `close` go to the console and to the on-page `#status` line
+instead of to a host.
+
+To run it: serve `Resources\web` over http (ES modules will not load from `file://`) and open
+`http://127.0.0.1:PORT/rolodex/index.html?mock=1`.
+
+## 7. Rules for anyone editing this page
+
+1. Dark first. The host swaps a WebView2 HWND straight over the velvet grid and an HWND cannot
+   fade, so `html`/`body` and the GL clear colour are all `#0b0710` before any script runs. Never
+   introduce a light default.
+2. Resize-safe. The host resizes the HWND; `sizeToViewport` is wired to both `resize` and a
+   `ResizeObserver`. Do not cache viewport dimensions anywhere else.
+3. Everything animated goes through `tween` / `approach` so reduced motion keeps working.
+4. No `AddHostObjectToScript`, ever: postMessage only, same as dtrh and arcademy.
+5. Keep `bridge.js` a verbatim copy of the dtrh original (header comment aside). If the protocol
+   moves, move both.

--- a/ConditioningControlPanel/Resources/web/rolodex/bridge.js
+++ b/ConditioningControlPanel/Resources/web/rolodex/bridge.js
@@ -1,0 +1,62 @@
+/* ============================================================================
+ * bridge.js - COPY of Resources/web/dtrh/bridge.js (protocol v1), unchanged
+ * apart from this header. The rolodex page is hosted by RolodexEmbedView on the
+ * C# side; same transport, same ready handshake, same reserved 'log' type.
+ * Keep this file in sync with the dtrh original if the protocol ever moves.
+ *
+ * Transport: window.chrome.webview.postMessage (JS->C#) and the host's
+ * PostWebMessageAsJson (C#->JS). The host queues everything until we announce
+ * 'ready', and we buffer any message that lands before its handler is
+ * registered - so neither side ever races the other's boot.
+ * ==========================================================================*/
+
+export const PROTOCOL = 1;
+
+const webview = window.chrome && window.chrome.webview;
+const handlers = new Map();   // type -> fn
+const preBuffer = [];         // messages that arrived before their handler
+
+if (webview) {
+  webview.addEventListener('message', (e) => {
+    const m = e.data;
+    if (!m || typeof m.type !== 'string') return;
+    const h = handlers.get(m.type);
+    if (h) h(m);
+    else preBuffer.push(m);
+  });
+}
+
+/** Register a handler; replays any buffered messages of that type in order. */
+export function on(type, fn) {
+  handlers.set(type, fn);
+  for (let i = 0; i < preBuffer.length; i++) {
+    if (preBuffer[i].type === type) {
+      const m = preBuffer.splice(i, 1)[0];
+      i--;
+      fn(m);
+    }
+  }
+}
+
+/** Post a message object (must carry a string `type`) to the host. */
+export function send(msg) {
+  try { webview && webview.postMessage(msg); } catch (e) { /* host gone */ }
+}
+
+/**
+ * Serilog passthrough. `level` is optional and defaults to 'debug' (same signature as the
+ * arcademy bridge: `log(msg)` or `log(level, msg)`).
+ *
+ * The default is the QUIET one. The host files 'info' and above; 'debug' still reaches the
+ * flight recorder, so it is dumped with any crash, hang or bug report - it just stops being
+ * written to disk on every run. Say 'warn' for a degraded surface, 'error' for a broken one.
+ */
+export function log(level, msg) {
+  if (msg === undefined) { msg = level; level = 'debug'; }
+  send({ type: 'log', level: String(level), msg: String(msg).slice(0, 400) });
+}
+
+/** Announce boot completion - the host flushes its queued init/manifest on receipt. */
+export function announceReady() { send({ type: 'ready', protocol: PROTOCOL }); }
+
+export const isHosted = !!webview;

--- a/ConditioningControlPanel/Resources/web/rolodex/index.html
+++ b/ConditioningControlPanel/Resources/web/rolodex/index.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+<title>Feature Picker</title>
+<link rel="stylesheet" href="./style.css">
+<!--
+  The rolodex - the 3D feature picker for the customizable Home dashboard
+  (plan: home-dashboard-slots-rolodex.md, phase E).
+
+  Hosted by the WPF app in a WebView2 at https://ccp.game/rolodex/index.html,
+  and runnable in a plain browser with ?mock=1 (edit mode) or ?mock=tour.
+  three.js is resolved from the shared vendored ESM build; the specifier below
+  is relative to this document so the page works from any mount point.
+-->
+<script type="importmap">
+{
+  "imports": {
+    "three": "../vendor/three/three.module.min.js",
+    "three/addons/": "../vendor/three/addons/"
+  }
+}
+</script>
+</head>
+<body>
+  <!-- The 3D layer. rolodex.js owns this canvas and nothing else touches it. -->
+  <canvas id="stage"></canvas>
+
+  <!-- The HUD. Everything here is DOM so it stays crisp at any HWND size and
+       needs no font work inside the WebGL layer. -->
+  <div id="hud">
+    <header id="bar">
+      <div id="title">Pick a feature</div>
+      <div id="count" hidden></div>
+      <button id="btn-close" type="button" title="Close (Esc)" aria-label="Close">&#215;</button>
+    </header>
+
+    <div id="hint">Drag or arrow keys to spin &#183; up and down to change shelf &#183; Enter to pick</div>
+
+    <button id="btn-done" type="button" hidden>Done</button>
+
+    <!-- Mock-only readout of what the page would have posted to the host. -->
+    <div id="status" hidden></div>
+  </div>
+
+  <script type="module" src="./rolodex.js"></script>
+</body>
+</html>

--- a/ConditioningControlPanel/Resources/web/rolodex/rolodex.js
+++ b/ConditioningControlPanel/Resources/web/rolodex/rolodex.js
@@ -1,0 +1,722 @@
+/* ============================================================================
+ * rolodex.js - the 3D feature picker for the customizable Home dashboard.
+ * Phase E of plan `home-dashboard-slots-rolodex.md`. No bundler, no network,
+ * no dependency beyond the vendored three.js r169 under ../vendor/three.
+ *
+ * MESSAGE CONTRACT (postMessage JSON, {type:...} envelope, see bridge.js)
+ *
+ *   Host -> page
+ *     init  { rings: [ { ring:1..4,
+ *                        faces:[ { key, title, blurb,
+ *                                  tier:0|1|2, locked:bool,
+ *                                  art:dataUri|null } ] } ],
+ *             slot:int|null, mode:'edit'|'tour', picks:int,
+ *             reducedMotion:bool, lang:string }
+ *     focus { key }   spin to that face and make its ring the focused one
+ *     close           the host is tearing the view down; stop everything
+ *
+ *   Page -> host
+ *     ready                     once, on load (bridge.announceReady)
+ *     pick     { key }          edit mode, one pick, then the host closes us
+ *     tourDone { keys:[...] }   tour mode, sent when Done is pressed
+ *     close                     Esc or the close button
+ *     log      { level, msg }   bridge.log passthrough to Serilog
+ *
+ * The page never knows the layout rules: replace / split / move prompting all
+ * stays WPF-side after `pick`. `slot` and `lang` ride along for display only;
+ * nothing here localizes, the host sends strings already localized.
+ *
+ * MOCK MODE: index.html?mock=1 (edit) or ?mock=tour (tour, picks 3). Also
+ * engaged automatically when window.chrome.webview is absent, so the page is
+ * iterable in a plain browser. The fixture feeds the 27 real keys in their 4
+ * rings with placeholder art, and pick / tourDone / close land in the console
+ * and in the on-page status line instead of on the host.
+ * ==========================================================================*/
+
+import * as THREE from 'three';
+import * as bridge from './bridge.js';
+
+/* ---------------------------------------------------------------- geometry */
+
+const CARD_W = 1.6;            // 16:9 card, world units
+const CARD_H = 0.9;
+const FACE_GAP = 1.22;         // chord multiplier; keeps neighbours from touching
+const RING_GAP = 1.34;         // vertical distance between ring planes
+const CAM_BACKOFF = 2.85;      // camera sits this far in front of the front card
+const MIN_RADIUS = 1.55;
+const TEX_W = 512, TEX_H = 288;
+const VELVET = 0x0b0710;
+const DIM = 0.34;              // unfocused ring opacity
+const DRAG_PX_PER_FACE = 150;  // horizontal pixels that advance one card
+const STEP_PX = 78;            // vertical pixels that step one ring
+const CLICK_SLOP = 6;          // pointer travel below which a drag is a click
+
+/* ------------------------------------------------------------------- state */
+
+const S = {
+  rings: [],        // [{ n, step, radius, group, faces[], backMat, dim, dimTarget }]
+  byKey: new Map(), // key -> face
+  focus: 0,         // index into S.rings
+  mode: 'edit',
+  picks: 1,
+  picked: [],       // keys, tour mode
+  slot: null,
+  lang: 'en',
+  reduced: false,
+  started: false,
+  dead: false
+};
+
+const el = {
+  stage: document.getElementById('stage'),
+  title: document.getElementById('title'),
+  count: document.getElementById('count'),
+  hint: document.getElementById('hint'),
+  done: document.getElementById('btn-done'),
+  close: document.getElementById('btn-close'),
+  status: document.getElementById('status')
+};
+
+const QS = new URLSearchParams(location.search);
+const MOCK = QS.has('mock') || !bridge.isHosted;
+
+/* ------------------------------------------------------------------- three */
+
+const renderer = new THREE.WebGLRenderer({ canvas: el.stage, antialias: true, alpha: false });
+renderer.setClearColor(VELVET, 1);
+const scene = new THREE.Scene();
+const camera = new THREE.PerspectiveCamera(45, 1, 0.1, 60);
+const cam = { y: 0, z: 4 };            // tweened; camera looks at (0, cam.y, 0)
+const raycaster = new THREE.Raycaster();
+const pointerNdc = new THREE.Vector2();
+const cardGeo = new THREE.PlaneGeometry(CARD_W, CARD_H);
+
+function sizeToViewport() {
+  const w = Math.max(1, window.innerWidth);
+  const h = Math.max(1, window.innerHeight);
+  renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
+  renderer.setSize(w, h, false);
+  camera.aspect = w / h;
+  camera.updateProjectionMatrix();
+}
+window.addEventListener('resize', sizeToViewport);
+// The host resizes the HWND without always firing `resize`, so watch the box too.
+if (window.ResizeObserver) new ResizeObserver(sizeToViewport).observe(document.documentElement);
+sizeToViewport();
+
+/* ------------------------------------------------------------------ tweens */
+
+const tweens = [];
+const easeOut = (t) => 1 - Math.pow(1 - t, 3);
+
+/** Tween obj[prop] to `to`. reducedMotion collapses every tween to a cut. */
+function tween(obj, prop, to, dur) {
+  for (let i = tweens.length - 1; i >= 0; i--) {
+    if (tweens[i].obj === obj && tweens[i].prop === prop) tweens.splice(i, 1);
+  }
+  if (S.reduced || dur <= 0) { obj[prop] = to; return; }
+  tweens.push({ obj, prop, from: obj[prop], to, t: 0, dur });
+}
+
+function stepTweens(dt) {
+  for (let i = tweens.length - 1; i >= 0; i--) {
+    const tw = tweens[i];
+    tw.t += dt;
+    const k = Math.min(1, tw.t / tw.dur);
+    tw.obj[tw.prop] = tw.from + (tw.to - tw.from) * easeOut(k);
+    if (k >= 1) tweens.splice(i, 1);
+  }
+}
+
+/** Frame-rate independent approach, also a cut under reduced motion. */
+function approach(cur, target, rate, dt) {
+  if (S.reduced) return target;
+  return cur + (target - cur) * (1 - Math.exp(-rate * dt));
+}
+
+/* ------------------------------------------------------------ card texture */
+
+const TIER = {
+  0: { rim: 'rgba(148,120,190,0.50)', ink: '#cbb6e8', badge: null, fill: null },
+  1: { rim: 'rgba(226,183,85,0.95)', ink: '#1c1206', badge: 'TIER 1', fill: '#e2b755' },
+  2: { rim: 'rgba(190,240,255,0.95)', ink: '#06212a', badge: 'LAB', fill: '#bef0ff' }
+};
+
+function hashHue(s) {
+  let h = 0;
+  for (let i = 0; i < s.length; i++) h = (h * 31 + s.charCodeAt(i)) >>> 0;
+  return h % 360;
+}
+
+function roundRect(ctx, x, y, w, h, r) {
+  ctx.beginPath();
+  ctx.moveTo(x + r, y);
+  ctx.arcTo(x + w, y, x + w, y + h, r);
+  ctx.arcTo(x + w, y + h, x, y + h, r);
+  ctx.arcTo(x, y + h, x, y, r);
+  ctx.arcTo(x, y, x + w, y, r);
+  ctx.closePath();
+}
+
+function fitText(ctx, text, maxW) {
+  if (ctx.measureText(text).width <= maxW) return text;
+  let t = text;
+  while (t.length > 1 && ctx.measureText(t + '…').width > maxW) t = t.slice(0, -1);
+  return t + '…';
+}
+
+/** Draw the whole card face. Called at build, on art load and on pick toggle. */
+function drawFace(face) {
+  const ctx = face.ctx;
+  const hue = hashHue(face.key);
+  const style = TIER[face.tier] || TIER[0];
+  ctx.clearRect(0, 0, TEX_W, TEX_H);
+
+  // Body, clipped to the rounded card so the art never squares off the corners.
+  ctx.save();
+  roundRect(ctx, 0, 0, TEX_W, TEX_H, 18);
+  ctx.clip();
+
+  if (face.img) {
+    const sc = Math.max(TEX_W / face.img.width, TEX_H / face.img.height);   // cover fit
+    const dw = face.img.width * sc, dh = face.img.height * sc;
+    ctx.drawImage(face.img, (TEX_W - dw) / 2, (TEX_H - dh) / 2, dw, dh);
+  } else {
+    // Placeholder: a hue-tinted wash keyed off the feature key, plus its initial.
+    const g = ctx.createLinearGradient(0, 0, TEX_W, TEX_H);
+    g.addColorStop(0, 'hsl(' + hue + ' 55% 26%)');
+    g.addColorStop(0.55, 'hsl(' + ((hue + 28) % 360) + ' 48% 16%)');
+    g.addColorStop(1, 'hsl(' + ((hue + 300) % 360) + ' 40% 10%)');
+    ctx.fillStyle = g;
+    ctx.fillRect(0, 0, TEX_W, TEX_H);
+    ctx.globalAlpha = 0.16;
+    ctx.fillStyle = '#ffffff';
+    ctx.font = '700 190px "Segoe UI", system-ui, sans-serif';
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillText(face.title.slice(0, 1).toUpperCase(), TEX_W * 0.5, TEX_H * 0.42);
+    ctx.globalAlpha = 1;
+    ctx.textAlign = 'left';
+    ctx.textBaseline = 'alphabetic';
+  }
+
+  // Scrim so the copy reads over any art.
+  const scrim = ctx.createLinearGradient(0, TEX_H * 0.36, 0, TEX_H);
+  scrim.addColorStop(0, 'rgba(8,4,14,0)');
+  scrim.addColorStop(0.55, 'rgba(8,4,14,0.72)');
+  scrim.addColorStop(1, 'rgba(8,4,14,0.94)');
+  ctx.fillStyle = scrim;
+  ctx.fillRect(0, TEX_H * 0.36, TEX_W, TEX_H * 0.64);
+
+  const lift = face.locked ? 46 : 0;   // the lockband owns the bottom strip
+
+  ctx.fillStyle = '#f3ecff';
+  ctx.font = '700 34px "Segoe UI", system-ui, sans-serif';
+  ctx.fillText(fitText(ctx, face.title, TEX_W - 56), 28, TEX_H - 52 - lift);
+
+  ctx.fillStyle = 'rgba(201,186,222,0.92)';
+  ctx.font = '400 19px "Segoe UI", system-ui, sans-serif';
+  ctx.fillText(fitText(ctx, face.blurb || '', TEX_W - 56), 28, TEX_H - 24 - lift);
+
+  // Tier badge, top right. Tier 0 has none.
+  if (style.badge) {
+    ctx.font = '700 17px "Segoe UI", system-ui, sans-serif';
+    const bw = ctx.measureText(style.badge).width + 26;
+    ctx.fillStyle = style.fill;
+    roundRect(ctx, TEX_W - 18 - bw, 16, bw, 30, 15);
+    ctx.fill();
+    ctx.fillStyle = style.ink;
+    ctx.fillText(style.badge, TEX_W - 18 - bw + 13, 37);
+  }
+
+  // Lockband.
+  if (face.locked) {
+    ctx.fillStyle = 'rgba(10,5,16,0.80)';
+    ctx.fillRect(0, TEX_H - 44, TEX_W, 44);
+    ctx.fillStyle = 'rgba(255,255,255,0.06)';
+    ctx.fillRect(0, TEX_H - 44, TEX_W, 1);
+    ctx.fillStyle = style.fill || '#d8c8f2';
+    ctx.font = '700 18px "Segoe UI", system-ui, sans-serif';
+    ctx.textAlign = 'center';
+    ctx.fillText('L O C K E D', TEX_W / 2, TEX_H - 16);
+    ctx.textAlign = 'left';
+  }
+
+  // Picked check, tour mode.
+  if (face.picked) {
+    ctx.fillStyle = 'rgba(154,102,238,0.96)';
+    ctx.beginPath();
+    ctx.arc(46, 46, 26, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.strokeStyle = '#ffffff';
+    ctx.lineWidth = 6;
+    ctx.lineCap = 'round';
+    ctx.lineJoin = 'round';
+    ctx.beginPath();
+    ctx.moveTo(33, 47);
+    ctx.lineTo(43, 57);
+    ctx.lineTo(60, 35);
+    ctx.stroke();
+  }
+  ctx.restore();
+
+  // Rim last, outside the clip, so it is never eaten by the art.
+  ctx.lineWidth = 4;
+  ctx.strokeStyle = style.rim;
+  roundRect(ctx, 3, 3, TEX_W - 6, TEX_H - 6, 16);
+  ctx.stroke();
+  if (face.tier === 2) {          // the diamond rim gets a second, inner hairline
+    ctx.lineWidth = 1.5;
+    ctx.strokeStyle = 'rgba(255,255,255,0.55)';
+    roundRect(ctx, 9, 9, TEX_W - 18, TEX_H - 18, 12);
+    ctx.stroke();
+  }
+
+  face.tex.needsUpdate = true;
+}
+
+/* ---------------------------------------------------------------- building */
+
+function buildFace(spec, ringIdx, i) {
+  const canvas = document.createElement('canvas');
+  canvas.width = TEX_W;
+  canvas.height = TEX_H;
+  const tex = new THREE.CanvasTexture(canvas);
+  tex.colorSpace = THREE.SRGBColorSpace;
+  tex.anisotropy = renderer.capabilities.getMaxAnisotropy();
+
+  const face = {
+    key: String(spec.key || ''),
+    title: String(spec.title || spec.key || ''),
+    blurb: String(spec.blurb || ''),
+    tier: Number(spec.tier) || 0,
+    locked: !!spec.locked,
+    picked: false,
+    img: null,
+    canvas: canvas,
+    ctx: canvas.getContext('2d'),
+    tex: tex,
+    ringIdx: ringIdx,
+    index: i,
+    mesh: null,
+    scale: 1
+  };
+  drawFace(face);
+
+  if (spec.art) {
+    const img = new Image();
+    img.onload = () => { face.img = img; drawFace(face); };
+    img.onerror = () => bridge.log('warn', 'rolodex: art failed for ' + face.key);
+    img.src = spec.art;      // data URI from the host; never a network fetch
+  }
+  return face;
+}
+
+function buildRings(ringSpecs) {
+  for (const r of S.rings) scene.remove(r.group);
+  S.rings.length = 0;
+  S.byKey.clear();
+
+  const list = ringSpecs.filter((r) => r && Array.isArray(r.faces) && r.faces.length);
+  list.forEach((spec, ri) => {
+    const faces = spec.faces;
+    const n = faces.length;
+    const step = (Math.PI * 2) / n;
+    // A radius that keeps the chord between neighbours wider than a card.
+    const radius = Math.max(MIN_RADIUS, (CARD_W * FACE_GAP) / (2 * Math.sin(Math.PI / n)));
+    const group = new THREE.Group();
+    group.position.y = ((list.length - 1) / 2 - ri) * RING_GAP;   // ring 1 on top
+
+    // One back material per ring so a ring dims as a unit.
+    const backMat = new THREE.MeshBasicMaterial({ color: 0x1a1020, transparent: true, opacity: 1 });
+
+    const built = [];
+    for (let i = 0; i < n; i++) {
+      const face = buildFace(faces[i], ri, i);
+      const a = step * i;
+      const mat = new THREE.MeshBasicMaterial({ map: face.tex, transparent: true, opacity: 1 });
+      const mesh = new THREE.Mesh(cardGeo, mat);
+      mesh.position.set(radius * Math.sin(a), 0, radius * Math.cos(a));
+      mesh.rotation.y = a;                     // normal points out of the cylinder
+      mesh.userData.face = face;
+      face.mesh = mesh;
+      group.add(mesh);
+
+      // A dark back so the far side of the ring reads as card backs, not holes.
+      const back = new THREE.Mesh(cardGeo, backMat);
+      back.position.copy(mesh.position).multiplyScalar(0.998);
+      back.rotation.y = a + Math.PI;
+      group.add(back);
+
+      built.push(face);
+      S.byKey.set(face.key, face);
+    }
+
+    scene.add(group);
+    S.rings.push({
+      n: n, step: step, radius: radius, group: group, faces: built, backMat: backMat,
+      dim: 1, dimTarget: 1, ring: Number(spec.ring) || (ri + 1)
+    });
+  });
+}
+
+/* -------------------------------------------------------------- navigation */
+
+const ring = () => S.rings[S.focus];
+
+/** Index of the card currently nearest the front of a ring. */
+function frontIndex(r) {
+  const k = Math.round(-r.group.rotation.y / r.step);
+  return ((k % r.n) + r.n) % r.n;
+}
+function frontFace(r) { return r.faces[frontIndex(r)]; }
+
+/** The continuous turn count that lands `index` at the front, shortest way. */
+function nearestTurnFor(r, index) {
+  const cur = -r.group.rotation.y / r.step;
+  const base = Math.round((cur - index) / r.n);
+  return index + base * r.n;
+}
+
+/**
+ * Snap a ring to the nearest card, or to a named turn count. Rotation is kept
+ * as an unbounded continuous value, so there is never a wrap discontinuity to
+ * tween across.
+ */
+function snapToTurn(r, turn, dur) {
+  const k = (turn === undefined || turn === null)
+    ? Math.round(-r.group.rotation.y / r.step)
+    : turn;
+  tween(r.group.rotation, 'y', -k * r.step, dur === undefined ? 0.34 : dur);
+}
+function snapToFace(r, index, dur) { snapToTurn(r, nearestTurnFor(r, index), dur); }
+
+function setFocus(next, dur) {
+  const clamped = Math.max(0, Math.min(S.rings.length - 1, next));
+  S.focus = clamped;
+  for (let i = 0; i < S.rings.length; i++) S.rings[i].dimTarget = (i === clamped ? 1 : DIM);
+  const r = ring();
+  tween(cam, 'y', r.group.position.y, dur === undefined ? 0.4 : dur);
+  tween(cam, 'z', r.radius + CAM_BACKOFF, dur === undefined ? 0.4 : dur);
+}
+
+function focusKey(key) {
+  const face = S.byKey.get(key);
+  if (!face) return;
+  setFocus(face.ringIdx);
+  snapToFace(S.rings[face.ringIdx], face.index);
+}
+
+/* ----------------------------------------------------------------- picking */
+
+function pickFace(face) {
+  if (!face || S.dead || !S.started) return;
+  if (S.mode === 'tour') {
+    const at = S.picked.indexOf(face.key);
+    if (at >= 0) {
+      S.picked.splice(at, 1);                 // an already picked face toggles off
+      face.picked = false;
+    } else {
+      if (S.picked.length >= S.picks) {
+        // Over the ask: drop the oldest so the newest choice always lands.
+        const of = S.byKey.get(S.picked.shift());
+        if (of) { of.picked = false; drawFace(of); }
+      }
+      S.picked.push(face.key);
+      face.picked = true;
+    }
+    drawFace(face);
+    refreshHud();
+  } else {
+    say({ type: 'pick', key: face.key });
+    // One ask per open: the host closes us after the pick (plan 9.2).
+    S.dead = true;
+    el.hint.textContent = 'Picked ' + face.title;
+  }
+}
+
+function requestClose() {
+  say({ type: 'close' });
+  S.dead = true;
+}
+
+/* ------------------------------------------------------------------- input */
+
+let drag = null;   // { x, y, ox, oy, axis, theta0, travel }
+
+el.stage.addEventListener('pointerdown', (e) => {
+  if (S.dead || !S.started) return;
+  try { el.stage.setPointerCapture(e.pointerId); } catch (err) { /* no capture, fine */ }
+  el.stage.classList.add('dragging');
+  drag = {
+    x: e.clientX, y: e.clientY, ox: e.clientX, oy: e.clientY,
+    axis: null, theta0: ring().group.rotation.y, travel: 0
+  };
+});
+
+el.stage.addEventListener('pointermove', (e) => {
+  if (!drag) return;
+  const dx = e.clientX - drag.ox;
+  const dy = e.clientY - drag.oy;
+  drag.travel = Math.max(drag.travel,
+    Math.abs(e.clientX - drag.x) + Math.abs(e.clientY - drag.y));
+  if (!drag.axis && (Math.abs(dx) > CLICK_SLOP || Math.abs(dy) > CLICK_SLOP)) {
+    drag.axis = Math.abs(dx) >= Math.abs(dy) ? 'x' : 'y';
+  }
+  if (drag.axis === 'x') {
+    const r = ring();
+    // Dragging right carries the cards right, the way a physical wheel would.
+    r.group.rotation.y = drag.theta0 + (dx / DRAG_PX_PER_FACE) * r.step;
+  } else if (drag.axis === 'y' && Math.abs(dy) >= STEP_PX) {
+    setFocus(S.focus + (dy > 0 ? -1 : 1));    // drag down reveals the shelf above
+    drag.oy = e.clientY;
+    drag.ox = e.clientX;
+    drag.theta0 = ring().group.rotation.y;
+  }
+});
+
+function endDrag(e) {
+  if (!drag) return;
+  const axis = drag.axis;
+  const travel = drag.travel;
+  drag = null;
+  el.stage.classList.remove('dragging');
+  if (axis === 'x') { snapToTurn(ring()); return; }
+  if (axis === null && travel <= CLICK_SLOP) clickAt(e);
+}
+el.stage.addEventListener('pointerup', endDrag);
+el.stage.addEventListener('pointercancel', () => {
+  if (!drag) return;
+  drag = null;
+  el.stage.classList.remove('dragging');
+  snapToTurn(ring());
+});
+
+/** A click on the front card picks; a click on any other card spins to it. */
+function clickAt(e) {
+  if (S.dead || !S.started) return;
+  pointerNdc.x = (e.clientX / window.innerWidth) * 2 - 1;
+  pointerNdc.y = -(e.clientY / window.innerHeight) * 2 + 1;
+  raycaster.setFromCamera(pointerNdc, camera);
+  const hits = raycaster.intersectObjects(scene.children, true);
+  for (const hit of hits) {
+    const face = hit.object.userData && hit.object.userData.face;
+    if (!face) continue;                       // a card back: ignore, keep looking
+    const r = S.rings[face.ringIdx];
+    if (face.ringIdx === S.focus && face === frontFace(r)) pickFace(face);
+    else { setFocus(face.ringIdx); snapToFace(r, face.index); }
+    return;
+  }
+}
+
+let wheelLock = 0;
+el.stage.addEventListener('wheel', (e) => {
+  if (S.dead || !S.started) return;
+  e.preventDefault();
+  const now = performance.now();
+  if (now < wheelLock) return;
+  wheelLock = now + 190;
+  setFocus(S.focus + (e.deltaY > 0 ? 1 : -1));
+}, { passive: false });
+
+window.addEventListener('keydown', (e) => {
+  if (e.key === 'Escape') { requestClose(); e.preventDefault(); return; }
+  if (S.dead || !S.started) return;
+  const r = ring();
+  switch (e.key) {
+    case 'ArrowLeft':
+      snapToTurn(r, nearestTurnFor(r, frontIndex(r)) - 1); e.preventDefault(); break;
+    case 'ArrowRight':
+      snapToTurn(r, nearestTurnFor(r, frontIndex(r)) + 1); e.preventDefault(); break;
+    case 'ArrowUp':
+      setFocus(S.focus - 1); e.preventDefault(); break;
+    case 'ArrowDown':
+      setFocus(S.focus + 1); e.preventDefault(); break;
+    case 'Enter':
+    case ' ':
+      pickFace(frontFace(r)); e.preventDefault(); break;
+    default:
+      break;
+  }
+});
+
+el.close.addEventListener('click', requestClose);
+el.done.addEventListener('click', () => {
+  if (S.picked.length < S.picks) return;
+  say({ type: 'tourDone', keys: S.picked.slice() });
+  S.dead = true;
+});
+
+/* --------------------------------------------------------------------- HUD */
+
+function refreshHud() {
+  if (S.mode === 'tour') {
+    const left = Math.max(0, S.picks - S.picked.length);
+    el.count.hidden = false;
+    el.count.textContent = left > 0 ? 'pick ' + left : S.picks + ' picked';
+    el.title.textContent = 'Pick your favourites';
+    el.done.hidden = S.picked.length < S.picks;
+  } else {
+    el.count.hidden = true;
+    el.done.hidden = true;
+    el.title.textContent = (S.slot === null || S.slot === undefined)
+      ? 'Pick a feature'
+      : 'Pick a feature for slot ' + (S.slot + 1);
+  }
+}
+
+/** Post to the host; in mock, narrate to the console and the status line. */
+function say(msg) {
+  bridge.send(msg);
+  if (MOCK) {
+    const line = JSON.stringify(msg);
+    console.log('[rolodex -> host]', line);
+    el.status.hidden = false;
+    el.status.textContent = (el.status.textContent ? el.status.textContent + '\n' : '') + line;
+  }
+}
+
+/* -------------------------------------------------------------- frame loop */
+
+let last = performance.now();
+function frame(now) {
+  requestAnimationFrame(frame);
+  const dt = Math.min(0.05, (now - last) / 1000);
+  last = now;
+  stepTweens(dt);
+
+  for (let i = 0; i < S.rings.length; i++) {
+    const r = S.rings[i];
+    r.dim = approach(r.dim, r.dimTarget, 9, dt);
+    r.backMat.opacity = r.dim;
+    const fi = (i === S.focus) ? frontIndex(r) : -1;
+    for (let j = 0; j < r.faces.length; j++) {
+      const f = r.faces[j];
+      f.mesh.material.opacity = r.dim;
+      f.scale = approach(f.scale, (j === fi) ? 1.07 : 1, 12, dt);
+      f.mesh.scale.setScalar(f.scale);
+    }
+  }
+
+  camera.position.set(0, cam.y + 0.06, cam.z);
+  camera.lookAt(0, cam.y, 0);
+  renderer.render(scene, camera);
+}
+requestAnimationFrame(frame);
+
+/* ---------------------------------------------------------------- handlers */
+
+const HANDLERS = {
+  init(m) {
+    S.mode = (m.mode === 'tour') ? 'tour' : 'edit';
+    S.picks = Math.max(1, Number(m.picks) || 1);
+    S.slot = (m.slot === null || m.slot === undefined) ? null : Number(m.slot);
+    S.lang = String(m.lang || 'en');
+    S.reduced = !!m.reducedMotion ||
+      !!(window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches);
+    S.picked.length = 0;
+
+    buildRings(Array.isArray(m.rings) ? m.rings : []);
+    if (!S.rings.length) { bridge.log('error', 'rolodex: init carried no rings'); return; }
+
+    S.started = true;
+    S.dead = false;
+    setFocus(0, 0);                 // cut to the first ring, never tween the boot
+    refreshHud();
+    bridge.log('info', 'rolodex: init mode=' + S.mode + ' rings=' + S.rings.length +
+                       ' faces=' + S.byKey.size + (S.reduced ? ' reduced' : ''));
+  },
+
+  focus(m) { if (m && m.key) focusKey(String(m.key)); },
+
+  close() { S.dead = true; S.started = false; }
+};
+
+for (const type of Object.keys(HANDLERS)) bridge.on(type, HANDLERS[type]);
+bridge.announceReady();
+
+/* --------------------------------------------------------------- mock mode */
+
+const MOCK_RINGS = [
+  { ring: 1, tier: 0, keys: ['flash', 'video', 'subliminal', 'bouncingtext', 'bubblecount', 'bubbles'] },
+  { ring: 2, tier: 0, keys: ['spiral', 'pinkfilter', 'mindwipe', 'braindrain', 'lockcard', 'goon', 'gradedintake'] },
+  { ring: 3, tier: 1, keys: ['fyp', 'blinktrainer', 'remotecontrol', 'bambitakeover', 'shelistening', 'haptics', 'awareness', 'lockdown'] },
+  { ring: 4, tier: 2, keys: ['dtrh', 'justdrop', 'arcademy', 'piecebypiece', 'gaze', 'focusgaze'] }
+];
+
+const MOCK_TITLES = {
+  flash: 'Flash Images', video: 'Mandatory Videos', subliminal: 'Subliminals',
+  bouncingtext: 'Bouncing Text', bubblecount: 'Bubble Count', bubbles: 'Bubble Pop',
+  spiral: 'Spiral Overlay', pinkfilter: 'Pink Filter', mindwipe: 'Mind Wipers',
+  braindrain: 'Brain Drain', lockcard: 'Phrase Lock', goon: 'Goon Mode',
+  gradedintake: 'Graded Intake', fyp: 'For You Page', blinktrainer: 'Blink Trainer',
+  remotecontrol: 'Remote Control', bambitakeover: 'Takeover', shelistening: 'She Is Listening',
+  haptics: 'Haptics', awareness: 'Awareness Engine', lockdown: 'Lockdown',
+  dtrh: 'Down the Rabbit Hole', justdrop: 'Just Drop', arcademy: 'The Arcademy',
+  piecebypiece: 'Piece by Piece', gaze: 'Gaze Minigame', focusgaze: 'Focus Gaze'
+};
+
+const MOCK_BLURBS = {
+  flash: 'Images that land faster than you can read them.',
+  video: 'Clips that interrupt whatever you were doing.',
+  subliminal: 'Quiet lines under everything else.',
+  bouncingtext: 'One phrase that will not sit still.',
+  bubblecount: 'Count them. Out loud, if you like.',
+  bubbles: 'Pop them before they drift away.',
+  spiral: 'A spiral over the whole screen.',
+  pinkfilter: 'Everything, a little softer.',
+  mindwipe: 'Wipers across the glass.',
+  braindrain: 'A slow pull downward.',
+  lockcard: 'Type the phrase to get your desktop back.',
+  goon: 'A long session with no exits.',
+  gradedintake: 'Answer the questions. Take the grade.',
+  fyp: 'An endless feed picked for you.',
+  blinktrainer: 'Blink when it says blink.',
+  remotecontrol: 'Someone else holds the dial.',
+  bambitakeover: 'The screen stops being yours.',
+  shelistening: 'She hears the room.',
+  haptics: 'Toys that follow along.',
+  awareness: 'The panel watches what you open.',
+  lockdown: 'A timer you cannot argue with.',
+  dtrh: 'Fall through the tunnel.',
+  justdrop: 'One door. No preview.',
+  arcademy: 'Play your way through the lessons.',
+  piecebypiece: 'A game of chess for stakes.',
+  gaze: 'Hold your eyes where it says.',
+  focusgaze: 'Focus tracked, corrected, scored.'
+};
+
+/** Fixture `init`: the 27 real keys, placeholder art, a stable locked mix. */
+function mockInit() {
+  let seed = 7;
+  const rand = () => (seed = (seed * 1103515245 + 12345) & 0x7fffffff) / 0x7fffffff;
+  const tour = QS.get('mock') === 'tour';
+  return {
+    type: 'init',
+    rings: MOCK_RINGS.map((r) => ({
+      ring: r.ring,
+      faces: r.keys.map((k) => ({
+        key: k,
+        title: MOCK_TITLES[k] || k,
+        blurb: MOCK_BLURBS[k] || 'A feature of the panel.',
+        tier: r.tier,
+        locked: r.tier > 0 ? rand() < 0.55 : rand() < 0.12,
+        art: null                       // no real images: drawFace paints a placeholder
+      }))
+    })),
+    slot: 4,
+    mode: tour ? 'tour' : 'edit',
+    picks: tour ? 3 : 1,
+    reducedMotion: QS.get('reduced') === '1',
+    lang: 'en'
+  };
+}
+
+if (MOCK) {
+  const msg = mockInit();
+  HANDLERS.init(msg);
+  el.status.hidden = false;
+  el.status.textContent = '[mock] mode=' + msg.mode + ' picks=' + msg.picks +
+    ' slot=' + msg.slot + ' faces=' + S.byKey.size;
+  console.log('[rolodex] mock init', msg);
+}

--- a/ConditioningControlPanel/Resources/web/rolodex/style.css
+++ b/ConditioningControlPanel/Resources/web/rolodex/style.css
@@ -1,0 +1,148 @@
+/* ============================================================================
+ * style.css - the rolodex HUD. The 3D layer paints itself; everything here is
+ * chrome laid over it.
+ *
+ * Dark first, always: the host swaps a WebView2 HWND straight over the velvet
+ * feature grid, and an HWND cannot fade in, so a single white frame would read
+ * as a flash. html and body carry the velvet colour before any script runs.
+ * ==========================================================================*/
+
+:root {
+  --velvet-0: #0b0710;   /* deepest, the canvas clear colour in rolodex.js too */
+  --velvet-1: #150c1d;
+  --ink:      #f3ecff;
+  --ink-dim:  #b9a9cf;
+  --gold:     #e2b755;
+  --lab:      #bef0ff;
+  --accent:   #c48cff;
+}
+
+html, body {
+  margin: 0;
+  padding: 0;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  background: var(--velvet-0);
+  color: var(--ink);
+  font-family: "Segoe UI", system-ui, -apple-system, sans-serif;
+  -webkit-user-select: none;
+  user-select: none;
+  overscroll-behavior: none;
+}
+
+#stage {
+  position: fixed;
+  inset: 0;
+  display: block;
+  width: 100%;
+  height: 100%;
+  touch-action: none;      /* we own drag; never let the page pan */
+  cursor: grab;
+}
+#stage.dragging { cursor: grabbing; }
+
+/* A vignette sold in CSS rather than in a postprocessing pass: the rings read
+   as lit from the middle and the HWND edges stay dark. */
+#hud {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;    /* children opt back in */
+  background: radial-gradient(ellipse at 50% 46%,
+              rgba(0,0,0,0) 38%, rgba(6,3,10,0.55) 78%, rgba(6,3,10,0.9) 100%);
+}
+
+#bar {
+  position: absolute;
+  top: 0; left: 0; right: 0;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 14px 18px;
+}
+
+#title {
+  font-size: 15px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--ink-dim);
+}
+
+#count {
+  font-size: 15px;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  color: var(--accent);
+  padding: 3px 11px;
+  border: 1px solid rgba(196,140,255,0.45);
+  border-radius: 999px;
+  background: rgba(196,140,255,0.10);
+}
+
+#btn-close {
+  margin-left: auto;
+  pointer-events: auto;
+  width: 34px;
+  height: 34px;
+  line-height: 1;
+  font-size: 22px;
+  color: var(--ink-dim);
+  background: rgba(255,255,255,0.05);
+  border: 1px solid rgba(255,255,255,0.12);
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background 120ms linear, color 120ms linear;
+}
+#btn-close:hover { background: rgba(255,255,255,0.12); color: var(--ink); }
+
+#hint {
+  position: absolute;
+  left: 0; right: 0;
+  bottom: 16px;
+  text-align: center;
+  font-size: 12px;
+  letter-spacing: 0.05em;
+  color: rgba(185,169,207,0.6);
+}
+
+#btn-done {
+  position: absolute;
+  left: 50%;
+  bottom: 46px;
+  transform: translateX(-50%);
+  pointer-events: auto;
+  padding: 10px 30px;
+  font-size: 14px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #180d22;
+  background: linear-gradient(180deg, #e6c6ff 0%, var(--accent) 100%);
+  border: 0;
+  border-radius: 999px;
+  box-shadow: 0 6px 24px rgba(150,80,220,0.45);
+  cursor: pointer;
+}
+#btn-done:hover { filter: brightness(1.08); }
+
+/* Mock harness only. Never visible under the host. */
+#status {
+  position: absolute;
+  left: 14px;
+  bottom: 40px;
+  max-width: 62vw;
+  font-family: Consolas, "Cascadia Mono", monospace;
+  font-size: 12px;
+  line-height: 1.5;
+  color: #8de8c0;
+  background: rgba(0,0,0,0.45);
+  border-left: 2px solid #8de8c0;
+  padding: 6px 10px;
+  white-space: pre-wrap;
+}
+
+/* The host also passes reducedMotion in init; this covers a plain browser. */
+@media (prefers-reduced-motion: reduce) {
+  #btn-close, #btn-done { transition: none; }
+}


### PR DESCRIPTION
Stack 6 of 7 (base: D). Web only, no C# change; ships under the existing `Resources\web\**` Content glob.

## What

`Resources/web/rolodex/`: `index.html`, `rolodex.js` (722 lines, three.js r169 via the relative vendor import map), `style.css`, `bridge.js` (verbatim dtrh copy), `CLAUDE.md` (the message contract).

Four stacked rings, one per tier band, flat 16:9 canvas-textured cards (art, title, blurb, tier badge, lockband). Drag or arrows rotate the focused ring with snap; wheel or up/down step rings; Enter or click picks; Esc closes. Tour mode counts picks and shows Done at N. Reduced motion collapses every tween.

Contract: host sends `init { rings, slot, mode, picks, reducedMotion, lang }`, `focus`, `close`; page sends `ready`, `pick`, `tourDone`, `close`, `log`.

## Verified

Headless Chrome over CDP: `?mock=1`, `?mock=tour`, `?mock=1&reduced=1` build 27 faces with zero page errors; a scripted tour run produced the expected `tourDone` keys and `close`. Open `index.html?mock=1` from a static server on the `Resources/web` root to try it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VW2mrHU1ZQQ1RNTumPsrfm
