### PR TITLE
feat(backroom): fx dispatcher, hero queue and 6 Hz pacer (C3b)

### DIFF
--- a/ConditioningControlPanel/Services/BackRoom/BackRoomFx.cs
+++ b/ConditioningControlPanel/Services/BackRoom/BackRoomFx.cs
@@ -1,0 +1,180 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using ConditioningControlPanel.Models;
+
+namespace ConditioningControlPanel.Services.BackRoom;
+
+/// <summary>
+/// The primitive calls, one per contract primitive. The real one (<c>BackRoomFxServices</c>)
+/// maps these onto the app's existing overlay services; tests use a recorder. Every call arrives on
+/// the scheduler's thread (the UI dispatcher in the app).
+/// </summary>
+public interface IBackRoomFxSink
+{
+    void FlashBurst(int amount);
+    void GifRain(int durationMs);
+    void GlitchWash(int durationMs, double opacity);
+    void Subliminal(string text);
+    /// <summary><paramref name="level"/> is a fraction of the user's own spiral opacity.</summary>
+    void Spiral(int durationMs, double level, bool still);
+    /// <summary><paramref name="level"/> is a fraction of the user's own brain drain intensity.</summary>
+    void BrainDrain(int durationMs, double level, bool melt);
+    void GifFull(BackRoomGif gif, int durationMs, bool still);
+    /// <summary>Stop everything this sink started.</summary>
+    void StopAll();
+}
+
+/// <summary>A clock plus a one-shot timer. The app's runs on the UI dispatcher.</summary>
+public interface IFxScheduler
+{
+    long NowMs { get; }
+    IDisposable After(int delayMs, Action action);
+}
+
+/// <summary>The settings a fire reads, captured once per fire.</summary>
+public sealed record FxEnvironment(MotionLevel Motion, BackRoomFxIntensity Intensity, FxGates Gates);
+
+/// <summary>
+/// The effect dispatcher (C3). Resolves an fx id through <see cref="BackRoomFxPlan"/>, admits it
+/// through the hero gate, paces every repeated onset under the 6 Hz ceiling, and schedules the
+/// primitives on the sink. The ack goes back synchronously: what will play, and every skip.
+/// </summary>
+public sealed class BackRoomFx : IBackRoomFx
+{
+    private readonly IBackRoomFxSink _sink;
+    private readonly IFxScheduler _scheduler;
+    private readonly Func<FxEnvironment> _env;
+    private readonly Random _rng;
+    private readonly FxHeroGate _gate;
+    private readonly FxStrobePacer _pacer = new();
+    private readonly object _lock = new();
+    private readonly HashSet<PendingOnset> _pending = new();
+
+    public BackRoomFx(IBackRoomFxSink sink, IFxScheduler scheduler, Func<FxEnvironment> env, Random? rng = null)
+    {
+        _sink = sink;
+        _scheduler = scheduler;
+        _env = env;
+        _rng = rng ?? new Random();
+        _gate = new FxHeroGate(() => _scheduler.NowMs);
+    }
+
+    internal FxHeroGate Gate => _gate;
+
+    /// <summary>Primitive onsets still waiting to run (tests, diagnostics).</summary>
+    public int PendingCount { get { lock (_lock) return _pending.Count; } }
+
+    public BackRoomFxAck Fire(string fxId, string station, IReadOnlyList<string> symbolKeys, BackRoomMediaDeal deal)
+        => Fire(fxId, symbolKeys, deal, _env());
+
+    /// <summary>Fire under an explicit environment. The room never calls this; the dev rig does, so a
+    /// desk run can walk every intensity without touching the user's settings.</summary>
+    internal BackRoomFxAck Fire(string fxId, IReadOnlyList<string>? symbolKeys, BackRoomMediaDeal? deal, FxEnvironment env)
+    {
+        fxId ??= string.Empty;
+        try
+        {
+            FxPlan plan;
+            lock (_rng) plan = BackRoomFxPlan.Resolve(fxId, env.Intensity, env.Motion, env.Gates, symbolKeys, deal, _rng);
+            if (plan.Steps.Count == 0) return new BackRoomFxAck(Array.Empty<string>(), plan.Skipped);
+
+            var admission = _gate.Admit(fxId, plan.HeroMs);
+            switch (admission.Kind)
+            {
+                case FxAdmitKind.Busy:
+                    var busy = plan.Skipped.Concat(plan.Fired.Distinct()
+                        .Select(p => new BackRoomFxSkip(p, BackRoomFxSkipReason.Busy))).ToList();
+                    return new BackRoomFxAck(Array.Empty<string>(), busy);
+                case FxAdmitKind.Merged:
+                    // It plays once, as the copy already on stage or in the queue.
+                    return new BackRoomFxAck(plan.Fired, plan.Skipped);
+            }
+
+            long baseAt = _scheduler.NowMs + admission.DelayMs;
+            foreach (var planned in plan.Steps) Schedule(planned, baseAt);
+            return new BackRoomFxAck(plan.Fired, plan.Skipped);
+        }
+        catch (Exception ex)
+        {
+            App.Logger?.Warning(ex, "[BackRoom] fx fire failed ({FxId})", fxId);
+            return new BackRoomFxAck(Array.Empty<string>(), new[] { new BackRoomFxSkip(fxId, BackRoomFxSkipReason.Unknown) });
+        }
+    }
+
+    private void Schedule(FxPlannedStep planned, long baseAt)
+    {
+        var s = planned.Step;
+        long at = baseAt + s.AtMs;
+        switch (s.Prim)
+        {
+            case FxPrim.SubSingle:
+            case FxPrim.SubSeq:
+            case FxPrim.SubBurst9:
+                for (int i = 0; i < planned.Words.Count; i++)
+                {
+                    var word = planned.Words[i];
+                    At(_pacer.Reserve(FxChannel.Subliminal, at + i * BackRoomFxPlan.WordGapMs), () => _sink.Subliminal(word));
+                }
+                break;
+            case FxPrim.GlitchBubbles:
+                for (int i = 0; i < Math.Max(1, s.Count); i++)
+                    At(_pacer.Reserve(FxChannel.Glitch, at + i * BackRoomFxPlan.GlitchWashMs),
+                        () => _sink.GlitchWash(BackRoomFxPlan.GlitchWashMs, BackRoomFxPlan.GlitchOpacity));
+                break;
+            case FxPrim.FlashBurst:
+                At(_pacer.Reserve(FxChannel.Flash, at), () => _sink.FlashBurst(Math.Max(1, s.Count)));
+                break;
+            case FxPrim.GifRain:
+                At(at, () => _sink.GifRain(s.DurationMs));
+                break;
+            case FxPrim.SpiralFull:
+                At(at, () => _sink.Spiral(s.DurationMs, s.Level, s.Still));
+                break;
+            case FxPrim.BrainDrainMelt:
+            case FxPrim.BrainDrain:
+                At(at, () => _sink.BrainDrain(s.DurationMs, s.Level, s.Prim == FxPrim.BrainDrainMelt));
+                break;
+            case FxPrim.GifFull:
+                var gif = planned.Gif!;
+                At(at, () => _sink.GifFull(gif, s.DurationMs, s.Still));
+                break;
+        }
+    }
+
+    private sealed class PendingOnset { public IDisposable? Timer; }
+
+    private void At(long atMs, Action action)
+    {
+        int delay = (int)Math.Max(0, atMs - _scheduler.NowMs);
+        // The token is pending BEFORE the timer exists, so a timer that fires early (or a scheduler
+        // that runs inline) always finds it, and a CancelAll that wins the race always silences it.
+        var onset = new PendingOnset();
+        lock (_lock) _pending.Add(onset);
+        onset.Timer = _scheduler.After(delay, () =>
+        {
+            lock (_lock) { if (!_pending.Remove(onset)) return; }
+            try { action(); }
+            catch (Exception ex) { App.Logger?.Warning(ex, "[BackRoom] fx primitive failed"); }
+        });
+    }
+
+    /// <summary>Suspend or close: drop every waiting onset, forget the hero windows, stop what is up.</summary>
+    public void CancelAll()
+    {
+        List<PendingOnset> doomed;
+        lock (_lock)
+        {
+            doomed = _pending.ToList();
+            _pending.Clear();
+        }
+        foreach (var h in doomed)
+        {
+            try { h.Timer?.Dispose(); } catch (Exception ex) { Diag.Swallowed(ex, "fx timer already gone"); }
+        }
+        _gate.Clear();
+        _pacer.Clear();
+        try { _sink.StopAll(); }
+        catch (Exception ex) { App.Logger?.Warning(ex, "[BackRoom] fx stop failed"); }
+    }
+}

--- a/ConditioningControlPanel/Services/BackRoom/BackRoomFxQueue.cs
+++ b/ConditioningControlPanel/Services/BackRoom/BackRoomFxQueue.cs
@@ -1,0 +1,124 @@
+using System;
+using System.Collections.Generic;
+
+namespace ConditioningControlPanel.Services.BackRoom;
+
+// THE BACK ROOM, effects half two: the Brake as code. The hero gate (Brake 2, one hero at a time)
+// and the strobe pacer (no strobe over 6 Hz) are pure and clock-driven, so the rules are pinned by
+// tests instead of by watching a desk run.
+
+/// <summary>What the hero gate decided for one arriving fx.</summary>
+public enum FxAdmitKind
+{
+    /// <summary>Play now.</summary>
+    Now,
+    /// <summary>Queued: play after <see cref="FxAdmission.DelayMs"/>.</summary>
+    Queued,
+    /// <summary>The same id is already running or waiting; it plays once for both.</summary>
+    Merged,
+    /// <summary>It would wait more than <see cref="FxHeroGate.MaxQueueMs"/>; dropped.</summary>
+    Busy,
+}
+
+public readonly record struct FxAdmission(FxAdmitKind Kind, int DelayMs);
+
+/// <summary>
+/// One hero window at a time (CONTRACT section 4, Brake 2). An fx arriving while a hero window runs
+/// is queued, merged if the same id is already running or queued, and dropped as <c>busy</c> when it
+/// would wait more than four seconds. A queued hero opens its own window when it starts, so heroes
+/// chain; non-heroes behind a hero all start when the stage frees and never extend the wait.
+/// The decision is made at arrival, which is what lets the ack go back synchronously.
+/// </summary>
+public sealed class FxHeroGate
+{
+    public const int MaxQueueMs = 4000;
+
+    private readonly Func<long> _nowMs;
+    private readonly object _lock = new();
+    // Every hero window that is running or waiting, in start order: (id, startMs, endMs).
+    private readonly List<(string Id, long Start, long End)> _heroes = new();
+    // Non-heroes waiting behind a hero: (id, startMs).
+    private readonly List<(string Id, long Start)> _waiting = new();
+
+    public FxHeroGate(Func<long> nowMs) => _nowMs = nowMs;
+
+    public FxAdmission Admit(string fxId, int heroMs)
+    {
+        lock (_lock)
+        {
+            long now = _nowMs();
+            _heroes.RemoveAll(h => h.End <= now);
+            _waiting.RemoveAll(w => w.Start <= now);
+
+            // The stage frees when the last running or queued hero window closes.
+            long tail = _heroes.Count == 0 ? now : Math.Max(now, _heroes[^1].End);
+            if (tail <= now)
+            {
+                if (heroMs > 0) _heroes.Add((fxId, now, now + heroMs));
+                return new FxAdmission(FxAdmitKind.Now, 0);
+            }
+
+            // Overlapping wins merge into one (Brake 2): the same id already running or waiting.
+            if (_heroes.Exists(h => h.Id == fxId) || _waiting.Exists(w => w.Id == fxId))
+                return new FxAdmission(FxAdmitKind.Merged, 0);
+
+            long wait = tail - now;
+            if (wait > MaxQueueMs) return new FxAdmission(FxAdmitKind.Busy, 0);
+
+            if (heroMs > 0) _heroes.Add((fxId, tail, tail + heroMs));
+            else _waiting.Add((fxId, tail));
+            return new FxAdmission(FxAdmitKind.Queued, (int)wait);
+        }
+    }
+
+    /// <summary>Forget every running and waiting window (suspend, close).</summary>
+    public void Clear()
+    {
+        lock (_lock) { _heroes.Clear(); _waiting.Clear(); }
+    }
+}
+
+/// <summary>The families that share one on-screen channel and so share one onset clock.</summary>
+public enum FxChannel
+{
+    Subliminal,
+    Flash,
+    Glitch,
+}
+
+/// <summary>
+/// Brake: no strobe over 6 Hz at any intensity. Every onset on a channel is pushed back until it
+/// sits at least <see cref="MinGapMs"/> after the previous one on that channel, ACROSS fx: a
+/// <c>fx.sub_single</c> landing on top of a <c>fx.sub_cascade</c> is paced into the same run rather
+/// than doubling its rate.
+/// </summary>
+public sealed class FxStrobePacer
+{
+    private readonly object _lock = new();
+    private readonly Dictionary<FxChannel, long> _last = new();
+
+    public static int MinGapMs(FxChannel c) => c switch
+    {
+        FxChannel.Subliminal => BackRoomFxPlan.WordGapMs,
+        FxChannel.Glitch => BackRoomFxPlan.GlitchWashMs,
+        // FlashService admits one one-shot at a time anyway; this keeps a queue of them honest.
+        _ => 1000,
+    };
+
+    /// <summary>The absolute time the onset may happen, never earlier than <paramref name="desiredMs"/>.</summary>
+    public long Reserve(FxChannel channel, long desiredMs)
+    {
+        lock (_lock)
+        {
+            long at = desiredMs;
+            if (_last.TryGetValue(channel, out long prev)) at = Math.Max(at, prev + MinGapMs(channel));
+            _last[channel] = at;
+            return at;
+        }
+    }
+
+    public void Clear()
+    {
+        lock (_lock) _last.Clear();
+    }
+}

--- a/Tests/ConditioningControlPanel.Tests/BackRoomFxTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/BackRoomFxTests.cs
@@ -1,0 +1,291 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using ConditioningControlPanel.Models;
+using ConditioningControlPanel.Services.BackRoom;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// THE BACK ROOM effect dispatcher with the services behind a fake: the hero queue (Brake 2), the
+/// 6 Hz ceiling across every recipe, cancel on suspend/close, and the symbol keys the page sends.
+/// </summary>
+public class BackRoomFxTests
+{
+    internal static readonly BackRoomMediaDeal Deal = new(7,
+        new[]
+        {
+            new BackRoomGif("g0", "https://ccp.assets/images/a.gif", 480, 270, "pool"),
+            new BackRoomGif("g1", "https://ccp.assets/images/b.gif", 480, 270, "pool"),
+            new BackRoomGif("g2", "https://ccp.assets/images/c.gif", 480, 270, "pool"),
+            new BackRoomGif("g3", "https://ccp.game/backroom/stations/slot/fallback/gif3.webp", 0, 0, "fallback"),
+        },
+        new[]
+        {
+            new BackRoomWord("s0", "Drop", "preset"), new BackRoomWord("s1", "Relax", "preset"),
+            new BackRoomWord("s2", "Let Go", "preset"), new BackRoomWord("s3", "Sink", "preset"),
+        });
+
+    internal sealed class FakeScheduler : IFxScheduler
+    {
+        private readonly List<(long At, Action Run, Handle H)> _q = new();
+        public long NowMs { get; private set; }
+
+        internal sealed class Handle : IDisposable
+        {
+            public bool Disposed;
+            public void Dispose() => Disposed = true;
+        }
+
+        public IDisposable After(int delayMs, Action action)
+        {
+            var h = new Handle();
+            _q.Add((NowMs + delayMs, action, h));
+            return h;
+        }
+
+        public void Advance(long ms)
+        {
+            long end = NowMs + ms;
+            while (true)
+            {
+                var next = _q.Where(x => x.At <= end).OrderBy(x => x.At).FirstOrDefault();
+                if (next.Run == null) break;
+                _q.Remove(next);
+                NowMs = Math.Max(NowMs, next.At);
+                if (!next.H.Disposed) next.Run();
+            }
+            NowMs = end;
+        }
+    }
+
+    internal sealed class RecordingSink : IBackRoomFxSink
+    {
+        private readonly FakeScheduler _clock;
+        public readonly List<(long At, string Call)> Calls = new();
+        public int Stops;
+        public RecordingSink(FakeScheduler clock) => _clock = clock;
+        private void Add(string c) => Calls.Add((_clock.NowMs, c));
+        public void FlashBurst(int amount) => Add($"flash:{amount}");
+        public void GifRain(int durationMs) => Add($"rain:{durationMs}");
+        public void GlitchWash(int durationMs, double opacity) => Add($"glitch:{durationMs}");
+        public void Subliminal(string text) => Add($"sub:{text}");
+        public void Spiral(int durationMs, double level, bool still) => Add($"spiral:{durationMs}:{level}:{still}");
+        public void BrainDrain(int durationMs, double level, bool melt) => Add($"drain:{durationMs}:{level}:{melt}");
+        public void GifFull(BackRoomGif gif, int durationMs, bool still) => Add($"giffull:{gif.Key}:{durationMs}:{still}");
+        public void StopAll() => Stops++;
+    }
+
+    private static (BackRoomFx Fx, FakeScheduler Clock, RecordingSink Sink) Make(
+        BackRoomFxIntensity intensity = BackRoomFxIntensity.Normal, MotionLevel motion = MotionLevel.Full)
+    {
+        var clock = new FakeScheduler();
+        var sink = new RecordingSink(clock);
+        var fx = new BackRoomFx(sink, clock, () => new FxEnvironment(motion, intensity, FxGates.AllOn), new Random(5));
+        return (fx, clock, sink);
+    }
+
+    private static BackRoomFxAck Fire(BackRoomFx fx, string id, params string[] symbols)
+        => fx.Fire(id, "slot", symbols, Deal);
+
+    // ---- hero gate -------------------------------------------------------------------------------
+
+    [Fact]
+    public void Gate_DuringAHero_OthersQueueUntilItEnds()
+    {
+        long now = 0;
+        var gate = new FxHeroGate(() => now);
+        gate.Admit("fx.jackpot", 2400);
+        now = 400;
+        Assert.Equal(new FxAdmission(FxAdmitKind.Queued, 2000), gate.Admit("fx.gif_storm", 0));
+        Assert.Equal(new FxAdmission(FxAdmitKind.Queued, 2000), gate.Admit("fx.melt", 0));   // both start as the stage frees
+        now = 2400;
+        Assert.Equal(FxAdmitKind.Now, gate.Admit("fx.gif_burst", 0).Kind);
+    }
+
+    [Fact]
+    public void Gate_SameId_Merges_RunningOrQueued()
+    {
+        long now = 0;
+        var gate = new FxHeroGate(() => now);
+        gate.Admit("fx.jackpot", 4000);
+        now = 100;
+        Assert.Equal(FxAdmitKind.Merged, gate.Admit("fx.jackpot", 4000).Kind);
+        Assert.Equal(FxAdmitKind.Queued, gate.Admit("fx.sub_single", 0).Kind);
+        Assert.Equal(FxAdmitKind.Merged, gate.Admit("fx.sub_single", 0).Kind);
+    }
+
+    [Fact]
+    public void Gate_HeroesChain_AndAnythingWaitingOverFourSecondsIsBusy()
+    {
+        long now = 0;
+        var gate = new FxHeroGate(() => now);
+        gate.Admit("fx.jackpot", 4000);
+        now = 500;
+        Assert.Equal(new FxAdmission(FxAdmitKind.Queued, 3500), gate.Admit("fx.hero_b", 3000));   // opens 4000..7000
+        Assert.Equal(FxAdmitKind.Busy, gate.Admit("fx.gif_storm", 0).Kind);                        // would wait 6500
+        now = 3100;
+        Assert.Equal(new FxAdmission(FxAdmitKind.Queued, 3900), gate.Admit("fx.gif_storm", 0));
+    }
+
+    // ---- dispatcher --------------------------------------------------------------------------------
+
+    [Fact]
+    public void JackpotNormal_SpiralFirst_ThenTheRestAtTheHeroEdge()
+    {
+        var (fx, clock, sink) = Make();
+        var ack = Fire(fx, "fx.jackpot");
+        Assert.Equal(new[] { "spiral-full", "flash-burst", "gif-rain", "glitch-bubbles", "sub-burst9" }, ack.Fired);
+        clock.Advance(10_000);
+        Assert.Equal((0L, "spiral:2400:1:False"), sink.Calls[0]);
+        Assert.Contains((2400L, "flash:4"), sink.Calls);
+        Assert.Contains((2400L, "rain:2000"), sink.Calls);
+        Assert.Equal(9, sink.Calls.Count(c => c.Call.StartsWith("sub:")));
+    }
+
+    [Fact]
+    public void QueuedBehindAHero_PlaysWhenTheWindowCloses()
+    {
+        var (fx, clock, sink) = Make();
+        Fire(fx, "fx.jackpot");
+        clock.Advance(1000);
+        var ack = Fire(fx, "fx.melt");
+        Assert.Equal(new[] { "brain-drain-melt" }, ack.Fired);
+        clock.Advance(10_000);
+        Assert.Contains((2400L, "drain:6000:1:True"), sink.Calls);
+    }
+
+    [Fact]
+    public void BusyFx_AcksEveryPrimitiveAsBusy_AndSchedulesNothing()
+    {
+        var (fx, clock, sink) = Make();
+        Fire(fx, "fx.jackpot");                       // hero 0..2400
+        fx.Gate.Admit("fx.future_hero", 3000);        // a later station's hero chains to 2400..5400
+        clock.Advance(100);
+        int pending = fx.PendingCount;
+        var ack = Fire(fx, "fx.gif_storm");           // would wait 5300 ms
+        Assert.Empty(ack.Fired);
+        Assert.Equal(new[] { "flash-burst", "gif-rain", "glitch-bubbles" }, ack.Skipped.Select(s => s.Prim));
+        Assert.All(ack.Skipped, s => Assert.Equal(BackRoomFxSkipReason.Busy, s.Why));
+        Assert.Equal(pending, fx.PendingCount);
+    }
+
+    [Fact]
+    public void CancelAll_SilencesEverythingWaiting_AndStopsTheSink()
+    {
+        var (fx, clock, sink) = Make(BackRoomFxIntensity.Full);
+        Fire(fx, "fx.jackpot");
+        clock.Advance(100);
+        Assert.True(fx.PendingCount > 0);
+        fx.CancelAll();
+        Assert.Equal(0, fx.PendingCount);
+        Assert.Equal(1, sink.Stops);
+        var callsAtCancel = sink.Calls.Count;
+        clock.Advance(20_000);
+        Assert.Equal(callsAtCancel, sink.Calls.Count);
+        // and the stage is free again
+        Assert.NotEmpty(Fire(fx, "fx.gif_burst").Fired);
+        clock.Advance(10);
+        Assert.Contains(sink.Calls, c => c.Call == "flash:3");
+    }
+
+    // ---- 6 Hz -------------------------------------------------------------------------------------
+
+    public static IEnumerable<object[]> Combos() => BackRoomFxPlanTests.AllCombos();
+
+    private static void AssertUnderSixHz(RecordingSink sink, string label)
+    {
+        foreach (var family in new[] { "sub:", "glitch:", "flash:" })
+        {
+            var onsets = sink.Calls.Where(c => c.Call.StartsWith(family)).Select(c => c.At).OrderBy(t => t).ToList();
+            for (int i = 1; i < onsets.Count; i++)
+                Assert.True(onsets[i] - onsets[i - 1] >= 1000 / 6.0, $"{label}: {family} onsets {onsets[i - 1]} and {onsets[i]} strobe over 6 Hz");
+            for (int i = 0; i + 6 < onsets.Count; i++)
+                Assert.True(onsets[i + 6] - onsets[i] >= 1000, $"{label}: more than 6 {family} onsets inside one second");
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(Combos))]
+    public void NoRecipe_StrobesOverSixHz(string id, BackRoomFxIntensity i, MotionLevel m)
+    {
+        var (fx, clock, sink) = Make(i, m);
+        Fire(fx, id, "sub0", "sub1", "sub2", "sub3", "gif0");
+        clock.Advance(30_000);
+        AssertUnderSixHz(sink, $"{id} {i} {m}");
+    }
+
+    [Fact]
+    public void StackedFx_OnOneSpin_StayUnderSixHz_Together()
+    {
+        // One outcome can carry fx.sub_cascade plus fx.sub_single, and the next spin lands 800 ms on.
+        var (fx, clock, sink) = Make(BackRoomFxIntensity.Full);
+        Fire(fx, "fx.sub_cascade", "sub0", "sub1", "sub2");
+        Fire(fx, "fx.sub_single", "sub0", "sub1", "sub2");
+        Fire(fx, "fx.sub_pair", "sub3");
+        Fire(fx, "fx.gif_storm");
+        Fire(fx, "fx.gif_burst");
+        clock.Advance(800);
+        Fire(fx, "fx.sub_single", "sub3");
+        Fire(fx, "fx.gif_storm");
+        clock.Advance(30_000);
+        AssertUnderSixHz(sink, "stacked");
+    }
+
+    // ---- symbols ------------------------------------------------------------------------------------
+
+    [Fact]
+    public void Symbols_ResolveOnlyThroughTheDeal()
+    {
+        var media = BackRoomFxPlan.ResolveSymbols(new[] { "sub3", "gif1", "s1", "g2", "spiral0", "emi3", "melt" }, Deal, new Random(3));
+        Assert.Equal(new[] { "Sink", "Relax" }, media.Words);
+        Assert.Equal(new[] { "g1", "g2" }, media.Gifs.Select(g => g.Key));
+    }
+
+    [Theory]
+    [InlineData("C:\\Windows\\win.ini")]
+    [InlineData("https://evil.example/x.gif")]
+    [InlineData("../../secrets.txt")]
+    [InlineData("sub9")]
+    [InlineData("gif7")]
+    [InlineData("<b>BOLD</b>")]
+    public void UnknownKeys_BecomeARandomDealtItem_NeverThePagesText(string hostile)
+    {
+        for (int seed = 0; seed < 20; seed++)
+        {
+            var media = BackRoomFxPlan.ResolveSymbols(new[] { hostile }, Deal, new Random(seed));
+            Assert.Equal(1, media.Words.Count + media.Gifs.Count);
+            Assert.All(media.Words, w => Assert.Contains(Deal.Words, d => d.Text == w));
+            Assert.All(media.Gifs, g => Assert.Contains(g, Deal.Gifs));
+        }
+    }
+
+    [Fact]
+    public void GifFull_UsesTheNamedGif_ElseADealtOne()
+    {
+        var (fx, clock, sink) = Make();
+        Fire(fx, "fx.sub_cascade", "gif2");
+        clock.Advance(5000);
+        Assert.Contains(sink.Calls, c => c.Call == "giffull:g2:1500:False");
+    }
+
+    [Fact]
+    public void EmptyDeal_SkipsMediaPrimitives_AsUnknown_WithoutThrowing()
+    {
+        var p = BackRoomFxPlan.Resolve("fx.sub_cascade", BackRoomFxIntensity.Normal, MotionLevel.Full, FxGates.AllOn,
+            new[] { "sub0" }, new BackRoomMediaDeal(0, Array.Empty<BackRoomGif>(), Array.Empty<BackRoomWord>()), new Random(0));
+        Assert.Empty(p.Fired);
+        Assert.Contains(new BackRoomFxSkip("sub-burst9", BackRoomFxSkipReason.Unknown), p.Skipped);
+        Assert.Contains(new BackRoomFxSkip("gif-full", BackRoomFxSkipReason.Unknown), p.Skipped);
+    }
+
+    [Fact]
+    public void NullInputs_NeverThrow()
+    {
+        var (fx, _, _) = Make();
+        var ack = fx.Fire(null!, "slot", null!, null!);
+        Assert.Empty(ack.Fired);
+        Assert.Single(ack.Skipped);
+    }
+}


### PR DESCRIPTION
Lane C3b, stacked on https://github.com/CodeBambi/Conditioning-Control-Panel---CSharp-WPF/pull/1115. Stack: a -> **b** -> c -> d.

- `BackRoomFx` (implements `IBackRoomFx`): walks a plan onto an `IBackRoomFxSink` through an `IFxScheduler`, ack returned synchronously.
- `FxHeroGate`: one hero window at a time; arrivals during a hero queue to the stage edge, the same id merges (running or queued), anything that would wait over 4 s acks every primitive as `busy`.
- `FxStrobePacer`: per-channel onset spacing (subliminal 220 ms, glitch wash 800 ms, flash 1 s), shared across fx so stacked fx cannot strobe over 6 Hz.
- `CancelAll`: drops every waiting onset (race-safe tokens), clears gate and pacer, stops the sink.
- Tests: `BackRoomFxTests` (hero queue rules, 6 Hz over every id x intensity x motion plus a stacked spin, cancel, hostile symbol keys).

Changed lines: 595.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V3c2CJTNfpbeBYqwjT6ZAj
