### PR TITLE
fix(vault): keep the tier livery band behind the tier badge

### DIFF
--- a/ConditioningControlPanel/Controls/TierFxBorder.cs
+++ b/ConditioningControlPanel/Controls/TierFxBorder.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Documents;
@@ -350,6 +351,7 @@ namespace ConditioningControlPanel.Controls
 
                 HookVisibility();
                 _wantClock = ambient;
+                _badges = null;   // re-find the card's tier signs on the next frame
 
                 if (!ambient)
                 {
@@ -507,6 +509,11 @@ namespace ConditioningControlPanel.Controls
                 double bandLength = _perimeter * BandFraction;
                 double segment = bandLength / BandSegments;
 
+                // The adorner layer paints above the whole card, so without this the band would
+                // cut straight through the tier sign pinned on the corner. Punch the sign out.
+                var occluder = BadgeOccluder(size);
+                if (occluder != null) drawingContext.PushClip(occluder);
+
                 // Dimmest segments first so the bright core paints over its own falloff.
                 for (int i = 0; i < BandSegments; i++)
                 {
@@ -519,8 +526,73 @@ namespace ConditioningControlPanel.Controls
                 }
 
                 if (_tier >= 2) DrawGlints(drawingContext, phase);
+
+                if (occluder != null) drawingContext.Pop();
             }
             catch (Exception ex) { App.Logger?.Debug("TierFxBorderAdorner.OnRender: {E}", ex.Message); }
+        }
+
+        /// <summary>
+        /// The clip that keeps the band BEHIND any <see cref="TierBadge"/> on the card. An adorner
+        /// always paints over the adorned element's content, and Panel.ZIndex cannot reach across
+        /// into the adorner layer, so the band would otherwise cross the sign. The badge art is an
+        /// opaque rounded plate edge to edge (the stamp is close enough), so each visible image's
+        /// own box, carried through its live tilt and wobble, is the hole. Null when there is no
+        /// visible badge, which leaves an unbadged card drawing exactly as before.
+        /// </summary>
+        internal Geometry? BadgeOccluder(Size size)
+        {
+            _badges ??= FindBadges(AdornedElement);
+            if (_badges.Count == 0) return null;
+
+            GeometryGroup? holes = null;
+            foreach (var badge in _badges)
+            {
+                if (badge.Visibility != Visibility.Visible) continue;
+                AddHole(badge.TierImage);
+                AddHole(badge.StampImage);
+            }
+            if (holes == null) return null;
+
+            // Generous outer rect: the band's round caps and the glints can sit a few px past the
+            // element's own box.
+            var everything = new RectangleGeometry(new Rect(-16, -16, size.Width + 32, size.Height + 32));
+            var clip = new CombinedGeometry(GeometryCombineMode.Exclude, everything, holes);
+            clip.Freeze();
+            return clip;
+
+            void AddHole(Image image)
+            {
+                if (image.Visibility != Visibility.Visible || image.Source == null) return;
+                var box = image.RenderSize;
+                if (box.Width <= 0 || box.Height <= 0) return;
+                if (!image.IsDescendantOf(AdornedElement)) return;
+
+                // Includes the image's RenderTransform, so the hole follows the sway frame by frame.
+                if (image.TransformToAncestor(AdornedElement) is not Transform toCard) return;
+
+                double radius = box.Height * 0.11;
+                var hole = new RectangleGeometry(new Rect(box), radius, radius) { Transform = toCard.CloneCurrentValue() };
+                holes ??= new GeometryGroup { FillRule = FillRule.Nonzero };
+                holes.Children.Add(hole);
+            }
+        }
+
+        private List<TierBadge>? _badges;
+
+        private static List<TierBadge> FindBadges(DependencyObject root)
+        {
+            var found = new List<TierBadge>();
+            var stack = new Stack<DependencyObject>();
+            stack.Push(root);
+            while (stack.Count > 0)
+            {
+                var node = stack.Pop();
+                if (node is TierBadge badge) { found.Add(badge); continue; }
+                int n = VisualTreeHelper.GetChildrenCount(node);
+                for (int i = 0; i < n; i++) stack.Push(VisualTreeHelper.GetChild(node, i));
+            }
+            return found;
         }
 
         /// <summary>Paint order 0,10,1,9,2,8,... - the two faint tips go down first and the bright

--- a/Tests/ConditioningControlPanel.Tests/TierFxBorderBadgeOcclusionTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/TierFxBorderBadgeOcclusionTests.cs
@@ -1,0 +1,105 @@
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Documents;
+using System.Windows.Media;
+using ConditioningControlPanel.Controls;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// The tier livery band is an adorner, and an adorner paints over everything inside the card it
+/// decorates - including the tier sign pinned on that card's corner. Owner screenshot (2026-09-13):
+/// the gold band on "The Collection" cutting straight through BASIC SUBJECT. The band now clips a
+/// hole for every visible <see cref="TierBadge"/>; these pin where that hole is.
+/// </summary>
+[Collection(CompanionWpfRenderCollection.Name)]
+public class TierFxBorderBadgeOcclusionTests
+{
+    private static (Border Card, TierBadge? Badge, TierFxBorderAdorner Band) Build(int tier, bool withBadge, bool freeToday = false)
+    {
+        var inner = new Grid();
+        TierBadge? badge = null;
+        if (withBadge)
+        {
+            // Shelf-card posture (MainWindow.Exclusives.cs): top-right, tucked over the corner.
+            badge = new TierBadge
+            {
+                MotionOverride = false,
+                Margin = new Thickness(0, -6, -6, 0),
+            };
+            badge.Tier = tier;
+            badge.FreeToday = freeToday;
+            inner.Children.Add(badge);
+        }
+
+        var card = new Border
+        {
+            Width = 336,
+            Height = 200,
+            Margin = new Thickness(12),
+            CornerRadius = new CornerRadius(12),
+            BorderThickness = new Thickness(3),
+            BorderBrush = Brushes.Goldenrod,
+            Child = inner,
+        };
+        var decorator = new AdornerDecorator { Child = new Grid { Children = { card } } };
+        decorator.Measure(new Size(360, 224));
+        decorator.Arrange(new Rect(0, 0, 360, 224));
+        decorator.UpdateLayout();
+
+        var band = new TierFxBorderAdorner(card, tier, 12, 3);
+        AdornerLayer.GetAdornerLayer(card)!.Add(band);
+        decorator.UpdateLayout();
+        return (card, badge, band);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(2)]
+    public void TheBandSkipsTheSignButKeepsTheRestOfTheRim(int tier)
+    {
+        WpfRenderHarness.OnStaThread(() =>
+        {
+            var (card, badge, band) = Build(tier, withBadge: true);
+            var clip = band.BadgeOccluder(card.RenderSize);
+            Assert.NotNull(clip);
+
+            // Where the top rim runs under the sign (the art spans roughly x 191..342 on a 336 card).
+            var image = badge!.TierImage;
+            var mid = image.TransformToAncestor(card).Transform(
+                new Point(image.RenderSize.Width * 0.5, image.RenderSize.Height * 0.12));
+            Assert.False(clip!.FillContains(new Point(mid.X, 1.5)),
+                $"tier {tier}: the band still paints the top rim under the sign at x={mid.X:F0}");
+            Assert.False(clip.FillContains(new Point(334.5, 30)),
+                $"tier {tier}: the band still paints the right rim under the sign");
+
+            // ...and everywhere the sign is not, the band still laps.
+            Assert.True(clip.FillContains(new Point(40, 1.5)), "top-left rim lost its band");
+            Assert.True(clip.FillContains(new Point(334.5, 180)), "bottom-right rim lost its band");
+            Assert.True(clip.FillContains(new Point(1.5, 100)), "left rim lost its band");
+        });
+    }
+
+    [Fact]
+    public void TheRestampedSignIsStillCovered()
+    {
+        WpfRenderHarness.OnStaThread(() =>
+        {
+            var (card, _, band) = Build(1, withBadge: true, freeToday: true);
+            var clip = band.BadgeOccluder(card.RenderSize);
+            Assert.NotNull(clip);
+            Assert.False(clip!.FillContains(new Point(334.5, 30)));
+        });
+    }
+
+    [Fact]
+    public void ACardWithNoSignIsNotClipped()
+    {
+        WpfRenderHarness.OnStaThread(() =>
+        {
+            var (card, _, band) = Build(1, withBadge: false);
+            Assert.Null(band.BadgeOccluder(card.RenderSize));
+        });
+    }
+}


### PR DESCRIPTION
## Bug
On The Collection (Exclusives vault) the animated gold/diamond rim highlight cut straight through the BASIC SUBJECT / PRIME SUBJECT sign pinned on each tiered card's corner.

## Cause
The traveling band is `TierFxBorderAdorner`, which lives in the AdornerLayer. That layer paints above all of the adorned card's content, so the `TierBadge` (a child of the card) is always underneath it, and `Panel.ZIndex` cannot reach into the adorner layer. The static rim is the Border's own stroke and was already correctly below the badge; only the moving band was on top.

## Fix
`TierFxBorderAdorner.OnRender` now pushes a clip that excludes every visible `TierBadge` image on the card (tier sign and FREE TODAY stamp), transformed through the badge's live tilt and wobble. The art is an opaque rounded plate edge to edge, so the image box with a matching corner radius is the hole. Cards with no badge get no clip and draw exactly as before. Covers the vault shelf, the vault spotlight and the Play tab wall, which all use the same adorner.

## Verification
- New `TierFxBorderBadgeOcclusionTests` (tier 1, tier 2, re-stamped, no badge): the rim under the sign is clipped, the rest of the rim is not.
- Offscreen RenderTargetBitmap renders mid-lap, before vs after: before, the band crosses the sign on the top and right rims; after, it passes behind it. Both tiers.
- `ExclusivesRenderTests` still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AgAAgsPyWe6eibEyqDvFKc