### PR TITLE
feat(backroom): C2c slot station, media, fx, dev harness

### DIFF
--- a/ConditioningControlPanel/Resources/web/backroom/stations/slot/dev.html
+++ b/ConditioningControlPanel/Resources/web/backroom/stations/slot/dev.html
@@ -1,0 +1,89 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<link rel="icon" href="data:,">
+<title>Slot station - dev harness</title>
+<!-- Dev harness only: a mock ctx and mock-server.js stand in for the room, the host and the server.
+     Serve ConditioningControlPanel/Resources as the web root (the dev GIFs come from avatar0_emotes),
+     then open /web/backroom/stations/slot/dev.html. Query: ?sp=57&melt=0&floor=800&latency=120&reduced -->
+<script type="importmap">{"imports":{"three":"../../../vendor/three/three.module.min.js","three/addons/":"../../../vendor/three/addons/"}}</script>
+<style>
+  html, body { margin: 0; height: 100%; overflow: hidden; background: #160e20; font: 12px Segoe UI, Arial, sans-serif; color: #fce5f3; }
+  #room { position: fixed; inset: 0; background: #160e20 url(../../room/backroom_final.png) center / contain no-repeat; }
+  #root { position: fixed; inset: 0; }
+  #sit { position: fixed; left: 50%; top: 50%; transform: translate(-50%, -50%); padding: 12px 22px; border-radius: 20px;
+         background: #28172fea; color: inherit; border: 1px solid #edb1d177; font: inherit; font-size: 14px; cursor: pointer; }
+  #dev { position: fixed; top: 130px; right: 8px; z-index: 50; display: flex; flex-direction: column; gap: 4px; opacity: .85; }
+  #dev button { font: 11px Segoe UI, Arial, sans-serif; padding: 3px 8px; }
+  #dev summary { cursor: pointer; text-align: right; }
+</style>
+</head>
+<body>
+<div id="room"></div>
+<div id="root"></div>
+<button id="sit" type="button">Take a seat</button>
+<details id="dev"><summary>dev</summary>
+  <button data-do="jackpot">next: EMI x3</button>
+  <button data-do="melt">next: melt</button>
+  <button data-do="spirals">next: 3 spirals</button>
+  <button data-do="too_fast">fault: too_fast</button>
+  <button data-do="timeout">fault: lost reply</button>
+  <button data-do="door">toggle door</button>
+  <button data-do="broke">set SP 0</button>
+</details>
+<script type="module">
+import { mount } from './station.js';
+import { createMockServer } from './mock-server.js';
+
+const q = new URLSearchParams(location.search);
+const num = (k, d) => (q.has(k) ? Number(q.get(k)) : d);
+const server = createMockServer({ sp: num('sp', 57), melt: num('melt', 0), floorMs: num('floor', 800) });
+const latency = num('latency', 120);
+const sent = [];
+const spFns = new Set();
+const wait = ms => new Promise(r => setTimeout(r, ms));
+const gif = name => `../../../../avatar0_emotes/${name}.gif`;
+
+const ctx = {
+  root: document.getElementById('root'),
+  bridge: { send: m => { sent.push(m); console.log('[bridge]', JSON.stringify(m)); } },
+  request: async (op, body, idem) => { await wait(latency); return server.handle(op, body, idem); },
+  fx: async (fxId, symbols) => { sent.push({ type: 'fx', fxId, symbols }); console.log('[fx]', fxId, symbols); return { fired: [], skipped: [] }; },
+  media: async () => {
+    await wait(latency);
+    return { seed: 918273,
+      gifs: [{ key: 'g0', url: gif('cheer'), src: 'pool' }, { key: 'g1', url: gif('giggle'), src: 'pool' },
+             { key: 'g2', url: gif('flirt'), src: 'pool' }, { key: 'g3', url: './fallback/gif3.webp', src: 'fallback' }],
+      words: [{ key: 's0', text: 'Drop', src: 'preset' }, { key: 's1', text: 'Relax', src: 'preset' },
+              { key: 's2', text: 'Let Go', src: 'preset' }, { key: 's3', text: 'Sink', src: 'preset' }] };
+  },
+  sp: () => server.user.sp,
+  onSp: fn => { spFns.add(fn); return () => spFns.delete(fn); },
+  reduced: q.has('reduced'), motion: q.has('reduced') ? 'Reduced' : 'Full', intensity: 'Normal',
+  lex: (key, fallback) => fallback,
+  standUp: () => stand(),
+};
+
+const station = await mount(ctx);
+const sit = document.getElementById('sit');
+async function stand() { await station.close(); sit.hidden = false; sit.focus(); }
+async function open() { sit.hidden = true; await station.open(); }
+sit.onclick = open;
+
+let door = true;
+const rows = { jackpot: ['emi', 'emi', 'emi'], melt: ['gif1', 'melt', 'spiral2'], spirals: ['spiral0', 'spiral1', 'spiral2'] };
+document.getElementById('dev').addEventListener('click', e => {
+  const act = e.target.dataset && e.target.dataset.do;
+  if (rows[act]) server.script(rows[act]);
+  if (act === 'too_fast') server.fail('tape', 'too_fast', 1, { body: { retryInMs: 1500 } });
+  if (act === 'timeout') server.fail('tape', 'timeout', 1, { apply: true });
+  if (act === 'door') server.setOpen(door = !door);
+  if (act === 'broke') { server.user.sp = 0; spFns.forEach(fn => fn(0)); }
+});
+
+window.dev = { server, station, ctx, sent, open, stand };
+</script>
+</body>
+</html>

--- a/ConditioningControlPanel/Resources/web/backroom/stations/slot/media.js
+++ b/ConditioningControlPanel/Resources/web/backroom/stations/slot/media.js
@@ -1,0 +1,75 @@
+/* media.js - the sit-down deal (CONTRACT.md section 5) as the reel painter sees it.
+ * gif0..gif3 = gifs[0..3], sub0..sub3 = words[0..3], kept until the player stands up. GIFs load as
+ * <img> inside a hidden holder in the document so Chromium keeps them animating while the reel
+ * canvas redraws them. Only ccp.assets / ccp.game (or this page's own origin, for dev.html) URLs
+ * are loaded; anything else, or a load failure, falls back to the built-in art in symbols.js.
+ * Keys, never URLs, leave this file. */
+
+import { kindOf } from './symbols.js';
+
+const LOAD_MS = 2500;
+
+function allowed(url) {
+  try {
+    const u = new URL(url, location.href);
+    return u.origin === 'https://ccp.assets' || u.origin === 'https://ccp.game' || u.origin === location.origin;
+  } catch { return false; }
+}
+
+export function createMedia(holder, lex = (k, f) => f) {
+  let gifs = [], words = [], imgs = [];
+
+  function clear() {
+    imgs.forEach(img => img && img.remove());
+    imgs = []; gifs = []; words = [];
+  }
+
+  return {
+    /** Adopt a `media` reply. Resolves once every GIF loaded or failed (capped), never rejects. */
+    deal(media) {
+      clear();
+      gifs = Array.isArray(media && media.gifs) ? media.gifs.slice(0, 4) : [];
+      words = Array.isArray(media && media.words) ? media.words.slice(0, 4) : [];
+      imgs = gifs.map(g => {
+        if (!g || typeof g.url !== 'string' || !allowed(g.url)) return null;
+        const img = new Image();
+        img.decoding = 'async'; img.alt = '';
+        img.src = new URL(g.url, location.href).href;
+        holder.append(img);
+        return img;
+      });
+      const waits = imgs.filter(Boolean).map(img => new Promise(done => {
+        if (img.complete) return done();
+        img.onload = img.onerror = () => done();
+      }));
+      return Promise.race([Promise.all(waits), new Promise(done => setTimeout(done, LOAD_MS))]);
+    },
+    /** A drawable for gif{i}, or null when missing or broken (the painter draws fallback art). */
+    gif(i) {
+      const img = imgs[i];
+      return img && img.complete && img.naturalWidth > 0 ? img : null;
+    },
+    word(i) {
+      const w = words[i];
+      if (!w || typeof w.text !== 'string' || !w.text) return null;
+      return w.src === 'preset' ? lex(w.text, w.text) : w.text;
+    },
+    /** Symbol id -> the dealt key (g0, s1...), or null for symbols with no media behind them. */
+    keyFor(id) {
+      const { kind, n } = kindOf(id);
+      const item = kind === 'gif' ? gifs[n] : kind === 'sub' ? words[n] : null;
+      return item && typeof item.key === 'string' ? item.key : null;
+    },
+    get animated() { return imgs.some(Boolean); },
+    dispose: clear,
+  };
+}
+
+/** The dealt keys an effect should carry for one outcome (section 4: host resolves them). */
+export function fxSymbols(fxId, outcome, media) {
+  const row = Array.isArray(outcome.symbols) ? outcome.symbols : [];
+  const pick = fxId.startsWith('fx.sub_') ? (Array.isArray(outcome.subs) ? outcome.subs : row.filter(s => kindOf(s).kind === 'sub'))
+    : fxId.startsWith('fx.gif_') ? row.filter(s => kindOf(s).kind === 'gif')
+    : row;
+  return [...new Set(pick.map(s => media.keyFor(s)).filter(Boolean))];
+}

--- a/ConditioningControlPanel/Resources/web/backroom/stations/slot/media.js
+++ b/ConditioningControlPanel/Resources/web/backroom/stations/slot/media.js
@@ -16,6 +16,18 @@ function allowed(url) {
   } catch { return false; }
 }
 
+/** False when drawing the image would taint a canvas (served without CORS), checked once per img. */
+function readable(img) {
+  if (img.dataset.readable) return img.dataset.readable === '1';
+  let ok = true;
+  try {
+    const c = document.createElement('canvas'); c.width = c.height = 1;
+    const g = c.getContext('2d'); g.drawImage(img, 0, 0, 1, 1); g.getImageData(0, 0, 1, 1);
+  } catch { ok = false; console.warn('[slot] dealt GIF is not CORS-readable, using fallback art'); }
+  img.dataset.readable = ok ? '1' : '0';
+  return ok;
+}
+
 export function createMedia(holder, lex = (k, f) => f) {
   let gifs = [], words = [], imgs = [];
 
@@ -34,6 +46,9 @@ export function createMedia(holder, lex = (k, f) => f) {
         if (!g || typeof g.url !== 'string' || !allowed(g.url)) return null;
         const img = new Image();
         img.decoding = 'async'; img.alt = '';
+        // ccp.assets is another origin: without CORS mode the reel canvas is tainted and the WebGL
+        // upload throws (same rule as dtrh/engine/spawner.js). Set before src.
+        img.crossOrigin = 'anonymous';
         img.src = new URL(g.url, location.href).href;
         holder.append(img);
         return img;
@@ -47,7 +62,7 @@ export function createMedia(holder, lex = (k, f) => f) {
     /** A drawable for gif{i}, or null when missing or broken (the painter draws fallback art). */
     gif(i) {
       const img = imgs[i];
-      return img && img.complete && img.naturalWidth > 0 ? img : null;
+      return img && img.complete && img.naturalWidth > 0 && readable(img) ? img : null;
     },
     word(i) {
       const w = words[i];

--- a/ConditioningControlPanel/Resources/web/backroom/stations/slot/station.css
+++ b/ConditioningControlPanel/Resources/web/backroom/stations/slot/station.css
@@ -1,0 +1,74 @@
+/* station.css - slot station chrome, ported from blender-scripting slot/preview/style.css.
+   Everything is scoped under .slot-station so the room's own styles never collide. */
+.slot-station { position: absolute; inset: 0; z-index: 20; overflow: hidden; color: #fce5f3;
+  font-family: Segoe UI, Arial, sans-serif; color-scheme: dark; }
+.slot-station * { box-sizing: border-box; }
+.slot-station button, .slot-station summary { font: inherit; cursor: pointer; }
+.slot-station button { border: 1px solid #ab79a766; color: #fce5f3; background: #28172fe8; border-radius: 10px;
+  padding: 10px 18px; min-height: 40px; transition: background .15s, transform .1s; }
+.slot-station button:hover { background: #583056; }
+.slot-station button:active { transform: scale(.96); }
+.slot-station button:focus-visible, .slot-station summary:focus-visible { outline: 2px solid #ff8ed2; outline-offset: 3px; }
+.slot-station button:disabled { opacity: .45; cursor: default; }
+.slot-station [hidden] { display: none !important; }
+
+.slot-dim { position: absolute; inset: 0; backdrop-filter: brightness(.45) blur(3px); -webkit-backdrop-filter: brightness(.45) blur(3px);
+  background: radial-gradient(ellipse at 45% 45%, #bc4e9520, transparent 65%), linear-gradient(0deg, #09051099, transparent 60%);
+  transition: opacity .38s ease-out; }
+.slot-station[data-phase="leaving"] .slot-dim { opacity: 0; }
+.slot-stage { position: absolute; inset: 0; width: 100%; height: 100%; touch-action: none; }
+.slot-media { position: absolute; width: 1px; height: 1px; overflow: hidden; opacity: .01; pointer-events: none; }
+.slot-media img { width: 1px; height: 1px; }
+.slot-hint { position: absolute; transform: translate(-50%, -100%); white-space: nowrap; font-size: 12px; letter-spacing: .6px;
+  color: #f5cfe7; pointer-events: none; text-shadow: 0 2px 5px #160e20; }
+
+.slot-top { position: absolute; top: 18px; left: 22px; right: 22px; display: flex; align-items: center; gap: 14px; z-index: 4; }
+.slot-readouts { display: flex; gap: 8px; }
+.slot-readouts span { background: #201229e8; border: 1px solid #b77da247; padding: 8px 14px; border-radius: 30px; font-size: 13px; }
+.slot-sp { color: #ffe3f2; font-weight: 600; }
+.slot-jackpot { color: #f7d5af; }
+.slot-status { margin-left: auto; background: #201229e8; border: 1px solid #b77da247; padding: 10px 18px; border-radius: 30px;
+  font-size: 13px; color: #edc7df; white-space: pre; }
+.slot-face { width: 58px; height: 52px; image-rendering: pixelated; border: 3px solid #6b507e; border-radius: 10px;
+  box-shadow: 0 3px 20px #0a0412; }
+
+.slot-controls { position: absolute; bottom: 72px; left: 50%; transform: translateX(-50%); width: min(82vw, 1060px);
+  display: flex; justify-content: center; align-items: center; gap: 24px; z-index: 3; pointer-events: none; }
+.slot-controls button { pointer-events: auto; }
+.slot-freeze { display: flex; gap: 12px; flex: 1; justify-content: space-around; }
+.slot-freeze button { font-size: 12px; letter-spacing: 1px; min-width: 125px; background: #301835ed; border-color: #d7a8ca55;
+  box-shadow: inset 0 1px #ffe9f21a, 0 4px 14px #08030c55; }
+.slot-freeze button[aria-pressed="true"] { background: #a45fb4; color: #fff; border-color: #ffd4ee; box-shadow: 0 0 18px #d37ad777; }
+.slot-spin { position: absolute; z-index: 4; right: 22px; bottom: 18px; min-width: 120px; font-weight: 700; color: #26122f !important;
+  background: linear-gradient(135deg, #e59cca, #a562b4) !important; border-color: #efc4de !important;
+  box-shadow: inset 0 1px 0 #fff5, 0 4px 22px #c767b32b, 0 5px 24px #08040b99; }
+.slot-spin span, .slot-spin small { display: block; }
+.slot-spin small { font-size: 10px; font-weight: 500; opacity: .8; }
+
+.slot-odds { position: absolute; left: 22px; bottom: 18px; z-index: 4; font-size: 12px; max-width: min(360px, calc(100vw - 180px)); }
+.slot-odds summary { list-style: none; border: 1px solid #ab79a766; background: #28172fe8; border-radius: 8px; padding: 7px 12px; display: inline-block; }
+.slot-odds[open] { background: #24142df5; border: 1px solid #ab79a766; border-radius: 12px; padding: 10px; }
+.slot-odds table { border-collapse: collapse; margin-top: 8px; width: 100%; }
+.slot-odds th { text-align: left; font-weight: 500; padding: 3px 10px 3px 0; }
+.slot-odds td { text-align: right; padding: 3px 0 3px 10px; color: #edc7df; white-space: nowrap; }
+.slot-odds p { margin: 8px 0 0; color: #bda2bf; }
+
+.slot-card { position: absolute; left: 50%; top: 42%; transform: translate(-50%, -50%); z-index: 6; background: #28172ff2;
+  border: 1px solid #edb1d177; border-radius: 14px; padding: 18px 22px; text-align: center; max-width: min(420px, calc(100vw - 32px)); }
+.slot-card p { margin: 0 0 12px; }
+.slot-loading { position: absolute; left: 50%; top: 50%; transform: translate(-50%, -50%); padding: 15px 22px;
+  background: #28172fea; border-radius: 12px; z-index: 5; }
+.slot-station[data-phase="closed"] :is(.slot-controls, .slot-spin, .slot-odds) { display: none; }
+
+@media (max-width: 800px) {
+  .slot-top { top: 10px; left: 12px; right: 12px; gap: 8px; flex-wrap: wrap; }
+  .slot-status { font-size: 11px; padding: 8px 10px; white-space: normal; order: 5; margin-left: 0; flex-basis: 100%; }
+  .slot-readouts span { font-size: 11px; padding: 6px 10px; }
+  .slot-face { margin-left: auto; width: 44px; height: 40px; }
+  .slot-controls { bottom: 72px; width: calc(100vw - 24px); gap: 8px; }
+  .slot-freeze { gap: 4px; }
+  .slot-freeze button { min-width: 0; padding: 8px; font-size: 10px; }
+  .slot-spin { right: 12px; bottom: 12px; min-width: 96px; }
+  .slot-odds { left: 12px; bottom: 12px; }
+}
+@media (prefers-reduced-motion: reduce) { .slot-station * { transition: none !important; } }

--- a/ConditioningControlPanel/Resources/web/backroom/stations/slot/station.js
+++ b/ConditioningControlPanel/Resources/web/backroom/stations/slot/station.js
@@ -90,6 +90,7 @@ export async function mount(ctx) {
   function refusalText(reason) {
     if (reason === 'insufficient') return t('br_slot_insufficient', 'Not enough SP for this spin.');
     if (reason === 'closed') return t('br_slot_closed', 'The cabinet is closed for a moment.');
+    if (reason === 'empty' || reason === 'tape_unplayed') return t('br_slot_stuck', 'The reels stuck. Pull again.');
     return t('br_slot_offline', 'The house is not answering. Try again in a moment.');
   }
 
@@ -204,7 +205,7 @@ export async function mount(ctx) {
     if (e.key === 'Escape') { e.preventDefault(); back(); return; }
     if (e.target && e.target.closest && e.target.closest('button, summary, input, select')) return;
     if (e.code === 'Space') { e.preventDefault(); press(); }
-    if (['1', '2', '3'].includes(e.key)) toggleFreeze(Number(e.key) - 1);
+    if (['1', '2', '3'].includes(e.key) && tape && tape.snapshot().canFreeze) toggleFreeze(Number(e.key) - 1);
   }
   const onResize = () => scene && scene.resize();
 
@@ -265,7 +266,7 @@ export async function mount(ctx) {
     unSp = null;
     const s = scene, root = el, m = media;
     if (root) root.dataset.phase = 'leaving';
-    if (s) await Promise.race([s.sink(), new Promise(r => setTimeout(r, 380))]);
+    if (s) await Promise.race([s.sink(), new Promise(r => setTimeout(r, 340))]);
     if (s) s.dispose();
     if (m) m.dispose();
     if (root) root.remove();

--- a/ConditioningControlPanel/Resources/web/backroom/stations/slot/station.js
+++ b/ConditioningControlPanel/Resources/web/backroom/stations/slot/station.js
@@ -1,0 +1,291 @@
+/* ============================================================================
+ * station.js - the slot station (CONTRACT.md section 7). The room calls
+ * mount(ctx) once, then open()/close() per sit-down. Back is live at every
+ * frame (Law VI): it never waits on the glb, the server or an animation.
+ *
+ *   tape.js   what plays next, and the readouts (server-settled outcomes)
+ *   scene.js  the cabinet, one WebGL context per open(), freed in close()
+ *   media.js  the dealt GIFs and words painted on the reel cells
+ * ==========================================================================*/
+
+import { createTape, stopsFor } from './tape.js';
+import { createScene, FACES } from './scene.js';
+import { createMedia, fxSymbols } from './media.js';
+
+const STATION = 'slot';
+const LINE_LABELS = {
+  emi3: '3 EMI', gif3same: '3 of the same GIF', sub3: '3 subliminals', spiral3: '3 spirals',
+  gif3: '3 GIFs', sub2: '2 subliminals', spiral2: '2 spirals', melt: 'Melt',
+};
+const fmt = n => Number(n || 0).toLocaleString('en-US');
+
+function loadCss() {
+  if (document.querySelector('link[data-slot-css]')) return;
+  const link = document.createElement('link');
+  link.rel = 'stylesheet'; link.href = new URL('./station.css', import.meta.url).href; link.dataset.slotCss = '';
+  document.head.append(link);
+}
+
+export async function mount(ctx) {
+  const t = (key, fallback, vars = {}) => {
+    const s = typeof ctx.lex === 'function' ? ctx.lex(key, fallback) : fallback;
+    return String(s ?? fallback).replace(/\{(\w+)\}/g, (_, k) => (k in vars ? vars[k] : `{${k}}`));
+  };
+  const reduced = !!ctx.reduced || (typeof matchMedia === 'function' && matchMedia('(prefers-reduced-motion: reduce)').matches);
+  loadCss();
+
+  let el = null, scene = null, tape = null, media = null, session = 0, alive = false;
+  let busy = false, suspended = false, unSp = null, lastMelt = null;
+  const $ = sel => el.querySelector(sel);
+
+  function sendMelt(left) {
+    if (left === lastMelt) return;
+    lastMelt = left;
+    const frame = { type: 'melt', station: STATION, left };
+    if (typeof ctx.melt === 'function') ctx.melt(left);
+    else if (ctx.bridge && typeof ctx.bridge.send === 'function') ctx.bridge.send(frame);
+  }
+
+  function build() {
+    const root = document.createElement('div');
+    root.className = 'slot-station'; root.dataset.phase = 'loading';
+    root.innerHTML = `
+      <div class="slot-dim"></div>
+      <canvas class="slot-stage" aria-label="${t('br_slot_stage', 'Slot cabinet')}"></canvas>
+      <div class="slot-media" aria-hidden="true"></div>
+      <div class="slot-hint" hidden>${t('br_slot_pull', 'Pull down')} &darr;</div>
+      <header class="slot-top">
+        <button class="slot-back" type="button">&larr; ${t('br_slot_back', 'Back')}</button>
+        <div class="slot-readouts">
+          <span class="slot-sp"></span><span class="slot-jackpot"></span>
+        </div>
+        <div class="slot-status" aria-live="polite"></div>
+        <canvas class="slot-face" width="152" height="137" aria-hidden="true"></canvas>
+      </header>
+      <div class="slot-controls">
+        <div class="slot-freeze">${[0, 1, 2].map(i => `<button type="button" data-col="${i}" aria-pressed="false"></button>`).join('')}</div>
+      </div>
+      <button class="slot-spin" type="button"><span></span><small></small></button>
+      <details class="slot-odds"><summary>${t('br_slot_odds', 'Odds')}</summary><table></table><p></p></details>
+      <div class="slot-card" role="status" hidden><p></p><button class="slot-card-back" type="button">${t('br_slot_back', 'Back')}</button></div>
+      <div class="slot-loading">${t('br_slot_loading', 'Preparing the cabinet')}</div>`;
+    root.querySelector('.slot-back').onclick = back;
+    root.querySelector('.slot-card-back').onclick = back;
+    root.querySelector('.slot-spin').onclick = () => press();
+    root.querySelectorAll('[data-col]').forEach(b => { b.onclick = () => toggleFreeze(Number(b.dataset.col)); });
+    return root;
+  }
+
+  function back() {
+    if (typeof ctx.standUp === 'function') ctx.standUp();
+    else close();
+  }
+
+  function card(text) {
+    if (!el) return;
+    $('.slot-card p').textContent = text || '';
+    $('.slot-card').hidden = !text;
+  }
+
+  function refusalText(reason) {
+    if (reason === 'insufficient') return t('br_slot_insufficient', 'Not enough SP for this spin.');
+    if (reason === 'closed') return t('br_slot_closed', 'The cabinet is closed for a moment.');
+    return t('br_slot_offline', 'The house is not answering. Try again in a moment.');
+  }
+
+  function sync() {
+    if (!el || !tape) return;
+    const s = tape.snapshot();
+    $('.slot-sp').textContent = t('br_slot_sp', '{n} SP', { n: fmt(s.shownSp) });
+    $('.slot-jackpot').textContent = t('br_slot_jackpot', 'Jackpot {n}', { n: fmt(s.jackpot) });
+    const parts = [t('br_slot_last_win', 'Last win {n}', { n: fmt(s.lastWin) }), t('br_slot_free_left', 'Free spins {n}', { n: s.free })];
+    parts.push(s.melt ? t('br_slot_melt_left', 'Melt: {n} spins at half', { n: s.melt }) : t('br_slot_ready', 'Ready'));
+    $('.slot-status').textContent = parts.join('  ·  ');
+    const playing = el.dataset.phase === 'play';
+    el.querySelectorAll('[data-col]').forEach((b, i) => {
+      const on = s.hold === i, roman = ['I', 'II', 'III'][i];
+      b.setAttribute('aria-pressed', String(on));
+      b.textContent = on ? t('br_slot_frozen', 'Frozen {n}', { n: roman }) : t('br_slot_freeze', 'Freeze {n}', { n: roman });
+      b.disabled = !playing || busy || !s.canFreeze;
+    });
+    const spin = $('.slot-spin');
+    spin.disabled = !playing || busy;
+    spin.querySelector('span').textContent = t('br_slot_spin', 'Spin');
+    spin.querySelector('small').textContent =
+      s.hold !== null ? t('br_slot_cost', '{n} SP', { n: s.freezeCost })
+      : s.nextKind === 'free' || s.nextKind === 'respin' ? t('br_slot_free_spin', 'Free spin')
+      : s.onTape ? t('br_slot_on_tape', '{n} left on tape', { n: s.onTape })
+      : s.sp >= 1 ? t('br_slot_tape_cost', '{n} SP for {n} spins', { n: Math.min(10, Math.floor(s.sp)) })
+      : t('br_slot_cost', '{n} SP', { n: s.stake });
+    if (scene) {
+      scene.setHold(s.hold);
+      scene.screen('marquee', t('br_slot_marquee', 'CANDY'));   // the slot name is still open (6)
+      scene.screen('screen_jackpot', t('br_slot_screen_jackpot', 'JACKPOT {n}', { n: fmt(s.jackpot) }));
+      scene.screen('screen_status', s.melt ? t('br_slot_screen_melt', 'MELT · {n} SPINS AT HALF', { n: s.melt })
+        : t('br_slot_screen_status', 'WIN {n} · FREE {m}', { n: fmt(s.lastWin), m: s.free }));
+    }
+  }
+
+  function faceFor(o) {
+    if (!o) return 'idle0_0';
+    if (o.line === 'emi3') return 'jackpot';
+    if (o.pay > 0) return 'hearts';
+    if (o.meltLeft > 0) return 'melt';
+    if (o.freeLeft > 0) return 'spirals';
+    return 'idle0_0';
+  }
+
+  function drawHud(name) {
+    const c = el && $('.slot-face'), img = scene && scene.faceImage;
+    if (!c || !img) return;
+    const g = c.getContext('2d');
+    g.clearRect(0, 0, 152, 137);
+    g.drawImage(img, (FACES[name] ?? 3) * 152, 0, 152, 137, 0, 0, 152, 137);
+  }
+  function setFace(name) { if (scene) scene.setFace(name); drawHud(name); }
+
+  function renderOdds() {
+    const s = tape.snapshot();
+    const table = $('.slot-odds table');
+    table.replaceChildren(...s.lines.map(l => {
+      const tr = document.createElement('tr');
+      for (const [tag, text] of [['th', t(`br_slot_line_${l.id}`, LINE_LABELS[l.id] || String(l.id))], ['td', fmt(l.pays)], ['td', String(l.odds || '')]]) {
+        const cell = document.createElement(tag); cell.textContent = text; tr.append(cell);
+      }
+      return tr;
+    }));
+    $('.slot-odds p').textContent = t('br_slot_stake', 'Each spin costs {n} SP. A freeze costs {m} SP.', { n: s.stake, m: s.freezeCost });
+  }
+
+  function toggleFreeze(col) {
+    if (!alive || busy || !tape || el.dataset.phase !== 'play') return;
+    tape.toggleHold(col);
+    sync();
+  }
+
+  function fire(o) {
+    if (suspended || typeof ctx.fx !== 'function') return;
+    for (const fxId of Array.isArray(o.fx) ? o.fx : []) {
+      try {
+        const keys = fxSymbols(fxId, o, media);
+        const p = ctx.fx(fxId, keys.length ? keys : undefined);   // never awaited: fx-ack is advisory
+        if (p && typeof p.catch === 'function') p.catch(() => {});
+      } catch (e) { console.warn('[slot] fx failed', e); }
+    }
+  }
+
+  async function press() {
+    if (!alive || busy || suspended || !scene || el.dataset.phase !== 'play') return;
+    const my = session, before = tape.snapshot();
+    busy = true; card(null); sync();
+    const r = await tape.press();
+    if (my !== session || !alive) return;
+    if (r.kind !== 'play') {
+      busy = false;
+      if (r.kind === 'refused') card(refusalText(r.reason));
+      sync();
+      return;
+    }
+    const o = r.outcome;
+    setFace('idle0_0');
+    sync();
+    await scene.spin(Array.isArray(o.stops) ? o.stops : stopsFor(before.strips, o.symbols), o.kind === 'freeze' ? before.hold : null);
+    if (my !== session || !alive) return;
+    tape.land(o);
+    fire(o);
+    if (o.line === 'emi3') scene.celebrate(o.pay);
+    setFace(faceFor(o));
+    busy = false;
+    sync();
+  }
+
+  function onKey(e) {
+    if (!alive) return;
+    if (e.key === 'Escape') { e.preventDefault(); back(); return; }
+    if (e.target && e.target.closest && e.target.closest('button, summary, input, select')) return;
+    if (e.code === 'Space') { e.preventDefault(); press(); }
+    if (['1', '2', '3'].includes(e.key)) toggleFreeze(Number(e.key) - 1);
+  }
+  const onResize = () => scene && scene.resize();
+
+  async function open() {
+    if (alive) return;
+    alive = true; busy = false; suspended = false; lastMelt = null;
+    const my = ++session;
+    el = build();
+    ctx.root.append(el);
+    addEventListener('keydown', onKey); addEventListener('resize', onResize);
+    tape = createTape({ request: (op, body, idem) => ctx.request(op, body, idem), onMelt: sendMelt });
+    media = createMedia($('.slot-media'), ctx.lex);
+    if (typeof ctx.onSp === 'function') unSp = ctx.onSp(v => { if (tape) { tape.setServerSp(v); sync(); } });
+    const dealt = Promise.resolve().then(() => (typeof ctx.media === 'function' ? ctx.media() : null))
+      .then(m => (my === session ? media.deal(m) : null)).catch(() => null);
+    const [made, state] = await Promise.all([
+      createScene({ canvas: $('.slot-stage'), reduced, hint: $('.slot-hint'), canPull: () => !busy && !suspended,
+                    onLever: () => press(), onFreeze: col => toggleFreeze(col) }).catch(e => ({ error: e })),
+      tape.open(),
+    ]);
+    if (my !== session) { if (made && made.dispose) made.dispose(); return; }
+    $('.slot-loading').hidden = true;
+    if (made.error) { console.error('[slot] cabinet failed to load', made.error); el.dataset.phase = 'closed'; card(refusalText('closed')); return; }
+    if (made.missing.length) {
+      made.dispose();
+      el.dataset.phase = 'closed';
+      card(t('br_slot_model_missing', 'Model missing {n}', { n: made.missing.join(', ') }));
+      return;
+    }
+    if (!state.ok) { made.dispose(); el.dataset.phase = 'closed'; card(refusalText('closed')); return; }   // 3.4: no state, no fallback table
+    scene = made;
+    const s = tape.snapshot();
+    scene.setStrips(s.strips);
+    scene.setStops(s.last && Array.isArray(s.last.stops) ? s.last.stops : stopsFor(s.strips, s.shown));
+    scene.setLook({ gif: i => media.gif(i), word: i => media.word(i) });
+    dealt.then(() => { if (my === session && scene) scene.setLook({ gif: i => media.gif(i), word: i => media.word(i) }); });
+    renderOdds();
+    setFace(!s.last && s.melt ? 'melt' : faceFor(s.last));
+    el.dataset.phase = 'rise';
+    sync();
+    await scene.rise();
+    if (my !== session) return;
+    el.dataset.phase = 'play';
+    sync();
+  }
+
+  async function close() {
+    if (!alive) return;
+    alive = false;
+    const my = ++session;
+    if (tape) {
+      tape.abort();
+      const cur = tape.cursor();
+      if (cur) Promise.resolve(ctx.request('cursor', cur)).catch(() => {});
+    }
+    removeEventListener('keydown', onKey); removeEventListener('resize', onResize);
+    if (typeof unSp === 'function') unSp();
+    unSp = null;
+    const s = scene, root = el, m = media;
+    if (root) root.dataset.phase = 'leaving';
+    if (s) await Promise.race([s.sink(), new Promise(r => setTimeout(r, 380))]);
+    if (s) s.dispose();
+    if (m) m.dispose();
+    if (root) root.remove();
+    if (my === session) { scene = null; el = null; tape = null; media = null; busy = false; }
+  }
+
+  return {
+    open,
+    close,
+    suspend(on) {
+      suspended = !!on;
+      if (suspended && scene) scene.cancelPull();
+      if (el) sync();
+    },
+    async destroy() {
+      await close();
+      document.querySelectorAll('link[data-slot-css]').forEach(l => l.remove());
+    },
+    /** For dev.html and CDP checks only. */
+    debug: () => ({ phase: el && el.dataset.phase, busy, alive, snapshot: tape && tape.snapshot(),
+                    spinning: !!(scene && scene.spinning), sceneAlive: !!scene }),
+  };
+}

--- a/ConditioningControlPanel/Resources/web/backroom/stations/slot/station.md
+++ b/ConditioningControlPanel/Resources/web/backroom/stations/slot/station.md
@@ -1,0 +1,32 @@
+# Slot station
+
+The Candy cabinet (CONTRACT.md sections 2-7). Entry `station.js`, loaded by the room from `stations.json`.
+
+| File | What |
+|---|---|
+| `station.js` | `mount(ctx)` -> `{open, close, suspend, destroy}`. DOM, readouts, press flow, fx, melt. |
+| `tape.js` | Pure tape client: state, buys, idem reuse, freeze, shownSp. No DOM. |
+| `scene.js` | three.js cabinet. One WebGL context per `open`, freed in `close`. |
+| `symbols.js` / `media.js` | Reel cell art and the sit-down deal (keys only leave the page). |
+| `nodes.js` | The glb node names the page drives. |
+| `mock-server.js`, `dev.html` | Standalone harness. Not shipped behaviour. |
+
+## What the page needs from the room
+
+- An import map for `three` and `three/addons/` pointing at `/vendor/three/` (GLTFLoader imports `three` bare).
+- `ctx.request(op, body, idem)` resolving a `station-result`, `ctx.fx(fxId, symbols)`, `ctx.media()`,
+  `ctx.onSp(fn)`, `ctx.lex(key, fallback)`, `ctx.standUp()`.
+- The `melt` frame goes out through `ctx.melt(left)` when present, else `ctx.bridge.send({type:'melt', ...})`.
+
+## Checks
+
+```
+node --test ConditioningControlPanel/Resources/web/backroom/stations/slot/tests/
+node ConditioningControlPanel/Resources/web/backroom/stations/slot/tests/nodes-check.mjs [slot.glb]
+```
+
+Run the node check on every new `slot.glb` drop. Required nodes (`cabinet`, `reel_1..3`, `lever`,
+`cam_seat`, `cam_target`) fail it and show "Model missing X" in the page; the rest only warn.
+
+Dev harness: serve `ConditioningControlPanel/Resources` as the web root and open
+`/web/backroom/stations/slot/dev.html` (`?sp=57&melt=0&floor=800&latency=120&reduced`).

--- a/ConditioningControlPanel/Resources/web/backroom/stations/slot/tests/media.test.mjs
+++ b/ConditioningControlPanel/Resources/web/backroom/stations/slot/tests/media.test.mjs
@@ -1,0 +1,15 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { fxSymbols } from '../media.js';
+
+// keyFor as media.js deals it: gif{n} -> g{n}, sub{n} -> s{n}, gif3 never dealt.
+const media = { keyFor: id => (/^gif[0-2]$/.test(id) ? `g${id[3]}` : /^sub\d$/.test(id) ? `s${id[3]}` : null) };
+
+test('fx carry dealt KEYS for the symbols they are about, never urls', () => {
+  const o = { symbols: ['gif1', 'sub0', 'gif3'], subs: ['sub0'] };
+  assert.deepEqual(fxSymbols('fx.sub_single', o, media), ['s0']);
+  assert.deepEqual(fxSymbols('fx.gif_burst', o, media), ['g1'], 'undealt gif3 is left out');
+  assert.deepEqual(fxSymbols('fx.jackpot', o, media), ['g1', 's0']);
+  assert.deepEqual(fxSymbols('fx.melt', { symbols: ['melt', 'spiral0', 'emi'] }, media), []);
+  assert.deepEqual(fxSymbols('fx.gif_storm', { symbols: ['gif2', 'gif2', 'gif2'] }, media), ['g2']);
+});


### PR DESCRIPTION
Lane C2, part c of 3 (stacked on https://github.com/CodeBambi/Conditioning-Control-Panel---CSharp-WPF/pull/1126). The slot station module, media deal, fx wiring and the standalone harness. CONTRACT.md sections 2 (page side), 4, 5, 7.

## What
- `station.js`: `mount(ctx)` -> `{open, close, suspend, destroy}`. Back is live while loading, rising and spinning (no network wait). One outcome per press (lever, Spin, Space); 1/2/3 light a freeze column. Readouts: `shownSp`, jackpot from `table.jackpot`, last win / free spins / melt on the status line and the cabinet screens, odds panel from `table.lines`. Refusals: quiet card with Back. No state: "closed for a moment" and Back (no fallback table). Cursor flushed on close.
- `media.js`: `ctx.media()` on sit-down, `gif0-3` / `sub0-3` map to the dealt items, GIFs kept animating in a hidden holder and redrawn into the reel canvas every 100 ms, fallback art when an item is missing or fails to load. Only ccp.assets / ccp.game URLs (or the page's own origin for dev) are loaded.
- fx: every landed outcome sends `outcome.fx` in order with dealt KEYS (`g1`, `s0`), never urls; `melt {left}` whenever it changes. Nothing waits on `fx-ack`; fx are dropped while suspended.
- `dev.html` + `mock-server.js`: runs standalone. Serve `ConditioningControlPanel/Resources` as root, open `/web/backroom/stations/slot/dev.html` (`?sp=&melt=&floor=&latency=&reduced`).

## Evidence (`C:/wt-br2/_evidence/c2/`)
- `evidence-run.log` / `evidence.json`: 34/34 CDP checks at 1280x720 and 390x844 (driver `evidence.cjs`).
- Rise: `d1280_01_rise_250.png`, `_450`, `_900`, `d1280_02_seated.png`, `p390_02_seated.png`.
- 10-spin tape: `d1280_03_tape_spin1.png`, `d1280_04_tape_spin6.png`, `d1280_05_tape_done.png` (+ p390).
- Freeze mid-tape: `d1280_06_freeze_armed.png`, `d1280_07_freeze_spinning.png` (+ p390).
- Melt carry-over: `d1280_08_melt_landed.png`, `d1280_10_melt_reopened.png` (+ p390).
- Back during spin / rise / loading: `d1280_09_back_during_spin.png`, `d1280_11_rise_before_back.png`, `model_loading_before_back.png`.
- Reduced motion: `reduced_01_seated.png`, `reduced_02_after_press.png`. Lever drag: `lever_01_pulled.png`.
- Model contract: `model_missing_required.png`, `model_missing_optional.png`, `model_door_closed.png`. Insufficient + odds: `d1280_13_insufficient_odds.png`.
- `node-tests.log` (14/14), `nodes-check.log`.

## Integration notes
- The room page must declare an import map for `three` and `three/addons/` (GLTFLoader imports `three` bare).
- `melt` goes out via `ctx.melt(left)` if the room provides it, else `ctx.bridge.send(...)`.
- `dev.html`, `mock-server.js` and `tests/` should join the csproj harness exclude so they stay out of the installer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V3c2CJTNfpbeBYqwjT6ZAj



---
**Small-balance tape:** merged up (de7b57844); the idle Spin caption reads `tapeCount` (12749657c). At 16 SP it shows "3 SP for 3 spins", evidence `C:/wt-br2/_evidence/c2/low-balance-tape.png`. Slot tests 16/16 pass, nodes-check OK.

---
**Pace (236f00713):** press() runs breath -> spin -> reveal -> idle from PACE; the buy runs inside the breath so latency is absorbed; a press during the reveal is kept. Freeze and re-spins hold `r.held`. Measured over a 10-spin tape (Space held): 4,056-4,141 ms per outcome (mean 4,102), reduced motion 4,060-4,111 ms (mean 4,087). Back leaves within 10-29 ms in breath, spin, reveal and idle. Evidence `C:/wt-br2/_evidence/c2/pace-4s/` (`timings.txt`, screencast frames `01_outcome_*`, `freeze-run.log` + `05/06_freeze_*`), `node-tests-pace.log` (18/18), `nodes-check-pace.log` (OK).
