### PR TITLE
Back Room C1a: station relay with the Ops whitelist and null fx/media

### DIFF
--- a/ConditioningControlPanel/Services/BackRoom/BackRoomApi.cs
+++ b/ConditioningControlPanel/Services/BackRoom/BackRoomApi.cs
@@ -1,0 +1,180 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace ConditioningControlPanel.Services.BackRoom;
+
+/// <summary>One answer to one <c>station-request</c> (CONTRACT section 2.2, <c>station-result</c>).
+/// A host refusal has <see cref="Status"/> 0 and a reason of <c>offline</c>, <c>closed</c> or
+/// <c>bad_op</c>; a request that ran out of time is <c>timeout</c>.</summary>
+public sealed record BackRoomStationResult(bool Ok, int Status, string? Reason, JToken? Body)
+{
+    public static BackRoomStationResult Refuse(string reason) => new(false, 0, reason, null);
+}
+
+/// <summary>What the host needs from the relay. The service owns one; tests hand in a fake.</summary>
+public interface IBackRoomRelay
+{
+    Task<BackRoomStationResult> RelayAsync(string station, string op, string? idem, JObject? body, CancellationToken ct = default);
+}
+
+/// <summary>
+/// THE STATION RELAY (CONTRACT section 3). The only way a Back Room page reaches the server: the
+/// page names a station and an op, this class looks the pair up in <see cref="Ops"/>, attaches the
+/// account's token door (<c>X-Auth-Token</c> plus <c>unified_id</c>, the same pair
+/// ProfileSyncService and the Arcademy sync services send) and hands back one result. The page
+/// never sees the token, the base url or a fetch, so a station cannot call a route this table
+/// does not name.
+///
+/// <para>Budget: <see cref="Timeout"/> across every attempt, because the page gives up at 6 s and
+/// an answer after that helps nobody. A request that failed on the NETWORK (never reached the
+/// server) is sent once more with the same <c>idem</c>, which the server's receipt table turns
+/// into a byte-identical replay if the first one did land after all. Nothing else is retried.</para>
+///
+/// <para>Any <c>sp</c> in a reply is adopted through <c>adoptSp</c> the moment it arrives: the
+/// server settles the whole tape up front (Law I), so the true balance is always the reply's.</para>
+/// </summary>
+public sealed class BackRoomApi : IBackRoomRelay
+{
+    public const string BaseUrl = "https://codebambi-proxy.vercel.app";
+
+    /// <summary>Total time for one relay, retries included.</summary>
+    public static readonly TimeSpan Timeout = TimeSpan.FromSeconds(5);
+
+    /// <summary>
+    /// The whitelist. One row per station, and the ONLY C# that changes when a station is added
+    /// (CONTRACT section 7). op maps to <c>{METHOD} /v2/backroom/{station}/{op}</c>.
+    /// </summary>
+    public static readonly IReadOnlyDictionary<string, (string Method, string Path)[]> Ops =
+        new Dictionary<string, (string Method, string Path)[]>(StringComparer.Ordinal)
+        {
+            ["slot"] = new[] { ("GET", "state"), ("POST", "tape"), ("POST", "cursor") },
+            // ["wheel"] = new[] { ("GET", "state"), ("POST", "spin") },   // later stations append a row
+        };
+
+    private static readonly HttpClient SharedHttp = new() { Timeout = System.Threading.Timeout.InfiniteTimeSpan };
+
+    private readonly HttpClient _http;
+    private readonly Func<(string UnifiedId, string Token)?> _identity;
+    private readonly Action<int>? _adoptSp;
+
+    /// <param name="http">Null = the shared client. Tests pass one over a fake handler.</param>
+    /// <param name="identity">Null result = no account (or offline): every request refuses <c>offline</c>.</param>
+    /// <param name="adoptSp">Receives every <c>body.sp</c> the server answers with.</param>
+    public BackRoomApi(HttpClient? http, Func<(string UnifiedId, string Token)?> identity, Action<int>? adoptSp)
+    {
+        _http = http ?? SharedHttp;
+        _identity = identity;
+        _adoptSp = adoptSp;
+    }
+
+    /// <summary>The account's token door off AppSettings, or null when there is none to use.</summary>
+    public static (string UnifiedId, string Token)? AppIdentity()
+    {
+        try
+        {
+            var s = App.Settings?.Current;
+            if (s == null || s.OfflineMode) return null;
+            if (string.IsNullOrWhiteSpace(s.UnifiedId) || string.IsNullOrWhiteSpace(s.AuthToken)) return null;
+            return (s.UnifiedId, s.AuthToken);
+        }
+        catch { return null; }
+    }
+
+    /// <summary>Whitelist lookup. Exact, case-sensitive match on both station and op.</summary>
+    public static bool TryResolve(string? station, string? op, out string method, out string path)
+    {
+        method = path = string.Empty;
+        if (string.IsNullOrEmpty(station) || string.IsNullOrEmpty(op)) return false;
+        if (!Ops.TryGetValue(station, out var rows)) return false;
+        foreach (var (m, p) in rows)
+        {
+            if (!string.Equals(p, op, StringComparison.Ordinal)) continue;
+            method = m;
+            path = $"/v2/backroom/{station}/{op}";
+            return true;
+        }
+        return false;
+    }
+
+    public async Task<BackRoomStationResult> RelayAsync(string station, string op, string? idem, JObject? body, CancellationToken ct = default)
+    {
+        if (!TryResolve(station, op, out var method, out var path)) return BackRoomStationResult.Refuse("bad_op");
+        var id = _identity();
+        if (id == null) return BackRoomStationResult.Refuse("offline");
+
+        using var budget = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        budget.CancelAfter(Timeout);
+        for (int attempt = 0; attempt < 2; attempt++)
+        {
+            try
+            {
+                using var req = BuildRequest(method, path, id.Value, idem, body);
+                using var res = await _http.SendAsync(req, budget.Token).ConfigureAwait(false);
+                var text = await res.Content.ReadAsStringAsync(budget.Token).ConfigureAwait(false);
+                return Read((int)res.StatusCode, res.IsSuccessStatusCode, text);
+            }
+            catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+            {
+                return BackRoomStationResult.Refuse("timeout");
+            }
+            catch (OperationCanceledException)
+            {
+                return BackRoomStationResult.Refuse("closed");
+            }
+            catch (HttpRequestException ex)
+            {
+                // Never reached the server (or the socket died under the reply). Once more, same idem.
+                App.Logger?.Debug("BackRoom relay {Station}/{Op} network failure (attempt {N}): {E}",
+                    station, op, attempt + 1, ex.Message);
+            }
+        }
+        return BackRoomStationResult.Refuse("offline");
+    }
+
+    private static HttpRequestMessage BuildRequest(string method, string path, (string UnifiedId, string Token) id,
+        string? idem, JObject? body)
+    {
+        HttpRequestMessage req;
+        if (method == "GET")
+        {
+            req = new HttpRequestMessage(HttpMethod.Get, $"{BaseUrl}{path}?unified_id={Uri.EscapeDataString(id.UnifiedId)}");
+        }
+        else
+        {
+            // The page's body, then the fields only the host may write. A page cannot name another
+            // account: unified_id is stamped last and overwrites whatever the body carried.
+            var o = body != null ? (JObject)body.DeepClone() : new JObject();
+            if (!string.IsNullOrEmpty(idem)) o["idem"] = idem;
+            o["unified_id"] = id.UnifiedId;
+            req = new HttpRequestMessage(HttpMethod.Post, BaseUrl + path)
+            {
+                Content = new StringContent(o.ToString(Formatting.None), Encoding.UTF8, "application/json"),
+            };
+        }
+        req.Headers.Add("X-Auth-Token", id.Token);
+        return req;
+    }
+
+    private BackRoomStationResult Read(int status, bool success, string text)
+    {
+        JObject? o = null;
+        try { o = JsonConvert.DeserializeObject(text) as JObject; } catch { }
+        if (o == null) return new BackRoomStationResult(false, status, "bad_reply", null);
+
+        if (o["sp"] is JValue { Type: JTokenType.Integer } sp)
+        {
+            try { _adoptSp?.Invoke(sp.Value<int>()); }
+            catch (Exception ex) { App.Logger?.Debug("BackRoom adopt sp failed: {E}", ex.Message); }
+        }
+        bool ok = success && o.Value<bool?>("ok") == true;
+        var reason = o.Value<string?>("reason");
+        if (!ok && string.IsNullOrEmpty(reason)) reason = success ? "refused" : "http_" + status;
+        return new BackRoomStationResult(ok, status, ok ? null : reason, o);
+    }
+}

--- a/ConditioningControlPanel/Services/BackRoom/BackRoomApi.cs
+++ b/ConditioningControlPanel/Services/BackRoom/BackRoomApi.cs
@@ -161,11 +161,17 @@ public sealed class BackRoomApi : IBackRoomRelay
         return req;
     }
 
+    /// <summary>
+    /// Host refusals are only ever <c>offline</c>, <c>closed</c>, <c>bad_op</c> or <c>timeout</c>
+    /// (CONTRACT section 2.2). A reply the server did not word itself (a gateway HTML page, a JSON
+    /// refusal with no reason) is the server being unreachable in all but name, so it is <c>offline</c>;
+    /// the HTTP status still rides along for the log.
+    /// </summary>
     private BackRoomStationResult Read(int status, bool success, string text)
     {
         JObject? o = null;
         try { o = JsonConvert.DeserializeObject(text) as JObject; } catch { }
-        if (o == null) return new BackRoomStationResult(false, status, "bad_reply", null);
+        if (o == null) return new BackRoomStationResult(false, status, "offline", null);
 
         if (o["sp"] is JValue { Type: JTokenType.Integer } sp)
         {
@@ -174,7 +180,7 @@ public sealed class BackRoomApi : IBackRoomRelay
         }
         bool ok = success && o.Value<bool?>("ok") == true;
         var reason = o.Value<string?>("reason");
-        if (!ok && string.IsNullOrEmpty(reason)) reason = success ? "refused" : "http_" + status;
+        if (!ok && string.IsNullOrEmpty(reason)) reason = "offline";
         return new BackRoomStationResult(ok, status, ok ? null : reason, o);
     }
 }

--- a/ConditioningControlPanel/Services/BackRoom/BackRoomStubs.cs
+++ b/ConditioningControlPanel/Services/BackRoom/BackRoomStubs.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ConditioningControlPanel.Services.BackRoom;
+
+// Null objects for the two seams C3 (fx) and C4 (media) fill in. The host runs on these until those
+// lanes land, and they are what the room falls back to if a real implementation throws: a page that
+// fires effects is told honestly that nothing played, and a sit-down always gets a full deal.
+
+/// <summary>Acks every effect as skipped <c>unknown</c>. Plays nothing, cancels nothing.</summary>
+public sealed class NullBackRoomFx : IBackRoomFx
+{
+    public BackRoomFxAck Fire(string fxId, string station, IReadOnlyList<string> symbolKeys, BackRoomMediaDeal deal) =>
+        new(Array.Empty<string>(), new[] { new BackRoomFxSkip(string.IsNullOrEmpty(fxId) ? "?" : fxId, BackRoomFxSkipReason.Unknown) });
+
+    public void CancelAll() { }
+}
+
+/// <summary>Deals the fallback presets only: four built-in GIF slots and the four preset words
+/// (CONTRACT section 5, in that order), with preset text resolved through the lexicon.</summary>
+public sealed class NullBackRoomMedia : IBackRoomMedia
+{
+    /// <summary>Preset words, in contract order, as (lexicon key, neutral fallback).</summary>
+    public static readonly (string Key, string Fallback)[] Presets =
+    {
+        ("br_preset_drop", "Drop"), ("br_preset_relax", "Relax"), ("br_preset_let_go", "Let Go"), ("br_preset_sink", "Sink"),
+    };
+
+    private readonly Func<string, string>? _lex;
+
+    /// <param name="lex">Lexicon lookup returning the key itself on a miss (Loc.Get's contract). Null = fallbacks.</param>
+    public NullBackRoomMedia(Func<string, string>? lex) => _lex = lex;
+
+    public BackRoomMediaDeal Deal(string station, int seed)
+    {
+        var gifs = Enumerable.Range(0, 4)
+            .Select(i => new BackRoomGif("g" + i, $"https://ccp.game/backroom/stations/slot/fallback/gif{i}.webp", 0, 0, "fallback"))
+            .ToList();
+        var words = Presets.Select((p, i) => new BackRoomWord("s" + i, Word(p.Key, p.Fallback), "preset")).ToList();
+        return new BackRoomMediaDeal(seed, gifs, words);
+    }
+
+    private string Word(string key, string fallback)
+    {
+        try
+        {
+            var s = _lex?.Invoke(key);
+            return string.IsNullOrWhiteSpace(s) || s == key ? fallback : s;
+        }
+        catch { return fallback; }
+    }
+}

--- a/Tests/ConditioningControlPanel.Tests/BackRoomApiTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/BackRoomApiTests.cs
@@ -1,0 +1,156 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using ConditioningControlPanel.Services.BackRoom;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// The Back Room relay (CONTRACT section 3): the Ops whitelist is the only door to the server,
+/// the token door is attached by the host and never by the page, a network failure is retried
+/// exactly once with the same idem, and every <c>sp</c> in a reply is adopted.
+/// </summary>
+public class BackRoomApiTests
+{
+    private sealed class FakeHandler : HttpMessageHandler
+    {
+        public readonly List<(HttpMethod Method, string Url, string? Token, string? Body)> Seen = new();
+        public Func<int, HttpResponseMessage> Answer = _ => Json(200, "{\"ok\":true}");
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage r, CancellationToken ct)
+        {
+            var body = r.Content == null ? null : await r.Content.ReadAsStringAsync(ct);
+            Seen.Add((r.Method, r.RequestUri!.ToString(), r.Headers.TryGetValues("X-Auth-Token", out var v) ? v.First() : null, body));
+            return Answer(Seen.Count);
+        }
+    }
+
+    private static HttpResponseMessage Json(int status, string body) =>
+        new((HttpStatusCode)status) { Content = new StringContent(body) };
+
+    private static (BackRoomApi Api, FakeHandler H, List<int> Sp) Make((string, string)? identity = null, bool signedOut = false)
+    {
+        var h = new FakeHandler();
+        var sp = new List<int>();
+        var api = new BackRoomApi(new HttpClient(h), () => signedOut ? null : identity ?? ("uid-1", "tok-1"), sp.Add);
+        return (api, h, sp);
+    }
+
+    [Theory]
+    [InlineData("slot", "state", "GET")]
+    [InlineData("slot", "tape", "POST")]
+    [InlineData("slot", "cursor", "POST")]
+    public void Whitelist_ResolvesTheContractRows(string station, string op, string method)
+    {
+        Assert.True(BackRoomApi.TryResolve(station, op, out var m, out var path));
+        Assert.Equal(method, m);
+        Assert.Equal($"/v2/backroom/{station}/{op}", path);
+    }
+
+    [Theory]
+    [InlineData("slot", "spin")]
+    [InlineData("slot", "STATE")]
+    [InlineData("wheel", "state")]
+    [InlineData("slot", "../admin")]
+    [InlineData("", "state")]
+    [InlineData(null, null)]
+    public void Whitelist_RefusesEverythingElse(string? station, string? op)
+        => Assert.False(BackRoomApi.TryResolve(station, op, out _, out _));
+
+    [Fact]
+    public async Task BadOp_NeverTouchesTheNetwork()
+    {
+        var (api, h, _) = Make();
+        var r = await api.RelayAsync("slot", "withdraw", null, null, TestContext.Current.CancellationToken);
+        Assert.Equal(("bad_op", 0, false), (r.Reason, r.Status, r.Ok));
+        Assert.Empty(h.Seen);
+    }
+
+    [Fact]
+    public async Task SignedOut_RefusesOffline()
+    {
+        var (api, h, _) = Make(signedOut: true);
+        var r = await api.RelayAsync("slot", "state", null, null, TestContext.Current.CancellationToken);
+        Assert.Equal("offline", r.Reason);
+        Assert.Empty(h.Seen);
+    }
+
+    [Fact]
+    public async Task Post_StampsIdemAndUnifiedIdOverThePageBody()
+    {
+        var (api, h, _) = Make();
+        var body = JObject.Parse("{\"count\":10,\"unified_id\":\"someone-else\"}");
+        await api.RelayAsync("slot", "tape", "idem-0123456789abcdef", body, TestContext.Current.CancellationToken);
+
+        var (method, url, token, sent) = Assert.Single(h.Seen);
+        Assert.Equal(HttpMethod.Post, method);
+        Assert.Equal(BackRoomApi.BaseUrl + "/v2/backroom/slot/tape", url);
+        Assert.Equal("tok-1", token);
+        var o = JObject.Parse(sent!);
+        Assert.Equal("uid-1", (string?)o["unified_id"]);
+        Assert.Equal("idem-0123456789abcdef", (string?)o["idem"]);
+        Assert.Equal(10, (int)o["count"]!);
+        Assert.Equal("someone-else", (string?)body["unified_id"]);   // the page's object is not mutated
+    }
+
+    [Fact]
+    public async Task Get_CarriesUnifiedIdInTheQuery()
+    {
+        var (api, h, _) = Make();
+        await api.RelayAsync("slot", "state", null, null, TestContext.Current.CancellationToken);
+        Assert.Equal(BackRoomApi.BaseUrl + "/v2/backroom/slot/state?unified_id=uid-1", h.Seen[0].Url);
+        Assert.Null(h.Seen[0].Body);
+    }
+
+    [Fact]
+    public async Task NetworkFailure_RetriesOnceWithTheSameIdem()
+    {
+        var (api, h, _) = Make();
+        h.Answer = n => n == 1 ? throw new HttpRequestException("reset") : Json(200, "{\"ok\":true,\"sp\":51}");
+        var r = await api.RelayAsync("slot", "tape", "idem-aaaaaaaaaaaaaaaa", new JObject { ["count"] = 1 }, TestContext.Current.CancellationToken);
+
+        Assert.True(r.Ok);
+        Assert.Equal(2, h.Seen.Count);
+        Assert.All(h.Seen, s => Assert.Equal("idem-aaaaaaaaaaaaaaaa", (string?)JObject.Parse(s.Body!)["idem"]));
+    }
+
+    [Fact]
+    public async Task NetworkFailureTwice_IsOffline_AndStopsAtTwoAttempts()
+    {
+        var (api, h, _) = Make();
+        h.Answer = _ => throw new HttpRequestException("down");
+        var r = await api.RelayAsync("slot", "state", null, null, TestContext.Current.CancellationToken);
+        Assert.Equal("offline", r.Reason);
+        Assert.Equal(2, h.Seen.Count);
+    }
+
+    [Fact]
+    public async Task Refusal_KeepsServerReasonAndStatus_AndStillAdoptsSp()
+    {
+        var (api2, h2, sp2) = Make();
+        h2.Answer = _ => Json(200, "{\"ok\":false,\"reason\":\"insufficient\",\"sp\":3}");
+        var r = await api2.RelayAsync("slot", "tape", "idem-bbbbbbbbbbbbbbbb", null, TestContext.Current.CancellationToken);
+        Assert.Equal((false, 200, "insufficient"), (r.Ok, r.Status, r.Reason));
+        Assert.Equal(new[] { 3 }, sp2);
+
+        h2.Answer = _ => Json(403, "{\"ok\":false,\"reason\":\"closed\"}");
+        var closed = await api2.RelayAsync("slot", "state", null, null, TestContext.Current.CancellationToken);
+        Assert.Equal((false, 403, "closed"), (closed.Ok, closed.Status, closed.Reason));
+    }
+
+    [Fact]
+    public async Task NonJsonReply_IsBadReply()
+    {
+        var (api, h, sp) = Make();
+        h.Answer = _ => Json(502, "<html>gateway</html>");
+        var r = await api.RelayAsync("slot", "state", null, null, TestContext.Current.CancellationToken);
+        Assert.Equal((false, 502, "bad_reply"), (r.Ok, r.Status, r.Reason));
+        Assert.Empty(sp);
+    }
+}

--- a/Tests/ConditioningControlPanel.Tests/BackRoomApiTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/BackRoomApiTests.cs
@@ -144,13 +144,19 @@ public class BackRoomApiTests
         Assert.Equal((false, 403, "closed"), (closed.Ok, closed.Status, closed.Reason));
     }
 
-    [Fact]
-    public async Task NonJsonReply_IsBadReply()
+    [Theory]
+    [InlineData(502, "<html>gateway</html>")]
+    [InlineData(504, "")]
+    [InlineData(200, "{\"ok\":false}")]
+    [InlineData(500, "{\"error\":\"boom\"}")]
+    [InlineData(200, "[1,2]")]
+    public async Task UnwordedReplies_AreRefusedOffline(int status, string body)
     {
+        // CONTRACT 2.2: the host's own reasons are offline, closed, bad_op and timeout, nothing else.
         var (api, h, sp) = Make();
-        h.Answer = _ => Json(502, "<html>gateway</html>");
+        h.Answer = _ => Json(status, body);
         var r = await api.RelayAsync("slot", "state", null, null, TestContext.Current.CancellationToken);
-        Assert.Equal((false, 502, "bad_reply"), (r.Ok, r.Status, r.Reason));
+        Assert.Equal((false, status, "offline"), (r.Ok, r.Status, r.Reason));
         Assert.Empty(sp);
     }
 }


### PR DESCRIPTION
Lane C1 (room shell), part a of 6. Builds to `Resources/web/backroom/CONTRACT.md` section 3 (host relay).

- `Services/BackRoom/BackRoomApi.cs`: the `Ops` whitelist table from section 3 (slot: GET state, POST tape, POST cursor), `X-Auth-Token` + `unified_id` stamped by the host (a page body cannot override `unified_id`), a 5 s budget across attempts, one retry with the same `idem` on a network failure only, `body.sp` adopted from every reply. Host refusals: `offline`, `closed`, `bad_op`; out of time: `timeout`.
- `Services/BackRoom/BackRoomStubs.cs`: `NullBackRoomFx` (every fx acks skipped `unknown`) and `NullBackRoomMedia` (four fallback gif slots, preset words Drop, Relax, Let Go, Sink through the lexicon). C3 and C4 replace them.
- `Tests/BackRoomApiTests.cs`: whitelist rows and refusals, token door, idem stamping, retry once, refusal pass-through, non-JSON replies.

Stack: **a** relay -> b bridge -> c host -> d room scene -> e room boot + smoke -> f entry points.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V3c2CJTNfpbeBYqwjT6ZAj
