### PR TITLE
Back Room C1e: room boot, station loader and exits, with the smoke check

### DIFF
--- a/ConditioningControlPanel/ConditioningControlPanel.csproj
+++ b/ConditioningControlPanel/ConditioningControlPanel.csproj
@@ -558,14 +558,16 @@
       Resources\web\arcademy\vn\demo.html;
       Resources\web\arcademy\emi\demo.html;
       Resources\web\arcademy\shell\recordsroom.demo.html;
-      Resources\web\arcademy\games\**\smoke\**\*
+      Resources\web\arcademy\games\**\smoke\**\*;
+      Resources\web\backroom\smoke\**\*
     </ArcademyHarnessExclude>
     <ArcademyHarnessExcludeAbs>
       $(MSBuildProjectDirectory)\Resources\web\arcademy\annex\demo.html;
       $(MSBuildProjectDirectory)\Resources\web\arcademy\vn\demo.html;
       $(MSBuildProjectDirectory)\Resources\web\arcademy\emi\demo.html;
       $(MSBuildProjectDirectory)\Resources\web\arcademy\shell\recordsroom.demo.html;
-      $(MSBuildProjectDirectory)\Resources\web\arcademy\games\**\smoke\**\*
+      $(MSBuildProjectDirectory)\Resources\web\arcademy\games\**\smoke\**\*;
+      $(MSBuildProjectDirectory)\Resources\web\backroom\smoke\**\*
     </ArcademyHarnessExcludeAbs>
   </PropertyGroup>
 

--- a/ConditioningControlPanel/Resources/web/backroom/index.html
+++ b/ConditioningControlPanel/Resources/web/backroom/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>The Back Room</title>
+  <link rel="stylesheet" href="room/room.css">
+</head>
+<body>
+  <main id="br-stage" class="br-stage"></main>
+  <header class="br-hud">
+    <button id="br-back" type="button" class="br-back">Back</button>
+    <div class="br-sp" aria-live="polite"><span id="br-sp-label">SP</span> <b id="br-sp-value">0</b></div>
+  </header>
+  <div id="br-layer" class="br-layer"></div>
+  <script type="module" src="room/main.js"></script>
+</body>
+</html>

--- a/ConditioningControlPanel/Resources/web/backroom/room/loader.js
+++ b/ConditioningControlPanel/Resources/web/backroom/room/loader.js
@@ -1,0 +1,145 @@
+/* ============================================================================
+ * backroom/room/loader.js - how a station takes the screen and gives it back
+ * (CONTRACT section 7). The room calls mount(ctx) and the four methods it
+ * returns, and nothing else.
+ *
+ *   soon   -> a dust-sheet card. No code is loaded, no model is asked for.
+ *   live   -> import(entry), mount(ctx), open(). A module that fails to load or
+ *             to mount gets a plain card instead, and the room stays usable.
+ *
+ * LAW VI: Back is live before open() resolves and while close() runs. close()
+ * gets CLOSE_BUDGET_MS; a station that has not settled by then is destroyed
+ * anyway, because nobody waits on a station to leave a room.
+ * ==========================================================================*/
+
+import * as bridge from '../bridge.js';
+
+export const CLOSE_BUDGET_MS = 420;
+export const REQUEST_TIMEOUT_MS = 6000;
+
+const withTimeout = (p, ms) => Promise.race([Promise.resolve(p).catch(() => {}), new Promise((r) => setTimeout(r, ms))]);
+
+/**
+ * @param {Object} room  { layer, state, lex(key, fallback), onSp(fn), standUp(), log(level,msg) }
+ */
+export function createLoader(room) {
+  let current = null;   // { station, handle, root, kind }
+  let seq = 0;
+
+  function card(kind, station, title, body) {
+    const root = document.createElement('div');
+    root.className = 'br-card-veil';
+    root.innerHTML = '<section class="br-card" role="dialog" aria-modal="true">'
+      + '<div class="br-card-sheet" aria-hidden="true"></div>'
+      + '<h2 class="br-card-title"></h2><p class="br-card-body"></p>'
+      + '<button type="button" class="br-card-back"></button></section>';
+    root.classList.add('is-' + kind);
+    root.querySelector('.br-card-title').textContent = title;
+    root.querySelector('.br-card-body').textContent = body;
+    const back = root.querySelector('.br-card-back');
+    back.textContent = room.lex('br_back', 'Back');
+    back.addEventListener('click', () => room.standUp());
+    root.addEventListener('pointerdown', (e) => { if (e.target === root) room.standUp(); });
+    room.layer.appendChild(root);
+    requestAnimationFrame(() => { try { back.focus(); } catch (e) { /* noop */ } });
+    return root;
+  }
+
+  function buildCtx(station, root) {
+    const s = room.state;
+    return {
+      root,
+      bridge,
+      request(op, body, idem) {
+        const reqId = bridge.mintId();
+        return bridge.request(
+          { type: 'station-request', reqId, station: station.id, op: String(op), idem: idem || undefined, body: body || {} },
+          'station-result', (m) => m.reqId === reqId, REQUEST_TIMEOUT_MS,
+        ).then((res) => {
+          if (res && res.body && Number.isFinite(res.body.sp)) s.sp = res.body.sp;   // true value; displays may lie
+          return res;
+        });
+      },
+      fx(fxId, symbols) {
+        const token = bridge.mintId();
+        const msg = { type: 'fx', token, fxId: String(fxId), station: station.id };
+        if (Array.isArray(symbols)) msg.symbols = symbols.map(String);
+        return bridge.request(msg, 'fx-ack', (m) => m.token === token, REQUEST_TIMEOUT_MS,
+          { token, fired: [], skipped: [{ prim: String(fxId), why: 'unknown' }] });
+      },
+      media() {
+        const reqId = bridge.mintId();
+        return bridge.request({ type: 'media-request', reqId, station: station.id }, 'media',
+          (m) => m.reqId === reqId, REQUEST_TIMEOUT_MS, { reqId, seed: 0, gifs: [], words: [], timeout: true });
+      },
+      sp: () => s.sp,
+      onSp: (fn) => room.onSp(fn),
+      get reduced() { return s.reduced; },
+      get motion() { return s.motion; },
+      get intensity() { return s.intensity; },
+      lex: (key, fallback) => room.lex(key, fallback),
+      standUp: () => room.standUp(),
+    };
+  }
+
+  /** Take the screen for `station`. Resolves once it is interactive (or carded). */
+  async function open(station) {
+    if (current) await close();
+    const my = ++seq;
+    if (station.state !== 'live') {
+      const root = card('soon', station, room.lex(station.labelKey, station.id),
+        room.lex('br_soon_body', 'Under a dust sheet for now. This one opens soon.'));
+      current = { station, handle: null, root, kind: 'soon' };
+      return 'soon';
+    }
+
+    const root = document.createElement('div');
+    root.className = 'br-station';
+    root.dataset.station = station.id;
+    room.layer.appendChild(root);
+    current = { station, handle: null, root, kind: 'live' };
+    try {
+      const mod = await import('../' + station.entry);
+      if (my !== seq) return 'superseded';
+      if (typeof mod.mount !== 'function') throw new Error('no mount export');
+      const handle = await mod.mount(buildCtx(station, root));
+      if (my !== seq) { try { handle && handle.destroy && handle.destroy(); } catch (e) { /* noop */ } return 'superseded'; }
+      current.handle = handle;
+      bridge.send({ type: 'station-open', station: station.id });
+      await (handle && typeof handle.open === 'function' ? handle.open() : null);
+      return 'live';
+    } catch (e) {
+      if (my !== seq) return 'superseded';
+      room.log('warn', 'station ' + station.id + ' failed: ' + ((e && e.message) || e));
+      if (current && current.handle) {
+        try { current.handle.destroy(); } catch (err) { /* noop */ }
+        bridge.send({ type: 'station-close', station: station.id });
+      }
+      root.remove();
+      current = { station, handle: null, root: card('failed', station, room.lex(station.labelKey, station.id),
+        room.lex('br_station_failed', 'This station would not start. Try again in a moment.')), kind: 'failed' };
+      return 'failed';
+    }
+  }
+
+  /** Give the screen back. Settles within CLOSE_BUDGET_MS whatever the station does. */
+  async function close(budgetMs) {
+    const c = current;
+    if (!c) return;
+    current = null;
+    seq++;
+    if (c.handle) {
+      await withTimeout(typeof c.handle.close === 'function' ? c.handle.close() : null, budgetMs || CLOSE_BUDGET_MS);
+      try { if (typeof c.handle.destroy === 'function') c.handle.destroy(); } catch (e) { room.log('warn', 'destroy threw: ' + e); }
+      bridge.send({ type: 'station-close', station: c.station.id });
+    }
+    try { c.root.remove(); } catch (e) { /* noop */ }
+  }
+
+  function suspend(on) {
+    const h = current && current.handle;
+    try { if (h && typeof h.suspend === 'function') h.suspend(!!on); } catch (e) { room.log('warn', 'suspend threw: ' + e); }
+  }
+
+  return { open, close, suspend, get current() { return current ? { id: current.station.id, kind: current.kind } : null; } };
+}

--- a/ConditioningControlPanel/Resources/web/backroom/room/main.js
+++ b/ConditioningControlPanel/Resources/web/backroom/room/main.js
@@ -1,0 +1,155 @@
+/* ============================================================================
+ * backroom/room/main.js - boot, the Back button, and the three ways out.
+ *
+ * Boot: subscribe, post `ready`, wait for `init`, read stations.json, draw the
+ * room. The Back button and Escape are wired BEFORE any of that, so the room
+ * can be left at every frame, including a boot that never finishes (Law VI).
+ *
+ * Leaving:
+ *   Back / Escape with a station open  -> the station closes, the room stays.
+ *   Back / Escape in the room          -> `exit`, then `exit-done` once settled.
+ *   host `close` (app exit, panic)     -> settle inside 300 ms, `exit-done`.
+ * ==========================================================================*/
+
+import * as bridge from '../bridge.js';
+import { normaliseStations } from './geometry.js';
+import { createScene } from './scene.js';
+import { createLoader } from './loader.js';
+
+const PAGE_SETTLE_MS = 300;
+
+const state = { sp: 0, reduced: false, motion: 'full', intensity: 'normal', lex: {}, open: null, suspended: false };
+const spListeners = new Set();
+let scene = null;
+let loader = null;
+let leaving = false;
+
+const $ = (sel) => document.querySelector(sel);
+
+function lex(key, fallback) {
+  const v = state.lex && state.lex[key];
+  return (typeof v === 'string' && v && v !== key) ? v : (fallback == null ? key : fallback);
+}
+
+function paintChrome() {
+  const back = $('#br-back');
+  back.textContent = lex('br_back', 'Back');
+  back.setAttribute('aria-label', lex('br_back', 'Back'));
+  $('#br-sp-label').textContent = lex('br_balance', 'SP');
+  $('#br-sp-value').textContent = String(state.sp);
+  document.title = lex('br_room_title', 'The Back Room');
+  document.documentElement.classList.toggle('br-reduced', !!state.reduced);
+  document.documentElement.classList.toggle('br-suspended', !!state.suspended);
+}
+
+function setSp(sp) {
+  if (!Number.isFinite(sp)) return;
+  state.sp = sp;
+  paintChrome();
+  for (const fn of Array.from(spListeners)) { try { fn(sp); } catch (e) { bridge.log('warn', 'onSp threw: ' + e); } }
+}
+
+/** Back, from anywhere. A station closes first; an empty room is left. */
+async function back(reason) {
+  if (leaving) return;
+  if (loader && loader.current) {
+    await loader.close();
+    return;
+  }
+  leave(reason || 'back');
+}
+
+async function leave(reason) {
+  if (leaving) return;
+  leaving = true;
+  document.documentElement.classList.add('br-leaving');
+  bridge.send({ type: 'exit', reason });
+  if (scene) scene.halt();
+  if (loader) await loader.close(PAGE_SETTLE_MS - 60);
+  bridge.send({ type: 'exit-done' });
+}
+
+function wireExits() {
+  $('#br-back').addEventListener('click', () => back('back'));
+  window.addEventListener('keydown', (e) => {
+    if (e.key !== 'Escape') return;
+    e.preventDefault();
+    back('key');
+  }, true);
+  bridge.on('close', async () => {
+    if (leaving) return;
+    leaving = true;
+    if (scene) scene.halt();
+    if (loader) await loader.close(PAGE_SETTLE_MS - 60);
+    bridge.send({ type: 'exit-done' });
+  });
+}
+
+async function readStations() {
+  try {
+    const res = await fetch('stations.json', { cache: 'no-store' });
+    return normaliseStations(await res.json());
+  } catch (e) {
+    bridge.log('error', 'stations.json unreadable: ' + ((e && e.message) || e));
+    return [];
+  }
+}
+
+async function start(init) {
+  Object.assign(state, {
+    sp: Number.isFinite(init.sp) ? init.sp : 0,
+    reduced: !!init.reduced,
+    motion: String(init.motion || 'full'),
+    intensity: String(init.intensity || 'normal'),
+    lex: (init.lex && typeof init.lex === 'object') ? init.lex : {},
+    open: typeof init.open === 'boolean' ? init.open : null,
+  });
+  bridge.markInitialized();
+  paintChrome();
+
+  bridge.on('balance', (m) => setSp(m.sp));
+  bridge.on('settings', (m) => {
+    state.motion = String(m.motion || state.motion);
+    state.intensity = String(m.intensity || state.intensity);
+    state.reduced = !!m.reduced;
+    if (scene) scene.setReduced(state.reduced);
+    paintChrome();
+  });
+  bridge.on('suspend', (m) => {
+    state.suspended = !!m.on;
+    if (scene) scene.pause(state.suspended);
+    if (loader) loader.suspend(state.suspended);
+    paintChrome();
+  });
+
+  const stations = await readStations();
+  if (leaving) return;
+  loader = createLoader({
+    layer: $('#br-layer'),
+    state,
+    lex,
+    onSp: (fn) => { spListeners.add(fn); return () => spListeners.delete(fn); },
+    standUp: () => back('back'),
+    log: (level, msg) => bridge.log(level, msg),
+  });
+  scene = createScene({
+    mount: $('#br-stage'),
+    stations,
+    label: (s) => lex(s.labelKey, s.id),
+    reduced: state.reduced,
+    onArrive: (s) => { if (!leaving) loader.open(s); },
+    log: (msg) => bridge.log('warn', msg),
+  });
+  document.documentElement.classList.add('br-ready');
+  bridge.log('info', 'room up: ' + stations.length + ' stations, ' + stations.filter((s) => s.state === 'live').length + ' live');
+
+  // Test seam for the smoke checks (never read by the room itself).
+  window.__backroom = { state, stations, scene, loader, back, lex };
+}
+
+wireExits();
+paintChrome();
+bridge.once('init', (m) => {
+  start(m).catch((e) => bridge.log('error', 'boot failed: ' + ((e && e.stack) || e)));
+});
+bridge.announceReady();

--- a/ConditioningControlPanel/Resources/web/backroom/smoke/mock-station.js
+++ b/ConditioningControlPanel/Resources/web/backroom/smoke/mock-station.js
@@ -1,0 +1,25 @@
+/* backroom/smoke/mock-station.js - a stand-in for stations/slot/station.js that
+ * the room smoke check serves at that path. No glb, no WebGL: it proves the room
+ * mounts a station through the section 7 shape and the ctx works. */
+
+export async function mount(ctx) {
+  const seen = { opened: false, closed: false, destroyed: false, suspended: null, state: null };
+  window.__mockStation = { seen, ctxKeys: Object.keys(ctx) };
+  let panel = null;
+  return {
+    async open() {
+      panel = document.createElement('div');
+      panel.className = 'mock-slot';
+      panel.style.cssText = 'position:absolute;inset:18% 28%;display:grid;place-items:center;border-radius:18px;'
+        + 'background:#2a1838;border:2px solid #ffcf6b;color:#f4e8ff;font:600 22px Segoe UI,sans-serif;text-align:center';
+      panel.textContent = ctx.lex('br_station_slot', 'Slot') + ' (mock) - SP ' + ctx.sp();
+      ctx.root.appendChild(panel);
+      seen.opened = true;
+      seen.state = await ctx.request('state', {});
+      panel.textContent += ' - state ' + (seen.state.ok ? 'ok' : seen.state.reason);
+    },
+    close() { seen.closed = true; return new Promise((r) => setTimeout(r, 30)); },
+    suspend(on) { seen.suspended = on; },
+    destroy() { seen.destroyed = true; if (panel) panel.remove(); },
+  };
+}

--- a/ConditioningControlPanel/Resources/web/backroom/smoke/room-check.mjs
+++ b/ConditioningControlPanel/Resources/web/backroom/smoke/room-check.mjs
@@ -1,0 +1,227 @@
+/* ============================================================================
+ * backroom/smoke/room-check.mjs - the room shell, pure first, then the real page
+ * in headless Chrome with a fake host on chrome.webview.
+ *
+ *   node backroom/smoke/room-check.mjs [evidenceDir]    (exit 0 = pass)
+ *
+ * Nothing leaves the machine: the page is served from Resources/web on
+ * 127.0.0.1, stations/slot/station.js is replaced by smoke/mock-station.js, and
+ * the fake host answers ready/station-request/media-request itself.
+ *
+ * Screenshots (into evidenceDir, default ./_evidence): the room at 1280x720 and
+ * 1920x1080, a walk to the slot hotspot mid-stride and on arrival with the mock
+ * station open, a soon station's dust-sheet card, and the reduced-motion walk.
+ * CHROME: CHROME_PATH, else the usual Windows install.
+ * ==========================================================================*/
+
+import { spawn } from 'node:child_process';
+import { createServer } from 'node:http';
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { readFileSync, mkdtempSync, rmSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, extname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { FLOOR, DOOR, ROOM_W, ROOM_H, onFloor, normaliseStations, resolveClick, toArt } from '../room/geometry.js';
+
+let fails = 0;
+const ok = (c, what) => { if (!c) { console.error('FAIL ' + what); fails++; } else console.log('  ok  ' + what); };
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const HERE = resolve(fileURLToPath(import.meta.url), '..');
+const BACKROOM = resolve(HERE, '..');
+const WEB = resolve(BACKROOM, '..');
+const OUT = resolve(process.argv[2] || join(process.cwd(), '_evidence'));
+await mkdir(OUT, { recursive: true });
+
+/* ---------------------------------------------------------------- 1. pure */
+const rows = JSON.parse(readFileSync(join(BACKROOM, 'stations.json'), 'utf8'));
+const stations = normaliseStations(rows);
+ok(stations.length === 5, 'stations.json has the five contract rows');
+ok(['slot', 'wheel', 'scratcher', 'cards', 'counter'].every((id) => stations.some((s) => s.id === id)), 'with the contract ids');
+ok(stations.find((s) => s.id === 'slot').state === 'live', 'slot is live');
+ok(stations.filter((s) => s.state === 'soon').length === 4, 'the other four are soon');
+ok(stations.every((s) => s.placed), 'every hotspot has a stand on the floor');
+ok(stations.every((s) => s.hotspot[0] >= 0 && s.hotspot[1] >= 0 && s.hotspot[0] + s.hotspot[2] <= ROOM_W && s.hotspot[1] + s.hotspot[3] <= ROOM_H), 'every hotspot is inside the art');
+ok(onFloor(DOOR), 'the door stands on the floor');
+ok(resolveClick([700, 460], stations).kind === 'floor', 'a click on the spiral carpet is a floor walk');
+ok(resolveClick([20, 20], stations).kind === 'none', 'a click on the dark outside the walls is nothing');
+ok(resolveClick([200, 500], stations).station?.id === 'slot', 'a click on the machines is the slot');
+ok(normaliseStations([{ id: 'x', state: 'live', entry: 'https://evil/x.js', hotspot: [0, 0, 1, 1], stand: [700, 400] }])[0].state === 'soon', 'a live row with a foreign entry is demoted to soon');
+{
+  const [x, y] = toArt(640, 360, { left: 0, top: 0, width: 1280, height: 720 });
+  ok(Math.abs(x - ROOM_W / 2) < 1 && Math.abs(y - ROOM_H / 2) < 1, 'client centre maps to art centre');
+}
+
+/* ---------------------------------------------------------------- 2. page */
+const CHROME = process.env.CHROME_PATH || 'C:/Program Files/Google/Chrome/Application/chrome.exe';
+if (!existsSync(CHROME)) { console.error('FAIL no chrome at ' + CHROME); process.exit(1); }
+const PORT = 8891, DEBUG_PORT = 9391;
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.mjs': 'text/javascript', '.css': 'text/css', '.json': 'application/json', '.png': 'image/png', '.webp': 'image/webp', '.svg': 'image/svg+xml' };
+const server = createServer(async (req, res) => {
+  let path = decodeURIComponent(new URL(req.url, 'http://x').pathname);
+  if (path.indexOf('..') >= 0) { res.writeHead(400); return res.end(); }
+  const file = path === '/backroom/stations/slot/station.js' ? join(HERE, 'mock-station.js') : join(WEB, path);
+  try {
+    const body = await readFile(file);
+    res.writeHead(200, { 'content-type': MIME[extname(file).toLowerCase()] || 'application/octet-stream' });
+    res.end(body);
+  } catch (e) { res.writeHead(404); res.end('no'); }
+});
+await new Promise((r) => server.listen(PORT, '127.0.0.1', r));
+
+/* The fake host, installed before any page script. It records every frame and
+ * answers the three requests the room and the mock make. */
+const FAKE_HOST = `(() => {
+  const q = new URLSearchParams(location.search);
+  const listeners = [];
+  const emit = (data) => setTimeout(() => listeners.forEach((fn) => fn({ data })), 0);
+  window.__hostEmit = emit;
+  window.__posted = [];
+  window.chrome = window.chrome || {};
+  window.chrome.webview = {
+    addEventListener(type, fn) { if (type === 'message') listeners.push(fn); },
+    postMessage(m) {
+      window.__posted.push(m);
+      if (m.type === 'ready') emit({ type: 'init', protocol: 1, sp: 57, reduced: q.get('reduced') === '1',
+        motion: q.get('reduced') === '1' ? 'reduced' : 'full', intensity: 'normal', lang: 'en',
+        lex: { br_back: 'Back', br_balance: 'SP', br_station_slot: 'The Slot', br_station_wheel: 'Daily Spin',
+          br_soon_body: 'Under a dust sheet for now. This one opens soon.' }, stations: ['slot'], open: null });
+      if (m.type === 'station-request') emit({ type: 'station-result', reqId: m.reqId, ok: true, status: 200, body: { ok: true, sp: 57 } });
+      if (m.type === 'media-request') emit({ type: 'media', reqId: m.reqId, seed: 1, gifs: [], words: [] });
+    },
+  };
+})();`;
+
+const prof = mkdtempSync(join(tmpdir(), 'backroom-room-'));
+const chrome = spawn(CHROME, ['--headless=new', `--remote-debugging-port=${DEBUG_PORT}`, `--user-data-dir=${prof}`,
+  '--no-first-run', '--no-default-browser-check', '--mute-audio', '--hide-scrollbars', '--window-size=1280,720', 'about:blank'], { stdio: 'ignore' });
+
+async function done(code) {
+  try { chrome.kill(); } catch (e) { /* noop */ }
+  server.close();
+  await sleep(300);
+  try { rmSync(prof, { recursive: true, force: true }); } catch (e) { /* noop */ }
+  process.exit(code);
+}
+
+let target = null;
+for (let i = 0; i < 60 && !target; i++) {
+  await sleep(250);
+  try { target = (await (await fetch(`http://127.0.0.1:${DEBUG_PORT}/json/list`)).json()).find((t) => t.type === 'page'); } catch (e) { /* not up */ }
+}
+if (!target) { console.error('FAIL chrome never answered'); await done(1); }
+const ws = new WebSocket(target.webSocketDebuggerUrl);
+await new Promise((r) => { ws.onopen = r; });
+let msgId = 0;
+const waits = new Map(), errs = [];
+ws.onmessage = (e) => {
+  const m = JSON.parse(e.data);
+  if (m.id && waits.has(m.id)) { waits.get(m.id)(m); waits.delete(m.id); }
+  if (m.method === 'Runtime.exceptionThrown') errs.push(m.params.exceptionDetails?.exception?.description || m.params.exceptionDetails?.text);
+  if (m.method === 'Runtime.consoleAPICalled' && m.params.type === 'error') errs.push('console: ' + m.params.args.map((a) => a.value || a.description).join(' '));
+  if (m.method === 'Network.loadingFailed' && !m.params.canceled) errs.push('load failed: ' + m.params.errorText);
+};
+const cdp = (method, params) => new Promise((res) => { const i = ++msgId; waits.set(i, res); ws.send(JSON.stringify({ id: i, method, params })); });
+const ev = async (x) => (await cdp('Runtime.evaluate', { expression: x, returnByValue: true, awaitPromise: true })).result?.result?.value;
+await cdp('Runtime.enable'); await cdp('Page.enable'); await cdp('Network.enable');
+await cdp('Page.addScriptToEvaluateOnNewDocument', { source: FAKE_HOST });
+
+async function shot(name) {
+  const r = await cdp('Page.captureScreenshot', { format: 'png' });
+  await writeFile(join(OUT, name), Buffer.from(r.result.data, 'base64'));
+  console.log('  shot ' + join(OUT, name));
+}
+async function boot(w, h, query) {
+  await cdp('Emulation.setDeviceMetricsOverride', { width: w, height: h, deviceScaleFactor: 1, mobile: false });
+  await cdp('Page.navigate', { url: `http://127.0.0.1:${PORT}/backroom/index.html${query || ''}` });
+  for (let i = 0; i < 80; i++) {
+    await sleep(100);
+    if (await ev(`document.documentElement.classList.contains('br-ready') && !!document.querySelector('.br-art') && document.querySelector('.br-art').getBBox().width > 0`)) break;
+  }
+  await sleep(400);   // let the png decode
+}
+/** Press at art coordinates through the real pointer path. */
+async function pressArt(x, y) {
+  const [cx, cy] = await ev(`(() => { const b = document.querySelector('.br-scene').getBoundingClientRect();
+    const s = Math.min(b.width / ${ROOM_W}, b.height / ${ROOM_H});
+    return [b.left + (b.width - ${ROOM_W} * s) / 2 + ${x} * s, b.top + (b.height - ${ROOM_H} * s) / 2 + ${y} * s]; })()`);
+  await cdp('Input.dispatchMouseEvent', { type: 'mousePressed', x: cx, y: cy, button: 'left', clickCount: 1 });
+  await cdp('Input.dispatchMouseEvent', { type: 'mouseReleased', x: cx, y: cy, button: 'left', clickCount: 1 });
+}
+const posted = (type) => ev(`window.__posted.filter((m) => m.type === ${JSON.stringify(type)})`);
+
+// 2a. the room at two sizes
+await boot(1280, 720);
+ok((await posted('ready')).length === 1, 'the page posts ready once');
+ok(await ev(`document.querySelectorAll('.br-spot').length`) === 5, 'five hotspots drawn');
+ok(await ev(`document.querySelector('#br-sp-value').textContent`) === '57', 'the SP chip shows init.sp');
+ok(await ev(`!!document.querySelector('.br-you .gh-sprite')`), 'the player wears the campus student sprite');
+await shot('room-1280x720.png');
+await boot(1920, 1080);
+await shot('room-1920x1080.png');
+
+// 2b. walk to the slot, arrive, mock station opens
+await boot(1280, 720);
+await pressArt(210, 520);
+await sleep(250);
+ok(await ev(`window.__backroom.scene.walking()`), 'a press on the slot starts a walk');
+await shot('walk-to-slot-mid.png');
+for (let i = 0; i < 40 && !(await ev(`!!(window.__mockStation && window.__mockStation.seen.state)`)); i++) await sleep(100);
+const at = await ev(`window.__backroom.scene.at()`);
+ok(Math.abs(at[0] - 362) < 1 && Math.abs(at[1] - 566) < 1, 'the player stands on the slot stand');
+ok((await posted('station-open')).some((m) => m.station === 'slot'), 'station-open slot was posted');
+ok(await ev(`window.__mockStation.seen.opened && window.__mockStation.seen.state.ok === true`), 'the mock opened and its ctx.request got a result');
+ok(await ev(`['root','bridge','request','fx','media','sp','onSp','reduced','motion','intensity','lex','standUp'].every((k) => window.__mockStation.ctxKeys.includes(k))`), 'ctx carries every section 7 field');
+await sleep(200);
+await shot('walk-to-slot-station-open.png');
+await ev(`document.querySelector('#br-back').click()`);
+await sleep(300);
+ok((await posted('station-close')).some((m) => m.station === 'slot'), 'Back closes the station (station-close posted)');
+ok(await ev(`window.__mockStation.seen.closed && window.__mockStation.seen.destroyed`), 'close() then destroy() were called');
+ok((await posted('exit')).length === 0, 'and the room itself stays open');
+
+// 2c. a soon station gets the dust-sheet card and never loads code
+await pressArt(385, 230);
+for (let i = 0; i < 40 && !(await ev(`!!document.querySelector('.br-card-veil.is-soon')`)); i++) await sleep(100);
+ok(await ev(`!!document.querySelector('.br-card-veil.is-soon')`), 'the wheel shows its dust-sheet card');
+ok((await posted('station-open')).every((m) => m.station !== 'wheel'), 'a soon station never posts station-open');
+await sleep(400);
+await shot('soon-station-card.png');
+await cdp('Input.dispatchKeyEvent', { type: 'keyDown', key: 'Escape', code: 'Escape', windowsVirtualKeyCode: 27 });
+await sleep(150);
+ok(!(await ev(`!!document.querySelector('.br-card-veil')`)), 'Escape closes the card');
+await cdp('Input.dispatchKeyEvent', { type: 'keyDown', key: 'Escape', code: 'Escape', windowsVirtualKeyCode: 27 });
+await sleep(200);
+ok((await posted('exit')).some((m) => m.reason === 'key'), 'Escape in the empty room posts exit (key)');
+ok((await posted('exit-done')).length === 1, 'and exit-done follows');
+
+// 2d. reduced motion: the state, not the travel
+await boot(1280, 720, '?reduced=1');
+await pressArt(880, 560);
+await sleep(60);
+const floorSnap = await ev(`window.__backroom.scene.at()`);
+ok(Math.abs(floorSnap[0] - 880) < 1 && Math.abs(floorSnap[1] - 560) < 1 && !(await ev(`window.__backroom.scene.walking()`)), 'reduced motion: a floor walk lands on the same frame');
+await shot('reduced-motion-snap.png');
+await pressArt(210, 520);
+await sleep(30);
+const snapped = await ev(`window.__backroom.scene.at()`);
+ok(Math.abs(snapped[0] - 362) < 1 && Math.abs(snapped[1] - 566) < 1, 'reduced motion: the player is on the stand at once');
+ok(await ev(`document.documentElement.classList.contains('br-reduced')`), 'reduced motion flag reaches the page');
+for (let i = 0; i < 20 && !(await ev(`!!(window.__mockStation && window.__mockStation.seen.state)`)); i++) await sleep(100);
+ok(await ev(`!!(window.__mockStation && window.__mockStation.seen.opened)`), 'and the station still opens');
+await sleep(200);
+await shot('reduced-motion-station-open.png');
+
+// 2e. host close with a station open: exit-done inside the 300 ms budget
+await boot(1280, 720);
+await pressArt(210, 520);
+for (let i = 0; i < 40 && !(await ev(`!!(window.__mockStation && window.__mockStation.seen.opened)`)); i++) await sleep(100);
+const settleMs = await ev(`new Promise((r) => { const t0 = performance.now();
+  window.__hostEmit({ type: 'close', reason: 'panic' });
+  const tick = () => window.__posted.some((m) => m.type === 'exit-done') ? r(performance.now() - t0) : setTimeout(tick, 5);
+  tick(); })`);
+ok(settleMs < 300, 'host close: exit-done after ' + Math.round(settleMs) + ' ms (budget 300)');
+ok((await posted('station-close')).some((m) => m.station === 'slot'), 'and the open station was closed on the way out');
+ok(errs.length === 0, 'no page errors' + (errs.length ? ': ' + errs.join(' | ') : ''));
+console.log(fails ? `\n${fails} FAILED` : '\nall room checks passed');
+await done(fails ? 1 : 0);


### PR DESCRIPTION
Lane C1, part e of 6. CONTRACT section 7 station loader, Law VI exits.

- `backroom/index.html`, `room/main.js`: boot (ready -> init -> stations.json), Back button and Escape wired first; Back closes an open station, then leaves the room (`exit`, `exit-done`); host `close` answered with `exit-done` inside 300 ms (measured 35-45 ms with a station open).
- `room/loader.js`: soon stations get a dust-sheet card and never load code; live stations are imported and `mount(ctx)` with root, bridge, request, fx, media, sp, onSp, reduced, motion, intensity, lex, standUp; a failing import gets a plain card; `close()` has 420 ms before `destroy()`.
- `smoke/room-check.mjs` + `smoke/mock-station.js`: pure checks, then the real page in headless Chrome against a fake host with the mock served at `stations/slot/station.js`. Excluded from publish like the Arcademy harnesses.

Run: `node ConditioningControlPanel/Resources/web/backroom/smoke/room-check.mjs <outDir>`

Evidence (`C:/wt-br2/_evidence/C1/`): `room-1280x720.png`, `room-1920x1080.png`, `walk-to-slot-mid.png`, `walk-to-slot-station-open.png`, `soon-station-card.png`, `reduced-motion-snap.png`, `reduced-motion-station-open.png`, `room-check.log` (all checks passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V3c2CJTNfpbeBYqwjT6ZAj
