### PR TITLE
feat(quests): Deeper Every Month header with a dead-season glitch

### DIFF
--- a/ConditioningControlPanel/MainWindow/MainWindow.Animations.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.Animations.cs
@@ -80,6 +80,55 @@ namespace ConditioningControlPanel
             catch { }
         }
 
+        private Views.Controls.SeasonTitleGlitch? _seasonTitleGlitch;
+
+        /// <summary>Once per app session: the glitch is news the first time and noise after that.</summary>
+        private static bool _seasonTitleGlitchPlayed;
+
+        /// <summary>
+        /// Plays the "Airhead August" to permanent-title glitch on the Quests header. Returns true
+        /// when it took over the title, in which case the shimmer starts when it finishes instead of
+        /// now. Full motion only: it is a burst of hard flicker, so Reduced gets the final title.
+        /// Clicking the header replays it (an easter egg, and how the owner vets it).
+        /// </summary>
+        private bool TryPlaySeasonTitleGlitch(bool replay)
+        {
+            if (!replay && _seasonTitleGlitchPlayed) return false;
+            if (Services.MotionFx.Level != MotionLevel.Full) return false;
+            var title = QuestsTab?.TxtSeasonTitle;
+            var finalTitle = App.QuestDefinitions?.SeasonTitle;
+            if (title == null || string.IsNullOrWhiteSpace(finalTitle)) return false;
+
+            _seasonTitleGlitchPlayed = true;
+            try
+            {
+                if (_seasonTitleGlitch == null)
+                {
+                    _seasonTitleGlitch = new Views.Controls.SeasonTitleGlitch(title);
+                    if (title.Parent is Border banner)
+                        banner.MouseLeftButtonUp += (_, _) => TryPlaySeasonTitleGlitch(replay: true);
+                }
+                StopSeasonTitleShimmer();
+                _seasonTitleGlitch.Play(Views.Controls.SeasonTitleGlitch.DeadTitle, finalTitle, () =>
+                {
+                    if (QuestsTab?.Visibility == Visibility.Visible) StartSeasonTitleShimmer();
+                });
+                return true;
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Warning("[Quests] Season title glitch failed: {Error}", ex.Message);
+                title.Text = finalTitle;
+                return false;
+            }
+        }
+
+        private void StopSeasonTitleGlitch()
+        {
+            try { _seasonTitleGlitch?.Stop(); }
+            catch (Exception ex) { Diag.Swallowed(ex, "season title glitch stop"); }
+        }
+
         private void StartLockdownPulse()
         {
             if (_lockdownPulseStoryboard != null) return; // already running

--- a/ConditioningControlPanel/MainWindow/MainWindow.QuestsTab.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.QuestsTab.cs
@@ -199,9 +199,10 @@ namespace ConditioningControlPanel
             // Proactively recalculate streak from calendar so stale values are caught immediately
             questService.RecalculateStreak();
 
-            // Update season title from server or defaults
+            // Header title: an event title from the server, else "Deeper Every Month". Left alone
+            // while the glitch owns the text; it lands on the same title when it finishes.
             var seasonTitle = App.QuestDefinitions?.SeasonTitle;
-            if (!string.IsNullOrEmpty(seasonTitle))
+            if (!string.IsNullOrEmpty(seasonTitle) && _seasonTitleGlitch?.IsPlaying != true)
             {
                 QuestsTab.TxtSeasonTitle.Text = seasonTitle;
             }

--- a/ConditioningControlPanel/MainWindow/MainWindow.TabNavigation.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.TabNavigation.cs
@@ -178,6 +178,7 @@ namespace ConditioningControlPanel
 
             // Stop animations on tabs we're leaving to reduce idle CPU
             StopSeasonTitleShimmer();
+            StopSeasonTitleGlitch();
             StopLockdownPulse();
             StopSkillTreeAnimations();
             StopExclusivesMotion();
@@ -305,8 +306,9 @@ namespace ConditioningControlPanel
                 case "quests":
                     QuestsTab.Visibility = Visibility.Visible;
                     AnimateTabIn(QuestsTab);
-                    StartSeasonTitleShimmer();
                     RefreshQuestUI();
+                    // The first visit plays the dead-season glitch; the shimmer follows it.
+                    if (!TryPlaySeasonTitleGlitch(replay: false)) StartSeasonTitleShimmer();
                     break;
 
                 case "programs":

--- a/ConditioningControlPanel/MainWindow/MainWindow.UiUpdates.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.UiUpdates.cs
@@ -2546,6 +2546,7 @@ namespace ConditioningControlPanel
             if (!Services.MotionFx.AllowAmbientLoops)
             {
                 StopSeasonTitleShimmer();
+                StopSeasonTitleGlitch();
                 StopSkillTreeAnimations();
                 StopProgramBannerFx();
                 StopLockdownPulse();

--- a/ConditioningControlPanel/Services/Progression/QuestDefinitionService.cs
+++ b/ConditioningControlPanel/Services/Progression/QuestDefinitionService.cs
@@ -45,39 +45,43 @@ public class QuestDefinitionService : IDisposable
     public DateTime? LastUpdated => _cache?.FetchedAt;
 
     /// <summary>
-    /// Default sissy-themed month names used when server doesn't provide a season title
+    /// The permanent Quests header title. Monthly seasons ended with The Descent (v6.9.0):
+    /// progress never resets and only the monthly board rotates, so the header no longer
+    /// names a month.
     /// </summary>
-    private static readonly Dictionary<int, string> DefaultMonthNames = new()
-    {
-        { 1, "Jerk-it January" },
-        { 2, "Fucked-up February" },
-        { 3, "Mindless March" },
-        { 4, "Airhead April" },
-        { 5, "Mooing May" },
-        { 6, "Juicy June" },
-        { 7, "Jelly July" },
-        { 8, "Ass-up August" },
-        { 9, "Sissygasm September" },
-        { 10, "Obey-tober" },
-        { 11, "No-nut November" },
-        { 12, "Dick-ember" }
-    };
+    internal const string PermanentTitle = "Deeper Every Month";
 
     /// <summary>
-    /// Current season title (from server or default month name). The cached server
-    /// title is only trusted while it was fetched in the CURRENT UTC month: the
-    /// month-rollover refetch (IsCacheStale) fires on startup, but when it fails —
-    /// offline launch, server hiccup — RefreshFromServerAsync leaves the old cache
-    /// loaded, and the Quests header kept showing last month's season ("Juicy June"
-    /// in July, #480). Falling back to the local month name self-corrects on the 1st
-    /// even with no network; the next successful refetch restores the server title.
+    /// A month name as a whole word ("Airhead August", "No-nut November"), or one of the two
+    /// punned months. "May" and "March" only count as the LAST word, so an event title such as
+    /// "You May Obey" or "March of the Bimbos" is not mistaken for a dead season.
     /// </summary>
-    public string SeasonTitle =>
-        (_cache?.FetchedAt is { } fetched
-            && fetched.Year == DateTime.UtcNow.Year
-            && fetched.Month == DateTime.UtcNow.Month
-            ? _cache?.SeasonTitle : null)
-        ?? DefaultMonthNames.GetValueOrDefault(DateTime.Now.Month, DateTime.Now.ToString("MMMM"));
+    private static readonly System.Text.RegularExpressions.Regex DeadSeasonPattern = new(
+        @"\b(january|february|april|june|july|august|september|october|november|december)\b"
+        + @"|\b(may|march)\s*$|obey-?tober|dick-?ember",
+        System.Text.RegularExpressions.RegexOptions.IgnoreCase
+        | System.Text.RegularExpressions.RegexOptions.CultureInvariant);
+
+    /// <summary>True for a title in the old monthly-season style, which must never be shown again.</summary>
+    internal static bool IsDeadSeasonTitle(string title) => DeadSeasonPattern.IsMatch(title);
+
+    /// <summary>
+    /// The server's title wins only when it is set, was fetched in the CURRENT UTC month (a failed
+    /// month-rollover refetch leaves the old cache loaded, #480) and is not a dead season name. The
+    /// server still says "Airhead August", so without that last check every client would show it.
+    /// Anything else resolves to <see cref="PermanentTitle"/>, which leaves the server free to
+    /// override the header for an event later.
+    /// </summary>
+    internal static string ResolveSeasonTitle(string? serverTitle, DateTime? fetchedAtUtc, DateTime utcNow)
+    {
+        if (string.IsNullOrWhiteSpace(serverTitle)) return PermanentTitle;
+        if (fetchedAtUtc is not { } fetched || fetched.Year != utcNow.Year || fetched.Month != utcNow.Month)
+            return PermanentTitle;
+        return IsDeadSeasonTitle(serverTitle) ? PermanentTitle : serverTitle.Trim();
+    }
+
+    /// <summary>Current Quests header title. See <see cref="ResolveSeasonTitle"/>.</summary>
+    public string SeasonTitle => ResolveSeasonTitle(_cache?.SeasonTitle, _cache?.FetchedAt, DateTime.UtcNow);
 
     public QuestDefinitionService()
     {

--- a/ConditioningControlPanel/Views/Controls/SeasonTitleGlitch.cs
+++ b/ConditioningControlPanel/Views/Controls/SeasonTitleGlitch.cs
@@ -1,0 +1,362 @@
+using System;
+using System.Diagnostics;
+using System.Text;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using System.Windows.Media.Effects;
+using System.Windows.Threading;
+
+namespace ConditioningControlPanel.Views.Controls;
+
+/// <summary>
+/// The Quests header's one-shot "the season is dead" glitch: the old title ("Airhead August")
+/// tears apart through RGB split, sliced bands, scrambled glyphs and a couple of dead season
+/// names, then snaps clean into the permanent title.
+///
+/// <para><b>How it draws.</b> On first use the title TextBlock is lifted out of its Border into a
+/// Grid alongside two colour ghosts (pink, cyan) and a stack of band copies, each clipped to a
+/// horizontal strip. During glitch frames the real title is hidden and the bands carry the text,
+/// so shifting a band sideways tears that strip of the word. Everything shares one cell and one
+/// font, and the Grid's height is pinned to the font's natural line height, so nothing below the
+/// header reflows while the string length morphs. The noise alphabet is plain ASCII for the same
+/// reason: a fallback-font glyph could grow the line.</para>
+///
+/// <para><b>Timing.</b> Every frame is a pure function of elapsed time (<see cref="RenderFrame"/>)
+/// quantized to 30 steps per second, which gives the stepped digital look and lets a test render
+/// any instant offscreen.</para>
+/// </summary>
+internal sealed class SeasonTitleGlitch
+{
+    internal const double DurationSeconds = 1.6;
+    internal const string DeadTitle = "Airhead August";
+
+    private const int BandCount = 6;
+    private const string Noise = "!<>-_/\\[]{}=+*^?#%&@$01XZ|~";
+
+    private static readonly Brush PinkGhost = Frozen(Color.FromRgb(0xFF, 0x14, 0x93));
+    private static readonly Brush CyanGhost = Frozen(Color.FromRgb(0x00, 0xE5, 0xFF));
+    private static readonly Brush HotWhite = Frozen(Color.FromRgb(0xFF, 0xF0, 0xFA));
+
+    private readonly TextBlock _title;
+    private readonly Stopwatch _clock = new();
+    private readonly TextBlock[] _bands = new TextBlock[BandCount];
+    private readonly RectangleGeometry[] _bandClips = new RectangleGeometry[BandCount];
+    private Grid? _stage;
+    private TextBlock? _ghostPink, _ghostCyan;
+    private Grid? _bandHost;
+    private DispatcherTimer? _timer;
+    private Action? _onDone;
+    private string _from = DeadTitle, _to = DeadTitle;
+    private uint _seed = 0x5EED;
+
+    internal SeasonTitleGlitch(TextBlock title) => _title = title;
+
+    internal bool IsPlaying => _timer != null;
+
+    /// <summary>Plays from <paramref name="from"/> into <paramref name="to"/>; <paramref name="onDone"/> fires only on a natural finish.</summary>
+    internal void Play(string from, string to, Action? onDone)
+    {
+        Cancel();
+        _from = from;
+        _to = to;
+        _onDone = onDone;
+        if (!EnsureStage())
+        {
+            _title.Text = to;
+            onDone?.Invoke();
+            return;
+        }
+        _seed = (uint)Environment.TickCount;
+        RenderAt(0);
+        _clock.Restart();
+        _timer = new DispatcherTimer(DispatcherPriority.Render) { Interval = TimeSpan.FromMilliseconds(16) };
+        _timer.Tick += OnTick;
+        _timer.Start();
+    }
+
+    /// <summary>Stops a running glitch and leaves the final title clean. Does not fire onDone.</summary>
+    internal void Stop()
+    {
+        if (!IsPlaying) return;
+        Cancel();
+        RenderClean(_to);
+    }
+
+    /// <summary>Renders one instant of the glitch with a fixed seed; for offscreen previews and tests.</summary>
+    internal void RenderFrame(string from, string to, double seconds)
+    {
+        _from = from;
+        _to = to;
+        _seed = 0x5EED;
+        if (EnsureStage()) RenderAt(seconds);
+    }
+
+    private void OnTick(object? sender, EventArgs e)
+    {
+        try
+        {
+            if (Application.Current?.Dispatcher is not { HasShutdownStarted: false })
+            {
+                Cancel();
+                return;
+            }
+            var t = _clock.Elapsed.TotalSeconds;
+            if (t < DurationSeconds)
+            {
+                RenderAt(t);
+                return;
+            }
+            var done = _onDone;
+            Cancel();
+            RenderClean(_to);
+            done?.Invoke();
+        }
+        catch (Exception ex)
+        {
+            Diag.Swallowed(ex, "season title glitch tick");
+            Cancel();
+            try { RenderClean(_to); } catch (Exception inner) { Diag.Swallowed(inner, "season title glitch reset"); }
+        }
+    }
+
+    private void Cancel()
+    {
+        _onDone = null;
+        if (_timer == null) return;
+        _timer.Stop();
+        _timer.Tick -= OnTick;
+        _timer = null;
+        _clock.Reset();
+    }
+
+    private bool EnsureStage()
+    {
+        if (_stage != null) return true;
+        if (_title.Parent is not Border border || !ReferenceEquals(border.Child, _title)) return false;
+
+        border.Child = null;
+        // Pinned to the font's natural line height: the header can never grow or shrink mid-glitch.
+        _stage = new Grid
+        {
+            Height = _title.ActualHeight > 0 ? _title.ActualHeight : _title.FontFamily.LineSpacing * _title.FontSize
+        };
+        _ghostCyan = Layer(CyanGhost);
+        _ghostPink = Layer(PinkGhost);
+        _bandHost = new Grid
+        {
+            IsHitTestVisible = false,
+            Effect = new DropShadowEffect { Color = Color.FromRgb(0xFF, 0x69, 0xB4), BlurRadius = 12, ShadowDepth = 0, Opacity = 0.7 }
+        };
+        for (int i = 0; i < BandCount; i++)
+        {
+            _bandClips[i] = new RectangleGeometry();
+            _bands[i] = Layer(_title.Foreground);
+            _bands[i].Clip = _bandClips[i];
+            _bandHost.Children.Add(_bands[i]);
+        }
+        _stage.Children.Add(_ghostCyan);
+        _stage.Children.Add(_ghostPink);
+        _stage.Children.Add(_title);
+        _stage.Children.Add(_bandHost);
+        border.Child = _stage;
+        return true;
+    }
+
+    private TextBlock Layer(Brush foreground) => new()
+    {
+        FontFamily = _title.FontFamily,
+        FontSize = _title.FontSize,
+        FontWeight = _title.FontWeight,
+        FontStyle = _title.FontStyle,
+        HorizontalAlignment = _title.HorizontalAlignment,
+        VerticalAlignment = _title.VerticalAlignment,
+        TextAlignment = _title.TextAlignment,
+        Foreground = foreground,
+        IsHitTestVisible = false,
+        Opacity = 0,
+        RenderTransform = new TranslateTransform()
+    };
+
+    private void RenderClean(string text)
+    {
+        _title.Text = text;
+        _title.Opacity = 1;
+        if (_stage == null) return;
+        _ghostPink!.Opacity = 0;
+        _ghostCyan!.Opacity = 0;
+        _bandHost!.Opacity = 0;
+    }
+
+    // ---- the timeline -----------------------------------------------------------------------
+    //
+    //   0.00-0.30  "Airhead August" holds, one 2-frame twitch at 0.20
+    //   0.30-0.55  onset: RGB split opens, bands start slipping, letters begin to rot
+    //   0.55-0.60  hard flicker: blank
+    //   0.60-0.95  full glitch: scrambled old title, "Sissygasm Sep", pure noise, "Juicy J", noise
+    //   0.95-0.98  hard flicker: blank
+    //   0.98-1.02  white-hot frame, the new title fully scrambled
+    //   1.02-1.38  decode: "Deeper Every Month" locks in left to right while the tearing calms
+    //   1.38-1.42  one last slice kick
+    //   1.42-1.60  clean final title, then the shimmer takes over
+    private void RenderAt(double t)
+    {
+        int frame = (int)(t * 30);
+        string text;
+        double intensity;
+        bool blank = false, white = false;
+
+        if (t < 0.30)
+        {
+            text = _from;
+            intensity = t >= 0.20 && t < 0.27 ? 0.25 : 0;
+        }
+        else if (t < 0.55)
+        {
+            double p = (t - 0.30) / 0.25;
+            intensity = 0.35 + 0.35 * p;
+            text = Morph(Scramble(_from, 0.12 + 0.35 * p, frame, 1), frame, p);
+        }
+        else if (t < 0.60) { text = _from; intensity = 0; blank = true; }
+        else if (t < 0.95)
+        {
+            // The dead names tear a little less than the noise around them, so they can be read.
+            bool deadName = t is >= 0.66 and < 0.76 or >= 0.84 and < 0.91;
+            intensity = deadName ? 0.55 : 1;
+            text = t switch
+            {
+                < 0.66 => Scramble(_from, 0.6, frame, 2),
+                < 0.76 => Scramble("Sissygasm Sep", 0.08, frame, 3),
+                < 0.84 => NoiseOfLength(13 + (int)((t - 0.76) / 0.08 * 5), frame),
+                < 0.91 => Scramble("Juicy J", 0.06, frame, 4),
+                _ => NoiseOfLength(_to.Length, frame)
+            };
+        }
+        else if (t < 0.98) { text = _to; intensity = 0; blank = true; }
+        else if (t < 1.02) { text = Scramble(_to, 1, frame, 5); intensity = 1; white = true; }
+        else if (t < 1.38)
+        {
+            double p = (t - 1.02) / 0.36;
+            intensity = 0.8 * (1 - p) + 0.1;
+            text = Decode(_to, 1 - Math.Pow(1 - p, 2), frame);
+        }
+        else if (t < 1.42) { text = _to; intensity = 0.6; }
+        else { text = _to; intensity = 0; }
+
+        if (blank)
+        {
+            _title.Text = text;
+            _title.Opacity = 0;
+            _ghostPink!.Opacity = 0;
+            _ghostCyan!.Opacity = 0;
+            _bandHost!.Opacity = 0;
+            return;
+        }
+        if (intensity <= 0)
+        {
+            RenderClean(text);
+            return;
+        }
+
+        _title.Text = text;
+        _title.Opacity = 0;
+        _bandHost!.Opacity = 1;
+
+        double split = 2 + 8 * intensity * Rnd(frame, 10) + (white ? 6 : 0);
+        Ghost(_ghostPink!, text, -split, (Rnd(frame, 11) - 0.5) * 3 * intensity, 0.55 + 0.35 * intensity);
+        Ghost(_ghostCyan!, text, split * (0.7 + 0.6 * Rnd(frame, 12)), (Rnd(frame, 13) - 0.5) * 3 * intensity, 0.5 + 0.35 * intensity);
+
+        // Random cut points down the line, sorted, so the bands tile the full height every frame.
+        double height = _stage!.Height;
+        Span<double> cuts = stackalloc double[BandCount + 1];
+        cuts[0] = -height;
+        cuts[BandCount] = height * 2;
+        for (int i = 1; i < BandCount; i++) cuts[i] = height * (i + (Rnd(frame, 20 + i) - 0.5) * 0.9) / BandCount;
+        cuts.Slice(1, BandCount - 1).Sort();
+
+        int tinted = Rnd(frame, 30) < intensity * 0.35 ? (int)(Rnd(frame, 31) * BandCount) : -1;
+        for (int i = 0; i < BandCount; i++)
+        {
+            var band = _bands[i];
+            band.Text = text;
+            band.Opacity = 1;
+            _bandClips[i].Rect = new Rect(-4000, cuts[i], 8000, Math.Max(0, cuts[i + 1] - cuts[i]));
+            double shift = Rnd(frame, 40 + i) < 0.3 + 0.55 * intensity
+                ? (Rnd(frame, 50 + i) - 0.5) * 2 * (4 + 26 * intensity)
+                : 0;
+            ((TranslateTransform)band.RenderTransform).X = shift;
+            band.Foreground = white ? HotWhite : i == tinted ? (Rnd(frame, 32) < 0.5 ? CyanGhost : HotWhite) : _title.Foreground;
+        }
+    }
+
+    private static void Ghost(TextBlock ghost, string text, double dx, double dy, double opacity)
+    {
+        ghost.Text = text;
+        ghost.Opacity = opacity;
+        var move = (TranslateTransform)ghost.RenderTransform;
+        move.X = dx;
+        move.Y = dy;
+    }
+
+    private string Scramble(string source, double fraction, int frame, int salt)
+    {
+        var sb = new StringBuilder(source.Length);
+        for (int i = 0; i < source.Length; i++)
+        {
+            char c = source[i];
+            sb.Append(c != ' ' && Rnd(frame, salt * 100 + i) < fraction ? NoiseChar(frame, salt * 100 + i + 57) : c);
+        }
+        return sb.ToString();
+    }
+
+    /// <summary>The string length breathes during onset: a character or two dropped or tacked on.</summary>
+    private string Morph(string text, int frame, double progress)
+    {
+        double roll = Rnd(frame, 60);
+        if (roll < 0.25 * progress && text.Length > 4) return text.Remove((int)(Rnd(frame, 61) * text.Length), 1);
+        if (roll > 1 - 0.3 * progress) return text + NoiseChar(frame, 62) + (Rnd(frame, 63) < 0.5 ? NoiseChar(frame, 64).ToString() : "");
+        return text;
+    }
+
+    private string NoiseOfLength(int length, int frame)
+    {
+        var sb = new StringBuilder(length);
+        for (int i = 0; i < length; i++) sb.Append(Rnd(frame, 70 + i) < 0.12 ? ' ' : NoiseChar(frame, 90 + i));
+        return sb.ToString();
+    }
+
+    private string Decode(string target, double locked, int frame)
+    {
+        int lockedCount = (int)(target.Length * locked);
+        var sb = new StringBuilder(target.Length);
+        for (int i = 0; i < target.Length; i++)
+        {
+            char c = target[i];
+            sb.Append(c == ' ' || i < lockedCount ? c : NoiseChar(frame, 200 + i));
+        }
+        return sb.ToString();
+    }
+
+    private char NoiseChar(int frame, int salt) => Noise[(int)(Rnd(frame, salt) * Noise.Length)];
+
+    private double Rnd(int frame, int salt)
+    {
+        unchecked
+        {
+            uint h = (uint)frame * 73856093u ^ (uint)salt * 19349663u ^ _seed;
+            h ^= h >> 13;
+            h *= 0x5bd1e995u;
+            h ^= h >> 15;
+            h *= 0x27d4eb2du;
+            h ^= h >> 16;
+            return (h & 0xFFFFFF) / 16777216.0;
+        }
+    }
+
+    private static Brush Frozen(Color color)
+    {
+        var brush = new SolidColorBrush(color);
+        brush.Freeze();
+        return brush;
+    }
+}

--- a/ConditioningControlPanel/Views/Tabs/QuestsTabView.xaml
+++ b/ConditioningControlPanel/Views/Tabs/QuestsTabView.xaml
@@ -27,8 +27,9 @@
                     <StackPanel x:Name="DailyWeeklyPanel" x:FieldModifier="internal">
                         <!-- Season Title Banner -->
                         <!-- The Text below is only ever the pre-first-paint placeholder: RefreshQuestUI
-                             overwrites it with QuestDefinitionService.SeasonTitle (server title, else the
-                             local month name). It must stay season-NEUTRAL - it used to hardcode
+                             overwrites it with QuestDefinitionService.SeasonTitle (an event title from the
+                             server, else "Deeper Every Month"; SeasonTitleGlitch wraps this TextBlock in a
+                             Grid on the first Quests visit). It must stay season-NEUTRAL - it used to hardcode
                              "Airhead April", so any lost first-paint race showed a long-dead season.
                              Mirrors the same neutral fallback LeaderboardTabView uses. -->
                         <Border Background="{DynamicResource DarkerBgBrush}" CornerRadius="12" Padding="20,14" Margin="0,0,0,18"

--- a/Tests/ConditioningControlPanel.Tests/QuestSeasonTitleTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/QuestSeasonTitleTests.cs
@@ -1,0 +1,56 @@
+using System;
+using ConditioningControlPanel.Services;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// Pins the Quests header title after The Descent ended monthly seasons: the permanent title
+/// unless the server sends a live, non-season event title. The server still says "Airhead August",
+/// which is exactly the case that must NOT reach the header.
+/// </summary>
+public class QuestSeasonTitleTests
+{
+    private static readonly DateTime Now = new(2026, 9, 13, 12, 0, 0, DateTimeKind.Utc);
+
+    [Fact]
+    public void NoServerTitle_IsPermanentTitle()
+    {
+        Assert.Equal("Deeper Every Month", QuestDefinitionService.ResolveSeasonTitle(null, Now, Now));
+        Assert.Equal("Deeper Every Month", QuestDefinitionService.ResolveSeasonTitle("  ", Now, Now));
+        Assert.Equal("Deeper Every Month", QuestDefinitionService.ResolveSeasonTitle(null, null, Now));
+    }
+
+    [Theory]
+    [InlineData("Airhead August")]
+    [InlineData("Sissygasm September")]
+    [InlineData("Jerk-it January")]
+    [InlineData("Mooing May")]
+    [InlineData("Mindless March")]
+    [InlineData("No-nut November")]
+    [InlineData("Obey-tober")]
+    [InlineData("Dick-ember")]
+    [InlineData("AIRHEAD AUGUST")]
+    public void DeadSeasonName_IsPermanentTitle(string server)
+    {
+        Assert.True(QuestDefinitionService.IsDeadSeasonTitle(server));
+        Assert.Equal("Deeper Every Month", QuestDefinitionService.ResolveSeasonTitle(server, Now, Now));
+    }
+
+    [Theory]
+    [InlineData("Bimbo Halloween Hunt")]
+    [InlineData("You May Obey")]
+    [InlineData("March of the Bimbos")]
+    public void CustomEventTitle_Wins(string server)
+    {
+        Assert.False(QuestDefinitionService.IsDeadSeasonTitle(server));
+        Assert.Equal(server, QuestDefinitionService.ResolveSeasonTitle(server, Now, Now));
+    }
+
+    [Fact]
+    public void EventTitleFetchedLastMonth_IsPermanentTitle()
+    {
+        var august = new DateTime(2026, 8, 31, 23, 0, 0, DateTimeKind.Utc);
+        Assert.Equal("Deeper Every Month", QuestDefinitionService.ResolveSeasonTitle("Bimbo Halloween Hunt", august, Now));
+    }
+}


### PR DESCRIPTION
## What

Monthly seasons ended in v6.9.0 (The Descent), but the Quests header still showed a season name: the server's stale "Airhead August", or a local month dictionary ("Sissygasm September").

**Title resolution** (`Services/Progression/QuestDefinitionService.cs`)
- The 12-month default dictionary is removed.
- `SeasonTitle` = the server title only if it is set, fetched this UTC month, and not a dead season-style name; otherwise **"Deeper Every Month"**.
- Dead = any month name as a whole word, or Obey-tober / Dick-ember. "May" and "March" only count as the last word, so an event title like "You May Obey" still works.
- So clients show the right title today even though the server still sends "Airhead August", and the server can still override later for events.

**The glitch** (`Views/Controls/SeasonTitleGlitch.cs`, wired in `MainWindow.Animations.cs` / `TabNavigation.cs`)
- Plays on the first Quests visit of each session, and again whenever you click the header (easter egg).
- It is 1.6s long and steps at 30fps. The beats:
  - 0.00-0.30: "Airhead August" holds, with a small twitch at 0.20
  - 0.30-0.55: the text starts to break up: pink/cyan RGB-split ghosts, horizontal bands slipping sideways, letters swapped for noise, and the length changing
  - 0.55-0.60: hard flicker (blank)
  - 0.60-0.95: full glitch: scrambled old title, then "Sissygasm Sep", noise, "Juicy J", noise
  - 0.95-0.98: blank, then a white-hot frame of the new title scrambled
  - 1.02-1.38: "Deeper Every Month" decodes left to right while the tearing calms down
  - 1.38-1.42: one last slice kick
  - After that the title is clean and the existing shimmer takes over
- Layout: the header height is pinned to the font's natural line height, and the noise glyphs are ASCII only (no fallback-font glyphs). Checked offscreen: the banner height was identical on all 49 frames.
- Runs at Full motion only. Reduced or Off just shows the final title, because the effect is hard flicker.
- Cleanup: stopped together with the shimmer when leaving the tab or lowering the motion level. The timer tick checks `Dispatcher.HasShutdownStarted`, and errors go through `Diag.Swallowed`.
- The Leaderboard tab shows the resolved title with no glitch (no change needed there).

**Stale "seasons reset" copy:** already fixed on main. `label_no_streak_fixes_left` now says "next month", and the season-recap fallback dialog on the rotation path now says progress carries forward. The admin `level_reset` path keeps its wipe list on purpose, so nothing was changed here.

## Tests
- New `QuestSeasonTitleTests`: null/blank title, dead month names, event titles, and an event title fetched last month.
- Full suite: 6169 passed, 0 failed.

## Size
544 changed lines (510 additions, 34 deletions), under the 600 cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AgAAgsPyWe6eibEyqDvFKc
