### PR TITLE
fix(lost-and-found): one picture, one seat - and hers on exactly one

### DIFF
--- a/ConditioningControlPanel/Resources/web/arcademy/CLAUDE.md
+++ b/ConditioningControlPanel/Resources/web/arcademy/CLAUDE.md
@@ -3517,6 +3517,50 @@ and it is not a third gate** - see trap 99, `init.devAnnex`.
     second (scratchpad `lfroom-drive.mjs`, `wrap gap` line). Any marquee that clones for a
     wrap has this law; check it against the narrowest tile the mobile pass can deal.
 
+147. **A HUNT DEDUPES ON THE PICTURE OR IT DOES NOT DEDUPE (LOST & FOUND, 2026-09-11).**
+    Owner: "an image can be in multiple places as a copy but seems like only one is correct.
+    We should be sure that the target doesn't get duplicated and there is only one." Two
+    separate doors let her onto a second seat. The loud one was deliberate: `assignWarm()`
+    dealt up to `PLAYTEST.NEAR_TWIN_URL_CAP` (4) "strong" near-twins carrying the TARGET'S
+    ACTUAL MEDIA at a shifted hue - and the constant's own comment predicted the bug it
+    caused ("uncapped, half a tier-4 board would be literal copies - which reads as a bug,
+    not as difficulty"). It read as a bug at 4 too. The quiet one was the dedupe itself:
+    every guard in the room compared EXACT URLS (`drawLive`'s `have` set, `sleeperUsed`,
+    `parkedUrl`, the target filters), and one picture reaches a page under several urls -
+    a clip and its own poster (`loop5.mp4` / `loop5.jpg`; the web host adds a clip's poster
+    to the STILL pool, provider shim `absorb`), a second rendition (`-640x800`, or reddit's
+    size-as-a-query preview host), a crosspost, the same file on a CDN's `preview.` and `i.`
+    subdomains. `board.js mediaKey()` is the identity that survives all of it and `setUrl()`
+    is the one gate that enforces it.
+    **THE LAW HAS TWO TIERS AND THAT IS THE DESIGN.** HER picture is absolute - no second
+    seat, no `lastResort` past it - because that is the report. Any OTHER repeat is merely
+    unwanted: the seat re-draws `UNIQUE_DRAW_TRIES` times and then TAKES the copy. Strict
+    global uniqueness is the trap inside the trap: a tier-4 board is 52 seats and a library
+    smaller than the wall is ordinary (the rig's own feed delivers nine distinct pictures
+    behind those 52), so a strict rule answers a duplicate complaint by parking forty seats
+    on the glyph floor - a worse wall, not a fixed one.
+    **KEY ON THE PATH, NEVER THE FILE NAME.** Name-only keying breaks the DESKTOP outright:
+    the shell serves a local library as `https://ccp.assets/<folder>/<file>` off the
+    player's own tree, and a folder of `001.jpg` beside another folder of `001.jpg` is the
+    ordinary shape of a saved library. Same trap remotely - `v.redd.it/<post>/DASH_720.mp4`
+    puts the identity in the PARENT segment. Drop the scheme and host, keep every segment,
+    fold only what is provably a rendition of one file (query, the `#.ext` animation hint,
+    extension, `-WxH`, a thumb/poster/small/mobile marker, case).
+    **THE SECOND DOOR IS `setTarget`.** A round rotation PROMOTES a seat that is already
+    dressed - no provider draw, so `setUrl`'s gate never sees it - and a shared park resting
+    on that picture puts her on two seats again from round two on. Measured on main: five
+    seats at the deal, NINE by the end of the class. The law is enforced in `setTarget` too.
+    Rig (headless Edge, 844x390 coarse + touch, 2 Mbps / 100 ms / x4, a feed that serves the
+    same picture as a rendition, a repost, and a clip's own poster): main dealt her onto 5
+    seats and a tap on a decoy wearing her picture scored a MISS; the fix deals her onto 1,
+    end of class 1, no decoy wears her, and no seat went bare (0 on the glyph floor, both
+    builds). A `shared:true` draw - parking a sleeper on a live url, one decoder and one
+    clock - is the one legal two-seat case and says so at the call site.
+    **Wrap clones are not a third door**: `buildTileEl` registers every clone in `byEl`, so
+    `tileFromNode` resolves rep 0, rep 1 and a set `fitWrap` adds after a rotation to the
+    SAME tile object. Verified by tapping each rep (trap 146 built those clone sets); do not
+    "fix" it by counting clones - `duplicateKeys()` counts primary seats for that reason.
+
 ## 5. The game module contract (short version)
 
 ```js

--- a/ConditioningControlPanel/Resources/web/arcademy/games/lost-and-found/board.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/lost-and-found/board.js
@@ -86,6 +86,87 @@ const WRAP_REPS_MAX = 6;
 const WRAP_FIT_DEBOUNCE_MS = 180;
 
 /* ----------------------------------------------------------------------------
+ * THE ONE-PICTURE LAW (owner, 0911): a picture sits on exactly ONE seat of the
+ * wall, and the target's picture on exactly one seat - so a tap on "her" is
+ * never a miss because a copy of her was dealt as a decoy. The wall used to
+ * dedupe on the exact url, which is not the same thing: the feed hands the
+ * same picture out under several urls - a clip and its own poster (the poster
+ * is the clip's first frame, and the target is drawn from the STILLS, so the
+ * clip could animate her on another seat), a rendition at another size (the
+ * `-640x800` / `-1280x1600` suffix), a repost under a second niche - and the
+ * recency ring only spreads draws within one bucket. mediaKey() is the
+ * identity that survives all of that: the whole path, rendition markers and
+ * extension folded away, case folded.
+ *
+ * THE LAW HAS TWO TIERS, and the difference is the whole design. THE TARGET'S
+ * picture is absolute: no second seat may wear it, ever, whatever else has to
+ * give - that is the owner's report, word for word. Any OTHER repeat is
+ * merely unwanted: setUrl refuses it so the caller draws again
+ * (UNIQUE_DRAW_TRIES), and only when every draw came back a repeat does the
+ * caller ask again with `lastResort` and take the copy. A library SMALLER than
+ * the wall is ordinary - a tier-4 board is 52 seats and a player may own
+ * twenty pictures - and on one of those a strict rule would answer the owner's
+ * duplicate complaint by leaving thirty seats on the glyph floor, which is a
+ * worse wall, not a fixed one. So: her picture once, the rest as distinct as
+ * the library allows.
+ *
+ * `evict` is the target's own draw (she lands and the copies are bared),
+ * `shared:true` is a draw that is MEANT to be two seats on one resource
+ * (parking a sleeper on a live url when the library has no stills - one
+ * decoder, one clock), and the bundled placeholder floor is exempt.
+ * -------------------------------------------------------------------------- */
+const SIZE_SUFFIX_RE = /[-_]\d{2,5}x\d{2,5}(?=[-_.]|$)/g;
+const RENDITION_MARK_RE = /[-_](?:thumb(?:nail)?|poster|small|mobile)(?=[-_.]|$)/gi;
+const SCHEME_HOST_RE = /^[a-z][a-z0-9+.-]*:\/\/[^/]*/i;
+const PLACEHOLDER_URL_RE = /\/ae-ph-\d+\.svg(\?|#|$)/i;
+
+/**
+ * The media identity of a url: what the player SEES, not where it came from.
+ *
+ * THE PATH, never the bare file name, and the choice is load-bearing in both
+ * directions. Key on too much (the whole url) and a second rendition of one
+ * picture reads as a second picture. Key on too little (the last segment) and
+ * the DESKTOP breaks outright: the shell serves a local library as
+ * `https://ccp.assets/<folder>/<file>` straight off the player's own tree
+ * (ArcademyHostService.ToAssetsUrl), and a folder of 001.jpg / 002.jpg beside
+ * another folder of 001.jpg / 002.jpg is the ordinary shape of a saved
+ * library - name-only keying would call those one picture and bare half the
+ * wall. The same trap remotely: v.redd.it puts the identity in the PARENT
+ * segment and a resolution in the file name (<post>/DASH_720.mp4), so every
+ * reddit clip on the wall would collapse onto "dash_720".
+ *
+ * So: drop the scheme and host - one CDN hands the same file out under its
+ * `preview.` and `i.` subdomains, and inside the Discord Activity the web shim
+ * rewrites every remote row to `<frame origin>/scrolller-media/...`
+ * (inventory.js) - keep every path segment, and fold only what is provably a
+ * rendition of ONE file: the query (reddit's preview host puts the size
+ * there), the host's `#.ext` animation hint, the extension (a clip and its own
+ * poster sit side by side as loop5.mp4 / loop5.jpg), a `-640x800` size suffix,
+ * a thumb/poster/small/mobile rendition marker, and case.
+ */
+export function mediaKey(url) {
+  let s = String(url || '').trim();
+  if (!s) return '';
+  if (/^(blob|data):/i.test(s)) return s;          // a pile row: the url is the picture
+  const hash = s.indexOf('#'); if (hash >= 0) s = s.slice(0, hash);   // the host's ext hint
+  const q = s.indexOf('?'); if (q >= 0) s = s.slice(0, q);
+  s = s.replace(SCHEME_HOST_RE, '').replace(/\\/g, '/').replace(/^\.?\/+/, '');
+  const slash = s.lastIndexOf('/');
+  const dir = slash >= 0 ? s.slice(0, slash + 1) : '';
+  let name = slash >= 0 ? s.slice(slash + 1) : s;
+  const dot = name.lastIndexOf('.');
+  if (dot > 0) name = name.slice(0, dot);
+  name = name.replace(SIZE_SUFFIX_RE, '').replace(RENDITION_MARK_RE, '');
+  return ((dir + name) || s).toLowerCase();
+}
+
+/** A key the one-picture law counts: real media only, never the glyph floor. */
+export function uniqueKey(url) {
+  if (!url || PLACEHOLDER_URL_RE.test(String(url))) return '';
+  return mediaKey(url);
+}
+
+/* ----------------------------------------------------------------------------
  * LOOK PAINTING - shared by the board tiles and by every card in hud.js, so a
  * briefing card, a peek card and the found spotlight are guaranteed to render
  * the target exactly as the board does (same gradient, same hue, same url, same
@@ -676,6 +757,24 @@ export function createBoard(o) {
     const anim = isAnimatedUrl(url);
     if (anim && liveBlocked(tile, url)) return false;
     if (isVid && !tile.isVideo && videoTiles >= videoCap) return false;
+    /* THE ONE-PICTURE LAW (see mediaKey). Checked before any budget moves, so
+     * a refusal costs nothing. */
+    const key = (draw && draw.shared) ? '' : uniqueKey(url);
+    if (key) {
+      const evict = !!(o && o.evict);
+      // TIER ONE - HER picture, and no `lastResort` buys a way past it: a
+      // second seat wearing the target is the bug being fixed, not a repeat.
+      const target = tiles.find((t) => t.target);
+      if (!evict && target && target !== tile && uniqueKey(target.url) === key) return false;
+      // TIER TWO - any other repeat. EVERY wearer, not just the first: a
+      // shared park can legally rest two seats on one picture, so the target's
+      // own draw has to clear the whole set to land alone.
+      const others = tiles.filter((t) => t !== tile && t.url && uniqueKey(t.url) === key);
+      if (others.length) {
+        if (!evict) { if (!(o && o.lastResort)) return false; }
+        else for (const other of others) setUrl(other, { url: null });  // bare; the dress re-seats it
+      }
+    }
 
     releaseLive(tile);
     if (tile.isVideo && !isVid) videoTiles = Math.max(0, videoTiles - 1);
@@ -740,50 +839,34 @@ export function createBoard(o) {
    *
    * The provider is ASKED for same-niche decoys (claim spec nearTwinBias) but does
    * not honour the hint yet, so this is the local fallback that makes the tease
-   * real either way:
-   *   STRONG twins carry the target's actual media at a different hue (capped, or
-   *   half the board would be literal copies);
-   *   WEAK twins take the target's gradient at an unused hue - visually adjacent,
-   *   never ambiguous.
-   * Both are tagged `warm`, which is the only thing index.js reads.
+   * real either way: a twin takes the target's GRADIENT at an unused hue -
+   * visually adjacent, never ambiguous. Tagged `warm`, which is the only thing
+   * index.js reads.
+   *
+   * There are no "strong" twins any more (0911). Up to four seats used to wear
+   * the target's own picture at a shifted hue, and the owner read it exactly
+   * as the constants file predicted it would: "an image can be in multiple
+   * places but only one is correct" - a bug, not difficulty. The one-picture
+   * law (setUrl) would refuse the copy now anyway; the branch is gone so the
+   * intent is in one place.
    */
   function assignWarm(o) {
     const opts = o || {};
     const share = clamp(opts.share, 0, 1);
     const wantRng = typeof opts.rng === 'function' ? opts.rng : rng;
-    // Optional stagger for the strong-twin repaints (per-round target rotation
-    // on touch): the url still lands NOW - bookkeeping stays correct - only the
-    // paint is deferred, through setUrl's own paintDelayMs seam.
-    const paintDelay = Math.max(0, opts.paintDelayMs | 0);
     for (const tile of tiles) if (!tile.target) tile.warm = false;
     if (share <= 0) return 0;
 
     const target = api.targetTile();
     if (!target) return 0;
-    const urlCap = Number.isFinite(opts.urlCap) ? opts.urlCap : PLAYTEST.NEAR_TWIN_URL_CAP;
     const want = Math.min(Math.round(share * tiles.length), Math.floor(tiles.length / 2));
     const used = usedSignatures();
     const freeHues = HUES.filter((h) => !used.has(target.grad + ':' + h));
     const candidates = shuffle(tiles.filter((tile) => !tile.target), wantRng);
 
     let made = 0;
-    let strong = 0;
     for (const tile of candidates) {
       if (made >= want) break;
-      if (strong < urlCap && target.url
-        // The target's own url is free to copy when it is already on the wall
-        // (it always is - this IS the target's url), so a strong twin never
-        // mints a decoder. setUrl still arbitrates, so the budget cannot be
-        // side-stepped through this door either.
-        && setUrl(tile, { url: target.url, remote: target.remote },
-          paintDelay ? { paintDelayMs: paintDelay * (strong + 1) } : null)) {
-        // same media, different hue: the honest local version of a near-twin
-        used.delete(tile.grad + ':' + tile.hue);
-        tile.warm = true;
-        used.add(tile.grad + ':' + tile.hue);
-        strong += 1; made += 1;
-        continue;
-      }
       const hue = freeHues.shift();
       if (hue == null) break;                 // out of collision-free signatures
       used.delete(tile.grad + ':' + tile.hue);
@@ -866,15 +949,52 @@ export function createBoard(o) {
     fitWrap(why) { return fitWrap(why || 'host'); },
     /** Clone sets per row, after the fit. */
     repsPerRow() { return rows.map((r) => r.reps | 0); },
+    /** The one-picture law's telemetry: every media key worn by more than one
+     *  seat (a shared park is the one legal case; it is listed all the same,
+     *  so a log line can say how many). Empty is the promise kept. */
+    duplicateKeys() {
+      const seen = new Map();
+      for (const t of tiles) {
+        const k = uniqueKey(t.url);
+        if (!k) continue;
+        seen.set(k, (seen.get(k) | 0) + 1);
+      }
+      const out = [];
+      for (const [k, n] of seen) if (n > 1) out.push({ key: k, seats: n });
+      return out;
+    },
+    /** How many seats wear the target's PICTURE - the law says exactly 1, and
+     *  0 while she is on her gradient signature alone (a dry pool, the glyph
+     *  floor), which the dress line already reports in words. */
+    targetSeats() {
+      const target = api.targetTile();
+      const k = target ? uniqueKey(target.url) : '';
+      if (!k) return 0;
+      return tiles.reduce((n, t) => n + (uniqueKey(t.url) === k ? 1 : 0), 0);
+    },
     tileFor(node) { return byEl.get(node) || null; },
     targetTile() { return tiles.find((t) => t.target) || null; },
 
     setUrl, repaint, swapLooks, assignWarm,
 
-    /** Mark/unmark the hunt target (a look field, so it rides swaps). */
+    /** Mark/unmark the hunt target (a look field, so it rides swaps).
+     *
+     *  THE ONE-PICTURE LAW's second door. A round rotation promotes a seat
+     *  that is ALREADY dressed (rotateTarget picks off the wall - no provider
+     *  draw, no new decoder), so the law's setUrl gate never sees it. If a
+     *  shared park happens to rest on the picture being promoted, she is on
+     *  two seats again from round two on: the owner's bug, one round later.
+     *  Bare the other wearers here instead; the next onlyBare dress re-seats
+     *  them from the provider's next batch. */
     setTarget(tile) {
       for (const t of tiles) t.target = false;
-      if (tile) tile.target = true;
+      if (!tile) return;
+      tile.target = true;
+      const key = uniqueKey(tile.url);
+      if (!key) return;
+      for (const t of tiles) {
+        if (t !== tile && t.url && uniqueKey(t.url) === key) setUrl(t, { url: null });
+      }
     },
 
     /** Class toggling on every copy of a tile (found rim, pity, warm). */

--- a/ConditioningControlPanel/Resources/web/arcademy/games/lost-and-found/constants.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/lost-and-found/constants.js
@@ -222,12 +222,17 @@ export const PLAYTEST = Object.freeze({
   /** How long the near-miss "warm" shimmer sits on the true target. */
   NEAR_TWIN_SHIMMER_MS: 400,
   /**
-   * How many near-twins may carry the target's ACTUAL media (at a different hue).
-   * The rest are same-gradient/adjacent-hue lookalikes. Uncapped, half a tier-4
-   * board would be literal copies of the target - which reads as a bug, not as
-   * difficulty. Prime tuning candidate once the provider honours nearTwinBias.
+   * How many times a seat re-draws when the one-picture law (board.js
+   * mediaKey / setUrl) refuses what the pool handed it - another seat already
+   * wears that picture. After the last try the seat takes the repeat rather
+   * than sit on the glyph floor (`lastResort`), because a library smaller than
+   * the wall is ordinary and a bare seat is the worse answer. The TARGET's
+   * picture is never the repeat that gets taken; that tier of the law has no
+   * last resort. (The old NEAR_TWIN_URL_CAP - up to four near-twins carrying
+   * the target's ACTUAL picture - is gone: the owner read those copies as a
+   * bug, and they were one.)
    */
-  NEAR_TWIN_URL_CAP: 4,
+  UNIQUE_DRAW_TRIES: 3,
 });
 
 /* ----------------------------------------------------------------------------

--- a/ConditioningControlPanel/Resources/web/arcademy/games/lost-and-found/index.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/lost-and-found/index.js
@@ -51,7 +51,7 @@ import {
   DENSITY_LEVELS, DENSITY_HARD_CAP, DENSITY_COARSE_CAP, TOUCH_MIN_TILE_H,
 } from './constants.js';
 import { makeRng } from '../../core/rng.js';
-import { createBoard, paintLook, isVideoUrl, isAnimatedUrl } from './board.js';
+import { createBoard, paintLook, isVideoUrl, isAnimatedUrl, mediaKey } from './board.js';
 import { createHud } from './hud.js';
 import { createTrickster } from './trickster.js';
 import { createCasino } from './casino.js';
@@ -441,7 +441,10 @@ export default {
      */
     function drawLive(targetUrl) {
       if (!pool || typeof pool.next !== 'function' || !board) return null;
-      const have = new Set(board.liveUrls().map((e) => e.url));
+      // keyed on the PICTURE, not the url: a clip is the same clock as itself
+      // at another size, and the target's clip is the target (one-picture law)
+      const have = new Set(board.liveUrls().map((e) => mediaKey(e.url)));
+      const targetKey = mediaKey(targetUrl);
       // Preferring video is only useful while there is a player slot left for
       // one: past the element ceiling every video draw would be refused and the
       // seat would fall back to a still, quietly shrinking the live window.
@@ -451,8 +454,8 @@ export default {
       for (let i = 0; i < PLAYTEST.LIVE_DRAW_TRIES; i++) {
         const got = pool.next('loop');
         if (!got || !got.url) break;
-        if (targetUrl && got.url === targetUrl) continue;
-        if (have.has(got.url)) continue;
+        if (targetKey && mediaKey(got.url) === targetKey) continue;
+        if (have.has(mediaKey(got.url))) continue;
         // the bundled placeholder floor lands in the loop pool too and animates
         // nothing - usable, but never worth spending a live seat on
         if (!isAnimatedUrl(got.url)) { if (!fallback) fallback = got; continue; }
@@ -471,9 +474,14 @@ export default {
       if (reduced || !board) return null;         // reduced motion parks nowhere
       const live = board.liveUrls();
       if (!live.length) return null;
+      const targetKey = mediaKey(targetUrl);
       for (let i = 0; i < 3; i++) {
         const pick = live[Math.floor(rng() * live.length)];
-        if (pick && pick.url && (!targetUrl || pick.url !== targetUrl)) return pick;
+        // `shared`: a park is the one draw the one-picture law lets two seats
+        // wear - it IS the same resource on purpose (see board.js)
+        if (pick && pick.url && (!targetKey || mediaKey(pick.url) !== targetKey)) {
+          return { url: pick.url, remote: pick.remote, shared: true };
+        }
       }
       return null;
     }
@@ -492,6 +500,13 @@ export default {
      *   bank  drawn-but-unspent urls, oldest first
      * ---------------------------------------------------------------------- */
     const SLEEPER_BANK_MAX = 8;
+    /* KEYED ON THE PICTURE, not the url (0911). This ledger's whole job is
+     * "no seat repeats what another seat already wears", which is the
+     * one-picture law read from the draw side - and the feed hands one picture
+     * out under several urls. Keyed on the url it would cheerfully deal the
+     * same picture twice, board.setUrl would refuse the second, and dressTile
+     * would burn its UNIQUE_DRAW_TRIES on a pool that keeps offering the same
+     * thing. Keyed on mediaKey the retry actually gets something new. */
     let sleeperUsed = new Set();
     const sleeperBank = [];
     function sleeperReset() {
@@ -499,8 +514,8 @@ export default {
       sleeperBank.length = 0;
     }
     function sleeperBankPush(got) {
-      if (!got || !got.url || sleeperUsed.has(got.url)) return;
-      if (sleeperBank.some((e) => e.url === got.url)) return;
+      if (!got || !got.url || sleeperUsed.has(mediaKey(got.url))) return;
+      if (sleeperBank.some((e) => mediaKey(e.url) === mediaKey(got.url))) return;
       sleeperBank.push(got);
       while (sleeperBank.length > SLEEPER_BANK_MAX) sleeperBank.shift();
     }
@@ -509,8 +524,8 @@ export default {
       let at = -1;
       for (let i = 0; i < sleeperBank.length; i++) {
         const e = sleeperBank[i];
-        if (!e || !e.url || sleeperUsed.has(e.url)) continue;
-        if (targetUrl && e.url === targetUrl) continue;
+        if (!e || !e.url || sleeperUsed.has(mediaKey(e.url))) continue;
+        if (targetUrl && mediaKey(e.url) === mediaKey(targetUrl)) continue;
         if (!isAnimatedUrl(e.url)) { at = i; break; }
         if (at < 0) at = i;
       }
@@ -518,13 +533,14 @@ export default {
     }
     function sleeperTake(got, targetUrl) {
       if (!got || !got.url) return got;
-      if (!sleeperUsed.has(got.url)) { sleeperUsed.add(got.url); return got; }
+      const key = mediaKey(got.url);
+      if (!sleeperUsed.has(key)) { sleeperUsed.add(key); return got; }
       /* this seat would repeat: spend a banked url if one is free, and bank the
        * repeat in its place (it may still dress a later seat) */
       const alt = sleeperBankTake(targetUrl);
       if (!alt) return got;                       // nothing banked: the repeat stands
       sleeperBankPush(got);
-      sleeperUsed.add(alt.url);
+      sleeperUsed.add(mediaKey(alt.url));
       return alt;
     }
 
@@ -537,7 +553,7 @@ export default {
       for (let i = 0; i < 3; i++) {
         const got = pool.next('still');
         if (!got || !got.url) break;
-        if (targetUrl && got.url === targetUrl) continue;
+        if (targetUrl && mediaKey(got.url) === mediaKey(targetUrl)) continue;
         // the still we actually asked for
         if (!isAnimatedUrl(got.url)) { if (animated) sleeperBankPush(animated); return sleeperTake(got, targetUrl); }
         if (!animated) animated = got;            // a pool that ignores `kind`
@@ -580,12 +596,17 @@ export default {
       if (!tile || !board) return false;
       let got = null;
       try { got = pool && typeof pool.next === 'function' ? pool.next('still') : null; } catch (e) { got = null; }
-      if (got && got.url && !isAnimatedUrl(got.url) && board.setUrl(tile, got)) return true;
+      // the law may refuse this still (another seat wears that picture); a
+      // resting seat would rather take the repeat than fall to the floor
+      if (got && got.url && !isAnimatedUrl(got.url)
+        && (board.setUrl(tile, got) || board.setUrl(tile, got, { lastResort: true }))) return true;
       const target = board.targetTile();
+      const targetKey = target ? mediaKey(target.url) : '';
       const live = board.liveUrls().filter((e) => !isVideoUrl(e.url)
-        && (!target || e.url !== target.url));
+        && (!targetKey || mediaKey(e.url) !== targetKey));
       const pick = live.length ? live[Math.floor(Math.random() * live.length)] : null;
-      if (pick && board.setUrl(tile, pick)) return true;
+      // a park is a SHARED seat by design (one resource, one clock) - see board.js
+      if (pick && board.setUrl(tile, { url: pick.url, remote: pick.remote, shared: true })) return true;
       return board.setUrl(tile, { url: null });
     }
 
@@ -710,16 +731,26 @@ export default {
      *  an error). Returns true if any look took. */
     function dressTile(tile, targetUrl, wantLive, delayMs) {
       const o = { paintDelayMs: delayMs };
-      if (wantLive) {
-        const got = drawLive(targetUrl);
-        if (got && board.setUrl(tile, got, o)) return true;
-      }
-      const rest = drawSleeper(targetUrl);
-      if (rest && board.setUrl(tile, rest, o)) return true;
-      if (!wantLive) {
-        const got = drawLive(targetUrl);          // still-less library, cap free
-        if (got && board.setUrl(tile, got, o)) return true;
-      }
+      /* A draw the one-picture law refuses (board.setUrl: another seat already
+       * wears that picture) is drawn AGAIN, a few times. If the pool has
+       * nothing new left - a library smaller than the wall, which is ordinary
+       * - the last draw is taken ANYWAY (`lastResort`): a repeated decoy is a
+       * better wall than a seat on the glyph floor, and setUrl still refuses
+       * the one repeat that matters, the target's own picture. */
+      const tries = Math.max(1, PLAYTEST.UNIQUE_DRAW_TRIES | 0);
+      const seat = (draw) => {
+        let last = null;
+        for (let i = 0; i < tries; i++) {
+          const got = draw();
+          if (!got || !got.url) break;
+          if (board.setUrl(tile, got, o)) return true;
+          last = got;
+        }
+        return !!last && board.setUrl(tile, last, Object.assign({ lastResort: true }, o));
+      };
+      if (wantLive && seat(() => drawLive(targetUrl))) return true;
+      if (seat(() => drawSleeper(targetUrl))) return true;
+      if (!wantLive && seat(() => drawLive(targetUrl))) return true;   // still-less library, cap free
       return false;
     }
 
@@ -768,7 +799,9 @@ export default {
       try {
         if (!late && (!onlyBare || wearsPlaceholder(target))) {
           const got = pool.next('target');
-          if (got && got.url) { targetUrl = got.url; board.setUrl(target, got); }
+          // `evict`: if a decoy already wears this picture (a late batch, a
+          // repost), it is bared and re-seated below - she lands exactly once
+          if (got && got.url && board.setUrl(target, got, { evict: true })) targetUrl = got.url;
         }
       } catch (e) { say('target draw failed - gradient target stands'); }
       /* THE LIVE WINDOW. Only `cap` seats animate; the rest wear stills. On a
@@ -813,10 +846,13 @@ export default {
       // remote/local media can land after the briefing card is up
       if (hud) hud.refreshCards(targetLook());
       const after = board.liveStats();
+      const dupes = board.duplicateKeys();
       say('board dressed: ' + density + ' tiles, ' + warm + ' near-twins, '
         + after.used + '/' + after.cap + ' live urls on ' + after.tiles + ' seats ('
         + after.elements + ' animated els, ' + after.videoTiles + ' video), '
-        + (targetUrl ? 'target media ok' : 'target on its look signature only'));
+        + (targetUrl ? 'target media ok' : 'target on its look signature only')
+        + ', target on ' + board.targetSeats() + ' seat(s), '
+        + (dupes.length ? dupes.length + ' shared picture(s)' : 'no shared picture'));
     }
 
     /* ---------------------------------------------------------------- swaps */
@@ -897,8 +933,17 @@ export default {
             const target = board.targetTile();
             // ...on the SAME side of the live window the seat is already on, so
             // a remote batch can never quietly inflate the animated set.
-            const got = tile ? drawFor(tile, target ? target.url : null) : null;
-            if (got) board.setUrl(tile, got);
+            /* A refusal here is the one-picture law, not a budget: this seat
+             * was offered a picture some other seat already wears. Draw again
+             * rather than drop the upgrade - and on a pool with nothing new
+             * left the seat simply keeps the media it already had. */
+            const tries = Math.max(1, PLAYTEST.UNIQUE_DRAW_TRIES | 0);
+            for (let k = 0; tile && k < tries; k++) {
+              const got = drawFor(tile, target ? target.url : null);
+              if (!got || !got.url) break;
+              // the last try takes the repeat rather than drop the upgrade
+              if (board.setUrl(tile, got, k === tries - 1 ? { lastResort: true } : null)) break;
+            }
           }
         };
         step();
@@ -989,15 +1034,9 @@ export default {
       board.setTarget(pick);
       pick.warm = false;             // setTarget marks, it never un-warms - and
                                      // a target that is warm would tease, not find
-      // Near-twins re-key to the NEW look, seeded off the round stream. On
-      // touch the strong-twin repaint is capped and staggered so the ceremony
-      // tail never lands on a decode stampede (paintDelayMs = board.js seam).
-      board.assignWarm({
-        share: dials.nearTwinShare,
-        rng: r,
-        urlCap: touch ? Math.min(2, PLAYTEST.NEAR_TWIN_URL_CAP) : undefined,
-        paintDelayMs: touch ? 240 : 0,
-      });
+      // Near-twins re-key to the NEW look, seeded off the round stream (hue
+      // twins only - the target's picture is on one seat, board.js).
+      board.assignWarm({ share: dials.nearTwinShare, rng: r });
       // THE FUNNEL: refreshCards repaints the chip AND any live peek/spot card
       // and the howto polaroid - never setTargetArt alone.
       if (hud) hud.refreshCards(targetLook());


### PR DESCRIPTION
## What the owner saw

> "an image can be in multiple places as a copy but seems like only one is correct. We should be sure that the target doesn't get duplicated and there is only one."

## Root cause - two doors, not one

**The loud one was on purpose.** `assignWarm()` dealt up to `PLAYTEST.NEAR_TWIN_URL_CAP` (4) "strong" near-twins carrying **the target's actual media** at a shifted hue. The constant's own comment predicted the bug it caused - *"uncapped, half a tier-4 board would be literal copies of the target - which reads as a bug, not as difficulty"*. It reads as a bug at four as well. That branch is gone; a near-twin is now a gradient-and-hue lookalike and nothing else.

**The quiet one was the dedupe.** Every guard in the room compared **exact urls** (`drawLive`'s `have` set, `sleeperUsed`, `parkedUrl`, the target filters), and one picture reaches the page under several urls:

- a clip and its own poster - and the web host puts a clip's poster straight into the **still** pool (`provider shim absorb`), while the target is drawn from the stills, so her clip can animate on another seat
- a second rendition (`-640x800`, or reddit's size-as-a-query preview host)
- a crosspost, or the same file on a CDN's `preview.` and `i.` subdomains

`board.js mediaKey()` is the identity that survives all of that, and `setUrl()` is the one gate that enforces it.

## The law has two tiers, and that is the design

- **Her picture is absolute.** No second seat, ever, and no `lastResort` buys a way past it.
- **Any other repeat is merely unwanted.** The seat re-draws `UNIQUE_DRAW_TRIES` times and then **takes the copy** rather than sit on the glyph floor.

Strict global uniqueness is the trap inside the trap. A tier-4 board is 52 seats, a library smaller than the wall is ordinary, and the rig's own feed delivers **nine** distinct pictures behind those 52 - a strict rule would answer a duplicate complaint by parking forty seats on the placeholder floor. That is a worse wall, not a fixed one.

**`setTarget` is the second door.** A round rotation promotes a seat that is **already dressed** (no provider draw, so `setUrl`'s gate never sees it), and a shared park resting on that picture puts her on two seats again from round two on. On main the target grew from 5 seats at the deal to **8-10 by the end of the class**. The law is enforced in `setTarget` too.

**`mediaKey` keys on the PATH, never the file name.** Name-only keying breaks the desktop outright: the shell serves a local library as `https://ccp.assets/<folder>/<file>` off the player's own tree, and a folder of `001.jpg` beside another folder of `001.jpg` is the ordinary shape of a saved library. Same trap remotely - `v.redd.it/<post>/DASH_720.mp4` puts the identity in the **parent** segment. So: drop the scheme and host, keep every segment, fold only what is provably a rendition of one file (query, the `#.ext` animation hint, extension, `-WxH`, a thumb/poster/small/mobile marker, case).

## Verified in the rig

Headless Edge over CDP, iPhone-ish 844x390, coarse pointer + touch, 2 Mbps / 100 ms / x4 CPU, tier 4. Mock Scrolller feed that serves the same picture as a rendition, as a byte-identical repost, and as a clip's own poster, with the target's picture present in the decoy pages. Both builds measured with the same page-side key function, `main@63aaee133` on one origin and this branch on another, at the same time.

| measured on the board's primary seats | main | this branch |
| --- | --- | --- |
| primary seats / with media / on the glyph floor | 52 / 52 / **0** | 52 / 52 / **0** |
| distinct pictures available to the deal | 9 | 9 |
| duplicated media keys at the deal | 8 over 51 seats | 7 over 50 seats |
| **seats wearing the target's picture, at the deal** | **5** | **1** |
| **decoys wearing the target's picture** | **4** | **0** |
| **seats wearing the target's picture, end of class** | **8 - 10** | **1** |
| decoys wearing her, end of class | 7 - 9 | **0** |
| **tap on a decoy that wears her picture** | **Misses 0 -> 1** | not possible, none wears her |
| Misses after the target taps | 1 | 0 |
| console errors | 0 | 0 |
| wrap-gap samples over the class (trap 146 stays fixed) | 0 / 33 | 0 / 33 |

Desktop shape (1600x900, fine pointer, no throttle, 123 tiles): target on **1** seat at the deal and at the end, 0 decoys wearing her, **0** seats on the glyph floor, reps unchanged at x2, 0 errors.

## The marquee clones

Every clone `buildTileEl` makes is registered in `byEl`, so `tileFromNode` walks any clone up to the same tile object. Proved rather than asserted, two ways:

- **the press road's own walk**, sampled live: ~10,000 reachable clone points over a class (`elementFromPoint` -> `closest('.g-lf-tile')`), **rep0 2615/2615, rep1 3116/3116, rep2 138/138, zero misresolutions** - rep 2 being the clone set `fitWrap` adds after a portrait-to-landscape rotation (PR #1091). Same result on main (1905/1905, 1959/1959, 28/28).
- **real taps**: a touch on the target's rep 0, rep 1 and the post-rotation rep 2 each scored **FOUND** with the Misses counter unmoved. (A tier-4 hunt relocates the target mid-hunt, so a synthetic tap measured one CDP round-trip earlier sometimes lands after she has moved; that is the rig, and the probe above is the part that is timing-free.)

## Not verified

- Real iOS Safari, and the desktop WebView2 build with an actual local folder tree. `mediaKey` is unit-checked against the local url shape (`ccp.assets/<folder>/<file>`, the `#.ext` animation hint, two folders of `001.jpg`) but nobody has run the app.
- The arcademy headless module suite was not rebuilt (no repo test dir).

Trap 147 added to `arcademy/CLAUDE.md`. Do not merge - the coordinator merges and dispatches the cclabs-web sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NDhyuyET1jY4ZKSp4RFu7F
