### PR TITLE
feat(sp): Sparkle Points cap to 99,999 (Back Room C0)

### DIFF
--- a/ConditioningControlPanel/MainWindow/MainWindow.Enhancements.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.Enhancements.cs
@@ -62,7 +62,7 @@ namespace ConditioningControlPanel
             EnsureEnhancementsFx();
 
             // Update skill points display
-            EnhancementsTab.TxtSkillPoints.Text = settings.SkillPoints.ToString();
+            EnhancementsTab.TxtSkillPoints.Text = settings.SkillPoints.ToString("N0");
 
             // Update XP multiplier display
             var multiplier = App.SkillTree?.GetTotalXpMultiplier() ?? 1.0;
@@ -275,7 +275,7 @@ namespace ConditioningControlPanel
             });
             pointsInfoStack.Children.Add(new TextBlock
             {
-                Text = settings.SkillPoints.ToString(),
+                Text = settings.SkillPoints.ToString("N0"),
                 Foreground = new SolidColorBrush((Color)ColorConverter.ConvertFromString(App.Mods?.GetAccentColorHex() ?? "#FF69B4")),
                 FontSize = 24,
                 FontWeight = FontWeights.Bold

--- a/ConditioningControlPanel/Models/AppSettings.cs
+++ b/ConditioningControlPanel/Models/AppSettings.cs
@@ -451,11 +451,12 @@ namespace ConditioningControlPanel.Models
         /// <summary>
         /// Available skill points to spend on the enhancement tree.
         /// Earned per level-up (SkillTreeService.PointsPerLevel) and per 100 bubbles popped.
+        /// Clamped to [0, SparklePoints.Cap] so every write path shares the server's ceiling.
         /// </summary>
         public int SkillPoints
         {
             get => _skillPoints;
-            set { _skillPoints = Math.Max(0, value); OnPropertyChanged(); }
+            set { _skillPoints = SparklePoints.Clamp(value); OnPropertyChanged(); }
         }
 
         /// <summary>

--- a/ConditioningControlPanel/Models/SparklePoints.cs
+++ b/ConditioningControlPanel/Models/SparklePoints.cs
@@ -1,0 +1,28 @@
+using System;
+
+namespace ConditioningControlPanel.Models
+{
+    /// <summary>
+    /// The one place the Sparkle Points (skill points) ceiling lives on the client.
+    ///
+    /// The server clamps <c>skill_points</c> to <c>SKILL_POINTS_CAP</c> on every write path; this
+    /// constant must match it. It was 9,999 and rose to 99,999 with the Back Room (CONTRACT.md 3.4),
+    /// so a slot win can take a balance past four digits. Every client write goes through
+    /// <see cref="AppSettings.SkillPoints"/>, which clamps with <see cref="Clamp"/>, so earn paths,
+    /// sync merges, restores and purchase responses all agree on the same ceiling.
+    /// </summary>
+    public static class SparklePoints
+    {
+        /// <summary>Highest balance an account can hold. Matches server SKILL_POINTS_CAP.</summary>
+        public const int Cap = 99_999;
+
+        /// <summary>Clamp a balance into [0, <see cref="Cap"/>].</summary>
+        public static int Clamp(int value) => Math.Clamp(value, 0, Cap);
+
+        /// <summary>
+        /// Sync merge rule: the balance only rises outside a purchase or an admin reset, so the
+        /// higher of server and local wins, clamped to the cap.
+        /// </summary>
+        public static int MergeMax(int server, int local) => Clamp(Math.Max(server, local));
+    }
+}

--- a/ConditioningControlPanel/Services/Settings/ProfileSyncService.cs
+++ b/ConditioningControlPanel/Services/Settings/ProfileSyncService.cs
@@ -1668,7 +1668,7 @@ namespace ConditioningControlPanel.Services
                             // always correct.
                             // This also shields the balance from an older server that still zeroes
                             // skill_points at rollover.
-                            var maxPoints = Math.Max(v2Result.SkillPoints.Value, settings.SkillPoints);
+                            var maxPoints = SparklePoints.MergeMax(v2Result.SkillPoints.Value, settings.SkillPoints);
                             if (maxPoints != settings.SkillPoints)
                             {
                                 App.Logger?.Information("V2 Sync: Skill points server={Server}, local={Local} — taking max ({Max})",
@@ -2994,7 +2994,7 @@ namespace ConditioningControlPanel.Services
             // Merge skill tree data - take max of server/local (skill points only increase)
             if (cloudProfile.SkillPoints.HasValue)
             {
-                var maxPoints = Math.Max(cloudProfile.SkillPoints.Value, settings.SkillPoints);
+                var maxPoints = SparklePoints.MergeMax(cloudProfile.SkillPoints.Value, settings.SkillPoints);
                 if (maxPoints != settings.SkillPoints)
                 {
                     App.Logger?.Information("Skill tree sync: Skill points server={Server}, local={Local} — taking max ({Max})",
@@ -3673,6 +3673,25 @@ namespace ConditioningControlPanel.Services
         }
 
         /// <summary>
+        /// Adopt a successful purchase response: the server's balance replaces local (it already
+        /// has the cost taken off), skills are unioned so none are ever lost. The balance goes
+        /// through the AppSettings setter, so it shares the SparklePoints.Cap clamp.
+        /// </summary>
+        internal static void ApplyPurchaseResult(AppSettings settings, int? serverSkillPoints, List<string>? serverSkills)
+        {
+            if (serverSkillPoints.HasValue)
+                settings.SkillPoints = serverSkillPoints.Value;
+            if (serverSkills != null)
+            {
+                // Merge: take union to never lose skills
+                var merged = new HashSet<string>(settings.UnlockedSkills ?? new List<string>());
+                foreach (var skill in serverSkills)
+                    merged.Add(skill);
+                settings.UnlockedSkills = merged.ToList();
+            }
+        }
+
+        /// <summary>
         /// Purchase a skill via server-authoritative endpoint.
         /// Server validates cost, prerequisites, and deducts points.
         /// Returns (success, error) — on success, updates local SkillPoints and UnlockedSkills from server response.
@@ -3765,16 +3784,7 @@ namespace ConditioningControlPanel.Services
                 }
 
                 // Apply server's authoritative values
-                if (result.SkillPoints.HasValue)
-                    settings.SkillPoints = result.SkillPoints.Value;
-                if (result.UnlockedSkills != null)
-                {
-                    // Merge: take union to never lose skills
-                    var merged = new HashSet<string>(settings.UnlockedSkills ?? new List<string>());
-                    foreach (var skill in result.UnlockedSkills)
-                        merged.Add(skill);
-                    settings.UnlockedSkills = merged.ToList();
-                }
+                ApplyPurchaseResult(settings, result.SkillPoints, result.UnlockedSkills);
 
                 // Prestige: count the spend locally, then adopt the server total when it's
                 // ahead (it already includes this purchase, so this never double-counts —

--- a/Tests/ConditioningControlPanel.Tests/SparklePointsCapTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/SparklePointsCapTests.cs
@@ -1,0 +1,92 @@
+using System.Collections.Generic;
+using ConditioningControlPanel.Models;
+using ConditioningControlPanel.Services;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// Back Room CONTRACT.md 3.4: the Sparkle Points cap rose from 9,999 to 99,999, client and server
+/// together. The client has one constant (SparklePoints.Cap) and one clamp (the AppSettings
+/// setter), and these tests pin that a five-digit balance survives every path that writes it:
+/// settings load, both sync merges, and a skill purchase response.
+/// </summary>
+public class SparklePointsCapTests
+{
+    private const int FiftyK = 50_000;
+
+    [Fact]
+    public void CapMatchesTheServer()
+        => Assert.Equal(99_999, SparklePoints.Cap);
+
+    [Theory]
+    [InlineData(-5, 0)]
+    [InlineData(0, 0)]
+    [InlineData(9_999, 9_999)]
+    [InlineData(10_000, 10_000)]
+    [InlineData(FiftyK, FiftyK)]
+    [InlineData(99_999, 99_999)]
+    [InlineData(100_000, 99_999)]
+    [InlineData(int.MaxValue, 99_999)]
+    public void SetterClampsIntoZeroToCap(int written, int expected)
+    {
+        var s = new AppSettings { SkillPoints = written };
+        Assert.Equal(expected, s.SkillPoints);
+    }
+
+    [Fact]
+    public void FiftyThousandSurvivesSettingsLoad()
+    {
+        var json = JsonConvert.SerializeObject(new AppSettings { SkillPoints = FiftyK });
+        // Same object-creation rule SettingsService.Load uses.
+        var loaded = JsonConvert.DeserializeObject<AppSettings>(json,
+            new JsonSerializerSettings { ObjectCreationHandling = ObjectCreationHandling.Replace })!;
+
+        Assert.Equal(FiftyK, loaded.SkillPoints);
+    }
+
+    [Fact]
+    public void OverCapFileLoadsAtTheCap()
+    {
+        var loaded = JsonConvert.DeserializeObject<AppSettings>("{\"SkillPoints\": 250000}")!;
+        Assert.Equal(SparklePoints.Cap, loaded.SkillPoints);
+    }
+
+    [Theory]
+    [InlineData(FiftyK, 9_999)]   // server ahead of an old local
+    [InlineData(9_999, FiftyK)]   // local ahead of an old server still clamping at 9,999
+    [InlineData(FiftyK, FiftyK)]
+    public void FiftyThousandSurvivesSyncMerge(int server, int local)
+    {
+        var s = new AppSettings { SkillPoints = local };
+        s.SkillPoints = SparklePoints.MergeMax(server, s.SkillPoints);
+
+        Assert.Equal(FiftyK, s.SkillPoints);
+    }
+
+    [Fact]
+    public void SyncMergeNeverExceedsTheCap()
+        => Assert.Equal(SparklePoints.Cap, SparklePoints.MergeMax(150_000, 20));
+
+    [Fact]
+    public void FiftyThousandSurvivesASkillPurchase()
+    {
+        var s = new AppSettings { SkillPoints = FiftyK, UnlockedSkills = new List<string> { "a" } };
+
+        // Server answers with the balance after a 10-point cost.
+        ProfileSyncService.ApplyPurchaseResult(s, FiftyK - 10, new List<string> { "b" });
+
+        Assert.Equal(FiftyK - 10, s.SkillPoints);
+        Assert.Contains("a", s.UnlockedSkills);
+        Assert.Contains("b", s.UnlockedSkills);
+    }
+
+    [Fact]
+    public void PurchaseWithoutABalanceKeepsLocal()
+    {
+        var s = new AppSettings { SkillPoints = FiftyK };
+        ProfileSyncService.ApplyPurchaseResult(s, null, null);
+        Assert.Equal(FiftyK, s.SkillPoints);
+    }
+}


### PR DESCRIPTION
Back Room lane C0, client half of the cap raise in CONTRACT.md 3.4 (server half is lane S0, `SKILL_POINTS_CAP`).

## What the audit found
The client never clamped Sparkle Points at 9,999. The only ceiling was server-side (`Math.min(9999, ...)` in the proxy). On the client `AppSettings.SkillPoints` had a floor of 0, the two sync merges took `Math.Max(server, local)`, `PreserveLocalOnlyFields` does not touch SP, the pristine-cloud/anti-cheat clamps are XP/level only, and the AchievementService / SkillTreeService earn paths are plain `+=` through the setter. No XAML width assumes 4 digits (the balance TextBlocks are auto-sized).

## Change
- `Models/SparklePoints.cs`: one constant `Cap = 99_999`, `Clamp`, `MergeMax`.
- `AppSettings.SkillPoints` setter clamps to [0, Cap], so load, earn, merge, restore, admin reset and purchase all share it.
- Both ProfileSyncService take-max merges use `SparklePoints.MergeMax`.
- Purchase response apply extracted to `ProfileSyncService.ApplyPurchaseResult` (no behaviour change) so it is testable.
- Enhancements balance renders `N0` so 50,000 reads cleanly.

## Tests
`SparklePointsCapTests` (17 cases): 50,000 survives settings load, both merge directions (including an old server still at 9,999) and a skill purchase; over-cap values clamp to 99,999.
Full test project: 6172 passed, 0 failed.

Order note: safe to ship before or after S0. Against an old server the take-max merge keeps a local balance above 9,999 exactly as it did before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V3c2CJTNfpbeBYqwjT6ZAj
