### PR TITLE
Back Room C1c: host window, panic ladder and app-exit flush

### DIFF
--- a/ConditioningControlPanel/App.xaml.cs
+++ b/ConditioningControlPanel/App.xaml.cs
@@ -5314,6 +5314,8 @@ Application State:
             // exit-done, and that timer can never tick from inside OnExit - so the flush it guards
             // never happened and the last class's grades/streak went with the process.
             try { Services.Arcademy.ArcademyHostService.ShutdownFlush(); } catch (Exception ex) { Diag.Swallowed(ex); }
+            // The Back Room: same posture - the last tape cursor goes out and the window is disposed now.
+            try { Services.BackRoom.BackRoomHostService.ShutdownFlush(); } catch (Exception ex) { Diag.Swallowed(ex); }
 
             // The Emergency Exit's friction door: a WebView2 process outliving the app is a leak, and
             // Close() is safe from here - it has no state to flush and never touches the lockdown (any

--- a/ConditioningControlPanel/MainWindow/MainWindow.xaml.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.xaml.cs
@@ -1573,6 +1573,14 @@ namespace ConditioningControlPanel
                 return;
             }
 
+            // The Back Room: the Arcademy's ladder, same reason (press 1 suspends, press 2 closes).
+            if (Services.BackRoom.BackRoomHostService.IsActive)
+            {
+                VideoDiag.Log("PANIC", "handed off to the Back Room window (suspend, then close)");
+                Services.BackRoom.BackRoomHostService.HandlePanicPress();
+                return;
+            }
+
             // For You feed: a two-rung ladder. Press 1 drops ghost mode if the feed is parked as a
             // see-through mirror (otherwise the user is staring at a translucent pane they cannot
             // grab — the mouse passes straight through it, its own close button included), press 2
@@ -1642,6 +1650,7 @@ namespace ConditioningControlPanel
                 return App.Chaos?.IsDescending == true
                     || Services.Chaos.DtrhHostService.IsActive
                     || Services.Arcademy.ArcademyHostService.IsActive
+                    || Services.BackRoom.BackRoomHostService.IsActive
                     || Services.Fyp.FypHostService.IsActive
                     || Services.JustDrop.JustDropHostService.IsActive;
             }
@@ -1853,6 +1862,7 @@ namespace ConditioningControlPanel
             Step("chaos", () => App.Chaos?.ForceShutdown());
             Step("DtRH", () => Services.Chaos.DtrhHostService.CloseActive());
             Step("Arcademy", () => Services.Arcademy.ArcademyHostService.CloseActive());
+            Step("Back Room", () => Services.BackRoom.BackRoomHostService.CloseActive("panic"));
             Step("For You feed", () => Services.Fyp.FypHostService.Close());
             Step("Just Drop", () => Services.JustDrop.JustDropHostService.CloseActive());
             Step("Lab minigames", () => App.BlinkTrainer?.Stop());

--- a/ConditioningControlPanel/Models/FeatureDayLog.cs
+++ b/ConditioningControlPanel/Models/FeatureDayLog.cs
@@ -30,7 +30,9 @@ public class FeatureDayEntry
     public static readonly string[] EventKeys =
     {
         "e_fl", "e_vd", "e_sb", "e_ov", "e_bb", "e_bc", "e_bt", "e_lk", "e_mw",
-        "e_pq", "e_bl", "e_cp", "e_ch", "e_dt", "e_rc", "e_pb"
+        "e_pq", "e_bl", "e_cp", "e_ch", "e_dt", "e_rc", "e_pb",
+        // The Back Room: one per station sit-down (BackRoomBridge, `station-open`).
+        "e_backroom_slot", "e_backroom_wheel", "e_backroom_scratcher", "e_backroom_cards", "e_backroom_counter"
     };
 
     public static bool IsEventKey(string key) => Array.IndexOf(EventKeys, key) >= 0;

--- a/ConditioningControlPanel/Services/BackRoom/BackRoomHostService.cs
+++ b/ConditioningControlPanel/Services/BackRoom/BackRoomHostService.cs
@@ -1,0 +1,318 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Windows;
+using System.Windows.Threading;
+using Microsoft.Web.WebView2.Core;
+using Newtonsoft.Json.Linq;
+using ConditioningControlPanel.Localization;
+
+namespace ConditioningControlPanel.Services.BackRoom;
+
+/// <summary>
+/// Host for THE BACK ROOM (<c>Resources/web/backroom</c>): the SP room with a game station in each
+/// corner. Its own <see cref="ChaosWebViewHost"/>, windowed, owned by MainWindow, free for every
+/// account (CONTRACT section 1). Everything the page and the host say to each other is
+/// <see cref="BackRoomBridge"/>; this class is only the window, the settings watch and the three
+/// ways a room is left (the page's Back, the panic ladder, app exit).
+/// </summary>
+internal static class BackRoomHostService
+{
+    public const string ProductName = "The Back Room";
+    public const string StartUrl = "https://ccp.game/backroom/index.html";
+
+    /// <summary>Constant on purpose (AGENTS.md: the argument string must not vary per launch, or
+    /// WebView2 refuses to share the browser process between hosts).</summary>
+    public const string BrowserArguments = "--autoplay-policy=no-user-gesture-required";
+
+    /// <summary>Room lexicon rows the page reads through <c>init.lex</c>. Stations may ask for more
+    /// with a fallback; every row here has one in en.json.</summary>
+    internal static readonly string[] LexKeys =
+    {
+        "br_room_title", "br_back", "br_balance", "br_walk_hint", "br_soon_title", "br_soon_body",
+        "br_station_slot", "br_station_wheel", "br_station_scratcher", "br_station_cards", "br_station_counter",
+        "br_station_failed", "br_station_closed", "br_model_missing", "br_suspended",
+        "br_preset_drop", "br_preset_relax", "br_preset_let_go", "br_preset_sink",
+    };
+
+    private static readonly TimeSpan PanicDoublePressWindow = TimeSpan.FromSeconds(2);
+
+    private static ChaosWebViewHost? _host;
+    private static BackRoomBridge? _bridge;
+    private static Models.AppSettings? _hookedSettings;
+    private static bool _replaceHooked;
+    private static bool _disposing;
+    private static bool _panicSuspended;
+    private static bool _minimised;
+    private static DateTime _lastPanicPressUtc;
+
+    /// <summary>C3 and C4 replace these at integration; until then the null objects answer.</summary>
+    internal static IBackRoomFx Fx { get; set; } = new NullBackRoomFx();
+    internal static IBackRoomMedia Media { get; set; } = new NullBackRoomMedia(Loc.Get);
+
+    public static bool IsActive => _host != null;
+
+    public static void Launch()
+    {
+        if (_host != null) { _host.FocusWeb(); return; }
+        try { App.EmiDesk?.NoteOpen("backroom"); } catch (Exception ex) { Diag.Swallowed(ex); }
+
+        try
+        {
+            _panicSuspended = _minimised = false;
+            _lastPanicPressUtc = DateTime.MinValue;
+
+            var api = new BackRoomApi(null, BackRoomApi.AppIdentity, sp => _bridge?.AdoptSp(sp));
+            _bridge = new BackRoomBridge(new BackRoomBridge.Deps
+            {
+                Post = Post,
+                Relay = api,
+                Fx = Fx,
+                Media = Media,
+                BuildInit = BuildInit,
+                CloseWindow = DisposeAll,
+                Schedule = Schedule,
+                NoteEvent = key => App.FeatureDayLog?.Note(key),
+                SetSp = sp => { if (App.Settings?.Current is { } s) s.SkillPoints = sp; },
+                OnUi = OnUi,
+                Log = msg => App.Logger?.Debug("BackRoom: {Msg}", msg),
+            });
+
+            var webRoot = Path.Combine(AppContext.BaseDirectory, "Resources", "web");
+            var mappings = new List<(string, string, CoreWebView2HostResourceAccessKind)>
+            {
+                ("ccp.game", webRoot, CoreWebView2HostResourceAccessKind.Deny),
+                // The player's own media (the C4 feed deals ccp.assets urls). Allow, because the
+                // slot paints dealt GIFs into reel textures and a tainted image cannot reach WebGL.
+                ("ccp.assets", App.EffectiveAssetsPath, CoreWebView2HostResourceAccessKind.Allow),
+            };
+
+            _host = new ChaosWebViewHost(new ChaosWebViewHost.Options
+            {
+                StartUrl = StartUrl,
+                PrimaryHost = "ccp.game",
+                Mappings = mappings,
+                UserDataFolderName = "backroom",
+                InputEnabled = true,
+                StartFullscreen = false,
+                OwnedByMainWindow = true,
+                CenterOnMainWindow = true,
+                WindowTitle = ProductName,
+                LogTag = "BackRoom",
+                ExtraBrowserArguments = BrowserArguments,
+                OnReady = () => _bridge?.OnReady(),
+                OnMessage = m => _bridge?.Handle(m),
+                OnProcessFailed = kind => { App.Logger?.Warning("BackRoom: process failed ({Kind}), closing", kind); OnUi(DisposeAll); },
+            });
+            HookSettings(true);
+            _host.Show();
+            if (_host.Window is { } w)
+            {
+                w.Closed += (_, _) => _bridge?.CloseNow();
+                w.StateChanged += (_, _) => OnWindowStateChanged(w);
+                w.Activated += (_, _) => OnWindowActivated();
+            }
+            App.Logger?.Information("BackRoomHostService: launched");
+        }
+        catch (Exception ex)
+        {
+            App.Logger?.Error(ex, "BackRoomHostService.Launch failed");
+            DisposeAll();
+        }
+    }
+
+    /// <summary>Graceful close (the panic stop pass, an entitlement or mod change): the page gets
+    /// <c>close</c> and 800 ms. Idempotent.</summary>
+    public static void CloseActive(string reason = "panic")
+    {
+        try
+        {
+            if (_host == null) return;
+            if (_host.IsReady && _bridge != null) _bridge.RequestClose(reason);
+            else DisposeAll();
+        }
+        catch (Exception ex) { App.Logger?.Debug("BackRoom.CloseActive: {E}", ex.Message); DisposeAll(); }
+    }
+
+    /// <summary>APP EXIT ONLY. No round trip and no timer (a DispatcherTimer never ticks inside
+    /// OnExit): send the last cursor and dispose now.</summary>
+    public static void ShutdownFlush()
+    {
+        try
+        {
+            if (_host == null) return;
+            try { _host.Post(new { type = "close", reason = "app-exit" }); } catch (Exception ex) { Diag.Swallowed(ex); }
+            if (_bridge != null) _bridge.CloseNow(); else DisposeAll();
+        }
+        catch (Exception ex) { App.Logger?.Debug("BackRoom.ShutdownFlush: {E}", ex.Message); }
+    }
+
+    /// <summary>
+    /// THE PANIC LADDER while the room is up (MainWindow hands the key here, as it does for the
+    /// Arcademy, so two taps inside a game window never exit the app). Press 1 suspends: every
+    /// effect the room started is cancelled and the page goes quiet. Press 2 inside 2 s closes the
+    /// room. A suspended room wakes the next time its window is activated after the double-press
+    /// window has passed, because protocol 1 has no page-side resume request.
+    /// </summary>
+    public static void HandlePanicPress()
+    {
+        if (_host == null || _bridge == null) return;
+        var now = DateTime.UtcNow;
+        bool second = _panicSuspended && (now - _lastPanicPressUtc) <= PanicDoublePressWindow;
+        _lastPanicPressUtc = now;
+        if (second)
+        {
+            App.Logger?.Information("BackRoom: panic press 2 - closing the room");
+            _panicSuspended = false;
+            CloseActive("panic");
+            return;
+        }
+        App.Logger?.Information("BackRoom: panic press 1 - suspending (press again to leave)");
+        _panicSuspended = true;
+        _bridge.Suspend(true, "panic");
+    }
+
+    private static void OnWindowStateChanged(Window w)
+    {
+        bool min = w.WindowState == WindowState.Minimized;
+        if (min == _minimised) return;
+        _minimised = min;
+        _bridge?.Suspend(min, "minimise");
+    }
+
+    private static void OnWindowActivated()
+    {
+        if (!_panicSuspended || DateTime.UtcNow - _lastPanicPressUtc <= PanicDoublePressWindow) return;
+        _panicSuspended = false;
+        _bridge?.Suspend(false, "panic");
+    }
+
+    // ============================ projection ============================
+
+    private static object BuildInit()
+    {
+        var s = App.Settings?.Current;
+        var motion = s?.MotionLevel ?? Models.MotionLevel.Full;
+        return new
+        {
+            type = "init",
+            protocol = BackRoomBridge.Protocol,
+            sp = s?.SkillPoints ?? 0,
+            reduced = motion != Models.MotionLevel.Full,
+            motion = MotionWire(motion),
+            intensity = IntensityWire(s, motion),
+            lang = LocalizationManager.Instance.CurrentLanguage,
+            lex = LexKeys.ToDictionary(k => k, Loc.Get),
+            stations = BackRoomApi.Ops.Keys.ToArray(),
+            // No door endpoint exists yet: null = unknown, and the page learns `closed` from its
+            // first station-request (CONTRACT section 3, 403 closed).
+            open = (bool?)null,
+        };
+    }
+
+    private static object SettingsMessage()
+    {
+        var s = App.Settings?.Current;
+        var motion = s?.MotionLevel ?? Models.MotionLevel.Full;
+        return new { type = "settings", motion = MotionWire(motion), intensity = IntensityWire(s, motion), reduced = motion != Models.MotionLevel.Full };
+    }
+
+    internal static string MotionWire(Models.MotionLevel m) => m.ToString().ToLowerInvariant();
+
+    /// <summary>The effective intensity: <c>calm</c> whenever MotionLevel is not Full (CONTRACT
+    /// section 4), otherwise <c>AppSettings.BackRoomFxIntensity</c>, which C3 adds. Read by name so
+    /// this lane builds before that property exists; absent reads as <c>normal</c>.</summary>
+    internal static string IntensityWire(Models.AppSettings? s, Models.MotionLevel motion)
+    {
+        if (motion != Models.MotionLevel.Full) return "calm";
+        try
+        {
+            var v = s?.GetType().GetProperty("BackRoomFxIntensity")?.GetValue(s)?.ToString();
+            if (!string.IsNullOrEmpty(v)) return v.ToLowerInvariant();
+        }
+        catch (Exception ex) { Diag.Swallowed(ex); }
+        return "normal";
+    }
+
+    // ============================ plumbing ============================
+
+    private static void Post(object msg) => OnUi(() => _host?.Post(msg));
+
+    private static void OnUi(Action a)
+    {
+        var d = Application.Current?.Dispatcher;
+        if (d == null || d.HasShutdownStarted) return;
+        if (d.CheckAccess()) { try { a(); } catch (Exception ex) { App.Logger?.Debug("BackRoom.OnUi: {E}", ex.Message); } }
+        else d.BeginInvoke(() => { try { a(); } catch (Exception ex) { App.Logger?.Debug("BackRoom.OnUi: {E}", ex.Message); } });
+    }
+
+    private static Action Schedule(TimeSpan delay, Action fn)
+    {
+        DispatcherTimer? t = null;
+        OnUi(() =>
+        {
+            t = new DispatcherTimer { Interval = delay };
+            t.Tick += (_, _) => { t?.Stop(); fn(); };
+            t.Start();
+        });
+        return () => OnUi(() => t?.Stop());
+    }
+
+    private static void HookSettings(bool on)
+    {
+        try
+        {
+            if (_hookedSettings != null) _hookedSettings.PropertyChanged -= OnSettingChanged;
+            _hookedSettings = null;
+            if (App.Settings == null) return;
+            if (_replaceHooked) { App.Settings.CurrentReplaced -= OnSettingsReplaced; _replaceHooked = false; }
+            if (!on) return;
+            App.Settings.CurrentReplaced += OnSettingsReplaced;
+            _replaceHooked = true;
+            if (App.Settings.Current is { } s) { s.PropertyChanged += OnSettingChanged; _hookedSettings = s; }
+        }
+        catch (Exception ex) { Diag.Swallowed(ex); }
+    }
+
+    private static void OnSettingsReplaced()
+    {
+        if (_host == null) return;
+        HookSettings(true);
+        _bridge?.PushSettings(SettingsMessage());
+        if (App.Settings?.Current is { } s) _bridge?.OnSpChanged(s.SkillPoints, "sync");
+    }
+
+    private static void OnSettingChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (_bridge == null || sender is not Models.AppSettings s) return;
+        switch (e.PropertyName)
+        {
+            case nameof(Models.AppSettings.SkillPoints):
+                _bridge.OnSpChanged(s.SkillPoints, "earn");
+                break;
+            case nameof(Models.AppSettings.MotionLevel):
+            case "BackRoomFxIntensity":
+                _bridge.PushSettings(SettingsMessage());
+                break;
+        }
+    }
+
+    private static void DisposeAll()
+    {
+        if (_disposing) return;
+        _disposing = true;
+        try
+        {
+            HookSettings(false);
+            var host = _host;
+            _host = null;
+            _bridge = null;
+            try { host?.Dispose(); } catch (Exception ex) { Diag.Swallowed(ex); }
+            _panicSuspended = _minimised = false;
+            App.Logger?.Information("BackRoomHostService: closed");
+        }
+        finally { _disposing = false; }
+    }
+}

--- a/Tests/ConditioningControlPanel.Tests/BackRoomBridgeLifecycleTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/BackRoomBridgeLifecycleTests.cs
@@ -1,0 +1,119 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using ConditioningControlPanel.Services.BackRoom;
+using Newtonsoft.Json.Linq;
+using Xunit;
+using static ConditioningControlPanel.Tests.BackRoomBridgeTests;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// Back Room protocol 1, the lifecycle half: the close timings (300 ms page budget, 800 ms force),
+/// the cursor backstop, silent SP adoption, the day-log hook and the null fx/media objects the host
+/// runs on until C3 and C4 land. Same manual clock and fake relay as <see cref="BackRoomBridgeTests"/>.
+/// </summary>
+public class BackRoomBridgeLifecycleTests
+{
+    [Fact]
+    public void Close_PostsClose_AndForceClosesAt800ms()
+    {
+        var rig = new Rig();
+        rig.Bridge.RequestClose("panic");
+        var c = Assert.Single(rig.Of("close"));
+        Assert.Equal("panic", (string?)c["reason"]);
+        Assert.Equal(0, rig.Closed);
+
+        Assert.Contains(rig.Clock.Timers, t => t.At == TimeSpan.FromMilliseconds(800));
+        Assert.DoesNotContain(rig.Clock.Timers, t => t.At > TimeSpan.FromMilliseconds(800) && t.At < TimeSpan.FromSeconds(5));
+        rig.Clock.Fire(TimeSpan.FromMilliseconds(800));
+        Assert.Equal(1, rig.Closed);
+        Assert.Equal(300, BackRoomBridge.PageSettleMs);
+    }
+
+    [Fact]
+    public void ExitDone_ClosesImmediately_AndOnlyOnce()
+    {
+        var rig = new Rig();
+        rig.Bridge.RequestClose("app-exit");
+        rig.Send("{\"type\":\"exit-done\"}");
+        Assert.Equal(1, rig.Closed);
+        Assert.True(rig.Clock.Timers.Single().Cancelled);
+        rig.Clock.Fire(TimeSpan.FromMilliseconds(800));
+        rig.Send("{\"type\":\"exit-done\"}");
+        Assert.Equal(1, rig.Closed);
+    }
+
+    [Fact]
+    public void PageExit_ArmsTheSameWatchdog()
+    {
+        var rig = new Rig();
+        rig.Send("{\"type\":\"exit\",\"reason\":\"key\"}");
+        Assert.Equal(0, rig.Closed);
+        rig.Clock.Fire(TimeSpan.FromMilliseconds(800));
+        Assert.Equal(1, rig.Closed);
+    }
+
+    [Fact]
+    public void Exit_FlushesTheReportedCursor_ToTheCursorRoute()
+    {
+        var rig = new Rig();
+        rig.Send("{\"type\":\"exit\",\"reason\":\"back\",\"station\":\"slot\",\"cursor\":{\"tapeId\":\"t_1\",\"played\":7}}");
+        var call = Assert.Single(rig.Relay.Calls);
+        Assert.Equal(("slot", "cursor"), (call.Station, call.Op));
+        Assert.Equal(7, (int)call.Body!["played"]!);
+        rig.Send("{\"type\":\"station-close\",\"station\":\"slot\",\"cursor\":{\"tapeId\":\"t_1\",\"played\":7}}");
+        Assert.Single(rig.Relay.Calls);   // already flushed: not sent twice
+    }
+
+    [Fact]
+    public async Task AdoptedSp_IsNotPushedBack_ButAnOutsideChangeIs()
+    {
+        var rig = new Rig();
+        rig.Bridge.AdoptSp(51);
+        Assert.Equal(51, rig.Sp);
+        Assert.Empty(rig.Of("balance"));
+
+        rig.Bridge.OnSpChanged(60, "earn");
+        var b = Assert.Single(await rig.SettleAsync("balance", 1));
+        Assert.Equal((60, "earn"), ((int)b["sp"]!, (string?)b["why"]));
+    }
+
+    [Fact]
+    public void StationOpen_NotesTheDayLogEvent_ForValidIdsOnly()
+    {
+        var rig = new Rig();
+        rig.Send("{\"type\":\"station-open\",\"station\":\"slot\"}");
+        rig.Send("{\"type\":\"station-open\",\"station\":\"../x\"}");
+        Assert.Equal(new[] { "e_backroom_slot" }, rig.Events);
+        Assert.Contains("e_backroom_slot", ConditioningControlPanel.Models.FeatureDayEntry.EventKeys);
+    }
+
+    [Fact]
+    public void Media_DealsFallbackPresets_AndFxAcksUnknown_OnTheNullObjects()
+    {
+        var rig = new Rig();
+        rig.Send("{\"type\":\"media-request\",\"reqId\":\"" + Req + "\",\"station\":\"slot\"}");
+        var media = Assert.Single(rig.Of("media"));
+        Assert.Equal(42, (int)media["seed"]!);
+        Assert.Equal(4, ((JArray)media["gifs"]!).Count);
+        Assert.Equal(new[] { "Drop", "Relax", "Let Go", "Sink" }, ((JArray)media["words"]!).Select(w => (string)w["text"]!));
+        Assert.All((JArray)media["gifs"]!, g => Assert.StartsWith("https://ccp.game/", (string)g["url"]!));
+
+        rig.Send("{\"type\":\"fx\",\"token\":\"k1\",\"fxId\":\"fx.gif_storm\",\"station\":\"slot\",\"symbols\":[\"gif1\"]}");
+        var ack = Assert.Single(rig.Of("fx-ack"));
+        Assert.Equal("k1", (string?)ack["token"]);
+        Assert.Empty((JArray)ack["fired"]!);
+        var skip = Assert.Single((JArray)ack["skipped"]!);
+        Assert.Equal(("fx.gif_storm", "unknown"), ((string)skip["prim"]!, (string)skip["why"]!));
+    }
+
+    [Fact]
+    public void Suspend_IsForwardedWithItsReason()
+    {
+        var rig = new Rig();
+        rig.Bridge.Suspend(true, "minimise");
+        var s = Assert.Single(rig.Of("suspend"));
+        Assert.Equal((true, "minimise"), ((bool)s["on"]!, (string?)s["reason"]));
+    }
+}

--- a/Tests/ConditioningControlPanel.Tests/FeatureDayLogTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/FeatureDayLogTests.cs
@@ -62,7 +62,7 @@ public class FeatureDayLogTests
     [Fact]
     public void AllEventKeys_HaveWireNamesAndNoOverlapWithCounters()
     {
-        Assert.Equal(16, FeatureDayEntry.EventKeys.Length);
+        Assert.Equal(21, FeatureDayEntry.EventKeys.Length);
         Assert.All(FeatureDayEntry.EventKeys, k => Assert.StartsWith("e_", k));
         Assert.Empty(FeatureDayEntry.EventKeys.Intersect(FeatureDayEntry.CounterKeys));
         Assert.Equal(FeatureDayEntry.EventKeys.Length, FeatureDayEntry.EventKeys.Distinct().Count());


### PR DESCRIPTION
Lane C1, part c of 6. CONTRACT sections 1 and 2.

- `Services/BackRoom/BackRoomHostService.cs` on `ChaosWebViewHost`: windowed, `OwnedByMainWindow`, centred on main, free for everyone. Origins: `ccp.game` -> `Resources\web` (Deny), `ccp.assets` -> the user's assets (Allow). Constant browser args.
- `init` = sp, reduced, motion, effective intensity (calm whenever MotionLevel is not Full; reads `AppSettings.BackRoomFxIntensity` by name so it builds before C3 adds it), lang, lex, relayed stations, `open: null`.
- Pushes `settings` on MotionLevel / intensity changes and `balance` on outside SkillPoints changes (follows `CurrentReplaced`).
- `suspend` on minimise and on panic press 1; panic press 2 inside 2 s closes; a panic suspend lifts when the window is activated again after that window. The global panic stop pass closes the room; app exit flushes the cursor and disposes synchronously.
- Day log: `e_backroom_slot|wheel|scratcher|cards|counter` join `FeatureDayEntry.EventKeys`.
- `Tests/BackRoomBridgeLifecycleTests.cs`: close timing (800 ms force, exit-done), cursor flush, silent SP adoption, day-log hook, null fx/media acks.

Test log: `C:/wt-br2/_evidence/C1/host-tests.log` (118 passed), full suite `C:/wt-br2/_evidence/C1/full-suite.log` (6188 passed, at the top of the stack).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V3c2CJTNfpbeBYqwjT6ZAj
