### PR TITLE
feat(dashboard): the rolodex over the wall, cloud re-render and first-run tour (phase F)

### DIFF
--- a/ConditioningControlPanel/Controls/Dashboard/RolodexEmbedView.cs
+++ b/ConditioningControlPanel/Controls/Dashboard/RolodexEmbedView.cs
@@ -1,0 +1,366 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using ConditioningControlPanel.Services.Dashboard;
+using Microsoft.Web.WebView2.Core;
+using Microsoft.Web.WebView2.Wpf;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace ConditioningControlPanel.Controls.Dashboard
+{
+    /// <summary>
+    /// THE ROLODEX EMBED - the WebView2 that lays the three.js feature picker straight over the
+    /// Home wall (<c>Resources\web\rolodex</c>, plan 9.1). Same shape as
+    /// <see cref="ConditioningControlPanel.Controls.SpiralEmbedView"/>: probe the runtime before
+    /// building anything, own the environment, hand the page everything it draws over postMessage,
+    /// and fail soft into the picker that has no browser in it.
+    ///
+    /// <para>AIRSPACE - READ BEFORE MOVING THIS. A WebView2 is a native child HWND: it does not
+    /// clip to rounded corners, does not fade with an opacity animation, and CANNOT BE DRAWN OVER.
+    /// That last one is a rule this host obeys twice. Everything under the rolodex is parked while
+    /// it is up (the mosaic canvas, the lock ribbon, the nine cells and their pencils), and the
+    /// Replace / Split question that follows a pick is asked only AFTER the view is gone - a WPF
+    /// dialog over this rectangle would be a dialog nobody can see. See SpiralEmbedView:48-53 for
+    /// the long version.</para>
+    ///
+    /// <para>NO HOST OBJECTS, EVER. postMessage both ways, like every other hosted surface in the
+    /// app (page CLAUDE.md §7.4). The page is handed art as data URIs and localized strings; it
+    /// has no way to ask this process for anything else.</para>
+    /// </summary>
+    public sealed class RolodexEmbedView : Grid, IDisposable
+    {
+        /// <summary>The virtual host the whole <c>Resources\web</c> tree already answers on.</summary>
+        public const string PageHost = "ccp.game";
+
+        /// <summary>Navigation is locked to this. The page has no links; anything else loading
+        /// here is either a mistake or something wearing the app's chrome.</summary>
+        public const string PageUrl = "https://" + PageHost + "/rolodex/index.html";
+
+        /// <summary>Its own profile. The picker shares nothing with the tunnel or the Arcademy -
+        /// it has no cookies, no storage and no network, so a folder of its own costs a directory
+        /// and buys a browser that cannot be wedged by somebody else's crash.</summary>
+        private const string UserDataFolderName = "browser_data_rolodex";
+
+        private readonly List<string> _pending = new();
+        private WebView2? _web;
+        private Window? _window;
+        private bool _initStarted;
+        private bool _disposed;
+
+        /// <summary>True once the page has posted <c>ready</c> and the queue has been flushed.</summary>
+        public bool IsReady { get; private set; }
+
+        /// <summary>Edit mode, one pick, exactly once. The page goes inert after it and the host
+        /// closes the view (page CLAUDE.md §2).</summary>
+        public event Action<string>? Picked;
+
+        /// <summary>Tour mode, the keys in pick order. Fires once; a <see cref="CloseRequested"/>
+        /// may still follow it, which is why closing has to be idempotent.</summary>
+        public event Action<IReadOnlyList<string>>? TourDone;
+
+        /// <summary>Esc, the close button, or the page giving up. The host owns the teardown.</summary>
+        public event Action? CloseRequested;
+
+        /// <summary>No runtime, no core, a dead process or a navigation failure. The host latches
+        /// <see cref="RolodexAvailability"/> on this and never asks again this session.</summary>
+        public event Action<string>? InitFailed;
+
+        public RolodexEmbedView()
+        {
+            // The page's own ground colour, before a single byte of it has loaded. There is no
+            // transparent WebView2 and no fade into one, so the first frame has to already be the
+            // right darkness or the wall flashes (page CLAUDE.md §7.1).
+            Background = new SolidColorBrush(Color.FromRgb(0x0B, 0x07, 0x10));
+        }
+
+        // ============================== lifecycle ==============================
+
+        /// <summary>
+        /// Build the browser and navigate. Safe to call twice; only the first does anything.
+        /// Returns immediately, and every failure path ends at <see cref="InitFailed"/> - including
+        /// the runtime probe, which is SYNCHRONOUS, so a machine with no WebView2 can report back
+        /// before this call has returned.
+        /// </summary>
+        public void Start()
+        {
+            if (_initStarted || _disposed) return;
+            _initStarted = true;
+            HookWindow();
+            _ = InitAsync();
+        }
+
+        private async Task InitAsync()
+        {
+            try
+            {
+                // PROBE FIRST, like the spiral embed. An install with no runtime should reach the
+                // flat picker without ever constructing a control or creating a profile folder.
+                string? version = null;
+                try { version = CoreWebView2Environment.GetAvailableBrowserVersionString(); }
+                catch (Exception ex) { Fail("WebView2 runtime not installed: " + ex.Message); return; }
+                if (string.IsNullOrEmpty(version)) { Fail("WebView2 runtime not installed"); return; }
+
+                _web = new WebView2
+                {
+                    DefaultBackgroundColor = System.Drawing.Color.FromArgb(0x0B, 0x07, 0x10),
+                    HorizontalAlignment = HorizontalAlignment.Stretch,
+                    VerticalAlignment = VerticalAlignment.Stretch,
+                };
+                Children.Add(_web);
+
+                var userDataFolder = Path.Combine(App.UserDataPath, UserDataFolderName);
+                Directory.CreateDirectory(userDataFolder);
+
+                // The app's anti-MPO / anti-occlusion pair, merged through the one composer so a
+                // command line never names --disable-features twice (only the last copy survives,
+                // and this page spins on rAF: an occlusion tracker that decides a tab-docked view
+                // is covered would freeze the rings mid-turn). PrefersReducedMotionArgument is the
+                // same override every other hosted surface gets - the page ALSO receives the
+                // app's own flag in `init`, and honours whichever is stricter.
+                var options = new CoreWebView2EnvironmentOptions
+                {
+                    AdditionalBrowserArguments = ChaosWebViewHost.ComposeBrowserArguments(
+                        "--disable-direct-composition-video-overlays "
+                        + "--disable-features=CalculateNativeWinOcclusion "
+                        + "--disable-backgrounding-occluded-windows",
+                        ChaosWebViewHost.PrefersReducedMotionArgument(
+                            App.Settings?.Current?.MotionLevel ?? Models.MotionLevel.Full)),
+                };
+
+                var env = await CoreWebView2Environment
+                    .CreateAsync(browserExecutableFolder: null, userDataFolder: userDataFolder, options: options)
+                    .ConfigureAwait(true);
+                if (_disposed) return;
+
+                await _web.EnsureCoreWebView2Async(env).ConfigureAwait(true);
+                if (_disposed) return;
+
+                var core = _web.CoreWebView2;
+                if (core == null) { Fail("WebView2 core was null after Ensure"); return; }
+
+                var s = core.Settings;
+                s.AreDevToolsEnabled = false;
+                s.AreDefaultContextMenusEnabled = false;
+                s.IsStatusBarEnabled = false;
+                s.AreBrowserAcceleratorKeysEnabled = false;
+                s.IsZoomControlEnabled = false;
+                s.IsBuiltInErrorPageEnabled = false;
+                s.AreDefaultScriptDialogsEnabled = false;
+                s.IsWebMessageEnabled = true;
+
+                // Allow, not DenyCors: the card faces are drawn into a canvas from these images,
+                // and a tainted canvas cannot be read back (DtrhHostService.cs:107-113).
+                var webRoot = Path.Combine(AppContext.BaseDirectory, "Resources", "web");
+                if (Directory.Exists(webRoot))
+                {
+                    core.SetVirtualHostNameToFolderMapping(
+                        PageHost, webRoot, CoreWebView2HostResourceAccessKind.Allow);
+                }
+                else
+                {
+                    // Silently: a build with no web folder has bigger problems than this picker,
+                    // and the navigation below fails into the flat one a beat later anyway.
+                    App.Logger?.Debug("[Rolodex] no Resources/web folder to map");
+                }
+
+                core.NavigationStarting += OnNavigationStarting;
+                core.NavigationCompleted += OnNavigationCompleted;
+                core.WebMessageReceived += OnWebMessageReceived;
+                core.ProcessFailed += OnProcessFailed;
+
+                core.Navigate(PageUrl);
+            }
+            catch (Exception ex)
+            {
+                Fail(ex.Message);
+            }
+        }
+
+        /// <summary>Locked to the page's own origin. It has no links and fetches nothing, so any
+        /// other navigation is cancelled rather than followed.</summary>
+        private void OnNavigationStarting(object? sender, CoreWebView2NavigationStartingEventArgs e)
+        {
+            if (string.IsNullOrEmpty(e.Uri) ||
+                !e.Uri.StartsWith("https://" + PageHost + "/", StringComparison.OrdinalIgnoreCase))
+            {
+                e.Cancel = true;
+            }
+        }
+
+        private void OnNavigationCompleted(object? sender, CoreWebView2NavigationCompletedEventArgs e)
+        {
+            if (!e.IsSuccess) Fail("navigation failed: " + e.WebErrorStatus);
+        }
+
+        private void OnProcessFailed(object? sender, CoreWebView2ProcessFailedEventArgs e)
+            => Fail("browser process failed: " + e.ProcessFailedKind);
+
+        // ============================== the bridge ==============================
+
+        /// <summary>
+        /// Send a message. Queued until the page says <c>ready</c> and flushed in order - the
+        /// whole scene arrives in one <c>init</c>, and the host builds it the instant the view is
+        /// in the tree rather than waiting on a handshake it would then have to remember.
+        /// </summary>
+        public void Post(object? message)
+        {
+            if (_disposed || message == null) return;
+            try
+            {
+                var json = message is JToken token
+                    ? token.ToString(Formatting.None)
+                    : JsonConvert.SerializeObject(message);
+
+                if (IsReady && _web?.CoreWebView2 != null) _web.CoreWebView2.PostWebMessageAsJson(json);
+                else _pending.Add(json);
+            }
+            catch (Exception ex) { App.Logger?.Debug("[Rolodex] Post: {E}", ex.Message); }
+        }
+
+        private void OnWebMessageReceived(object? sender, CoreWebView2WebMessageReceivedEventArgs e)
+        {
+            // The browser's message loop. Nothing here may block or go modal - which is also why
+            // the host closes the view before it asks the user anything.
+            try
+            {
+                var msg = RolodexBridgeRule.Parse(e.WebMessageAsJson);
+                switch (msg.Kind)
+                {
+                    case RolodexMessageKind.Ready:
+                        IsReady = true;
+                        foreach (var queued in _pending)
+                        {
+                            try { _web?.CoreWebView2?.PostWebMessageAsJson(queued); }
+                            catch (Exception ex) { Diag.Swallowed(ex, "the page went away mid-flush"); }
+                        }
+                        _pending.Clear();
+                        break;
+
+                    case RolodexMessageKind.Pick:
+                        Raise(() => Picked?.Invoke(msg.Key!), "Picked");
+                        break;
+
+                    case RolodexMessageKind.TourDone:
+                        Raise(() => TourDone?.Invoke(msg.Keys ?? Array.Empty<string>()), "TourDone");
+                        break;
+
+                    case RolodexMessageKind.Close:
+                        Raise(() => CloseRequested?.Invoke(), "CloseRequested");
+                        break;
+
+                    case RolodexMessageKind.Log:
+                        App.Logger?.Write(RolodexBridgeRule.LogLevel(msg.Level), "[Rolodex][page]: {Msg}", msg.Text);
+                        break;
+                }
+            }
+            catch (Exception ex) { App.Logger?.Debug("[Rolodex] OnWebMessageReceived: {E}", ex.Message); }
+        }
+
+        /// <summary>A throwing host handler must not take the browser down with it.</summary>
+        private static void Raise(Action raise, string what)
+        {
+            try { raise(); }
+            catch (Exception ex) { App.Logger?.Warning(ex, "[Rolodex] {What} handler threw", what); }
+        }
+
+        // ============================== render visibility ==============================
+
+        private void HookWindow()
+        {
+            try
+            {
+                _window = Window.GetWindow(this);
+                if (_window != null) _window.StateChanged += OnWindowStateChanged;
+            }
+            catch (Exception ex) { App.Logger?.Debug("[Rolodex] HookWindow: {E}", ex.Message); }
+        }
+
+        /// <summary>
+        /// A minimize / restore cycle can leave the controller's IsVisible stuck false, and a
+        /// picker that came back as a black rectangle is a picker the user has to guess at. Same
+        /// two-lever bounce <c>ChaosWebViewHost.KickRenderVisibility</c> ships: set the controller
+        /// directly through the SDK's internals (allowed to miss on a future SDK), then bounce the
+        /// ELEMENT's Visibility so the wrapper re-pushes visibility whichever way it was stuck.
+        /// </summary>
+        private void OnWindowStateChanged(object? sender, EventArgs e)
+        {
+            if (_disposed || _web == null || _window == null) return;
+            if (_window.WindowState == WindowState.Minimized) return;
+
+            try
+            {
+                bool? controllerWas = null;
+                try
+                {
+                    var t = _web.GetType();
+                    object? ctrl = t.GetProperty("CoreWebView2Controller",
+                            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic
+                            | System.Reflection.BindingFlags.Public)?.GetValue(_web)
+                        ?? t.GetField("_coreWebView2Controller",
+                            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)?.GetValue(_web);
+                    if (ctrl is CoreWebView2Controller c)
+                    {
+                        controllerWas = c.IsVisible;
+                        c.IsVisible = true;
+                    }
+                }
+                catch (Exception ex) { Diag.Swallowed(ex, "SDK internals moved, the element bounce still re-drives the wrapper"); }
+
+                _web.Visibility = Visibility.Hidden;
+                _web.Visibility = Visibility.Visible;
+
+                App.Logger?.Information("[Rolodex] render visibility kicked (window restored; controller={Ctrl})",
+                    controllerWas?.ToString() ?? "n/a");
+            }
+            catch (Exception ex) { App.Logger?.Debug("[Rolodex] KickRenderVisibility: {E}", ex.Message); }
+        }
+
+        // ============================== teardown ==============================
+
+        private void Fail(string reason)
+        {
+            App.Logger?.Information("[Rolodex] embed unavailable: {Reason} - falling back", reason);
+            Dispose();
+            Raise(() => InitFailed?.Invoke(reason), "InitFailed");
+        }
+
+        /// <summary>Tear the browser down and empty the view. Idempotent, and the ONE way an HWND
+        /// on this wall is ever allowed to end.</summary>
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _disposed = true;
+            IsReady = false;
+            _pending.Clear();
+            try
+            {
+                if (_window != null)
+                {
+                    _window.StateChanged -= OnWindowStateChanged;
+                    _window = null;
+                }
+
+                if (_web != null)
+                {
+                    var core = _web.CoreWebView2;
+                    if (core != null)
+                    {
+                        core.NavigationStarting -= OnNavigationStarting;
+                        core.NavigationCompleted -= OnNavigationCompleted;
+                        core.WebMessageReceived -= OnWebMessageReceived;
+                        core.ProcessFailed -= OnProcessFailed;
+                    }
+                    Children.Remove(_web);
+                    _web.Dispose();
+                    _web = null;
+                }
+            }
+            catch (Exception ex) { App.Logger?.Debug("[Rolodex] dispose: {E}", ex.Message); }
+        }
+    }
+}

--- a/ConditioningControlPanel/Controls/Dashboard/RolodexEmbedView.cs
+++ b/ConditioningControlPanel/Controls/Dashboard/RolodexEmbedView.cs
@@ -46,11 +46,25 @@ namespace ConditioningControlPanel.Controls.Dashboard
         /// and buys a browser that cannot be wedged by somebody else's crash.</summary>
         private const string UserDataFolderName = "browser_data_rolodex";
 
+        /// <summary>Two strikes, the same stand-down BrowserVideoEngine.ReportProcessFailure runs
+        /// app-wide: one dead renderer is bad luck, a second one in the same session is a machine
+        /// whose browser will not stay up, and the flat shelf takes the rest of the launch.</summary>
+        private const int MaxProcessFailures = 2;
+
+        private static int _processFailures;
+
         private readonly List<string> _pending = new();
         private WebView2? _web;
         private Window? _window;
         private bool _initStarted;
         private bool _disposed;
+
+        /// <summary>True once the page itself has loaded. A cancelled navigation AFTER that is the
+        /// lock in <see cref="OnNavigationStarting"/> doing its job, not the picker failing.</summary>
+        private bool _navigated;
+
+        /// <summary>Page log lines spent this open. See <see cref="RolodexBridgeRule.MaxLogLinesPerOpen"/>.</summary>
+        private int _logLines;
 
         /// <summary>True once the page has posted <c>ready</c> and the queue has been flushed.</summary>
         public bool IsReady { get; private set; }
@@ -66,9 +80,16 @@ namespace ConditioningControlPanel.Controls.Dashboard
         /// <summary>Esc, the close button, or the page giving up. The host owns the teardown.</summary>
         public event Action? CloseRequested;
 
-        /// <summary>No runtime, no core, a dead process or a navigation failure. The host latches
-        /// <see cref="RolodexAvailability"/> on this and never asks again this session.</summary>
+        /// <summary>No runtime, no core, or an environment that would not build. The host latches
+        /// <see cref="RolodexAvailability"/> on this and never asks again this session, because
+        /// none of those come back before a restart.</summary>
         public event Action<string>? InitFailed;
+
+        /// <summary>This open is over and the flat shelf takes the question - but the session is
+        /// not over. A page that failed to load once, or a renderer that died once, says nothing
+        /// about whether the next pencil can open a rolodex, and latching on either turned one bad
+        /// second into a launch with no 3D picker in it.</summary>
+        public event Action<string>? OpenAborted;
 
         public RolodexEmbedView()
         {
@@ -116,20 +137,22 @@ namespace ConditioningControlPanel.Controls.Dashboard
                 var userDataFolder = Path.Combine(App.UserDataPath, UserDataFolderName);
                 Directory.CreateDirectory(userDataFolder);
 
-                // The app's anti-MPO / anti-occlusion pair, merged through the one composer so a
-                // command line never names --disable-features twice (only the last copy survives,
-                // and this page spins on rAF: an occlusion tracker that decides a tab-docked view
-                // is covered would freeze the rings mid-turn). PrefersReducedMotionArgument is the
-                // same override every other hosted surface gets - the page ALSO receives the
-                // app's own flag in `init`, and honours whichever is stricter.
+                // The app's anti-MPO / anti-occlusion pair, and NOTHING THAT VARIES. This page
+                // spins on rAF, so an occlusion tracker that decided a tab-docked view was covered
+                // would freeze the rings mid-turn - but the string itself has to be the same on
+                // every open, the way SpiralEmbedView's is. WebView2 ties a user-data folder to the
+                // options its environment was built with, and a second environment asking for the
+                // same folder with a different command line fails to create at all. The
+                // reduced-motion override used to ride along here and it flips with a setting the
+                // user can change between two opens, so a motion toggle could leave this picker
+                // permanently unable to start. Reduced motion travels in the `init` message
+                // instead (`reducedMotion`), which is the copy the page actually reads.
                 var options = new CoreWebView2EnvironmentOptions
                 {
-                    AdditionalBrowserArguments = ChaosWebViewHost.ComposeBrowserArguments(
-                        "--disable-direct-composition-video-overlays "
-                        + "--disable-features=CalculateNativeWinOcclusion "
-                        + "--disable-backgrounding-occluded-windows",
-                        ChaosWebViewHost.PrefersReducedMotionArgument(
-                            App.Settings?.Current?.MotionLevel ?? Models.MotionLevel.Full)),
+                    AdditionalBrowserArguments =
+                        "--disable-direct-composition-video-overlays " +
+                        "--disable-features=CalculateNativeWinOcclusion " +
+                        "--disable-backgrounding-occluded-windows",
                 };
 
                 var env = await CoreWebView2Environment
@@ -189,16 +212,40 @@ namespace ConditioningControlPanel.Controls.Dashboard
                 !e.Uri.StartsWith("https://" + PageHost + "/", StringComparison.OrdinalIgnoreCase))
             {
                 e.Cancel = true;
+                App.Logger?.Debug("[Rolodex] navigation refused: {Uri}", e.Uri);
             }
         }
 
         private void OnNavigationCompleted(object? sender, CoreWebView2NavigationCompletedEventArgs e)
         {
-            if (!e.IsSuccess) Fail("navigation failed: " + e.WebErrorStatus);
+            if (e.IsSuccess) { _navigated = true; return; }
+
+            // A navigation THIS VIEW cancelled is not a failure worth reporting: the lock above
+            // refuses everything that is not the page, and a refusal arrives here looking exactly
+            // like a load that did not work. Once the page is up, nothing that fails after it is
+            // the picker failing to start either.
+            if (_navigated || e.WebErrorStatus == CoreWebView2WebErrorStatus.OperationCanceled)
+            {
+                App.Logger?.Debug("[Rolodex] navigation ended {Status} (page already up: {Up})",
+                                  e.WebErrorStatus, _navigated);
+                return;
+            }
+
+            // One bad load closes THIS open, and the next pencil is allowed to try again.
+            Abort("navigation failed: " + e.WebErrorStatus);
         }
 
         private void OnProcessFailed(object? sender, CoreWebView2ProcessFailedEventArgs e)
-            => Fail("browser process failed: " + e.ProcessFailedKind);
+        {
+            _processFailures++;
+            var reason = "browser process failed: " + e.ProcessFailedKind;
+            if (_processFailures >= MaxProcessFailures)
+            {
+                Fail(reason + " (strike " + _processFailures + " this session)");
+                return;
+            }
+            Abort(reason);
+        }
 
         // ============================== the bridge ==============================
 
@@ -254,11 +301,33 @@ namespace ConditioningControlPanel.Controls.Dashboard
                         break;
 
                     case RolodexMessageKind.Log:
-                        App.Logger?.Write(RolodexBridgeRule.LogLevel(msg.Level), "[Rolodex][page]: {Msg}", msg.Text);
+                        WritePageLog(msg);
                         break;
                 }
             }
             catch (Exception ex) { App.Logger?.Debug("[Rolodex] OnWebMessageReceived: {E}", ex.Message); }
+        }
+
+        /// <summary>
+        /// One page log line, cut short and counted. A page stuck in a loop can post faster than
+        /// the log can be written, and the file it would fill is the one users are asked to attach
+        /// to a bug report - so a line is capped and an open has a budget, after which the host
+        /// says so once and stops listening.
+        /// </summary>
+        private void WritePageLog(RolodexMessage msg)
+        {
+            if (_logLines > RolodexBridgeRule.MaxLogLinesPerOpen) return;
+
+            _logLines++;
+            if (_logLines > RolodexBridgeRule.MaxLogLinesPerOpen)
+            {
+                App.Logger?.Information("[Rolodex][page]: {Max} log lines this open - the rest is dropped",
+                                        RolodexBridgeRule.MaxLogLinesPerOpen);
+                return;
+            }
+
+            App.Logger?.Write(RolodexBridgeRule.LogLevel(msg.Level), "[Rolodex][page]: {Msg}",
+                              RolodexBridgeRule.ClampPageLog(msg.Text));
         }
 
         /// <summary>A throwing host handler must not take the browser down with it.</summary>
@@ -322,12 +391,27 @@ namespace ConditioningControlPanel.Controls.Dashboard
 
         // ============================== teardown ==============================
 
+        /// <summary>The permanent one: there is no rolodex on this machine this session. Only the
+        /// runtime probe and an environment that will not build get here.</summary>
         private void Fail(string reason)
         {
             App.Logger?.Information("[Rolodex] embed unavailable: {Reason} - falling back", reason);
             Dispose();
             Raise(() => InitFailed?.Invoke(reason), "InitFailed");
         }
+
+        /// <summary>The one-shot one: this open is over, the flat shelf answers the question this
+        /// time, and nothing is latched.</summary>
+        private void Abort(string reason)
+        {
+            if (_disposed) return;
+            App.Logger?.Information("[Rolodex] this open is over: {Reason} - the flat picker takes it", reason);
+            Dispose();
+            Raise(() => OpenAborted?.Invoke(reason), "OpenAborted");
+        }
+
+        /// <summary>Tests only. The two-strike count is a session fact, not a product setting.</summary>
+        internal static void ResetProcessFailuresForTests() => _processFailures = 0;
 
         /// <summary>Tear the browser down and empty the view. Idempotent, and the ONE way an HWND
         /// on this wall is ever allowed to end.</summary>

--- a/ConditioningControlPanel/Localization/Languages/de.json
+++ b/ConditioningControlPanel/Localization/Languages/de.json
@@ -5124,6 +5124,8 @@
   "dash_picker_split": "Teilen",
   "dash_picker_cancel": "Abbrechen",
   "dash_pencil_tip": "Diese Kachel ändern",
+  "dash_tour_title": "Deine Startwand",
+  "dash_tour_pick_three": "Wähle drei zum Anfang.",
   "dash_toggle_hint_rail": "Rechtsklick = an/aus",
   "inbox_programs_title": "Programme",
   "inbox_programs_summary": "was ein Programm ist, und die Auswahl von heute.",

--- a/ConditioningControlPanel/Localization/Languages/en.json
+++ b/ConditioningControlPanel/Localization/Languages/en.json
@@ -119,6 +119,8 @@
   "dash_picker_split": "Split",
   "dash_picker_cancel": "Cancel",
   "dash_pencil_tip": "Change this tile",
+  "dash_tour_title": "Your Home wall",
+  "dash_tour_pick_three": "Pick three to start with.",
   "dash_toggle_hint_rail": "right-click = on/off",
   "inbox_programs_title": "Programs",
   "inbox_programs_summary": "what a program is, and today's pick.",

--- a/ConditioningControlPanel/Localization/Languages/es.json
+++ b/ConditioningControlPanel/Localization/Languages/es.json
@@ -5115,6 +5115,8 @@
   "dash_picker_split": "Dividir",
   "dash_picker_cancel": "Cancelar",
   "dash_pencil_tip": "Cambiar esta casilla",
+  "dash_tour_title": "Tu muro de inicio",
+  "dash_tour_pick_three": "Elige tres para empezar.",
   "dash_toggle_hint_rail": "clic derecho = on/off",
   "inbox_programs_title": "Programas",
   "inbox_programs_summary": "qué es un programa, y la elección de hoy.",

--- a/ConditioningControlPanel/Localization/Languages/fr.json
+++ b/ConditioningControlPanel/Localization/Languages/fr.json
@@ -5124,6 +5124,8 @@
   "dash_picker_split": "Partager",
   "dash_picker_cancel": "Annuler",
   "dash_pencil_tip": "Changer cette tuile",
+  "dash_tour_title": "Votre mur d'accueil",
+  "dash_tour_pick_three": "Choisissez-en trois pour commencer.",
   "dash_toggle_hint_rail": "clic droit = on/off",
   "inbox_programs_title": "Programmes",
   "inbox_programs_summary": "ce qu'est un programme, et le choix du jour.",

--- a/ConditioningControlPanel/Localization/Languages/ja.json
+++ b/ConditioningControlPanel/Localization/Languages/ja.json
@@ -5115,6 +5115,8 @@
   "dash_picker_split": "分割",
   "dash_picker_cancel": "キャンセル",
   "dash_pencil_tip": "このタイルを変更",
+  "dash_tour_title": "ホームの壁",
+  "dash_tour_pick_three": "まずは3つ選んでください。",
   "dash_toggle_hint_rail": "右クリック = オン/オフ",
   "inbox_programs_title": "プログラム",
   "inbox_programs_summary": "プログラムとは何か、そして今日のおすすめ。",

--- a/ConditioningControlPanel/Localization/Languages/ko.json
+++ b/ConditioningControlPanel/Localization/Languages/ko.json
@@ -5122,6 +5122,8 @@
   "dash_picker_split": "분할",
   "dash_picker_cancel": "취소",
   "dash_pencil_tip": "이 타일 변경",
+  "dash_tour_title": "홈 화면 벽",
+  "dash_tour_pick_three": "먼저 세 개를 골라 주세요.",
   "dash_toggle_hint_rail": "우클릭 = 켜기/끄기",
   "inbox_programs_title": "프로그램",
   "inbox_programs_summary": "프로그램이 무엇인지, 그리고 오늘의 추천.",

--- a/ConditioningControlPanel/Localization/Languages/pt-BR.json
+++ b/ConditioningControlPanel/Localization/Languages/pt-BR.json
@@ -5123,6 +5123,8 @@
   "dash_picker_split": "Dividir",
   "dash_picker_cancel": "Cancelar",
   "dash_pencil_tip": "Trocar este bloco",
+  "dash_tour_title": "Seu mural inicial",
+  "dash_tour_pick_three": "Escolha três para começar.",
   "dash_toggle_hint_rail": "clique direito = liga/desliga",
   "inbox_programs_title": "Programas",
   "inbox_programs_summary": "o que é um programa, e a escolha de hoje.",

--- a/ConditioningControlPanel/Localization/Languages/ru.json
+++ b/ConditioningControlPanel/Localization/Languages/ru.json
@@ -5122,6 +5122,8 @@
   "dash_picker_split": "Разделить",
   "dash_picker_cancel": "Отмена",
   "dash_pencil_tip": "Изменить эту плитку",
+  "dash_tour_title": "Ваша главная стена",
+  "dash_tour_pick_three": "Выберите три для начала.",
   "dash_toggle_hint_rail": "ПКМ = вкл/выкл",
   "inbox_programs_title": "Программы",
   "inbox_programs_summary": "что такое программа и выбор на сегодня.",

--- a/ConditioningControlPanel/Localization/Languages/zh-CN.json
+++ b/ConditioningControlPanel/Localization/Languages/zh-CN.json
@@ -5580,6 +5580,8 @@
   "dash_picker_split": "拆分",
   "dash_picker_cancel": "取消",
   "dash_pencil_tip": "更换此磁贴",
+  "dash_tour_title": "你的主页墙",
+  "dash_tour_pick_three": "先挑三个开始。",
   "dash_toggle_hint_rail": "右键 = 开/关",
   "inbox_programs_title": "计划",
   "inbox_programs_summary": "什么是计划，以及今日推荐。",

--- a/ConditioningControlPanel/MainWindow/MainWindow.DashboardEdit.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.DashboardEdit.cs
@@ -229,7 +229,11 @@ namespace ConditioningControlPanel
                 pencil.Opacity = 0;
             }
 
-            if (!show) CloseDashboardPicker();
+            if (show) return;
+            CloseDashboardPicker();
+            // Both pickers answer to the lock. The rolodex is a native HWND, so one left up over a
+            // session's ribbon would be a rectangle the ribbon cannot paint through.
+            if (_rolodex != null) CloseRolodex();
         }
 
         // ---- the two seams -------------------------------------------------------------
@@ -249,6 +253,20 @@ namespace ConditioningControlPanel
             if (RefuseActionIfSessionLocked("dashboard:edit")) return;
             if (slot < 0 || slot >= DashboardLayout.SlotCount) return;
 
+            // PHASE F. The rolodex first; the flat shelf when it cannot run. One session-wide
+            // give-up flag decides that (RolodexAvailability), so a machine with no WebView2
+            // runtime probes once and opens the shelf nine times out of nine after it.
+            if (TryOpenRolodexPicker(slot)) return;
+            OpenFlatDashboardPicker(slot);
+        }
+
+        /// <summary>
+        /// The flat shelf: four ring groups of art tiles laid over the wall. Still the picker on
+        /// every machine the rolodex will not run on, and still the one a keyboard can drive, so it
+        /// is never deleted and never allowed to rot.
+        /// </summary>
+        private void OpenFlatDashboardPicker(int slot)
+        {
             try
             {
                 var grid = SettingsTab?.VelvetFeatureGrid;
@@ -275,7 +293,7 @@ namespace ConditioningControlPanel
                 _dashboardPicker = picker;
                 picker.ShowFor(slot);
             }
-            catch (Exception ex) { App.Logger?.Warning(ex, "OpenDashboardPicker failed for slot {Slot}", slot); }
+            catch (Exception ex) { App.Logger?.Warning(ex, "OpenFlatDashboardPicker failed for slot {Slot}", slot); }
         }
 
         /// <summary>Closes whatever picker is open. A no-op when none is.</summary>
@@ -320,8 +338,18 @@ namespace ConditioningControlPanel
             var picker = _dashboardPicker;
             if (picker == null)
             {
-                // No picker on screen means no room to ask - a host that raised a pick from its
-                // own chrome. A plain replace is what the question would have defaulted to.
+                // The rolodex raised this pick and its HWND is already gone (nothing may be drawn
+                // over one, which is why it goes first), so there is no chrome left to ask in.
+                // Bring the flat shelf up on the same slot and ask there rather than defaulting
+                // the question away: Split is a real answer, and the 3D picker must not be the one
+                // that cannot reach it.
+                OpenFlatDashboardPicker(slot);
+                picker = _dashboardPicker;
+            }
+
+            if (picker == null)
+            {
+                // No shelf either. A plain replace is what the question would have defaulted to.
                 CommitDashboardPick(slot, key, split: false);
                 return;
             }

--- a/ConditioningControlPanel/MainWindow/MainWindow.DashboardEdit.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.DashboardEdit.cs
@@ -51,6 +51,12 @@ namespace ConditioningControlPanel
         /// whatever was there first.</summary>
         private DashboardPickerPopup? _dashboardPicker;
 
+        /// <summary>True when the flat shelf on screen was opened only to host the Replace / Split
+        /// question after a rolodex pick. Such a shelf was never asked for, so backing out of the
+        /// question takes it with it; a shelf the user opened themselves stays, because they are
+        /// still picking.</summary>
+        private bool _dashboardShelfForAsk;
+
         /// <summary>One template for all nine. A ControlTemplate is shareable and sealed on first
         /// use, so building it once is both cheaper and the only way to be sure the nine pencils
         /// cannot drift apart.</summary>
@@ -288,6 +294,11 @@ namespace ConditioningControlPanel
                 picker.Picked += key => HandleDashboardPick(picker.Slot, key);
                 picker.ResetRequested += ResetDashboardLayout;
                 picker.CloseRequested += CloseDashboardPicker;
+                picker.AskCancelled += OnDashboardAskCancelled;
+
+                // Opened by a pencil until somebody says otherwise; AskDashboardPickChoice is the
+                // only caller that says otherwise, and it says it right after this returns.
+                _dashboardShelfForAsk = false;
 
                 grid.Children.Add(picker);
                 _dashboardPicker = picker;
@@ -303,7 +314,9 @@ namespace ConditioningControlPanel
             {
                 var picker = _dashboardPicker;
                 _dashboardPicker = null;
+                _dashboardShelfForAsk = false;
                 if (picker == null) return;
+                picker.AskCancelled -= OnDashboardAskCancelled;
                 (picker.Parent as Panel)?.Children.Remove(picker);
             }
             catch (Exception ex) { App.Logger?.Debug("CloseDashboardPicker: {E}", ex.Message); }
@@ -318,6 +331,17 @@ namespace ConditioningControlPanel
         internal void HandleDashboardPick(int slot, string key)
         {
             if (RefuseActionIfSessionLocked("dashboard:edit")) return;
+
+            // A key the catalog does not know cannot become a tile, so nothing downstream of here
+            // can do anything but refuse it - and the refusal used to happen at the far end, after
+            // AskDashboardPickChoice had built a whole flat shelf to host a question whose only
+            // possible answers were Replace-into-nothing and Cancel. Refuse it at the door. Debug,
+            // not a warning: the only way here is a stale page or a mod that moved.
+            if (FeatureCatalog.Find(key) == null)
+            {
+                App.Logger?.Debug("[Dashboard] pick ignored for slot {Slot}: no catalog row for '{Key}'", slot, key);
+                return;
+            }
 
             var prompt = DashboardPickerRule.Decide(CurrentLayout, slot, key);
             if (prompt is PickPrompt.Place or PickPrompt.Move)
@@ -345,6 +369,10 @@ namespace ConditioningControlPanel
                 // that cannot reach it.
                 OpenFlatDashboardPicker(slot);
                 picker = _dashboardPicker;
+
+                // ... and it is here for the question and nothing else, so Cancel closes it rather
+                // than leaving a shelf up that the user never opened.
+                _dashboardShelfForAsk = picker != null;
             }
 
             if (picker == null)
@@ -355,6 +383,15 @@ namespace ConditioningControlPanel
             }
 
             picker.Ask(offerSplit, split => CommitDashboardPick(slot, key, split));
+        }
+
+        /// <summary>Never mind, from the strip or from Escape. Only the shelf that was conjured
+        /// up to ask goes away with the question; the one the user opened is still theirs.</summary>
+        private void OnDashboardAskCancelled()
+        {
+            if (!_dashboardShelfForAsk) return;
+            App.Logger?.Debug("[Dashboard] ask cancelled; the shelf it was asked in goes too");
+            CloseDashboardPicker();
         }
 
         // ---- the accepted edit ---------------------------------------------------------

--- a/ConditioningControlPanel/MainWindow/MainWindow.DashboardFx.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.DashboardFx.cs
@@ -196,6 +196,16 @@ namespace ConditioningControlPanel
                 var tab = SettingsTab;
                 if (tab == null) return;
 
+                // Phase F: the rolodex is a native HWND over this entire grid, and half a dozen
+                // callers re-run this method. Without the gate, any one of them would restart the
+                // fog behind a browser nobody can see it through.
+                if (_dashboardRolodexParked)
+                {
+                    try { tab.MosaicFx?.Pause(); }
+                    catch (Exception ex) { Diag.Swallowed(ex, "the canvas is already parked"); }
+                    return;
+                }
+
                 // The canvas parks itself on deactivate/minimise/tab-hide. This call is for the
                 // other direction: coming back UP from Reduced/Off, nothing else would poke it.
                 if (tab.MosaicFx != null &&

--- a/ConditioningControlPanel/MainWindow/MainWindow.DashboardRolodex.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.DashboardRolodex.cs
@@ -47,6 +47,11 @@ namespace ConditioningControlPanel
         /// <summary>What the program lock ribbon was doing before we took the grid.</summary>
         private Visibility _ribbonBeforeRolodex = Visibility.Collapsed;
 
+        /// <summary>What the mosaic canvas was doing before we took the grid. It is Visible almost
+        /// always and Collapsed on the machines that matter (Motion off, a low-end GPU), which is
+        /// exactly why restoring it to a hard-coded Visible was wrong.</summary>
+        private Visibility _mosaicBeforeRolodex = Visibility.Visible;
+
         /// <summary>The static event's handler, kept so the window can let go of it on the way
         /// out. A static event holding an instance delegate pins the window for the life of the
         /// process.</summary>
@@ -83,9 +88,11 @@ namespace ConditioningControlPanel
                 }
                 finally { _rolodexOpening = false; }
 
-                // The probe failed while we were still on the stack: the view is already gone and
-                // the flag is latched, so say so and let the caller reach for the flat picker.
-                return !RolodexAvailability.GivenUp;
+                // The probe failed, or this open was aborted, while we were still on the stack:
+                // the view is already gone, so say so and let the caller reach for the flat
+                // picker. Asked of the VIEW rather than of the give-up flag, because an abort
+                // closes this open without latching anything.
+                return _rolodex != null;
             }
             catch (Exception ex)
             {
@@ -113,8 +120,9 @@ namespace ConditioningControlPanel
 
             view.Picked += OnRolodexPicked;
             view.TourDone += OnRolodexTourDone;
-            view.CloseRequested += CloseRolodex;
+            view.CloseRequested += OnRolodexCloseRequested;
             view.InitFailed += OnRolodexInitFailed;
+            view.OpenAborted += OnRolodexOpenAborted;
 
             _rolodex = view;
             _rolodexSlot = slot;
@@ -139,45 +147,113 @@ namespace ConditioningControlPanel
         /// HWND is torn down FIRST, and only then does the shared accepted-edit path run - because
         /// that path may raise the Replace / Split question, and a WPF dialog over a browser
         /// rectangle is a dialog nobody can see.
+        ///
+        /// <para>POSTED, not run here. This arrives on the browser's own message loop
+        /// (<c>WebMessageReceived</c>), and the first thing the teardown does is dispose the
+        /// WebView2 that is calling us - a reentrant dispose from inside a WebView2 callback. Both
+        /// halves go into ONE posted callback so the order above survives the hop.</para>
         /// </summary>
         private void OnRolodexPicked(string key)
         {
             var slot = _rolodexSlot;
-            CloseRolodex();
-            HandleDashboardPick(slot, key);
+            PostAfterRolodexMessage(() =>
+            {
+                CloseRolodex(RolodexMessageKind.Pick);
+                HandleDashboardPick(slot, key);
+            });
+        }
+
+        /// <summary>Esc, the close button, or the page giving up on itself. Posted for the same
+        /// reason a pick is, and it is the close that SPENDS a tour: skipping is an answer.</summary>
+        private void OnRolodexCloseRequested()
+            => PostAfterRolodexMessage(() => CloseRolodex(RolodexMessageKind.Close));
+
+        /// <summary>
+        /// Hop off the browser's message loop before tearing its host down. A throwing callback is
+        /// logged rather than allowed to reach the dispatcher's unhandled handler, because by the
+        /// time this runs there is nobody left on the stack who knows what it was for.
+        /// </summary>
+        private void PostAfterRolodexMessage(Action work)
+        {
+            try
+            {
+                Dispatcher.BeginInvoke(new Action(() =>
+                {
+                    try { work(); }
+                    catch (Exception ex) { App.Logger?.Warning(ex, "[Rolodex] posted teardown failed"); }
+                }));
+            }
+            catch (Exception ex) { App.Logger?.Warning(ex, "[Rolodex] posting the teardown failed"); }
         }
 
         private void OnRolodexInitFailed(string reason)
         {
             RolodexAvailability.GiveUp(reason);
+            FallBackFromRolodex();
+        }
+
+        /// <summary>This open failed, the session did not. Same fallback, no latch - and the next
+        /// pencil probes the browser again.</summary>
+        private void OnRolodexOpenAborted(string reason)
+        {
+            App.Logger?.Debug("[Rolodex] open aborted: {Reason}", reason);
+            FallBackFromRolodex();
+        }
+
+        private void FallBackFromRolodex()
+        {
             var slot = _rolodexSlot;
             var tour = _rolodexTour;
             var opening = _rolodexOpening;
-            CloseRolodex();
 
-            // The opener is still on the stack and will fall back itself. A tour that never opened
-            // spends nothing: the flag stays unset and the next launch offers it again.
-            if (opening || tour) return;
+            // Unknown, not Close: a rolodex that never got going made no offer, so it spends
+            // nothing. The next launch offers the tour again.
+            CloseRolodex(RolodexMessageKind.Unknown);
+
+            // The opener is still on the stack and will fall back itself. A tour has no flat
+            // version at all - there is nothing to fall back TO - so it simply does not happen.
+            if (opening || tour) { if (tour) _dashboardTourOffered = false; return; }
             OpenFlatDashboardPicker(slot);
         }
 
         /// <summary>Removes and disposes the view and gives the wall back. Idempotent - the page
         /// may send <c>close</c> after a <c>tourDone</c>, and a tab hide may arrive on top of
         /// both.</summary>
-        internal void CloseRolodex()
+        internal void CloseRolodex() => CloseRolodex(RolodexMessageKind.Close);
+
+        /// <summary>
+        /// As above, plus what ENDED it - which is the whole of the tour's bookkeeping.
+        ///
+        /// <para>The tour is a once-ever offer, and every way out of it is an answer: Done, Esc,
+        /// the close button, leaving the Home tab, a session starting underneath. All of them come
+        /// through here, so all of them mark it shown, and the offer is not made again next launch
+        /// to somebody who already said no. The one exception is a rolodex that never started
+        /// (<see cref="RolodexMessageKind.Unknown"/>): an offer the app could not make is not an
+        /// offer the user waved away. <see cref="RolodexBridgeRule.TourOutcomeFor"/> holds the
+        /// rule, where it can be read without a browser.</para>
+        /// </summary>
+        private void CloseRolodex(RolodexMessageKind why)
         {
             try
             {
                 var view = _rolodex;
+                var tour = _rolodexTour;
                 _rolodex = null;
                 _rolodexTour = false;
 
                 if (view != null)
                 {
+                    if (RolodexBridgeRule.TourOutcomeFor(tour ? "tour" : "edit", why)
+                        == RolodexCloseOutcome.MarkTourShown)
+                    {
+                        MarkDashboardTourShown();
+                    }
+
                     view.Picked -= OnRolodexPicked;
                     view.TourDone -= OnRolodexTourDone;
-                    view.CloseRequested -= CloseRolodex;
+                    view.CloseRequested -= OnRolodexCloseRequested;
                     view.InitFailed -= OnRolodexInitFailed;
+                    view.OpenAborted -= OnRolodexOpenAborted;
                     (view.Parent as Panel)?.Children.Remove(view);
                     view.Dispose();
                 }
@@ -205,20 +281,31 @@ namespace ConditioningControlPanel
 
                 _dashboardRolodexParked = true;
 
+                // EVERYTHING IS CAPTURED BEFORE ANYTHING IS TOUCHED, in a try of its own. Parking
+                // can throw halfway - Pause() is the likely one - and a restore that then wrote a
+                // default nobody chose would hand the user back a wall that is not the wall they
+                // had. Reading two Visibility properties cannot throw in any way that matters, and
+                // if it somehow does the fallbacks below are at least written down.
+                try
+                {
+                    if (tab.MosaicFx != null) _mosaicBeforeRolodex = tab.MosaicFx.Visibility;
+                    if (tab.ProgramFeatureLockRibbon != null)
+                        _ribbonBeforeRolodex = tab.ProgramFeatureLockRibbon.Visibility;
+                }
+                catch (Exception ex) { App.Logger?.Debug("[Rolodex] capturing the wall: {E}", ex.Message); }
+
                 foreach (var host in DashboardSlotHosts())
                     if (host != null) host.Visibility = Visibility.Collapsed;
 
                 if (tab.MosaicFx != null)
                 {
-                    tab.MosaicFx.Pause();
+                    try { tab.MosaicFx.Pause(); }
+                    catch (Exception ex) { App.Logger?.Debug("[Rolodex] mosaic pause: {E}", ex.Message); }
                     tab.MosaicFx.Visibility = Visibility.Collapsed;
                 }
 
                 if (tab.ProgramFeatureLockRibbon != null)
-                {
-                    _ribbonBeforeRolodex = tab.ProgramFeatureLockRibbon.Visibility;
                     tab.ProgramFeatureLockRibbon.Visibility = Visibility.Collapsed;
-                }
 
                 ApplyDashboardFxLoops();
             }
@@ -240,7 +327,9 @@ namespace ConditioningControlPanel
                 foreach (var host in DashboardSlotHosts())
                     if (host != null) host.Visibility = Visibility.Visible;
 
-                if (tab.MosaicFx != null) tab.MosaicFx.Visibility = Visibility.Visible;
+                // Both restored to what they WERE, never to a default: a mosaic the user turned
+                // off does not come back on because a picker closed.
+                if (tab.MosaicFx != null) tab.MosaicFx.Visibility = _mosaicBeforeRolodex;
                 if (tab.ProgramFeatureLockRibbon != null)
                     tab.ProgramFeatureLockRibbon.Visibility = _ribbonBeforeRolodex;
 
@@ -396,29 +485,53 @@ namespace ConditioningControlPanel
             catch (Exception ex) { App.Logger?.Warning(ex, "[Dashboard] tour offer failed"); }
         }
 
-        /// <summary>Opens the rolodex in tour mode over the Home wall. Refuses quietly if the tab
-        /// is not the one on screen - the picker covers a grid, and covering one nobody is looking
-        /// at would be a browser running for no reason.</summary>
+        /// <summary>
+        /// Opens the rolodex in tour mode over the Home wall.
+        ///
+        /// <para>THE WALK COMES FIRST. This is the Inbox row's <c>Open</c>, and an Inbox row can be
+        /// clicked from any tab in the app - while the picker covers the Home grid and nothing
+        /// else. Refusing when Home is not on screen made the row a dead click from everywhere but
+        /// the one tab that did not need it, and <c>StartupPresenter.OpenItem</c> has already
+        /// removed the row by then, so the offer was gone and nothing had happened. Walk to Home
+        /// and then open, the way every other row in the Inbox takes the user where it lives.</para>
+        ///
+        /// <para>And if it still cannot open, the offer is handed BACK: the session latch comes off
+        /// so a later visit to Home offers it again, and the once-ever flag is never spent by an
+        /// attempt that showed the user nothing.</para>
+        /// </summary>
         private void StartDashboardTour()
         {
+            var opened = false;
             try
             {
                 if (App.Settings?.Current?.DashboardTourShown == true) return;
+                if (RolodexAvailability.GivenUp) return;
                 if (IsSessionFeatureLockActive) return;
+
+                // "settings" IS the Home tab (SettingsTabView, the nine-cell wall). Cheap when it
+                // is already the one on screen: ShowTab re-shows the tab it is on.
+                if (SettingsTab?.IsVisible != true) ShowTab("settings");
 
                 var grid = SettingsTab?.VelvetFeatureGrid;
                 if (grid == null || SettingsTab?.IsVisible != true) return;
-                if (RolodexAvailability.GivenUp) return;
 
                 CloseDashboardPicker();
-                CloseRolodex();
+                CloseRolodex(RolodexMessageKind.Unknown);
                 EnsureDashboardSlotsRendered();
 
                 _rolodexOpening = true;
-                try { ShowRolodex(grid, 0, tour: true); }
+                try { opened = ShowRolodex(grid, 0, tour: true); }
                 finally { _rolodexOpening = false; }
             }
             catch (Exception ex) { App.Logger?.Warning(ex, "[Dashboard] tour open failed"); }
+            finally
+            {
+                // Nothing opened, so nothing was offered. DashboardTourShown is untouched, which
+                // means the next launch asks again; dropping the session latch means this one can
+                // too, the next time the Home tab comes up.
+                if (!opened && App.Settings?.Current?.DashboardTourShown != true)
+                    _dashboardTourOffered = false;
+            }
         }
 
         /// <summary>
@@ -429,10 +542,19 @@ namespace ConditioningControlPanel
         /// </summary>
         private void OnRolodexTourDone(IReadOnlyList<string> keys)
         {
-            // The HWND goes first, exactly as it does after a pick: everything below this line can
-            // re-render the wall, and none of it can be seen through a browser.
-            CloseRolodex();
+            // Posted off the browser's message loop for the same reason a pick is, and in one
+            // callback so the order below survives the hop: the HWND goes first, exactly as it
+            // does after a pick, because everything after it re-renders the wall and none of that
+            // can be seen through a browser.
+            PostAfterRolodexMessage(() =>
+            {
+                CloseRolodex(RolodexMessageKind.TourDone);
+                CommitDashboardTour(keys);
+            });
+        }
 
+        private void CommitDashboardTour(IReadOnlyList<string> keys)
+        {
             try
             {
                 MarkDashboardTourShown();

--- a/ConditioningControlPanel/MainWindow/MainWindow.DashboardRolodex.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.DashboardRolodex.cs
@@ -1,0 +1,470 @@
+using System;
+using System.Collections.Generic;
+using System.Windows;
+using System.Windows.Controls;
+using ConditioningControlPanel.Controls.Dashboard;
+using ConditioningControlPanel.Localization;
+using ConditioningControlPanel.Models.Dashboard;
+using ConditioningControlPanel.Services;
+using ConditioningControlPanel.Services.Dashboard;
+
+namespace ConditioningControlPanel
+{
+    /// <summary>
+    /// THE ROLODEX OVER THE WALL: the 3D picker swapped in behind the Phase C seams, the cloud
+    /// adopt's re-render, and the first-run "pick three" tour.
+    ///
+    /// <para>Nothing here knows a layout rule. <c>OpenDashboardPicker</c> chooses a picker and
+    /// <c>HandleDashboardPick</c> takes the answer; both live in
+    /// <c>MainWindow.DashboardEdit.cs</c> and both are unchanged in what they mean. What this file
+    /// adds is the one thing a native HWND makes different from a WPF overlay: the wall underneath
+    /// has to be PARKED, because a browser rectangle cannot be drawn over, faded or clipped, and
+    /// the question that follows a pick has to wait until it is gone.</para>
+    /// </summary>
+    public partial class MainWindow
+    {
+        // ---- state ---------------------------------------------------------------------
+
+        private RolodexEmbedView? _rolodex;
+
+        /// <summary>The slot the open rolodex is picking for. Meaningless in tour mode.</summary>
+        private int _rolodexSlot;
+
+        /// <summary>True while the open view is running the first-run tour rather than one edit.</summary>
+        private bool _rolodexTour;
+
+        /// <summary>True inside <see cref="TryOpenRolodexPicker"/>. The runtime probe is
+        /// synchronous, so a machine with no WebView2 reports its failure while the opener is still
+        /// on the stack - and the opener, not the failure handler, is the one that must fall back,
+        /// or the flat picker opens twice.</summary>
+        private bool _rolodexOpening;
+
+        /// <summary>True while the wall under the rolodex is parked. Read by
+        /// <c>ApplyDashboardFxLoops</c>, which is otherwise re-run by half a dozen callers that
+        /// would happily restart the fog behind a browser.</summary>
+        private bool _dashboardRolodexParked;
+
+        /// <summary>What the program lock ribbon was doing before we took the grid.</summary>
+        private Visibility _ribbonBeforeRolodex = Visibility.Collapsed;
+
+        /// <summary>The static event's handler, kept so the window can let go of it on the way
+        /// out. A static event holding an instance delegate pins the window for the life of the
+        /// process.</summary>
+        private Action? _dashboardAdoptHandler;
+
+        /// <summary>Latched once the first-run tour has been offered this launch, so walking back
+        /// to Home does not offer it again while the first offer is still sitting in the Inbox.</summary>
+        private bool _dashboardTourOffered;
+
+        // ---- the swap ------------------------------------------------------------------
+
+        /// <summary>
+        /// Try to open the 3D picker for one slot. False means "not this session" - no runtime, a
+        /// browser that would not start, or no wall to cover - and the caller opens the flat picker
+        /// instead. The flat picker is never deleted and never becomes a fallback in name only: it
+        /// is the keyboard path and the no-GPU path both.
+        /// </summary>
+        private bool TryOpenRolodexPicker(int slot)
+        {
+            if (RolodexAvailability.GivenUp) return false;
+
+            var grid = SettingsTab?.VelvetFeatureGrid;
+            if (grid == null) return false;
+
+            try
+            {
+                CloseDashboardPicker();
+                CloseRolodex();
+
+                _rolodexOpening = true;
+                try
+                {
+                    if (!ShowRolodex(grid, slot, tour: false)) return false;
+                }
+                finally { _rolodexOpening = false; }
+
+                // The probe failed while we were still on the stack: the view is already gone and
+                // the flag is latched, so say so and let the caller reach for the flat picker.
+                return !RolodexAvailability.GivenUp;
+            }
+            catch (Exception ex)
+            {
+                _rolodexOpening = false;
+                App.Logger?.Warning(ex, "[Rolodex] open failed for slot {Slot}", slot);
+                CloseRolodex();
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Build the view, park the wall, add it to the grid and post its one message. The rect is
+        /// the flat picker's rect exactly - rows 0-3, columns 0-3 of <c>VelvetFeatureGrid</c>, over
+        /// the lock ribbon's ZIndex 30 - because both pickers answer the same question about the
+        /// same nine cells and neither is allowed to be somewhere else on screen.
+        /// </summary>
+        private bool ShowRolodex(Grid grid, int slot, bool tour)
+        {
+            var view = new RolodexEmbedView();
+            Grid.SetRow(view, 0);
+            Grid.SetRowSpan(view, 4);
+            Grid.SetColumn(view, 0);
+            Grid.SetColumnSpan(view, 4);
+            Panel.SetZIndex(view, 40);
+
+            view.Picked += OnRolodexPicked;
+            view.TourDone += OnRolodexTourDone;
+            view.CloseRequested += CloseRolodex;
+            view.InitFailed += OnRolodexInitFailed;
+
+            _rolodex = view;
+            _rolodexSlot = slot;
+            _rolodexTour = tour;
+
+            ParkWallForRolodex();
+            grid.Children.Add(view);
+
+            // Must be in the visual tree of a shown window before the browser is built
+            // (BrowserVideoSurface.InitAsync:82 says the same thing out loud).
+            view.Start();
+            if (_rolodex == null) return false;   // the probe failed synchronously
+
+            view.Post(BuildRolodexInit(tour ? "tour" : "edit", tour ? null : slot,
+                                       tour ? RolodexBridgeRule.TourPickCount : 1));
+            App.Logger?.Information("[Rolodex] open (mode={Mode}, slot={Slot})", tour ? "tour" : "edit", slot);
+            return true;
+        }
+
+        /// <summary>
+        /// One pick, and then the view goes. The order is the airspace rule made procedural: the
+        /// HWND is torn down FIRST, and only then does the shared accepted-edit path run - because
+        /// that path may raise the Replace / Split question, and a WPF dialog over a browser
+        /// rectangle is a dialog nobody can see.
+        /// </summary>
+        private void OnRolodexPicked(string key)
+        {
+            var slot = _rolodexSlot;
+            CloseRolodex();
+            HandleDashboardPick(slot, key);
+        }
+
+        private void OnRolodexInitFailed(string reason)
+        {
+            RolodexAvailability.GiveUp(reason);
+            var slot = _rolodexSlot;
+            var tour = _rolodexTour;
+            var opening = _rolodexOpening;
+            CloseRolodex();
+
+            // The opener is still on the stack and will fall back itself. A tour that never opened
+            // spends nothing: the flag stays unset and the next launch offers it again.
+            if (opening || tour) return;
+            OpenFlatDashboardPicker(slot);
+        }
+
+        /// <summary>Removes and disposes the view and gives the wall back. Idempotent - the page
+        /// may send <c>close</c> after a <c>tourDone</c>, and a tab hide may arrive on top of
+        /// both.</summary>
+        internal void CloseRolodex()
+        {
+            try
+            {
+                var view = _rolodex;
+                _rolodex = null;
+                _rolodexTour = false;
+
+                if (view != null)
+                {
+                    view.Picked -= OnRolodexPicked;
+                    view.TourDone -= OnRolodexTourDone;
+                    view.CloseRequested -= CloseRolodex;
+                    view.InitFailed -= OnRolodexInitFailed;
+                    (view.Parent as Panel)?.Children.Remove(view);
+                    view.Dispose();
+                }
+            }
+            catch (Exception ex) { App.Logger?.Debug("[Rolodex] close: {E}", ex.Message); }
+            finally { RestoreWallAfterRolodex(); }
+        }
+
+        // ---- parking -------------------------------------------------------------------
+
+        /// <summary>
+        /// Everything under the rectangle stops. The nine cells are COLLAPSED rather than merely
+        /// covered, which parks each card's ambient clock through the gate it already has
+        /// (<c>FeatureCard.AmbientAllowed</c> reads IsVisible) and takes the pencils down with
+        /// them; the mosaic canvas is paused and hidden; the lock ribbon is collapsed and
+        /// remembered. None of it is visible either way - the point is that none of it is DRAWING
+        /// either, behind a browser that is.
+        /// </summary>
+        private void ParkWallForRolodex()
+        {
+            try
+            {
+                var tab = SettingsTab;
+                if (tab == null) return;
+
+                _dashboardRolodexParked = true;
+
+                foreach (var host in DashboardSlotHosts())
+                    if (host != null) host.Visibility = Visibility.Collapsed;
+
+                if (tab.MosaicFx != null)
+                {
+                    tab.MosaicFx.Pause();
+                    tab.MosaicFx.Visibility = Visibility.Collapsed;
+                }
+
+                if (tab.ProgramFeatureLockRibbon != null)
+                {
+                    _ribbonBeforeRolodex = tab.ProgramFeatureLockRibbon.Visibility;
+                    tab.ProgramFeatureLockRibbon.Visibility = Visibility.Collapsed;
+                }
+
+                ApplyDashboardFxLoops();
+            }
+            catch (Exception ex) { App.Logger?.Warning(ex, "[Rolodex] parking the wall failed"); }
+        }
+
+        /// <summary>The other half, and it runs even when the close went wrong: a wall left
+        /// collapsed is a Home tab with nothing on it.</summary>
+        private void RestoreWallAfterRolodex()
+        {
+            if (!_dashboardRolodexParked) return;
+            _dashboardRolodexParked = false;
+
+            try
+            {
+                var tab = SettingsTab;
+                if (tab == null) return;
+
+                foreach (var host in DashboardSlotHosts())
+                    if (host != null) host.Visibility = Visibility.Visible;
+
+                if (tab.MosaicFx != null) tab.MosaicFx.Visibility = Visibility.Visible;
+                if (tab.ProgramFeatureLockRibbon != null)
+                    tab.ProgramFeatureLockRibbon.Visibility = _ribbonBeforeRolodex;
+
+                // Re-derived, never restored from a remembered value: a session may have started
+                // while the picker was up, and the pencils answer to that and nothing else.
+                ApplyDashboardEditLock(IsSessionFeatureLockActive);
+                ApplyDashboardFxLoops();
+            }
+            catch (Exception ex) { App.Logger?.Warning(ex, "[Rolodex] restoring the wall failed"); }
+        }
+
+        /// <summary>The nine cells, in slot order. Null when the tab has not been built.</summary>
+        private IEnumerable<Grid?> DashboardSlotHosts()
+        {
+            var tab = SettingsTab;
+            if (tab == null) yield break;
+            yield return tab.Slot0; yield return tab.Slot1; yield return tab.Slot2;
+            yield return tab.Slot3; yield return tab.Slot4; yield return tab.Slot5;
+            yield return tab.Slot6; yield return tab.Slot7; yield return tab.Slot8;
+        }
+
+        // ---- the init message ----------------------------------------------------------
+
+        /// <summary>
+        /// The whole scene, in one envelope. Titles and blurbs go up already localized and already
+        /// mod-aware, through the SAME helper the tiles use, so the face a user picks and the tile
+        /// they get are named the same thing.
+        /// </summary>
+        private Newtonsoft.Json.Linq.JObject BuildRolodexInit(string mode, int? slot, int picks)
+            => RolodexInitBuilder.BuildInit(
+                mode, slot, picks,
+                // The bridge's own meaning of reduced, matching SpiralEmbedView: anything but Full
+                // collapses the page's tweens to cuts.
+                reducedMotion: MotionFx.Level != Models.MotionLevel.Full,
+                lang: SafeLanguage(),
+                title: DashboardTitle,
+                blurb: f => Loc.Get(f.BlurbLocKey),
+                entitled: IsDashboardFeatureEntitled,
+                art: RolodexInitBuilder.ArtDataUri);
+
+        private static string SafeLanguage()
+        {
+            try { return LocalizationManager.Instance.CurrentLanguage; }
+            catch (Exception ex) { App.Logger?.Debug("[Rolodex] language: {E}", ex.Message); return "en"; }
+        }
+
+        // ---- the cloud adopt re-render -------------------------------------------------
+
+        /// <summary>
+        /// Subscribe once to the fill-if-empty adopt. It fires OFF the UI thread, from the middle
+        /// of a sync response, so the handler does nothing but hop threads and re-read the setting
+        /// the adopt just wrote - the wall is rendered from settings, never from an event payload.
+        /// </summary>
+        private void HookDashboardCloudAdopt()
+        {
+            if (_dashboardAdoptHandler != null) return;
+            try
+            {
+                _dashboardAdoptHandler = OnDashboardLayoutAdopted;
+                ProfileSyncService.DashboardLayoutAdopted += _dashboardAdoptHandler;
+            }
+            catch (Exception ex) { App.Logger?.Debug("[Dashboard] adopt hook: {E}", ex.Message); }
+        }
+
+        /// <summary>Let the static event go, so it cannot keep this window alive past its close.</summary>
+        private void UnhookDashboardCloudAdopt()
+        {
+            try
+            {
+                if (_dashboardAdoptHandler == null) return;
+                ProfileSyncService.DashboardLayoutAdopted -= _dashboardAdoptHandler;
+                _dashboardAdoptHandler = null;
+            }
+            catch (Exception ex) { App.Logger?.Debug("[Dashboard] adopt unhook: {E}", ex.Message); }
+        }
+
+        private void OnDashboardLayoutAdopted()
+        {
+            try
+            {
+                Dispatcher.BeginInvoke(new Action(() =>
+                {
+                    try
+                    {
+                        // A wall that has never been built has nothing to re-render; the next show
+                        // of the tab reads the same setting and gets there first.
+                        if (!_dashboardSlotsRendered) return;
+
+                        var wire = App.Settings?.Current?.DashboardLayoutWire;
+                        if (string.IsNullOrWhiteSpace(wire)) return;
+
+                        App.Logger?.Information("[Dashboard] re-rendering the wall after a cloud adopt");
+                        RenderDashboardSlots(DashboardLayoutRule.FromWire(wire));
+                    }
+                    catch (Exception ex) { App.Logger?.Warning(ex, "[Dashboard] adopt re-render failed"); }
+                }));
+            }
+            catch (Exception ex) { App.Logger?.Debug("[Dashboard] adopt dispatch: {E}", ex.Message); }
+        }
+
+        // ---- the first-run tour --------------------------------------------------------
+
+        /// <summary>
+        /// Offer the tour, once ever, to a wall nobody has touched.
+        ///
+        /// <para>It goes through <see cref="Services.Startup.StartupPresenter.PresentOrInbox"/>,
+        /// the app's one route for a passive first-launch surface. That is what keeps it off the
+        /// short walk's toes: the presenter counts a running tutorial, a running session and the
+        /// startup ladder as quiet, so on a busy first launch the tour becomes a row in the Inbox
+        /// with its own copy and opens when the user asks for it. <c>EnqueueModal</c> was the
+        /// alternative and is the wrong shape - it requires a call that BLOCKS until the surface
+        /// is gone, and this one is an in-tab overlay with an async browser inside it.</para>
+        ///
+        /// <para>TODO(6.10 merge): move into the first-run queue. Main's first-run redesign
+        /// (client #1036, "two screens, one walk, one queue") owns first launch there and this
+        /// belongs in it as one more queue step; on this 6.9.5 base that queue does not exist.</para>
+        /// </summary>
+        private void MaybeOfferDashboardTour()
+        {
+            try
+            {
+                if (_dashboardTourOffered) return;
+
+                var settings = App.Settings?.Current;
+                if (settings == null) return;
+                if (settings.DashboardTourShown || settings.DashboardLayoutTouched) return;
+
+                // No runtime, no tour. There is no flat version of this: the tour is an offer, and
+                // an offer the app cannot keep is better never made.
+                if (RolodexAvailability.GivenUp) return;
+
+                // A session running means the window was re-shown mid-session, not launched.
+                if (_sessionEngine?.IsRunning == true) return;
+                if (IsSessionFeatureLockActive) return;
+
+                _dashboardTourOffered = true;
+
+                var presenter = App.StartupLadder;
+                if (presenter == null) { StartDashboardTour(); return; }
+
+                presenter.PresentOrInbox(new Services.Startup.InboxItem
+                {
+                    Key = "dashboard-tour",
+                    Glyph = "🎛️",
+                    Title = Loc.Get("dash_tour_title"),
+                    Summary = Loc.Get("dash_tour_pick_three"),
+                    Open = StartDashboardTour,
+                    // Waved away without opening: still spent. The wall has a default and it is a
+                    // good one; asking again next launch would make a one-time offer a nag.
+                    Dismiss = MarkDashboardTourShown,
+                });
+            }
+            catch (Exception ex) { App.Logger?.Warning(ex, "[Dashboard] tour offer failed"); }
+        }
+
+        /// <summary>Opens the rolodex in tour mode over the Home wall. Refuses quietly if the tab
+        /// is not the one on screen - the picker covers a grid, and covering one nobody is looking
+        /// at would be a browser running for no reason.</summary>
+        private void StartDashboardTour()
+        {
+            try
+            {
+                if (App.Settings?.Current?.DashboardTourShown == true) return;
+                if (IsSessionFeatureLockActive) return;
+
+                var grid = SettingsTab?.VelvetFeatureGrid;
+                if (grid == null || SettingsTab?.IsVisible != true) return;
+                if (RolodexAvailability.GivenUp) return;
+
+                CloseDashboardPicker();
+                CloseRolodex();
+                EnsureDashboardSlotsRendered();
+
+                _rolodexOpening = true;
+                try { ShowRolodex(grid, 0, tour: true); }
+                finally { _rolodexOpening = false; }
+            }
+            catch (Exception ex) { App.Logger?.Warning(ex, "[Dashboard] tour open failed"); }
+        }
+
+        /// <summary>
+        /// Three picks, three cells. The keys go through <see cref="DashboardLayoutRule.Place"/>
+        /// like any other edit, so one that was already on the shipped wall MOVES rather than
+        /// appearing twice, and the result is written through the same pair the picker writes -
+        /// touched, saved, nudged. A tour that ends with fewer than three picks fills what it has.
+        /// </summary>
+        private void OnRolodexTourDone(IReadOnlyList<string> keys)
+        {
+            // The HWND goes first, exactly as it does after a pick: everything below this line can
+            // re-render the wall, and none of it can be seen through a browser.
+            CloseRolodex();
+
+            try
+            {
+                MarkDashboardTourShown();
+
+                var placements = RolodexBridgeRule.TourPlacements(keys);
+                if (placements.Count == 0)
+                {
+                    App.Logger?.Information("[Dashboard] tour finished with nothing picked; the default wall stands");
+                    return;
+                }
+
+                foreach (var (slot, key) in placements)
+                    DashboardLayoutRule.Place(CurrentLayout, slot, key, split: false);
+
+                RenderDashboardSlots(CurrentLayout);
+                SaveDashboardLayout(DashboardPickerRule.Commit(CurrentLayout));
+                App.Logger?.Information("[Dashboard] tour placed {Count} features", placements.Count);
+            }
+            catch (Exception ex) { App.Logger?.Warning(ex, "[Dashboard] tour commit failed"); }
+        }
+
+        /// <summary>Spent once, either way. Skipping is an answer.</summary>
+        private static void MarkDashboardTourShown()
+        {
+            try
+            {
+                var settings = App.Settings?.Current;
+                if (settings == null || settings.DashboardTourShown) return;
+                settings.DashboardTourShown = true;
+                App.Settings?.Save();
+            }
+            catch (Exception ex) { App.Logger?.Debug("[Dashboard] tour flag: {E}", ex.Message); }
+        }
+    }
+}

--- a/ConditioningControlPanel/MainWindow/MainWindow.TabNavigation.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.TabNavigation.cs
@@ -1101,7 +1101,25 @@ namespace ConditioningControlPanel
         {
             try
             {
-                if (!visible || _dashboardIntroQueued) return;
+                if (!visible)
+                {
+                    // Leaving the tab takes both pickers with it, the rolodex above all: a native
+                    // child HWND does not go away because the panel it sits in was collapsed, and
+                    // an orphan one would hang over whatever tab came next.
+                    CloseDashboardPicker();
+                    CloseRolodex();
+                    return;
+                }
+
+                // The wall is on screen, so the cloud is allowed to redraw it. Hooked here because
+                // this is the one entry that fires for the tab the app LANDS on; it latches itself,
+                // so the later visits cost a null check.
+                HookDashboardCloudAdopt();
+
+                // ... and the once-ever "pick three" offer, for a wall nobody has touched.
+                MaybeOfferDashboardTour();
+
+                if (_dashboardIntroQueued) return;
                 // A session running at this point means the window was re-shown mid-session, not
                 // a launch. Leave the queue unarmed so a later, quieter visit gets the card.
                 if (_sessionEngine?.IsRunning == true) return;

--- a/ConditioningControlPanel/MainWindow/MainWindow.WindowChrome.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.WindowChrome.cs
@@ -185,7 +185,11 @@ namespace ConditioningControlPanel
 
                 // The Home wall's browser, if one is up. Disposed by hand rather than left to the
                 // teardown: an HWND is not a WPF child that goes quietly with its parent.
-                CloseRolodex();
+                //
+                // Unknown, not Close: quitting the app is not skipping the first-run tour. Every
+                // other way out of it spends the once-ever offer (Esc, Done, leaving the tab); a
+                // user who closed the window mid-tour is owed it again next launch.
+                CloseRolodex(Services.Dashboard.RolodexMessageKind.Unknown);
 
                 // Unsubscribe service events to allow GC of this window
                 UnsubscribeWebcamDebug();

--- a/ConditioningControlPanel/MainWindow/MainWindow.WindowChrome.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.WindowChrome.cs
@@ -183,8 +183,15 @@ namespace ConditioningControlPanel
                 _startSheenTimer?.Stop();
                 _staggerCleanupTimer?.Stop();
 
+                // The Home wall's browser, if one is up. Disposed by hand rather than left to the
+                // teardown: an HWND is not a WPF child that goes quietly with its parent.
+                CloseRolodex();
+
                 // Unsubscribe service events to allow GC of this window
                 UnsubscribeWebcamDebug();
+                // ProfileSyncService.DashboardLayoutAdopted is STATIC; an instance handler left on
+                // it pins this window for the life of the process.
+                UnhookDashboardCloudAdopt();
                 if (_onPillStateChanged != null && App.Webcam != null)
                 {
                     App.Webcam.OnTrackingStateChanged -= _onPillStateChanged;

--- a/ConditioningControlPanel/MainWindow/MainWindow.xaml.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.xaml.cs
@@ -2550,6 +2550,12 @@ namespace ConditioningControlPanel
                 // convention, while a .ccpmod that overrides the BASE path still wins outright.
                 RefreshDashboardArt();
 
+                // The rolodex ships those same paths to its page as JPEG data URIs and caches the
+                // encode. This method is the one signal the wall re-skins on - the ctor, and every
+                // ApplyActiveModChange - so it is where the picker's copy is dropped too. A picker
+                // still showing the last mod's faces would promise a tile the wall will not paint.
+                Services.Dashboard.RolodexInitBuilder.InvalidateArt();
+
                 if (SettingsTab.CardMystery != null)
                 {
                     var img = ModTileVariant("mysterybox", TileDecodeWidth);

--- a/ConditioningControlPanel/Models/AppSettings.cs
+++ b/ConditioningControlPanel/Models/AppSettings.cs
@@ -8040,6 +8040,20 @@ namespace ConditioningControlPanel.Models
             set { _dashboardLayoutTouched = value; OnPropertyChanged(); }
         }
 
+        private bool _dashboardTourShown = false;
+        /// <summary>
+        /// The once-ever "pick three to start with" offer, spent the moment it is answered EITHER
+        /// WAY - three picked, or the row waved away. Separate from
+        /// <see cref="DashboardLayoutTouched"/> on purpose: a user who arranged their wall by hand
+        /// was never offered the tour, and a user who skipped it has not touched their wall.
+        /// </summary>
+        [JsonProperty("dashboard_tour_shown")]
+        public bool DashboardTourShown
+        {
+            get => _dashboardTourShown;
+            set { _dashboardTourShown = value; OnPropertyChanged(); }
+        }
+
         #endregion
 
         #region First-time experience

--- a/ConditioningControlPanel/Services/Dashboard/RolodexBridgeRule.cs
+++ b/ConditioningControlPanel/Services/Dashboard/RolodexBridgeRule.cs
@@ -20,6 +20,10 @@ namespace ConditioningControlPanel.Services.Dashboard
         string? Level = null,
         string? Text = null);
 
+    /// <summary>What a closing rolodex owes the settings file. The once-ever tour is either spent
+    /// by this close or it is not, and nothing else about a teardown is a decision.</summary>
+    public enum RolodexCloseOutcome { Nothing, MarkTourShown }
+
     /// <summary>
     /// THE PAGE SIDE OF THE ROLODEX, WITH NO BROWSER IN IT: what an incoming message means, where
     /// the tour's picks land, and whether the 3D picker is still on the table this session.
@@ -107,6 +111,42 @@ namespace ConditioningControlPanel.Services.Dashboard
                 placements.Add((TourSlots[placements.Count], row.Key));
             }
             return placements;
+        }
+
+        /// <summary>
+        /// Whether the close that is happening spends the once-ever tour.
+        ///
+        /// <para>Skipping is an answer. Esc, the close button, walking off the Home tab and a
+        /// session starting underneath all end a tour as surely as pressing Done, and a tour that
+        /// ended without marking itself shown is one the app offers again every launch forever. An
+        /// EDIT close spends nothing, because there is no offer in it; so does a close that
+        /// follows a failure to start (<see cref="RolodexMessageKind.Unknown"/>), because an offer
+        /// the app never managed to make is not one the user waved away.</para>
+        /// </summary>
+        public static RolodexCloseOutcome TourOutcomeFor(string? mode, RolodexMessageKind why)
+        {
+            if (!string.Equals(mode?.Trim(), "tour", StringComparison.OrdinalIgnoreCase))
+                return RolodexCloseOutcome.Nothing;
+
+            return why is RolodexMessageKind.Close or RolodexMessageKind.TourDone
+                ? RolodexCloseOutcome.MarkTourShown
+                : RolodexCloseOutcome.Nothing;
+        }
+
+        /// <summary>How much of one page log line reaches the app log. A page in a loop is a page
+        /// that can write a megabyte a second into a file the user is asked to attach to a bug
+        /// report.</summary>
+        public const int MaxLogChars = 400;
+
+        /// <summary>How many page log lines one open may spend before the host stops listening.</summary>
+        public const int MaxLogLinesPerOpen = 200;
+
+        /// <summary>One page log line, cut to <see cref="MaxLogChars"/>. Null is an empty line,
+        /// never a throw: this runs on the browser's message loop.</summary>
+        public static string ClampPageLog(string? text)
+        {
+            var line = text ?? string.Empty;
+            return line.Length <= MaxLogChars ? line : line[..MaxLogChars] + "...";
         }
 
         private static string? CleanKey(string? raw)

--- a/ConditioningControlPanel/Services/Dashboard/RolodexBridgeRule.cs
+++ b/ConditioningControlPanel/Services/Dashboard/RolodexBridgeRule.cs
@@ -1,0 +1,160 @@
+using System;
+using System.Collections.Generic;
+using ConditioningControlPanel.Models.Dashboard;
+using Newtonsoft.Json.Linq;
+
+namespace ConditioningControlPanel.Services.Dashboard
+{
+    /// <summary>What the rolodex page just said. Anything else it says is <see cref="Unknown"/>,
+    /// which the host drops on the floor.</summary>
+    public enum RolodexMessageKind { Unknown, Ready, Pick, TourDone, Close, Log }
+
+    /// <summary>
+    /// One parsed page message. Every field is optional because every field belongs to one kind:
+    /// <c>Key</c> to a pick, <c>Keys</c> to a tour, <c>Level</c>/<c>Text</c> to a log line.
+    /// </summary>
+    public sealed record RolodexMessage(
+        RolodexMessageKind Kind,
+        string? Key = null,
+        IReadOnlyList<string>? Keys = null,
+        string? Level = null,
+        string? Text = null);
+
+    /// <summary>
+    /// THE PAGE SIDE OF THE ROLODEX, WITH NO BROWSER IN IT: what an incoming message means, where
+    /// the tour's picks land, and whether the 3D picker is still on the table this session.
+    ///
+    /// <para>The embed view holds the WebView2 and the events; everything it DECIDES is here, so
+    /// the decisions can be tested without an STA thread, a runtime or a window - the same split
+    /// <see cref="DashboardPickerRule"/> makes for the flat picker.</para>
+    /// </summary>
+    public static class RolodexBridgeRule
+    {
+        /// <summary>A tour asks for three, and these are the three cells it fills: the top row's
+        /// singles, left to right, skipping the one the shipped wall gives to a split tile. Slot 1
+        /// is video|bubblecount out of the box and a tour that took it would silently drop a
+        /// feature the user never touched (plan 11.2, owner default).</summary>
+        public static readonly IReadOnlyList<int> TourSlots = new[] { 0, 2, 3 };
+
+        /// <summary>How many faces the tour collects. The page draws its own counter from this.</summary>
+        public const int TourPickCount = 3;
+
+        /// <summary>
+        /// Parse one <c>{type:...}</c> envelope. Malformed JSON, a missing type and a type nobody
+        /// here knows all answer <see cref="RolodexMessageKind.Unknown"/>: this runs on the
+        /// browser's message loop, where a throw is a crash and a page that has learned a new word
+        /// is not an error.
+        /// </summary>
+        public static RolodexMessage Parse(string? json)
+        {
+            if (string.IsNullOrWhiteSpace(json)) return new RolodexMessage(RolodexMessageKind.Unknown);
+
+            JObject o;
+            try { o = JObject.Parse(json); }
+            catch (Exception) { return new RolodexMessage(RolodexMessageKind.Unknown); }
+
+            var type = ((string?)o["type"])?.Trim().ToLowerInvariant();
+            switch (type)
+            {
+                case "ready":
+                    return new RolodexMessage(RolodexMessageKind.Ready);
+
+                case "pick":
+                    var key = CleanKey((string?)o["key"]);
+                    // A pick with no key is not a pick. Closing on it would take the picker away
+                    // and leave the slot as it was, with nothing said.
+                    return key == null
+                        ? new RolodexMessage(RolodexMessageKind.Unknown)
+                        : new RolodexMessage(RolodexMessageKind.Pick, Key: key);
+
+                case "tourdone":
+                    return new RolodexMessage(RolodexMessageKind.TourDone, Keys: ReadKeys(o["keys"]));
+
+                case "close":
+                    return new RolodexMessage(RolodexMessageKind.Close);
+
+                case "log":
+                    return new RolodexMessage(RolodexMessageKind.Log,
+                        Level: (string?)o["level"], Text: (string?)o["msg"]);
+
+                default:
+                    return new RolodexMessage(RolodexMessageKind.Unknown);
+            }
+        }
+
+        /// <summary>The page's <c>level</c> mapped onto Serilog's, through the one mapping every
+        /// other bridge in the app already uses. Absent is chatter, never loud.</summary>
+        public static Serilog.Events.LogEventLevel LogLevel(string? level)
+            => ChaosWebViewHost.PageLogLevel(level);
+
+        /// <summary>
+        /// Where a finished tour's picks go. In order, one per <see cref="TourSlots"/> entry, and
+        /// short lists simply fill fewer cells - a user who pressed Done with two is not owed a
+        /// third tile they did not choose. Keys the catalog does not know are dropped here rather
+        /// than refused later, so a stale page cannot leave a gap in the middle of the run.
+        /// </summary>
+        public static IReadOnlyList<(int Slot, string Key)> TourPlacements(IReadOnlyList<string>? keys)
+        {
+            var placements = new List<(int, string)>();
+            if (keys == null) return placements;
+
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var raw in keys)
+            {
+                if (placements.Count >= TourSlots.Count) break;
+                var row = FeatureCatalog.Find(CleanKey(raw));
+                if (row == null || !seen.Add(row.Key)) continue;
+                placements.Add((TourSlots[placements.Count], row.Key));
+            }
+            return placements;
+        }
+
+        private static string? CleanKey(string? raw)
+        {
+            var key = raw?.Trim();
+            return string.IsNullOrEmpty(key) ? null : key;
+        }
+
+        private static IReadOnlyList<string> ReadKeys(JToken? token)
+        {
+            var keys = new List<string>();
+            if (token is not JArray array) return keys;
+            foreach (var item in array)
+            {
+                var key = CleanKey((string?)item);
+                if (key != null) keys.Add(key);
+            }
+            return keys;
+        }
+    }
+
+    /// <summary>
+    /// ONE GIVE-UP FLAG FOR THE SESSION. A machine with no WebView2 runtime, or one whose browser
+    /// will not start, must not pay for the attempt nine times - so the first failure latches and
+    /// every later pencil opens the flat picker instead, with no second probe and no second log
+    /// line.
+    ///
+    /// <para>It never un-latches. A runtime that was missing at 10:00 is missing at 10:05, and the
+    /// flat picker is not a degraded experience that owes anyone a retry: it is the picker, with
+    /// fewer polygons.</para>
+    /// </summary>
+    public static class RolodexAvailability
+    {
+        private static bool _givenUp;
+
+        /// <summary>True once the rolodex has failed to start. The host reads this before it
+        /// builds anything.</summary>
+        public static bool GivenUp => _givenUp;
+
+        /// <summary>Latch it. Idempotent, and only the first call is logged.</summary>
+        public static void GiveUp(string reason)
+        {
+            if (_givenUp) return;
+            _givenUp = true;
+            App.Logger?.Information("[Rolodex] unavailable this session ({Reason}); the flat picker has it", reason);
+        }
+
+        /// <summary>Tests only. There is no product path back from a give-up.</summary>
+        internal static void ResetForTests() => _givenUp = false;
+    }
+}

--- a/ConditioningControlPanel/Services/Dashboard/RolodexInitBuilder.cs
+++ b/ConditioningControlPanel/Services/Dashboard/RolodexInitBuilder.cs
@@ -1,0 +1,189 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Windows.Media.Imaging;
+using ConditioningControlPanel.Models.Dashboard;
+using Newtonsoft.Json.Linq;
+
+namespace ConditioningControlPanel.Services.Dashboard
+{
+    /// <summary>Turns a catalog art path into a <c>data:</c> URI, or null when the art will not
+    /// resolve. Injected so the message can be built - and asserted - with no WPF imaging at
+    /// all.</summary>
+    public delegate string? RolodexArtResolver(string artPath);
+
+    /// <summary>
+    /// THE ONE MESSAGE THE ROLODEX EVER NEEDS. The page localizes nothing, gates nothing and
+    /// fetches nothing (Resources\web\rolodex\CLAUDE.md §2), so everything it draws is decided
+    /// here: the four rings, each face's title and blurb in the user's language, its tier livery,
+    /// whether this account may open it, and its picture as bytes.
+    ///
+    /// <para>Pure apart from the art. Titles, blurbs and entitlement all arrive as functions, so
+    /// the shape of the message is testable against a fake catalog reader while the real host
+    /// passes the SAME title path the wall's own tiles use - a face that named a feature
+    /// differently from the tile it becomes would be a picker for a different app.</para>
+    ///
+    /// <para>Every <c>init</c> rebuilds the page's scene, so this is also what a mod switch costs:
+    /// one more init, and (because the art cache is keyed on the mod) one more encode pass.</para>
+    /// </summary>
+    public static class RolodexInitBuilder
+    {
+        /// <summary>What the page's card texture is drawn at (512x288), so a wider decode would be
+        /// bytes nobody can see.</summary>
+        public const int ArtDecodeWidth = 512;
+
+        /// <summary>Quality 80 puts a tile at roughly 30 KB, which is ~1 MB for all 27 faces on one
+        /// message. The same figure the Arcademy's avatar encode settled on, one notch lower
+        /// because this is a background plate rather than a face at 2x.</summary>
+        public const int ArtJpegQuality = 80;
+
+        private const string DataUriPrefix = "data:image/jpeg;base64,";
+
+        // ---- the message ---------------------------------------------------------------
+
+        /// <summary>
+        /// Build the <c>init</c> envelope. <paramref name="slot"/> is display only (the page puts
+        /// "slot 5" in its header and nothing else); <paramref name="mode"/> is "edit" or "tour",
+        /// and anything else is normalised to "edit" rather than trusted, because it reaches a
+        /// page that behaves differently in each.
+        /// </summary>
+        public static JObject BuildInit(
+            string? mode,
+            int? slot,
+            int picks,
+            bool reducedMotion,
+            string? lang,
+            Func<DashboardFeature, string> title,
+            Func<DashboardFeature, string> blurb,
+            Func<DashboardFeature, bool> entitled,
+            RolodexArtResolver art)
+        {
+            if (title == null) throw new ArgumentNullException(nameof(title));
+            if (blurb == null) throw new ArgumentNullException(nameof(blurb));
+            if (entitled == null) throw new ArgumentNullException(nameof(entitled));
+            if (art == null) throw new ArgumentNullException(nameof(art));
+
+            var rings = new JArray();
+            foreach (var group in FeatureCatalog.All.GroupBy(f => f.Ring).OrderBy(g => g.Key))
+            {
+                var faces = new JArray();
+                foreach (var f in group)
+                {
+                    var uri = Safe<string?>(() => art(f.ArtPath), null);
+                    faces.Add(new JObject
+                    {
+                        ["key"] = f.Key,
+                        ["title"] = Safe(() => title(f), f.Key),
+                        ["blurb"] = Safe(() => blurb(f), ""),
+                        // Livery, not entitlement: the badge says what the door costs, `locked`
+                        // says whether this account is holding the key (page CLAUDE.md §2).
+                        ["tier"] = f.Tier,
+                        ["locked"] = !Safe(() => entitled(f), true),
+                        ["art"] = uri == null ? JValue.CreateNull() : new JValue(uri),
+                    });
+                }
+                rings.Add(new JObject { ["ring"] = group.Key, ["faces"] = faces });
+            }
+
+            return new JObject
+            {
+                ["type"] = "init",
+                ["rings"] = rings,
+                ["slot"] = slot.HasValue ? new JValue(slot.Value) : JValue.CreateNull(),
+                ["mode"] = string.Equals(mode, "tour", StringComparison.OrdinalIgnoreCase) ? "tour" : "edit",
+                ["picks"] = Math.Max(1, picks),
+                ["reducedMotion"] = reducedMotion,
+                ["lang"] = string.IsNullOrWhiteSpace(lang) ? "en" : lang,
+            };
+        }
+
+        // ---- the art cache -------------------------------------------------------------
+
+        /// <summary>The encoded faces, keyed by art path, for ONE mod. A rolodex open costs 27
+        /// decodes and 27 JPEG encodes the first time and nothing at all afterwards, which is the
+        /// difference between a picker that appears and a picker that takes a beat.</summary>
+        private static readonly Dictionary<string, string?> _artCache = new(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>Which mod's art is in the cache. A mismatch empties it without anyone having
+        /// to remember to - the belt to <see cref="InvalidateArt"/>'s braces.</summary>
+        private static string? _artModId;
+
+        /// <summary>
+        /// Drop the cached faces. Called from <c>LoadFeatureImages</c>, which is the ONE signal the
+        /// wall itself re-skins on (the ctor, and every <c>ApplyActiveModChange</c>), so the picker
+        /// and the tiles behind it can never be showing two different mods' art.
+        /// </summary>
+        public static void InvalidateArt()
+        {
+            _artCache.Clear();
+            _artModId = null;
+        }
+
+        /// <summary>
+        /// The real resolver: the catalog's own art path, through the mod override chain, decoded
+        /// at <see cref="ArtDecodeWidth"/> and re-encoded as a JPEG. Null when the art will not
+        /// resolve, which the page draws as its keyed placeholder rather than as a hole.
+        /// </summary>
+        public static string? ArtDataUri(string artPath)
+        {
+            if (string.IsNullOrWhiteSpace(artPath)) return null;
+
+            var modId = App.Mods?.ActiveModId;
+            if (!string.Equals(modId, _artModId, StringComparison.OrdinalIgnoreCase))
+            {
+                _artCache.Clear();
+                _artModId = modId;
+            }
+
+            if (_artCache.TryGetValue(artPath, out var cached)) return cached;
+
+            var uri = Encode(artPath);
+            _artCache[artPath] = uri;
+            return uri;
+        }
+
+        /// <summary>
+        /// Decode at the texture's width, flatten to Bgr24, encode. The flatten is deliberate and
+        /// the Arcademy's cache explains it best: JPEG has no alpha, so a transparent corner has to
+        /// become a defined colour here rather than an encoder's opinion of one.
+        /// </summary>
+        private static string? Encode(string artPath)
+        {
+            try
+            {
+                var src = ModResourceResolver.ResolveImageDecoded(artPath, ArtDecodeWidth) as BitmapSource
+                          ?? ModResourceResolver.ResolveImage(artPath) as BitmapSource;
+                if (src == null) return null;
+
+                var flat = new FormatConvertedBitmap(src, System.Windows.Media.PixelFormats.Bgr24, null, 0);
+                flat.Freeze();
+
+                var enc = new JpegBitmapEncoder { QualityLevel = ArtJpegQuality };
+                enc.Frames.Add(BitmapFrame.Create(flat));
+                using var ms = new MemoryStream();
+                enc.Save(ms);
+                var bytes = ms.ToArray();
+                return bytes.Length == 0 ? null : DataUriPrefix + Convert.ToBase64String(bytes);
+            }
+            catch (Exception ex)
+            {
+                // Debug, not Warning: a face with no picture still reads (the page paints a keyed
+                // placeholder with the title's initial), and a mod with one missing override would
+                // otherwise file 27 lines on every open.
+                App.Logger?.Debug("[Rolodex] art encode failed: {E}", ex.Message);
+                return null;
+            }
+        }
+
+        private static T Safe<T>(Func<T> read, T fallback)
+        {
+            try { return read(); }
+            catch (Exception ex)
+            {
+                App.Logger?.Debug("[Rolodex] init field: {E}", ex.Message);
+                return fallback;
+            }
+        }
+    }
+}

--- a/ConditioningControlPanel/Views/Controls/Dashboard/DashboardPickerPopup.xaml.cs
+++ b/ConditioningControlPanel/Views/Controls/Dashboard/DashboardPickerPopup.xaml.cs
@@ -48,6 +48,12 @@ namespace ConditioningControlPanel.Views.Controls.Dashboard
         /// <summary>Done, Escape, or a click that finished the job.</summary>
         internal event Action? CloseRequested;
 
+        /// <summary>The Replace / Split question was backed out of. Separate from
+        /// <see cref="CloseRequested"/> because the shelf normally stays up after a cancel - the
+        /// user is still picking - but a shelf that was opened ONLY to host this question has
+        /// nothing left to be, and the host is the one that knows which it is.</summary>
+        internal event Action? AskCancelled;
+
         /// <summary>The slot this picker was opened for. Read by the host when a pick comes back.</summary>
         internal int Slot { get; private set; }
 
@@ -229,7 +235,16 @@ namespace ConditioningControlPanel.Views.Controls.Dashboard
 
         private void OnAskSplitClick(object sender, RoutedEventArgs e) => Answer(true);
 
-        private void OnAskCancelClick(object sender, RoutedEventArgs e) => HideAsk();
+        /// <summary>Never mind. The strip goes away and the host is told, because the answer to
+        /// "should the shelf go too" depends on why the shelf is there.</summary>
+        private void CancelAsk()
+        {
+            var wasAsking = AskStrip.Visibility == Visibility.Visible;
+            HideAsk();
+            if (wasAsking) AskCancelled?.Invoke();
+        }
+
+        private void OnAskCancelClick(object sender, RoutedEventArgs e) => CancelAsk();
 
         // ---- footer --------------------------------------------------------------------
 
@@ -254,7 +269,7 @@ namespace ConditioningControlPanel.Views.Controls.Dashboard
             if (e.Key != Key.Escape) return;
             e.Handled = true;
 
-            if (AskStrip.Visibility == Visibility.Visible) { HideAsk(); return; }
+            if (AskStrip.Visibility == Visibility.Visible) { CancelAsk(); return; }
             CloseRequested?.Invoke();
         }
     }

--- a/Tests/ConditioningControlPanel.Tests/RolodexBridgeRuleTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/RolodexBridgeRuleTests.cs
@@ -1,0 +1,358 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using ConditioningControlPanel.Models.Dashboard;
+using ConditioningControlPanel.Services.Dashboard;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// THE ROLODEX'S DECISIONS, WITH NO BROWSER IN THE ROOM. Everything the embed view does that is
+/// not "hold a WebView2" lives in <see cref="RolodexBridgeRule"/> and
+/// <see cref="RolodexInitBuilder"/>, which is what makes any of it testable: a page message is a
+/// string, a tour result is three integers, and the init envelope is a JObject.
+///
+/// <para>The one thing a test cannot see is the airspace - whether the HWND lands on exactly the
+/// grid rect under the root Viewbox's scale. What it CAN pin is that both pickers are told to go
+/// to the same place, which is the last scrape at the bottom of this file.</para>
+/// </summary>
+public class RolodexBridgeRuleTests
+{
+    // ── message parsing ──────────────────────────────────────────
+
+    [Fact]
+    public void ReadyIsRecognised()
+        => Assert.Equal(RolodexMessageKind.Ready, RolodexBridgeRule.Parse("{\"type\":\"ready\",\"protocol\":1}").Kind);
+
+    [Fact]
+    public void APickCarriesItsKey()
+    {
+        var msg = RolodexBridgeRule.Parse("{\"type\":\"pick\",\"key\":\"braindrain\"}");
+        Assert.Equal(RolodexMessageKind.Pick, msg.Kind);
+        Assert.Equal("braindrain", msg.Key);
+    }
+
+    [Fact]
+    public void APickWithNoKeyIsNotAPick()
+    {
+        // It would close the picker and change nothing, which reads to the user as a picker that
+        // ate their click.
+        Assert.Equal(RolodexMessageKind.Unknown, RolodexBridgeRule.Parse("{\"type\":\"pick\"}").Kind);
+        Assert.Equal(RolodexMessageKind.Unknown, RolodexBridgeRule.Parse("{\"type\":\"pick\",\"key\":\"  \"}").Kind);
+    }
+
+    [Fact]
+    public void TourDoneCarriesItsKeysInOrder()
+    {
+        var msg = RolodexBridgeRule.Parse("{\"type\":\"tourDone\",\"keys\":[\"fyp\",\"dtrh\",\"spiral\"]}");
+        Assert.Equal(RolodexMessageKind.TourDone, msg.Kind);
+        Assert.Equal(new[] { "fyp", "dtrh", "spiral" }, msg.Keys);
+    }
+
+    [Fact]
+    public void TourDoneWithNoKeysIsStillATourDone()
+    {
+        // Done with an empty list ends the tour; it does not leave the browser up waiting for a
+        // list that is never coming.
+        var msg = RolodexBridgeRule.Parse("{\"type\":\"tourDone\"}");
+        Assert.Equal(RolodexMessageKind.TourDone, msg.Kind);
+        Assert.Empty(msg.Keys!);
+    }
+
+    [Fact]
+    public void CloseIsRecognised()
+        => Assert.Equal(RolodexMessageKind.Close, RolodexBridgeRule.Parse("{\"type\":\"close\"}").Kind);
+
+    [Theory]
+    [InlineData("error", "Error")]
+    [InlineData("FATAL", "Error")]
+    [InlineData("warn", "Warning")]
+    [InlineData("warning", "Warning")]
+    [InlineData("info", "Information")]
+    [InlineData("debug", "Debug")]
+    [InlineData("", "Debug")]
+    [InlineData("nonsense", "Debug")]
+    public void ALogLineMapsOntoTheAppsLevels(string level, string expected)
+    {
+        var msg = RolodexBridgeRule.Parse("{\"type\":\"log\",\"level\":\"" + level + "\",\"msg\":\"boot\"}");
+        Assert.Equal(RolodexMessageKind.Log, msg.Kind);
+        Assert.Equal("boot", msg.Text);
+        Assert.Equal(expected, RolodexBridgeRule.LogLevel(msg.Level).ToString());
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("not json at all")]
+    [InlineData("{\"type\":")]
+    [InlineData("[1,2,3]")]
+    [InlineData("{\"nope\":true}")]
+    [InlineData("{\"type\":\"somethingNew\"}")]
+    public void AnythingUnreadableIsIgnoredRatherThanThrown(string json)
+    {
+        // This runs on the browser's message loop, where a throw is a crash and a page that has
+        // learned a new word is not an error.
+        Assert.Equal(RolodexMessageKind.Unknown, RolodexBridgeRule.Parse(json).Kind);
+    }
+
+    // ── the tour's slot assignment ───────────────────────────────
+
+    [Fact]
+    public void ThreePicksLandInSlotsZeroTwoAndThree()
+    {
+        var placed = RolodexBridgeRule.TourPlacements(new[] { "fyp", "dtrh", "arcademy" });
+        Assert.Equal(new[] { 0, 2, 3 }, placed.Select(p => p.Slot));
+        Assert.Equal(new[] { "fyp", "dtrh", "arcademy" }, placed.Select(p => p.Key));
+    }
+
+    [Fact]
+    public void SlotOneIsLeftAloneBecauseTheShippedWallSplitsIt()
+    {
+        // video|bubblecount out of the box. A tour that took that cell would silently drop a
+        // feature the user never touched.
+        Assert.DoesNotContain(1, RolodexBridgeRule.TourSlots);
+        Assert.Equal(RolodexBridgeRule.TourPickCount, RolodexBridgeRule.TourSlots.Count);
+    }
+
+    [Fact]
+    public void FewerThanThreePicksFillWhatTheyHave()
+    {
+        var placed = RolodexBridgeRule.TourPlacements(new[] { "haptics" });
+        var one = Assert.Single(placed);
+        Assert.Equal(0, one.Slot);
+        Assert.Equal("haptics", one.Key);
+
+        Assert.Empty(RolodexBridgeRule.TourPlacements(Array.Empty<string>()));
+        Assert.Empty(RolodexBridgeRule.TourPlacements(null));
+    }
+
+    [Fact]
+    public void MoreThanThreePicksStopAtThree()
+        => Assert.Equal(3, RolodexBridgeRule.TourPlacements(
+            new[] { "fyp", "dtrh", "arcademy", "haptics", "awareness" }).Count);
+
+    [Fact]
+    public void KeysTheCatalogDoesNotKnowAreDropped()
+    {
+        // Dropped here rather than refused later by Place, so a stale page cannot leave a gap in
+        // the middle of the run and push everything else down a cell.
+        var placed = RolodexBridgeRule.TourPlacements(new[] { "not-a-feature", "fyp", "", "dtrh" });
+        Assert.Equal(new[] { "fyp", "dtrh" }, placed.Select(p => p.Key));
+        Assert.Equal(new[] { 0, 2 }, placed.Select(p => p.Slot));
+    }
+
+    [Fact]
+    public void OneFeaturePickedTwiceStillOnlyTakesOneCell()
+    {
+        var placed = RolodexBridgeRule.TourPlacements(new[] { "fyp", "FYP", "dtrh" });
+        Assert.Equal(new[] { "fyp", "dtrh" }, placed.Select(p => p.Key));
+    }
+
+    [Fact]
+    public void APickAlreadyOnTheWallMovesRatherThanAppearingTwice()
+    {
+        // flash and subliminal are slots 0 and 2 of the shipped wall; bubbles is slot 7. Running
+        // the tour's placements over the default layout must leave every key exactly once.
+        var layout = DashboardLayout.Default();
+        foreach (var (slot, key) in RolodexBridgeRule.TourPlacements(new[] { "bubbles", "flash", "subliminal" }))
+            DashboardLayoutRule.Place(layout, slot, key, split: false);
+
+        Assert.Equal("bubbles", layout.Slots[0].Primary);
+        Assert.Equal("flash", layout.Slots[2].Primary);
+        Assert.Equal("subliminal", layout.Slots[3].Primary);
+
+        // Slot 7 held bubbles and is now a hole, which is a legal layout - and the invariant that
+        // matters is that nothing is on the wall twice.
+        var keys = layout.Slots.SelectMany(s => new[] { s.Primary, s.Secondary })
+                               .Where(k => !string.IsNullOrEmpty(k)).ToList();
+        Assert.Equal(keys.Count, keys.Distinct(StringComparer.OrdinalIgnoreCase).Count());
+    }
+
+    // ── the give-up flag ─────────────────────────────────────────
+
+    [Fact]
+    public void TheGiveUpFlagLatchesAndNeverComesBack()
+    {
+        try
+        {
+            RolodexAvailability.ResetForTests();
+            Assert.False(RolodexAvailability.GivenUp);
+
+            RolodexAvailability.GiveUp("no runtime");
+            Assert.True(RolodexAvailability.GivenUp);
+
+            // Nine pencils, one probe. There is no product path back: a runtime that was missing
+            // at 10:00 is missing at 10:05.
+            RolodexAvailability.GiveUp("still no runtime");
+            Assert.True(RolodexAvailability.GivenUp);
+        }
+        finally { RolodexAvailability.ResetForTests(); }
+    }
+
+    // ── the init envelope ────────────────────────────────────────
+
+    /// <summary>An art resolver that never touches WPF imaging: the path comes back as a fake data
+    /// URI, or null for the one path we want to see fail.</summary>
+    private static RolodexArtResolver FakeArt(string? failFor = null)
+        => path => string.Equals(path, failFor, StringComparison.OrdinalIgnoreCase)
+            ? null
+            : "data:image/jpeg;base64,FAKE/" + path;
+
+    private static JObject BuildInit(Func<DashboardFeature, bool>? entitled = null, string? failArtFor = null)
+        => RolodexInitBuilder.BuildInit(
+            mode: "edit", slot: 4, picks: 1, reducedMotion: false, lang: "de",
+            title: f => "T:" + f.Key,
+            blurb: f => "B:" + f.Key,
+            entitled: entitled ?? (_ => true),
+            art: FakeArt(failArtFor));
+
+    [Fact]
+    public void TheEnvelopeCarriesEveryFieldThePageReads()
+    {
+        var init = BuildInit();
+        Assert.Equal("init", (string?)init["type"]);
+        Assert.Equal("edit", (string?)init["mode"]);
+        Assert.Equal(4, (int?)init["slot"]);
+        Assert.Equal(1, (int?)init["picks"]);
+        Assert.False((bool?)init["reducedMotion"]);
+        Assert.Equal("de", (string?)init["lang"]);
+    }
+
+    [Fact]
+    public void TheRingsAreTheCatalogsRingsInOrder()
+    {
+        var rings = (JArray)BuildInit()["rings"]!;
+        var expected = FeatureCatalog.All.GroupBy(f => f.Ring).OrderBy(g => g.Key).ToList();
+
+        Assert.Equal(expected.Count, rings.Count);
+        for (int i = 0; i < expected.Count; i++)
+        {
+            Assert.Equal(expected[i].Key, (int?)rings[i]["ring"]);
+            Assert.Equal(expected[i].Select(f => f.Key),
+                         ((JArray)rings[i]["faces"]!).Select(f => (string?)f["key"]));
+        }
+
+        // Every catalog row reaches the page exactly once. A feature the picker cannot show is a
+        // feature the wall can hold and the user can never choose.
+        var faces = rings.SelectMany(r => (JArray)r["faces"]!).Select(f => (string?)f["key"]).ToList();
+        Assert.Equal(FeatureCatalog.All.Count, faces.Count);
+        Assert.Equal(faces.Count, faces.Distinct(StringComparer.OrdinalIgnoreCase).Count());
+    }
+
+    [Fact]
+    public void TitleBlurbAndTierRideAlongAlreadyResolved()
+    {
+        var face = Faces(BuildInit()).First(f => (string?)f["key"] == "dtrh");
+        Assert.Equal("T:dtrh", (string?)face["title"]);
+        Assert.Equal("B:dtrh", (string?)face["blurb"]);
+        Assert.Equal(FeatureCatalog.Find("dtrh")!.Tier, (int?)face["tier"]);
+    }
+
+    [Fact]
+    public void LockedIsTheOppositeOfEntitled_AndTierIsNotLocked()
+    {
+        // Two separate columns on purpose: tier is the livery (a gold or diamond rim), locked is
+        // whether this account is holding the key. A locked face is still pickable by design.
+        var init = BuildInit(entitled: f => f.Tier == 0);
+        foreach (var face in Faces(init))
+        {
+            var row = FeatureCatalog.Find((string?)face["key"])!;
+            Assert.Equal(row.Tier != 0, (bool?)face["locked"]);
+        }
+
+        var allOpen = Faces(BuildInit(entitled: _ => true));
+        Assert.All(allOpen, f => Assert.False((bool?)f["locked"]));
+        Assert.Contains(allOpen, f => (int?)f["tier"] > 0);
+    }
+
+    [Fact]
+    public void ArtThatWillNotResolveGoesUpAsNullRatherThanAsAHole()
+    {
+        var flash = FeatureCatalog.Find("flash")!;
+        var faces = Faces(BuildInit(failArtFor: flash.ArtPath));
+
+        var broken = faces.First(f => (string?)f["key"] == "flash");
+        Assert.Equal(JTokenType.Null, broken["art"]!.Type);
+
+        var fine = faces.First(f => (string?)f["key"] == "bubbles");
+        Assert.StartsWith("data:image/jpeg;base64,", (string?)fine["art"]);
+    }
+
+    [Fact]
+    public void ATourAsksForThreeAndAnUnknownModeIsNotTrusted()
+    {
+        var tour = RolodexInitBuilder.BuildInit("tour", null, RolodexBridgeRule.TourPickCount, true, "en",
+            f => f.Key, f => f.Key, _ => true, FakeArt());
+        Assert.Equal("tour", (string?)tour["mode"]);
+        Assert.Equal(3, (int?)tour["picks"]);
+        Assert.Equal(JTokenType.Null, tour["slot"]!.Type);
+        Assert.True((bool?)tour["reducedMotion"]);
+
+        // The mode reaches a page that behaves differently in each, so it is normalised, not
+        // forwarded. Same for a picks count below one and a blank language.
+        var junk = RolodexInitBuilder.BuildInit("TOUR-ish", 0, 0, false, "  ",
+            f => f.Key, f => f.Key, _ => true, FakeArt());
+        Assert.Equal("edit", (string?)junk["mode"]);
+        Assert.Equal(1, (int?)junk["picks"]);
+        Assert.Equal("en", (string?)junk["lang"]);
+    }
+
+    private static List<JToken> Faces(JObject init)
+        => ((JArray)init["rings"]!).SelectMany(r => (JArray)r["faces"]!).ToList();
+
+    // ── the seam ─────────────────────────────────────────────────
+
+    [Fact]
+    public void BothPickersAreHandedTheSameRectOnTheSameGrid()
+    {
+        // The flat overlay and the rolodex answer the same question about the same nine cells, so
+        // neither is allowed to be somewhere else on screen. Nothing in the compiler can see that
+        // they agree: both reach VelvetFeatureGrid by name and set their own spans.
+        foreach (var source in new[] { Source("MainWindow.DashboardEdit.cs"), Source("MainWindow.DashboardRolodex.cs") })
+        {
+            Assert.Contains("SettingsTab?.VelvetFeatureGrid", source, StringComparison.Ordinal);
+            Assert.Contains("Grid.SetRowSpan(", source, StringComparison.Ordinal);
+            Assert.Contains("Grid.SetColumnSpan(", source, StringComparison.Ordinal);
+            Assert.Contains(", 4)", source, StringComparison.Ordinal);
+            // Over the program lock ribbon's ZIndex 30, the highest thing authored on this grid.
+            Assert.Contains("Panel.SetZIndex(", source, StringComparison.Ordinal);
+            Assert.Contains(", 40)", source, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public void TheFlatPickerIsStillThere()
+    {
+        // The fallback is not a fallback if it has been deleted. OpenDashboardPicker must still be
+        // able to reach it, and the rolodex must be the thing that gives way.
+        var edit = Source("MainWindow.DashboardEdit.cs");
+        Assert.Contains("OpenFlatDashboardPicker", edit, StringComparison.Ordinal);
+        Assert.Contains("TryOpenRolodexPicker", edit, StringComparison.Ordinal);
+        Assert.Contains("new DashboardPickerPopup", edit, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void EveryNewLocKeyIsInEnglish()
+    {
+        var en = JObject.Parse(File.ReadAllText(
+            Path.Combine(RepoRoot(), "ConditioningControlPanel", "Localization", "Languages", "en.json")));
+        foreach (var key in new[] { "dash_tour_title", "dash_tour_pick_three" })
+            Assert.True(en[key] != null && !string.IsNullOrWhiteSpace((string?)en[key]),
+                        key + " is missing from en.json");
+    }
+
+    private static string Source(string file) => File.ReadAllText(
+        Path.Combine(RepoRoot(), "ConditioningControlPanel", "MainWindow", file));
+
+    private static string RepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir != null && !Directory.Exists(Path.Combine(dir.FullName, "ConditioningControlPanel", "Resources")))
+            dir = dir.Parent;
+        Assert.True(dir != null, "could not locate the repo root from " + AppContext.BaseDirectory);
+        return dir!.FullName;
+    }
+}

--- a/Tests/ConditioningControlPanel.Tests/RolodexBridgeRuleTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/RolodexBridgeRuleTests.cs
@@ -171,6 +171,56 @@ public class RolodexBridgeRuleTests
         Assert.Equal(keys.Count, keys.Distinct(StringComparer.OrdinalIgnoreCase).Count());
     }
 
+    // ── what a close owes the tour ───────────────────────────────
+
+    [Theory]
+    [InlineData(RolodexMessageKind.Close)]
+    [InlineData(RolodexMessageKind.TourDone)]
+    public void EveryWayOUTOfATourSpendsIt(RolodexMessageKind why)
+    {
+        // Done and Esc are the same answer to a once-ever offer. Leaving the Home tab and a
+        // session starting underneath both arrive as Close too, which is why they are the same
+        // line of code and not three.
+        Assert.Equal(RolodexCloseOutcome.MarkTourShown, RolodexBridgeRule.TourOutcomeFor("tour", why));
+    }
+
+    [Fact]
+    public void ATourThatNeverStartedSpendsNothing()
+    {
+        // An offer the app could not make is not an offer the user waved away: the browser failed,
+        // the user saw nothing, and the next launch owes them the tour.
+        Assert.Equal(RolodexCloseOutcome.Nothing,
+                     RolodexBridgeRule.TourOutcomeFor("tour", RolodexMessageKind.Unknown));
+    }
+
+    [Theory]
+    [InlineData(RolodexMessageKind.Close)]
+    [InlineData(RolodexMessageKind.TourDone)]
+    [InlineData(RolodexMessageKind.Pick)]
+    public void AnEditCloseIsNeverTheTour(RolodexMessageKind why)
+    {
+        // One pencil, one slot, no offer in it. Nothing an edit does may spend the tour.
+        Assert.Equal(RolodexCloseOutcome.Nothing, RolodexBridgeRule.TourOutcomeFor("edit", why));
+        Assert.Equal(RolodexCloseOutcome.Nothing, RolodexBridgeRule.TourOutcomeFor(null, why));
+    }
+
+    // ── the page log budget ──────────────────────────────────────
+
+    [Fact]
+    public void ALongPageLogLineIsCutRatherThanWrittenWhole()
+    {
+        var clamped = RolodexBridgeRule.ClampPageLog(new string('x', 5000));
+        Assert.Equal(RolodexBridgeRule.MaxLogChars + 3, clamped.Length);
+        Assert.EndsWith("...", clamped);
+    }
+
+    [Fact]
+    public void AShortPageLogLineIsLeftExactlyAsItCame()
+    {
+        Assert.Equal("rings built", RolodexBridgeRule.ClampPageLog("rings built"));
+        Assert.Equal(string.Empty, RolodexBridgeRule.ClampPageLog(null));
+    }
+
     // ── the give-up flag ─────────────────────────────────────────
 
     [Fact]
@@ -321,6 +371,26 @@ public class RolodexBridgeRuleTests
             Assert.Contains("Panel.SetZIndex(", source, StringComparison.Ordinal);
             Assert.Contains(", 40)", source, StringComparison.Ordinal);
         }
+    }
+
+    [Fact]
+    public void OnlyTheThingsThatCannotComeBackLatchTheGiveUp()
+    {
+        // A navigation that failed once and a renderer that died once are this OPEN's problem, not
+        // the session's: both close the rolodex and hand the question to the flat shelf, and only
+        // the runtime probe and an environment that will not build latch. Nothing in the compiler
+        // can see the difference, so the two routes are pinned by name.
+        var embed = File.ReadAllText(Path.Combine(
+            RepoRoot(), "ConditioningControlPanel", "Controls", "Dashboard", "RolodexEmbedView.cs"));
+
+        Assert.Contains("Abort(\"navigation failed: \"", embed, StringComparison.Ordinal);
+        Assert.Contains("OpenAborted", embed, StringComparison.Ordinal);
+        // Two strikes on a dead renderer, the same stand-down BrowserVideoEngine runs app-wide.
+        Assert.Contains("MaxProcessFailures = 2", embed, StringComparison.Ordinal);
+        // ... and the argument string is a CONSTANT: WebView2 ties a user-data folder to the
+        // options it was built with, so a reduced-motion switch that flips between two opens would
+        // leave this picker unable to create an environment at all.
+        Assert.DoesNotContain("PrefersReducedMotionArgument", embed, StringComparison.Ordinal);
     }
 
     [Fact]


### PR DESCRIPTION
Stack 7 of 7 (base: E). Three commits: embed view + init builder, swap + adopt + tour, one review-fix round.

## What

- `Controls/Dashboard/RolodexEmbedView.cs : Grid` (the SpiralEmbedView shape): runtime probe, own env (`browser_data_rolodex`, constant args), `ccp.game` mapping with Allow, hardened settings, queued `Post` until `ready`, message switch. Permanent give-up only on a missing runtime or env failure; a navigation or first process failure falls back to the flat picker for that open only.
- `Services/Dashboard/RolodexInitBuilder.cs`: the 27 faces grouped by ring, localized title and blurb, `locked` from the same entitlement check the wall uses, art as JPEG data URIs (decode 512, quality 80) cached per mod.
- `OpenDashboardPicker(slot)` tries the rolodex first, else the flat shelf. The wall is parked (hosts collapsed, `MosaicFx` paused, ribbon collapsed, FX loops gated) and restored in a `finally`. A pick removes the HWND first, then runs the shared Place/Replace/Split path; teardown is posted off the WebView2 callback. Both pickers close on tab hide and on session start.
- Cloud adopt re-render on `ProfileSyncService.DashboardLayoutAdopted` via the Dispatcher, unhooked on close.
- First-run tour: `mode:'tour', picks:3` through `StartupPresenter.PresentOrInbox` (the first-run redesign is main-only; `TODO(6.10 merge)` to move it into the queue). Picks land in slots 0, 2, 3 via the same persistence path; skip and done both spend `DashboardTourShown`.

## Loc / settings

`dash_tour_title`, `dash_tour_pick_three`; `AppSettings.DashboardTourShown`.

## Tests

`RolodexBridgeRuleTests` (47). Suite at the top of the stack: 6091.

## Not verifiable without a desk run

The HWND rect under the `Viewbox Stretch=Fill` (the browser card is the only precedent; the `PointToScreen` mitigation from plan 10.1 is not implemented), per-monitor DPI, the WebView2 runtime probe and fallback, minimize/restore, the real init message size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VW2mrHU1ZQQ1RNTumPsrfm
