### PR TITLE
feat(backroom): C2a slot tape client, mock server, tests

### DIFF
--- a/ConditioningControlPanel/Resources/web/backroom/stations/slot/mock-server.js
+++ b/ConditioningControlPanel/Resources/web/backroom/stations/slot/mock-server.js
@@ -1,0 +1,159 @@
+/* mock-server.js - a stand-in for /v2/backroom/slot/* (CONTRACT.md section 3) for dev.html and
+ * the node tests. NOT the paytable (that is CCP-Server, lane S1): it only reproduces the body shapes
+ * and the rules the page must cope with (tape_unplayed, idem receipts, too_fast, insufficient,
+ * closed, melt in draw order, inline free spins, one-column freeze mid-tape).
+ * handle() resolves like the host relay: {ok:true, status, body} or a host refusal {ok:false, reason}. */
+
+const STRIPS = [
+  ['gif0', 'spiral0', 'sub0', 'gif1', 'emi', 'spiral1', 'gif2', 'sub1', 'spiral2', 'gif3', 'sub2', 'sub3', 'melt'],
+  ['sub1', 'gif2', 'spiral1', 'melt', 'gif0', 'sub3', 'emi', 'spiral2', 'gif3', 'sub0', 'spiral0', 'gif1', 'sub2'],
+  ['spiral2', 'gif3', 'sub2', 'gif1', 'spiral0', 'emi', 'sub0', 'gif0', 'melt', 'sub3', 'gif2', 'spiral1', 'sub1'],
+];
+
+const LINES = [
+  { id: 'emi3', pays: 2500, odds: '1 in 25,000', fx: ['fx.jackpot'] },
+  { id: 'gif3same', pays: 40, odds: '1 in 150', fx: ['fx.gif_storm'] },
+  { id: 'sub3', pays: 15, odds: '1 in 120', fx: ['fx.sub_cascade'] },
+  { id: 'spiral3', pays: 10, odds: '1 in 120', fx: ['fx.spiral_full'], free: 3 },
+  { id: 'gif3', pays: 3, odds: '1 in 12', fx: ['fx.gif_burst'] },
+  { id: 'sub2', pays: 2, odds: '1 in 15', fx: ['fx.sub_pair'] },
+  { id: 'spiral2', pays: 1, odds: '1 in 15', fx: ['fx.spiral_brief'], respin: 1 },
+  { id: 'melt', pays: 0, odds: '1 in 20', fx: ['fx.melt'] },
+];
+
+const kindOf = s => (s.startsWith('gif') ? 'gif' : s.startsWith('sub') ? 'sub' : s.startsWith('spiral') ? 'spiral' : s);
+
+/** The single best line for three payline symbols (section 4). */
+export function lineFor(symbols) {
+  const k = symbols.map(kindOf), count = t => k.filter(x => x === t).length;
+  if (count('emi') === 3) return 'emi3';
+  if (count('gif') === 3) return symbols[0] === symbols[1] && symbols[1] === symbols[2] ? 'gif3same' : 'gif3';
+  if (count('sub') === 3) return 'sub3';
+  if (count('spiral') === 3) return 'spiral3';
+  if (count('sub') === 2) return 'sub2';
+  if (count('spiral') === 2) return 'spiral2';
+  return k.includes('melt') ? 'melt' : 'none';
+}
+
+function mulberry32(a) {
+  return () => {
+    a |= 0; a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+export function createMockServer({ sp = 57, melt = 0, seed = 9013, floorMs = 800, now = () => Date.now(),
+                                   open = true } = {}) {
+  const rnd = mulberry32(seed);
+  const user = { sp, melt, tape: null, shown: ['gif0', 'spiral1', 'sub2'], nextBuyAt: 0, lastBuyAt: -1e9 };
+  const receipts = new Map();
+  const faults = [];          // { op, reason, times, apply, body }
+  const script = [];          // forced symbol rows for the next draws, e.g. ['emi','emi','emi']
+  const log = [];
+
+  const table = () => ({ v: 3, stake: 1, freezeCost: 1, jackpot: 2500, rtp: 1.02, rtpFrozen: 1.02,
+                         lines: LINES.map(({ id, pays, odds }) => ({ id, pays, odds })) });
+
+  function drawRow(held) {
+    if (script.length) return script.shift().map((s, c) => (held && held.col === c ? held.sym : s));
+    return [0, 1, 2].map(c => (held && held.col === c ? held.sym : STRIPS[c][Math.floor(rnd() * 13)]));
+  }
+
+  /** One spin plus everything it expands into, consuming melt in draw order. */
+  function spin(kind, held, out) {
+    const queue = [kind];
+    while (queue.length && out.length < 60) {
+      const k = queue.shift();
+      const symbols = drawRow(k === 'freeze' || k === 'paid' ? held : null);
+      const line = lineFor(symbols), def = LINES.find(l => l.id === line);
+      let pay = def ? def.pays : 0, halved = false;
+      if (user.melt > 0) { user.melt--; if (pay) { pay = Math.floor(pay / 2); halved = true; } }
+      if (line === 'melt') user.melt = 3;
+      for (let i = 0; i < (def && def.free || 0); i++) queue.push('free');
+      for (let i = 0; i < (def && def.respin || 0); i++) queue.push('respin');
+      const subs = symbols.filter(s => kindOf(s) === 'sub');
+      const fx = def ? [...def.fx] : [];
+      if (subs.length && !fx.some(f => f.startsWith('fx.sub_'))) fx.push('fx.sub_single');
+      out.push({ i: out.length, kind: k, stops: symbols.map((s, c) => STRIPS[c].indexOf(s)), symbols, line, pay,
+                 halved, meltLeft: user.melt, freeLeft: queue.length, fx, subs });
+    }
+    return out;
+  }
+
+  function tape(body, idem) {
+    if (!/^[A-Za-z0-9_-]{16,64}$/.test(idem || '')) return { ok: false, reason: 'bad_idem' };
+    if (receipts.has(idem)) return receipts.get(idem);
+    const count = Math.floor(Number(body.count));
+    const freeze = body.freeze && [0, 1, 2].includes(body.freeze.col) ? body.freeze : null;
+    if (!(count >= 1 && count <= 20) || (freeze && count !== 1)) return { ok: false, reason: 'bad_count' };
+    const cur = body.cursor;
+    if (cur && user.tape && cur.tapeId === user.tape.id) user.tape.played = Math.max(user.tape.played, cur.played | 0);
+    const cost = freeze ? 1 + table().freezeCost : count;
+    if (user.sp < cost) return { ok: false, reason: 'insufficient', sp: user.sp };
+    const t = now();
+    if (!freeze && user.tape && user.tape.played !== user.tape.outcomes.length) {
+      return { ok: false, reason: 'tape_unplayed', sp: user.sp, tape: structuredClone(user.tape) };
+    }
+    if (!freeze && t < user.nextBuyAt) return { ok: false, reason: 'too_fast', retryInMs: user.nextBuyAt - t };
+    if (freeze && t - user.lastBuyAt < 700) return { ok: false, reason: 'too_fast', retryInMs: 700 - (t - user.lastBuyAt) };
+    const spBefore = user.sp, out = [];
+    const tp = user.tape;
+    const at = tp && tp.played > 0 ? tp.outcomes[tp.played - 1].symbols : user.shown;
+    const held = freeze ? { col: freeze.col, sym: (user.lastFreeze || at)[freeze.col] } : null;
+    if (freeze) spin('freeze', held, out);
+    else for (let i = 0; i < count; i++) spin('paid', null, out);
+    const won = out.reduce((s, o) => s + o.pay, 0);
+    const raw = spBefore - cost + won, capped = raw > 99999;
+    user.sp = Math.min(99999, raw);
+    const id = (freeze ? 'f_' : 't_') + Math.floor(rnd() * 0xffffffff).toString(16).padStart(8, '0');
+    const tapeOut = { id, played: 0, outcomes: out };
+    if (freeze) user.lastFreeze = out[out.length - 1].symbols;
+    else { user.tape = structuredClone(tapeOut); user.lastFreeze = null; user.nextBuyAt = t + out.length * floorMs; }
+    user.lastBuyAt = t;
+    const receipt = { ok: true, idem, sp: user.sp, spBefore, cost, capped, melt: user.melt, jackpot: 2500, tape: tapeOut };
+    receipts.set(idem, receipt);
+    return receipt;
+  }
+
+  function state() {
+    return { ok: true, sp: user.sp, open, melt: user.melt, tape: user.tape ? structuredClone(user.tape) : null,
+             shown: user.shown, table: table(), strips: STRIPS, floorMs };
+  }
+
+  async function handle(op, body = {}, idem) {
+    log.push({ op, idem, body: structuredClone(body) });
+    const f = faults.find(x => x.op === op && x.times > 0);
+    if (f) {
+      f.times--;
+      if (f.apply) await handle.raw(op, body, idem);
+      return f.reason === 'too_fast' || f.reason === 'busy' || f.reason === 'closed'
+        ? { ok: true, status: f.reason === 'closed' ? 403 : f.reason === 'busy' ? 409 : 200,
+            body: { ok: false, reason: f.reason, ...(f.body || {}) } }
+        : { ok: false, status: 0, reason: f.reason };
+    }
+    return handle.raw(op, body, idem);
+  }
+  handle.raw = async (op, body, idem) => {
+    if (!open) return { ok: true, status: 403, body: { ok: false, reason: 'closed' } };
+    if (op === 'state') return { ok: true, status: 200, body: state() };
+    if (op === 'cursor') {
+      if (user.tape && body.tapeId === user.tape.id) user.tape.played = Math.max(user.tape.played, body.played | 0);
+      return { ok: true, status: 200, body: { ok: true } };
+    }
+    if (op === 'tape') return { ok: true, status: 200, body: tape(body, idem) };
+    return { ok: false, status: 0, reason: 'bad_op' };
+  };
+
+  return {
+    handle,
+    log,
+    user,
+    /** Next `times` calls to `op` fail with `reason`; apply:true runs the op first (a lost reply). */
+    fail(op, reason, times = 1, { apply = false, body } = {}) { faults.push({ op, reason, times, apply, body }); },
+    /** Force the payline rows of the next draws, in order. */
+    script(...rows) { script.push(...rows); },
+    setOpen(v) { open = !!v; },
+  };
+}

--- a/ConditioningControlPanel/Resources/web/backroom/stations/slot/tape.js
+++ b/ConditioningControlPanel/Resources/web/backroom/stations/slot/tape.js
@@ -1,0 +1,222 @@
+/* tape.js - the slot's tape client (CONTRACT.md sections 2, 3, 9.1). PURE: no DOM, no three, no
+ * fetch; request(op, body, idem?), sleep(ms), mint() and onMelt(left) arrive injected, so node:test
+ * drives it against mock-server.js.
+ *
+ * The server has already settled every outcome it hands us. This file only decides WHICH settled
+ * outcome plays next and what the readouts say meanwhile (Law I). Two queues: `side` (a freeze spin
+ * and whatever it expanded into) drains before `main` (the bought tape) resumes, so a freeze bought
+ * mid-tape never skips, voids or reorders a tape outcome. */
+
+export const TAPE_DEFAULT = 10;
+const RETRYABLE = new Set(['timeout', 'offline', 'busy']);
+const MAX_RETRIES = 3;     // per press, for timeout/offline/busy
+const MAX_WAITS = 12;      // per press, for too_fast (the floor is honest, this only stops a loop)
+
+export function mintId() {
+  const bytes = new Uint8Array(16);
+  globalThis.crypto.getRandomValues(bytes);
+  return Array.from(bytes, b => b.toString(16).padStart(2, '0')).join('');
+}
+
+/** station-result -> {ok, reason, body}. A host refusal and a server refusal read the same. */
+export function normalize(res) {
+  const body = (res && typeof res.body === 'object' && res.body) || {};
+  const ok = !!res && res.ok !== false && body.ok !== false;
+  return { ok, reason: ok ? null : (res && res.reason) || body.reason || 'unknown', body };
+}
+
+/** THE BANK formula (section 2): the server balance minus every win still on a tape. */
+export function shownSpOf(serverSp, ...tapes) {
+  return tapes.reduce((s, t) => s - (t ? t.outcomes.slice(t.played).reduce((a, o) => a + (o.pay || 0), 0) : 0), serverSp);
+}
+
+/** Rest stop per reel for a row of symbol ids (first cell carrying that id). */
+export function stopsFor(strips, shown) {
+  return [0, 1, 2].map(r => {
+    const k = strips && strips[r] && shown ? strips[r].indexOf(shown[r]) : -1;
+    return k < 0 ? 0 : k;
+  });
+}
+
+function adoptTape(t) {
+  if (!t || !Array.isArray(t.outcomes)) return null;
+  const played = Math.max(0, Math.min(t.outcomes.length, Math.floor(Number(t.played) || 0)));
+  return { id: String(t.id || ''), played, outcomes: t.outcomes };
+}
+
+const unplayed = t => !!t && t.played < t.outcomes.length;
+
+export function createTape({ request, sleep = ms => new Promise(r => setTimeout(r, ms)),
+                             mint = mintId, onMelt = () => {} }) {
+  let sp = 0, table = null, strips = null, shown = null, floorMs = 800;
+  let main = null, side = null;
+  let hold = null;          // ONE frozen column (9.1), null when none
+  let pending = null;       // { key, idem, op, body }: kept until a definitive answer
+  let melt = 0, free = 0, lastWin = 0, last = null;
+  let epoch = 0;            // abort() bumps it; a press from an older epoch resolves 'aborted'
+  let reported = null;
+
+  function reportMelt() {
+    if (melt === reported) return;
+    reported = melt;
+    onMelt(melt);
+  }
+
+  function adopt(body) {
+    if (Number.isFinite(body.sp)) sp = body.sp;
+    if (body.table) table = body.table;
+    if (Number.isFinite(body.jackpot) && table) table = { ...table, jackpot: body.jackpot };
+    if (Array.isArray(body.strips)) strips = body.strips;
+    if (Array.isArray(body.shown)) shown = body.shown;
+    if (Number.isFinite(body.floorMs)) floorMs = body.floorMs;
+  }
+
+  /** GET state. Resumes an unplayed tape and carries melt over from the server. */
+  async function open() {
+    const my = ++epoch;
+    pending = null; side = null; hold = null; main = null; last = null;
+    let res, tries = 0;
+    for (;;) {
+      res = normalize(await request('state', {}));
+      if (my !== epoch) return { ok: false, reason: 'aborted' };
+      if (res.ok || !RETRYABLE.has(res.reason) || tries++ >= MAX_RETRIES) break;
+      await sleep(400 * tries);
+      if (my !== epoch) return { ok: false, reason: 'aborted' };
+    }
+    if (!res.ok) return { ok: false, reason: res.reason };
+    adopt(res.body);
+    main = adoptTape(res.body.tape);
+    // Played part of a stored tape: the readouts continue from its last landed spin.
+    // Nothing played yet: the server's own melt (section 3.1) is the carried state.
+    last = main && main.played > 0 ? main.outcomes[main.played - 1] : null;
+    melt = last ? last.meltLeft || 0 : Number(res.body.melt) || 0;
+    free = last ? last.freeLeft || 0 : 0;
+    lastWin = last ? last.pay || 0 : 0;
+    reported = null;
+    reportMelt();
+    return { ok: true };
+  }
+
+  function next() {
+    if (unplayed(side)) return side.outcomes[side.played];
+    if (unplayed(main)) return main.outcomes[main.played];
+    return null;
+  }
+
+  const freezeCost = () => 1 + (Number(table && table.freezeCost) || 1);
+  const canFreeze = () => !unplayed(side);
+
+  /** Send one intent, reusing its idem verbatim on every retry of that same intent. */
+  async function send(key, op, body, my) {
+    if (!pending || pending.key !== key) pending = { key, idem: mint(), op, body };
+    let tries = 0, waits = 0;
+    for (;;) {
+      const res = normalize(await request(pending.op, pending.body, pending.idem));
+      if (my !== epoch) return { kind: 'aborted' };
+      if (res.ok) { pending = null; return { ok: true, body: res.body }; }
+      let wait = 0;
+      if (res.reason === 'too_fast' && waits++ < MAX_WAITS) {
+        wait = Math.min(20000, Math.max(50, Number(res.body.retryInMs) || floorMs));
+      } else if (RETRYABLE.has(res.reason) && tries++ < MAX_RETRIES) {
+        wait = 400 * tries;
+      } else {
+        if (!RETRYABLE.has(res.reason) && res.reason !== 'too_fast') pending = null;
+        if (Number.isFinite(res.body.sp)) sp = res.body.sp;
+        return { ok: false, reason: res.reason, body: res.body };
+      }
+      await sleep(wait);   // silently: the page shows nothing for a floor wait
+      if (my !== epoch) return { kind: 'aborted' };
+    }
+  }
+
+  /** The next outcome, and which queue it comes off (a freeze tape drains first). */
+  const play = () => ({ kind: 'play', outcome: next(), from: unplayed(side) ? 'side' : 'main' });
+
+  const cursorBody = () => (main ? { cursor: { tapeId: main.id, played: main.played } } : {});
+  const refuse = reason => ({ kind: 'refused', reason });
+
+  async function buyTape(my) {
+    const count = Math.min(TAPE_DEFAULT, Math.floor(sp));
+    if (count < 1) return refuse('insufficient');
+    const r = await send('tape', 'tape', { count, ...cursorBody() }, my);
+    if (r.kind) return r;
+    if (!r.ok && r.reason === 'tape_unplayed' && r.body.tape) {
+      adopt(r.body);
+      main = adoptTape(r.body.tape);
+      return next() ? play() : refuse('tape_unplayed');
+    }
+    if (!r.ok) return refuse(r.reason);
+    adopt(r.body);
+    main = adoptTape(r.body.tape);
+    return next() ? play() : refuse('empty');
+  }
+
+  async function buyFreeze(my) {
+    const col = hold;
+    if (!canFreeze()) return refuse('busy');
+    if (sp < freezeCost()) return refuse('insufficient');
+    const r = await send(`freeze:${col}`, 'tape', { count: 1, freeze: { col }, ...cursorBody() }, my);
+    if (r.kind) return r;
+    if (!r.ok) return refuse(r.reason);
+    adopt(r.body);
+    const t = adoptTape(r.body.tape);
+    if (t && main && t.id === main.id) {
+      // Defensive: a server that answers with the stored tape keeps our place in it.
+      main = { ...t, played: Math.max(t.played, main.played) };
+    } else {
+      side = t ? { ...t, played: 0 } : null;
+    }
+    hold = null;
+    return next() ? play() : refuse('empty');
+  }
+
+  return {
+    open,
+    next,
+    /** One press = one outcome (section 8). Buys a tape or a freeze spin only when needed. */
+    async press() {
+      const my = epoch;
+      if (hold !== null) return buyFreeze(my);
+      return next() ? play() : buyTape(my);
+    },
+    /** The reels have stopped on `outcome`: its pay lands, readouts move to its after-state. */
+    land(outcome) {
+      if (unplayed(side) && side.outcomes[side.played] === outcome) {
+        side.played++;
+        if (!unplayed(side)) side = null;
+      } else if (unplayed(main) && main.outcomes[main.played] === outcome) {
+        main.played++;
+      } else {
+        return false;
+      }
+      last = outcome;
+      melt = outcome.meltLeft || 0;
+      free = outcome.freeLeft || 0;
+      lastWin = outcome.pay || 0;
+      if (Array.isArray(outcome.symbols)) shown = outcome.symbols;
+      reportMelt();
+      return true;
+    },
+    /** Light a column; lighting another moves the hold, lighting the same one clears it. */
+    toggleHold(col) {
+      if (![0, 1, 2].includes(col)) return hold;
+      hold = hold === col ? null : col;
+      return hold;
+    },
+    clearHold() { hold = null; },
+    abort() { epoch++; },
+    setServerSp(v) { if (Number.isFinite(v)) sp = v; },
+    cursor() { return main ? { tapeId: main.id, played: main.played } : null; },
+    snapshot() {
+      const n = next();
+      return {
+        sp, shownSp: shownSpOf(sp, main, side), melt, free, lastWin, last, hold,
+        jackpot: table ? table.jackpot : 0, lines: table ? table.lines || [] : [],
+        stake: table ? table.stake || 1 : 1, freezeCost: freezeCost(), canFreeze: canFreeze(),
+        strips, shown, floorMs, nextKind: n ? n.kind : null,
+        onTape: (unplayed(main) ? main.outcomes.length - main.played : 0) +
+                (unplayed(side) ? side.outcomes.length - side.played : 0),
+      };
+    },
+  };
+}

--- a/ConditioningControlPanel/Resources/web/backroom/stations/slot/tape.js
+++ b/ConditioningControlPanel/Resources/web/backroom/stations/slot/tape.js
@@ -103,7 +103,7 @@ export function createTape({ request, sleep = ms => new Promise(r => setTimeout(
     return null;
   }
 
-  const freezeCost = () => 1 + (Number(table && table.freezeCost) || 1);
+  const freezeCost = () => { const f = Number(table && table.freezeCost); return 1 + (table && table.freezeCost != null && Number.isFinite(f) ? f : 1); };
   const canFreeze = () => !unplayed(side);
 
   /** Send one intent, reusing its idem verbatim on every retry of that same intent. */

--- a/ConditioningControlPanel/Resources/web/backroom/stations/slot/tests/tape.test.mjs
+++ b/ConditioningControlPanel/Resources/web/backroom/stations/slot/tests/tape.test.mjs
@@ -1,0 +1,217 @@
+// node --test ConditioningControlPanel/Resources/web/backroom/stations/slot/tests/
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createTape, shownSpOf, stopsFor, normalize } from '../tape.js';
+import { createMockServer } from '../mock-server.js';
+
+function rig(opts = {}) {
+  let t = 0;
+  const server = createMockServer({ now: () => t, ...opts });
+  const sleeps = [], melts = [];
+  const tape = createTape({
+    request: (op, body, idem) => server.handle(op, body, idem),
+    sleep: async ms => { sleeps.push(ms); t += ms; },
+    onMelt: left => melts.push(left),
+  });
+  return { server, tape, sleeps, melts, advance: ms => { t += ms; } };
+}
+
+/** Press and land until `n` outcomes have played; returns them. */
+async function play(r, n) {
+  const out = [];
+  for (let i = 0; i < n; i++) {
+    const p = await r.tape.press();
+    assert.equal(p.kind, 'play', `press ${i} refused: ${p.reason}`);
+    assert.ok(r.tape.land(p.outcome));
+    out.push(p.outcome);
+    r.advance(1000);
+  }
+  return out;
+}
+
+const tapeCalls = r => r.server.log.filter(x => x.op === 'tape');
+
+test('shownSp is the server balance minus the pays still on the tape', () => {
+  const tape = { played: 1, outcomes: [{ pay: 40 }, { pay: 3 }, { pay: 0 }, { pay: 10 }] };
+  assert.equal(shownSpOf(100, tape), 87);
+  assert.equal(shownSpOf(100, tape, { played: 0, outcomes: [{ pay: 5 }] }), 82);
+  assert.equal(shownSpOf(100, null), 100);
+  assert.deepEqual(stopsFor([['a', 'b'], ['b', 'a'], ['x']], ['b', 'b', 'q']), [1, 0, 0]);
+  assert.equal(normalize({ ok: false, reason: 'timeout' }).reason, 'timeout');
+  assert.equal(normalize({ ok: true, body: { ok: false, reason: 'too_fast' } }).reason, 'too_fast');
+  assert.equal(normalize(null).ok, false);
+});
+
+test('a bought tape ticks the readout per landing and ends on the server balance', async () => {
+  const r = rig({ sp: 57 });
+  assert.equal((await r.tape.open()).ok, true);
+  const first = await r.tape.press();
+  assert.equal(first.kind, 'play');
+  const s = r.tape.snapshot();
+  assert.equal(tapeCalls(r)[0].body.count, 10);
+  assert.equal(s.shownSp, 57 - 10, 'wins have not landed yet');
+  let expected = 47;
+  r.tape.land(first.outcome);
+  expected += first.outcome.pay;
+  assert.equal(r.tape.snapshot().shownSp, expected);
+  const rest = await play(r, s.onTape - 1);
+  for (const o of rest) expected += o.pay;
+  assert.equal(r.tape.snapshot().shownSp, expected);
+  assert.equal(r.tape.snapshot().shownSp, r.server.user.sp);
+  assert.equal(tapeCalls(r).length, 1, 'free spins and re-spins came off the same tape');
+});
+
+test('open resumes an unplayed tape without buying', async () => {
+  const r = rig({ sp: 30 });
+  await r.tape.open();
+  await play(r, 4);
+  const before = r.server.user.sp;
+  // Leave mid-tape: the host flushes the cursor, the page reopens later.
+  await r.server.handle('cursor', r.tape.cursor());
+  r.tape.abort();
+  const again = createTape({ request: (op, b, i) => r.server.handle(op, b, i), sleep: async () => {} });
+  await again.open();
+  assert.equal(again.snapshot().onTape, r.server.user.tape.outcomes.length - 4);
+  const p = await again.press();
+  assert.equal(p.outcome, again.next());
+  assert.equal(p.outcome.i, 4, 'picks up at the cursor');
+  assert.equal(tapeCalls(r).length, 1);
+  assert.equal(r.server.user.sp, before);
+});
+
+test('tape_unplayed from the server is adopted and played, not re-bought', async () => {
+  const r = rig({ sp: 30 });
+  // A second page opens before any tape exists, then the first page buys and plays two.
+  const stale = createTape({ request: (op, b, i) => r.server.handle(op, b, i), sleep: async () => {} });
+  await stale.open();
+  await r.tape.open();
+  await play(r, 2);
+  await r.server.handle('cursor', r.tape.cursor());
+  const p = await stale.press();
+  assert.equal(r.server.log.at(-1).op, 'tape');
+  assert.equal(p.kind, 'play');
+  assert.equal(p.outcome.i, 2, 'resumes at the stored cursor');
+  assert.equal(tapeCalls(r).length, 2, 'the refused buy debited nothing');
+  assert.equal(stale.snapshot().shownSp, r.tape.snapshot().shownSp);
+});
+
+test('a lost reply retries with the same idem and debits once', async () => {
+  const r = rig({ sp: 20 });
+  await r.tape.open();
+  r.server.fail('tape', 'timeout', 1, { apply: true });
+  const p = await r.tape.press();
+  assert.equal(p.kind, 'play');
+  const calls = tapeCalls(r);
+  assert.equal(calls.length, 2);
+  assert.equal(calls[0].idem, calls[1].idem);
+  const receipt = r.server.user.tape.outcomes.reduce((t, o) => t + o.pay, 0);
+  assert.equal(r.server.user.sp, 20 - 10 + receipt, 'debited once');
+  assert.equal(r.tape.snapshot().shownSp, 10);
+});
+
+test('a press after retries ran out reuses the same intent; a new intent mints a new idem', async () => {
+  const r = rig({ sp: 20 });
+  await r.tape.open();
+  r.server.fail('tape', 'offline', 4);
+  assert.deepEqual(await r.tape.press(), { kind: 'refused', reason: 'offline' });
+  const p = await r.tape.press();
+  assert.equal(p.kind, 'play');
+  const ids = new Set(tapeCalls(r).map(c => c.idem));
+  assert.equal(ids.size, 1);
+  await play(r, r.tape.snapshot().onTape - 1 + 1);
+  r.advance(60000);
+  await r.tape.press();
+  assert.equal(new Set(tapeCalls(r).map(c => c.idem)).size, 2);
+});
+
+test('too_fast waits out retryInMs silently on the same idem, cursor folded in', async () => {
+  const r = rig({ sp: 40, floorMs: 800 });
+  await r.tape.open();
+  await play(r, 1);
+  while (r.tape.snapshot().onTape) { const p = await r.tape.press(); r.tape.land(p.outcome); }
+  const done = r.tape.cursor();   // no time passed since the buy: the floor refuses the next one
+  assert.equal((await r.tape.press()).kind, 'play');
+  assert.ok(r.sleeps[0] > 0, 'slept on retryInMs');
+  const calls = tapeCalls(r);
+  assert.equal(calls.at(-1).idem, calls.at(-2).idem);
+  assert.deepEqual(calls.at(-1).body.cursor, done);
+});
+
+test('a freeze mid-tape plays first, costs 2, and never skips a tape outcome', async () => {
+  const r = rig({ sp: 50 });
+  await r.tape.open();
+  const head = await play(r, 3);
+  const mainId = r.tape.cursor().tapeId;
+  const stored = r.server.user.tape.outcomes.map(o => o.i);
+  const spBefore = r.server.user.sp;
+  assert.equal(r.tape.toggleHold(0), 0);
+  assert.equal(r.tape.toggleHold(1), 1, 'one column: lighting another moves the hold');
+  const f = await r.tape.press();
+  assert.equal(f.outcome.kind, 'freeze');
+  assert.equal(f.outcome.symbols[1], head[2].symbols[1], 'held column keeps what was showing');
+  const buy = tapeCalls(r).at(-1);
+  assert.deepEqual([buy.body.freeze, buy.body.count, buy.body.cursor], [{ col: 1 }, 1, { tapeId: mainId, played: 3 }]);
+  assert.equal(r.tape.snapshot().hold, null, 'the hold is spent on one spin');
+  // The freeze and anything it expanded into drain before the tape resumes.
+  const side = [f.outcome];
+  r.tape.land(f.outcome);
+  let p = await r.tape.press();
+  while (p.from === 'side') {
+    side.push(p.outcome); r.tape.land(p.outcome); p = await r.tape.press();
+  }
+  assert.equal(r.server.user.sp, spBefore - 2 + side.reduce((s, o) => s + o.pay, 0));
+  assert.equal(p.outcome.i, 3);
+  assert.equal(r.tape.cursor().tapeId, mainId);
+  const tail = [];
+  for (;;) {
+    tail.push(p.outcome); r.tape.land(p.outcome);
+    if (!r.tape.snapshot().onTape) break;
+    p = await r.tape.press();
+  }
+  assert.deepEqual([...head, ...tail].map(o => o.i), stored);
+  assert.equal(tapeCalls(r).length, 2);
+  assert.equal(r.tape.snapshot().shownSp, r.server.user.sp);
+});
+
+test('insufficient: nothing sent below 1 SP, a freeze below its cost is refused quietly', async () => {
+  const r = rig({ sp: 0 });
+  await r.tape.open();
+  assert.deepEqual(await r.tape.press(), { kind: 'refused', reason: 'insufficient' });
+  assert.equal(tapeCalls(r).length, 0);
+  const r2 = rig({ sp: 1 });
+  await r2.tape.open(); r2.tape.toggleHold(0);
+  assert.deepEqual(await r2.tape.press(), { kind: 'refused', reason: 'insufficient' });
+  r2.tape.clearHold();
+  const p = await r2.tape.press();
+  assert.equal(tapeCalls(r2)[0].body.count, 1, 'count is min(10, sp)');
+  assert.equal(p.kind, 'play');
+});
+
+test('melt is carried over from the server on open and reported when it changes', async () => {
+  const r = rig({ sp: 20, melt: 2 });
+  await r.tape.open();
+  assert.equal(r.tape.snapshot().melt, 2);
+  assert.deepEqual(r.melts, [2]);
+  r.server.script(['gif0', 'sub1', 'spiral0'], ['gif1', 'melt', 'spiral2'], ['gif0', 'gif0', 'gif0']);
+  const [a, b, c] = await play(r, 3);
+  assert.equal(a.meltLeft, 1);
+  assert.equal(b.line, 'melt');
+  assert.deepEqual([c.halved, c.pay], [true, 20]);
+  assert.deepEqual(r.melts, [2, 1, 3, 2]);
+});
+
+test('free spins play from the tape and abort drops a press in flight', async () => {
+  const r = rig({ sp: 20 });
+  await r.tape.open();
+  r.server.script(['spiral0', 'spiral1', 'spiral2']);
+  const [win] = await play(r, 1);
+  assert.deepEqual([win.line, win.freeLeft], ['spiral3', 3]);
+  assert.equal(r.tape.next().kind, 'free');
+  assert.equal(r.tape.snapshot().free, 3);
+  await play(r, r.tape.snapshot().onTape);
+  assert.equal(tapeCalls(r).length, 1);
+  r.server.fail('tape', 'too_fast', 1, { body: { retryInMs: 500 } });
+  const inflight = r.tape.press();
+  r.tape.abort();
+  assert.deepEqual(await inflight, { kind: 'aborted' });
+});


### PR DESCRIPTION
Lane C2, part a of 3 (stacked: a -> b -> c). Builds to `backroom/CONTRACT.md` sections 2, 3 and 9.1.

## What
- `stations/slot/tape.js`: pure tape client (no DOM, no fetch). GET state on open resumes an unplayed tape and carries melt over; buys tapes of `min(10, sp)`; the idem is kept until a definitive answer and reused verbatim on every retry of the same intent (timeout, offline, busy, too_fast, and a later press after retries ran out); the cursor is folded into every buy; `too_fast` waits `retryInMs` silently; `tape_unplayed` adopts the stored tape; ONE freeze column (lighting another moves the hold), cost `1 + freezeCost`; a freeze spin plays ahead of the tape and never skips or reorders a tape outcome; free spins and re-spins play off the tape; `shownSp` is the section 2 formula.
- `stations/slot/mock-server.js`: section 3 body shapes for the dev harness and tests (not the paytable).
- `stations/slot/tests/tape.test.mjs`: resume, tape_unplayed, lost reply idem reuse, press-after-retries idem reuse, too_fast wait + cursor, shownSp math, freeze mid-tape ordering and cost, insufficient, melt carry-over, free spins, abort.

## Tests
`node --test ConditioningControlPanel/Resources/web/backroom/stations/slot/tests/` (14/14 across the stack; this part 11/11).

## Assumptions for S1 (listed as deviations in the lane result)
- A freeze response carries its own short `tape` (the freeze outcome plus anything it expanded into); the stored tape is untouched. If the server answers with the stored tape id instead, the client keeps its place in it.
- Refusals (`too_fast`, `busy`, `insufficient`) are not stored as idem receipts, so reusing the idem after a refusal is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V3c2CJTNfpbeBYqwjT6ZAj



---
**Small-balance tape (c7d3d695e):** tape.js exports `defaultTapeCount(sp) = clamp(floor(sp / 5), 1, 10)` and `affordableTapeCount(count, sp)`. The tape follows the balance until the player picks a count this sit-down (`pickCount`, max 20), every count is clamped to the balance, snapshot carries `tapeCount`. Tests for sp 0/1/4/5/16/49/50/500 plus the pick and clamp; slot tests 16/16 pass.

---
**Freeze response shape (68660cc31):** the real server answers a freeze with `freeze: {col, held, outcomes}` and `tape` as the stored tape's `{id, played}` only, or `null` (CONTRACT 10.10). The Assumptions note above is superseded. `mock-server.js` now follows `settle()` (refusal order, 700 ms freeze floor, freeze sealed from melt, re-spin keeps the hold, `shownAt()` held symbol, cursor clamp); `tape.js` plays `freeze.outcomes` on the side queue, names the held column on each freeze/re-spin (`held`), and leaves the tape cursor untouched until the tape resumes. shownSp counts unplayed freeze pays. New tests: freeze mid-tape with a re-spin (balance before/during/after, same cursor, hold kept) and a freeze with no stored tape. Slot tests 18/18 across the stack. Note: this PR was 660 lines before this round and is 700 now (see lane result).