### PR TITLE
fix(race): desktop levels get their words, the race comes forward on play

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/hostMedia.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/hostMedia.js
@@ -80,9 +80,10 @@ export function createHostMediaSource() {
   let favorites = []; // host-ranked asset names (dtrh_asset_stats.json, most-engaged first)
 
   const counts = () => {
-    let images = 0, videos = 0;
+    let images = 0, videos = 0, remoteImages = 0, remoteVideos = 0;
     for (const e of entries) (e.kind === 'image' ? images++ : videos++);
-    return { images, videos, skipped };
+    for (const e of remote) (e.kind === 'image' ? remoteImages++ : remoteVideos++);
+    return { images, videos, skipped, remoteImages, remoteVideos };
   };
 
   function reshuffle() {

--- a/ConditioningControlPanel/Resources/web/dtrh/race/hostWords.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/hostWords.js
@@ -1,0 +1,66 @@
+/* ============================================================================
+ * race/hostWords.js - the shipped transcript, laid on a desktop host's chart.
+ *
+ *   wordHostChart(chart, { log, fetch }) -> Promise<chart | null>
+ *
+ * WHY. The web lane builds its road in race/cloudChart.js: the energy walk AND the
+ * whisper transcript from race/words/, one word a bubble. The desktop host charts
+ * the audio in C# instead, and its only word pass is Vosk, which is not shipped, so
+ * a desktop road came back with the curve and no words at all, even for the eleven
+ * levels whose transcripts sit right here next to this file.
+ *
+ * WHAT. A host chart that carries no words and matches a words/index.json row (by
+ * cloudId, then hash) is laid again through the web's own wordedRoad(), with the
+ * host's energy curve standing in for the peaks. Same builder, same triggers, same
+ * offset + nudge, so a level drives the same on both hosts. Anything else answers
+ * null and the host's chart stands as it was: an authored chart, a chart that
+ * already has words, a track with no transcript, or any failure on the way.
+ * ==========================================================================*/
+
+import { normalizeChart } from './chart.js';
+import { wordedRoad } from './cloudChart.js';
+import { loadWords } from './words.js';
+import { shiftRoad, readNudge } from './wordSync.js';
+
+/**
+ * The host's energy curve as the peaks pair list energyFromPeaks reads ([min, max] per
+ * slice, amplitude (max - min) / 2), one slice per host bin. It renormalises on the way
+ * back in, so a curve that is already 0..1 comes out as itself.
+ */
+function peaksFromEnergy(energy) {
+  const out = new Float32Array(energy.length * 2);
+  for (let i = 0; i < energy.length; i++) {
+    const a = Math.max(0, Math.min(1, Number(energy[i]) || 0));
+    out[i * 2] = -a; out[i * 2 + 1] = a;
+  }
+  return out;
+}
+
+export async function wordHostChart(chart, { log = null, fetch: f = null } = {}) {
+  const say = (m) => { try { if (log) log('host words: ' + m); } catch (e) { /* no log */ } };
+  try {
+    if (!chart || chart.hand === true) return null;
+    if (Array.isArray(chart.words) && chart.words.length) return null;
+    const src = chart.source || {};
+    const hash = String(src.hash || ''), cloudId = String(src.cloudId || '');
+    const energy = Array.isArray(chart.energy) ? chart.energy : [];
+    const binSec = Number(chart.binSec) > 0 ? Number(chart.binSec) : 0.5;
+    const durationSec = Number(src.durationSec) > 0 ? Number(src.durationSec) : energy.length * binSec;
+    if (!energy.length || !(durationSec > 0)) return null;
+
+    const words = await loadWords({ cloudId, hash, fetch: f, log });
+    if (!words || !words.words || !words.words.length) return null;
+
+    const road = wordedRoad({ peaks: peaksFromEnergy(energy), perSec: 1 / binSec, durationSec, name: src.name || 'track', hash, words });
+    const key = words.cloudId || cloudId || hash;
+    const sec = (Number(words.offsetSec) || 0) + readNudge(key);
+    const out = normalizeChart(shiftRoad(normalizeChart(road), sec, { trackId: key }));
+    say(`${road.words.length} words and ${road.analysis.lexicon.length} triggers on ${src.name || key}`);
+    return out;
+  } catch (err) {
+    say((err && err.message) || String(err));
+    return null;
+  }
+}
+
+export default wordHostChart;

--- a/ConditioningControlPanel/Resources/web/dtrh/race/menu.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/menu.js
@@ -740,7 +740,12 @@ export function createMenu({ root, renderer, pixel, audio, settings = {}, log = 
     if (webMedia) { if (pile.images || pile.videos) parts.push(`your files (${counts(pile.images, pile.videos)})`); }
     else if (media && typeof media.stats === 'function') {
       let c = null; try { c = media.stats(); } catch (e) { c = null; }
-      if (c) { known = true; if (c.images || c.videos) parts.push(`your library (${counts(c.images | 0, c.videos | 0)})`); }
+      if (c) {
+        known = true;
+        if (c.images || c.videos) parts.push(`your library (${counts(c.images | 0, c.videos | 0)})`);
+        // the host's online pool rides the overlay, not the walls, but it is still on screen
+        if (!feed && (c.remoteImages || c.remoteVideos)) parts.push(`online feed (${counts(c.remoteImages | 0, c.remoteVideos | 0)})`);
+      }
     }
     // the best on this track rides the track line when the plate is not up to carry it (paintStatus)
     const best = name ? bestLine(trackBestRec) : '';

--- a/ConditioningControlPanel/Resources/web/dtrh/race/smoke/host-words-check.mjs
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/smoke/host-words-check.mjs
@@ -1,0 +1,29 @@
+// race/hostWords.js: a wordless desktop chart for a shipped level comes back with the words on it,
+// and a chart for a track with no transcript, or one that already has words, comes back null.
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { wordHostChart } from '../hostWords.js';
+
+const here = new URL('../', import.meta.url);
+const fsFetch = async (u) => {
+  const p = fileURLToPath(new URL(u, here));
+  try { const txt = await readFile(p, 'utf8'); return { ok: true, status: 200, json: async () => JSON.parse(txt) }; }
+  catch (e) { return { ok: false, status: 404 }; }
+};
+let fail = 0;
+const ok = (c, m) => { console.log((c ? 'ok   ' : 'FAIL ') + m); if (!c) fail++; };
+
+const dur = 726, bins = Math.ceil(dur / 0.5);
+const energy = Array.from({ length: bins }, (_, i) => 0.4 + 0.3 * Math.sin(i / 20));
+const host = { version: 1, binSec: 0.5, energy, events: [], acts: [], source: { name: 'Bambi IQ Lock', hash: '823b233f84fe3f3525fea00b6967fe79650eeb1f', durationSec: dur, sampleRate: 16000 }, analysis: { partial: true } };
+
+const got = await wordHostChart(host, { fetch: fsFetch, log: console.log });
+ok(got && got.words.length > 100, `IQ Lock by hash gets words (${got && got.words.length})`);
+ok(got && got.events.some((e) => e.kind === 'word'), 'word bubbles are on the road');
+ok(got && got.source.cloudId === '6c909be2-7a5b-495b-9f09-fabe1e3d5c16', 'the road is filed under the level cloudId');
+ok(got && got.source.durationSec === dur, 'the host duration stands');
+
+ok(await wordHostChart({ ...host, source: { ...host.source, hash: 'nope' } }, { fetch: fsFetch }) === null, 'no transcript -> null');
+ok(await wordHostChart({ ...host, words: [{ t: 1, w: 'x' }] }, { fetch: fsFetch }) === null, 'already worded -> null');
+ok(await wordHostChart({ ...host, hand: true }, { fetch: fsFetch }) === null, 'authored -> null');
+process.exit(fail ? 1 : 0);

--- a/ConditioningControlPanel/Resources/web/dtrh/raceBoot.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/raceBoot.js
@@ -258,16 +258,36 @@ const keysOf = (chart) => {
 };
 
 // ---- track charts (CHART.md host protocol). The run owns the clock; this only relays. ----
+// A desktop host charts the audio itself and ships no transcript pass, so a chart that lands
+// wordless is laid again with the shipped transcript (race/hostWords.js) and swapped in the way
+// the host's own words pass would be. `wordsGen` drops an answer that a newer chart outran.
+let wordsGen = 0;
+const worded = new Map();   // hash|cloudId -> the worded chart, so the partial and final frames share one pass
 bridge.on('track-chart', (m) => {
   if (!race || !m || !m.chart) return;
+  const gen = ++wordsGen;
+  if (!applyTrackChart(m) || m.authored) return;
+  const k = keysOf(m.chart), key = k.hash + '|' + k.cloudId;
+  let work = worded.get(key);
+  if (!work) {
+    work = import('./race/hostWords.js').then((mod) => mod.wordHostChart(m.chart, { log: host.log }));
+    worded.set(key, work);
+  }
+  work.then((chart) => {
+    if (!chart) { worded.delete(key); return; }
+    if (gen === wordsGen && race) applyTrackChart({ ...m, chart });
+  }, (e) => { worded.delete(key); host.log('host words: ' + e); });
+});
+function applyTrackChart(m) {
   try { (race.track && started) ? race.replaceTrack(m.chart) : race.setTrack(m.chart); }
-  catch (err) { host.log('track-chart: ' + ((err && err.message) || err)); trackError(String((err && err.message) || err)); return; }
+  catch (err) { host.log('track-chart: ' + ((err && err.message) || err)); trackError(String((err && err.message) || err)); return false; }
   const t = race.track, st = race.trackStats ? race.trackStats() : null;
   // `authored` is the host saying a person wrote this chart: the plate marks it, and nothing
   // fuller is coming behind it (an authored chart is never partial and never replaced).
   trackReady = t ? { stage: 'ready', name: t.name, durationSec: t.durationSec, countable: st ? st.countable : 0, partial: !!m.partial, authored: !!m.authored, ...keysOf(t.chart) } : null;
   plate(trackReady);
-});
+  return true;
+}
 bridge.on('track-clock', (m) => { if (race && m) race.trackClock(Number(m.t) || 0, m.playing !== false); });
 bridge.on('track-ended', () => { if (race) race.trackEnded(); });
 bridge.on('track-error', (m) => trackError((m && m.message) || 'the track would not load'));

--- a/ConditioningControlPanel/Services/Chaos/CaucusHostService.cs
+++ b/ConditioningControlPanel/Services/Chaos/CaucusHostService.cs
@@ -1095,7 +1095,9 @@ internal static class CaucusHostService
     }
 
     /// <summary>Their player started. If the race is still sitting on the menu, this is what starts
-    /// the run: the audio is the clock, so the run begins when the audio does.</summary>
+    /// the run: the audio is the clock, so the run begins when the audio does. A play pressed over
+    /// there hands the focus back to the race, so the player is not left steering a browser while
+    /// the run starts behind it. The BambiCloud window stays open (the audio lives in it), just under.</summary>
     private static void OnCloudPlay()
     {
         if (_cloudClock == null || !ReferenceEquals(_clock, _cloudClock)) return;
@@ -1103,6 +1105,7 @@ internal static class CaucusHostService
         if (!_runActive) PostTrack(new { type = "cloud-run" });
         StartTrackClock();
         PostClock();
+        if (_cloud?.IsFocused == true) _host?.FocusWeb();
     }
 
     /// <summary>Their element ran out. Same ending a local file gets: the page winds the lap up and

--- a/ConditioningControlPanel/Services/Race/RaceCloudWindow.cs
+++ b/ConditioningControlPanel/Services/Race/RaceCloudWindow.cs
@@ -50,6 +50,10 @@ internal sealed class RaceCloudWindow : IDisposable
 
     public bool IsOpen => _window != null && _window.IsVisible;
 
+    /// <summary>True while this window has the focus: the player is pressing things on their site
+    /// rather than driving.</summary>
+    public bool IsFocused => _window != null && _window.IsActive;
+
     /// <summary>Open the window, or bring it back if it was closed to the tray of the mind.
     /// <paramref name="url"/> is the page to land on (a track's own page, from the levels
     /// panel); null keeps whatever is already loaded, or the site's front door on a fresh


### PR DESCRIPTION
Desktop Racing Thoughts, BambiCloud levels: three things the web build does and the desktop did not.

## What was wrong
- **No words in the bubbles.** The web lays its road from the shipped whisper transcripts in `race/words/`. The desktop charts the audio in C# and its only word pass is Vosk, which is not shipped, so a level came back with the energy curve and zero words (`no Vosk model under %APP%\Resources\Models\vosk, the word pass is skipped`).
- **Race stuck behind BambiCloud.** Pressing play in the BambiCloud window started the run behind it, so the player had to duck the browser to drive.
- **Menu said "no assets"** while the host had 30 online-feed videos in the pool (they ride the DOM overlay, not the walls, and `stats()` only counted local entries).

## The fix
- `race/hostWords.js` (new): a wordless, non-authored host chart that matches a `words/index.json` row (cloudId, then hash) is laid again through the web's own `wordedRoad()`, with the host energy curve standing in for the peaks, then shifted by the row offset + nudge like `cloudChart.js` does. `raceBoot.js` swaps it in behind the host's frame (one pass shared by the partial and final frames, a generation guard drops stale answers).
- `CaucusHostService.OnCloudPlay`: when the BambiCloud window has focus, hand focus back to the race window. BambiCloud stays open (the audio lives in it).
- `hostMedia.stats()` also returns `remoteImages` / `remoteVideos`; the menu shows `online feed (N videos)` on a host with no feed panel.

## Tested
- New `race/smoke/host-words-check.mjs`: Bambi IQ Lock by hash gets 1626 words / 22 triggers, filed under its cloudId; no transcript, already worded and authored all return null.
- Existing smokes pass: words, cloud-chart, remote-feed, menu-return, lyrics-road, levels.
- Desk run on a Debug build: levels -> IQ Lock -> play on BambiCloud; captions and word bubbles on the road (popped 13 / 1284), race window in front.

Not in scope: walls stay bare on a profile with no local images (remote media never textures the walls, by design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016fSzHGbBBuYbN3xoHCccWv