### PR TITLE
Back Room C1d: room page bridge, station registry and the walk

### DIFF
--- a/ConditioningControlPanel/Resources/web/backroom/bridge.js
+++ b/ConditioningControlPanel/Resources/web/backroom/bridge.js
@@ -1,0 +1,121 @@
+/* ============================================================================
+ * backroom/bridge.js - the postMessage contract with BackRoomHostService.
+ * Protocol 1, CONTRACT section 2. The arcademy/bridge.js pattern:
+ *   - the host queues its frames until we post `ready`;
+ *   - host frames that land before anyone subscribed are pre-buffered;
+ *   - page frames wait for `init`, except `ready`, `log` and `exit`.
+ *
+ * One difference, from the contract: request() never rejects AND never
+ * resolves null. A missing reply resolves as {ok:false, reason:'timeout'} so a
+ * station can read `res.ok` / `res.reason` on every path.
+ * ==========================================================================*/
+
+export const PROTOCOL = 1;
+
+const win = (typeof window !== 'undefined') ? window : null;
+const webview = win && win.chrome && win.chrome.webview;
+
+export const isHosted = !!webview;
+
+const handlers = new Map();   // type -> Set(fn)
+const preBuffer = [];
+const outQueue = [];
+const BOOT_LANE = new Set(['ready', 'log', 'exit']);
+const MAX_BUFFER = 200;
+let initialized = false;
+
+function dispatch(m) {
+  if (!m || typeof m.type !== 'string') return;
+  const set = handlers.get(m.type);
+  if (!set || !set.size) {
+    if (preBuffer.length < MAX_BUFFER) preBuffer.push(m);
+    return;
+  }
+  for (const fn of Array.from(set)) {
+    try { fn(m); } catch (e) { log('error', 'handler ' + m.type + ' threw: ' + ((e && e.message) || e)); }
+  }
+}
+
+if (webview) {
+  webview.addEventListener('message', (e) => { try { dispatch(e.data); } catch (err) { /* keep listening */ } });
+}
+
+/** Subscribe to a host frame type; replays pre-buffered frames of that type. */
+export function on(type, fn) {
+  if (typeof fn !== 'function') return () => {};
+  let set = handlers.get(type);
+  if (!set) { set = new Set(); handlers.set(type, set); }
+  set.add(fn);
+  for (let i = 0; i < preBuffer.length; i++) {
+    if (preBuffer[i].type !== type) continue;
+    const m = preBuffer.splice(i, 1)[0];
+    i--;
+    try { fn(m); } catch (e) { log('error', 'replay ' + type + ' threw: ' + ((e && e.message) || e)); }
+  }
+  return () => off(type, fn);
+}
+
+export function off(type, fn) {
+  const set = handlers.get(type);
+  if (set) set.delete(fn);
+}
+
+export function once(type, fn) {
+  const stop = on(type, (m) => { stop(); fn(m); });
+  return stop;
+}
+
+function post(msg) {
+  try { if (webview) webview.postMessage(msg); } catch (e) { /* host gone */ }
+}
+
+/** Post a frame. Held until init unless it is on the boot lane. */
+export function send(msg) {
+  if (!msg || typeof msg.type !== 'string') return;
+  if (initialized || BOOT_LANE.has(msg.type)) { post(msg); return; }
+  if (outQueue.length < MAX_BUFFER) outQueue.push(msg);
+}
+
+/** Called once `init` is handled: flush held frames in arrival order. */
+export function markInitialized() {
+  if (initialized) return;
+  initialized = true;
+  while (outQueue.length) post(outQueue.shift());
+}
+
+export function isInitialized() { return initialized; }
+
+/** Serilog passthrough; 'debug' unless the caller says otherwise. */
+export function log(level, msg) {
+  if (msg === undefined) { msg = level; level = 'debug'; }
+  send({ type: 'log', level: String(level), msg: String(msg).slice(0, 400) });
+}
+
+export function announceReady() { send({ type: 'ready', protocol: PROTOCOL }); }
+
+/** 32 hex chars from the platform rng (reqIds, idem keys, fx tokens). */
+export function mintId() {
+  const b = new Uint8Array(16);
+  try { crypto.getRandomValues(b); } catch (e) { for (let i = 0; i < 16; i++) b[i] = Math.floor(Math.random() * 256); }
+  return Array.from(b, (x) => x.toString(16).padStart(2, '0')).join('');
+}
+
+/**
+ * Correlated request. Resolves with the first `replyType` frame `match` accepts,
+ * or with `fallback` (default {ok:false, reason:'timeout'}) after `timeoutMs`.
+ * NEVER rejects.
+ */
+export function request(msg, replyType, match, timeoutMs, fallback) {
+  return new Promise((resolve) => {
+    let done = false;
+    const finish = (v) => { if (!done) { done = true; stop(); clearTimeout(timer); resolve(v); } };
+    const stop = on(replyType, (m) => {
+      try { if (!match || match(m)) finish(m); } catch (e) { finish(fallback || { ok: false, reason: 'timeout' }); }
+    });
+    const timer = setTimeout(() => finish(fallback || { ok: false, reason: 'timeout' }), timeoutMs || 6000);
+    send(msg);
+  });
+}
+
+export const bridge = { send, on, off, once, log, request, mintId, get initialized() { return initialized; } };
+export default bridge;

--- a/ConditioningControlPanel/Resources/web/backroom/room/geometry.js
+++ b/ConditioningControlPanel/Resources/web/backroom/room/geometry.js
@@ -1,0 +1,106 @@
+/* ============================================================================
+ * backroom/room/geometry.js - where things are in the room, and nothing else.
+ *
+ * Every coordinate is a pixel of room/backroom_final.png (1376 x 768). The room
+ * scales the picture to the window with an SVG viewBox, so these numbers never
+ * change with the window size. Station rects live in stations.json (CONTRACT
+ * section 7); the floor and the door live here because they belong to the art,
+ * not to any station.
+ *
+ * PURE: no DOM, importable from node for the smoke checks.
+ * ==========================================================================*/
+
+export const ROOM_W = 1376;
+export const ROOM_H = 768;
+
+/** The walkable floor: the plum carpet inside the four walls. Convex, so a
+ * straight walk between two floor points never leaves it. */
+export const FLOOR = Object.freeze([[272, 200], [1106, 200], [1258, 664], [142, 664]]);
+
+/** Where the player comes in (just inside the door, bottom middle). */
+export const DOOR = Object.freeze([688, 640]);
+
+/** Sprite scale against the art: a stool is about 40 px tall, so is the player. */
+export const SPRITE_SCALE = 3.2;
+
+/** Is [x, y] inside a convex polygon (clockwise or counter-clockwise)? */
+export function inPolygon(pt, poly) {
+  if (!pt || !poly || poly.length < 3) return false;
+  const [x, y] = pt;
+  let sign = 0;
+  for (let i = 0; i < poly.length; i++) {
+    const [ax, ay] = poly[i];
+    const [bx, by] = poly[(i + 1) % poly.length];
+    const cross = (bx - ax) * (y - ay) - (by - ay) * (x - ax);
+    if (cross === 0) continue;
+    const s = cross > 0 ? 1 : -1;
+    if (sign === 0) sign = s;
+    else if (s !== sign) return false;
+  }
+  return true;
+}
+
+export const onFloor = (pt) => inPolygon(pt, FLOOR);
+
+/** Is [x, y] inside a [x, y, w, h] rect? */
+export function inRect(pt, r) {
+  return !!(pt && r && r.length >= 4
+    && pt[0] >= r[0] && pt[0] <= r[0] + r[2] && pt[1] >= r[1] && pt[1] <= r[1] + r[3]);
+}
+
+/**
+ * Validate stations.json into the rows the room can use. A row with no id is
+ * dropped; a row whose hotspot or stand is missing or off the floor keeps its
+ * place in the registry but is marked `placed:false` so the room draws no
+ * hotspot for it rather than one the player cannot walk to. `live` rows with no
+ * `entry` are treated as `soon` (nothing to load).
+ */
+export function normaliseStations(rows) {
+  const out = [];
+  if (!Array.isArray(rows)) return out;
+  for (const r of rows) {
+    if (!r || typeof r.id !== 'string' || !/^[a-z0-9_]{1,24}$/.test(r.id)) continue;
+    const hotspot = Array.isArray(r.hotspot) && r.hotspot.length === 4 && r.hotspot.every(Number.isFinite)
+      ? r.hotspot.slice() : null;
+    const stand = Array.isArray(r.stand) && r.stand.length === 2 && r.stand.every(Number.isFinite)
+      ? r.stand.slice() : null;
+    const live = r.state === 'live' && typeof r.entry === 'string' && /^stations\/[a-z0-9_/-]+\.js$/.test(r.entry);
+    out.push({
+      id: r.id,
+      spot: String(r.spot || ''),
+      state: live ? 'live' : 'soon',
+      entry: live ? r.entry : null,
+      hotspot,
+      stand,
+      labelKey: typeof r.labelKey === 'string' ? r.labelKey : 'br_station_' + r.id,
+      placed: !!(hotspot && stand && onFloor(stand)),
+    });
+  }
+  return out;
+}
+
+/** The station whose hotspot holds [x, y], or null. Later rows win a tie. */
+export function stationAt(pt, stations) {
+  let hit = null;
+  for (const s of stations || []) if (s.placed && inRect(pt, s.hotspot)) hit = s;
+  return hit;
+}
+
+/**
+ * What a click at [x, y] means: walk to a station, walk to a floor point, or
+ * nothing. Pure, so the smoke check can ask it without a mouse.
+ */
+export function resolveClick(pt, stations) {
+  const s = stationAt(pt, stations);
+  if (s) return { kind: 'station', station: s, to: s.stand };
+  if (onFloor(pt)) return { kind: 'floor', to: [pt[0], pt[1]] };
+  return { kind: 'none' };
+}
+
+/** Client pixels to art pixels for an SVG drawn with preserveAspectRatio meet. */
+export function toArt(clientX, clientY, box) {
+  const scale = Math.min(box.width / ROOM_W, box.height / ROOM_H);
+  const ox = box.left + (box.width - ROOM_W * scale) / 2;
+  const oy = box.top + (box.height - ROOM_H * scale) / 2;
+  return [(clientX - ox) / scale, (clientY - oy) / scale];
+}

--- a/ConditioningControlPanel/Resources/web/backroom/room/room.css
+++ b/ConditioningControlPanel/Resources/web/backroom/room/room.css
@@ -1,0 +1,85 @@
+/* backroom/room/room.css - the room shell. Plum and neon, lifted from the art. */
+
+:root {
+  --br-ground: #120c1c;
+  --br-plum: #2a1838;
+  --br-ink: #f4e8ff;
+  --br-ink-dim: #bfa6d6;
+  --br-pink: #ff6fb5;
+  --br-gold: #ffcf6b;
+  --br-lav: #b99cff;
+  color-scheme: dark;
+}
+
+html, body { margin: 0; height: 100%; background: var(--br-ground); color: var(--br-ink); overflow: hidden;
+  font: 14px/1.35 "Segoe UI", system-ui, sans-serif; user-select: none; }
+
+.br-stage { position: fixed; inset: 0; display: grid; place-items: center; }
+.br-scene { width: 100%; height: 100%; display: block; cursor: pointer; }
+.br-art { image-rendering: auto; }
+
+/* Hotspots: invisible until hovered. THE GLOW (in fast, out slow). */
+.br-spot { fill: rgba(255, 111, 181, 0); stroke: rgba(255, 207, 107, 0); stroke-width: 3;
+  transition: fill 480ms ease-out, stroke 480ms ease-out; }
+.br-spot:hover { fill: rgba(255, 111, 181, .10); stroke: rgba(255, 207, 107, .55); transition-duration: 90ms; }
+.br-spot.is-soon:hover { fill: rgba(185, 156, 255, .08); stroke: rgba(185, 156, 255, .45); }
+
+.br-target { fill: none; stroke: var(--br-gold); stroke-width: 2.5; opacity: 0; transform-box: fill-box;
+  transform-origin: center; }
+.br-target.is-on { opacity: .9; animation: br-ring 340ms cubic-bezier(.2, 1.5, .4, 1); }
+@keyframes br-ring { from { transform: scale(2.1); opacity: 0; } to { transform: scale(1); opacity: .9; } }
+
+/* The player: the campus student, in the room's light. */
+.br-you { pointer-events: none; }
+.br-youring { fill: rgba(255, 207, 107, .22); stroke: rgba(255, 207, 107, .8); stroke-width: 2; }
+.br-you .gh-sprite rect { shape-rendering: crispEdges; }
+.br-you .gh-skin { fill: #f1d7c9; }
+.br-you .gh-k1 { fill: #e2b9a4; }
+.br-you .gh-k2 { fill: #c48f78; }
+.br-you .gh-k3 { fill: #8f5f4c; }
+.br-you .gh-eye { fill: var(--br-ground); }
+.br-you .gh-leg { fill: #3b2c63; }
+.br-you .gh-bag { fill: #b58b3c; }
+.br-you .gh-hair { fill: var(--br-gold); }
+.br-you .gh-shirt { fill: #ff9fb0; }
+
+/* HUD: Back is always on top of everything, stations included (Law VI). */
+.br-hud { position: fixed; top: 12px; left: 12px; right: 12px; display: flex; justify-content: space-between;
+  align-items: center; z-index: 30; pointer-events: none; }
+.br-back, .br-card-back { pointer-events: auto; font: 600 14px/1 "Segoe UI", system-ui, sans-serif; color: var(--br-ink);
+  background: rgba(42, 24, 56, .88); border: 1px solid rgba(255, 111, 181, .55); border-radius: 999px;
+  padding: 9px 18px; cursor: pointer; transition: transform 120ms cubic-bezier(.2, 1.5, .4, 1); }
+.br-back:hover, .br-card-back:hover { border-color: var(--br-gold); }
+.br-back:active, .br-card-back:active { transform: scale(.96); }
+.br-back:focus-visible, .br-card-back:focus-visible { outline: 2px solid var(--br-gold); outline-offset: 2px; }
+.br-sp { pointer-events: auto; background: rgba(18, 12, 28, .8); border: 1px solid rgba(255, 207, 107, .4);
+  border-radius: 999px; padding: 7px 14px; color: var(--br-ink-dim); }
+.br-sp b { color: var(--br-gold); font-variant-numeric: tabular-nums; margin-left: 4px; }
+html.br-leaving .br-sp { opacity: .5; }
+
+/* The station layer: stations and cards sit over the room, under the HUD. */
+.br-layer { position: fixed; inset: 0; z-index: 20; pointer-events: none; }
+.br-layer > * { pointer-events: auto; }
+.br-station { position: absolute; inset: 0; background: var(--br-ground); }
+
+.br-card-veil { position: absolute; inset: 0; display: grid; place-items: center; background: rgba(12, 8, 20, .55);
+  animation: br-fade 220ms ease-out; }
+.br-card { position: relative; width: min(420px, calc(100vw - 48px)); padding: 26px 26px 22px; border-radius: 16px;
+  background: linear-gradient(160deg, #3a2550, #22152f); border: 1px solid rgba(185, 156, 255, .35);
+  box-shadow: 0 18px 50px rgba(0, 0, 0, .5); text-align: center; overflow: hidden;
+  animation: br-rise 340ms cubic-bezier(.2, 1.5, .4, 1); }
+/* The dust sheet: a pale cloth draped over the top of the card, folds by gradient only. */
+.br-card-sheet { position: absolute; left: -10%; right: -10%; top: -30px; height: 74px; border-radius: 0 0 50% 50% / 0 0 26px 26px;
+  background: repeating-linear-gradient(100deg, rgba(236, 226, 244, .20) 0 28px, rgba(236, 226, 244, .10) 28px 52px); }
+.br-card-veil.is-failed .br-card-sheet { display: none; }
+.br-card-title { position: relative; margin: 30px 0 8px; font-size: 20px; color: var(--br-ink); }
+.br-card-body { position: relative; margin: 0 0 18px; color: var(--br-ink-dim); }
+
+@keyframes br-fade { from { opacity: 0; } }
+@keyframes br-rise { from { transform: translateY(14px) scale(.96); opacity: 0; } }
+
+html.br-reduced .br-target.is-on, html.br-reduced .br-card, html.br-reduced .br-card-veil { animation: none; }
+html.br-reduced .br-spot, html.br-reduced .br-back { transition: none; }
+@media (prefers-reduced-motion: reduce) {
+  .br-target.is-on, .br-card, .br-card-veil { animation: none; }
+}

--- a/ConditioningControlPanel/Resources/web/backroom/room/scene.js
+++ b/ConditioningControlPanel/Resources/web/backroom/room/scene.js
@@ -1,0 +1,162 @@
+/* ============================================================================
+ * backroom/room/scene.js - the room you look down on, and the player in it.
+ *
+ * One SVG, viewBox = the art's own pixels, preserveAspectRatio meet: the
+ * picture scales to the window and every coordinate in geometry.js and
+ * stations.json stays true at any size.
+ *
+ * THE WALK borrows the Arcademy's pure helpers (shell/walk.js: pathLength,
+ * walkDurationMs, walkAt) and its student sprite (shell/ghosts.js), so the
+ * player crosses this room at the campus's pace in the campus's body. What is
+ * NOT borrowed is the campus walker itself: it paths along campus corridors and
+ * pays every onDone, while here a second click must CANCEL the first walk (you
+ * changed your mind about the slot) rather than open the station anyway.
+ *
+ * Reduced motion takes the state, not a faster version of the travel (Law VI):
+ * the player stands at the destination on the same frame.
+ * ==========================================================================*/
+
+import { pathLength, walkDurationMs, walkAt } from '../../arcademy/shell/walk.js';
+import { buildStudentSprite } from '../../arcademy/shell/ghosts.js';
+import { ROOM_W, ROOM_H, DOOR, SPRITE_SCALE, resolveClick, toArt } from './geometry.js';
+
+const SVGNS = 'http://www.w3.org/2000/svg';
+
+function node(tag, attrs, cls) {
+  const n = document.createElementNS(SVGNS, tag);
+  if (cls) n.setAttribute('class', cls);
+  for (const k of Object.keys(attrs || {})) n.setAttribute(k, String(attrs[k]));
+  return n;
+}
+
+/**
+ * @param {Object} o
+ * @param {Element} o.mount
+ * @param {Array} o.stations   normaliseStations() rows
+ * @param {Function} o.label   (station) => display name (lexicon)
+ * @param {boolean} o.reduced
+ * @param {Function} o.onArrive (station) => void, when a walk to a hotspot lands
+ * @param {Function=} o.log
+ */
+export function createScene(o) {
+  const say = typeof o.log === 'function' ? o.log : () => {};
+  let reduced = !!o.reduced;
+  let pos = DOOR.slice();
+  let facing = 1;
+  let run = null;
+  let paused = false;
+
+  const svg = node('svg', { viewBox: `0 0 ${ROOM_W} ${ROOM_H}`, preserveAspectRatio: 'xMidYMid meet', role: 'img' }, 'br-scene');
+  svg.appendChild(node('image', { href: 'room/backroom_final.png', x: 0, y: 0, width: ROOM_W, height: ROOM_H }, 'br-art'));
+
+  const spots = node('g', {}, 'br-spots');
+  for (const s of o.stations) {
+    if (!s.placed) continue;
+    const [x, y, w, h] = s.hotspot;
+    const r = node('rect', { x, y, width: w, height: h, rx: 18 }, 'br-spot is-' + s.state);
+    r.dataset.station = s.id;
+    const title = node('title');
+    title.textContent = o.label(s);
+    r.appendChild(title);
+    spots.appendChild(r);
+  }
+  svg.appendChild(spots);
+
+  const target = node('ellipse', { cx: 0, cy: 0, rx: 16, ry: 6 }, 'br-target');
+  svg.appendChild(target);
+
+  const you = node('g', {}, 'br-you gh-you');
+  you.appendChild(node('ellipse', { cx: 0, cy: 1, rx: 22, ry: 8 }, 'br-youring'));
+  const body = node('g', {}, 'br-youbody');
+  try {
+    const sprite = buildStudentSprite('self|backroom');
+    if (sprite) body.appendChild(sprite);
+  } catch (e) { say('sprite failed: ' + ((e && e.message) || e)); }
+  you.appendChild(body);
+  svg.appendChild(you);
+  o.mount.appendChild(svg);
+
+  function draw(t) {
+    you.setAttribute('transform', `translate(${Math.round(pos[0] * 10) / 10},${Math.round(pos[1] * 10) / 10})`);
+    const bob = (t != null && !reduced) ? -Math.abs(Math.sin((t / 220) * Math.PI)) * 2 : 0;
+    body.setAttribute('transform', `translate(0,${bob.toFixed(2)}) scale(${facing * SPRITE_SCALE},${SPRITE_SCALE})`);
+  }
+
+  function land(r, arrived) {
+    run = null;
+    pos = r.legs[r.legs.length - 1].slice();
+    draw(null);
+    target.classList.remove('is-on');
+    svg.classList.remove('is-walking');
+    if (arrived && r.station) {
+      try { o.onArrive(r.station); } catch (e) { say('onArrive threw: ' + ((e && e.message) || e)); }
+    }
+  }
+
+  function frame() {
+    const r = run;
+    if (!r) return;
+    if (paused) { r.t0 = performance.now() - r.at; r.raf = requestAnimationFrame(frame); return; }
+    r.at = performance.now() - r.t0;
+    if (r.at >= r.total) { land(r, true); return; }
+    const p = walkAt(r.legs, r.at, r.total);
+    pos = [p.x, p.y];
+    if (p.facing) facing = p.facing;
+    draw(r.at);
+    r.raf = requestAnimationFrame(frame);
+  }
+
+  /** Walk to [x, y]; `station` (optional) opens on arrival. A new walk cancels the old one. */
+  function walkTo(to, station) {
+    if (run) { cancelAnimationFrame(run.raf); run = null; }
+    const legs = [pos.slice(), to.slice()];
+    const dx = to[0] - pos[0];
+    if (Math.abs(dx) >= 0.5) facing = dx > 0 ? 1 : -1;
+    target.setAttribute('cx', to[0]);
+    target.setAttribute('cy', to[1]);
+    target.classList.add('is-on');
+    const r = { legs, station: station || null, total: walkDurationMs(pathLength(legs)), t0: performance.now(), at: 0, raf: 0 };
+    if (reduced || pathLength(legs) < 2) {
+      // THE STATE, NOT THE TRAVEL. Arrival still waits one turn, so a caller is
+      // never re-entered from inside its own click.
+      run = r;
+      pos = to.slice();
+      draw(null);
+      setTimeout(() => { if (run === r) land(r, true); }, 0);
+      return r.total;
+    }
+    run = r;
+    svg.classList.add('is-walking');
+    r.raf = requestAnimationFrame(frame);
+    return r.total;
+  }
+
+  function onClick(e) {
+    if (e.button !== 0) return;
+    const pt = toArt(e.clientX, e.clientY, svg.getBoundingClientRect());
+    const hit = resolveClick(pt, o.stations);
+    if (hit.kind === 'none') return;
+    // LAW VIII: the ring lands under the cursor on this frame, before any walk.
+    walkTo(hit.to, hit.kind === 'station' ? hit.station : null);
+  }
+  svg.addEventListener('pointerdown', onClick);
+  draw(null);
+
+  return {
+    walkTo,
+    /** Click at art coordinates, for the smoke check and keyboard use. */
+    clickArt(pt) { const hit = resolveClick(pt, o.stations); if (hit.kind !== 'none') walkTo(hit.to, hit.kind === 'station' ? hit.station : null); return hit.kind; },
+    at: () => pos.slice(),
+    walking: () => !!run,
+    setReduced(v) { reduced = !!v; if (reduced && run) { cancelAnimationFrame(run.raf); land(run, true); } },
+    pause(on) { paused = !!on; },
+    /** Stop any walk without arriving (a station opened some other way, or the room is leaving). */
+    halt() { if (run) { cancelAnimationFrame(run.raf); const r = run; r.station = null; land(r, false); } },
+    destroy() {
+      if (run) cancelAnimationFrame(run.raf);
+      run = null;
+      svg.removeEventListener('pointerdown', onClick);
+      svg.remove();
+    },
+  };
+}

--- a/ConditioningControlPanel/Resources/web/backroom/stations.json
+++ b/ConditioningControlPanel/Resources/web/backroom/stations.json
@@ -1,0 +1,12 @@
+[
+  { "id": "slot", "spot": "bottom-left", "state": "live", "entry": "stations/slot/station.js",
+    "hotspot": [150, 380, 240, 270], "stand": [362, 566], "labelKey": "br_station_slot" },
+  { "id": "wheel", "spot": "top-left", "state": "soon",
+    "hotspot": [280, 100, 210, 255], "stand": [470, 372], "labelKey": "br_station_wheel" },
+  { "id": "scratcher", "spot": "bottom-right", "state": "soon",
+    "hotspot": [990, 355, 270, 285], "stand": [962, 600], "labelKey": "br_station_scratcher" },
+  { "id": "cards", "spot": "top-right", "state": "soon",
+    "hotspot": [890, 205, 240, 210], "stand": [902, 440], "labelKey": "br_station_cards" },
+  { "id": "counter", "spot": "top-middle", "state": "soon",
+    "hotspot": [530, 70, 320, 270], "stand": [690, 372], "labelKey": "br_station_counter" }
+]


### PR DESCRIPTION
Lane C1, part d of 6. CONTRACT sections 2 (page side) and 7.

- `backroom/bridge.js`: the arcademy bridge pattern, protocol 1. `request()` never rejects and resolves `{ok:false, reason:'timeout'}`.
- `backroom/stations.json`: slot live (`stations/slot/station.js`), wheel / scratcher / cards / counter soon. Hotspot and stand rects measured on `room/backroom_final.png` (1376x768).
- `backroom/room/geometry.js` (pure): floor polygon, door, click resolution, client-to-art mapping, stations.json validation (a live row with a foreign entry is demoted to soon).
- `backroom/room/scene.js`: the art in an SVG viewBox (scales to any window), hover-glow hotspots, click-to-walk with the Arcademy student sprite (`shell/ghosts.js`) and the pure walk helpers (`shell/walk.js`). A second click cancels the first walk; reduced motion lands the state on the same frame.
- `backroom/room/room.css`.

The page boots in part e (index.html + main.js).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V3c2CJTNfpbeBYqwjT6ZAj
