### PR TITLE
feat(backroom): fx services sink, gif-full hero window, intensity setting (C3c)

### DIFF
--- a/ConditioningControlPanel/Chaos/ChaosFlashOverlay.cs
+++ b/ConditioningControlPanel/Chaos/ChaosFlashOverlay.cs
@@ -33,6 +33,10 @@ public sealed class ChaosFlashOverlay : Window
     private const double DEFAULT_OPACITY = 0.10;     // faint 10% wash
 
     private static ChaosFlashOverlay? _active;
+    // THE BACK ROOM's gif-full (CONTRACT section 4): a second instance of this same window, so a
+    // fullscreen hero GIF and a glitch wash can share a beat without swapping each other's image.
+    // Same decode path, same keep-alive discipline; it always spans every screen.
+    private static ChaosFlashOverlay? _hero;
     private static readonly Random _rng = new();
 
     /// <summary>Show a random flash-pool image full-screen for <paramref name="durationMs"/>
@@ -77,6 +81,61 @@ public sealed class ChaosFlashOverlay : Window
     /// <summary>Re-stack the live window above a mandatory video (see ChaosWindowZ). UI thread only.</summary>
     public static void RaiseActive() => ChaosWindowZ.RaiseTopmost(_active);
 
+    /// <summary>
+    /// Back Room <c>gif-full</c>: hold one specific LOCAL image over every screen for
+    /// <paramref name="durationMs"/>. <paramref name="still"/> decodes only the first frame
+    /// (MotionLevel Off). The caller resolves the path from its own dealt media; nothing else is
+    /// accepted. Any thread.
+    /// </summary>
+    public static void ShowHero(string path, int durationMs, double opacity, bool still)
+    {
+        try
+        {
+            if (string.IsNullOrEmpty(path) || Services.FlashService.IsRemotePath(path)) return;
+            var disp = Application.Current?.Dispatcher;
+            if (disp == null || disp.HasShutdownStarted) return;
+            disp.BeginInvoke(new Action(() =>
+            {
+                try
+                {
+                    if (_hero == null) { _hero = new ChaosFlashOverlay(spanAll: true); ((Window)_hero).Show(); }
+                    else if (!_hero.IsVisible) { try { ((Window)_hero).Show(); } catch (Exception ex) { Diag.Swallowed(ex, "hero window re-show"); } }
+                    ChaosWindowZ.RaiseAboveVideo(_hero);
+                    ChaosWindowZ.ForceTopmost(_hero);
+                    _hero.Display(path, durationMs, opacity, still);
+                }
+                catch (Exception ex) { App.Logger?.Debug("ChaosFlashOverlay.ShowHero: {E}", ex.Message); }
+            }));
+        }
+        catch (Exception ex) { App.Logger?.Debug("ChaosFlashOverlay.ShowHero: {E}", ex.Message); }
+    }
+
+    /// <summary>Take the hero image down now (suspend, close). The window idles hidden rather than
+    /// closing, for the same render-thread reason the washes keep theirs. Any thread.</summary>
+    public static void StopHero()
+    {
+        try
+        {
+            Application.Current?.Dispatcher?.BeginInvoke(new Action(() =>
+            {
+                var h = _hero;
+                if (h == null) return;
+                try
+                {
+                    h._life.Stop();
+                    h._pending = null;
+                    h.BeginAnimation(OpacityProperty, null);
+                    h.Opacity = 0;
+                    h.ClearImage();
+                    h._hideGrace.Stop();
+                    h._hideGrace.Start();
+                }
+                catch (Exception ex) { Diag.Swallowed(ex, "hero window tearing down"); }
+            }));
+        }
+        catch (Exception ex) { Diag.Swallowed(ex, "no dispatcher"); }
+    }
+
     /// <summary>Close any active overlay immediately (run teardown).</summary>
     public static void CloseActive() { try { _active?.CloseNow(); } catch { } }
 
@@ -86,11 +145,13 @@ public sealed class ChaosFlashOverlay : Window
     // window (DWM re-composition hitch at trigger time). The window now idles visible (Opacity 0,
     // image cleared, click-through) through this grace, hiding only after a truly quiet spell.
     private readonly DispatcherTimer _hideGrace;
-    private (string path, int durationMs, double opacity)? _pending;   // first Display can land before Loaded
+    private (string path, int durationMs, double opacity, bool still)? _pending;
+    private readonly bool _spanAll;   // the Back Room hero ignores the single-screen setting   // first Display can land before Loaded
     private int _displayGen;   // guards the async still-decode against a newer wash / a clear
 
-    private ChaosFlashOverlay()
+    private ChaosFlashOverlay(bool spanAll = false)
     {
+        _spanAll = spanAll;
         WindowStyle = WindowStyle.None;
         AllowsTransparency = true;
         Background = Brushes.Transparent;
@@ -103,7 +164,10 @@ public sealed class ChaosFlashOverlay : Window
         WindowStartupLocation = WindowStartupLocation.Manual;
         // Single-monitor by default: confine to the primary screen unless the user has multi-
         // monitor on (else this layered flash surface paints on every monitor — see StageBounds).
-        var (sl, st, sw, sh) = ChaosWindowZ.StageBounds();
+        var (sl, st, sw, sh) = spanAll
+            ? (SystemParameters.VirtualScreenLeft, SystemParameters.VirtualScreenTop,
+               SystemParameters.VirtualScreenWidth, SystemParameters.VirtualScreenHeight)
+            : ChaosWindowZ.StageBounds();
         Left = sl; Top = st; Width = sw; Height = sh;
         Opacity = 0;
 
@@ -113,7 +177,7 @@ public sealed class ChaosFlashOverlay : Window
         SourceInitialized += (_, _) => { ApplyExStyles(); PlacePhysical(); };
         Loaded += (_, _) =>
         {
-            if (_pending is { } p) { _pending = null; DisplayCore(p.path, p.durationMs, p.opacity); }
+            if (_pending is { } p) { _pending = null; DisplayCore(p.path, p.durationMs, p.opacity, p.still); }
         };
 
         _life = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(DEFAULT_DURATION_MS) };
@@ -137,13 +201,13 @@ public sealed class ChaosFlashOverlay : Window
         };
     }
 
-    private void Display(string path, int durationMs, double opacity)
+    private void Display(string path, int durationMs, double opacity, bool still = false)
     {
-        if (!IsLoaded) { _pending = (path, durationMs, opacity); return; }
-        DisplayCore(path, durationMs, opacity);
+        if (!IsLoaded) { _pending = (path, durationMs, opacity, still); return; }
+        DisplayCore(path, durationMs, opacity, still);
     }
 
-    private void DisplayCore(string path, int durationMs, double opacity)
+    private void DisplayCore(string path, int durationMs, double opacity, bool still = false)
     {
         _hideGrace.Stop();
         _life.Stop();
@@ -158,7 +222,9 @@ public sealed class ChaosFlashOverlay : Window
         // to the still branch, which is also the branch it belongs in.
         bool remote = Services.FlashService.IsRemotePath(path);
 
-        if (!remote && path.EndsWith(".gif", StringComparison.OrdinalIgnoreCase))
+        // still (Back Room hero at MotionLevel Off) takes the still branch below, which decodes the
+        // first frame only.
+        if (!still && !remote && path.EndsWith(".gif", StringComparison.OrdinalIgnoreCase))
         {
             // Was XamlAnimatedGif — which decodes at NATIVE resolution with no size cap, so a
             // large GIF looped full-screen for the whole wash held ~100MB+ of resident BGRA
@@ -168,7 +234,7 @@ public sealed class ChaosFlashOverlay : Window
             // wash doesn't need native res; ClearImage's Detach already tears this down.
             Services.AnimatedWebp.AttachAnimation(_img, path, maxDim: 1280, maxFrames: 40);
         }
-        else if (!remote && path.EndsWith(".webp", StringComparison.OrdinalIgnoreCase) && Services.AnimatedWebp.IsAnimated(path))
+        else if (!still && !remote && path.EndsWith(".webp", StringComparison.OrdinalIgnoreCase) && Services.AnimatedWebp.IsAnimated(path))
         {
             // Animated webp — XamlAnimatedGif is GIF-only, so these washed on as stills. Decode
             // is capped well below the still path's 2560: unlike XamlAnimatedGif's one-frame-at-
@@ -245,6 +311,7 @@ public sealed class ChaosFlashOverlay : Window
         try { _life.Stop(); } catch { }
         ClearImage();
         if (ReferenceEquals(_active, this)) _active = null;
+        if (ReferenceEquals(_hero, this)) _hero = null;
         try { Close(); } catch { }
     }
 
@@ -303,7 +370,7 @@ public sealed class ChaosFlashOverlay : Window
             var hwnd = new WindowInteropHelper(this).Handle;
             if (hwnd == IntPtr.Zero) return;
 
-            bool dual = App.Settings?.Current?.DualMonitorEnabled ?? true;
+            bool dual = _spanAll || (App.Settings?.Current?.DualMonitorEnabled ?? true);
             var b = dual
                 ? System.Windows.Forms.SystemInformation.VirtualScreen
                 : System.Windows.Forms.Screen.PrimaryScreen?.Bounds ?? System.Drawing.Rectangle.Empty;

--- a/ConditioningControlPanel/Models/AppSettings.cs
+++ b/ConditioningControlPanel/Models/AppSettings.cs
@@ -4852,6 +4852,24 @@ namespace ConditioningControlPanel.Models
             set { _motionLevel = value; OnPropertyChanged(); }
         }
 
+        private Services.BackRoom.BackRoomFxIntensity _backRoomFxIntensity = Services.BackRoom.BackRoomFxIntensity.Normal;
+        /// <summary>
+        /// THE BACK ROOM effects intensity (CONTRACT section 4): Calm, Normal or Full. Calm is also
+        /// forced whenever the effective motion level is not Full, and Full never breaks the Brake
+        /// (no strobe over 6 Hz, one hero at a time, feature toggles still win).
+        /// </summary>
+        [JsonProperty]
+        public Services.BackRoom.BackRoomFxIntensity BackRoomFxIntensity
+        {
+            get => _backRoomFxIntensity;
+            set
+            {
+                if (!Enum.IsDefined(typeof(Services.BackRoom.BackRoomFxIntensity), value)) value = Services.BackRoom.BackRoomFxIntensity.Normal;
+                _backRoomFxIntensity = value;
+                OnPropertyChanged();
+            }
+        }
+
         private bool _videoForceHardwareDecoding = false;
         /// <summary>
         /// Force GPU (DXVA) hardware decoding for mandatory videos. Default OFF — mandatory videos

--- a/ConditioningControlPanel/Services/BackRoom/BackRoomFxServices.cs
+++ b/ConditioningControlPanel/Services/BackRoom/BackRoomFxServices.cs
@@ -1,0 +1,265 @@
+using System;
+using System.IO;
+using System.Windows;
+using System.Windows.Threading;
+using ConditioningControlPanel.Models;
+using ConditioningControlPanel.Services.Chaos;
+
+namespace ConditioningControlPanel.Services.BackRoom;
+
+/// <summary>
+/// The real primitive sink: each contract primitive on the app's existing overlay services
+/// (CONTRACT section 4). Called on the UI dispatcher by <see cref="DispatcherFxScheduler"/>.
+///
+/// It stops only what it started. The rain and the glitch wash are shared singletons with a chaos
+/// run, and the one-shot flash and subliminal generations are service-wide, so StopAll touches each
+/// of those only when the room fired one recently; the spiral and brain drain ride the sustained
+/// holds, which already release without tearing down another owner.
+/// </summary>
+public sealed class BackRoomFxServices : IBackRoomFxSink
+{
+    private static BackRoomFx? _shared;
+    private static readonly object SharedLock = new();
+
+    /// <summary>The one dispatcher the room host and the dev rig share, so they share one hero gate.</summary>
+    public static BackRoomFx Shared
+    {
+        get
+        {
+            lock (SharedLock)
+                return _shared ??= new BackRoomFx(new BackRoomFxServices(), new DispatcherFxScheduler(), ReadEnvironment);
+        }
+    }
+
+    /// <summary>How long after a fire StopAll still considers a shared one-shot channel the room's.</summary>
+    private const int OwnershipMs = 12_000;
+
+    private long _flashAt = long.MinValue / 2, _subAt = long.MinValue / 2, _rainAt = long.MinValue / 2, _washAt = long.MinValue / 2;
+    private long _spiralUntil, _drainUntil;
+    private DispatcherTimer? _spiralTimer, _drainTimer;
+    private string? _drainKind;
+
+    private static long Now => Environment.TickCount64;
+    private static bool Recent(long at) => Now - at < OwnershipMs;
+
+    /// <summary>Settings for one fire. Motion is the EFFECTIVE level (user setting capped by the OS).</summary>
+    public static FxEnvironment ReadEnvironment()
+    {
+        var s = App.Settings?.Current;
+        if (s == null)
+            return new FxEnvironment(MotionFx.Level, BackRoomFxIntensity.Calm, new FxGates(false, false, false, false, false, false));
+        return new FxEnvironment(MotionFx.Level, s.BackRoomFxIntensity,
+            new FxGates(s.FlashEnabled, s.SubliminalEnabled, s.SpiralEnabled, s.BrainDrainEnabled, s.BrainDrainMeltEnabled,
+                SpiralStillPath(s) != null));
+    }
+
+    /// <summary>A spiral the gif-full window can hold as a still frame: the user's own spiral file, if
+    /// it is an image. A video spiral has no still here, so at Off it is skipped as motion.</summary>
+    internal static string? SpiralStillPath(AppSettings s)
+    {
+        try
+        {
+            var p = s.SpiralPath;
+            if (string.IsNullOrEmpty(p) || !File.Exists(p)) return null;
+            var ext = Path.GetExtension(p).ToLowerInvariant();
+            return ext is ".gif" or ".png" or ".jpg" or ".jpeg" or ".webp" or ".bmp" ? p : null;
+        }
+        catch (Exception ex) { Diag.Swallowed(ex, "spiral path probe"); return null; }
+    }
+
+    /// <summary>
+    /// Map a dealt media url back to the local file behind it. Only the two origins the room maps
+    /// (<c>ccp.assets</c> = the assets folder, <c>ccp.game</c> = Resources\web) are accepted, and
+    /// the result must stay inside that root, so even a hostile url in a deal cannot name a path.
+    /// </summary>
+    internal static string? TryLocalPath(string? url, string? assetsRoot, string? webRoot)
+    {
+        try
+        {
+            if (string.IsNullOrEmpty(url) || !Uri.TryCreate(url, UriKind.Absolute, out var uri)) return null;
+            if (uri.Scheme != Uri.UriSchemeHttps) return null;
+            string? root = uri.Host switch
+            {
+                "ccp.assets" => assetsRoot,
+                "ccp.game" => webRoot,
+                _ => null,
+            };
+            if (string.IsNullOrEmpty(root)) return null;
+
+            var rel = Uri.UnescapeDataString(uri.AbsolutePath).TrimStart('/').Replace('/', Path.DirectorySeparatorChar);
+            if (rel.Length == 0) return null;
+            var rootFull = Path.GetFullPath(root).TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
+            var full = Path.GetFullPath(Path.Combine(rootFull, rel));
+            return full.StartsWith(rootFull, StringComparison.OrdinalIgnoreCase) ? full : null;
+        }
+        catch (Exception ex) { Diag.Swallowed(ex, "bad media url"); return null; }
+    }
+
+    public void FlashBurst(int amount)
+    {
+        var s = App.Settings?.Current;
+        int? duration = s != null && s.FlashDuration > 0 ? s.FlashDuration : null;
+        _flashAt = Now;
+        App.Flash?.TriggerFlashOnce(amount, duration, null, true);
+    }
+
+    public void GifRain(int durationMs)
+    {
+        // A chaos run's rain already on screen keeps its own; a second cascade on top is noise.
+        if (ChaosGifCascadeOverlay.IsRaining) return;
+        _rainAt = Now;
+        ChaosGifCascadeOverlay.Show(
+            spawnRatePerSec: GifCascadePayload.SPAWN_RATE_PER_SEC,
+            durationSec: Math.Max(1.0, durationMs / 1000.0),
+            gifSize: GifCascadePayload.GIF_SIZE,
+            fallSpeed: GifCascadePayload.FALL_SPEED,
+            opacity: GifCascadePayload.OPACITY,
+            startScale: GifCascadePayload.START_SCALE);
+    }
+
+    public void GlitchWash(int durationMs, double opacity)
+    {
+        _washAt = Now;
+        ChaosFlashOverlay.Show(durationMs, opacity);
+    }
+
+    public void Subliminal(string text)
+    {
+        _subAt = Now;
+        App.Subliminal?.FlashSubliminalCustom(text, null, null, true);
+    }
+
+    public void Spiral(int durationMs, double level, bool still)
+    {
+        var s = App.Settings?.Current;
+        double opacity = 0.85;
+        if (s != null && s.SpiralOpacity > 0) opacity = Math.Clamp(s.SpiralOpacity / 100.0, 0.05, 1.0);
+        opacity = Math.Clamp(opacity * level, 0.02, 1.0);
+
+        if (still)
+        {
+            var path = s != null ? SpiralStillPath(s) : null;
+            if (path != null) ChaosFlashOverlay.ShowHero(path, durationMs, opacity, still: true);
+            return;
+        }
+
+        // Sustained plus our own timer instead of ShowOverlayTimed: a timed overlay cannot be taken
+        // down early, and suspend/close must end the spiral now, not when its timer runs out.
+        App.Overlay?.ShowOverlaySustained("spiral", opacity);
+        _spiralUntil = Math.Max(_spiralUntil, Now + durationMs);
+        _spiralTimer = Rearm(_spiralTimer, _spiralUntil, StopSpiral);
+    }
+
+    public void BrainDrain(int durationMs, double level, bool melt)
+    {
+        var s = App.Settings?.Current;
+        double strength = Math.Clamp((s?.BrainDrainIntensity ?? 20) / 100.0 * level, 0.01, 1.0);
+        var kind = melt ? "braindrain_melt" : "braindrain";
+        if (_drainKind != null && _drainKind != kind) App.Overlay?.HideOverlaySustained(_drainKind);
+        _drainKind = kind;
+        App.Overlay?.ShowOverlaySustained(kind, strength);
+        _drainUntil = Math.Max(_drainUntil, Now + durationMs);
+        _drainTimer = Rearm(_drainTimer, _drainUntil, StopDrain);
+    }
+
+    public void GifFull(BackRoomGif gif, int durationMs, bool still)
+    {
+        var path = TryLocalPath(gif.Url, App.EffectiveAssetsPath, Path.Combine(AppContext.BaseDirectory, "Resources", "web"));
+        if (path == null || !File.Exists(path))
+        {
+            App.Logger?.Debug("[BackRoom] gif-full: dealt item {Key} has no local file", gif.Key);
+            return;
+        }
+        ChaosFlashOverlay.ShowHero(path, durationMs, 0.9, still);
+    }
+
+    public void StopAll()
+    {
+        var disp = Application.Current?.Dispatcher;
+        if (disp == null || disp.HasShutdownStarted) return;
+        if (!disp.CheckAccess()) { disp.BeginInvoke(new Action(StopAll)); return; }
+        StopSpiral();
+        StopDrain();
+        ChaosFlashOverlay.StopHero();
+        if (Recent(_flashAt)) App.Flash?.StopOneShotFlashes();
+        if (Recent(_subAt)) App.Subliminal?.StopOneShotSubliminals();
+        if (Recent(_rainAt) && App.Chaos?.IsRunning != true) ChaosGifCascadeOverlay.CloseActive();
+        if (Recent(_washAt) && App.Chaos?.IsRunning != true) ChaosFlashOverlay.CloseActive();
+        _flashAt = _subAt = _rainAt = _washAt = long.MinValue / 2;
+    }
+
+    private void StopSpiral()
+    {
+        _spiralTimer?.Stop();
+        _spiralTimer = null;
+        if (_spiralUntil == 0) return;
+        _spiralUntil = 0;
+        App.Overlay?.HideOverlaySustained("spiral");
+    }
+
+    private void StopDrain()
+    {
+        _drainTimer?.Stop();
+        _drainTimer = null;
+        if (_drainKind == null) return;
+        var kind = _drainKind;
+        _drainKind = null;
+        _drainUntil = 0;
+        App.Overlay?.HideOverlaySustained(kind);
+    }
+
+    private static DispatcherTimer Rearm(DispatcherTimer? timer, long untilMs, Action onEnd)
+    {
+        timer?.Stop();
+        var t = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(Math.Max(50, untilMs - Now)) };
+        t.Tick += (_, _) =>
+        {
+            t.Stop();
+            try { onEnd(); } catch (Exception ex) { App.Logger?.Warning(ex, "[BackRoom] fx overlay release failed"); }
+        };
+        t.Start();
+        return t;
+    }
+}
+
+/// <summary>The app's fx scheduler: one-shot DispatcherTimers on the UI dispatcher (never Task.Delay,
+/// CLAUDE.md known issue 7).</summary>
+public sealed class DispatcherFxScheduler : IFxScheduler
+{
+    public long NowMs => Environment.TickCount64;
+
+    public IDisposable After(int delayMs, Action action)
+    {
+        var handle = new Handle();
+        var disp = Application.Current?.Dispatcher;
+        if (disp == null || disp.HasShutdownStarted) return handle;
+        disp.BeginInvoke(new Action(() =>
+        {
+            if (handle.Cancelled || disp.HasShutdownStarted) return;
+            var t = new DispatcherTimer(DispatcherPriority.Normal, disp) { Interval = TimeSpan.FromMilliseconds(Math.Max(0, delayMs)) };
+            t.Tick += (_, _) =>
+            {
+                t.Stop();
+                if (!handle.Cancelled) action();
+            };
+            handle.Timer = t;
+            t.Start();
+        }));
+        return handle;
+    }
+
+    private sealed class Handle : IDisposable
+    {
+        public volatile bool Cancelled;
+        public DispatcherTimer? Timer;
+
+        public void Dispose()
+        {
+            Cancelled = true;
+            var t = Timer;
+            if (t == null) return;
+            try { t.Dispatcher.BeginInvoke(new Action(t.Stop)); }
+            catch (Exception ex) { Diag.Swallowed(ex, "dispatcher gone"); }
+        }
+    }
+}

--- a/Tests/ConditioningControlPanel.Tests/BackRoomFxServicesTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/BackRoomFxServicesTests.cs
@@ -1,0 +1,66 @@
+using System.IO;
+using ConditioningControlPanel.Models;
+using ConditioningControlPanel.Services.BackRoom;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// THE BACK ROOM gif-full reads a dealt GIF back off disk. The url comes from the host's own deal,
+/// but the mapping is still fenced: only the two mapped origins, and never a path outside the root.
+/// Plus the intensity setting's default and its round trip.
+/// </summary>
+public class BackRoomFxServicesTests
+{
+    private static readonly string Assets = Path.Combine(Path.GetTempPath(), "ccp-assets");
+    private static readonly string Web = Path.Combine(Path.GetTempPath(), "ccp-web");
+
+    [Fact]
+    public void AssetsUrl_MapsIntoTheAssetsFolder_Unescaped()
+        => Assert.Equal(Path.Combine(Assets, "images", "my gif.gif"),
+            BackRoomFxServices.TryLocalPath("https://ccp.assets/images/my%20gif.gif", Assets, Web));
+
+    [Fact]
+    public void GameUrl_MapsIntoResourcesWeb()
+        => Assert.Equal(Path.Combine(Web, "backroom", "stations", "slot", "fallback", "gif3.webp"),
+            BackRoomFxServices.TryLocalPath("https://ccp.game/backroom/stations/slot/fallback/gif3.webp", Assets, Web));
+
+    [Fact]
+    public void AnimatedHintFragment_IsIgnored()
+        => Assert.Equal(Path.Combine(Assets, "a.webp"),
+            BackRoomFxServices.TryLocalPath("https://ccp.assets/a.webp#.gif", Assets, Web));
+
+    [Theory]
+    [InlineData("https://ccp.assets/..%2F..%2FWindows%2Fwin.ini")]
+    [InlineData("https://ccp.assets/C:%5CWindows%5Cwin.ini")]
+    [InlineData("https://evil.example/images/a.gif")]
+    [InlineData("http://ccp.assets/images/a.gif")]
+    [InlineData("file:///C:/Windows/win.ini")]
+    [InlineData("C:\\Windows\\win.ini")]
+    [InlineData("https://ccp.assets/")]
+    [InlineData("")]
+    [InlineData(null)]
+    public void AnythingElse_MapsToNothing(string? url)
+        => Assert.Null(BackRoomFxServices.TryLocalPath(url, Assets, Web));
+
+    [Fact]
+    public void DotSegments_TheUriCollapses_StillLandInsideTheRoot()
+    {
+        var p = BackRoomFxServices.TryLocalPath("https://ccp.assets/%2E%2E/%2E%2E/secret.txt", Assets, Web);
+        Assert.True(p == null || p.StartsWith(Assets + Path.DirectorySeparatorChar), p);
+    }
+
+    [Fact]
+    public void Intensity_DefaultsToNormal_AndRoundTrips()
+    {
+        Assert.Equal(BackRoomFxIntensity.Normal, new AppSettings().BackRoomFxIntensity);
+        Assert.Equal(BackRoomFxIntensity.Normal, JsonConvert.DeserializeObject<AppSettings>("{}")!.BackRoomFxIntensity);
+        var json = JsonConvert.SerializeObject(new AppSettings { BackRoomFxIntensity = BackRoomFxIntensity.Calm });
+        Assert.Equal(BackRoomFxIntensity.Calm, JsonConvert.DeserializeObject<AppSettings>(json)!.BackRoomFxIntensity);
+    }
+
+    [Fact]
+    public void Intensity_OutOfRange_FallsBackToNormal()
+        => Assert.Equal(BackRoomFxIntensity.Normal, new AppSettings { BackRoomFxIntensity = (BackRoomFxIntensity)9 }.BackRoomFxIntensity);
+}


### PR DESCRIPTION
Lane C3c, stacked on https://github.com/CodeBambi/Conditioning-Control-Panel---CSharp-WPF/pull/1116. Stack: a -> b -> **c** -> d.

- `BackRoomFxServices` (real sink) + `DispatcherFxScheduler` + `BackRoomFxServices.Shared` (the instance C1's host should call).
  - flash-burst: `App.Flash.TriggerFlashOnce(n, FlashDuration, null, true)`
  - gif-rain: `ChaosGifCascadeOverlay.Show` with `GifCascadePayload` constants, skipped if a chaos rain is already up
  - glitch-bubbles: `ChaosFlashOverlay.Show(800, 0.3)` per wash
  - sub-*: `App.Subliminal.FlashSubliminalCustom(text, null, null, true)`
  - spiral-full / brain-drain(-melt): `ShowOverlaySustained` + the room's own DispatcherTimer + `HideOverlaySustained` (deviation from `ShowOverlayTimed`, so suspend/close can end them now)
  - gif-full: NEW second, all-screens instance of `ChaosFlashOverlay` (same decode path, keep-alive window), first-frame still at MotionLevel Off
- Dealt urls map back to files only under `ccp.assets` (assets folder) or `ccp.game` (Resources\web), never outside the root.
- `AppSettings.BackRoomFxIntensity` (default Normal).
- Tests: `BackRoomFxServicesTests` (url fence, setting default and round trip).

Changed lines: 438.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V3c2CJTNfpbeBYqwjT6ZAj
